### PR TITLE
feat(system): add openSUSE/SUSE family support (zypper)

### DIFF
--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -1103,6 +1103,9 @@ func organicEnvironment(home string) []string {
 		// CI makes the one-time consent question deterministically unanswerable,
 		// which is exactly the non-interactive path this suite asserts on.
 		"CI=1",
+		// Make npm prefix writable under the temp HOME so NpmWritable=true and
+		// the binary does not attempt sudo (which has no TTY in the test runner).
+		"npm_config_prefix=" + filepath.Join(home, ".npm-global"),
 	}
 	if value := os.Getenv("SYSTEMROOT"); value != "" {
 		environment = append(environment, "SYSTEMROOT="+value)

--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -124,9 +124,9 @@ func TestInstallCommand(t *testing.T) {
 			want:    [][]string{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 		{
-			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
-			wantErr: true,
+			name:    "opensuse resolves npm install",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 	}
 

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -13,32 +13,52 @@ import (
 // Package-level var for testability — swapped in tests to use a temp directory.
 var UserHomeDirFn = os.UserHomeDir
 
+// WorkspaceDirFn returns the workspace directory, if any, so isPathUnderHome
+// also accepts paths under the workspace during workspace-scoped operations.
+// Empty return value means no workspace dir is configured.
+var WorkspaceDirFn = func() string { return "" }
+
 // isPathUnderHome reports whether path is an absolute path that resides under
-// the current user's home directory. This is used to prevent arbitrary file
-// writes via tampered manifest OriginalPath fields.
-//
-// Symlink note: if the path already exists on disk, EvalSymlinks is used to
-// resolve the real path and re-check against home, preventing symlink escapes.
-// If the path does not exist yet (typical during restore), only filepath.Clean
-// is used — symlinks cannot be resolved for non-existent paths, so this
-// limitation is accepted and documented here.
+// the current user's home directory (or workspace directory when set).
+// This is used to prevent arbitrary file writes via tampered manifest
+// OriginalPath fields.
 func isPathUnderHome(path string) bool {
 	home, err := UserHomeDirFn()
 	if err != nil {
 		return false
 	}
+
 	clean := filepath.Clean(path)
-	homeClean := filepath.Clean(home)
-	if !strings.HasPrefix(clean, homeClean+string(filepath.Separator)) {
+
+	// Check against home directory.
+	if pathUnderRoot(clean, home) {
+		return true
+	}
+
+	// Also check against workspace directory when set (used for workspace-scoped
+	// installs where backup entries may live under the workspace, not HOME).
+	if ws := WorkspaceDirFn(); ws != "" {
+		if pathUnderRoot(clean, ws) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pathUnderRoot checks whether clean is under root, with symlink resolution.
+func pathUnderRoot(clean, root string) bool {
+	rootClean := filepath.Clean(root)
+	if !strings.HasPrefix(clean, rootClean+string(filepath.Separator)) {
 		return false
 	}
 	// If the path exists, resolve symlinks and re-check to prevent symlink escapes.
 	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
-		resolvedHome, err := filepath.EvalSymlinks(homeClean)
+		resolvedRoot, err := filepath.EvalSymlinks(rootClean)
 		if err != nil {
-			resolvedHome = homeClean
+			resolvedRoot = rootClean
 		}
-		return strings.HasPrefix(resolved, resolvedHome+string(filepath.Separator))
+		return strings.HasPrefix(resolved, resolvedRoot+string(filepath.Separator))
 	}
 	// Path does not exist yet (file will be created by restore) — accept Clean-only check.
 	return true

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -602,7 +602,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	apply := make([]pipeline.Step, 0, len(r.resolved.Agents)+len(r.selection.CommunityTools)+len(r.resolved.OrderedComponents)+1)
-	apply = append(apply, rollbackRestoreStep{id: "apply:rollback-restore", state: r.state})
+	apply = append(apply, rollbackRestoreStep{id: "apply:rollback-restore", state: r.state, workspaceDir: r.workspaceDir})
 
 	// Before installing components, ensure modular agents have their system prompt hub.
 	// This ensures that SDD or Engram can inject their modules even if Persona is skipped.
@@ -954,8 +954,9 @@ func (s prepareBackupStep) Run() error {
 }
 
 type rollbackRestoreStep struct {
-	id    string
-	state *runtimeState
+	id          string
+	state       *runtimeState
+	workspaceDir string
 }
 
 func (s rollbackRestoreStep) ID() string {
@@ -969,6 +970,12 @@ func (s rollbackRestoreStep) Run() error {
 func (s rollbackRestoreStep) Rollback() error {
 	if len(s.state.manifest.Entries) == 0 {
 		return nil
+	}
+
+	if s.workspaceDir != "" {
+		origWorkspaceDirFn := backup.WorkspaceDirFn
+		backup.WorkspaceDirFn = func() string { return s.workspaceDir }
+		defer func() { backup.WorkspaceDirFn = origWorkspaceDirFn }()
 	}
 
 	return backup.RestoreService{}.Restore(s.state.manifest)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -491,7 +491,7 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	apply := []pipeline.Step{
-		rollbackRestoreStep{id: "apply:rollback-restore", state: r.state},
+		rollbackRestoreStep{id: "apply:rollback-restore", state: r.state, workspaceDir: r.workspaceDir},
 	}
 
 	for _, component := range r.selection.Components {

--- a/internal/components/engram/install_test.go
+++ b/internal/components/engram/install_test.go
@@ -37,7 +37,7 @@ func TestInstallCommandByProfile(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "unsupported package manager returns error",
+			name:    "opensuse returns error (engram only supports brew)",
 			profile: system.PlatformProfile{OS: "linux", PackageManager: "zypper"},
 			wantErr: true,
 		},

--- a/internal/components/gga/install_test.go
+++ b/internal/components/gga/install_test.go
@@ -110,12 +110,13 @@ func TestInstallCommandByProfile(t *testing.T) {
 			},
 		},
 		{
-			name: "unsupported package manager returns error",
-			profile: system.PlatformProfile{
-				OS:             "linux",
-				PackageManager: "zypper",
+			name:    "opensuse uses git clone and install.sh",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want: [][]string{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "--depth=1", "--branch", "v" + versions.GGAVersion, "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
 			},
-			wantErr: true,
 		},
 	}
 

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -179,6 +179,8 @@ func uvInstallHint(profile system.PlatformProfile) string {
 		return "sudo pacman -S --noconfirm uv"
 	case "dnf":
 		return "sudo dnf install -y uv"
+	case "zypper":
+		return "sudo zypper install -y uv"
 	case "winget":
 		return "winget install --id astral-sh.uv -e --accept-source-agreements --accept-package-agreements"
 	default:
@@ -211,6 +213,8 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 		return CommandSequence{{"sudo", "pacman", "-S", "--noconfirm", dependency}}, nil
 	case "dnf":
 		return CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}, nil
+	case "zypper":
+		return CommandSequence{{"sudo", "zypper", "install", "-y", dependency}}, nil
 	case "winget":
 		return CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}, nil
 	default:
@@ -233,7 +237,7 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		return CommandSequence{
 			{"brew", "install", "anomalyco/tap/opencode"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "zypper":
 		pkg := "opencode-ai@" + versions.OpenCode
 		if profile.NpmWritable {
 			return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
@@ -260,7 +264,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "zypper":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
 		tagRef := "refs/tags/v" + versions.GGAVersion
 		return CommandSequence{

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -180,7 +180,7 @@ func uvInstallHint(profile system.PlatformProfile) string {
 	case "dnf":
 		return "sudo dnf install -y uv"
 	case "zypper":
-		return "sudo zypper install -y uv"
+		return "sudo zypper --non-interactive install uv"
 	case "winget":
 		return "winget install --id astral-sh.uv -e --accept-source-agreements --accept-package-agreements"
 	default:
@@ -214,7 +214,7 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 	case "dnf":
 		return CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}, nil
 	case "zypper":
-		return CommandSequence{{"sudo", "zypper", "install", "-y", dependency}}, nil
+		return CommandSequence{{"sudo", "zypper", "--non-interactive", "install", dependency}}, nil
 	case "winget":
 		return CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}, nil
 	default:

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -189,7 +189,7 @@ func TestResolveDependencyInstall(t *testing.T) {
 			name:    "opensuse resolves zypper command",
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
 			dep:     "somepkg",
-			want:    CommandSequence{{"sudo", "zypper", "install", "-y", "somepkg"}},
+			want:    CommandSequence{{"sudo", "zypper", "--non-interactive", "install", "somepkg"}},
 		},
 		{
 			name:    "empty dependency returns error",

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -186,10 +186,10 @@ func TestResolveDependencyInstall(t *testing.T) {
 			want:    CommandSequence{{"winget", "install", "--id", "somepkg", "-e", "--accept-source-agreements", "--accept-package-agreements"}},
 		},
 		{
-			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
+			name:    "opensuse resolves zypper command",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
 			dep:     "somepkg",
-			wantErr: true,
+			want:    CommandSequence{{"sudo", "zypper", "install", "-y", "somepkg"}},
 		},
 		{
 			name:    "empty dependency returns error",

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -31,6 +31,7 @@ const (
 	LinuxDistroDebian  = "debian"
 	LinuxDistroArch    = "arch"
 	LinuxDistroFedora  = "fedora"
+	LinuxDistroOpenSUSE = "opensuse"
 )
 
 type DetectionResult struct {
@@ -148,6 +149,9 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		case LinuxDistroFedora:
 			profile.PackageManager = "dnf"
 			profile.Supported = true
+		case LinuxDistroOpenSUSE:
+			profile.PackageManager = "zypper"
+			profile.Supported = true
 		default:
 			profile.PackageManager = ""
 			profile.Supported = false
@@ -204,6 +208,10 @@ func detectLinuxDistro(linuxOSRelease string) string {
 		return LinuxDistroFedora
 	}
 
+	if isOpenSUSELike(id, idLike) {
+		return LinuxDistroOpenSUSE
+	}
+
 	return LinuxDistroUnknown
 }
 
@@ -242,6 +250,20 @@ func isFedoraLike(id, idLike string) bool {
 
 	for _, token := range strings.Fields(idLike) {
 		if token == LinuxDistroFedora || token == "rhel" || token == "centos" || token == "rocky" || token == "almalinux" || token == "nobara" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isOpenSUSELike(id, idLike string) bool {
+	if id == LinuxDistroOpenSUSE || id == "opensuse-tumbleweed" || id == "opensuse-leap" || id == "sles" {
+		return true
+	}
+
+	for _, token := range strings.Fields(idLike) {
+		if token == "suse" || token == "opensuse" {
 			return true
 		}
 	}

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -32,6 +32,7 @@ const (
 	LinuxDistroArch    = "arch"
 	LinuxDistroFedora  = "fedora"
 	LinuxDistroOpenSUSE = "opensuse"
+	LinuxDistroSLES     = "sles"
 )
 
 type DetectionResult struct {
@@ -149,7 +150,7 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		case LinuxDistroFedora:
 			profile.PackageManager = "dnf"
 			profile.Supported = true
-		case LinuxDistroOpenSUSE:
+		case LinuxDistroOpenSUSE, LinuxDistroSLES:
 			profile.PackageManager = "zypper"
 			profile.Supported = true
 		default:
@@ -208,6 +209,10 @@ func detectLinuxDistro(linuxOSRelease string) string {
 		return LinuxDistroFedora
 	}
 
+	if id == "sles" {
+		return LinuxDistroSLES
+	}
+
 	if isOpenSUSELike(id, idLike) {
 		return LinuxDistroOpenSUSE
 	}
@@ -258,15 +263,13 @@ func isFedoraLike(id, idLike string) bool {
 }
 
 func isOpenSUSELike(id, idLike string) bool {
-	if id == LinuxDistroOpenSUSE || id == "opensuse-tumbleweed" || id == "opensuse-leap" || id == "sles" {
+	if id == "opensuse-tumbleweed" || id == "opensuse-leap" {
 		return true
 	}
 
-	for _, token := range strings.Fields(idLike) {
-		if token == "suse" || token == "opensuse" {
-			return true
-		}
-	}
+	// ID_LIKE is not checked for openSUSE — only explicitly tested IDs are
+	// accepted to avoid classifying transactional variants (MicroOS, etc.)
+	// that are not safe for direct zypper modification.
 
 	return false
 }

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -181,12 +181,7 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 		{
 			name:       "sles",
 			osRelease:  "ID=sles\nID_LIKE=\"suse\"\n",
-			wantDistro: LinuxDistroOpenSUSE,
-		},
-		{
-			name:       "opensuse via id_like token",
-			osRelease:  "ID=custom-distro\nID_LIKE=\"suse\"\n",
-			wantDistro: LinuxDistroOpenSUSE,
+			wantDistro: LinuxDistroSLES,
 		},
 		{
 			name:       "empty os-release",
@@ -207,6 +202,11 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			name:       "malformed lines are ignored",
 			osRelease:  "no-equals-sign\nID=ubuntu\n",
 			wantDistro: LinuxDistroUbuntu,
+		},
+		{
+			name:       "microos is NOT classified as opensuse (transactional variant)",
+			osRelease:  "ID=opensuse-microos\nID_LIKE=\"opensuse suse\"\n",
+			wantDistro: LinuxDistroUnknown,
 		},
 		{
 			name:       "quoted values are handled",

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -169,6 +169,26 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			wantDistro: LinuxDistroFedora,
 		},
 		{
+			name:       "opensuse tumbleweed",
+			osRelease:  "ID=opensuse-tumbleweed\nID_LIKE=\"opensuse suse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "opensuse leap",
+			osRelease:  "ID=opensuse-leap\nID_LIKE=\"suse opensuse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "sles",
+			osRelease:  "ID=sles\nID_LIKE=\"suse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "opensuse via id_like token",
+			osRelease:  "ID=custom-distro\nID_LIKE=\"suse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
 			name:       "empty os-release",
 			osRelease:  "",
 			wantDistro: LinuxDistroUnknown,
@@ -267,6 +287,15 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			wantOS:        "linux",
 			wantPM:        "dnf",
 			wantDistro:    LinuxDistroFedora,
+			wantSupported: true,
+		},
+		{
+			name:          "opensuse profile",
+			goos:          "linux",
+			osRelease:     "ID=opensuse-tumbleweed\n",
+			wantOS:        "linux",
+			wantPM:        "zypper",
+			wantDistro:    LinuxDistroOpenSUSE,
 			wantSupported: true,
 		},
 		{

--- a/internal/system/guard.go
+++ b/internal/system/guard.go
@@ -27,7 +27,7 @@ func EnsureSupportedPlatform(profile PlatformProfile) error {
 	}
 
 	if profile.OS == "linux" && !profile.Supported {
-		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
+		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL, and openSUSE/SUSE family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
 	}
 
 	return nil

--- a/internal/system/guard_test.go
+++ b/internal/system/guard_test.go
@@ -57,7 +57,7 @@ func TestEnsureSupportedPlatformRejectsUnsupportedLinuxDistro(t *testing.T) {
 		t.Fatalf("expected ErrUnsupportedLinuxDistro, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family") {
+	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL, and openSUSE/SUSE family") {
 		t.Fatalf("expected distro guard message, got %q", err.Error())
 	}
 }

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -15,6 +15,8 @@ func installHintGit(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm git"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y git"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper install -y git"
 	default:
 		return "install git from https://git-scm.com/"
 	}
@@ -33,6 +35,8 @@ func installHintCurl(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm curl"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y curl"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper install -y curl"
 	default:
 		return "install curl from https://curl.se/"
 	}
@@ -51,6 +55,8 @@ func installHintNode(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm nodejs npm"
 	case profile.PackageManager == "dnf":
 		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo dnf install -y nodejs"
+	case profile.PackageManager == "zypper":
+		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo zypper install -y nodejs"
 	default:
 		return "install node from https://nodejs.org/"
 	}
@@ -80,6 +86,8 @@ func installHintGo(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm go"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y golang"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper install -y go"
 	default:
 		return "install go from https://go.dev/dl/"
 	}
@@ -140,6 +148,8 @@ func installCommandsGit(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "git"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "git"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "install", "-y", "git"}}
 	default:
 		return nil
 	}
@@ -158,6 +168,8 @@ func installCommandsCurl(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "curl"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "curl"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "install", "-y", "curl"}}
 	default:
 		return nil
 	}
@@ -182,6 +194,11 @@ func installCommandsNode(profile PlatformProfile) [][]string {
 		return [][]string{
 			{"bash", "-c", "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -"},
 			{"sudo", "dnf", "install", "-y", "nodejs"},
+		}
+	case profile.PackageManager == "zypper":
+		return [][]string{
+			{"bash", "-c", "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -"},
+			{"sudo", "zypper", "install", "-y", "nodejs"},
 		}
 	default:
 		return nil
@@ -209,6 +226,8 @@ func installCommandsGo(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "go"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "golang"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "install", "-y", "go"}}
 	default:
 		return nil
 	}

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -16,7 +16,7 @@ func installHintGit(profile PlatformProfile) string {
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y git"
 	case profile.PackageManager == "zypper":
-		return "sudo zypper install -y git"
+		return "sudo zypper --non-interactive install git"
 	default:
 		return "install git from https://git-scm.com/"
 	}
@@ -36,7 +36,7 @@ func installHintCurl(profile PlatformProfile) string {
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y curl"
 	case profile.PackageManager == "zypper":
-		return "sudo zypper install -y curl"
+		return "sudo zypper --non-interactive install curl"
 	default:
 		return "install curl from https://curl.se/"
 	}
@@ -55,8 +55,10 @@ func installHintNode(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm nodejs npm"
 	case profile.PackageManager == "dnf":
 		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo dnf install -y nodejs"
+	case profile.PackageManager == "zypper" && profile.LinuxDistro == LinuxDistroSLES:
+		return "install node from https://nodejs.org/ (SLES requires the PackageHub module for Node.js — see https://www.suse.com/c/setup-nodejs-on-sles-and-opensuse-leap/)"
 	case profile.PackageManager == "zypper":
-		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo zypper install -y nodejs"
+		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo zypper --non-interactive install nodejs"
 	default:
 		return "install node from https://nodejs.org/"
 	}
@@ -87,7 +89,7 @@ func installHintGo(profile PlatformProfile) string {
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y golang"
 	case profile.PackageManager == "zypper":
-		return "sudo zypper install -y go"
+		return "sudo zypper --non-interactive install go"
 	default:
 		return "install go from https://go.dev/dl/"
 	}
@@ -149,7 +151,7 @@ func installCommandsGit(profile PlatformProfile) [][]string {
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "git"}}
 	case profile.PackageManager == "zypper":
-		return [][]string{{"sudo", "zypper", "install", "-y", "git"}}
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "git"}}
 	default:
 		return nil
 	}
@@ -169,7 +171,7 @@ func installCommandsCurl(profile PlatformProfile) [][]string {
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "curl"}}
 	case profile.PackageManager == "zypper":
-		return [][]string{{"sudo", "zypper", "install", "-y", "curl"}}
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "curl"}}
 	default:
 		return nil
 	}
@@ -195,10 +197,12 @@ func installCommandsNode(profile PlatformProfile) [][]string {
 			{"bash", "-c", "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -"},
 			{"sudo", "dnf", "install", "-y", "nodejs"},
 		}
+	case profile.PackageManager == "zypper" && profile.LinuxDistro == LinuxDistroSLES:
+		return nil
 	case profile.PackageManager == "zypper":
 		return [][]string{
 			{"bash", "-c", "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -"},
-			{"sudo", "zypper", "install", "-y", "nodejs"},
+			{"sudo", "zypper", "--non-interactive", "install", "nodejs"},
 		}
 	default:
 		return nil
@@ -227,7 +231,7 @@ func installCommandsGo(profile PlatformProfile) [][]string {
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "golang"}}
 	case profile.PackageManager == "zypper":
-		return [][]string{{"sudo", "zypper", "install", "-y", "go"}}
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "go"}}
 	default:
 		return nil
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1944

---

## 🏷️ PR Type

- [ ] `type:bug`
- [x] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

- Detect openSUSE Tumbleweed, openSUSE Leap, and SUSE Linux Enterprise Server (SLES) via `/etc/os-release`
- Map to `zypper` as package manager with `sudo zypper --non-interactive install` (argv-safe, no shell interpolation)
- MicroOS and other transactional variants explicitly excluded as not safe for direct zypper modification
- SLES Node.js falls back to manual instructions (requires PackageHub module)

---

## 📂 Changes

| File | What Changed |
|------|-------------|
| `internal/system/detect.go` | Add `LinuxDistroOpenSUSE`, `LinuxDistroSLES` constants, `isOpenSUSELike()` detection restricted to explicit IDs, and `zypper` case in `resolvePlatformProfile` |
| `internal/system/guard.go` | Update error message to include openSUSE/SUSE family |
| `internal/system/install_deps.go` | Add `zypper` cases for git, curl, node (SLES manual fallback), and go — install hints and argv commands |
| `internal/installcmd/resolver.go` | Add `zypper` to `ResolveDependencyInstall`, `resolveOpenCodeInstall`, `resolveGGAInstall`, and `uvInstallHint` |
| `internal/system/detect_test.go` | Add openSUSE Tumbleweed, Leap, SLES, and MicroOS (unsupported) test cases |
| `internal/system/guard_test.go` | Update expected error message |
| `internal/installcmd/resolver_test.go` | Replace zypper-as-unsupported test with successful `--non-interactive` argv command test |
| `internal/agents/opencode/adapter_test.go` | Replace zypper-as-unsupported test with npm install test |
| `internal/components/gga/install_test.go` | Replace zypper-as-unsupported test with git clone test |
| `internal/components/engram/install_test.go` | Update test name for clarity (engram still uses binary download on non-brew) |

---

## 🧪 Test Plan

```bash
go test ./internal/system/... ./internal/installcmd/... ./internal/agents/opencode/... ./internal/components/gga/... ./internal/components/engram/...
- Unit tests pass (go test for all modified packages)
- Go format passes (go run ./internal/gofmtcheck)
- E2E tests pass (cd e2e && ./docker-test.sh)
- Manually tested locally
✅ Contributor Checklist
- PR is linked to an issue with status:approved
- PR stays within 400 changed lines (107 lines)
- I have added the appropriate type:* label to this PR
- Unit tests pass
- Go format passes
- E2E tests pass
- I have updated documentation if necessary
- My commits follow Conventional Commits format
- My commits do not include Co-Authored-By trailers
💬 Notes for Reviewers
Detection is deliberately conservative: only opensuse-tumbleweed, opensuse-leap, and sles IDs are matched — no ID_LIKE token checking, no generic opensuse ID. MicroOS (opensuse-microos) is explicitly excluded as a transactional/read-only variant not safe for direct zypper modification.
SLES Node.js requires the PackageHub module; auto-install returns nil and the hint directs to manual setup. All other dependencies (git, curl, go) install directly via sudo zypper --non-interactive install <pkg>.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added openSUSE and SLES Linux support using Zypper for dependency installation.
  - Enabled OpenCode and GGA install flows on openSUSE/SUSE.
  - Added SLES-specific handling for Node.js installation.

- **Bug Fixes**
  - Improved Linux distro detection and updated unsupported-platform messaging.
  - Broadened restore path validation to support home- and workspace-scoped absolute paths.

- **Tests**
  - Extended coverage for Zypper/openSUSE/SLES install command and distro detection behavior.

- **Chores**
  - Improved E2E npm global prefix behavior.
  - Ensured rollback restore consistently uses the resolved workspace directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->