### PR TITLE
fix(review): classify escalated_recovery_authorization_inexact as typed pre_native failure

### DIFF
--- a/bench/axis_damaged_store.go
+++ b/bench/axis_damaged_store.go
@@ -497,6 +497,8 @@ const (
 	scratchLiveSnapshot        = "damaged-store/live-snapshot"
 )
 
+const scratchDamagedAuthorityBeforeFinalize = "damaged-store/authority-before-finalize"
+
 // The successor names are the operator's to choose, so this axis chooses two
 // and keeps them stable across runs.
 const (
@@ -1183,7 +1185,49 @@ func proveStoreRecovered(r *journeyRun) error {
 // proveStoreStillDamaged is its mirror, for the steps that claim an operation
 // changed nothing.
 func proveStoreStillDamaged(r *journeyRun) error {
-	return requireDamagedStoreReportsItsDamage(r.sandbox)
+	if err := requireDamagedStoreReportsItsDamage(r.sandbox); err != nil {
+		return err
+	}
+	before, captured := r.sandbox.Scratch[scratchDamagedAuthorityBeforeFinalize]
+	if !captured {
+		return nil
+	}
+	lineage, err := scratchValue(r.sandbox, scratchSuccessor)
+	if err != nil {
+		return err
+	}
+	path, err := storeStatePath(r.sandbox, lineage)
+	if err != nil {
+		return err
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read damaged authority after failed FINALIZE: %w", err)
+	}
+	if !bytes.Equal([]byte(before), after) {
+		return errors.New("failed FINALIZE changed the damaged authority bytes")
+	}
+	return nil
+}
+
+// captureDamagedAuthorityBytes records the exact persisted successor before
+// ds14 crosses the public FINALIZE boundary. The follow-up proof still checks
+// that the store remains invalid, then verifies this record was untouched.
+func captureDamagedAuthorityBytes(sandbox *Sandbox) error {
+	lineage, err := scratchValue(sandbox, scratchSuccessor)
+	if err != nil {
+		return err
+	}
+	path, err := storeStatePath(sandbox, lineage)
+	if err != nil {
+		return err
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read damaged authority before FINALIZE: %w", err)
+	}
+	sandbox.Scratch[scratchDamagedAuthorityBeforeFinalize] = string(payload)
+	return nil
 }
 
 // repairAssessment is the subset of `review repair --preflight` that says
@@ -2048,6 +2092,7 @@ func damagedStoreJourneys() []Journey {
 			// mutation that never started.
 			Steps: []Step{
 				{Name: "fixture: non-pristine successor with a schema-prefixed mismatched authorization", Fixture: damagedEdgeWithResults},
+				{Name: "capture the damaged authority before FINALIZE", Fixture: captureDamagedAuthorityBytes},
 				{Name: "negotiate FINALIZE over the damaged successor", Requires: finalizeAuthorizationFailureCapability,
 					Args:  damagedSuccessorFinalizeArgs,
 					After: requireTypedAuthorizationMismatchFailure},

--- a/bench/axis_damaged_store.go
+++ b/bench/axis_damaged_store.go
@@ -1680,6 +1680,11 @@ var repairDispositionExecuteCapability = &Capability{
 	Flags: []string{"--cwd", "--plan-digest", "--inventory-revision", "--actor", "--reason", "--authorization"},
 }
 
+var finalizeAuthorizationFailureCapability = &Capability{
+	Verb:  []string{"review", "finalize"},
+	Flags: []string{"--cwd", "--contract", "--lineage", "--captured-results"},
+}
+
 // ---------------------------------------------------------------------------
 // Corpus
 // ---------------------------------------------------------------------------
@@ -2031,7 +2036,58 @@ func damagedStoreJourneys() []Journey {
 						invalidEdgesWithNoAnomalyClass(1))},
 			},
 		},
+		{
+			ID:     "ds14-finalize-authorization-mismatch-is-typed",
+			Title:  "A real FINALIZE over a schema-prefixed authorization mismatch is typed before mutation and names review repair",
+			Source: "issue #1928: review finalize must classify pre-native recovery authorization failures and expose the current review.repair route",
+			// The fixture reproduces the issue's original boundary: the successor
+			// already contains product-captured reviewer output, but its recorded
+			// schema-prefixed authorization binds a reason different from the one
+			// persisted in the recovery provenance. FINALIZE must fail while
+			// validating that edge, not report operation_outcome_unknown after a
+			// mutation that never started.
+			Steps: []Step{
+				{Name: "fixture: non-pristine successor with a schema-prefixed mismatched authorization", Fixture: damagedEdgeWithResults},
+				{Name: "negotiate FINALIZE over the damaged successor", Requires: finalizeAuthorizationFailureCapability,
+					Args:  damagedSuccessorFinalizeArgs,
+					After: requireTypedAuthorizationMismatchFailure},
+				{Name: "the failed FINALIZE did not mutate the damaged authority", Composite: proveStoreStillDamaged},
+			},
+		},
 	}, closureDispositionJourneys()...)
