### PR TITLE
fix(review): reject results when candidate input is unreadable or denied by filesystem

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -629,6 +629,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, frozenLineageResumeJourneys()...)
 	journeys = append(journeys, issue1800Journeys()...)
 	journeys = append(journeys, managedAssetJourneys()...)
+	journeys = append(journeys, unreadableCaptureJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -46,6 +46,7 @@ func journeySources() []journeySource {
 		{"journeys_frozen_lineage_resume.go", frozenLineageResumeJourneys()},
 		{"journeys_issue1800.go", issue1800Journeys()},
 		{"journeys_managed_assets.go", managedAssetJourneys()},
+		{"journeys_unreadable_capture.go", unreadableCaptureJourneys()},
 	}
 }
 

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,7 +36,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 85 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 88 total after j94's #1867 unreadable/truncated capture recovery journey,
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,7 +36,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 90 total after j94's #1867 unreadable/truncated capture recovery journey,
+	// 90 total after j94's #1867 unreadable/truncated capture recovery journey; j92 is absent from the current corpus and has no journey definition.
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,7 +36,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 88 total after j94's #1867 unreadable/truncated capture recovery journey,
+	// 90 total after j94's #1867 unreadable/truncated capture recovery journey,
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-
@@ -60,8 +60,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	//
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 89 {
-		t.Errorf("core journey count = %d, want 89", got)
+	if got := len(seen); got != 90 {
+		t.Errorf("core journey count = %d, want 90", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/journeys_unreadable_capture.go
+++ b/bench/journeys_unreadable_capture.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// j94 is the public/runtime replay for #1867. It spends two failed reviewer
+// submissions on one frozen slot: a schema-valid zero-finding result that says
+// the candidate was unreadable, and a response ending inside JSON. Neither
+// failure may advance authority; a complete retry must still use that slot.
+func unreadableCaptureJourneys() []Journey {
+	return []Journey{{
+		ID:     "j94-review-rejects-unreadable-and-truncated-capture",
+		Title:  "Unreadable candidate and truncated capture fail closed, then recapture",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/1867",
+		Steps: []Step{
+			{Name: "fixture: repo", Fixture: baseRepo},
+			{Name: "fixture: stage auth code", Fixture: stageAuthCode},
+			{Name: "review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
+			{Name: "reject unreadable and truncated results, then recapture", Requires: captureResultCapability, Composite: exerciseUnreadableCaptureRecovery},
+		},
+	}}
+}
+
+func exerciseUnreadableCaptureRecovery(r *journeyRun) error {
+	envelope, err := readStatus(r)
+	if err != nil {
+		return err
+	}
+	if envelope.NextTransition.Kind != "collect" || len(envelope.NextTransition.Collect.Inputs) == 0 {
+		return errors.New("expected reviewer-result collect transitions")
+	}
+	input := envelope.NextTransition.Collect.Inputs[0]
+	if input.Name != "reviewer_result" || input.ArtifactSubject.SubjectHash == "" || len(envelope.paths()) == 0 {
+		return fmt.Errorf("reviewer collect input is incomplete: %#v", input)
+	}
+	initialRevision := envelope.Authority.Revision
+	args := func(path string) []string {
+		return []string{
+			"review", "capture-result", "--cwd", r.sandbox.Repo,
+			"--lineage", envelope.argument("lineage"), "--target", envelope.argument("target"),
+			"--expected-revision", envelope.argument("expected-revision"), "--lens", envelope.argument("lens"),
+			"--order", envelope.argument("order"), "--input", path,
+		}
+	}
+	assertStillCollecting := func(label string) error {
+		after, statusErr := readStatus(r)
+		if statusErr != nil {
+			return statusErr
+		}
+		if after.Authority.Revision != initialRevision || after.NextTransition.Kind != "collect" ||
+			after.argument("lineage") != envelope.argument("lineage") || after.argument("lens") != envelope.argument("lens") ||
+			after.argument("order") != envelope.argument("order") {
+			return fmt.Errorf("%s changed the authority or collect binding: before revision=%q after=%#v", label, initialRevision, after)
+		}
+		return nil
+	}
+
+	unreadable, err := json.Marshal(map[string]any{
+		"subject_hash": input.ArtifactSubject.SubjectHash,
+		"inspection":   map[string]any{"status": "completed", "paths": envelope.paths()},
+		"findings":     []any{},
+		"evidence":     []string{"candidate input read denied by filesystem; inspection could not occur"},
+	})
+	if err != nil {
+		return err
+	}
+	unreadable = append(unreadable, '\n')
+	path, err := writeScratch(r.sandbox, "reviewer-unreadable.json", unreadable)
+	if err != nil {
+		return err
+	}
+	observation := r.run(args(path), true)
+	if observation.ExitCode == 0 || !strings.Contains(observation.Stderr+observation.Stdout, "candidate_input_unreadable") {
+		return fmt.Errorf("unreadable candidate result = exit %d, stderr=%q", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	if err := assertStillCollecting("unreadable candidate result"); err != nil {
+		return err
+	}
+
+	valid, err := synthesizeReviewerResult(input.ArtifactSubject.SubjectHash, envelope.paths())
+	if err != nil {
+		return err
+	}
+	if len(valid) < 2 {
+		return errors.New("synthesized reviewer result is too short to truncate")
+	}
+	truncatedPath, err := writeScratch(r.sandbox, "reviewer-truncated.json", valid[:len(valid)-1])
+	if err != nil {
+		return err
+	}
+	observation = r.run(args(truncatedPath), true)
+	if observation.ExitCode == 0 || !strings.Contains(observation.Stderr+observation.Stdout, "truncated_capture") {
+		return fmt.Errorf("truncated reviewer result = exit %d, stderr=%q", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	if err := assertStillCollecting("truncated reviewer result"); err != nil {
+		return err
+	}
+
+	validPath, err := writeScratch(r.sandbox, "reviewer-corrected.json", valid)
+	if err != nil {
+		return err
+	}
+	if observation = r.run(args(validPath), true); observation.ExitCode != 0 {
+		return fmt.Errorf("corrected reviewer result failed: %s", firstLine(observation.Stderr))
+	}
+	final, err := readStatus(r)
+	if err != nil {
+		return err
+	}
+	if final.NextTransition.Kind != "collect" ||
+		(final.argument("lens") == envelope.argument("lens") && final.argument("order") == envelope.argument("order")) {
+		return fmt.Errorf("corrected capture did not advance the exact collect slot: %#v", final)
+	}
+	return nil
+}

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -188,15 +188,123 @@ type admittedReviewerResult struct {
 }
 
 // ReviewerResultPayloadError is returned when a raw reviewer result payload is
-// structurally invalid before JSON decoding is attempted. Code is
-// machine-readable: "empty_result" for empty/whitespace-only payloads and
-// "nested_envelope" for payloads that still contain an XML task envelope.
+// structurally invalid before admission or publication. Code is machine-
+// readable and maps to the incident class that can be retained for audit.
 type ReviewerResultPayloadError struct {
 	Code    string
 	Message string
 }
 
-func (e *ReviewerResultPayloadError) Error() string { return e.Message }
+func (e *ReviewerResultPayloadError) Error() string {
+	if e.Code == "" {
+		return e.Message
+	}
+	return e.Message + " [" + e.Code + "]"
+}
+
+func reviewerResultPayloadError(code, message string) error {
+	return &ReviewerResultPayloadError{Code: code, Message: message}
+}
+
+// readReviewerResultPayload bounds both file and stdin capture before any
+// decoder or store code sees the bytes. A provider that ends a stream early or
+// exceeds the native bound therefore cannot publish a partial artifact.
+func readReviewerResultPayload(path string) ([]byte, error) {
+	var reader io.Reader = os.Stdin
+	var file *os.File
+	if path != "-" {
+		var err error
+		file, err = os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+		reader = file
+	}
+	payload, err := io.ReadAll(io.LimitReader(reader, reviewResultArtifactLimit+1))
+	if err != nil {
+		if len(payload) > reviewResultArtifactLimit {
+			return nil, reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
+				"reviewer artifact admission incomplete: reviewer result capture exceeded the native size bound before atomic publication")
+		}
+		if len(payload) > 0 {
+			return payload, reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
+				"reviewer artifact admission incomplete: reviewer result capture ended during a read before atomic publication")
+		}
+		return payload, err
+	}
+	if len(payload) > reviewResultArtifactLimit {
+		return nil, reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
+			"reviewer artifact admission incomplete: reviewer result capture exceeded the native size bound before atomic publication")
+	}
+	return payload, nil
+}
+
+func reviewerResultPayloadLooksTruncated(payload []byte) bool {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 || json.Valid(trimmed) || !bytes.Contains(trimmed, []byte("{")) {
+		return false
+	}
+	var value any
+	err := json.Unmarshal(trimmed, &value)
+	return strings.Contains(err.Error(), "unexpected end of JSON input") || strings.Contains(err.Error(), "unexpected EOF")
+}
+
+func reviewerResultExtractionError(payload []byte, decision reviewtransaction.ArtifactAdmissionDecision, cause error) error {
+	if decision == reviewtransaction.ArtifactAdmissionIncomplete && reviewerResultPayloadLooksTruncated(payload) {
+		return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
+			"reviewer artifact admission incomplete: reviewer result capture ended before a complete JSON object was available; no partial result was published")
+	}
+	return fmt.Errorf("reviewer artifact admission %s: %w", decision, cause)
+}
+
+func reviewerResultIncidentClass(err error) (reviewtransaction.ResultIncidentClass, bool) {
+	var payloadErr *ReviewerResultPayloadError
+	if errors.As(err, &payloadErr) {
+		switch reviewtransaction.ResultIncidentClass(payloadErr.Code) {
+		case reviewtransaction.ResultIncidentEmptyResult, reviewtransaction.ResultIncidentNestedEnvelope, reviewtransaction.ResultIncidentTruncatedCapture:
+			return reviewtransaction.ResultIncidentClass(payloadErr.Code), true
+		}
+	}
+	var admissionErr *reviewtransaction.ArtifactAdmissionError
+	if errors.As(err, &admissionErr) && admissionErr.Diagnostic != nil {
+		switch admissionErr.Diagnostic.Code {
+		case reviewtransaction.ArtifactAdmissionDiagnosticCandidateInputUnreadable, reviewtransaction.ArtifactAdmissionDiagnosticInspectionIncomplete:
+			return reviewtransaction.ResultIncidentScopeUnavailable, true
+		}
+	}
+	return "", false
+}
+
+func reviewCaptureResultPreflightError(err error) error {
+	class, ok := reviewerResultIncidentClass(err)
+	if !ok {
+		return reviewPreflightError(err)
+	}
+	code := string(class)
+	message := "The reviewer result was not admissible and no artifact or receipt was published."
+	if class == reviewtransaction.ResultIncidentScopeUnavailable {
+		code = reviewtransaction.ArtifactAdmissionDiagnosticCandidateInputUnreadable
+		message = "The reviewer could not establish complete candidate inspection; the same-lineage capture must be retried after access is restored."
+	}
+	return reviewPreflightRefusal(reviewPreflightReason{
+		Code: code, Message: message, RequiredInputs: []string{"incident"}, NextAction: "review.status",
+	}, err)
+}
+
+func preserveCaptureFailure(ctx context.Context, repo, lineage, target, lens string, order int, raw []byte, preflight, opaque bool, err error) error {
+	class, ok := reviewerResultIncidentClass(err)
+	if !ok || preflight || len(raw) == 0 {
+		return reviewCaptureResultPreflightError(err)
+	}
+	if _, preserveErr := preserveIncidentArtifact(ctx, repo, lineage, target, lens, order, raw, class); preserveErr != nil {
+		if opaque {
+			return reviewCaptureResultPreflightError(fmt.Errorf("%w; invalid reviewer result could not be retained for audit", err))
+		}
+		return reviewCaptureResultPreflightError(fmt.Errorf("%w; invalid reviewer result could not be retained for audit: %v", err, preserveErr))
+	}
+	return reviewCaptureResultPreflightError(fmt.Errorf("%w; invalid reviewer result was retained as a non-admitted audit incident; retry the same lineage after correcting the provider input", err))
+}
 
 // validateReviewerResultPayload inspects the raw bytes of a reviewer result
 // before JSON decoding. It rejects two structurally distinct failure modes
@@ -206,17 +314,11 @@ func (e *ReviewerResultPayloadError) Error() string { return e.Message }
 //     task wrapper before being passed as the strict JSON payload.
 func validateReviewerResultPayload(payload []byte) error {
 	if len(bytes.TrimSpace(payload)) == 0 {
-		return &ReviewerResultPayloadError{
-			Code:    "empty_result",
-			Message: "reviewer result payload is empty or whitespace-only: the task may have completed without producing output",
-		}
+		return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentEmptyResult), "reviewer result payload is empty or whitespace-only: the task may have completed without producing output")
 	}
 	if bytes.Contains(payload, []byte("<task_result>")) || bytes.Contains(payload, []byte("</task_result>")) {
 		if !json.Valid(payload) {
-			return &ReviewerResultPayloadError{
-				Code:    "nested_envelope",
-				Message: "reviewer result payload contains a raw XML task envelope: extract the strict JSON reviewer output from <task_result> before capture",
-			}
+			return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentNestedEnvelope), "reviewer result payload contains a raw XML task envelope: extract the strict JSON reviewer output from <task_result> before capture")
 		}
 	}
 	return nil
@@ -359,23 +461,26 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 			ChangedPathManifest: append([]reviewtransaction.ChangedPathManifestEntry{}, frozen.ChangedPathManifest...),
 		})
 	}
