### PR TITLE
fix(upgrade): reject unsupported options before effects

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -125,6 +125,21 @@ func RunArgs(args []string, stdout io.Writer) error {
 		}
 	}
 
+	// Issue #535: parse the upgrade command's arguments exactly once, before
+	// any platform validation, system detection, self-update, update check,
+	// backup, or execution effect. Unsupported pre-delimiter dash arguments
+	// are rejected here with zero effects. The parsed value is forwarded to
+	// runUpgrade below so the executor never reparses raw CLI args. The
+	// help selection branch is added in the follow-up help-behavior change.
+	var parsedUpgrade *upgradeArgs
+	if len(args) > 0 && args[0] == "upgrade" {
+		parsed, err := parseUpgradeArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		parsedUpgrade = &parsed
+	}
+
 	if err := ensureCurrentOSSupported(); err != nil {
 		return err
 	}
@@ -230,7 +245,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 	case "update":
 		return runUpdate(context.Background(), Version, resolveProfile(), stdout)
 	case "upgrade":
-		return runUpgrade(context.Background(), args[1:], result, stdout)
+		return runUpgrade(context.Background(), *parsedUpgrade, result, stdout)
 	case "install":
 		installResult, err := cli.RunInstall(args[1:], result)
 		if err != nil {
@@ -442,21 +457,14 @@ func runUpdate(ctx context.Context, currentVersion string, profile system.Platfo
 //   - Executes binary-only upgrades; does NOT invoke install or sync pipelines
 //   - Skips gentle-ai itself when running as a dev build (version="dev")
 //   - Falls back to source-install guidance where official binaries are unavailable
-func runUpgrade(ctx context.Context, args []string, detection system.DetectionResult, stdout io.Writer) error {
-	dryRun := false
-	noBackup := false
-	var toolFilter []string
-
-	for _, arg := range args {
-		switch {
-		case arg == "--dry-run" || arg == "-n":
-			dryRun = true
-		case arg == "--no-backup":
-			noBackup = true
-		case !strings.HasPrefix(arg, "-"):
-			toolFilter = append(toolFilter, arg)
-		}
-	}
+//
+// Issue #535: runUpgrade consumes a structured upgradeArgs value parsed once
+// in RunArgs. It forwards the parsed flags and tool filters to the update
+// check and executor exactly once and never reparses raw CLI arguments.
+func runUpgrade(ctx context.Context, args upgradeArgs, detection system.DetectionResult, stdout io.Writer) error {
+	dryRun := args.dryRun
+	noBackup := args.noBackup
+	toolFilter := args.toolFilter
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2250,23 +2250,25 @@ func installUpgradeSentinels(t *testing.T, home string) {
 	}
 }
 
-// TestRunArgs_UpgradeUnsupportedOptionStopsBeforeAnyEffect proves an unsupported
-// dash-prefixed argument (before the delimiter) is rejected with an
-// identifiable token and zero effects — no platform/system/self-update/check/
-// backup/execution effect runs (spec scenario: unsupported option rejected
-// early).
+// TestRunArgs_UpgradeUnsupportedOptionStopsBeforeAnyEffect proves unsupported
+// dash args (--verbose) and the #535 remediation (--help, -h) are rejected
+// before every effect: identifiable token, errors.Is, zero effects.
 func TestRunArgs_UpgradeUnsupportedOptionStopsBeforeAnyEffect(t *testing.T) {
-	installUpgradeSentinels(t, t.TempDir())
-
-	var buf bytes.Buffer
-	err := RunArgs([]string{"upgrade", "--verbose"}, &buf)
-	if err == nil {
-		t.Fatalf("RunArgs(upgrade --verbose) error = nil, want unsupported-argument error")
-	}
-	if !strings.Contains(err.Error(), `unsupported upgrade argument: "--verbose"`) {
-		t.Fatalf("RunArgs(upgrade --verbose) error = %v, want error containing the exact token", err)
-	}
-	if !errors.Is(err, errUnsupportedUpgradeArgument) {
-		t.Fatalf("RunArgs(upgrade --verbose) error is not identifiable: %v", err)
+	for _, token := range []string{"--verbose", "--help", "-h"} {
+		t.Run(token, func(t *testing.T) {
+			installUpgradeSentinels(t, t.TempDir())
+			var buf bytes.Buffer
+			err := RunArgs([]string{"upgrade", token}, &buf)
+			if err == nil {
+				t.Fatalf("RunArgs(upgrade %s) error = nil, want error", token)
+			}
+			want := fmt.Sprintf(`unsupported upgrade argument: %q`, token)
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("RunArgs(upgrade %s) error = %v, want %q", token, err, want)
+			}
+			if !errors.Is(err, errUnsupportedUpgradeArgument) {
+				t.Fatalf("RunArgs(upgrade %s) error not identifiable: %v", token, err)
+			}
+		})
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -2192,5 +2193,80 @@ func TestCustomClearRoundTripLeavesFutureSyncInPreserveMode(t *testing.T) {
 	loadPersistedAssignments(home, &future)
 	if future.CodexOrchestratorAssignment != nil || future.ClearCodexOrchestratorAssignment {
 		t.Fatalf("future sync did not return to preserve mode: assignment=%#v clear=%v", future.CodexOrchestratorAssignment, future.ClearCodexOrchestratorAssignment)
+	}
+}
+
+// ─── Issue #535: upgrade argument validation pre-effect gate ───────────────
+
+// installUpgradeSentinels replaces every effect that the upgrade preflight
+// MUST NOT reach, with stubs that fail the test if invoked. It restores the
+// originals on cleanup. HOME is isolated to a temp dir so the parser cannot
+// accidentally trigger real home-directory effects.
+func installUpgradeSentinels(t *testing.T, home string) {
+	t.Helper()
+	setupMockHome(t, home)
+
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origSelfUpdate := selfUpdateFn
+	origCheckFiltered := updateCheckFiltered
+	origCheckAll := updateCheckAll
+	origUpgradeExecute := upgradeExecute
+	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
+	t.Cleanup(func() {
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		selfUpdateFn = origSelfUpdate
+		updateCheckFiltered = origCheckFiltered
+		updateCheckAll = origCheckAll
+		upgradeExecute = origUpgradeExecute
+		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
+	})
+
+	ensureCurrentOSSupported = func() error {
+		return fmt.Errorf("ensureCurrentOSSupported must not run for this upgrade invocation")
+	}
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{}, fmt.Errorf("detectSystem must not run for this upgrade invocation")
+	}
+	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+		return fmt.Errorf("selfUpdate must not run for this upgrade invocation")
+	}
+	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
+		t.Fatalf("updateCheckFiltered must not run for this upgrade invocation")
+		return nil
+	}
+	updateCheckAll = func(context.Context, string, system.PlatformProfile) []update.UpdateResult {
+		t.Fatalf("updateCheckAll must not run for this upgrade invocation")
+		return nil
+	}
+	upgradeExecute = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, ...io.Writer) upgrade.UpgradeReport {
+		t.Fatalf("upgradeExecute must not run for this upgrade invocation")
+		return upgrade.UpgradeReport{}
+	}
+	upgradeExecuteWithOptions = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, upgrade.ExecuteOptions) upgrade.UpgradeReport {
+		t.Fatalf("upgradeExecuteWithOptions must not run for this upgrade invocation")
+		return upgrade.UpgradeReport{}
+	}
+}
+
+// TestRunArgs_UpgradeUnsupportedOptionStopsBeforeAnyEffect proves an unsupported
+// dash-prefixed argument (before the delimiter) is rejected with an
+// identifiable token and zero effects — no platform/system/self-update/check/
+// backup/execution effect runs (spec scenario: unsupported option rejected
+// early).
+func TestRunArgs_UpgradeUnsupportedOptionStopsBeforeAnyEffect(t *testing.T) {
+	installUpgradeSentinels(t, t.TempDir())
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"upgrade", "--verbose"}, &buf)
+	if err == nil {
+		t.Fatalf("RunArgs(upgrade --verbose) error = nil, want unsupported-argument error")
+	}
+	if !strings.Contains(err.Error(), `unsupported upgrade argument: "--verbose"`) {
+		t.Fatalf("RunArgs(upgrade --verbose) error = %v, want error containing the exact token", err)
+	}
+	if !errors.Is(err, errUnsupportedUpgradeArgument) {
+		t.Fatalf("RunArgs(upgrade --verbose) error is not identifiable: %v", err)
 	}
 }

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -47,9 +48,11 @@ func TestRunUpdate_ReturnsErrorWhenChecksFail(t *testing.T) {
 func TestRunUpgrade_ReturnsErrorBeforeExecutingWhenChecksFail(t *testing.T) {
 	origCheckFiltered := updateCheckFiltered
 	origUpgradeExecute := upgradeExecute
+	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheckFiltered
 		upgradeExecute = origUpgradeExecute
+		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
 	})
 
 	called := false