+}
+
+func damagedSuccessorFinalizeArgs(sandbox *Sandbox) ([]string, error) {
+	lineage, err := scratchValue(sandbox, scratchSuccessor)
+	if err != nil {
+		return nil, err
+	}
+	return []string{"review", "finalize", "--contract", reviewContract, "--lineage", lineage, "--captured-results=true", "--cwd", sandbox.Repo}, nil
+}
+
+type typedAuthorizationMismatchFailure struct {
+	Operation       string `json:"operation"`
+	Code            string `json:"code"`
+	Phase           string `json:"phase"`
+	MutationOutcome string `json:"mutation_outcome"`
+	NextAction      string `json:"next_action"`
+	Cause           string `json:"cause"`
+}
+
+func requireTypedAuthorizationMismatchFailure(_ *Sandbox, observation Observation) error {
+	if observation.ExitCode == 0 {
+		return errors.New("review finalize succeeded over the damaged authorization")
+	}
+	var failure typedAuthorizationMismatchFailure
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &failure); err != nil {
+		return fmt.Errorf("parse negotiated finalize failure: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if failure.Operation != "review.finalize" || failure.Code != "escalated_recovery_authorization_inexact" ||
+		failure.Phase != "pre_native" || failure.MutationOutcome != "not_started" || failure.NextAction != "review.repair" ||
+		failure.Cause == "" || strings.Contains(observation.Stdout, "operation_outcome_unknown") || strings.Contains(observation.Stdout, "reconcile-authority") {
+		return fmt.Errorf("negotiated finalize failure = %#v, want typed pre-native repair route", failure)
+	}
+	return nil
 }
 
 // requireUnrelatedTargetIsRouted is ds13's measurement. The negotiated surface

--- a/internal/cli/review_damaged_store_denial_test.go
+++ b/internal/cli/review_damaged_store_denial_test.go
@@ -482,3 +482,36 @@ func TestReclaimRefusalOverTruncatedRecordNamesDiagnosisNotReconcile(t *testing.
 		t.Fatalf("the named diagnosis does not answer with the claimed damage: %#v", report)
 	}
 }
+
+func TestNegotiatedFinalizeClassifiesNamedDamagedAuthorization(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	_, successor := mintDamagedStoreRecoveryPair(t, repo)
+	forgeDamagedStoreRecoveryReason(t, repo, successor)
+	statePath := filepath.Join(damagedStoreLineageDir(t, repo, successor), "review-state.json")
+	before, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	runErr := RunReview([]string{"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", successor, "--captured-results"}, &output)
+	if runErr == nil {
+		t.Fatal("negotiated finalize accepted a named damaged authorization")
+	}
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Operation != ReviewIntegrationOperationFinalize || failure.Code != "escalated_recovery_authorization_inexact" ||
+		failure.Phase != "pre_native" || failure.MutationOutcome != ReviewMutationNotStarted ||
+		failure.NextAction != "review.repair" || failure.RetrySafe ||
+		failure.Replayability != reviewtransaction.ReplayabilityManualActionRequired ||
+		strings.Contains(output.String(), "operation_outcome_unknown") || strings.Contains(output.String(), "reconcile-authority") {
+		t.Fatalf("named damaged authorization failure = %#v\n%s", failure, output.String())
+	}
+	after, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("typed pre-native finalize changed the damaged authority bytes")
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2500,6 +2500,9 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 			current = current || leaf.StatePath() == store.StatePath()
 		}
 		if !current {
+			if blocked := reviewtransaction.CompactAuthorityLineageBlocked(ctx, root, *lineage); blocked != nil {
+				return blocked
+			}
 			return fmt.Errorf("review lineage %q is superseded", *lineage)
 		}
 	}

