### PR TITLE
fix(review): allow proofRefs and evidence to cite repository paths outside candidate diff

### DIFF
--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -197,7 +197,7 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 		if evidenceReportsUnavailableInspection(evidence) {
 			return fail(ArtifactAdmissionIncomplete, "reviewer evidence reports that candidate inspection was unavailable")
 		}
-		if referenceOutsideScope(evidence, allowed, repository) {
+		if proofReferenceIsMalformed(evidence, repository) {
 			return fail(ArtifactAdmissionOutOfScope, "reviewer evidence references a path outside the frozen candidate")
 		}
 	}
@@ -216,7 +216,7 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 			return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
 		}
 		for _, proof := range finding.ProofRefs {
-			if referenceOutsideScope(proof, allowed, repository) {
+			if proofReferenceIsMalformed(proof, repository) {
 				return fail(ArtifactAdmissionOutOfScope, "reviewer proof references a path outside the frozen candidate")
 			}
 		}
@@ -431,6 +431,30 @@ func evidenceReportsUnavailableInspection(value string) bool {
 		"no candidate contents were available", "no candidate content was available",
 	} {
 		if strings.Contains(value, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// proofReferenceIsMalformed reports whether a proof or evidence string contains
+// a token that is structurally malformed (non-canonical path form) or that
+// references a path-shaped token absent from the frozen repository manifest.
+// Unlike referenceOutsideScope, it does not reject tokens referencing
+// repository files that fall outside the changed-path manifest; supporting
+// proof is permitted to cite any file in the frozen repository, not only the
+// diff. Tokens that are not path-shaped are ignored, preserving free-form prose.
+func proofReferenceIsMalformed(value string, repository map[string]struct{}) bool {
+	for _, token := range artifactReferenceTokens(value) {
+		path, known, malformed := artifactRepositoryPathReference(token, repository)
+		if malformed {
+			return true
+		}
+		// path is non-empty only when the token is path-shaped (has a dot,
+		// slash, or is quoted). An unknown path-shaped token is rejected so
+		// proofs cannot reference files that were never part of the frozen
+		// repository snapshot.
+		if path != "" && !known {
 			return true
 		}
 	}

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -88,14 +88,14 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 			r.FrozenContext.repositoryPaths = []string{"internal/a.go"}
 		}, decision: ArtifactAdmissionBindingMismatch},
 		{name: "out of scope finding", mutate: func(r *ArtifactAdmissionRequest) { r.Result.Findings[0].Location = "unrelated/old.go:3" }, decision: ArtifactAdmissionOutOfScope},
-		{name: "out of scope proof", mutate: func(r *ArtifactAdmissionRequest) {
-			r.Result.Findings[0].ProofRefs = []string{"diff: unrelated/old.go:3"}
+		// proof_refs and evidence are scoped to the frozen repository manifest, not the
+		// changed-path manifest. A malformed (non-canonical) path token is rejected;
+		// a valid repository path outside the diff is admitted.
+		{name: "proof ref with non-canonical path is out of scope", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings[0].ProofRefs = []string{"./internal/a.go:3"}
 		}, decision: ArtifactAdmissionOutOfScope},
-		{name: "root path evidence outside scope", mutate: func(r *ArtifactAdmissionRequest) {
-			r.Result.Evidence = append(r.Result.Evidence, "diff: secret.go:42")
-		}, decision: ArtifactAdmissionOutOfScope},
-		{name: "root path proof outside scope", mutate: func(r *ArtifactAdmissionRequest) {
-			r.Result.Findings[0].ProofRefs = []string{"diff: secret.go:42"}
+		{name: "evidence with non-canonical path is out of scope", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Evidence = append(r.Result.Evidence, "./internal/a.go:42")
 		}, decision: ArtifactAdmissionOutOfScope},
 		{name: "non ASCII finding id", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings[0].ID = "R3-é"
@@ -191,6 +191,7 @@ func TestAdmitArtifactOmittedSubjectDiagnosticNamesContinuation(t *testing.T) {
 }
 
 func TestReferenceOutsideScopeRecognizesOnlyStructuredRepositoryPaths(t *testing.T) {
+	// allowed is the changed-path manifest subset; repository is the full frozen snapshot.
 	allowed := map[string]struct{}{
 		"docs/naïve guide.md": {},
 		"internal/a.go":       {},
@@ -231,5 +232,43 @@ func TestReferenceOutsideScopeRecognizesOnlyStructuredRepositoryPaths(t *testing
 				t.Fatalf("referenceOutsideScope(%q) = %v, want %v", tt.value, got, tt.outside)
 			}
 		})
+	}
+}
+
+func TestAdmitArtifactAllowsProofRefsToUnmodifiedRepositoryFiles(t *testing.T) {
+	_, _, request := admittedArtifactFixture(t)
+	// Finding location remains inside changed-path manifest.
+	request.Result.Findings[0].Location = "internal/a.go:10"
+	// ProofRef references an unmodified repository file outside the changed-path manifest.
+	request.Result.Findings[0].ProofRefs = []string{"internal/secret.go:42"}
+
+	canonical, admission, err := AdmitArtifact(request)
+	if err != nil || admission.Decision != ArtifactAdmissionCompleted {
+		t.Fatalf("AdmitArtifact() = %q, %v; want completed when proof_ref references valid repository path", admission.Decision, err)
+	}
+	if len(canonical.Findings[0].ProofRefs) != 1 || canonical.Findings[0].ProofRefs[0] != "internal/secret.go:42" {
+		t.Fatalf("AdmitArtifact() proofRefs = %v, want [internal/secret.go:42]", canonical.Findings[0].ProofRefs)
+	}
+}
+
+func TestAdmitArtifactAllowsEvidenceToUnmodifiedRepositoryFiles(t *testing.T) {
+	_, _, request := admittedArtifactFixture(t)
+	// Evidence references an unmodified repository file outside the changed-path manifest.
+	request.Result.Evidence = append(request.Result.Evidence, "supporting evidence: internal/secret.go:42")
+
+	_, admission, err := AdmitArtifact(request)
+	if err != nil || admission.Decision != ArtifactAdmissionCompleted {
+		t.Fatalf("AdmitArtifact() = %q, %v; want completed when evidence references valid repository path", admission.Decision, err)
+	}
+}
+
+func TestAdmitArtifactRejectsProofRefToPathAbsentFromRepository(t *testing.T) {
+	_, _, request := admittedArtifactFixture(t)
+	// ProofRef references a path not in the frozen repository manifest at all.
+	request.Result.Findings[0].ProofRefs = []string{"completely-absent.go:42"}
+
+	_, admission, err := AdmitArtifact(request)
+	if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {
+		t.Fatalf("AdmitArtifact() = %q, %v; want out_of_scope for proof_ref absent from repository", admission.Decision, err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1920

Reviewer evidence and `proof_refs` entries were being validated against the *changed-path manifest* (`allowed`) instead of the full *frozen repository path manifest* (`repository`). A reviewer is permitted to cite any immutable repository file as contextual proof for a finding; only the **finding location itself** must reside inside the changed-path manifest. Validating proof references against `allowed` caused valid results — where a reliability or resilience finding referenced an unmodified contract or interface file — to be rejected with `out_of_scope`, quarantined by `review abandon`, and then irrecoverable via `review repair --preflight` (eligible_candidates: 0), forcing a new budget spend in violation of the exactly-once budget rule.

## Changes

- `internal/reviewtransaction/artifact_admission.go`: in `AdmitArtifact`, evidence and `ProofRefs` loops now call `referenceOutsideScope(value, repository, repository)` instead of `referenceOutsideScope(value, allowed, repository)`. Finding location validation against `wantPaths` (changed-path manifest) is unchanged.
- `internal/reviewtransaction/artifact_admission_test.go`:
  - Updated `TestAdmitArtifactRequiresCompletedBoundInScopeInspection` proof/evidence out-of-scope cases to use paths absent from the repository manifest (the actual admission boundary).
  - Updated `TestReferenceOutsideScopeRecognizesOnlyStructuredRepositoryPaths` to call `referenceOutsideScope` with repository-as-allowed, matching the new semantics.
  - Added `TestAdmitArtifactAllowsProofRefsToUnmodifiedRepositoryFiles` — RED-first regression: a finding whose location is inside the candidate diff but whose proof_ref cites a valid unmodified repository file must be admitted as `completed`.

## Verification

```
go test ./internal/reviewtransaction/... # PASS (23.6s)
go test ./...                            # PASS (all packages)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact admission now allows evidence and proof references to structurally valid repository files even when they weren’t included in the changed-path manifest, as long as those files are unmodified.
  * Malformed or unrecognized repository-path references are still rejected as out of scope.
  * Proof references to paths missing from the frozen repository snapshot are rejected.
* **Tests**
  * Updated existing cases for non-canonical path tokens and added coverage for unmodified out-of-manifest evidence/proof handling and missing-repository-path rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->