### PR TITLE
fix(review): include --committed-only in compact START rerun hint

### DIFF
--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -380,7 +380,7 @@ const reviewGateFreshReviewContinuation = "run the fresh full review of the curr
 // of delivered history, so the continuation it names carries the base-ref
 // selector whose commit value only the operator knows.
 const reviewGateEmptyReceiptReason = "the terminal review receipt froze an empty candidate and covers no delivered content; " +
-	reviewGateFreshReviewContinuation + " --base-ref <commit>"
+	reviewGateFreshReviewContinuation + " --base-ref <commit> --committed-only"
 
 // reviewGateAmbiguousGovernanceReason is the one multi-receipt shape that
 // still blocks: several terminal receipts each exactly govern the identical

--- a/internal/sddstatus/review_gate_reason_test.go
+++ b/internal/sddstatus/review_gate_reason_test.go
@@ -1,0 +1,33 @@
+package sddstatus
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReviewGateEmptyReceiptReasonNamesBothSelectors proves issue #1924:
+// the empty-candidate receipt rerun hint must name both --base-ref and
+// --committed-only, matching the negotiated base-diff START validation in
+// validateReviewTransitionSelectorFlagCounts (review_facade.go:1680-1692)
+// and the recovery operation builder in ReviewGateDeniedError.Error()
+// (review.go:238-240).
+func TestReviewGateEmptyReceiptReasonNamesBothSelectors(t *testing.T) {
+	// The hint must name --base-ref <commit> AND --committed-only in that order.
+	// Without --committed-only the re-run lands on a stale_target_identity
+	// rejection even with the workspace unchanged.
+	if !strings.Contains(reviewGateEmptyReceiptReason, "--base-ref <commit>") {
+		t.Fatalf("reviewGateEmptyReceiptReason = %q, want it to contain %q", reviewGateEmptyReceiptReason, "--base-ref <commit>")
+	}
+	if !strings.Contains(reviewGateEmptyReceiptReason, "--committed-only") {
+		t.Fatalf("reviewGateEmptyReceiptReason = %q, want it to contain %q", reviewGateEmptyReceiptReason, "--committed-only")
+	}
+	// Verify order: --base-ref must appear before --committed-only.
+	baseRefIdx := strings.Index(reviewGateEmptyReceiptReason, "--base-ref <commit>")
+	committedIdx := strings.Index(reviewGateEmptyReceiptReason, "--committed-only")
+	if baseRefIdx == -1 || committedIdx == -1 {
+		t.Fatalf("reviewGateEmptyReceiptReason = %q, both selectors must be present", reviewGateEmptyReceiptReason)
+	}
+	if baseRefIdx > committedIdx {
+		t.Fatalf("reviewGateEmptyReceiptReason = %q, --base-ref must appear before --committed-only", reviewGateEmptyReceiptReason)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #1924

## 🏷️ PR Type
- [x] `type:bug` — pending maintainer (see `## Pending maintainer actions`)

## 📝 Summary
The empty-candidate receipt rerun hint (`reviewGateEmptyReceiptReason` in `internal/sddstatus/review_gate.go`) named `--base-ref <commit>` but omitted `--committed-only`. Re-running the suggested command landed on a `stale_target_identity` rejection even with an unchanged workspace, because the negotiated base-diff START validation in `validateReviewTransitionSelectorFlagCounts` (`internal/cli/review_facade.go:1684-1687`) requires both flags together. The hint now matches the validation rule and the recovery operation builder in `ReviewGateDeniedError.Error()` (`internal/cli/review.go:238-240`).

## 📂 Changes
| File | What Changed | Lines |
|------|--------------|-------|
| `internal/sddstatus/review_gate.go` | `reviewGateEmptyReceiptReason` now ends with `--base-ref <commit> --committed-only` (one-line constant change). | +1 / -1 |
| `internal/sddstatus/review_gate_reason_test.go` | New RED-first test `TestReviewGateEmptyReceiptReasonNamesBothSelectors` asserting both selectors are present and in order. | +33 / -0 |

Totals from `gh pr view --json additions,deletions,changedFiles`: **+34, -1, 2 files**.

## 🧪 Test Plan

**Local commands run (Windows):**
```bash
go test -count=1 -timeout 60s -run 'TestReviewGateEmptyReceiptReasonNamesBothSelectors' ./internal/sddstatus/...
# → ok github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus 1.524s

go vet ./internal/sddstatus/...
# → exit 0

go build ./...
# → exit 0

go run ./internal/gofmtcheck
# → exit 0
```

**CI checks observed at time of body revision:**
- ✅ Go Format
- ✅ Check PR Cognitive Load
- ✅ Check Issue Reference
- ✅ Check Issue Has `status:approved`
- ✅ E2E Tests (ubuntu, arch, fedora)
- ⏳ Unit Tests, Windows Runtime, Darwin Runtime, Organic Runtime E2E — in progress

**Pre-existing test hang (not caused by this PR):**
Running `go test ./internal/sddstatus/...` with a 60s timeout on Windows hits a pre-existing 60s+ hang in an unrelated test that uses `os/exec`. Verified on the clean baseline by `git stash`-ing this change before running the package. The new test `TestReviewGateEmptyReceiptReasonNamesBothSelectors` completes in <1s in isolation. CI may need a longer per-package timeout on Windows; this is a separate issue from #1924.

## ✅ Contributor Checklist
- [x] PR linked to issue #1924 (status:approved)
- [x] PR under 400 changed lines (+34, -1)
- [x] Unit tests pass for the new test (`go test -run TestReviewGateEmptyReceiptReasonNamesBothSelectors ./internal/sddstatus/...` → ok 1.5s)
- [x] `go vet ./internal/sddstatus/...` passes
- [x] `go build ./...` passes
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Conventional Commits format
- [x] No `Co-Authored-By` trailers
- [x] Branch name matches regex `fix/1924-base-diff-rerun-hint-flags`
- [ ] `type:bug` label applied — pending maintainer (see below)

## 💬 Notes for Reviewers
The fix mirrors the existing pattern in `internal/cli/review.go:238-240` and matches the negotiated base-diff START validation in `internal/cli/review_facade.go:1684-1687`. All other constant hints in `internal/sddstatus/review_gate.go` were already correct (verified by grep); this was the only orphan.

No exported items added, so docstring coverage requirement is not triggered.

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:bug` label applied to this PR — pending Alan (verified `gh pr edit --add-label type:bug` returns 403 `AddLabelsToLabelable` for this contributor)
- [ ] Fork workflow approval — `action_required` runs on first-time forks; once approved, all subsequent runs auto-approve
