### PR TITLE
fix(sdd): include review-ledger-contract.md in _shared skill sync

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -570,6 +570,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				"persistence-contract.md",
 				"engram-convention.md",
 				"openspec-convention.md",
+				"review-ledger-contract.md",
 				"sdd-phase-common.md",
 				"sdd-status-contract.md",
 				"skill-resolver.md",

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -3332,6 +3332,7 @@ func TestInjectWritesAllSharedFilesToDisk(t *testing.T) {
 		"persistence-contract.md",
 		"engram-convention.md",
 		"openspec-convention.md",
+		"review-ledger-contract.md",
 		"sdd-phase-common.md",
 		"sdd-status-contract.md",
 		"skill-resolver.md",
@@ -3388,9 +3389,57 @@ func TestInjectSharedDirCreatedWithAllFiles(t *testing.T) {
 		names[e.Name()] = true
 	}
 
-	for _, want := range []string{"persistence-contract.md", "engram-convention.md", "openspec-convention.md", "sdd-phase-common.md", "sdd-status-contract.md", "skill-resolver.md"} {
+	for _, want := range []string{"persistence-contract.md", "engram-convention.md", "openspec-convention.md", "review-ledger-contract.md", "sdd-phase-common.md", "sdd-status-contract.md", "skill-resolver.md"} {
 		if !names[want] {
 			t.Errorf("_shared directory missing %q after Inject()", want)
+		}
+	}
+}
+
+// TestInjectDeploysEveryEmbeddedSharedFile is a regression test for a class of
+// bug where a file physically present in the embedded skills/_shared/ asset
+// directory is never added to the sharedFiles deployment list inside Inject(),
+// so it silently never reaches disk (sync still exits 0, doctor does not catch
+// it). Instead of hardcoding filenames — which would not have caught the next
+// missing file either — this test discovers the ground truth directly from the
+// embedded FS and asserts every entry found there was actually written to disk
+// by Inject(). See gentleman-programming/gentle-ai#1485.
+func TestInjectDeploysEveryEmbeddedSharedFile(t *testing.T) {
+	mockNoPackageManager(t)
+	home := t.TempDir()
+
+	entries, err := assets.FS.ReadDir("skills/_shared")
+	if err != nil {
+		t.Fatalf("ReadDir(skills/_shared) error = %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("precondition failed: embedded skills/_shared directory is empty")
+	}
+
+	if _, err := Inject(home, opencodeAdapter(), ""); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	sharedDir := filepath.Join(home, ".config", "opencode", "skills", "_shared")
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		wantPath := "skills/_shared/" + entry.Name()
+		wantContent, readErr := assets.Read(wantPath)
+		if readErr != nil {
+			t.Fatalf("assets.Read(%q) error = %v", wantPath, readErr)
+		}
+
+		gotPath := filepath.Join(sharedDir, entry.Name())
+		gotContent, statErr := os.ReadFile(gotPath)
+		if statErr != nil {
+			t.Errorf("embedded shared file %q was never deployed to disk (missing from Inject()'s deployment list): %v", entry.Name(), statErr)
+			continue
+		}
+		if string(gotContent) != wantContent {
+			t.Errorf("deployed shared file %q content does not match embedded asset", entry.Name())
 		}
 	}
 }


### PR DESCRIPTION
Closes #1485

## Summary
- `review-ledger-contract.md` was never added to the `sharedFiles` deployment list in `Inject()` (`internal/components/sdd/inject.go`), so it silently never synced to `<skillDir>/_shared/review-ledger-contract.md` — sync exits 0, doctor doesn't catch it, and judgment-day is left with a dangling contract reference.
- Root cause confirmed against a real `manifest.json` produced by binary 2.1.11 during an actual `gentle-ai sync` (see issue comments).

## Changes
| File | Change |
|------|--------|
| `internal/components/sdd/inject.go` | Add `review-ledger-contract.md` to the `_shared` deployment list |
| `internal/components/sdd/inject_test.go` | Add `TestInjectDeploysEveryEmbeddedSharedFile`, a generic regression test that diffs the embedded `skills/_shared/` directory against what `Inject()` writes to disk, so any future file added there and not wired into the deploy list fails the build; also update two pre-existing hardcoded-list tests |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./internal/components/sdd/...`
- [x] `go test ./...` (full suite)
- [x] Confirmed new test fails without the fix and passes with it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the review ledger contract to the shared skill documents installed during setup.
* **Bug Fixes**
  * Improved shared skill file deployment to ensure all included documents are installed correctly and completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->