### PR TITLE
test(review): cover lifecycle recovery bindings

### DIFF
--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -90,6 +91,66 @@ func TestFinalizeNextTransitionBindsCorrectedCurrentSnapshot(t *testing.T) {
 	arguments := transition.Collect.Inputs[0].Arguments
 	if len(arguments) != 3 || arguments[2].Name != "target" || arguments[2].Value != currentTarget {
 		t.Fatalf("corrected validating target arguments = %#v, want current snapshot %q", arguments, currentTarget)
+	}
+}
+
+func TestCorrectedValidatingStatusCaptureTransitionRunsEndToEnd(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nwrong\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	reviewer := filepath.Join(t.TempDir(), "reviewer.json")
+	writeReviewCLIJSON(t, reviewer, facadeReviewerResult{Findings: []facadeFinding{{
+		Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong value",
+		ProofRefs: []string{"candidate-only failure"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+		CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, Evidence: []string{"focused differential failure"}})
+	if err := finalizeReviewCLIArgs(t, repo, []string{"--cwd", repo, "--result", reviewer, "--correction-lines", "2"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	validation := filepath.Join(t.TempDir(), "validation.json")
+	writeReviewCLIJSON(t, validation, facadeValidationResult{
+		OriginalCriteria:     facadeValidationCheck{Passed: true, Evidence: []string{"acceptance passes"}},
+		CorrectionRegression: facadeValidationCheck{Passed: true, Evidence: []string{"regression passes"}},
+		FollowUps:            []reviewtransaction.FollowUp{},
+	})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validation}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	status := selectorTransitionStatus(t, repo, "--lineage", started.LineageID)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("corrected validating status transition = %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.CaptureOperation != "review.capture-evidence" {
+		t.Fatalf("capture operation = %q, want review.capture-evidence", input.CaptureOperation)
+	}
+	arguments, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arguments["target"] != record.State.CurrentSnapshot.Identity || arguments["target"] == status.TargetIdentity {
+		t.Fatalf("emitted capture target = %q, authority current = %q, live workspace = %q", arguments["target"], record.State.CurrentSnapshot.Identity, status.TargetIdentity)
+	}
+	evidence := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidence, []byte("verification passed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReview([]string{
+		"capture-evidence", "--cwd", repo, "--lineage", arguments["lineage"], "--target", arguments["target"],
+		"--expected-revision", arguments["expected-revision"], "--input", evidence,
+	}, io.Discard); err != nil {
+		t.Fatalf("status-emitted capture transition failed: %v", err)
 	}
 }
 

--- a/internal/cli/review_recovery_target_kind_test.go
+++ b/internal/cli/review_recovery_target_kind_test.go
@@ -254,3 +254,46 @@ func reviewRecoverBaseDiffSuccessorIdentity(t *testing.T, repo, baseRef string) 
 	}
 	return snapshot.Identity
 }
+
+func TestEscalatedStatusRequiresChangedTargetAndExplicitRecoveryAuthorization(t *testing.T) {
+	repo, _, predecessor := escalatedCurrentChangesRecoveryFixture(t, "escalated-recovery-binding")
+
+	unchanged := selectorTransitionStatus(t, repo, "--lineage", predecessor.State.LineageID)
+	if unchanged.Action != reviewtransaction.TargetStatusActionStop || unchanged.NextTransition == nil ||
+		unchanged.NextTransition.Kind != reviewNextTransitionStop {
+		t.Fatalf("unchanged escalated status = %#v, want STOP", unchanged)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nmaterially-changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed := selectorTransitionStatus(t, repo, "--lineage", predecessor.State.LineageID)
+	if changed.Action != reviewtransaction.TargetStatusActionRecover || changed.ActionDisposition != reviewtransaction.RecoveryEscalated ||
+		changed.NextTransition == nil || changed.NextTransition.Kind != reviewNextTransitionCollect {
+		t.Fatalf("changed escalated status without authorization = %#v, want bound authorization collection", changed)
+	}
+	const successor = "escalated-recovery-successor"
+	const actor = "maintainer"
+	const reason = "abandon escalated candidate after material change"
+	authorization := reviewTransitionRecoveryAuthorization(ReviewTransitionBinding{
+		LineageID: predecessor.State.LineageID, Revision: predecessor.Revision, TargetIdentity: changed.TargetIdentity,
+	}, successor, actor, reason)
+	authorized := selectorTransitionStatus(t, repo,
+		"--lineage", predecessor.State.LineageID,
+		"--recovery-successor-lineage", successor,
+		"--recovery-actor", actor,
+		"--recovery-reason", reason,
+		"--recovery-authorization", authorization,
+	)
+	if authorized.NextTransition == nil || authorized.NextTransition.Kind != reviewNextTransitionExecute ||
+		authorized.NextTransition.Execute == nil || authorized.NextTransition.Execute.Operation != "review.recover" {
+		t.Fatalf("explicitly authorized escalated recovery = %#v, want exact native RECOVER", authorized.NextTransition)
+	}
+	payload := executeSelectorTransition(t, repo, authorized)
+	var recovered ReviewRecoverResult
+	decodeStrictReviewJSON(t, payload, &recovered)
+	if recovered.LineageID != successor || recovered.State != reviewtransaction.StateReviewing ||
+		recovered.Recovery.PredecessorLineageID != predecessor.State.LineageID || recovered.Recovery.Disposition != reviewtransaction.RecoveryEscalated {
+		t.Fatalf("recovered successor = %s", payload)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1928

## 🏷️ PR Type

- [x] `type:chore` — Build, CI, or tooling changes

## 📝 Summary

- Add end-to-end regression coverage for correction evidence bindings.
- Prove escalated recovery stays stopped until the candidate changes and a maintainer explicitly authorizes recovery.
- Exercise the exact native transition through the recovered fresh lineage.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_next_transition_test.go` | Executes the emitted correction evidence transition and verifies the accepted fix-diff target identity. |
| `internal/cli/review_recovery_target_kind_test.go` | Covers unchanged escalation stop and changed-candidate maintainer-authorized recovery. |

## 🧪 Test Plan

- [x] Focused changed lifecycle regressions pass.
- [x] Related CLI lifecycle suites pass.
- [x] Related review-transaction suites pass.
- [x] `git diff --check` passes.
- [ ] Full `go test ./internal/cli -count=1` completed; it timed out at 120s and 300s without reporting a failure.
- [ ] E2E Docker suite; not required for this test-only lifecycle coverage and left to CI.

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #1928.
- [x] PR stays within 400 changed lines.
- [x] Exactly one `type:*` label will be applied.
- [x] Focused and related tests pass.
- [x] Documentation is not required for this test-only change.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailer.

## 💬 Notes for Reviewers

The production lifecycle fixes are already on `main`. This PR prevents regressions by executing the native transitions that previously failed in real workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for corrected validation flows, including evidence capture and transition execution.
  * Added coverage ensuring escalated reviews require a changed target and explicit recovery authorization before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->