--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -1146,6 +1146,50 @@ func TestNewReviewIntegrationFailureCause(t *testing.T) {
 	}
 }
 
+func TestEscalatedRecoveryAuthorizationInexactUsesCurrentRepairRoute(t *testing.T) {
+	tests := []struct {
+		name           string
+		repairable     bool
+		wantNextAction string
+		wantMessage    string
+	}{
+		{
+			name:           "schema-prefixed content mismatch",
+			repairable:     true,
+			wantNextAction: "review.repair",
+			wantMessage:    "run review repair",
+		},
+		{
+			name:           "pre-contract authorization",
+			repairable:     false,
+			wantNextAction: "stop",
+			wantMessage:    "no advertised repair operation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runErr := fmt.Errorf("invalid compact authority graph: %w", &reviewtransaction.CompactRecoveryAuthorizationInexactError{
+				Projection: reviewtransaction.ProjectionWorkspace, TargetIdentity: "sha256:" + strings.Repeat("a", 64), Repairable: tt.repairable,
+			})
+			failure := newReviewIntegrationFailure(
+				ReviewIntegrationOperationFinalize,
+				[]string{"--lineage", "review-authorization-route"},
+				runErr,
+			)
+			if failure.Code != "escalated_recovery_authorization_inexact" || failure.Phase != "pre_native" ||
+				failure.MutationOutcome != ReviewMutationNotStarted || failure.AuthorityApplicability != "current_target" ||
+				failure.RetrySafe || failure.Replayability != reviewtransaction.ReplayabilityManualActionRequired ||
+				failure.NextAction != tt.wantNextAction || !strings.Contains(failure.Message, tt.wantMessage) ||
+				failure.NextAction == "reconcile-authority" || failure.Cause == "" {
+				t.Fatalf("authorization failure = %#v", failure)
+			}
+			if err := failure.Validate(); err != nil {
+				t.Fatalf("authorization failure validation = %v", err)
+			}
+		})
+	}
+}
+
 func decodeReviewIntegrationFailure(t *testing.T, payload []byte) ReviewIntegrationFailure {
 	t.Helper()
 	decoder := json.NewDecoder(bytes.NewReader(payload))

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -496,6 +496,23 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		failure.NextAction = "review.status"
 		return failure
 	}