-	rawPayload, err := readFacadeBytes(*input)
+	rawPayload, err := readReviewerResultPayload(*input)
 	if err != nil {
-		return reviewPreflightError(fmt.Errorf("read reviewer result: %w", err))
+		return preserveCaptureFailure(ctx, root, *lineage, *target, *lens, *order, rawPayload, *preflight, contextHandle != "", fmt.Errorf("read reviewer result: %w", err))
+	}
+	captureFailure := func(cause error) error {
+		return preserveCaptureFailure(ctx, root, *lineage, *target, *lens, *order, rawPayload, *preflight, contextHandle != "", cause)
 	}
 	if err := validateReviewerResultPayload(rawPayload); err != nil {
-		return reviewPreflightError(err)
+		return captureFailure(err)
 	}
 	payload, decision, err := reviewtransaction.ExtractBoundedSingleJSONObject(rawPayload, reviewResultArtifactLimit)
 	if err != nil {
-		return reviewPreflightError(fmt.Errorf("reviewer artifact admission %s: %w", decision, err))
+		return captureFailure(reviewerResultExtractionError(rawPayload, decision, err))
 	}
 	var result facadeReviewerResult
 	if err := decodeFacadeJSONBytes(payload, &result); err != nil {
-		return reviewPreflightError(fmt.Errorf("decode reviewer result: %w", err))
+		return captureFailure(fmt.Errorf("decode reviewer result: %w", err))
 	}
 	if result.Findings == nil || result.Evidence == nil {
-		return reviewPreflightError(errors.New("reviewer result requires explicit findings and evidence arrays"))
+		return captureFailure(errors.New("reviewer result requires explicit findings and evidence arrays"))
 	}
 	if result.SubjectHash != subject.SubjectHash {
 		legacyFrozen, legacyErr := (reviewtransaction.SnapshotBuilder{Repo: root}).WithLegacyCandidateDiff(ctx, state.InitialSnapshot, frozen)
@@ -391,7 +496,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	}
 	canonicalReviewerResult, err := reviewtransaction.CanonicalizeReviewerResult(payload, subject.Lens)
 	if err != nil {
-		return reviewPreflightError(err)
+		return captureFailure(err)
 	}
 	canonicalResult, err := json.Marshal(canonicalReviewerResult)
 	if err != nil {
@@ -411,11 +516,11 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	// issue-1699, confirmed unresolved by the earlier Group A fix).
 	canonicalForCausality, err := reviewtransaction.CanonicalCompactLensResult(nativeResult)
 	if err != nil {
-		return reviewPreflightError(fmt.Errorf("canonicalize reviewer result: %w", err))
+		return captureFailure(fmt.Errorf("canonicalize reviewer result: %w", err))
 	}
 	candidateCausalIDs, err := verifiedCandidateCausalFindingIDs(ctx, root, state.InitialSnapshot, canonicalForCausality)
 	if err != nil {
-		return reviewPreflightError(err)
+		return captureFailure(err)
 	}
 	_, admission, err := reviewtransaction.AdmitArtifact(ctx, reviewtransaction.ArtifactAdmissionRequest{
 		ExpectedSubject: subject, FrozenContext: frozen, EchoedSubjectHash: result.SubjectHash,
@@ -423,7 +528,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		RawPayload: rawPayload, CanonicalPayload: canonicalResult,
 	})
 	if err != nil {
-		return reviewPreflightError(err)
+		return captureFailure(err)
 	}
 	if *preflight {
 		return encodeReviewJSON(stdout, reviewResultDryRun{

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -193,6 +193,7 @@ type admittedReviewerResult struct {
 type ReviewerResultPayloadError struct {
 	Code    string
 	Message string
+	cause   error
 }
 
 func (e *ReviewerResultPayloadError) Error() string {
@@ -202,13 +203,14 @@ func (e *ReviewerResultPayloadError) Error() string {
 	return e.Message + " [" + e.Code + "]"
 }
 
-func reviewerResultPayloadError(code, message string) error {
-	return &ReviewerResultPayloadError{Code: code, Message: message}
+func (e *ReviewerResultPayloadError) Unwrap() error { return e.cause }
+
+func reviewerResultPayloadError(code, message string, cause error) error {
+	return &ReviewerResultPayloadError{Code: code, Message: message, cause: cause}
 }
 
-// readReviewerResultPayload bounds both file and stdin capture before any
-// decoder or store code sees the bytes. A provider that ends a stream early or
-// exceeds the native bound therefore cannot publish a partial artifact.
+// readReviewerResultPayload bounds file and stdin capture before decoding or
+// publication, rejecting partial artifacts from early or oversized streams.
 func readReviewerResultPayload(path string) ([]byte, error) {
 	var reader io.Reader = os.Stdin
 	var file *os.File
@@ -225,17 +227,17 @@ func readReviewerResultPayload(path string) ([]byte, error) {
 	if err != nil {
 		if len(payload) > reviewResultArtifactLimit {
 			return nil, reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
-				"reviewer artifact admission incomplete: reviewer result capture exceeded the native size bound before atomic publication")
+				"reviewer artifact admission incomplete: reviewer result capture exceeded the native size bound before atomic publication", err)
 		}
 		if len(payload) > 0 {
 			return payload, reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
-				"reviewer artifact admission incomplete: reviewer result capture ended during a read before atomic publication")
+				"reviewer artifact admission incomplete: reviewer result capture ended during a read before atomic publication", err)
 		}
 		return payload, err
 	}
 	if len(payload) > reviewResultArtifactLimit {
 		return nil, reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
-			"reviewer artifact admission incomplete: reviewer result capture exceeded the native size bound before atomic publication")
+			"reviewer artifact admission incomplete: reviewer result capture exceeded the native size bound before atomic publication", nil)
 	}
 	return payload, nil
 }
@@ -245,15 +247,14 @@ func reviewerResultPayloadLooksTruncated(payload []byte) bool {
 	if len(trimmed) == 0 || json.Valid(trimmed) || !bytes.Contains(trimmed, []byte("{")) {
 		return false
 	}
-	var value any
-	err := json.Unmarshal(trimmed, &value)
-	return strings.Contains(err.Error(), "unexpected end of JSON input") || strings.Contains(err.Error(), "unexpected EOF")
+	err := json.Unmarshal(trimmed, new(any))
+	return strings.Contains(err.Error(), "unexpected end of JSON input")
 }
 
 func reviewerResultExtractionError(payload []byte, decision reviewtransaction.ArtifactAdmissionDecision, cause error) error {
 	if decision == reviewtransaction.ArtifactAdmissionIncomplete && reviewerResultPayloadLooksTruncated(payload) {
 		return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentTruncatedCapture),
-			"reviewer artifact admission incomplete: reviewer result capture ended before a complete JSON object was available; no partial result was published")
+			"reviewer artifact admission incomplete: reviewer result capture ended before a complete JSON object was available; no partial result was published", nil)
 	}
 	return fmt.Errorf("reviewer artifact admission %s: %w", decision, cause)
 }
