### PR TITLE
fix(mcp): register Context7 where Claude Code reads MCP servers

### DIFF
--- a/internal/agents/claude/adapter.go
+++ b/internal/agents/claude/adapter.go
@@ -119,6 +119,13 @@ func (a *Adapter) MCPConfigPath(homeDir string, serverName string) string {
 	return filepath.Join(homeDir, ".claude", "mcp", serverName+".json")
 }
 
+// MCPRegistryPath satisfies agents.MCPRegistryPathProvider. Components use it
+// to write MCP servers where Claude Code actually reads them; MCPConfigPath is
+// kept for cleaning up registrations earlier versions left behind.
+func (a *Adapter) MCPRegistryPath(homeDir string) string {
+	return MCPRegistryPath(homeDir)
+}
+
 // --- Optional capabilities ---
 
 func (a *Adapter) SupportsOutputStyles() bool {

--- a/internal/agents/claude/paths.go
+++ b/internal/agents/claude/paths.go
@@ -5,3 +5,11 @@ import "path/filepath"
 func ConfigPath(homeDir string) string {
 	return filepath.Join(homeDir, ".claude")
 }
+
+// MCPRegistryPath returns ~/.claude.json, the only user-scope location Claude
+// Code loads MCP servers from. An mcpServers key written to
+// ~/.claude/settings.json is not a recognised setting and is ignored, and
+// ~/.claude/mcp/*.json is never read at all.
+func MCPRegistryPath(homeDir string) string {
+	return filepath.Join(homeDir, ".claude.json")
+}

--- a/internal/agents/interface.go
+++ b/internal/agents/interface.go
@@ -65,3 +65,23 @@ type Adapter interface {
 type EffectiveCodeGraphWiringDetector interface {
 	EffectiveCodeGraphWiring(homeDir string) (path string, configured bool)
 }
+
+// MCPRegistryPathProvider is an optional adapter capability for agents that
+// load MCP servers from a dedicated registry file instead of from the settings
+// file their other configuration lives in. Claude Code is the case in point: it
+// reads user-scope MCP servers from ~/.claude.json only.
+type MCPRegistryPathProvider interface {
+	MCPRegistryPath(homeDir string) string
+}
+
+// MCPRegistryPath returns the adapter's MCP registry file, or an empty string
+// when the agent has none and its MCPStrategy alone decides where MCP servers
+// are written.
+func MCPRegistryPath(adapter Adapter, homeDir string) string {
+	provider, ok := adapter.(MCPRegistryPathProvider)
+	if !ok {
+		return ""
+	}
+
+	return provider.MCPRegistryPath(homeDir)
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1826,10 +1826,8 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 		case model.ComponentContext7:
 			switch adapter.MCPStrategy() {
 			case model.StrategySeparateMCPFiles:
-				if adapter.Agent() == model.AgentClaudeCode {
-					if p := adapter.SettingsPath(homeDir); p != "" {
-						paths = append(paths, p)
-					}
+				if p := agents.MCPRegistryPath(adapter, homeDir); p != "" {
+					paths = append(paths, p)
 					break
 				}
 				paths = append(paths, adapter.MCPConfigPath(homeDir, "context7"))

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -355,19 +355,24 @@ func TestComponentPathsContext7KimiIncludesMCPConfig(t *testing.T) {
 	}
 }
 
-func TestComponentPathsContext7ClaudeUsesSettingsFile(t *testing.T) {
+func TestComponentPathsContext7ClaudeUsesMCPRegistry(t *testing.T) {
 	home := t.TempDir()
 	adapters := resolveAdapters([]model.AgentID{model.AgentClaudeCode})
 
 	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentContext7)
 
-	want := filepath.Join(home, ".claude", "settings.json")
+	// Verification and backup must track the file the injector actually writes.
+	want := filepath.Join(home, ".claude.json")
 	if !containsPath(paths, want) {
 		t.Fatalf("componentPaths(context7,claude) missing %q\npaths=%v", want, paths)
 	}
-	legacy := filepath.Join(home, ".claude", "mcp", "context7.json")
-	if containsPath(paths, legacy) {
-		t.Fatalf("componentPaths(context7,claude) should not verify legacy path %q\npaths=%v", legacy, paths)
+	for _, unwanted := range []string{
+		filepath.Join(home, ".claude", "settings.json"),
+		filepath.Join(home, ".claude", "mcp", "context7.json"),
+	} {
+		if containsPath(paths, unwanted) {
+			t.Fatalf("componentPaths(context7,claude) should not verify %q\npaths=%v", unwanted, paths)
+		}
 	}
 }
 

--- a/internal/components/filemerge/json_merge.go
+++ b/internal/components/filemerge/json_merge.go
@@ -30,6 +30,20 @@ func MergeJSONObjects(baseJSON []byte, overlayJSON []byte) ([]byte, error) {
 	return append(encoded, '\n'), nil
 }
 
+// MergeJSONObjectsStrict merges like MergeJSONObjects but refuses to proceed
+// when the base document cannot be decoded, instead of falling back to an empty
+// base. Use it for files that carry irreplaceable user state: Claude Code's
+// ~/.claude.json holds the authenticated session and per-project trust
+// settings, so silently rewriting it from an empty object would sign the user
+// out rather than lose a reproducible config.
+func MergeJSONObjectsStrict(baseJSON []byte, overlayJSON []byte) ([]byte, error) {
+	if _, err := unmarshalJSONObject(baseJSON); err != nil {
+		return nil, fmt.Errorf("refusing to rewrite malformed json base: %w", err)
+	}
+
+	return MergeJSONObjects(baseJSON, overlayJSON)
+}
+
 func unmarshalJSONObject(raw []byte) (map[string]any, error) {
 	object := map[string]any{}
 	if len(bytes.TrimSpace(raw)) == 0 {

--- a/internal/components/filemerge/json_merge_test.go
+++ b/internal/components/filemerge/json_merge_test.go
@@ -114,6 +114,56 @@ func TestMergeJSONObjectsMalformedBaseReturnsOverlayOnly(t *testing.T) {
 	}
 }
 
+func TestMergeJSONObjectsStrictRefusesMalformedBase(t *testing.T) {
+	// The lenient path treats a broken base as {}, which is right for a config
+	// the installer can regenerate. A file such as Claude Code's ~/.claude.json
+	// carries the authenticated session, so the strict path must fail instead.
+	bases := [][]byte{
+		[]byte(`allow: all`),
+		[]byte(`{"oauthAccount": {"accountUuid": "abc"`),
+		[]byte(`a`),
+	}
+
+	for _, base := range bases {
+		t.Run(string(base), func(t *testing.T) {
+			merged, err := MergeJSONObjectsStrict(base, []byte(`{"mcpServers":{"context7":{"command":"npx"}}}`))
+			if err == nil {
+				t.Fatalf("MergeJSONObjectsStrict() error = nil, merged = %s; want a refusal", merged)
+			}
+			if merged != nil {
+				t.Fatalf("MergeJSONObjectsStrict() merged = %s; want nil on refusal", merged)
+			}
+		})
+	}
+}
+
+func TestMergeJSONObjectsStrictMergesParsableBase(t *testing.T) {
+	base := []byte(`{"oauthAccount":{"accountUuid":"abc"},"mcpServers":{"codegraph":{"command":"codegraph"}}}`)
+
+	merged, err := MergeJSONObjectsStrict(base, []byte(`{"mcpServers":{"context7":{"command":"npx"}}}`))
+	if err != nil {
+		t.Fatalf("MergeJSONObjectsStrict() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(merged, &got); err != nil {
+		t.Fatalf("merged result is not valid JSON: %v", err)
+	}
+	if _, ok := got["oauthAccount"]; !ok {
+		t.Fatalf("strict merge dropped oauthAccount; got keys: %v", got)
+	}
+
+	servers, ok := got["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("merged result missing mcpServers; got: %v", got)
+	}
+	for _, name := range []string{"codegraph", "context7"} {
+		if _, ok := servers[name]; !ok {
+			t.Fatalf("mcpServers missing %q; got: %v", name, servers)
+		}
+	}
+}
+
 // ─── __replace__ sentinel tests ───────────────────────────────────────────────
 
 func TestMergeJSONObjectsReplaceSentinelErasesBaseKeys(t *testing.T) {

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -23,8 +23,8 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 
 	switch adapter.MCPStrategy() {
 	case model.StrategySeparateMCPFiles:
-		if adapter.Agent() == model.AgentClaudeCode {
-			return injectMergeIntoSettings(homeDir, adapter)
+		if registryPath := agents.MCPRegistryPath(adapter, homeDir); registryPath != "" {
+			return injectMCPRegistry(registryPath)
 		}
 		return injectSeparateFile(homeDir, adapter)
 	case model.StrategyMergeIntoSettings:
@@ -94,6 +94,29 @@ func injectYAMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, er
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
+}
+
+// injectMCPRegistry merges the mcpServers-wrapped Context7 entry into the
+// agent's MCP registry file (Claude Code's ~/.claude.json). That file also
+// holds the user's session and per-project settings, so the merge is strict: a
+// base that cannot be parsed aborts the injection instead of replacing it.
+func injectMCPRegistry(registryPath string) (InjectionResult, error) {
+	baseJSON, err := osReadFile(registryPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	merged, err := filemerge.MergeJSONObjectsStrict(baseJSON, DefaultContext7OverlayJSON())
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("merge MCP registry %q: %w", registryPath, err)
+	}
+
+	writeResult, err := filemerge.WriteFileAtomic(registryPath, merged, 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{registryPath}}, nil
 }
 
 // injectSeparateFile writes a standalone JSON file per MCP server.

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -111,7 +111,7 @@ func assertOpenCodeRemoteContext7Schema(t *testing.T, path string) {
 
 // readMCPServersContext7Entry reads the mcpServers.context7 object used by
 // agents that store Context7 under an mcpServers-based config file.
-func readMCPServersContext7Entry(t *testing.T, path string) map[string]any {
+func readJSONObject(t *testing.T, path string) map[string]any {
 	t.Helper()
 
 	content, err := os.ReadFile(path)
@@ -123,6 +123,14 @@ func readMCPServersContext7Entry(t *testing.T, path string) map[string]any {
 	if err := json.Unmarshal(content, &parsed); err != nil {
 		t.Fatalf("Unmarshal(%q) error = %v", path, err)
 	}
+
+	return parsed
+}
+
+func readMCPServersContext7Entry(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	parsed := readJSONObject(t, path)
 
 	mcpServers, ok := parsed["mcpServers"].(map[string]any)
 	if !ok {
@@ -476,14 +484,11 @@ func TestInjectOpenCodePreservesOtherMCPEntriesWhenReplacingContext7(t *testing.
 	}
 }
 
-func TestInjectClaudeMergesContext7IntoSettingsAndIsIdempotent(t *testing.T) {
+func TestInjectClaudeMergesContext7IntoRegistryAndIsIdempotent(t *testing.T) {
 	home := t.TempDir()
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll(settings dir) error = %v", err)
-	}
-	if err := os.WriteFile(settingsPath, []byte(`{"theme":"dark"}`), 0o644); err != nil {
-		t.Fatalf("WriteFile(settings) error = %v", err)
+	registryPath := claude.MCPRegistryPath(home)
+	if err := os.WriteFile(registryPath, []byte(`{"oauthAccount":{"accountUuid":"abc"},"projects":{"/tmp/x":{"allowedTools":[]}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(registry) error = %v", err)
 	}
 
 	first, err := Inject(home, claudeAdapter())
@@ -502,12 +507,63 @@ func TestInjectClaudeMergesContext7IntoSettingsAndIsIdempotent(t *testing.T) {
 		t.Fatalf("Inject() second changed = true")
 	}
 
-	context7 := readMCPServersContext7Entry(t, settingsPath)
+	context7 := readMCPServersContext7Entry(t, registryPath)
 	if got := context7["command"]; got != "npx" {
 		t.Fatalf("mcpServers.context7.command = %#v; want npx", got)
 	}
+
+	// The session and per-project state living in the same file must survive.
+	root := readJSONObject(t, registryPath)
+	if _, ok := root["oauthAccount"]; !ok {
+		t.Fatalf("oauthAccount was dropped from %q", registryPath)
+	}
+	if _, ok := root["projects"]; !ok {
+		t.Fatalf("projects was dropped from %q", registryPath)
+	}
+
+	// Neither location Claude Code ignores may be written.
 	if _, err := os.Stat(filepath.Join(home, ".claude", "mcp", "context7.json")); !os.IsNotExist(err) {
 		t.Fatalf("Claude Context7 must not be written to ~/.claude/mcp/context7.json; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Fatalf("Claude Context7 must not be written to ~/.claude/settings.json; stat err = %v", err)
+	}
+}
+
+func TestInjectClaudeCreatesRegistryWhenMissing(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	context7 := readMCPServersContext7Entry(t, claude.MCPRegistryPath(home))
+	if got := context7["command"]; got != "npx" {
+		t.Fatalf("mcpServers.context7.command = %#v; want npx", got)
+	}
+}
+
+func TestInjectClaudeRefusesToRewriteMalformedRegistry(t *testing.T) {
+	// ~/.claude.json carries the authenticated session. Unlike a reproducible
+	// mcp.json, a base we cannot parse must abort the injection rather than be
+	// replaced with an overlay-only document.
+	home := t.TempDir()
+	registryPath := claude.MCPRegistryPath(home)
+	malformed := []byte("not json at all")
+	if err := os.WriteFile(registryPath, malformed, 0o644); err != nil {
+		t.Fatalf("WriteFile(malformed registry) error = %v", err)
+	}
+
+	if _, err := Inject(home, claudeAdapter()); err == nil {
+		t.Fatalf("Inject() error = nil; want a refusal to rewrite the malformed registry")
+	}
+
+	content, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("ReadFile(registry) error = %v", err)
+	}
+	if string(content) != string(malformed) {
+		t.Fatalf("registry was rewritten; got %q, want %q", content, malformed)
 	}
 }
 
@@ -527,7 +583,7 @@ func TestInjectClaudeLeavesLegacyContext7FileForExplicitUninstallCleanup(t *test
 	if _, err := os.Stat(legacyPath); err != nil {
 		t.Fatalf("legacy context7 file should be left for explicit uninstall cleanup: %v", err)
 	}
-	readMCPServersContext7Entry(t, filepath.Join(home, ".claude", "settings.json"))
+	readMCPServersContext7Entry(t, claude.MCPRegistryPath(home))
 }
 
 func TestInjectCursorWithMalformedMCPJsonRecovery(t *testing.T) {

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -721,8 +721,10 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 func context7Targets(adapter agents.Adapter, homeDir string) []string {
 	switch adapter.MCPStrategy() {
 	case model.StrategySeparateMCPFiles:
-		if adapter.Agent() == model.AgentClaudeCode {
-			return []string{adapter.SettingsPath(homeDir), adapter.MCPConfigPath(homeDir, "context7")}
+		if registryPath := agents.MCPRegistryPath(adapter, homeDir); registryPath != "" {
+			// SettingsPath and MCPConfigPath stay listed so registrations written
+			// by earlier versions, which never reached the registry, are cleaned up.
+			return []string{registryPath, adapter.SettingsPath(homeDir), adapter.MCPConfigPath(homeDir, "context7")}
 		}
 		return []string{adapter.MCPConfigPath(homeDir, "context7")}
 	case model.StrategyMergeIntoSettings, model.StrategyMCPConfigFile:
@@ -735,9 +737,14 @@ func context7Targets(adapter agents.Adapter, homeDir string) []string {
 func context7Operations(adapter agents.Adapter, homeDir string) []operation {
 	switch adapter.MCPStrategy() {
 	case model.StrategySeparateMCPFiles:
-		if adapter.Agent() == model.AgentClaudeCode {
+		if registryPath := agents.MCPRegistryPath(adapter, homeDir); registryPath != "" {
 			legacyPath := adapter.MCPConfigPath(homeDir, "context7")
-			return []operation{rewriteJSONFile(adapter.SettingsPath(homeDir), jsonPath{"mcpServers", "context7"}), removeManagedContext7File(legacyPath), removeDirIfEmpty(filepath.Dir(legacyPath))}
+			return []operation{
+				rewriteMCPRegistryFile(registryPath, jsonPath{"mcpServers", "context7"}),
+				rewriteJSONFile(adapter.SettingsPath(homeDir), jsonPath{"mcpServers", "context7"}),
+				removeManagedContext7File(legacyPath),
+				removeDirIfEmpty(filepath.Dir(legacyPath)),
+			}
 		}
 		path := adapter.MCPConfigPath(homeDir, "context7")
 		return []operation{removeFile(path), removeDirIfEmpty(filepath.Dir(path))}
@@ -836,6 +843,38 @@ func rewriteMarkdownFile(path string, mutate func(content string) (string, bool)
 			}
 			_, err = filemerge.WriteFileAtomic(path, []byte(updated), 0o644)
 			if err != nil {
+				return false, false, err
+			}
+			return true, false, nil
+		},
+	}
+}
+
+// rewriteMCPRegistryFile removes jsonPaths from an agent's MCP registry file
+// without ever deleting it. rewriteJSONFile drops a file that cleans out to an
+// empty object, which is right for a config gentle-ai created but wrong for
+// Claude Code's ~/.claude.json: that file also carries the authenticated
+// session, so an uninstall must leave "{}" behind rather than sign the user out.
+func rewriteMCPRegistryFile(path string, jsonPaths ...jsonPath) operation {
+	return operation{
+		typeID: opRewriteFile,
+		path:   path,
+		apply: func(path string) (bool, bool, error) {
+			raw, err := readManagedFile(path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return false, false, nil
+				}
+				return false, false, fmt.Errorf("read json file %q: %w", path, err)
+			}
+			updated, changed, err := removeJSONPaths(raw, jsonPaths...)
+			if err != nil {
+				return false, false, fmt.Errorf("clean json file %q: %w", path, err)
+			}
+			if !changed {
+				return false, false, nil
+			}
+			if _, err := filemerge.WriteFileAtomic(path, updated, 0o644); err != nil {
 				return false, false, err
 			}
 			return true, false, nil

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -405,6 +405,53 @@ func TestComponentOperationsContext7ClaudeRemovesSettingsAndManagedLegacyFile(t 
 	}
 }
 
+func TestComponentOperationsContext7ClaudeClearsRegistryWithoutDeletingTheFile(t *testing.T) {
+	// ~/.claude.json holds the authenticated session alongside the MCP servers.
+	// Even a registry whose only remaining content is the managed entry must be
+	// left in place — deleting it would sign the user out of Claude Code.
+	homeDir := t.TempDir()
+
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	adapter, ok := svc.registry.Get(model.AgentClaudeCode)
+	if !ok {
+		t.Fatal("Claude adapter not found in registry")
+	}
+
+	registryPath := agents.MCPRegistryPath(adapter, homeDir)
+	if registryPath == "" {
+		t.Fatal("Claude adapter reports no MCP registry path")
+	}
+	if err := os.WriteFile(registryPath, []byte(`{"mcpServers":{"context7":{"command":"npx"}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(registry) error = %v", err)
+	}
+
+	ops, targets, err := svc.componentOperations(adapter, model.ComponentContext7)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	if !slices.Contains(targets, registryPath) {
+		t.Fatalf("targets = %#v, want the MCP registry path %q", targets, registryPath)
+	}
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("operation %v on %q error = %v", op.typeID, op.path, err)
+		}
+	}
+
+	if _, err := os.Stat(registryPath); err != nil {
+		t.Fatalf("%q must survive uninstall; stat err = %v", registryPath, err)
+	}
+	registry := readJSONFileForTest(t, registryPath)
+	if servers, ok := registry["mcpServers"].(map[string]any); ok {
+		if _, still := servers["context7"]; still {
+			t.Fatalf("registry still contains mcpServers.context7: %#v", registry)
+		}
+	}
+}
+
 func TestComponentOperationsContext7ClaudePreservesCustomLegacyFile(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceDir := t.TempDir()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1868

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Claude Code loads user-scope MCP servers from `~/.claude.json` only. gentle-ai was merging the Context7 entry into `~/.claude/settings.json` under a top-level `mcpServers` key, which is not a recognised setting — Claude Code ignores it silently, so the registration was written, valid, error-free, and inert.

This PR points the Context7 registration at the file Claude Code actually reads, and moves the install-verification, backup, and uninstall consumers along with it.

Two details worth calling out, because `~/.claude.json` is not an ordinary config file — it also holds the authenticated session and per-project settings:

- **Merging is strict.** `MergeJSONObjects` resets an unparsable base to `{}`, which is the right recovery for a regenerable `mcp.json` but would replace a user's session here. `MergeJSONObjectsStrict` aborts instead. `MergeJSONObjects` is unchanged, so every other agent keeps the lenient recovery added for malformed Windows configs.
- **Uninstall never deletes the file.** `rewriteJSONFile` removes a file that cleans out to an empty object, and `deleteJSONPath` prunes the emptied parent — so on a machine where the registry held nothing but the managed entry, removing Context7 would have deleted `~/.claude.json` and signed the user out. `rewriteMCPRegistryFile` leaves `{}` behind instead.

Rather than adding another `adapter.Agent() == model.AgentClaudeCode` branch, the destination is expressed as an optional adapter capability (`agents.MCPRegistryPathProvider`), following the existing `EffectiveCodeGraphWiringDetector` pattern. This is the shape @Keesan12 and @acortesma argued for in #899: the injector, verifier, and uninstaller now all ask the adapter where its registry is, instead of each re-deriving a path from `MCPStrategy()`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/interface.go` | New optional capability `MCPRegistryPathProvider` + `agents.MCPRegistryPath(adapter, homeDir)` helper |
| `internal/agents/claude/paths.go`, `adapter.go` | `MCPRegistryPath` → `~/.claude.json`; `MCPConfigPath` kept for legacy cleanup |
| `internal/components/filemerge/json_merge.go` | New `MergeJSONObjectsStrict` — fails rather than resetting an unparsable base |
| `internal/components/mcp/inject.go` | Claude Code Context7 now merges into the registry instead of `settings.json` |
| `internal/cli/run.go` | Context7 verification and backup follow the registry path |
| `internal/components/uninstall/service.go` | New `rewriteMCPRegistryFile` (never deletes); Context7 cleanup covers registry + legacy locations |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`) — see the note on local environment failures below
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — 3/3 images, 79 passed, 0 failed
- [x] Manually tested locally

Behaviour covered by new/updated tests:

- Context7 lands in `~/.claude.json`, is idempotent on a second run, and preserves `oauthAccount` / `projects` in the same file
- The registry is created when absent
- A malformed registry aborts the injection and is left byte-for-byte untouched
- `~/.claude/settings.json` and `~/.claude/mcp/context7.json` are no longer written
- Verification and backup report the registry, not `settings.json`
- Uninstall clears `mcpServers.context7` and leaves the file in place — this one fails with `no such file or directory` if `rewriteMCPRegistryFile` is swapped back to `rewriteJSONFile`, which is exactly the regression it guards

Manual check on macOS: `claude mcp list` reports `context7 - ✔ Connected` after registering through the same destination this PR writes.

**On local environment failures.** Running `go test ./...` on macOS produces 49 failures on a clean `main` checkout, before any of this work. I ran the full suite on `main` in a separate worktree and diffed the failing-test sets: this branch's set is identical — no test fails here that does not also fail on `main`, and none stops failing. They are macOS artifacts rather than repository breakage:

- `internal/reviewtransaction` — `maintenance authority component "/var" is unsafe` and `review store lock could not be acquired: not a directory`. On macOS `$TMPDIR` lives under `/var/folders/...` and `/var` is a symlink to `/private/var`, which the path-safety check rejects.
- `internal/update` — `./scripts/canonicalize-release-public-keys.sh: line 20: declare: -A: invalid option`. macOS ships bash 3.2, which has no associative arrays.
- `internal/cli` — git operations exceeding the 15s aggregate budget.

Everything in the blast radius of this change is green: `internal/agents/...`, `internal/components/mcp`, `internal/components/filemerge`, `internal/components/uninstall`, `internal/components`, and `internal/components/engram`.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

I don't have permission to apply labels on this repo — could a maintainer add `type:bug`?

---

## 💬 Notes for Reviewers

**This is the first of two sequential PRs, and the second is deliberately not open yet.** #1868 reports two halves: Context7 landing in an ignored key, and Engram still landing in the dead `~/.claude/mcp/engram.json` from #899. Together they came to 497 changed lines, over the 400 budget, and the diff is ordinary code plus tests rather than the generated/vendor/migration case `size:exception` is meant for — so per CONTRIBUTING I split it instead of asking for the label.

I held the second PR back on purpose. In #1653/#1654/#1655 a three-part series was opened all at once and closed as a *"cumulative duplicate … three copies of the same branch"*, with the ask being *"a real reviewable stack with distinct boundaries"*. That outcome is unavoidable when later parts are opened against `main` before the earlier ones land, since each one carries its predecessors' commits — all three of those PRs measured an identical `+2920/-44`.

So this PR is the Context7 half plus the shared groundwork, standing alone at 317 changed lines. **The Engram half is already implemented and tested locally**; I'll open it against the updated `main` as soon as this merges, as a distinct 274-line diff with no overlap and linked to this same issue. Both halves stay under one approved issue rather than my opening a second one — #1868 already documents both defects, and splitting the tracking would put the follow-up behind a fresh `status:approved` gate for no benefit to you.

Merging this will auto-close #1868 while that second half is still outstanding, since CI requires the `Closes` keyword. **I'll reopen it myself** and it closes for good with the follow-up PR — no action needed on your side. Flagging it only so a closed issue isn't read as the work being finished.

Concretely, what still lands after this PR: `internal/components/engram/inject.go` writes `~/.claude/mcp/engram.json` for Claude Code, which is the original dead path from #899 and is untouched here. Verified against `main` at `b366f7ba` with a sandboxed `HOME` — after an Engram install, `~/.claude.json` and `~/.claude/settings.json` both have no `mcpServers`, and `claude mcp list` reports only `plugin:engram:engram`, i.e. the plugin's own channel rather than anything gentle-ai registered. The follow-up routes that branch through the same registry capability this PR introduces.

The uninstall file-deletion behaviour is the part I'd most like a second pair of eyes on — I only noticed it because `~/.claude.json` is one of the few targets where an empty result is not a disposable file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Context7 configuration for Claude Code is now stored in the correct MCP registry file.
  * Existing registry content is preserved during installation and removal.
  * Malformed registry files are no longer overwritten.
  * Uninstalling Context7 removes its configuration while retaining the registry file and unrelated settings.
* **Tests**
  * Added coverage for registry creation, preservation, validation, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->