### PR TITLE
fix(review): canonicalize provider finding IDs

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -299,13 +299,21 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	if _, err := prepareCompactReviewerResults(reviewtransaction.CompactState{SelectedLenses: []string{*lens}}, []facadeReviewerResult{result}, facadeRefuterResult{}); err != nil {
 		return reviewPreflightError(err)
 	}
+	nativeResult := result.nativeLensResult()
+	nativeResult.Lens = *lens
+	nativeResult, err = reviewtransaction.CanonicalCompactLensResult(nativeResult)
+	if err != nil {
+		return reviewPreflightError(err)
+	}
+	if decision, diagnostic := reviewtransaction.ValidateArtifactFindingIDs(nativeResult); decision != reviewtransaction.ArtifactAdmissionCompleted {
+		return reviewPreflightError(fmt.Errorf("reviewer artifact admission %s: %s", decision, diagnostic))
+	}
+	result = result.withCanonicalLensResult(nativeResult)
 	canonicalResult, err := json.Marshal(result)
 	if err != nil {
 		return err
 	}
 	canonicalResult = append(canonicalResult, '\n')
-	nativeResult := result.nativeLensResult()
-	nativeResult.Lens = *lens
 	candidateCausalIDs, err := verifiedCandidateCausalFindingIDs(ctx, root, state.InitialSnapshot, nativeResult)
 	if err != nil {
 		return reviewPreflightError(err)

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -124,6 +124,24 @@ func TestReviewCaptureResultRejectsSemanticAdmissionBeforePublication(t *testing
 				CausalDisposition: "introduced and behavior-activated",
 			}}
 		}},
+		{name: "malformed finding id", mutate: func(result *facadeReviewerResult) {
+			result.Findings = []facadeFinding{{ID: "R3-", Location: "tracked.txt:1", Severity: "WARNING", Claim: "malformed identity", ProofRefs: []string{"tracked.txt:1 observation"}}}
+		}},
+		{name: "cross-lens finding id", mutate: func(result *facadeReviewerResult) {
+			result.Findings = []facadeFinding{{ID: "R1-001", Location: "tracked.txt:1", Severity: "WARNING", Claim: "wrong lens identity", ProofRefs: []string{"tracked.txt:1 observation"}}}
+		}},
+		{name: "duplicate finding id", mutate: func(result *facadeReviewerResult) {
+			result.Findings = []facadeFinding{
+				{ID: "R3-001", Location: "tracked.txt:1", Severity: "WARNING", Claim: "first identity", ProofRefs: []string{"tracked.txt:1 observation"}},
+				{ID: "R3-001", Location: "tracked.txt:1", Severity: "SUGGESTION", Claim: "duplicate identity", ProofRefs: []string{"tracked.txt:1 observation"}},
+			}
+		}},
+		{name: "generated finding id collision", mutate: func(result *facadeReviewerResult) {
+			result.Findings = []facadeFinding{
+				{Location: "tracked.txt:1", Severity: "WARNING", Claim: "provider identity", ProofRefs: []string{"tracked.txt:1 observation"}},
+				{ID: "R3-001", Location: "tracked.txt:1", Severity: "SUGGESTION", Claim: "unstable explicit identity", ProofRefs: []string{"tracked.txt:1 observation"}},
+			}
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -143,6 +161,10 @@ func TestReviewCaptureResultRejectsSemanticAdmissionBeforePublication(t *testing
 				t.Fatalf("semantic rejection consumed the immutable result slot: %v", statErr)
 			}
 			assertArtifactRevision(t, store, record.Revision)
+			after, loadErr := store.Load()
+			if loadErr != nil || !reflect.DeepEqual(after.State, record.State) {
+				t.Fatalf("semantic rejection mutated authority: load=%v before=%#v after=%#v", loadErr, record.State, after.State)
+			}
 		})
 	}
 }
@@ -162,7 +184,7 @@ func TestReviewCaptureResultFinalizePreservesCausalClassification(t *testing.T) 
 			repo, started, store, record := newArtifactReview(t, false)
 			result := admittedReviewerResultForTest(t, repo, record, record.State.SelectedLenses[0], 0)
 			result.Findings = []facadeFinding{{
-				ID: "R3-001", Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "candidate failure",
+				Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "candidate failure",
 				ProofRefs: []string{"tracked.txt:1 candidate-specific proof"}, EvidenceClass: tt.class, CausalDisposition: tt.causality,
 			}}
 			input := filepath.Join(t.TempDir(), "result.json")
