### PR TITLE
fix(review): preserve selectors in compact START hints

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -127,10 +127,12 @@ const reviewStartEmptyCandidateHint = "the candidate has no pending changes; alr
 // and artifact_subjects that only the negotiated form returns, so the hint
 // names the exact rerun invocation, reusing this same response's own
 // target_identity and projection instead of only describing the requirement.
-func reviewStartNegotiateContractHint(targetIdentity string, projection reviewtransaction.Projection) string {
+func reviewStartNegotiateContractHint(snapshot reviewtransaction.Snapshot) string {
+	arguments := reviewStartArgumentsForTarget(snapshot.Identity, snapshot.Kind, facadeProjection(snapshot.Projection), snapshot.BaseTree, "")
+	command := reviewTransitionCommandLine("review.start", reviewTokenizedTransitionArguments(arguments))
 	return fmt.Sprintf(
-		"this response's selected lenses require the frozen candidate diff, changed-path manifest, and artifact subjects, which only the negotiated contract form returns; rerun with `gentle-ai review start --contract %s --target %s --projection %s` to receive them",
-		ReviewIntegrationContractV1, targetIdentity, projection,
+		"this response's selected lenses require the frozen candidate diff, changed-path manifest, and artifact subjects, which only the negotiated contract form returns; rerun with `%s` to receive them",
+		command,
 	)
 }
 
@@ -1588,7 +1590,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			case legacyResult.ChangedFiles == 0 && target.Kind == reviewtransaction.TargetCurrentChanges:
 				legacyResult.Hint = reviewStartEmptyCandidateHint
 			case legacyResult.LensesRequired:
-				legacyResult.Hint = reviewStartNegotiateContractHint(legacyResult.TargetIdentity, legacyResult.Projection)
+				legacyResult.Hint = reviewStartNegotiateContractHint(authority.InitialSnapshot)
 			}
 		}
 		return encodeReviewJSON(stdout, legacyResult)

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -375,16 +375,20 @@ type reviewTransitionSelector struct {
 }
 
 func reviewStartArguments(status ReviewTargetStatusResult, lineage string) []ReviewTransitionArgument {
+	return reviewStartArgumentsForTarget(status.TargetIdentity, status.Projection.Kind, status.Projection.Projection, status.Projection.BaseTree, lineage)
+}
+
+func reviewStartArgumentsForTarget(targetIdentity string, kind reviewtransaction.TargetKind, projection reviewtransaction.Projection, baseTree, lineage string) []ReviewTransitionArgument {
 	arguments := []ReviewTransitionArgument{
 		{Name: "contract", Value: ReviewIntegrationContractV1},
-		{Name: "target", Value: status.TargetIdentity},
-		{Name: "projection", Value: string(status.Projection.Projection)},
+		{Name: "target", Value: targetIdentity},
+		{Name: "projection", Value: string(projection)},
 	}
-	switch status.Projection.Kind {
+	switch kind {
 	case reviewtransaction.TargetBaseDiff:
-		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: status.Projection.BaseTree}, ReviewTransitionArgument{Name: "committed-only", Value: "true"})
+		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: baseTree}, ReviewTransitionArgument{Name: "committed-only", Value: "true"})
 	case reviewtransaction.TargetBaseWorkspaceOverlay:
-		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: status.Projection.BaseTree}, ReviewTransitionArgument{Name: "workspace-overlay", Value: "true"})
+		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: baseTree}, ReviewTransitionArgument{Name: "workspace-overlay", Value: "true"})
 	}
 	if strings.TrimSpace(lineage) != "" {
 		arguments = append(arguments, ReviewTransitionArgument{Name: "lineage", Value: lineage})

--- a/internal/cli/review_start_evidence_test.go
+++ b/internal/cli/review_start_evidence_test.go
@@ -308,8 +308,48 @@ func TestReviewFacadeStartLensesRequiredHintsNegotiatedContract(t *testing.T) {
 	if !started.LensesRequired || len(started.SelectedLenses) == 0 {
 		t.Fatalf("service-token start lenses_required = %v, selected_lenses = %v, want lenses selected", started.LensesRequired, started.SelectedLenses)
 	}
-	wantCommand := fmt.Sprintf("gentle-ai review start --contract %s --target %s --projection %s", ReviewIntegrationContractV1, started.TargetIdentity, started.Projection)
+	wantCommand := fmt.Sprintf("gentle-ai review start --contract=%s --target=%s --projection=%s", ReviewIntegrationContractV1, started.TargetIdentity, started.Projection)
 	if !strings.Contains(started.Hint, wantCommand) {
 		t.Fatalf("lenses-required start hint = %q, want it to contain %q", started.Hint, wantCommand)
+	}
+}
+
+func TestReviewFacadeStartBaseDiffHintResumesFrozenTarget(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'candidate'\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "service-token.ts")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base, "--committed-only"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	_, command, found := strings.Cut(started.Hint, "`")
+	if !found {
+		t.Fatalf("base-diff START hint does not contain a runnable command: %q", started.Hint)
+	}
+	command, _, found = strings.Cut(command, "`")
+	if !found {
+		t.Fatalf("base-diff START hint does not terminate its runnable command: %q", started.Hint)
+	}
+	argv := strings.Fields(command)
+	if len(argv) < 3 || !reflect.DeepEqual(argv[:3], []string{"gentle-ai", "review", "start"}) {
+		t.Fatalf("base-diff START hint command = %q", command)
+	}
+
+	var rerunOutput bytes.Buffer
+	args := append(append([]string(nil), argv[2:]...), "--cwd="+repo)
+	if err := RunReview(args, &rerunOutput); err != nil {
+		t.Fatalf("run emitted base-diff START hint: %v\n%s", err, rerunOutput.String())
+	}
+	rerun := decodeNegotiatedReviewStart(t, rerunOutput.Bytes())
+	if rerun.Action != string(reviewtransaction.CompactStartResumed) || rerun.LineageID != started.LineageID ||
+		len(rerun.ArtifactSubjects) == 0 || rerun.ArtifactSubjects[0].TargetIdentity != started.TargetIdentity {
+		t.Fatalf("emitted hint resumed %#v, want lineage %q and target %q", rerun, started.LineageID, started.TargetIdentity)
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #1924

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Compact START hints now use canonical selector-aware argument generation.
- Base-diff hints include `--base-ref` and `--committed-only`.
- Stale-target validation remains strict.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Builds compact START hints from the frozen snapshot through canonical argument and command rendering. |
| `internal/cli/review_next_transition.go` | Shares selector-aware START argument generation across transition and hint paths. |
| `internal/cli/review_start_evidence_test.go` | Adds a base-diff hint roundtrip regression and updates canonical command expectations. |

---

## Test Plan

Successful commands:

```bash
git diff --check
go test ./internal/cli -run 'TestReviewFacadeStart(LensesRequiredHintsNegotiatedContract|BaseDiffHintResumesFrozenTarget)$' -count=1
go test ./internal/cli -count=1
go test ./...
```

The regression test proves that the emitted compact base-diff hint resumes the same lineage and frozen target.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

Docker E2E was not run; the affected CLI behavior is covered by focused, package, and full Go test suites.

---

## Automated Checks

The repository's automated PR checks should validate issue approval, cognitive load, type labeling, formatting, unit tests, and E2E behavior.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

- [x] Challenged the strict stale-target integrity guard against the base-diff rerun population represented by Issue #1924 and the new roundtrip regression.
- [x] Confirmed the existing `guard:population` direction and claim remain unchanged and accurate.
- [x] Confirmed `.guard-population-baseline.txt` is unchanged because the guard contract remains strict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review start hints now generate accurate, runnable restart commands, including correct contract/target/projection and base-diff options.
  * Negotiated-contract-required hints now use consistent `--flag=value` formatting.
  * Hints preserve the correct workspace-overlay/committed-only behavior and lineage details when resuming.
* **Tests**
  * Added coverage to confirm base-diff review hints resume the original frozen target and retain its lineage, with a runnable command round-trip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->