+	var authorizationInexact *reviewtransaction.CompactRecoveryAuthorizationInexactError
+	if errors.As(runErr, &authorizationInexact) {
+		failure.Phase = "pre_native"
+		failure.Code = "escalated_recovery_authorization_inexact"
+		failure.MutationOutcome = ReviewMutationNotStarted
+		failure.AuthorityApplicability = "current_target"
+		failure.RetrySafe = false
+		failure.Replayability = reviewtransaction.ReplayabilityManualActionRequired
+		if authorizationInexact.Repairable {
+			failure.Message = "The escalated recovery authority carries a schema-prefixed authorization that does not match the exact binding; run review repair to derive the provider-owned disposition."
+			failure.NextAction = "review.repair"
+		} else {
+			failure.Message = "The escalated recovery authority carries an authorization that does not match the exact binding; no advertised repair operation admits this shape."
+			failure.NextAction = "stop"
+		}
+		return failure
+	}
 	var bindingConflict *sddstatus.BindingRevisionConflictError
 	if errors.As(runErr, &bindingConflict) {
 		failure.Phase = "pre_native"

--- a/internal/reviewtransaction/compact_fixture_test.go
+++ b/internal/reviewtransaction/compact_fixture_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -149,6 +150,8 @@ func TestClassifyCompactRecoveryEdgeAnomalies(t *testing.T) {
 		wantRefusal             string
 		wantAuthorizationDigest bool
 		wantDispositionClass    string
+		checkRepairability      bool
+		wantRepairable          bool
 	}{
 		{name: "valid edge", wantValid: true},
 		{
@@ -164,6 +167,7 @@ func TestClassifyCompactRecoveryEdgeAnomalies(t *testing.T) {
 				successor.State.Recovery.MaintainerAuthorization = preContractFixtureAuthorization
 			},
 			wantAnomalies: compactRecoveryEdgeMalformedAuthorization, wantAuthorizationDigest: true,
+			checkRepairability: true,
 		},
 		{
 			name: "dual anomaly in canonical order",
@@ -204,6 +208,8 @@ func TestClassifyCompactRecoveryEdgeAnomalies(t *testing.T) {
 			},
 			wantRefusal:          "corruption, not a pre-contract authorization",
 			wantDispositionClass: compactContentMismatchedRecoveryAuthorizationClass,
+			checkRepairability:   true,
+			wantRepairable:       true,
 		},
 	}
 
@@ -237,6 +243,15 @@ func TestClassifyCompactRecoveryEdgeAnomalies(t *testing.T) {
 			}
 			if got.DispositionClass != tt.wantDispositionClass {
 				t.Fatalf("disposition class = %q, want %q", got.DispositionClass, tt.wantDispositionClass)
+			}
+			if tt.checkRepairability {
+				var authorizationErr *CompactRecoveryAuthorizationInexactError
+				if !errors.As(got.ValidationError, &authorizationErr) {
+					t.Fatalf("validation error = %T %v, want authorization error", got.ValidationError, got.ValidationError)
+				}
+				if authorizationErr.Repairable != tt.wantRepairable {
+					t.Fatalf("authorization repairable = %t, want %t", authorizationErr.Repairable, tt.wantRepairable)
+				}
 			}
 			wantDigest := ""
 			if tt.wantAuthorizationDigest {

--- a/internal/reviewtransaction/compact_fixture_test.go
+++ b/internal/reviewtransaction/compact_fixture_test.go
@@ -197,7 +197,7 @@ func TestClassifyCompactRecoveryEdgeAnomalies(t *testing.T) {
 		},
 		{
 			// The other content-mismatch branch:
-			// errCompactRecoveryAuthorizationInexact with a schema-prefixed but
+			// ErrCompactRecoveryAuthorizationInexact with a schema-prefixed but
 			// wrong-content authorization.
 			name: "schema-prefixed different-content authorization is non-reconcilable corruption",
 			mutate: func(_ CompactRecord, successor *CompactRecord) {

--- a/internal/reviewtransaction/compact_reconcile.go
+++ b/internal/reviewtransaction/compact_reconcile.go
@@ -38,10 +38,11 @@ type compactRecoveryEdgeClassification struct {
 	// authorization bound to different content than the successor's own
 	// recorded fields. It is deliberately NOT surfaced on
 	// CompactRecoveryEdgeInspection.AnomalyClasses -- that would advertise a
-	// `review reconcile-authority` continuation this edge would then refuse
-	// (design decision 2) -- so CompactRecoveryEdgeInspection's JSON stays
-	// byte-identical. A caller that needs it re-derives classification
-	// directly from records, exactly as deriveAuthorityDispositionPlan does.
+	// continuation outside that inspection vocabulary (design decision 2) -- so
+	// CompactRecoveryEdgeInspection's JSON stays byte-identical. A caller that
+	// needs it re-derives classification directly from records, exactly as
+	// deriveAuthorityDispositionPlan does; the negotiated failure surface routes
+	// this closed class through `review.repair`.
 	DispositionClass string
 }
 

--- a/internal/reviewtransaction/compact_reconcile.go
+++ b/internal/reviewtransaction/compact_reconcile.go
@@ -108,7 +108,7 @@ func classifyCompactRecoveryEdgeAnomalies(predecessor, successor CompactRecord) 
 		recorded := sha256.Sum256([]byte(recovery.MaintainerAuthorization))
 		classification.RecordedAuthorizationSHA256 = "sha256:" + hex.EncodeToString(recorded[:])
 		return classification
-	case errors.Is(edgeErr, errCompactRecoveryAuthorizationInexact):
+	case errors.Is(edgeErr, ErrCompactRecoveryAuthorizationInexact):
 		if strings.HasPrefix(recovery.MaintainerAuthorization, compactRecoveryAuthorizationSchema) {
 			classification.NonReconcilableError = fmt.Errorf("successor %q records a %s binding bound to different content; that is corruption, not a pre-contract authorization", successor.State.LineageID, compactRecoveryAuthorizationSchema)
 			classification.DispositionClass = compactContentMismatchedRecoveryAuthorizationClass

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -81,9 +81,31 @@ func RecoveryPredecessorNotInvalidated(err error) bool {
 }
 
 // errCompactRecoveryAuthorizationInexact identifies the escalated-recovery
-// authorization-binding anomaly so reconcile-authority can gate quarantine of
-// historical pre-contract free-form authorizations to exactly this class.
+// authorization-binding anomaly. The public error below preserves whether the
+// current disposition planner admits the recorded authorization shape.
 var errCompactRecoveryAuthorizationInexact = errors.New("escalated recovery requires an exact maintainer authorization binding")
+
+// CompactRecoveryAuthorizationInexactError identifies a recovery edge whose
+// authorization does not bind the exact predecessor, successor, actor, and
+// reason. Repairable is true only for the schema-prefixed content-mismatch
+// class admitted by the current provider-owned disposition plan.
+type CompactRecoveryAuthorizationInexactError struct {
+	Projection     Projection
+	TargetIdentity string
+	Repairable     bool
+}
+
+func (err *CompactRecoveryAuthorizationInexactError) Error() string {
+	projection := err.Projection
+	if projection == "" {
+		projection = ProjectionWorkspace
+	}
+	return fmt.Sprintf("%s (projection=%s target_identity=%s)", errCompactRecoveryAuthorizationInexact, projection, err.TargetIdentity)
+}
+
+func (err *CompactRecoveryAuthorizationInexactError) Unwrap() error {
+	return errCompactRecoveryAuthorizationInexact
+}
 
 // compactRecoveryAuthorizationSchema is the first line of the exact six-line
 // escalated-recovery maintainer authorization binding.
@@ -310,7 +332,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) &&
 		!stagedScopeRecovery &&
 		request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
-		return CompactRecord{}, compactRecoveryAuthorizationError(request.Successor.InitialSnapshot)
+		return CompactRecord{}, compactRecoveryAuthorizationError(request.Successor.InitialSnapshot, request.MaintainerAuthorization)
 	}
 	// Every shape the three comparisons above do not cover still records the
 	// caller's authorization verbatim in the provenance below, so a supplied
@@ -321,7 +343,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 		!compactRecoverySuppliedAuthorizationBinds(request.MaintainerAuthorization, request.PredecessorLineageID,
 			predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Successor.LineageID,
 			request.Actor, request.Reason) {
-		return CompactRecord{}, compactRecoveryAuthorizationError(request.Successor.InitialSnapshot)
+		return CompactRecord{}, compactRecoveryAuthorizationError(request.Successor.InitialSnapshot, request.MaintainerAuthorization)
 	}
 	existing, existingErr := successorStore.Load()
 	if existingErr != nil && !os.IsNotExist(existingErr) {
@@ -584,7 +606,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 				return errCompactApprovedRecoveryScopeUnchanged
 			}
 			if forgedSchemaAuthorization() {
-				return compactRecoveryAuthorizationError(next)
+				return compactRecoveryAuthorizationError(next, recovery.MaintainerAuthorization)
 			}
 		case StateCorrectionRequired:
 			if strings.TrimSpace(recovery.MaintainerAuthorization) == "" {
@@ -603,7 +625,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 				}
 			}
 			if forgedSchemaAuthorization() {
-				return compactRecoveryAuthorizationError(successor.InitialSnapshot)
+				return compactRecoveryAuthorizationError(successor.InitialSnapshot, recovery.MaintainerAuthorization)
 			}
 			if !compactRecoveryAddsGenesisPath(predecessor.State, successor.InitialSnapshot) &&
 				!compactRecoveryContractsGenesisPaths(predecessor.State, successor.InitialSnapshot) {
@@ -617,12 +639,12 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 			return errCompactRecoveryPredecessorNotInvalidated
 		}
 		if forgedSchemaAuthorization() {
-			return compactRecoveryAuthorizationError(successor.InitialSnapshot)
+			return compactRecoveryAuthorizationError(successor.InitialSnapshot, recovery.MaintainerAuthorization)
 		}
 	case RecoveryEscalated:
 		if recovery.Evidence != nil {
 			if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
-				return compactRecoveryAuthorizationError(successor.InitialSnapshot)
+				return compactRecoveryAuthorizationError(successor.InitialSnapshot, recovery.MaintainerAuthorization)
 			}
 			if err := validateCompactRecoveredEvidenceEdge(predecessor, successor); err != nil {
 				return err
@@ -637,7 +659,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 			return errCompactRecoveryTargetUnchanged
 		}
 		if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
-			return compactRecoveryAuthorizationError(successor.InitialSnapshot)
+			return compactRecoveryAuthorizationError(successor.InitialSnapshot, recovery.MaintainerAuthorization)
 		}
 	case RecoveryFinalVerificationRetry:
 		return validateCompactFinalVerificationRetryEdge(predecessor, successor)
@@ -706,12 +728,15 @@ func sameRecoveryProjection(left, right Projection) bool {
 	return left == right
 }
 
-func compactRecoveryAuthorizationError(snapshot Snapshot) error {
+func compactRecoveryAuthorizationError(snapshot Snapshot, authorization string) error {
 	projection := snapshot.Projection
 	if projection == "" {
 		projection = ProjectionWorkspace
 	}
-	return fmt.Errorf("%w (projection=%s target_identity=%s)", errCompactRecoveryAuthorizationInexact, projection, snapshot.Identity)
+	return &CompactRecoveryAuthorizationInexactError{
+		Projection: projection, TargetIdentity: snapshot.Identity,
+		Repairable: strings.HasPrefix(authorization, compactRecoveryAuthorizationSchema),
+	}
 }
 
 func compactRecoveryAddsGenesisPath(predecessor CompactState, live Snapshot) bool {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -80,10 +80,10 @@ func RecoveryPredecessorNotInvalidated(err error) bool {
 	return errors.Is(err, errCompactRecoveryPredecessorNotInvalidated)
 }
 
-// errCompactRecoveryAuthorizationInexact identifies the escalated-recovery
-// authorization-binding anomaly. The public error below preserves whether the
+// ErrCompactRecoveryAuthorizationInexact identifies the escalated-recovery
+// authorization-binding anomaly. The typed error below preserves whether the
 // current disposition planner admits the recorded authorization shape.
-var errCompactRecoveryAuthorizationInexact = errors.New("escalated recovery requires an exact maintainer authorization binding")
+var ErrCompactRecoveryAuthorizationInexact = errors.New("escalated recovery requires an exact maintainer authorization binding")
 
 // CompactRecoveryAuthorizationInexactError identifies a recovery edge whose
 // authorization does not bind the exact predecessor, successor, actor, and
@@ -100,11 +100,11 @@ func (err *CompactRecoveryAuthorizationInexactError) Error() string {
 	if projection == "" {
 		projection = ProjectionWorkspace
 	}
-	return fmt.Sprintf("%s (projection=%s target_identity=%s)", errCompactRecoveryAuthorizationInexact, projection, err.TargetIdentity)
+	return fmt.Sprintf("%s (projection=%s target_identity=%s)", ErrCompactRecoveryAuthorizationInexact, projection, err.TargetIdentity)
 }
 
 func (err *CompactRecoveryAuthorizationInexactError) Unwrap() error {
-	return errCompactRecoveryAuthorizationInexact
+	return ErrCompactRecoveryAuthorizationInexact
 }
 
 // compactRecoveryAuthorizationSchema is the first line of the exact six-line

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -443,7 +443,7 @@ func TestAccountingOnlyEscalationRecoveryStillRequiresMaintainerAuthorization(t 
 		Successor: successor, Disposition: RecoveryEscalated, Reason: reason, Actor: actor,
 		MaintainerAuthorization: "wrong-authorization",
 	})
-	if err == nil || !errors.Is(err, errCompactRecoveryAuthorizationInexact) {
+	if err == nil || !errors.Is(err, ErrCompactRecoveryAuthorizationInexact) {
 		t.Fatalf("accounting-only recovery without exact maintainer authorization = %v, want authorization error", err)
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #1928

Issue #1928 is OPEN and has the `status:approved` label. The separate authority-disposition work tracked by #2014 remains out of scope.

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)

## Summary

- Classify escalated recovery authorization mismatches as typed failures before native authority mutation.
- Route repairable schema-prefixed content mismatches to `review.repair`; route non-repairable authorization shapes to `stop`.
- Preserve the exact failure cause and add public/runtime regression evidence for the negotiated FINALIZE boundary.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_store.go` | Add `CompactRecoveryAuthorizationInexactError` with projection, target identity, repairability, and exported `errors.Is` sentinel support. |
| `internal/reviewtransaction/compact_reconcile.go` | Preserve the distinct `content_mismatched_recovery_authorization` disposition class and document the current repair route. |
| `internal/cli/review_operation_contract.go` | Emit `pre_native`, `not_started`, `escalated_recovery_authorization_inexact` failures with `review.repair` or `stop`. |
| `internal/cli/review_facade.go` | Return the scoped blocked-lineage cause before the generic superseded-lineage fallback. |
| `internal/reviewtransaction/compact_fixture_test.go`, `internal/reviewtransaction/target_status_test.go` | Cover repairability and exported sentinel matching. |
| `internal/cli/review_failure_contract_test.go`, `internal/cli/review_damaged_store_denial_test.go` | Cover the negotiated failure envelope and unchanged damaged authority. |
| `bench/axis_damaged_store.go` | Add issue-linked `ds14-finalize-authorization-mismatch-is-typed`, including exact `review-state.json` byte preservation across failed FINALIZE. |

The current diff is 9 files with 260 additions and 21 deletions, below the 400-line review limit. This branch was rebased onto the exact `main` snapshot `f5650350d7c63d1bef34ac84740aefddb027f01c`. Live `main` later advanced to `69ac5a45534c9c6e3573607ee3a60b30c53d4aed`; GitHub reports this PR clean, so no second rebase was performed.

## Verification

### Focused and Full Go Tests

- [x] `go test -count=1 ./internal/reviewtransaction ./internal/cli`
- [x] Full `go test -count=1 ./...` with fresh isolated HOME, XDG directories, and GOCACHE
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`

The shared default HOME still reproduces three unrelated `internal/sddstatus` review-offer failures; the isolated full suite passes all packages, including `internal/sddstatus`. The changed packages pass in both environments.

### Benchmark Validation

- [x] `go build -trimpath -o <temporary>/gentle-ai ./cmd/gentle-ai`
- [x] `go -C bench build -o <temporary>/gentle-ai-bench .`
- [x] `go -C bench vet ./...`
- [x] `go -C bench test -count=1 ./...`
- [x] Driven `ds14-finalize-authorization-mismatch-is-typed`: 1 completed, 0 unsupported, 0 failed; one expected pre-native in-band block, `review.repair`, exact persisted authority bytes unchanged, and no Git calls.
- [x] Full damaged-store axis: 109 journeys, 103 completed, 6 unsupported crash-interruption journeys, 0 failed.

### Hosted Checks

- [x] Final-head hosted validation passed for corrective commit `20e75fbc`: issue approval/reference, cognitive load, type label, workflow scripts, Go Format, Unit Tests, Darwin/Windows runtime, all E2E lanes, all Organic Runtime E2E lanes, and CodeRabbit.

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Existing `type:bug` label is the only `type:*` label
- [x] Focused and isolated full unit tests pass
- [x] Go format check passes
- [x] Hosted E2E and runtime checks pass on the final rebased head
- [x] Benchmark validation is complete, including `ds14`
- [x] Documentation/comments were updated where behavior changed
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers

## Notes for Reviewers

- The failure occurs before native authority mutation, so `mutation_outcome` is `not_started` rather than unknown.
- Schema-prefixed content mismatches are the only repairable class advertised by this branch. Neighboring non-repairable shapes remain fail-closed with `stop`.
- Receipt-driven development remains disabled and unmanaged; no lifecycle command is required by this change.