@@ -199,6 +221,78 @@ func TestReviewCaptureResultFinalizePreservesCausalClassification(t *testing.T) 
 					finding, classification, finalized.State.State, finalized.State.Outcomes, finalized.State.FixFindingIDs)
 			}
 		})
+	}
+}
+
+func TestReviewCaptureResultCanonicalizesFindingIDsBeforeAdmissionAndReplay(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, false)
+	result := admittedReviewerResultForTest(t, repo, record, record.State.SelectedLenses[0], 0)
+	result.Findings = []facadeFinding{
+		{Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "candidate failure", ProofRefs: []string{"tracked.txt:1 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced},
+		{Location: "tracked.txt:1", Severity: "WARNING", Claim: "causality unknown", ProofRefs: []string{"tracked.txt:1 observation"}, EvidenceClass: reviewtransaction.EvidenceInsufficient, CausalDisposition: reviewtransaction.CausalUnknown},
+		{ID: "R3-CUSTOM", Location: "tracked.txt:1", Severity: "SUGGESTION", Claim: "explicit identity", ProofRefs: []string{"tracked.txt:1 observation"}},
+	}
+	input := filepath.Join(t.TempDir(), "result.json")
+	writeReviewCLIJSON(t, input, result)
+	raw, _ := os.ReadFile(input)
+	args := []string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input}
+	var first, replay bytes.Buffer
+	if err := RunReviewCaptureResult(args, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult(args, &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult(args, &replay); err != nil || first.String() != replay.String() {
+		t.Fatalf("canonical replay changed: %v", err)
+	}
+	if after, err := os.ReadFile(input); err != nil || !bytes.Equal(after, raw) {
+		t.Fatalf("capture rewrote preserved reviewer output: read=%v", err)
+	}
+	var artifact reviewResultArtifact
+	decodeStrictReviewJSON(t, first.Bytes(), &artifact)
+	payload, err := os.ReadFile(artifact.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope admittedReviewerResult
+	decodeStrictReviewJSON(t, payload, &envelope)
+	if got := []string{envelope.Result.Findings[0].ID, envelope.Result.Findings[1].ID, envelope.Result.Findings[2].ID}; !reflect.DeepEqual(got, []string{"R3-001", "R3-002", "R3-CUSTOM"}) {
+		t.Fatalf("canonical finding IDs = %v", got)
+	}
+	canonical, _ := json.Marshal(envelope.Result)
+	canonical = append(canonical, '\n')
+	if envelope.Admission.CanonicalSHA256 != facadePayloadHash(canonical) || artifact.SHA256 != facadePayloadHash(payload) {
+		t.Fatalf("canonical payload identity diverged: artifact=%#v admission=%#v", artifact, envelope.Admission)
+	}
+	if !reflect.DeepEqual(envelope.Admission.CandidateCausalFindingIDs, []string{"R3-001"}) {
+		t.Fatalf("candidate-causal IDs = %v", envelope.Admission.CandidateCausalFindingIDs)
+	}
+}
+
+func TestReviewCaptureResultCanonicalizesPreservedRiskFindingWithoutID(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, true)
+	if record.State.SelectedLenses[0] != reviewtransaction.LensRisk {
+		t.Fatalf("high-risk fixture first lens = %q", record.State.SelectedLenses[0])
+	}
+	result := admittedReviewerResultForTest(t, repo, record, reviewtransaction.LensRisk, 0)
+	result.Findings = []facadeFinding{{
+		Location: "service-token.ts:1", Severity: "CRITICAL", Claim: "preserved severe review-risk finding",
+		ProofRefs: []string{"service-token.ts:1 observation"}, EvidenceClass: reviewtransaction.EvidenceInsufficient, CausalDisposition: reviewtransaction.CausalUnknown,
+	}}
+	input := filepath.Join(t.TempDir(), "preserved-review-risk.json")
+	writeReviewCLIJSON(t, input, result)
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", reviewtransaction.LensRisk, "--order", "0", "--input", input}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var artifact reviewResultArtifact
+	decodeStrictReviewJSON(t, output.Bytes(), &artifact)
+	payload, _ := os.ReadFile(artifact.Path)
+	var envelope admittedReviewerResult
+	decodeStrictReviewJSON(t, payload, &envelope)
+	if got := envelope.Result.Findings[0].ID; got != "R1-001" {
+		t.Fatalf("preserved review-risk finding ID = %q", got)
 	}
 }
 
@@ -543,7 +637,10 @@ func TestReviewCaptureResultConcurrentSelectedLenses(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			input := filepath.Join(t.TempDir(), fmt.Sprintf("%d.json", order))
-			_ = os.WriteFile(input, admittedReviewerPayloadForTest(t, repo, record, lens, order), 0o600)
+			result := admittedReviewerResultForTest(t, repo, record, lens, order)
+			result.Findings = []facadeFinding{{Location: "service-token.ts:1", Severity: "WARNING", Claim: "concurrent finding", ProofRefs: []string{"service-token.ts:1 observation"}}}
+			payload, _ := json.Marshal(result)
+			_ = os.WriteFile(input, payload, 0o600)
 			var output bytes.Buffer
 			err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", fmt.Sprint(order), "--input", input}, &output)
 			if err != nil {

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -631,26 +631,45 @@ func TestReviewArtifactSubstitutionFailsBeforeMutation(t *testing.T) {
 func TestReviewCaptureResultConcurrentSelectedLenses(t *testing.T) {
 	repo, started, store, record := newArtifactReview(t, true)
 	manifests := make([]string, len(record.State.SelectedLenses))
+	inputs := make([]string, len(record.State.SelectedLenses))
+	for order := range inputs {
+		inputs[order] = filepath.Join(t.TempDir(), fmt.Sprintf("%d.json", order))
+	}
+	errs := make(chan error, len(record.State.SelectedLenses))
 	var wg sync.WaitGroup
 	for order, lens := range record.State.SelectedLenses {
 		wg.Add(1)
-		go func() {
+		go func(order int, lens, input string) {
 			defer wg.Done()
-			input := filepath.Join(t.TempDir(), fmt.Sprintf("%d.json", order))
-			result := admittedReviewerResultForTest(t, repo, record, lens, order)
-			result.Findings = []facadeFinding{{Location: "service-token.ts:1", Severity: "WARNING", Claim: "concurrent finding", ProofRefs: []string{"service-token.ts:1 observation"}}}
-			payload, _ := json.Marshal(result)
-			_ = os.WriteFile(input, payload, 0o600)
-			var output bytes.Buffer
-			err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", fmt.Sprint(order), "--input", input}, &output)
+			result, err := admittedReviewerResultForTestErr(repo, record, lens, order)
 			if err != nil {
-				t.Errorf("capture %s: %v", lens, err)
+				errs <- err
+				return
+			}
+			result.Findings = []facadeFinding{{Location: "service-token.ts:1", Severity: "WARNING", Claim: "concurrent finding", ProofRefs: []string{"service-token.ts:1 observation"}}}
+			payload, err := json.Marshal(result)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if err := os.WriteFile(input, payload, 0o600); err != nil {
+				errs <- err
+				return
+			}
+			var output bytes.Buffer
+			err = RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", fmt.Sprint(order), "--input", input}, &output)
+			if err != nil {
+				errs <- fmt.Errorf("capture %s: %w", lens, err)
 				return
 			}
 			manifests[order] = strings.TrimSpace(output.String())
-		}()
+		}(order, lens, inputs[order])
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
 	if _, err := readFacadeReviewerArtifacts(context.Background(), repo, manifests, store.Dir, record.State, record.Revision); err != nil {
 		t.Fatal(err)
 	}
@@ -725,13 +744,21 @@ func admittedReviewerPayloadForTest(t *testing.T, repo string, record reviewtran
 
 func admittedReviewerResultForTest(t *testing.T, repo string, record reviewtransaction.CompactRecord, lens string, order int) facadeReviewerResult {
 	t.Helper()
-	frozen, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).FrozenCandidateContext(context.Background(), record.State.InitialSnapshot)
+	result, err := admittedReviewerResultForTestErr(repo, record, lens, order)
 	if err != nil {
 		t.Fatal(err)
 	}
+	return result
+}
+
+func admittedReviewerResultForTestErr(repo string, record reviewtransaction.CompactRecord, lens string, order int) (facadeReviewerResult, error) {
+	frozen, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).FrozenCandidateContext(context.Background(), record.State.InitialSnapshot)
+	if err != nil {
+		return facadeReviewerResult{}, err
+	}
 	subject, err := reviewtransaction.NewArtifactSubject(record.State, record.Revision, frozen, lens, order, "")
 	if err != nil {
-		t.Fatal(err)
+		return facadeReviewerResult{}, err
 	}
 	paths := make([]string, len(frozen.ChangedPathManifest))
 	for index, entry := range frozen.ChangedPathManifest {
@@ -741,7 +768,7 @@ func admittedReviewerResultForTest(t *testing.T, repo string, record reviewtrans
 		SubjectHash: subject.SubjectHash,
 		Inspection:  reviewtransaction.ArtifactInspection{Status: reviewtransaction.ArtifactInspectionCompleted, Paths: paths},
 		Findings:    []facadeFinding{}, Evidence: []string{"inspection: reviewed every frozen candidate path"},
-	}
+	}, nil
 }
 
 func capturedArtifact(t *testing.T) (string, ReviewFacadeStartResult, reviewtransaction.CompactStore, reviewtransaction.CompactRecord, reviewResultArtifact) {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2210,6 +2210,20 @@ func (result facadeReviewerResult) nativeLensResult() reviewtransaction.LensResu
 	return reviewtransaction.LensResult{Lens: result.Lens, Findings: findings, Evidence: result.Evidence}
 }
 
+func (result facadeReviewerResult) withCanonicalLensResult(canonical reviewtransaction.LensResult) facadeReviewerResult {
+	result.Lens = canonical.Lens
+	result.Evidence = append([]string(nil), canonical.Evidence...)
+	result.Findings = make([]facadeFinding, len(canonical.Findings))
+	for index, finding := range canonical.Findings {
+		result.Findings[index] = facadeFinding{
+			ID: finding.ID, Lens: finding.Lens, Location: finding.Location, Severity: finding.Severity,
+			Claim: finding.Claim, ProofRefs: append([]string(nil), finding.ProofRefs...),
+			EvidenceClass: finding.EvidenceClass, CausalDisposition: finding.CausalDisposition,
+		}
+	}
+	return result
+}
+
 func (result facadeValidationResult) native(tx reviewtransaction.Transaction) (reviewtransaction.ScopedValidationResult, error) {
 	if len(result.OriginalCriteria.Evidence) == 0 || len(result.CorrectionRegression.Evidence) == 0 {
 		return reviewtransaction.ScopedValidationResult{}, errors.New("targeted validation requires original_criteria and correction_regression evidence")

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -206,7 +206,10 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 // ValidateArtifactFindingIDs enforces the provider-owned identity rules before
 // repository-derived classification and again during artifact admission.
 func ValidateArtifactFindingIDs(result LensResult) (ArtifactAdmissionDecision, string) {
-	wantPrefix := map[string]string{LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-"}[result.Lens]
+	wantPrefix, recognized := map[string]string{LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-"}[result.Lens]
+	if !recognized {
+		return ArtifactAdmissionBindingMismatch, "reviewer finding ID is not bound to the selected lens"
+	}
 	seen := make(map[string]struct{}, len(result.Findings))
 	for _, finding := range result.Findings {
 		if !artifactFindingID.MatchString(finding.ID) {

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -161,8 +161,9 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 	if err != nil {
 		return fail(ArtifactAdmissionIncomplete, err.Error())
 	}
-	wantPrefix := map[string]string{LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-"}[canonical.Lens]
-	seenFindingIDs := make(map[string]struct{}, len(canonical.Findings))
+	if decision, diagnostic := ValidateArtifactFindingIDs(canonical); decision != ArtifactAdmissionCompleted {
+		return fail(decision, diagnostic)
+	}
 	wantCandidateCausalIDs := make([]string, 0)
 	for _, evidence := range canonical.Evidence {
 		if evidenceReportsUnavailableInspection(evidence) {
@@ -173,16 +174,6 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 		}
 	}
 	for _, finding := range canonical.Findings {
-		if !artifactFindingID.MatchString(finding.ID) {
-			return fail(ArtifactAdmissionBindingMismatch, "reviewer finding ID does not match the native ASCII schema")
-		}
-		if !strings.HasPrefix(finding.ID, wantPrefix) {
-			return fail(ArtifactAdmissionBindingMismatch, "reviewer finding ID is not bound to the selected lens")
-		}
-		if _, duplicate := seenFindingIDs[finding.ID]; duplicate {
-			return fail(ArtifactAdmissionAmbiguous, "reviewer result repeats a finding ID")
-		}
-		seenFindingIDs[finding.ID] = struct{}{}
 		if !findingLocationInGenesis(finding.Location, wantPaths) {
 			return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
 		}
@@ -210,6 +201,26 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 	admission.Decision, admission.ResultHash = ArtifactAdmissionCompleted, canonical.ResultHash
 	admission.CandidateCausalFindingIDs = verifiedIDs
 	return canonical, admission, nil
+}
+
+// ValidateArtifactFindingIDs enforces the provider-owned identity rules before
+// repository-derived classification and again during artifact admission.
+func ValidateArtifactFindingIDs(result LensResult) (ArtifactAdmissionDecision, string) {
+	wantPrefix := map[string]string{LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-"}[result.Lens]
+	seen := make(map[string]struct{}, len(result.Findings))
+	for _, finding := range result.Findings {
+		if !artifactFindingID.MatchString(finding.ID) {
+			return ArtifactAdmissionBindingMismatch, "reviewer finding ID does not match the native ASCII schema"
+		}
+		if !strings.HasPrefix(finding.ID, wantPrefix) {
+			return ArtifactAdmissionBindingMismatch, "reviewer finding ID is not bound to the selected lens"
+		}
+		if _, duplicate := seen[finding.ID]; duplicate {
+			return ArtifactAdmissionAmbiguous, "reviewer result repeats a finding ID"
+		}
+		seen[finding.ID] = struct{}{}
+	}
+	return ArtifactAdmissionCompleted, ""
 }
 
 func payloadSHA256(payload []byte) string {

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -100,6 +100,18 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 		{name: "non ASCII finding id", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings[0].ID = "R3-é"
 		}, decision: ArtifactAdmissionBindingMismatch},
+		{name: "malformed finding id", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings[0].ID = "R3-"
+		}, decision: ArtifactAdmissionBindingMismatch},
+		{name: "cross-lens finding id", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings[0].ID = "R1-001"
+		}, decision: ArtifactAdmissionBindingMismatch},
+		{name: "duplicate finding id", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = append(r.Result.Findings, r.Result.Findings[0])
+		}, decision: ArtifactAdmissionAmbiguous},
+		{name: "generated id collision", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = append([]Finding{{Location: "internal/a.go:7", Severity: "WARNING", Claim: "generated", ProofRefs: []string{"diff: internal/a.go:7"}}}, r.Result.Findings...)
+		}, decision: ArtifactAdmissionAmbiguous},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -52,6 +52,13 @@ func TestExtractBoundedSingleJSONObject(t *testing.T) {
 	}
 }
 
+func TestValidateArtifactFindingIDsRejectsUnknownLens(t *testing.T) {
+	decision, diagnostic := ValidateArtifactFindingIDs(LensResult{Lens: "review-unknown"})
+	if decision != ArtifactAdmissionBindingMismatch || diagnostic != "reviewer finding ID is not bound to the selected lens" {
+		t.Fatalf("ValidateArtifactFindingIDs() = %q, %q; want binding mismatch with selected-lens diagnostic", decision, diagnostic)
+	}
+}
+
 func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 	_, _, request := admittedArtifactFixture(t)
 	canonical, admission, err := AdmitArtifact(request)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1699

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Canonicalize missing provider finding IDs before artifact admission; reject malformed, cross-lens, duplicate, and colliding IDs without mutating authority.
- Preserve candidate-causal IDs across capture/replay.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_artifact.go` | Canonicalize provider finding IDs before artifact admission and preserve candidate-causal identity. |
| `internal/cli/review_artifact_test.go` | Cover provider ID canonicalization, malformed/cross-lens/duplicate/collision rejection, and immutable authority behavior. |
| `internal/cli/review_facade.go` | Carry candidate-causal finding IDs through capture and replay. |
| `internal/reviewtransaction/artifact_admission.go` | Validate canonical IDs and reject malformed, cross-lens, duplicate, and colliding findings without mutating authority. |
| `internal/reviewtransaction/artifact_admission_test.go` | Test admission validation and non-mutation guarantees. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```
Passed: 7,031 tests across 61 packages.

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Passed.

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```
Passed on Ubuntu, Arch, and Fedora: 237 passed, 0 failed, 6 opt-in skipped.

- [x] Unit tests pass (`go test ./...`) — 7,031 tests across 61 packages
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — Ubuntu/Arch/Fedora, 237 passed, 0 failed, 6 opt-in skipped
- [x] Manually tested locally

Manual local verification passed.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 174 changed lines
- [ ] I have added the appropriate `type:*` label to this PR; `type:bug` awaits a maintainer with label permission
- [x] Unit tests pass (`go test ./...`): 7,031 tests across 61 packages
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`): Ubuntu/Arch/Fedora, 237 passed, 0 failed, 6 opt-in skipped
- [x] Documentation update not required for this change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Provider IDs are canonicalized before repository-derived admission and the original reviewer payload remains immutable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reviewer artifact admission now canonicalizes finding IDs before storing and producing the canonical payload, ensuring consistent behavior during downstream processing and replay.
  - Added stronger finding-ID validation during admission (rejects malformed, cross-lens, duplicate, and generated-collision IDs).
  - Rejected captures no longer mutate stored review state.
  - Preserved-risk findings can now be canonicalized deterministically even when the input omits explicit IDs.
- **Tests**
  - Expanded coverage for finding-ID validation, canonicalization-before-admission, replay determinism, and concurrent capture error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->