@@ -71,9 +74,16 @@ func TestRunUpgrade_ReturnsErrorBeforeExecutingWhenChecksFail(t *testing.T) {
 		called = true
 		return upgrade.UpgradeReport{}
 	}
+	upgradeExecuteWithOptions = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, upgrade.ExecuteOptions) upgrade.UpgradeReport {
+		called = true
+		return upgrade.UpgradeReport{}
+	}
 
+	// Issue #535: runUpgrade now consumes a structured upgradeArgs value
+	// parsed once in RunArgs, not raw CLI args. The check must run with the
+	// forwarded tool filter, and execution must be skipped on check failure.
 	var buf bytes.Buffer
-	err := runUpgrade(context.Background(), []string{"--no-backup"}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
+	err := runUpgrade(context.Background(), upgradeArgs{noBackup: true}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
 	if err == nil {
 		t.Fatal("runUpgrade() error = nil, want non-nil")
 	}
@@ -127,7 +137,7 @@ func TestRunUpgrade_RestartsAfterGentleAIUpgrade(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runUpgrade(context.Background(), []string{"--no-backup"}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
+	err := runUpgrade(context.Background(), upgradeArgs{noBackup: true}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
 	if err != nil {
 		t.Fatalf("runUpgrade() error = %v", err)
 	}
@@ -187,7 +197,7 @@ func TestRunUpgrade_DryRunDoesNotRestartAfterGentleAIUpgrade(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runUpgrade(context.Background(), []string{"--dry-run"}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", Supported: true}}}, &buf)
+	err := runUpgrade(context.Background(), upgradeArgs{dryRun: true}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", Supported: true}}}, &buf)
 	if err != nil {
 		t.Fatalf("runUpgrade() error = %v", err)
 	}
@@ -213,5 +223,60 @@ func TestTUIUpgrade_DoesNotRestartBeforeModelCanRenderReport(t *testing.T) {
 	report := tuiUpgrade(system.PlatformProfile{OS: "darwin", PackageManager: "brew"}, os.TempDir())(context.Background(), nil)
 	if len(report.Results) != 1 || report.Results[0].ToolName != "gentle-ai" {
 		t.Fatalf("tuiUpgrade() report = %#v", report)
+	}
+}
+
+// TestRunUpgrade_ForwardsParsedArgsOnceWithoutReparsing verifies the issue #535
+// contract: runUpgrade consumes the structured upgradeArgs (parsed once in
+// RunArgs) and forwards the flags/filters to updateCheckFiltered and
+// upgradeExecuteWithOptions exactly once. It must NOT reparse raw CLI args
+// (there are none to reparse), and unsupported flags can never reach it.
+func TestRunUpgrade_ForwardsParsedArgsOnceWithoutReparsing(t *testing.T) {
+	origCheckFiltered := updateCheckFiltered
+	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
+	t.Cleanup(func() {
+		updateCheckFiltered = origCheckFiltered
+		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
+	})
+
+	var checkFilters []string
+	checkCalls := 0
+	updateCheckFiltered = func(_ context.Context, _ string, _ system.PlatformProfile, filters []string) []update.UpdateResult {
+		checkCalls++
+		checkFilters = filters
+		return []update.UpdateResult{{Tool: update.ToolInfo{Name: "gentle-ai"}, Status: update.UpToDate}}
+	}
+
+	var execDryRun, execSkipBackup bool
+	execCalls := 0
+	upgradeExecuteWithOptions = func(_ context.Context, _ []update.UpdateResult, _ system.PlatformProfile, _ string, dryRun bool, opts upgrade.ExecuteOptions) upgrade.UpgradeReport {
+		execCalls++
+		execDryRun = dryRun
+		execSkipBackup = opts.SkipBackup
+		return upgrade.UpgradeReport{}
+	}
+
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	var buf bytes.Buffer
+	err := runUpgrade(context.Background(), upgradeArgs{dryRun: true, noBackup: true, toolFilter: []string{"engram", "gga"}}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
+	if err != nil {
+		t.Fatalf("runUpgrade() error = %v, want nil", err)
+	}
+	if checkCalls != 1 {
+		t.Fatalf("updateCheckFiltered called %d times, want exactly 1", checkCalls)
+	}
+	if !reflect.DeepEqual(checkFilters, []string{"engram", "gga"}) {
+		t.Fatalf("updateCheckFiltered filters = %#v, want [engram gga] forwarded once", checkFilters)
+	}
+	if execCalls != 1 {
+		t.Fatalf("upgradeExecuteWithOptions called %d times, want exactly 1", execCalls)
+	}
+	if !execDryRun {
+		t.Errorf("upgradeExecuteWithOptions dryRun = false, want true (forwarded once)")
+	}
+	if !execSkipBackup {
+		t.Errorf("upgradeExecuteWithOptions SkipBackup = false, want true (forwarded once)")
 	}
 }

--- a/internal/app/upgrade_args.go
+++ b/internal/app/upgrade_args.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// upgradeArgs is the structured, once-parsed representation of the `upgrade`
+// command's argument list. RunArgs parses the raw CLI args into this value
+// exactly once before any platform, system, self-update, update-check, backup,
+// or execution effect, and runUpgrade consumes only these fields without
+// reparsing. See issue #535.
+type upgradeArgs struct {
+	dryRun     bool
+	noBackup   bool
+	help       bool
+	toolFilter []string
+}
+
+// errUnsupportedUpgradeArgument is the identifiable sentinel returned when an
+// unsupported dash-prefixed argument appears before the standalone "--"
+// delimiter. Callers can match it with errors.Is to surface the offending
+// token deterministically.
+var errUnsupportedUpgradeArgument = errors.New("unsupported upgrade argument")
+
+// parseUpgradeArgs parses the upgrade command's argument list in a single
+// pass, honouring the standalone "--" delimiter. Before the delimiter it
+// recognises --dry-run/-n, --no-backup, and --help/-h; every other
+// dash-prefixed token is rejected with an error that wraps
+// errUnsupportedUpgradeArgument and names the exact offending token. After
+// the delimiter, every token (including --help or -x) is preserved as a
+// positional tool filter. Positional tool names are NOT validated by this
+// gate.
+func parseUpgradeArgs(args []string) (upgradeArgs, error) {
+	var parsed upgradeArgs
+	pastDelimiter := false
+
+	for _, arg := range args {
+		if pastDelimiter {
+			parsed.toolFilter = append(parsed.toolFilter, arg)
+			continue
+		}
+
+		// The standalone "--" ends option recognition. Everything after it
+		// (including dash-prefixed values) becomes a positional filter.
+		if arg == "--" {
+			pastDelimiter = true
+			continue
+		}
+
+		// Before the delimiter, only recognised options and help are allowed.
+		switch arg {
+		case "--dry-run", "-n":
+			parsed.dryRun = true
+		case "--no-backup":
+			parsed.noBackup = true
+		case "--help", "-h":
+			parsed.help = true
+		default:
+			// Positional tokens (no leading dash) are tool filters; unknown
+			// dash-prefixed options are rejected with the exact token so the
+			// caller can report it without ambiguity.
+			if strings.HasPrefix(arg, "-") {
+				return upgradeArgs{}, fmt.Errorf("%w: %q", errUnsupportedUpgradeArgument, arg)
+			}
+			parsed.toolFilter = append(parsed.toolFilter, arg)
+		}
+	}
+
+	return parsed, nil
+}

--- a/internal/app/upgrade_args.go
+++ b/internal/app/upgrade_args.go
@@ -14,7 +14,6 @@ import (
 type upgradeArgs struct {
 	dryRun     bool
 	noBackup   bool
-	help       bool
 	toolFilter []string
 }
 
@@ -26,12 +25,12 @@ var errUnsupportedUpgradeArgument = errors.New("unsupported upgrade argument")
 
 // parseUpgradeArgs parses the upgrade command's argument list in a single
 // pass, honouring the standalone "--" delimiter. Before the delimiter it
-// recognises --dry-run/-n, --no-backup, and --help/-h; every other
-// dash-prefixed token is rejected with an error that wraps
-// errUnsupportedUpgradeArgument and names the exact offending token. After
-// the delimiter, every token (including --help or -x) is preserved as a
-// positional tool filter. Positional tool names are NOT validated by this
-// gate.
+// recognises --dry-run/-n and --no-backup; --help and -h are intentionally
+// NOT recognised here so the unsupported-option path rejects them (help
+// output is deferred to the follow-up help-behavior change). Every other
+// dash-prefixed token is rejected with an error wrapping
+// errUnsupportedUpgradeArgument and naming the exact offending token. After
+// the delimiter, every token is a positional tool filter (not validated).
 func parseUpgradeArgs(args []string) (upgradeArgs, error) {
 	var parsed upgradeArgs
 	pastDelimiter := false
@@ -49,14 +48,12 @@ func parseUpgradeArgs(args []string) (upgradeArgs, error) {
 			continue
 		}
 
-		// Before the delimiter, only recognised options and help are allowed.
+		// Before the delimiter, only recognised options are allowed.
 		switch arg {
 		case "--dry-run", "-n":
 			parsed.dryRun = true
 		case "--no-backup":
 			parsed.noBackup = true
-		case "--help", "-h":
-			parsed.help = true
 		default:
 			// Positional tokens (no leading dash) are tool filters; unknown
 			// dash-prefixed options are rejected with the exact token so the

--- a/internal/app/upgrade_args_test.go
+++ b/internal/app/upgrade_args_test.go
@@ -81,6 +81,15 @@ func TestParseUpgradeArgs(t *testing.T) {
 			wantErr:   true,
 			wantToken: `unsupported upgrade argument: "--no-such-flag"`,
 		},
+		{
+			// #535 remediation: --help/-h rejected as unsupported until PR2.
+			name: "help long flag rejected as unsupported with exact token", args: []string{"--help"},
+			wantErr: true, wantToken: `unsupported upgrade argument: "--help"`,
+		},
+		{
+			name: "help short flag rejected as unsupported with exact token", args: []string{"-h"},
+			wantErr: true, wantToken: `unsupported upgrade argument: "-h"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -113,7 +122,7 @@ func TestParseUpgradeArgs(t *testing.T) {
 // equalUpgradeArgs compares two upgradeArgs field-by-field, treating nil and
 // empty toolFilter slices as equivalent so the table stays readable.
 func equalUpgradeArgs(a, b upgradeArgs) bool {
-	if a.dryRun != b.dryRun || a.noBackup != b.noBackup || a.help != b.help {
+	if a.dryRun != b.dryRun || a.noBackup != b.noBackup {
 		return false
 	}
 	if len(a.toolFilter) == 0 && len(b.toolFilter) == 0 {

--- a/internal/app/upgrade_args_test.go
+++ b/internal/app/upgrade_args_test.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseUpgradeArgs is the RED table-driven matrix for the single-pass,
+// delimiter-aware upgrade argument parser introduced by issue #535.
+//
+// PR 1 covers supported flags, preserved positional filters, and early
+// rejection of unsupported dash-prefixed tokens with the exact offending
+// token (errors.Is errUnsupportedUpgradeArgument). The help-selection and
+// standalone "--" delimiter-positional cases are added by the follow-up
+// help-behavior change, which also owns printUpgradeHelp.
+func TestParseUpgradeArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantArgs  upgradeArgs
+		wantErr   bool
+		wantToken string // substring the error must contain when wantErr
+	}{
+		{
+			name:     "empty args parses to zero state",
+			args:     nil,
+			wantArgs: upgradeArgs{},
+		},
+		{
+			name:     "dry-run long flag sets dry-run only",
+			args:     []string{"--dry-run"},
+			wantArgs: upgradeArgs{dryRun: true},
+		},
+		{
+			name:     "dry-run short alias -n sets dry-run only",
+			args:     []string{"-n"},
+			wantArgs: upgradeArgs{dryRun: true},
+		},
+		{
+			name:     "no-backup flag sets noBackup only",
+			args:     []string{"--no-backup"},
+			wantArgs: upgradeArgs{noBackup: true},
+		},
+		{
+			name:     "all supported flags set together",
+			args:     []string{"--dry-run", "-n", "--no-backup"},
+			wantArgs: upgradeArgs{dryRun: true, noBackup: true},
+		},
+		{
+			name:     "positional filters are preserved in order",
+			args:     []string{"tool-a", "tool-b"},
+			wantArgs: upgradeArgs{toolFilter: []string{"tool-a", "tool-b"}},
+		},
+		{
+			name:     "supported flags and filters preserved together (spec scenario)",
+			args:     []string{"--dry-run", "-n", "--no-backup", "tool-a", "tool-b"},
+			wantArgs: upgradeArgs{dryRun: true, noBackup: true, toolFilter: []string{"tool-a", "tool-b"}},
+		},
+		{
+			name:      "unsupported long option rejected with exact token",
+			args:      []string{"--verbose"},
+			wantErr:   true,
+			wantToken: `unsupported upgrade argument: "--verbose"`,
+		},
+		{
+			name:      "unsupported short option rejected with exact token",
+			args:      []string{"-x"},
+			wantErr:   true,
+			wantToken: `unsupported upgrade argument: "-x"`,
+		},
+		{
+			name:      "unsupported option rejected before any effect (first unsupported wins)",
+			args:      []string{"--dry-run", "--bogus", "tool-a"},
+			wantErr:   true,
+			wantToken: `unsupported upgrade argument: "--bogus"`,
+		},
+		{
+			name:      "unsupported option after positional filter still rejected",
+			args:      []string{"tool-a", "--no-such-flag"},
+			wantErr:   true,
+			wantToken: `unsupported upgrade argument: "--no-such-flag"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUpgradeArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseUpgradeArgs(%v) error = nil, want error containing %q", tt.args, tt.wantToken)
+				}
+				if !strings.Contains(err.Error(), tt.wantToken) {
+					t.Fatalf("parseUpgradeArgs(%v) error = %v, want error containing %q", tt.args, err, tt.wantToken)
+				}
+				// Error must be identifiable: it must wrap or be the sentinel so
+				// callers can match the offending token deterministically.
+				if !errors.Is(err, errUnsupportedUpgradeArgument) {
+					t.Fatalf("parseUpgradeArgs(%v) error is not identifiable: %v (want errors.Is errUnsupportedUpgradeArgument)", tt.args, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseUpgradeArgs(%v) error = %v, want nil", tt.args, err)
+			}
+			if !equalUpgradeArgs(got, tt.wantArgs) {
+				t.Fatalf("parseUpgradeArgs(%v) = %+v, want %+v", tt.args, got, tt.wantArgs)
+			}
+		})
+	}
+}
+
+// equalUpgradeArgs compares two upgradeArgs field-by-field, treating nil and
+// empty toolFilter slices as equivalent so the table stays readable.
+func equalUpgradeArgs(a, b upgradeArgs) bool {
+	if a.dryRun != b.dryRun || a.noBackup != b.noBackup || a.help != b.help {
+		return false
+	}
+	if len(a.toolFilter) == 0 && len(b.toolFilter) == 0 {
+		return true
+	}
+	if len(a.toolFilter) != len(b.toolFilter) {
+		return false
+	}
+	for i := range a.toolFilter {
+		if a.toolFilter[i] != b.toolFilter[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/upgrade_args_test.go
+++ b/internal/app/upgrade_args_test.go
@@ -9,11 +9,8 @@ import (
 // TestParseUpgradeArgs is the RED table-driven matrix for the single-pass,
 // delimiter-aware upgrade argument parser introduced by issue #535.
 //
-// PR 1 covers supported flags, preserved positional filters, and early
-// rejection of unsupported dash-prefixed tokens with the exact offending
-// token (errors.Is errUnsupportedUpgradeArgument). The help-selection and
-// standalone "--" delimiter-positional cases are added by the follow-up
-// help-behavior change, which also owns printUpgradeHelp.
+// PR 1 covers supported flags, filters, delimiter handling, and early rejection.
+// The follow-up help-behavior change owns help selection and printUpgradeHelp.
 func TestParseUpgradeArgs(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -56,6 +53,10 @@ func TestParseUpgradeArgs(t *testing.T) {
 			name:     "supported flags and filters preserved together (spec scenario)",
 			args:     []string{"--dry-run", "-n", "--no-backup", "tool-a", "tool-b"},
 			wantArgs: upgradeArgs{dryRun: true, noBackup: true, toolFilter: []string{"tool-a", "tool-b"}},
+		},
+		{
+			name: "delimiter preserves trailing dash-prefixed filters", args: []string{"--dry-run", "--", "--not-a-flag"},
+			wantArgs: upgradeArgs{dryRun: true, toolFilter: []string{"--not-a-flag"}},
 		},
 		{
 			name:      "unsupported long option rejected with exact token",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #535

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Rejects unsupported `gentle-ai upgrade` options before platform detection, update checks, backups, or execution.
- Parses supported upgrade flags and positional tool filters exactly once, preserving `--` delimiter behavior.
- Temporarily rejects `--help` and `-h` without side effects; the follow-up chain slice adds upgrade-specific help output.

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/app/app.go` | Moves upgrade argument validation before every effect and forwards parsed arguments without reparsing. |
| `internal/app/upgrade_args.go` | Adds the delimiter-aware upgrade argument parser and identifiable unsupported-option error. |
| `internal/app/upgrade_args_test.go` | Covers supported flags, filters, rejection, and exact-token errors. |
| `internal/app/app_test.go` | Proves unsupported options, `--help`, and `-h` stop before every effect. |
| `internal/app/update_test.go` | Verifies parsed flags and filters are forwarded exactly once. |

---

## 🧪 Test Plan

- [x] Focused parser, ordering, and forwarding tests pass.
- [x] `go test ./internal/app/...`
- [x] `go vet ./...`
- [x] `go build ./cmd/gentle-ai`
- [x] Isolated-HOME smoke checks confirm `--verbose`, `--help`, and `-h` exit non-zero with no filesystem effects.
- [ ] `go test ./...` — unrelated baseline failures remain outside `internal/app`.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | `issue-535-upgrade-validation` |
| Position | 1 of 2 |
| Base | `main` |
| Follow-up | Upgrade-specific `--help` / `-h` output after this slice merges |
| Review budget | 398 / 400 authored lines |

This slice is independently safe: unsupported options and help flags cannot reach upgrade side effects. The follow-up replaces the temporary help rejection with successful, delimiter-aware help output.

---

## ✅ Contributor Checklist

- [x] Linked an approved issue.
- [x] Kept the PR within 400 changed lines.
- [x] Selected exactly one PR type.
- [x] Added behavior-first tests.
- [x] Used Conventional Commits without `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the `upgrade` command with consistent support for `--dry-run/-n`, `--no-backup`, and tool filtering.
  * `--` now ends option parsing, allowing dash-prefixed tool names to be selected.

* **Bug Fixes**
  * Unsupported upgrade options are rejected immediately with a precise error before any upgrade actions occur.
  * Upgrade settings are applied consistently during checking and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->