### PR TITLE
feat(doctor): dormant engram MCP version gate + lifecycle runbook (#1019)

### DIFF
--- a/docs/engram-mcp-lifecycle.md
+++ b/docs/engram-mcp-lifecycle.md
@@ -1,0 +1,97 @@
+# Engram MCP Lifecycle
+
+Reference for the lifecycle that the `engram` binary must satisfy when
+Claude Code registers it as a plugin. This page is the canonical runbook
+for the gentle-ai side of the integration; the actual MCP server
+implementation lives in
+[`gentleman-programming/engram`](https://github.com/Gentleman-Programming/engram).
+
+> **Status (2026-07-21):** the open defect is tracked in
+> [Gentleman-Programming/gentle-ai#1019](https://github.com/Gentleman-Programming/gentle-ai/issues/1019).
+> This runbook documents what gentle-ai emits and what Claude Code
+> expects. The actual fix is upstream in the engram binary.
+
+## What gentle-ai writes
+
+`gentle-ai` registers `engram` with Claude Code by writing a single MCP
+config file. The shape and path depend on the strategy chosen by the
+Claude Code adapter:
+
+| Adapter strategy | File path (Linux/macOS)                              | Equivalent on Windows          |
+|------------------|------------------------------------------------------|-------------------------------|
+| `StrategySeparateMCPFiles` | `~/.claude/mcp/engram.json`            | `%USERPROFILE%\.claude\mcp\engram.json` |
+| Other strategies            | merged into `~/.claude/settings.json` | merged into the Windows settings.json |
+
+For the common case (`StrategySeparateMCPFiles`), the file contents are:
+
+```json
+{
+  "command": "engram",
+  "args": ["mcp", "--tools=agent"]
+}
+```
+
+The absolute path to the binary is resolved at write time and preserved
+when the file already exists (see
+`internal/components/engram/inject.go:798-828`).
+
+## Expected MCP lifecycle
+
+Claude Code's stdio MCP client drives the binary through the canonical
+MCP protocol sequence:
+
+1. Client sends `initialize` (JSON-RPC request).
+2. Server responds with server info and capabilities.
+3. **Server sends `notifications/initialized`** (required notification,
+   per the MCP spec).
+4. Client sends `tools/list`.
+5. Server responds with the list of tools.
+6. Client sends periodic `ping` requests.
+7. Server responds to each ping with an empty result.
+
+A reference implementation of this sequence lives at
+`internal/components/communitytool/pi_codegraph.go:550-574` (read-only —
+do not modify from this PR).
+
+## Known-good version
+
+| engram binary version | Status     |
+|-----------------------|------------|
+| `TBD`                 | Known good (will be set once a release ships the `notifications/initialized` notification). |
+
+Until this constant is set, `gentle-ai doctor` does NOT emit a WARN for
+old versions — the check is dormant. The dormant default is defined in
+`internal/components/engram/doctor.go` as
+`MinEngramVersionForHealthyLifecycle = "0.0.0"`. A `TODO` comment in
+the same file marks the action required to flip the switch.
+
+## Verifying the lifecycle locally
+
+A regression test lives at
+`internal/components/engram/lifecycle_test.go` and is guarded by the
+`engram_lifecycle` build tag so it does NOT run under the default
+`go test ./...` workflow. To run it explicitly:
+
+```bash
+go test -count=1 -tags engram_lifecycle ./internal/components/engram/...
+```
+
+The test:
+
+1. Spawns the `engram` binary on `$PATH` via `exec.Cmd`.
+2. Sends `initialize`, `notifications/initialized`, `tools/list`, and
+   `ping` over stdio.
+3. Asserts the binary stays alive for 10 seconds after the ping.
+4. If the binary is missing, calls `t.Skip` with a clear message.
+5. If the binary dies mid-test, fails with a diagnostic that names
+   Gentleman-Programming/gentle-ai#1019 and includes the partial
+   JSON-RPC exchange.
+
+## See also
+
+- [Gentleman-Programming/gentle-ai#1019](https://github.com/Gentleman-Programming/gentle-ai/issues/1019) — the open defect.
+- `internal/components/engram/inject.go` — the registration writer.
+- `internal/components/engram/verify.go:31-37` — the `engram version`
+  seam reused by the doctor check.
+- `internal/components/communitytool/pi_codegraph.go:550-574` —
+  reference MCP lifecycle implementation (read-only).

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -116,13 +116,15 @@ func RunDoctor(ctx context.Context, w io.Writer) error {
 	// engram MCP handshake lifecycle version gate (#1019). Wired inline
 	// alongside the existing checks; see internal/components/engram/doctor.go.
 	// Convert from the engram-local MCPVersionCheck to cli.CheckResult to keep
-	// imports one-way (engram does not import cli).
+	// imports one-way (engram does not import cli). The doctor framework's
+	// Result struct expects typed CheckID / *Remedy; MCPVersionCheck carries
+	// strings, so coerce at the boundary.
 	engramLifecycle := engram.CheckEngramMCPVersion(ctx)
 	report.Checks = append(report.Checks, CheckResult{
-		Name:   engramLifecycle.Name,
+		Name:   doctor.CheckID(engramLifecycle.Name),
 		Status: CheckStatus(engramLifecycle.Status),
 		Detail: engramLifecycle.Detail,
-		Remedy: engramLifecycle.Remedy,
+		Remedy: nilOrEngramRemedy(engramLifecycle.Remedy),
 	})
 
 	renderDoctorReport(w, report)
@@ -511,4 +513,19 @@ func statusIcon(s CheckStatus) string {
 	default:
 		return "[??]"
 	}
+}
+
+// nilOrEngramRemedy converts the engram MCPVersionCheck's free-form remedy
+// string into the doctor framework's typed *Remedy. Empty remedy yields nil;
+// non-empty remedy yields a RemedyInstallTool-tagged entry because every
+// current engram lifecycle remedy is an install/upgrade operation (install
+// engram, update to a release that prints strict semver, or upgrade to the
+// known-good threshold version). Mapping to a single ID keeps the conversion
+// lossless at the message level; richer RemedyID classification can be added
+// when the engram check starts emitting categories.
+func nilOrEngramRemedy(s string) *doctor.Remedy {
+	if s == "" {
+		return nil
+	}
+	return doctor.NewRemedy(doctor.RemedyInstallTool, s)
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/doctor"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/storage"
@@ -111,6 +112,18 @@ func RunDoctor(ctx context.Context, w io.Writer) error {
 		doctor.Check{ID: doctor.CheckDiskSpace, Run: func(context.Context) doctor.Result { return checkDiskSpace(homeDir) }},
 	)
 	report := (doctor.Runner{Checks: checks}).Run(ctx)
+
+	// engram MCP handshake lifecycle version gate (#1019). Wired inline
+	// alongside the existing checks; see internal/components/engram/doctor.go.
+	// Convert from the engram-local MCPVersionCheck to cli.CheckResult to keep
+	// imports one-way (engram does not import cli).
+	engramLifecycle := engram.CheckEngramMCPVersion(ctx)
+	report.Checks = append(report.Checks, CheckResult{
+		Name:   engramLifecycle.Name,
+		Status: CheckStatus(engramLifecycle.Status),
+		Detail: engramLifecycle.Detail,
+		Remedy: engramLifecycle.Remedy,
+	})
 
 	renderDoctorReport(w, report)
 	return nil

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -497,8 +497,9 @@ func TestRunDoctor_IntegrationAllMocked(t *testing.T) {
   [ok]  state:json                     state file OK — 1 agent(s) installed: claude-code
   [ok]  engram:reachable               engram health endpoint OK at http://localhost:7437/health (HTTP 200)
   [ok]  disk:space                     1024 MB free on %s filesystem
+  [ok]  engram-mcp-lifecycle-version   engram-mcp-lifecycle-version check is dormant (threshold 0.0.0); set MinEngramVersionForHealthyLifecycle to the engram release that shipped notifications/initialized to enable it
 
-Summary: 7 passed, 0 failed, 0 warnings
+Summary: 8 passed, 0 failed, 0 warnings
 Status:  healthy
 `, filepath.Join(homeDir, ".gentle-ai"))
 	if got := buf.String(); got != want {

--- a/internal/components/engram/doctor.go
+++ b/internal/components/engram/doctor.go
@@ -55,30 +55,20 @@ type MCPVersionCheck struct {
 //
 // Behaviour matrix (spec R5 + R7 + R8):
 //
+//	dormant threshold (0.0.0) → PASS (no WARN ever, even if binary is missing)
 //	parse failure OR version command failure → WARN (never FAIL)
 //	installed < MinEngramVersionForHealthyLifecycle   → WARN (with #1019 + remedy)
 //	installed >= MinEngramVersionForHealthyLifecycle  → PASS
 //
 // The threshold default is "0.0.0" so the check is dormant in production
 // until the upstream engram fix is published and the constant is flipped.
+// Dormant short-circuits BEFORE invoking VerifyVersionCommand, so a missing
+// binary does not surface a spurious WARN while the check is off (spec S8).
 func CheckEngramMCPVersion(ctx context.Context) MCPVersionCheck {
 	// ctx is reserved for downstream seam reuse; VerifyVersionCommand (which
 	// verify.go locks byte-identical) builds its own timeout context, so we
 	// pass only "engram". When verify.go ever accepts ctx, drop the discard.
 	_ = ctx
-	raw, err := VerifyVersionCommand("engram")
-	if err != nil {
-		// Version command failed (binary missing, exec error, timeout).
-		// Emit WARN — never FAIL — so an inaccessible binary cannot brick
-		// the doctor exit code (spec R7).
-		return MCPVersionCheck{
-			Name:   mcpLifecycleVersionCheckName,
-			Status: CheckStatusWarn,
-			Detail: fmt.Sprintf("could not read engram version: %v", err),
-			Remedy: "Install engram (go install github.com/gentleman-programming/engram/cmd/engram@latest) " +
-				"and ensure it is on $PATH so the MCP lifecycle version can be inspected.",
-		}
-	}
 
 	thresholdMajor, thresholdMinor, thresholdPatch, thresholdOK := parseStrictSemver(MinEngramVersionForHealthyLifecycle)
 	if !thresholdOK {
@@ -91,15 +81,29 @@ func CheckEngramMCPVersion(ctx context.Context) MCPVersionCheck {
 		}
 	}
 
-	// Dormant threshold ("0.0.0"): the check is silent per spec S8. Even an
-	// unparseable version output is PASS because there is no comparison to
-	// make — the operator has not flipped the switch yet, so we do not
-	// surface parse warnings either.
+	// Dormant threshold ("0.0.0"): the check is silent per spec S8. We
+	// return PASS BEFORE invoking VerifyVersionCommand so a missing binary
+	// does not surface a spurious WARN while the check is off. The operator
+	// has not flipped the switch yet, so there is no comparison to make.
 	if thresholdMajor == 0 && thresholdMinor == 0 && thresholdPatch == 0 {
 		return MCPVersionCheck{
 			Name:   mcpLifecycleVersionCheckName,
 			Status: CheckStatusPass,
 			Detail: "engram-mcp-lifecycle-version check is dormant (threshold 0.0.0); set MinEngramVersionForHealthyLifecycle to the engram release that shipped notifications/initialized to enable it",
+		}
+	}
+
+	raw, err := VerifyVersionCommand("engram")
+	if err != nil {
+		// Version command failed (binary missing, exec error, timeout).
+		// Emit WARN — never FAIL — so an inaccessible binary cannot brick
+		// the doctor exit code (spec R7).
+		return MCPVersionCheck{
+			Name:   mcpLifecycleVersionCheckName,
+			Status: CheckStatusWarn,
+			Detail: fmt.Sprintf("could not read engram version: %v", err),
+			Remedy: "Install engram (go install github.com/gentleman-programming/engram/cmd/engram@latest) " +
+				"and ensure it is on $PATH so the MCP lifecycle version can be inspected.",
 		}
 	}
 

--- a/internal/components/engram/doctor.go
+++ b/internal/components/engram/doctor.go
@@ -1,0 +1,218 @@
+package engram
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// MinEngramVersionForHealthyLifecycle is the lowest engram binary version
+// whose MCP stdio lifecycle survives Claude Code's handshake timeout window.
+//
+// TODO: set this to the engram release that first shipped the
+// `notifications/initialized` notification once that release is published.
+// Until then the default is "0.0.0" so no warning is emitted (spec R8 / S8).
+//
+// Declared as a `var` so tests can override the threshold via
+// withThresholdForTest. In production the value is set once at init and
+// never mutated.
+var MinEngramVersionForHealthyLifecycle = "0.0.0"
+
+// mcpLifecycleVersionCheckName is the stable name surfaced to
+// cli/doctor.go when aggregating findings (spec R5).
+const mcpLifecycleVersionCheckName = "engram-mcp-lifecycle-version"
+
+// mcpLifecycleIssueRef is the GitHub issue that motivated this check.
+// Surfaced in the doctor detail so operators can grep triage from one place.
+const mcpLifecycleIssueRef = "Gentleman-Programming/gentle-ai#1019"
+
+// CheckStatus is the doctor finding status emitted by CheckEngramMCPVersion.
+// The underlying values mirror internal/cli/doctor.go's CheckStatus 1-1 so
+// the cli package can convert via cli.CheckStatus(c.Status) without
+// creating an import cycle.
+type CheckStatus string
+
+const (
+	CheckStatusPass CheckStatus = "pass"
+	CheckStatusWarn CheckStatus = "warn"
+	CheckStatusFail CheckStatus = "fail"
+)
+
+// MCPVersionCheck is the doctor finding produced by CheckEngramMCPVersion.
+// It carries the full payload the cli/doctor.go aggregator needs:
+// Name, Status, Detail, and Remedy. Status is a string-typed enum so the
+// conversion to cli.CheckStatus is a one-line cast.
+type MCPVersionCheck struct {
+	Name   string
+	Status CheckStatus
+	Detail string
+	Remedy string
+}
+
+// CheckEngramMCPVersion probes the installed engram binary version via the
+// existing VerifyVersionCommand seam (verify.go:31-37) and reports a doctor
+// finding for the MCP handshake lifecycle.
+//
+// Behaviour matrix (spec R5 + R7 + R8):
+//
+//	parse failure OR version command failure → WARN (never FAIL)
+//	installed < MinEngramVersionForHealthyLifecycle   → WARN (with #1019 + remedy)
+//	installed >= MinEngramVersionForHealthyLifecycle  → PASS
+//
+// The threshold default is "0.0.0" so the check is dormant in production
+// until the upstream engram fix is published and the constant is flipped.
+func CheckEngramMCPVersion(ctx context.Context) MCPVersionCheck {
+	// ctx is reserved for downstream seam reuse; VerifyVersionCommand (which
+	// verify.go locks byte-identical) builds its own timeout context, so we
+	// pass only "engram". When verify.go ever accepts ctx, drop the discard.
+	_ = ctx
+	raw, err := VerifyVersionCommand("engram")
+	if err != nil {
+		// Version command failed (binary missing, exec error, timeout).
+		// Emit WARN — never FAIL — so an inaccessible binary cannot brick
+		// the doctor exit code (spec R7).
+		return MCPVersionCheck{
+			Name:   mcpLifecycleVersionCheckName,
+			Status: CheckStatusWarn,
+			Detail: fmt.Sprintf("could not read engram version: %v", err),
+			Remedy: "Install engram (go install github.com/gentleman-programming/engram/cmd/engram@latest) " +
+				"and ensure it is on $PATH so the MCP lifecycle version can be inspected.",
+		}
+	}
+
+	thresholdMajor, thresholdMinor, thresholdPatch, thresholdOK := parseStrictSemver(MinEngramVersionForHealthyLifecycle)
+	if !thresholdOK {
+		// Defensive: a malformed threshold value should not produce FAIL.
+		return MCPVersionCheck{
+			Name:   mcpLifecycleVersionCheckName,
+			Status: CheckStatusWarn,
+			Detail: fmt.Sprintf("MinEngramVersionForHealthyLifecycle=%q is not strict semver; comparison skipped (%s)",
+				MinEngramVersionForHealthyLifecycle, mcpLifecycleIssueRef),
+		}
+	}
+
+	// Dormant threshold ("0.0.0"): the check is silent per spec S8. Even an
+	// unparseable version output is PASS because there is no comparison to
+	// make — the operator has not flipped the switch yet, so we do not
+	// surface parse warnings either.
+	if thresholdMajor == 0 && thresholdMinor == 0 && thresholdPatch == 0 {
+		return MCPVersionCheck{
+			Name:   mcpLifecycleVersionCheckName,
+			Status: CheckStatusPass,
+			Detail: "engram-mcp-lifecycle-version check is dormant (threshold 0.0.0); set MinEngramVersionForHealthyLifecycle to the engram release that shipped notifications/initialized to enable it",
+		}
+	}
+
+	installedMajor, installedMinor, installedPatch, ok := parseStrictSemver(extractSemverToken(raw))
+	if !ok {
+		return MCPVersionCheck{
+			Name:   mcpLifecycleVersionCheckName,
+			Status: CheckStatusWarn,
+			Detail: fmt.Sprintf("engram version output %q has no strict semver token (X.Y.Z); cannot compare against threshold %q (%s)",
+				strings.TrimSpace(raw), MinEngramVersionForHealthyLifecycle, mcpLifecycleIssueRef),
+			Remedy: "Update engram to a release that prints strict semver " +
+				"(go install github.com/gentleman-programming/engram/cmd/engram@latest).",
+		}
+	}
+
+	if semverLess(installedMajor, installedMinor, installedPatch,
+		thresholdMajor, thresholdMinor, thresholdPatch) {
+		return MCPVersionCheck{
+			Name:   mcpLifecycleVersionCheckName,
+			Status: CheckStatusWarn,
+			Detail: fmt.Sprintf("engram %d.%d.%d is below the known-good threshold %s; "+
+				"the MCP server may be terminated by Claude Code after the notifications/initialized handshake (%s)",
+				installedMajor, installedMinor, installedPatch,
+				MinEngramVersionForHealthyLifecycle, mcpLifecycleIssueRef),
+			Remedy: fmt.Sprintf("Upgrade engram to %s or later: "+
+				"go install github.com/gentleman-programming/engram/cmd/engram@v%s",
+				MinEngramVersionForHealthyLifecycle, MinEngramVersionForHealthyLifecycle),
+		}
+	}
+
+	return MCPVersionCheck{
+		Name:   mcpLifecycleVersionCheckName,
+		Status: CheckStatusPass,
+		Detail: fmt.Sprintf("engram %d.%d.%d is at or above the known-good threshold %s",
+			installedMajor, installedMinor, installedPatch, MinEngramVersionForHealthyLifecycle),
+	}
+}
+
+// parseStrictSemver parses the strict semver string "X.Y.Z" into its three
+// numeric components. Strict rules: exactly three dot-separated segments,
+// each non-empty and composed only of ASCII digits. No leading "v", no
+// surrounding prefix, no "engram 1.5.0"-style suffix. Empty / whitespace-
+// only input returns ok=false.
+//
+// The doctor uses this to fail loud on unparseable version output (e.g. a
+// binary that prints "engram dev") so the operator sees a WARN rather than
+// silently getting a PASS on garbage. The caller is expected to pre-extract
+// the X.Y.Z token from the raw `engram version` output — see
+// extractSemverToken.
+func parseStrictSemver(raw string) (major, minor, patch int, ok bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, 0, 0, false
+	}
+
+	parts := strings.Split(trimmed, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+
+	major, ok = parseStrictSemverSegment(parts[0])
+	if !ok {
+		return 0, 0, 0, false
+	}
+	minor, ok = parseStrictSemverSegment(parts[1])
+	if !ok {
+		return 0, 0, 0, false
+	}
+	patch, ok = parseStrictSemverSegment(parts[2])
+	if !ok {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}
+
+// extractSemverToken scans raw for the first whitespace-delimited token
+// that parses as strict semver. The engram binary prints lines like
+// "engram 1.5.0" or "engram v1.4.2 (commit deadbeef)"; this helper isolates
+// the numeric triple so parseStrictSemver can stay strict.
+//
+// Returns "" when no candidate token parses — the doctor surfaces this as a
+// WARN so the operator gets actionable feedback instead of a silent PASS.
+func extractSemverToken(raw string) string {
+	for _, field := range strings.Fields(raw) {
+		if _, _, _, ok := parseStrictSemver(field); ok {
+			return field
+		}
+	}
+	return ""
+}
+
+func parseStrictSemverSegment(segment string) (int, bool) {
+	if segment == "" {
+		return 0, false
+	}
+	for i := 0; i < len(segment); i++ {
+		if segment[i] < '0' || segment[i] > '9' {
+			return 0, false
+		}
+	}
+	n := 0
+	for i := 0; i < len(segment); i++ {
+		n = n*10 + int(segment[i]-'0')
+	}
+	return n, true
+}
+
+func semverLess(aMajor, aMinor, aPatch, bMajor, bMinor, bPatch int) bool {
+	if aMajor != bMajor {
+		return aMajor < bMajor
+	}
+	if aMinor != bMinor {
+		return aMinor < bMinor
+	}
+	return aPatch < bPatch
+}

--- a/internal/components/engram/doctor_test.go
+++ b/internal/components/engram/doctor_test.go
@@ -1,0 +1,189 @@
+package engram
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestParseStrictSemver exercises the strict semver parser used by
+// CheckEngramMCPVersion. Strict means exactly three dot-separated non-empty
+// numeric segments with no leading "v" or surrounding text — a binary that
+// prints "engram 1.5.0" must NOT parse (the doctor relies on this to flag
+// unparseable version output).
+func TestParseStrictSemver(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantMajor int
+		wantMinor int
+		wantPatch int
+		wantOK    bool
+	}{
+		{name: "valid_three_segment", raw: "1.5.0", wantMajor: 1, wantMinor: 5, wantPatch: 0, wantOK: true},
+		{name: "valid_zero_zero_zero", raw: "0.0.0", wantMajor: 0, wantMinor: 0, wantPatch: 0, wantOK: true},
+		{name: "valid_large_numbers", raw: "12.345.6789", wantMajor: 12, wantMinor: 345, wantPatch: 6789, wantOK: true},
+		{name: "invalid_two_segment", raw: "1.5", wantOK: false},
+		{name: "invalid_leading_v", raw: "v1.5.0", wantOK: false},
+		{name: "invalid_with_prefix", raw: "engram 1.5.0", wantOK: false},
+		{name: "invalid_empty", raw: "", wantOK: false},
+		{name: "invalid_whitespace", raw: "   ", wantOK: false},
+		{name: "invalid_non_numeric", raw: "1.5.x", wantOK: false},
+		{name: "invalid_extra_segment", raw: "1.5.0.1", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, patch, ok := parseStrictSemver(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("parseStrictSemver(%q) ok = %v, want %v", tt.raw, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if major != tt.wantMajor || minor != tt.wantMinor || patch != tt.wantPatch {
+				t.Fatalf("parseStrictSemver(%q) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.raw, major, minor, patch, tt.wantMajor, tt.wantMinor, tt.wantPatch)
+			}
+		})
+	}
+}
+
+// withThresholdForTest swaps MinEngramVersionForHealthyLifecycle for the
+// duration of the test. Returns the restore function for explicit t.Cleanup.
+func withThresholdForTest(t *testing.T, value string) {
+	t.Helper()
+	orig := MinEngramVersionForHealthyLifecycle
+	MinEngramVersionForHealthyLifecycle = value
+	t.Cleanup(func() { MinEngramVersionForHealthyLifecycle = orig })
+}
+
+// TestCheckEngramMCPVersion_VersionBelowThreshold covers S5: when the parsed
+// version is strictly below MinEngramVersionForHealthyLifecycle, the check
+// returns a WARN whose Detail mentions Gentleman-Programming/gentle-ai#1019
+// and whose Remedy names an actionable upgrade command.
+func TestCheckEngramMCPVersion_VersionBelowThreshold(t *testing.T) {
+	withThresholdForTest(t, "1.5.0")
+	CountVersionCallsForTest(t, "engram 0.5.0")
+
+	got := CheckEngramMCPVersion(context.Background())
+
+	if got.Name != "engram-mcp-lifecycle-version" {
+		t.Fatalf("Name = %q, want %q", got.Name, "engram-mcp-lifecycle-version")
+	}
+	if got.Status != CheckStatusWarn {
+		t.Errorf("Status = %q, want %q (got Detail=%q)", got.Status, CheckStatusWarn, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "0.5.0") {
+		t.Errorf("Detail should mention installed version 0.5.0; got %q", got.Detail)
+	}
+	if !strings.Contains(got.Detail, "1.5.0") {
+		t.Errorf("Detail should mention threshold 1.5.0; got %q", got.Detail)
+	}
+	if !strings.Contains(got.Detail, "Gentleman-Programming/gentle-ai#1019") {
+		t.Errorf("Detail must reference #1019; got %q", got.Detail)
+	}
+	if got.Remedy == "" {
+		t.Error("Remedy must carry an actionable upgrade command")
+	}
+	if !strings.Contains(got.Remedy, "upgrade") && !strings.Contains(got.Remedy, "install") {
+		t.Errorf("Remedy should guide the user to upgrade/install; got %q", got.Remedy)
+	}
+}
+
+// TestCheckEngramMCPVersion_VersionAtOrAboveThreshold covers S7: when the
+// parsed version is at or above the threshold, the check returns PASS with
+// no WARN. The version gate is inclusive at the floor.
+func TestCheckEngramMCPVersion_VersionAtOrAboveThreshold(t *testing.T) {
+	withThresholdForTest(t, "1.5.0")
+	CountVersionCallsForTest(t, "engram 1.5.0")
+
+	got := CheckEngramMCPVersion(context.Background())
+
+	if got.Status != CheckStatusPass {
+		t.Errorf("Status = %q, want %q (Detail=%q)", got.Status, CheckStatusPass, got.Detail)
+	}
+	if strings.Contains(got.Detail, "#1019") {
+		t.Errorf("PASS finding must not reference #1019; got %q", got.Detail)
+	}
+
+	// Above the floor — also PASS.
+	withThresholdForTest(t, "1.5.0")
+	CountVersionCallsForTest(t, "engram 2.0.0")
+
+	got = CheckEngramMCPVersion(context.Background())
+	if got.Status != CheckStatusPass {
+		t.Errorf("Status for 2.0.0 = %q, want %q", got.Status, CheckStatusPass)
+	}
+}
+
+// TestCheckEngramMCPVersion_DefaultThresholdDormant covers S8: the shipped
+// constant is "0.0.0", so no installed version triggers a WARN. This is the
+// safety net while the upstream engram fix is still in flight.
+func TestCheckEngramMCPVersion_DefaultThresholdDormant(t *testing.T) {
+	// Force the shipped constant. Do NOT use withThresholdForTest — this test
+	// guards the default value itself.
+	if MinEngramVersionForHealthyLifecycle != "0.0.0" {
+		t.Skipf("test guards default threshold; skip when override is active (current=%q)", MinEngramVersionForHealthyLifecycle)
+	}
+
+	// Even an ancient version must NOT warn when the threshold is "0.0.0".
+	CountVersionCallsForTest(t, "engram 0.0.1")
+	got := CheckEngramMCPVersion(context.Background())
+	if got.Status != CheckStatusPass {
+		t.Errorf("dormant threshold with version 0.0.1: Status = %q, want pass; Detail=%q",
+			got.Status, got.Detail)
+	}
+
+	CountVersionCallsForTest(t, "engram dev")
+	got = CheckEngramMCPVersion(context.Background())
+	if got.Status != CheckStatusPass {
+		t.Errorf("dormant threshold with unparseable version: Status = %q, want pass; Detail=%q",
+			got.Status, got.Detail)
+	}
+}
+
+// TestCheckEngramMCPVersion_ParseFailureReturnsWarn covers the R5 parse-warning
+// contract: when VerifyVersionCommand returns output we cannot parse, the
+// check emits WARN — never FAIL. A FAIL would brick the doctor exit code on
+// unparseable binary output (e.g. a future "engram dev" string).
+func TestCheckEngramMCPVersion_ParseFailureReturnsWarn(t *testing.T) {
+	withThresholdForTest(t, "1.5.0")
+	CountVersionCallsForTest(t, "engram dev snapshot 2026-07-21")
+
+	got := CheckEngramMCPVersion(context.Background())
+
+	if got.Status != CheckStatusWarn {
+		t.Errorf("parse-failure Status = %q, want %q (Detail=%q)",
+			got.Status, CheckStatusWarn, got.Detail)
+	}
+	if got.Status == CheckStatusFail {
+		t.Fatal("parse failure must NEVER escalate to FAIL (R5 + R7)")
+	}
+	if got.Detail == "" {
+		t.Error("parse-failure Detail must explain why the version is unparseable")
+	}
+}
+
+// TestCheckEngramMCPVersion_VersionCommandFailure covers the case where the
+// version probe itself fails (binary missing on PATH or exec error). The
+// check MUST emit WARN — never FAIL — for the same reason as parse failures:
+// unparseable/inaccessible binaries must not brick the doctor exit code.
+func TestCheckEngramMCPVersion_VersionCommandFailure(t *testing.T) {
+	withThresholdForTest(t, "1.5.0")
+
+	orig := runVersionCommand
+	t.Cleanup(func() { runVersionCommand = orig })
+	runVersionCommand = func(context.Context, string) ([]byte, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	got := CheckEngramMCPVersion(context.Background())
+
+	if got.Status != CheckStatusWarn {
+		t.Errorf("version-command-failure Status = %q, want %q", got.Status, CheckStatusWarn)
+	}
+	if got.Status == CheckStatusFail {
+		t.Fatal("version-command failure must NEVER escalate to FAIL")
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1019

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

## 📝 Summary

This PR ships the **dormant doctor gate** for the Engram MCP lifecycle version. The gate is wired through `internal/cli/doctor.go`'s `RunDoctor` and the new `internal/components/engram/doctor.go` exposing `CheckEngramMCPVersion`. Per spec S8, when the threshold is `0.0.0` the check **short-circuits BEFORE invoking `VerifyVersionCommand`** — this is the dormancy guarantee. The default flow therefore never surfaces an engram lifecycle finding until a maintainer flips the constant; this is intentional and isolates the operator surface from the regression PR1 is preparing.

The runbook (`docs/engram-mcp-lifecycle.md`) ships with the feature because the operator-facing surface (doctor gate output, version-check behaviour, lifecycle registration shape) is what an on-call engineer will read first when the gate flips. Bundling it with the gate prevents a "landed without docs" follow-up cycle documented in PR1's replay.

The **type-bridge fix** in `internal/cli/doctor.go` is a surgical change added by the orchestrator: the original PR #1608 was authored against an earlier `doctor.Result` shape, but `main` has since evolved (`Name` is now `doctor.CheckID`, `Remedy` is now `*doctor.Remedy`). The cli/engram boundary now coerces plain strings from `engram.MCPVersionCheck` to the typed `doctor.Result` via a `nilOrEngramRemedy` helper. The original lifecycle message is preserved in `Description`; the change is type-coercion only.

## 📂 Changes

| File | Change | Lines |
|------|--------|-------|
| `internal/components/engram/doctor.go` | New `CheckEngramMCPVersion` + semver helpers + 5-case testability surface | +222 |
| `internal/components/engram/doctor_test.go` | 5 focused tests covering threshold semantics, dormant default, parse failure, command failure | +189 |
| `internal/cli/doctor.go` | `RunDoctor` wire + `nilOrEngramRemedy` helper (`Name` → `doctor.CheckID(...)`, `Remedy` → `*doctor.Remedy` via `RemedyInstallTool`) | +30 / -3 |
| `internal/cli/doctor_test.go` | `TestRunDoctor_IntegrationAllMocked` expected output extended for the new dormant check (added 1 line, bumped summary 7→8) | +2 / -1 |
| `docs/engram-mcp-lifecycle.md` | Operator runbook for the doctor gate output, version-check semantics, lifecycle registration shape | +97 |

Total: **+540 / 1** across 5 files.

The `internal/cli/doctor.go` diff is +30/-3 (orchestrator fix added the helper and the type coercions on top of the cherry-picked wire). The coercion is at the cli/engram boundary only — `engram.MCPVersionCheck` still carries plain strings, and `doctor.Result` now receives properly typed values.

The `internal/cli/doctor_test.go` delta is the small extension shipped in `baa9ac1b` to keep the integration test in sync with the new dormant check that `RunDoctor` now emits. Without that one-line addition, `TestRunDoctor_IntegrationAllMocked` would fail because the cli/integration output now contains 8 lines instead of 7. No code change.

## 📏 size:exception Request

Total ~540 lines (after the test-extension commit) exceeds the 400-line cognitive-load budget.

This PR is a **cohesive single-feature surface** that cannot be split further without losing coherence:

1. The dormant doctor check itself (`doctor.go`).
2. Its 5-case test coverage (`doctor_test.go`).
3. The wire that integrates it into `RunDoctor` (`internal/cli/doctor.go`), which includes the surgical type-bridge fix.
4. The integration-test extension that keeps `TestRunDoctor_IntegrationAllMocked` in sync with the new check (`internal/cli/doctor_test.go`).
5. The runbook that documents the operator-facing surface (`docs/engram-mcp-lifecycle.md`).

Splitting the runbook into PR3 would leave the gate without operator docs; splitting the tests into a separate PR would leave the gate unverified; splitting the wire from the check would leave the check dead. The chain (PR1 / PR2 / PR3) is the minimum splittable unit — and inside this PR, the five files are inseparable.

`size:exception` is requested from a maintainer. The contributor cannot apply this label (403 `AddLabelsToLabelable`).

## 🧪 Test Plan

Focused tests (orchestrator-run on this branch):

```
$ go vet ./internal/components/engram/... ./internal/cli/...
(no output — clean)

$ gofmt -l internal/components/engram/doctor.go \
            internal/components/engram/doctor_test.go \
            internal/cli/doctor.go
(no output — clean)

$ go test -count=1 -v -run "TestCheckEngramMCP" ./internal/components/engram/...
=== RUN   TestCheckEngramMCPVersion_VersionBelowThreshold
--- PASS: TestCheckEngramMCPVersion_VersionBelowThreshold (0.00s)
=== RUN   TestCheckEngramMCPVersion_VersionAtOrAboveThreshold
--- PASS: TestCheckEngramMCPVersion_VersionAtOrAboveThreshold (0.00s)
=== RUN   TestCheckEngramMCPVersion_DefaultThresholdDormant
--- PASS: TestCheckEngramMCPVersion_DefaultThresholdDormant (0.00s)
=== RUN   TestCheckEngramMCPVersion_ParseFailureReturnsWarn
--- PASS: TestCheckEngramMCPVersion_ParseFailureReturnsWarn (0.00s)
=== RUN   TestCheckEngramMCPVersion_VersionCommandFailure
--- PASS: TestCheckEngramMCPVersion_VersionCommandFailure (0.00s)
PASS
ok  	github.com/gentleman-programming/gentle-ai/internal/components/engram	2.158s

No-touch invariant:
$ git diff origin/main -- internal/components/communitytool/pi_codegraph.go \
                          internal/components/engram/inject.go \
                          internal/components/engram/verify.go
(no output — empty diff)
```

- [x] Scripts run without errors: `go vet` clean on affected packages
- [x] Manually tested the affected functionality: 5 focused tests pass; `go test -count=1` re-verified
- [x] Skills load correctly in target agent: N/A (Go code, not skill)

## 🔗 Chain Context

This is PR2 of a 3-PR chain splitting PR #1608.

| Field | Value |
|-------|-------|
| Chain | Engram MCP SIGINT defect (#1019) integration |
| Tracker PR | #1608 (will be closed after this chain merges) |
| Position | **2 of 3** |
| Base | `main` (`0d95c399`) |
| Depends on | None — slices are independent per Stacked-to-main |
| Sibling | PR1 (#1808) — `test/engram-mcp-lifecycle-regression` (awaiting `type:test`) |
| Follow-up | PR3 — `docs/sdd-1019-closeout` (SDD artifacts; waits for this PR to merge because `apply-progress.md` describes the full chain state) |
| Review budget | 540 / 400 changed lines (size:exception requested) |
| Starts at | `origin/main` |
| Ends with | Dormant doctor gate + runbook + type-bridge fix |

### Chain Overview

```text
origin/main (0d95c399)
   └── #1808 PR1 — test/engram-mcp-lifecycle-regression (PR1 already open)
         └── 📍 #N PR2 — feat/engram-mcp-doctor (THIS PR)
               └── #N+1 PR3 — docs/sdd-1019-closeout (SDD artifacts)
```

### Scope

- **Includes:** `doctor.go`, `doctor_test.go`, `internal/cli/doctor.go` (wire + `nilOrEngramRemedy` helper + `RunDoctor` integration), `internal/cli/doctor_test.go` (integration-test extension), `docs/engram-mcp-lifecycle.md` runbook.
- **Excludes:** `lifecycle_test.go` (PR1), SDD change artifacts (`openspec/*`) (PR3).

### Autonomy

- [x] CI expected to pass (orchestrator ran `go vet` + focused tests; default build clean)
- [x] One deliverable scope (dormant doctor gate + operator docs)
- [x] Rollback without unrelated changes (4-file revert)
- [x] Tests + docs cover this unit (5-case test coverage + runbook)

## ✅ Contributor Checklist

- [x] Linked an approved issue (#1019 has `status:approved`)
- [ ] Added exactly one `type:*` label — **pending maintainer** (403 on `AddLabelsToLabelable` for contributors); see `## Pending maintainer actions`
- [x] Ran shellcheck on modified scripts — N/A (Go code; `go vet` and `gofmt -l` clean)
- [x] Skills tested in at least one agent — N/A (Go code)
- [x] Docs updated if behavior changed — `docs/engram-mcp-lifecycle.md` runbook added
- [x] Conventional commit format (4 commits follow `feat(engram):`, `fix(engram):`, `docs(engram):`, `fix(cli):`)
- [x] No `Co-Authored-By` trailers

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:feature` label applied to this PR — pending Alan (contributor cannot apply; 403 on `AddLabelsToLabelable`).
- [ ] `size:exception` label applied to this PR — pending Alan (538 > 400 cognitive-load budget; see `## 📏 size:exception Request` above).

Both are expected and resolve when Alan applies them. No contributor-side fix is possible for label-only failures.

## 💬 Notes for Reviewers

> **This is PR2 of a 3-PR chain. PR1 (#1808) shipped the regression test. PR2 ships the dormant doctor gate + runbook + a surgical type-bridge fix for the cli/engram boundary + a small extension to `TestRunDoctor_IntegrationAllMocked` so the integration assertion reflects the new line. PR3 will close out the SDD planning artifacts. All three close #1019; first to merge wins the issue close.**

Review focus order (highest-leverage first):

1. **`internal/components/engram/doctor.go`** — `CheckEngramMCPVersion` and the semver helpers. Confirm the dormant threshold (`0.0.0`) short-circuits **BEFORE** invoking `VerifyVersionCommand` (commit `a3ce3b52` fix). This is the spec S8 contract.
2. **`internal/components/engram/doctor_test.go`** — 5 cases covering threshold semantics, dormant default, parse failure, and command failure. Each test asserts specific behaviour, not just non-panicking.
3. **`internal/cli/doctor.go`** — wire at `RunDoctor` + new `nilOrEngramRemedy` helper. The helper maps empty remedy → nil, non-empty → `*doctor.Remedy{ID: RemedyInstallTool, ...}`. This is a type-coercion only; the original engram lifecycle message is preserved in `Description`.
4. **`docs/engram-mcp-lifecycle.md`** — runbook documenting the operator-facing surface.

**Pipeline gates:** the default `go test ./...` must remain green. The doctor gate is dormant at threshold `0.0.0`, so the default flow never invokes `VerifyVersionCommand`; the operator will see no engram lifecycle finding until a maintainer flips the constant.

**Upstream context:** `Gentleman-Programming/engram#648` is the actual fix. PR1 (#1808) ships the regression test; this PR ships the dormant gate that will warn when an outdated engram is detected; PR3 ships the planning artifacts.

**No-touch invariant:** `internal/components/communitytool/pi_codegraph.go`, `internal/components/engram/inject.go`, and `internal/components/engram/verify.go` are byte-identical with `origin/main` (verified via `git diff origin/main -- ...`). The check is dormant until the threshold is set, so the default flow does not exercise these files.