@@ -314,11 +315,11 @@ func preserveCaptureFailure(ctx context.Context, repo, lineage, target, lens str
 //     task wrapper before being passed as the strict JSON payload.
 func validateReviewerResultPayload(payload []byte) error {
 	if len(bytes.TrimSpace(payload)) == 0 {
-		return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentEmptyResult), "reviewer result payload is empty or whitespace-only: the task may have completed without producing output")
+		return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentEmptyResult), "reviewer result payload is empty or whitespace-only: the task may have completed without producing output", nil)
 	}
 	if bytes.Contains(payload, []byte("<task_result>")) || bytes.Contains(payload, []byte("</task_result>")) {
 		if !json.Valid(payload) {
-			return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentNestedEnvelope), "reviewer result payload contains a raw XML task envelope: extract the strict JSON reviewer output from <task_result> before capture")
+			return reviewerResultPayloadError(string(reviewtransaction.ResultIncidentNestedEnvelope), "reviewer result payload contains a raw XML task envelope: extract the strict JSON reviewer output from <task_result> before capture", nil)
 		}
 	}
 	return nil

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -269,7 +269,7 @@ func reviewerResultIncidentClass(err error) (reviewtransaction.ResultIncidentCla
 	var admissionErr *reviewtransaction.ArtifactAdmissionError
 	if errors.As(err, &admissionErr) && admissionErr.Diagnostic != nil {
 		switch admissionErr.Diagnostic.Code {
-		case reviewtransaction.ArtifactAdmissionDiagnosticCandidateInputUnreadable, reviewtransaction.ArtifactAdmissionDiagnosticInspectionIncomplete:
+		case reviewtransaction.ArtifactAdmissionDiagnosticCandidateInputUnreadable:
 			return reviewtransaction.ResultIncidentScopeUnavailable, true
 		}
 	}

--- a/internal/cli/review_incident.go
+++ b/internal/cli/review_incident.go
@@ -246,7 +246,7 @@ func RunReviewPreserveResult(args []string, stdout io.Writer) error {
 	order := flags.Int("order", -1, "zero-based selected lens order from the capture binding")
 	revision := flags.String("expected-revision", "", "exact reviewing authority revision")
 	input := flags.String("input", "", "raw reviewer result file or - for stdin")
-	class := flags.String("class", "", "extraction-failure classification: empty_result or nested_envelope")
+	class := flags.String("class", "", "capture-failure classification: empty_result, nested_envelope, scope_unavailable, or truncated_capture")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}

--- a/internal/cli/review_incident_recapture_test.go
+++ b/internal/cli/review_incident_recapture_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -133,6 +134,51 @@ func TestReviewCaptureResultRecapturesSameLensAfterRejectedAdmission(t *testing.
 	// The recaptured lineage completes normally.
 	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result-artifact", strings.TrimSpace(captured.String())}, io.Discard); err != nil {
 		t.Fatalf("finalize after same-lineage recapture failed: %v", err)
+	}
+}
+
+func TestReviewCaptureResultTruncatedCaptureIsAtomicAndRecoverable(t *testing.T) {
+	repo, started, store, record := newArtifactReview(t, false)
+	lens := record.State.SelectedLenses[0]
+	valid := admittedReviewerPayloadForTest(t, repo, record, lens, 0)
+	if len(valid) < 2 || valid[len(valid)-1] != '}' {
+		t.Fatalf("test payload does not end in a JSON object: %q", valid)
+	}
+	truncated := valid[:len(valid)-1]
+	withFacadeStdin(t, truncated)
+	err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+		"--lens", lens, "--order", "0", "--input", "-",
+	}, io.Discard)
+	var payloadErr *ReviewerResultPayloadError
+	if err == nil || !errors.As(err, &payloadErr) || payloadErr.Code != string(reviewtransaction.ResultIncidentTruncatedCapture) {
+		t.Fatalf("truncated capture error = %v; want typed truncated_capture", err)
+	}
+	assertArtifactRevision(t, store, record.Revision)
+	if _, statErr := os.Stat(filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir)); !os.IsNotExist(statErr) {
+		t.Fatalf("truncated capture published a reviewer result: %v", statErr)
+	}
+	incidents, err := reviewtransaction.CompactIncidentsDir(t.Context(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(incidents, "*truncated_capture*.raw"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("truncated capture incident matches = %v, %v; want one", matches, err)
+	}
+	if preserved, readErr := os.ReadFile(matches[0]); readErr != nil || !bytes.Equal(preserved, truncated) {
+		t.Fatalf("truncated incident bytes = %v, %q; want original prefix", readErr, preserved)
+	}
+
+	corrected := filepath.Join(t.TempDir(), "corrected.json")
+	if err := os.WriteFile(corrected, valid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+		"--lens", lens, "--order", "0", "--input", corrected,
+	}, io.Discard); err != nil {
+		t.Fatalf("same-lineage corrected capture failed: %v", err)
 	}
 }
 

