### PR TITLE
fix(sdd): honor disabled review mode before pre-verify routing

### DIFF
--- a/internal/sddstatus/review_gate_disabled_test.go
+++ b/internal/sddstatus/review_gate_disabled_test.go
@@ -258,3 +258,37 @@ func TestDisabledSwitchDoesNotUnblockArchiveForNonReviewReasons(t *testing.T) {
 		t.Fatalf("archive gating never ran, so there is no gate to report: %#v", status.ReviewGate)
 	}
 }
+
+// TestDisabledReviewModeDoesNotBlockPreVerifyRouting is the regression guard for
+// issue-1932: when review mode is disabled, completing apply must leave verify
+// ready without forcing an implicit review/start obligation before independent
+// verification can run.
+func TestDisabledReviewModeDoesNotBlockPreVerifyRouting(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
+	// verifyReport is deliberately absent: apply is complete, verify is not run yet.
+	runSDDStatusGit(t, root, "init", "-q")
+	runSDDStatusGit(t, root, "config", "user.email", "status@example.com")
+	runSDDStatusGit(t, root, "config", "user.name", "Status Test")
+	runSDDStatusGit(t, root, "add", ".")
+	runSDDStatusGit(t, root, "commit", "-qm", "base")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", ReviewDisabled: true})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.ApplyState != ApplyAllDone {
+		t.Fatalf("fixture ApplyState = %q, want %q", status.ApplyState, ApplyAllDone)
+	}
+	if status.Dependencies.Verify != DependencyReady {
+		t.Fatalf("disabled Verify = %q, want ready", status.Dependencies.Verify)
+	}
+	if status.NextRecommended != "verify" {
+		t.Fatalf("disabled NextRecommended = %q, want verify", status.NextRecommended)
+	}
+	for _, reason := range status.BlockedReasons {
+		if strings.Contains(reason, "explicit bounded review/start(target) is required") {
+			t.Fatalf("disabled BlockedReasons contains review/start requirement: %v", status.BlockedReasons)
+		}
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -483,7 +483,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 		applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
 	}
 	if !bindingPresent && !bridge.Eligible && !bridge.Relevant {
-		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
+		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason, options.ReviewDisabled)
 	}
 
 	status := baseStatus(workspaceRoot, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))
@@ -794,7 +794,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		}
 		applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
 		if !bridge.Eligible && !bridge.Relevant {
-			applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
+			applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason, reviewDisabled)
 		}
 	}
 
@@ -851,11 +851,14 @@ func blockedEngramStatus(workspaceRoot string, changeName *string, next string, 
 	return status
 }
 
-func applyPreVerifyReviewRouting(dependencies *Dependencies, next *string, blockedReasons *blockerReasons, applyState ApplyState, verifyReportDone bool, transaction *reviewtransaction.Transaction, transactionReason string) {
+func applyPreVerifyReviewRouting(dependencies *Dependencies, next *string, blockedReasons *blockerReasons, applyState ApplyState, verifyReportDone bool, transaction *reviewtransaction.Transaction, transactionReason string, reviewDisabled bool) {
 	if applyState != ApplyAllDone || verifyReportDone {
 		return
 	}
 	if transaction == nil {
+		if reviewDisabled {
+			return
+		}
 		dependencies.Verify = DependencyBlocked
 		*next = "review"
 		blockedReasons.genuine = append(blockedReasons.genuine, "explicit bounded review/start(target) is required after apply before independent final verification: "+transactionReason)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1932

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

When review-driven development is disabled (`gentle-ai review mode disable`), the SDD dispatcher was still invoking `applyPreVerifyReviewRouting` after `apply` completes. Because it did not receive the `reviewDisabled` kill switch state, it created an implicit `review/start` obligation before independent verification could be reached.

Running `gentle-ai review start` then correctly refused because the kill switch was off, creating a deadlock.

This PR passes the `reviewDisabled` state into `applyPreVerifyReviewRouting` so that when review mode is disabled and no explicit review transaction governs the change, verification remains ready after `apply` without creating an un-fulfillable review obligation.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | Pass `reviewDisabled` to `applyPreVerifyReviewRouting` and bypass implicit `review/start` blocking when true |
| `internal/sddstatus/review_gate_disabled_test.go` | Add `TestDisabledReviewModeDoesNotBlockPreVerifyRouting` regression test |

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/sddstatus/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers