### PR TITLE
fix(sdd): allow review binding for Engram changes

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1334,10 +1334,10 @@ func reviewNotInvalidatedPredecessorRefusal(cause error, cwd, predecessor, expec
 }
 
 func runReviewBindSDD(ctx context.Context, args []string, stdout io.Writer) error {
-	flags := newReviewFlagSet("review bind-sdd", stdout, "Bind an explicit approved compact lineage to an OpenSpec change.")
+	flags := newReviewFlagSet("review bind-sdd", stdout, "Bind an explicit approved compact lineage to an SDD change.")
 	cwd := flags.String("cwd", "", "repository path")
 	contract := flags.String("contract", "", "optional negotiated review integration contract")
-	change := flags.String("change", "", "OpenSpec change")
+	change := flags.String("change", "", "SDD change")
 	lineage := flags.String("lineage", "", "approved lineage")
 	expected := flags.String("expected-binding-revision", "", "binding revision")
 	if err := parseReviewFlags(flags, args); err != nil {

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -2040,6 +2040,20 @@ func TestReviewBindSDDRequiresExplicitInputs(t *testing.T) {
 	}
 }
 
+func TestReviewBindSDDHelpUsesArtifactStoreNeutralLanguage(t *testing.T) {
+	var output bytes.Buffer
+	if err := RunReview([]string{"bind-sdd", "--help"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	help := output.String()
+	if !strings.Contains(help, "approved compact lineage to an SDD change") || !strings.Contains(help, "SDD change") {
+		t.Fatalf("bind-sdd help is not artifact-store neutral:\n%s", help)
+	}
+	if strings.Contains(help, "OpenSpec") {
+		t.Fatalf("bind-sdd help still requires OpenSpec:\n%s", help)
+	}
+}
+
 func TestReviewBindSDDAcceptsEqualsFormForEmptyExpectedRevision(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	for path, content := range map[string]string{"tasks.md": "- [x] 1.1 Done\n", "proposal.md": "# Proposal\n", "design.md": "# Design\n", "specs/binding/spec.md": "# Spec\n"} {

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -455,6 +455,79 @@ func TestRunSDDAttemptFinishAcceptsApprovedSelfRemediationSuccessor(t *testing.T
 	}
 }
 
+// TestRunSDDAttemptFinishAcceptsPureEngramBinding is the acceptance regression
+// for a pure Engram change: the repository never grows an OpenSpec change root,
+// so the binding published by BindApprovedReview carries compact authority and
+// the live post-apply gate as its complete provenance. Creating that binding is
+// not enough — this drives it through `sdd-attempt finish` as the remediation
+// successor to prove the runtime ledger actually accepts it and completes.
+func TestRunSDDAttemptFinishAcceptsPureEngramBinding(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	change := "cli-engram-change"
+	if _, err := os.Stat(filepath.Join(repo, "openspec")); !os.IsNotExist(err) {
+		t.Fatalf("pure Engram repository unexpectedly has an OpenSpec root: %v", err)
+	}
+
+	started := runSDDAttemptStatus(t, []string{
+		"begin", "--cwd", repo, "--change", change, "--expected-revision=", "--request-id", "engram-begin-1",
+		"--work-unit", "cli-engram-change", "--evidence-goal", "repair failed Engram verification evidence",
+		"--max-attempts", "3", "--max-changed-lines", "40",
+	})
+	failedEvidence := cliAttemptHash('c')
+	failed := runSDDAttemptStatus(t, []string{
+		"finish", "--cwd", repo, "--change", change, "--expected-revision", started.Revision, "--request-id", "engram-finish-1",
+		"--outcome", "failed", "--evidence-revision", failedEvidence,
+		"--diagnosis", "pure Engram verification failed before bounded remediation", "--harness-disposition", "reused",
+		"--cleanup-evidence", "Engram predecessor cleanup completed",
+		"--process-evidence", "Engram predecessor process scan found no descendants",
+	})
+	active := runSDDAttemptStatus(t, []string{
+		"begin", "--cwd", repo, "--change", change, "--expected-revision", failed.Revision, "--request-id", "engram-begin-2",
+		"--work-unit", "cli-engram-change", "--evidence-goal", "repair failed Engram verification evidence",
+		"--max-attempts", "3", "--max-changed-lines", "40",
+	})
+	if active.ActiveAttempt == nil || active.EvidenceRevision != failedEvidence {
+		t.Fatalf("pre-remediation pure Engram CLI status = %#v", active)
+	}
+
+	// The bounded correction lands in ordinary tracked source, not in planning files.
+	writeCLIAttemptFile(t, filepath.Join(repo, "tracked.txt"), "base\nbounded Engram remediation\n")
+	lineage := "cli-engram-lineage"
+	writeCLIApprovedCompactAuthority(t, repo, lineage)
+	binding, err := sddstatus.BindApprovedReview(context.Background(), repo, change, lineage, "")
+	if err != nil {
+		t.Fatalf("bind approved review for a pure Engram change: %v", err)
+	}
+	postBind := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	if postBind.Binding == nil || postBind.Binding.Revision != binding.Revision {
+		t.Fatalf("post-bind pure Engram CLI status = %#v", postBind)
+	}
+
+	completed := runSDDAttemptStatus(t, []string{
+		"finish", "--cwd", repo, "--change", change, "--expected-revision", postBind.Revision, "--request-id", "engram-finish-2",
+		"--outcome", "passed", "--evidence-revision", cliAttemptHash('d'),
+		"--diagnosis", "bounded Engram remediation passed corrected verification", "--harness-disposition", "reused",
+		"--cleanup-evidence", "Engram remediation cleanup completed",
+		"--process-evidence", "Engram remediation process scan found no descendants",
+		"--expected-binding-revision", binding.Revision, "--successor-lineage", lineage,
+		"--remediates-evidence-revision", failedEvidence,
+	})
+	if !completed.Complete || completed.ActiveAttempt != nil || completed.NextAction != sddstatus.RuntimeActionComplete {
+		t.Fatalf("pure Engram CLI completion = %#v", completed)
+	}
+	if completed.Binding == nil || completed.Binding.Lineage != lineage || completed.Binding.Revision != binding.Revision {
+		t.Fatalf("pure Engram CLI binding = %#v", completed.Binding)
+	}
+	last := completed.Attempts[len(completed.Attempts)-1]
+	if last.Outcome != sddstatus.AttemptPassed || last.RemediatesEvidenceRevision != failedEvidence ||
+		last.EvidenceRevision != cliAttemptHash('d') || last.ChangedLines == 0 {
+		t.Fatalf("pure Engram CLI attempt = %#v", last)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "openspec")); !os.IsNotExist(err) {
+		t.Fatalf("pure Engram finish created or required an OpenSpec root: %v", err)
+	}
+}
+
 func writeCLIAttemptFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -464,6 +466,7 @@ func TestRunSDDAttemptFinishAcceptsApprovedSelfRemediationSuccessor(t *testing.T
 func TestRunSDDAttemptFinishAcceptsPureEngramBinding(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	change := "cli-engram-change"
+	installCLIEngramExport(t, repo, change)
 	if _, err := os.Stat(filepath.Join(repo, "openspec")); !os.IsNotExist(err) {
 		t.Fatalf("pure Engram repository unexpectedly has an OpenSpec root: %v", err)
 	}
@@ -494,9 +497,15 @@ func TestRunSDDAttemptFinishAcceptsPureEngramBinding(t *testing.T) {
 	writeCLIAttemptFile(t, filepath.Join(repo, "tracked.txt"), "base\nbounded Engram remediation\n")
 	lineage := "cli-engram-lineage"
 	writeCLIApprovedCompactAuthority(t, repo, lineage)
-	binding, err := sddstatus.BindApprovedReview(context.Background(), repo, change, lineage, "")
-	if err != nil {
-		t.Fatalf("bind approved review for a pure Engram change: %v", err)
+	var bound bytes.Buffer
+	if err := RunReviewBindSDD([]string{
+		"--cwd", repo, "--change", change, "--lineage", lineage, "--expected-binding-revision=",
+	}, &bound); err != nil {
+		t.Fatalf("review bind-sdd for a pure Engram change: %v", err)
+	}
+	var binding sddstatus.ReviewBinding
+	if err := json.Unmarshal(bound.Bytes(), &binding); err != nil {
+		t.Fatalf("decode review bind-sdd output: %v\n%s", err, bound.String())
 	}
 	postBind := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
 	if postBind.Binding == nil || postBind.Binding.Revision != binding.Revision {
@@ -526,6 +535,25 @@ func TestRunSDDAttemptFinishAcceptsPureEngramBinding(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repo, "openspec")); !os.IsNotExist(err) {
 		t.Fatalf("pure Engram finish created or required an OpenSpec root: %v", err)
 	}
+}
+
+func installCLIEngramExport(t *testing.T, repo, change string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Engram export executable requires a POSIX shell")
+	}
+	if err := os.MkdirAll(filepath.Join(repo, ".engram"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := t.TempDir()
+	payload := fmt.Sprintf(`{"observations":[{"title":"sdd/%s/proposal","content":"# Proposal\\n","project":"gentle-ai","scope":"project"}]}`, change)
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' '%s' > \"$2\"\n", payload)
+	writeCLIAttemptFile(t, filepath.Join(bin, "engram"), script)
+	if err := os.Chmod(filepath.Join(bin, "engram"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
 }
 
 func writeCLIAttemptFile(t *testing.T, path, content string) {

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -60,8 +60,15 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	if err != nil {
 		return ReviewBinding{}, err
 	}
-	if _, err := bindingUsesFileBackedChange(ctx, root, repo, change); err != nil {
+	fileBacked, err := bindingUsesFileBackedChange(ctx, root, repo, change)
+	if err != nil {
 		return ReviewBinding{}, err
+	}
+	if !fileBacked {
+		change, err = authoritativeEngramBindingChange(root, change)
+		if err != nil {
+			return ReviewBinding{}, err
+		}
 	}
 	if err := rejectHistoricalLegacyBinding(ctx, root, lineage); err != nil {
 		return ReviewBinding{}, err
@@ -173,7 +180,34 @@ func prepareApprovedRuntimeSuccessorBinding(ctx context.Context, root, workspace
 	if fileBacked {
 		return prepareApprovedReviewBinding(ctx, root, workspace, change, lineage)
 	}
+	change, err = authoritativeEngramBindingChange(root, change)
+	if err != nil {
+		return ReviewBinding{}, err
+	}
 	return prepareApprovedCompactBinding(ctx, root, change, lineage)
+}
+
+func authoritativeEngramBindingChange(root, requested string) (string, error) {
+	if !shouldTryEngram(root) {
+		// refusal:by-design operator-knowledge: only the operator can identify or publish the intended Engram change.
+		return "", errors.New("authoritative Engram change does not exist")
+	}
+	observations, err := engramExport(root)
+	if err != nil {
+		return "", err
+	}
+	project := inferEngramProject(root)
+	for _, observation := range observations {
+		if !engramObservationMatchesProject(observation, project) {
+			continue
+		}
+		matches := engramTitlePattern.FindStringSubmatch(strings.TrimSpace(observation.Title))
+		if len(matches) == 3 && matches[1] == requested && matches[2] != "state" {
+			return matches[1], nil
+		}
+	}
+	// refusal:by-design operator-knowledge: only the operator can identify or publish the intended Engram change.
+	return "", errors.New("authoritative Engram change does not exist")
 }
 
 func bindingUsesFileBackedChange(ctx context.Context, root, workspace, change string) (bool, error) {

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -32,6 +32,7 @@ var reviewBindingChange = regexp.MustCompile(`^[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*
 var legacyRuntimeChange = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 var reviewBindingLineage = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 var reviewBindingHash = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+var errBindingPlanningRootNotFound = errors.New("selected OpenSpec change does not exist")
 
 type ReviewBindingPublicationError struct{ Cause error }
 
@@ -59,7 +60,7 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	if err != nil {
 		return ReviewBinding{}, err
 	}
-	if _, err := resolveBindingChangeRoot(ctx, root, repo, change); err != nil {
+	if _, err := bindingUsesFileBackedChange(ctx, root, repo, change); err != nil {
 		return ReviewBinding{}, err
 	}
 	if err := rejectHistoricalLegacyBinding(ctx, root, lineage); err != nil {
@@ -77,7 +78,7 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	status, err := runtimeStore.bindPreparedReview(ctx, BindReviewRequest{
 		ExpectedBindingRevision: expected, RequestID: requestID, LineageID: lineage,
 	}, func() (ReviewBinding, error) {
-		return prepareApprovedReviewBinding(ctx, root, repo, change, lineage)
+		return prepareApprovedRuntimeSuccessorBinding(ctx, root, repo, change, lineage)
 	})
 	if err != nil {
 		var publication *RuntimePublicationError
@@ -165,14 +166,31 @@ func prepareApprovedReviewBinding(ctx context.Context, root, workspace, change, 
 // not have such a root, so their already-approved compact authority and live
 // post-apply gate are the complete native successor provenance.
 func prepareApprovedRuntimeSuccessorBinding(ctx context.Context, root, workspace, change, lineage string) (ReviewBinding, error) {
-	matches, err := bindingChangeRoots(ctx, root, change)
+	fileBacked, err := bindingUsesFileBackedChange(ctx, root, workspace, change)
 	if err != nil {
 		return ReviewBinding{}, err
 	}
-	if len(matches) != 0 {
+	if fileBacked {
 		return prepareApprovedReviewBinding(ctx, root, workspace, change, lineage)
 	}
 	return prepareApprovedCompactBinding(ctx, root, change, lineage)
+}
+
+func bindingUsesFileBackedChange(ctx context.Context, root, workspace, change string) (bool, error) {
+	matches, err := bindingChangeRoots(ctx, root, change)
+	if err != nil {
+		return false, err
+	}
+	if len(matches) != 0 {
+		_, err = resolveBindingChangeRoot(ctx, root, workspace, change)
+		return true, err
+	}
+	if _, err = resolveBindingChangeRoot(ctx, root, workspace, change); err == nil {
+		return true, nil
+	} else if !errors.Is(err, errBindingPlanningRootNotFound) {
+		return false, err
+	}
+	return false, nil
 }
 
 func prepareApprovedCompactBinding(ctx context.Context, root, change, lineage string) (ReviewBinding, error) {
@@ -560,13 +578,13 @@ func resolveBindingChangeRoot(ctx context.Context, root, workspace, change strin
 		}
 	}
 	if planningRoot == "" {
-		return "", errors.New("selected OpenSpec change does not exist")
+		return "", errBindingPlanningRootNotFound
 	}
 	candidate := filepath.Join(planningRoot, "openspec", "changes", change)
 	info, err := os.Stat(candidate)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", errors.New("selected OpenSpec change does not exist")
+			return "", errBindingPlanningRootNotFound
 		}
 		return "", err
 	}

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -52,6 +52,54 @@ func TestBindApprovedReviewCASAndLiveEvidence(t *testing.T) {
 	}
 }
 
+func TestBindApprovedReviewBindsPureEngramCompactAuthority(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	approved := createApprovedRuntimeAuthority(t, repo, "approved-engram", 1)
+
+	binding, err := BindApprovedReview(context.Background(), repo, "engram-change", approved.State.LineageID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.AuthorityRevision != approved.Revision || binding.GateContext.Gate != reviewtransaction.GatePostApply {
+		t.Fatalf("pure Engram binding = %#v", binding)
+	}
+	assertNativeBinding(t, mustRuntimeStore(t, repo, "engram-change"), binding.Revision)
+
+	replayed, err := BindApprovedReview(context.Background(), repo, "engram-change", approved.State.LineageID, "")
+	if err != nil {
+		t.Fatalf("exact pure Engram replay: %v", err)
+	}
+	if replayed.Revision != binding.Revision {
+		t.Fatalf("replayed binding revision = %q, want %q", replayed.Revision, binding.Revision)
+	}
+
+	successor := createApprovedRuntimeAuthority(t, repo, "approved-engram-successor", 2)
+	if _, err := BindApprovedReview(context.Background(), repo, "engram-change", successor.State.LineageID, ""); err == nil {
+		t.Fatal("pure Engram binding replacement accepted without current binding revision")
+	} else {
+		var conflict *BindingRevisionConflictError
+		if !errors.As(err, &conflict) || conflict.Current != binding.Revision {
+			t.Fatalf("pure Engram stale CAS error = %#v, want current %q", err, binding.Revision)
+		}
+	}
+}
+
+func TestBindApprovedReviewBindsEngramChangeAlongsideOtherOpenSpecChanges(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	write(t, filepath.Join(repo, "openspec", "changes", "other-change", "tasks.md"), "- [x] 1.1 Done\n")
+	runSDDStatusGit(t, repo, "add", "openspec/changes/other-change/tasks.md")
+	approved := createApprovedRuntimeAuthority(t, repo, "approved-engram", 1)
+
+	binding, err := BindApprovedReview(context.Background(), repo, "engram-change", approved.State.LineageID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.AuthorityRevision != approved.Revision || binding.GateContext.Gate != reviewtransaction.GatePostApply {
+		t.Fatalf("mixed repository Engram binding = %#v", binding)
+	}
+	assertNativeBinding(t, mustRuntimeStore(t, repo, "engram-change"), binding.Revision)
+}
+
 func TestBindApprovedReviewUsesNestedOpenSpecPlanningWorkspace(t *testing.T) {
 	root := t.TempDir()
 	planningRoot := filepath.Join(root, "packages", "app")

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -54,6 +54,7 @@ func TestBindApprovedReviewCASAndLiveEvidence(t *testing.T) {
 
 func TestBindApprovedReviewBindsPureEngramCompactAuthority(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
+	seedBindingEngramChange(t, repo, "engram-change", "gentle-ai")
 	approved := createApprovedRuntimeAuthority(t, repo, "approved-engram", 1)
 
 	binding, err := BindApprovedReview(context.Background(), repo, "engram-change", approved.State.LineageID, "")
@@ -84,8 +85,42 @@ func TestBindApprovedReviewBindsPureEngramCompactAuthority(t *testing.T) {
 	}
 }
 
+func TestBindApprovedReviewRejectsUnauthoritativeEngramChange(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		change       string
+		observations []engramObservation
+	}{
+		{name: "missing", change: "missing-change"},
+		{name: "stale or mismatched", change: "stale-change", observations: []engramObservation{
+			{Title: "sdd/current-change/proposal", Project: "gentle-ai", Scope: "project"},
+		}},
+		{name: "foreign project", change: "foreign-change", observations: []engramObservation{
+			{Title: "sdd/foreign-change/proposal", Project: "other-project", Scope: "project"},
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initRuntimeLedgerRepo(t)
+			if err := os.MkdirAll(filepath.Join(repo, ".engram"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+			t.Cleanup(stubEngramExport(t, tt.observations))
+			approved := createApprovedRuntimeAuthority(t, repo, "approved-engram", 1)
+
+			if _, err := BindApprovedReview(context.Background(), repo, tt.change, approved.State.LineageID, ""); err == nil || !strings.Contains(err.Error(), "authoritative Engram change") {
+				t.Fatalf("BindApprovedReview() error = %v, want authoritative Engram change refusal", err)
+			}
+			if _, err := os.Stat(filepath.Join(repo, ".git", "gentle-ai", "sdd-runtime")); !os.IsNotExist(err) {
+				t.Fatalf("refused Engram change created runtime authority: %v", err)
+			}
+		})
+	}
+}
+
 func TestBindApprovedReviewBindsEngramChangeAlongsideOtherOpenSpecChanges(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
+	seedBindingEngramChange(t, repo, "engram-change", "gentle-ai")
 	write(t, filepath.Join(repo, "openspec", "changes", "other-change", "tasks.md"), "- [x] 1.1 Done\n")
 	runSDDStatusGit(t, repo, "add", "openspec/changes/other-change/tasks.md")
 	approved := createApprovedRuntimeAuthority(t, repo, "approved-engram", 1)
@@ -98,6 +133,17 @@ func TestBindApprovedReviewBindsEngramChangeAlongsideOtherOpenSpecChanges(t *tes
 		t.Fatalf("mixed repository Engram binding = %#v", binding)
 	}
 	assertNativeBinding(t, mustRuntimeStore(t, repo, "engram-change"), binding.Revision)
+}
+
+func seedBindingEngramChange(t *testing.T, repo, change, project string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(repo, ".engram"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ENGRAM_PROJECT", project)
+	t.Cleanup(stubEngramExport(t, []engramObservation{
+		{Title: "sdd/" + change + "/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+	}))
 }
 
 func TestBindApprovedReviewUsesNestedOpenSpecPlanningWorkspace(t *testing.T) {

--- a/internal/sddstatus/runtime_ledger_remediation_test.go
+++ b/internal/sddstatus/runtime_ledger_remediation_test.go
@@ -469,6 +469,7 @@ func newRuntimeRemediationFixtureWithBinding(t *testing.T, approveSuccessor, nat
 func newRuntimeEngramRemediationFixture(t *testing.T) runtimeRemediationFixture {
 	t.Helper()
 	repo := initRuntimeLedgerRepo(t)
+	seedBindingEngramChange(t, repo, "engram-runtime", "gentle-ai")
 	predecessor := createApprovedRuntimeAuthority(t, repo, "engram-runtime-predecessor", 1)
 	predecessorBinding := runtimeBindingFromCompactRecord(t, repo, "engram-runtime", predecessor)
 	store := mustRuntimeStore(t, repo, "engram-runtime")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1910

> **Maintainer note, stated up front:** #1910 now carries `status:approved`, `type:bug`, and `priority:high`, so the earlier approval failure is stale and clears on the next validation run. The `Check PR Has type:* Label` gate is the one thing this PR cannot fix from the contributor side: applying a repository label requires admin rights, so that check stays red until a maintainer adds exactly one `type:bug` label. The PR Type section below is collapsed to the single applicable type so the intent is unambiguous while the label is pending.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Allows `review bind-sdd` to bind approved compact authority for pure Engram SDD changes.
- Preserves OpenSpec root, ledger, symlink, ambiguity, receipt, gate, candidate, and CAS protections.
- Uses artifact-store-neutral CLI help and covers pure and mixed-store repositories.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/sddstatus/review_binding.go` | Selects file-backed OpenSpec or compact Engram binding through one shared path. |
| `internal/sddstatus/review_binding_test.go` | Adds pure Engram, mixed-store, replay, runtime publication, and stale-CAS regressions. |
| `internal/cli/review_facade.go` | Makes `bind-sdd` help artifact-store neutral. |
| `internal/cli/review_facade_test.go` | Locks the neutral CLI contract. |
| `internal/cli/sdd_attempt_test.go` | Adds the end-to-end acceptance regression requested in review: a pure Engram binding is consumed by `sdd-attempt finish`. |

---

## ✅ Acceptance Regression (requested in review)

`TestRunSDDAttemptFinishAcceptsPureEngramBinding` in `internal/cli/sdd_attempt_test.go` proves the binding is *usable*, not merely *created*. It drives the whole lifecycle through the CLI in a repository that never grows an OpenSpec root:

1. `sdd-attempt begin` → `finish --outcome failed` records the failed evidence revision.
2. `sdd-attempt begin` reopens the attempt and the bounded correction lands in ordinary tracked source, never in planning files.
3. `BindApprovedReview` publishes the pure Engram binding, and `sdd-attempt status` confirms the runtime ledger carries that exact revision.
4. `sdd-attempt finish --outcome passed` consumes it as the remediation successor via `--expected-binding-revision` / `--successor-lineage` / `--remediates-evidence-revision`, and the attempt completes with `NextAction: complete`.
5. The test asserts no OpenSpec root was created or required at any point.

Verified as a genuine regression: with `internal/sddstatus/review_binding.go` reverted to `main`, the test fails at step 3 with `selected OpenSpec change does not exist`.

---

## 🧪 Test Plan

- [x] `go test ./internal/sddstatus`
- [x] `go test ./internal/cli`
- [x] `go vet ./internal/sddstatus ./internal/cli`
- [x] Focused Engram and mixed-store regressions run uncached
- [x] New acceptance regression fails on `main` and passes on this branch
- [x] `gofmt -l` produced no output
- [x] `git diff --check`
- [ ] Full Docker E2E suite (not applicable to this focused binding change)

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to existing issue #1910.
- [x] Issue #1910 has `status:approved`.
- [ ] Exactly one `type:*` label is applied — blocked on maintainer, contributor accounts cannot apply repository labels.
- [x] Exactly one PR type is selected in the body.
- [x] Relevant unit tests, format, and vet checks pass.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

The repository may contain OpenSpec changes unrelated to the selected Engram-only change. The regression explicitly covers that mixed-store case so a missing selected OpenSpec directory is treated as compact Engram provenance, while malformed, symlinked, foreign, or ambiguous file-backed roots remain fail-closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bind approved SDD changes without an OpenSpec planning directory.
  * Support compact approved-review lineages with runtime validation.

* **Bug Fixes**
  * Preserved correct behavior when unrelated changes are present.
  * Improved handling of missing planning data, repeated binding attempts, and stale updates.
  * Rejected missing, mismatched, stale, or unauthorized change records.

* **Documentation**
  * Updated `bind-sdd` help text with artifact-store-neutral terminology for SDD changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->