--- a/internal/cli/review_incident_recapture_test.go
+++ b/internal/cli/review_incident_recapture_test.go
@@ -246,7 +246,7 @@ func TestReviewCaptureResultRecapturesSameLensAfterPreInspectionAccessFailure(t 
 		"--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", "0", "--input", failed,
 	}
 	if err := RunReviewCaptureResult(captureArgs, io.Discard); err == nil ||
-		!strings.Contains(err.Error(), "reviewer did not report completed candidate inspection") {
+		!strings.Contains(err.Error(), "reviewer did not report completed candidate inspection") || strings.Contains(err.Error(), "scope_unavailable") {
 		t.Fatalf("incomplete inspection capture error = %v", err)
 	}
 	afterFailure, err := store.Load()

--- a/internal/cli/review_incident_test.go
+++ b/internal/cli/review_incident_test.go
@@ -19,8 +19,10 @@ import (
 
 func TestValidResultIncidentClass(t *testing.T) {
 	cases := map[reviewtransaction.ResultIncidentClass]bool{
-		reviewtransaction.ResultIncidentEmptyResult:    true,
-		reviewtransaction.ResultIncidentNestedEnvelope: true,
+		reviewtransaction.ResultIncidentEmptyResult:      true,
+		reviewtransaction.ResultIncidentNestedEnvelope:   true,
+		reviewtransaction.ResultIncidentScopeUnavailable: true,
+		reviewtransaction.ResultIncidentTruncatedCapture: true,
 		"":                          true,
 		"wrong_target":              false,
 		"transport_syntax":          false,

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -28,7 +28,10 @@ const (
 
 type ArtifactInspectionStatus string
 
-const ArtifactInspectionCompleted ArtifactInspectionStatus = "completed"
+const (
+	ArtifactInspectionCompleted        ArtifactInspectionStatus = "completed"
+	ArtifactInspectionScopeUnavailable ArtifactInspectionStatus = "scope_unavailable"
+)
 
 // ArtifactInspection is the reviewer's structured assertion that every path
 // in the immutable manifest was actually inspected.
@@ -92,6 +95,11 @@ type ArtifactAdmissionDiagnostic struct {
 	MissingPathCount int    `json:"missing_path_count,omitempty"`
 	ForeignPathCount int    `json:"foreign_path_count,omitempty"`
 }
+
+const (
+	ArtifactAdmissionDiagnosticInspectionIncomplete     = "inspection_incomplete"
+	ArtifactAdmissionDiagnosticCandidateInputUnreadable = "candidate_input_unreadable"
+)
 
 func safeAdmissionLocation(code, value, reason string) string {
 	value = strings.TrimSpace(value)
@@ -325,7 +333,15 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 		wantPaths[index] = entry.Path
 	}
 	if request.Inspection.Status != ArtifactInspectionCompleted {
-		return fail(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection")
+		diagnostic := &ArtifactAdmissionDiagnostic{
+			Code:   ArtifactAdmissionDiagnosticInspectionIncomplete,
+			Reason: "reviewer_did_not_complete_candidate_inspection",
+		}
+		if request.Inspection.Status == ArtifactInspectionScopeUnavailable {
+			diagnostic.Code = ArtifactAdmissionDiagnosticCandidateInputUnreadable
+			diagnostic.Reason = "scope_unavailable"
+		}
+		return failFinding(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection", diagnostic, nil)
 	}
 	coverage, coverageErr := validateCompleteInspectionCoverage(request.Inspection.Paths, request.FrozenContext.ChangedPathManifest)
 	if coverageErr != nil {
@@ -357,7 +373,8 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 	wantCandidateCausalIDs := make([]string, 0)
 	for _, evidence := range canonical.Evidence {
 		if evidenceReportsUnavailableInspection(evidence) {
-			return fail(ArtifactAdmissionIncomplete, "reviewer evidence reports that candidate inspection was unavailable")
+			return failFinding(ArtifactAdmissionIncomplete, "reviewer evidence reports that candidate inspection was unavailable",
+				&ArtifactAdmissionDiagnostic{Code: ArtifactAdmissionDiagnosticCandidateInputUnreadable, Reason: "scope_unavailable"}, nil)
 		}
 		outside, lookupErr := referenceOutsideRepository(evidence, repository.contains)
 		if lookupErr != nil {

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -28,10 +28,7 @@ const (
 
 type ArtifactInspectionStatus string
 
-const (
-	ArtifactInspectionCompleted        ArtifactInspectionStatus = "completed"
-	ArtifactInspectionScopeUnavailable ArtifactInspectionStatus = "scope_unavailable"
-)
+const ArtifactInspectionCompleted ArtifactInspectionStatus = "completed"
 
 // ArtifactInspection is the reviewer's structured assertion that every path
 // in the immutable manifest was actually inspected.
@@ -96,10 +93,7 @@ type ArtifactAdmissionDiagnostic struct {
 	ForeignPathCount int    `json:"foreign_path_count,omitempty"`
 }
 
-const (
-	ArtifactAdmissionDiagnosticInspectionIncomplete     = "inspection_incomplete"
-	ArtifactAdmissionDiagnosticCandidateInputUnreadable = "candidate_input_unreadable"
-)
+const ArtifactAdmissionDiagnosticCandidateInputUnreadable = "candidate_input_unreadable"
 
 func safeAdmissionLocation(code, value, reason string) string {
 	value = strings.TrimSpace(value)
@@ -333,15 +327,8 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 		wantPaths[index] = entry.Path
 	}
 	if request.Inspection.Status != ArtifactInspectionCompleted {
-		diagnostic := &ArtifactAdmissionDiagnostic{
-			Code:   ArtifactAdmissionDiagnosticInspectionIncomplete,
-			Reason: "reviewer_did_not_complete_candidate_inspection",
-		}
-		if request.Inspection.Status == ArtifactInspectionScopeUnavailable {
-			diagnostic.Code = ArtifactAdmissionDiagnosticCandidateInputUnreadable
-			diagnostic.Reason = "scope_unavailable"
-		}
-		return failFinding(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection", diagnostic, nil)
+		return failFinding(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection",
+			&ArtifactAdmissionDiagnostic{Code: ArtifactAdmissionDiagnosticCandidateInputUnreadable, Reason: "scope_unavailable"}, nil)
 	}
 	coverage, coverageErr := validateCompleteInspectionCoverage(request.Inspection.Paths, request.FrozenContext.ChangedPathManifest)
 	if coverageErr != nil {

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -327,8 +327,7 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 		wantPaths[index] = entry.Path
 	}
 	if request.Inspection.Status != ArtifactInspectionCompleted {
-		return failFinding(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection",
-			&ArtifactAdmissionDiagnostic{Code: ArtifactAdmissionDiagnosticCandidateInputUnreadable, Reason: "scope_unavailable"}, nil)
+		return fail(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection")
 	}
 	coverage, coverageErr := validateCompleteInspectionCoverage(request.Inspection.Paths, request.FrozenContext.ChangedPathManifest)
 	if coverageErr != nil {

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -688,6 +688,9 @@ func evidenceReportsUnavailableInspection(value string) bool {
 		"candidate unavailable", "candidate was unavailable", "immutable candidate unavailable",
 		"could not inspect", "unable to inspect", "was not inspected", "not inspected",
 		"no candidate contents were available", "no candidate content was available",
+		"read denied", "read permission denied", "denied by filesystem", "denied by its filesystem",
+		"cannot read diff", "cannot read manifest", "unable to read diff", "unable to read manifest",
+		"file access denied", "filesystem access denied", "read capability denied",
 	} {
 		if strings.Contains(value, phrase) {
 			return true

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -106,6 +106,18 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 			r.Result.Findings = []Finding{}
 			r.Result.Evidence = []string{"Cannot read diff: file access denied."}
 		}, decision: ArtifactAdmissionIncomplete},
+		{name: "cannot read manifest", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Error: cannot read manifest."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "filesystem access denied", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Filesystem access denied during candidate inspection."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "read capability denied", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Read capability denied for frozen context."}
+		}, decision: ArtifactAdmissionIncomplete},
 		{name: "partial inspection", mutate: func(r *ArtifactAdmissionRequest) { r.Inspection.Paths = []string{"internal/a.go"} }, decision: ArtifactAdmissionIncomplete},
 		{name: "repository authority missing", mutate: func(r *ArtifactAdmissionRequest) {
 			r.FrozenContext.repositoryRoot = ""

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -171,6 +171,13 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 			if err == nil || admission.Decision != tc.decision {
 				t.Fatalf("AdmitArtifact() decision = %q, error = %v; want %q", admission.Decision, err, tc.decision)
 			}
+			if len(candidate.Result.Findings) == 0 {
+				var admissionErr *ArtifactAdmissionError
+				if !errors.As(err, &admissionErr) || admissionErr.Diagnostic == nil ||
+					admissionErr.Diagnostic.Code != ArtifactAdmissionDiagnosticCandidateInputUnreadable || admissionErr.Diagnostic.Reason != "scope_unavailable" {
+					t.Fatalf("unavailable inspection diagnostic = %#v, error = %v", admissionErr.Diagnostic, err)
+				}
+			}
 		})
 	}
 }

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -175,22 +175,6 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 	}
 }
 
-func TestAdmitArtifactClassifiesUnavailableScope(t *testing.T) {
-	_, _, request := admittedArtifactFixture(t)
-	request.Inspection.Status = ArtifactInspectionScopeUnavailable
-	request.Inspection.Paths = nil
-	_, admission, err := AdmitArtifact(t.Context(), request)
-	if err == nil || admission.Decision != ArtifactAdmissionIncomplete {
-		t.Fatalf("scope-unavailable admission = %q, %v; want incomplete", admission.Decision, err)
-	}
-	var admissionErr *ArtifactAdmissionError
-	if !errors.As(err, &admissionErr) || admissionErr.Diagnostic == nil ||
-		admissionErr.Diagnostic.Code != ArtifactAdmissionDiagnosticCandidateInputUnreadable ||
-		admissionErr.Diagnostic.Reason != "scope_unavailable" {
-		t.Fatalf("scope-unavailable diagnostic = %#v, error = %v", admissionErr, err)
-	}
-}
-
 func TestAdmitArtifactCanonicalizesCompleteInspectionCoverage(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -98,6 +98,14 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 			r.Result.Findings = []Finding{}
 			r.Result.Evidence = []string{"Inspection blocked: read access denied; no candidate contents were available."}
 		}, decision: ArtifactAdmissionIncomplete},
+		{name: "read denied by filesystem", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"The immutable diff and manifest were denied by its filesystem environment."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "file access denied", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Cannot read diff: file access denied."}
+		}, decision: ArtifactAdmissionIncomplete},
 		{name: "partial inspection", mutate: func(r *ArtifactAdmissionRequest) { r.Inspection.Paths = []string{"internal/a.go"} }, decision: ArtifactAdmissionIncomplete},
 		{name: "repository authority missing", mutate: func(r *ArtifactAdmissionRequest) {
 			r.FrozenContext.repositoryRoot = ""

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -98,9 +98,25 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 			r.Result.Findings = []Finding{}
 			r.Result.Evidence = []string{"Inspection blocked: read access denied; no candidate contents were available."}
 		}, decision: ArtifactAdmissionIncomplete},
+		{name: "read denied", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Read denied before candidate inspection."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "read permission denied", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Read permission denied before candidate inspection."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "denied by filesystem", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Candidate input was denied by filesystem policy."}
+		}, decision: ArtifactAdmissionIncomplete},
 		{name: "read denied by filesystem", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings = []Finding{}
 			r.Result.Evidence = []string{"The immutable diff and manifest were denied by its filesystem environment."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "cannot read diff", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Cannot read diff before candidate inspection."}
 		}, decision: ArtifactAdmissionIncomplete},
 		{name: "file access denied", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings = []Finding{}
@@ -113,6 +129,14 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 		{name: "filesystem access denied", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings = []Finding{}
 			r.Result.Evidence = []string{"Filesystem access denied during candidate inspection."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "unable to read diff", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Unable to read diff before candidate inspection."}
+		}, decision: ArtifactAdmissionIncomplete},
+		{name: "unable to read manifest", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Findings = []Finding{}
+			r.Result.Evidence = []string{"Unable to read manifest before candidate inspection."}
 		}, decision: ArtifactAdmissionIncomplete},
 		{name: "read capability denied", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings = []Finding{}
@@ -148,6 +172,22 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 				t.Fatalf("AdmitArtifact() decision = %q, error = %v; want %q", admission.Decision, err, tc.decision)
 			}
 		})
+	}
+}
+
+func TestAdmitArtifactClassifiesUnavailableScope(t *testing.T) {
+	_, _, request := admittedArtifactFixture(t)
+	request.Inspection.Status = ArtifactInspectionScopeUnavailable
+	request.Inspection.Paths = nil
+	_, admission, err := AdmitArtifact(t.Context(), request)
+	if err == nil || admission.Decision != ArtifactAdmissionIncomplete {
+		t.Fatalf("scope-unavailable admission = %q, %v; want incomplete", admission.Decision, err)
+	}
+	var admissionErr *ArtifactAdmissionError
+	if !errors.As(err, &admissionErr) || admissionErr.Diagnostic == nil ||
+		admissionErr.Diagnostic.Code != ArtifactAdmissionDiagnosticCandidateInputUnreadable ||
+		admissionErr.Diagnostic.Reason != "scope_unavailable" {
+		t.Fatalf("scope-unavailable diagnostic = %#v, error = %v", admissionErr, err)
 	}
 }
 

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -195,15 +195,17 @@ const (
 type ResultIncidentClass string
 
 const (
-	ResultIncidentEmptyResult    ResultIncidentClass = "empty_result"
-	ResultIncidentNestedEnvelope ResultIncidentClass = "nested_envelope"
+	ResultIncidentEmptyResult      ResultIncidentClass = "empty_result"
+	ResultIncidentNestedEnvelope   ResultIncidentClass = "nested_envelope"
+	ResultIncidentScopeUnavailable ResultIncidentClass = "scope_unavailable"
+	ResultIncidentTruncatedCapture ResultIncidentClass = "truncated_capture"
 )
 
 // ValidResultIncidentClass reports whether c is a known incident class or the
 // empty string (backward-compatible: omitting --class remains valid).
 func ValidResultIncidentClass(c ResultIncidentClass) bool {
 	switch c {
-	case "", ResultIncidentEmptyResult, ResultIncidentNestedEnvelope:
+	case "", ResultIncidentEmptyResult, ResultIncidentNestedEnvelope, ResultIncidentScopeUnavailable, ResultIncidentTruncatedCapture:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1867

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Reviewer processes running under permission-restricted sandboxes (such as Windows sandbox environments) could report file/diff read access denials in their evidence strings while returning 0 findings. The admission check allowed these results as valid clean approvals because `evidenceReportsUnavailableInspection` did not recognize filesystem permission denial phrases.

This PR expands `evidenceReportsUnavailableInspection` to recognize filesystem permission denial patterns and ensures unreadable candidate inputs are rejected as incomplete admission failures.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/artifact_admission.go` | Expand `evidenceReportsUnavailableInspection` phrase detection to cover filesystem access denials |
| `internal/reviewtransaction/artifact_admission_test.go` | Add unit test cases for filesystem access denial evidence |

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/reviewtransaction/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artifact validation for inspection access, read, filesystem, diff, and manifest failures.
  - Artifacts remain incomplete when required evidence is unavailable, unreadable, or truncated.
  - Invalid reviewer captures are preserved as audit incidents instead of discarded.
  - Invalid results no longer advance authority and can be corrected through same-lineage recapture.
- **New Features**
  - Added incident classifications for unavailable scope and truncated captures.
  - Added structured diagnostics for unreadable candidate input.
- **Tests**
  - Expanded coverage for access-denied, unreadable, truncated, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->