### PR TITLE
fix(doctor): stop counting symlinked PATH dirs as duplicate copies

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -278,7 +278,7 @@ func doctorToolCopies(tool string, pathDirs []string) []string {
 	seenDirs := make(map[string]struct{}, len(pathDirs))
 	copies := make([]string, 0, len(pathDirs))
 	for _, dir := range pathDirs {
-		cleanDir := filepath.Clean(dir)
+		cleanDir := doctorCanonicalDir(dir)
 		if _, seen := seenDirs[cleanDir]; seen {
 			continue
 		}
@@ -288,6 +288,20 @@ func doctorToolCopies(tool string, pathDirs []string) []string {
 		}
 	}
 	return copies
+}
+
+// doctorCanonicalDir resolves dir to its real filesystem location so that PATH
+// entries pointing at the same directory through a symlink collapse into a
+// single entry. Distributions that merge /bin into /usr/bin (usrmerge) ship
+// both paths in PATH, and a purely lexical Clean reports one binary as two
+// copies -- a duplicate warning the user cannot act on, because the remedy
+// would be deleting a system symlink. Unresolvable paths fall back to the
+// lexical form so a directory that does not exist still dedups against itself.
+func doctorCanonicalDir(dir string) string {
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return filepath.Clean(dir)
 }
 
 // executableExtensions returns the filename suffixes to probe when scanning a

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -261,6 +261,70 @@ func TestExecutableExtensionsFor(t *testing.T) {
 	}
 }
 
+// --- doctorToolCopies ---
+
+// writeFakeTool creates an executable file named tool inside dir.
+func writeFakeTool(t *testing.T, dir, tool string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, tool), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write %s in %s: %v", tool, dir, err)
+	}
+}
+
+// A usrmerge layout (/bin -> /usr/bin) puts both paths in PATH while holding a
+// single binary. Reporting that as a duplicate produces a warning whose only
+// remedy would be deleting a system symlink, so the copies must collapse.
+func TestDoctorToolCopiesDeduplicatesSymlinkedDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("usrmerge-style symlinked PATH directories are a POSIX layout")
+	}
+
+	root := t.TempDir()
+	realDir := filepath.Join(root, "usr", "bin")
+	writeFakeTool(t, realDir, "code")
+
+	linkDir := filepath.Join(root, "bin")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlinks unsupported on this filesystem: %v", err)
+	}
+
+	got := doctorToolCopies("code", []string{realDir, linkDir})
+	if len(got) != 1 {
+		t.Fatalf("symlinked PATH dirs must report one copy, got %d: %v", len(got), got)
+	}
+}
+
+// The dedup must not blind the check: genuinely distinct directories each
+// holding their own binary are a real ambiguity and must still be reported.
+func TestDoctorToolCopiesReportsDistinctDirs(t *testing.T) {
+	root := t.TempDir()
+	first := filepath.Join(root, "local", "bin")
+	second := filepath.Join(root, "opt", "bin")
+	writeFakeTool(t, first, "code")
+	writeFakeTool(t, second, "code")
+
+	got := doctorToolCopies("code", []string{first, second})
+	if len(got) != 2 {
+		t.Fatalf("distinct dirs must report two copies, got %d: %v", len(got), got)
+	}
+}
+
+// A PATH entry that does not exist cannot be resolved, and must not make the
+// scan drop the copies it did find.
+func TestDoctorToolCopiesToleratesMissingDirs(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "usr", "bin")
+	writeFakeTool(t, realDir, "code")
+
+	got := doctorToolCopies("code", []string{filepath.Join(root, "absent"), realDir})
+	if len(got) != 1 {
+		t.Fatalf("missing PATH dir must be skipped, got %d: %v", len(got), got)
+	}
+}
+
 // --- checkStateJSON ---
 
 func TestCheckStateJSON_Missing(t *testing.T) {


### PR DESCRIPTION
## Problem

On any distribution with usrmerge (Ubuntu, Fedora, Arch), `/bin` is a symlink to `/usr/bin`. Both are present in `PATH`, so `gentle-ai doctor` reports a single binary as two copies:

```
[!!]  tool:code   code resolved to /usr/bin/code but 2 copies found in PATH: /usr/bin/code, /bin/code
      Remedy: Remove duplicate binaries; keep only one copy of code in PATH
```

The suggested remedy is not actionable: there is no duplicate to remove, and following it would mean deleting a system symlink. The warning also keeps `doctor` reporting `degraded` on an otherwise healthy machine, which trains users to ignore warnings.

On one of our servers this fires three times in a single run (`claude`, `opencode`, `gemini`), all from the same cause.

## Root cause

`doctorToolCopies` deduplicates PATH entries with `filepath.Clean`, which normalizes the string but does not resolve symlinks, so `/bin` and `/usr/bin` are treated as distinct directories.

## Fix

Deduplicate on the resolved location via `filepath.EvalSymlinks`, falling back to the lexical form when the path cannot be resolved (a nonexistent PATH entry still dedups against itself).

Genuinely distinct directories that each hold their own binary are still reported: the check keeps its value, it just stops firing on a layout the user cannot change.

## Tests

Three cases added in `internal/cli/doctor_test.go`:

- symlinked dirs (usrmerge layout) collapse to one copy
- distinct dirs still report two copies
- an unresolvable PATH entry does not drop the copies that were found

Verified that the first test fails without the fix (reports 2 copies) and passes with it. Full `./internal/cli` suite passes locally on go1.25.10, matching the version in `go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI diagnostics to avoid reporting duplicate tool copies when PATH entries resolve to the same location through symlinks.
  * PATH entries for missing directories are now handled without hiding valid tool copies.
  * Distinct tool locations continue to be reported separately.

* **Tests**
  * Added coverage for symlinked, distinct, and missing PATH directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->