### PR TITLE
fix(sync): unify shared skill file list resolution from embedded directory

### DIFF
--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -22,3 +22,18 @@ func Read(path string) (string, error) {
 	}
 	return string(data), nil
 }
+
+// SharedSkillFileNames returns the list of all file basenames in skills/_shared/ sorted alphabetically.
+func SharedSkillFileNames() ([]string, error) {
+	entries, err := FS.ReadDir("skills/_shared")
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	return names, nil
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -37,3 +37,12 @@ func SharedSkillFileNames() ([]string, error) {
 	}
 	return names, nil
 }
+
+// MustSharedSkillFileNames returns the list of all file basenames in skills/_shared/ sorted alphabetically, or panics.
+func MustSharedSkillFileNames() []string {
+	names, err := SharedSkillFileNames()
+	if err != nil {
+		panic("assets: " + err.Error())
+	}
+	return names
+}

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -2218,3 +2218,28 @@ func TestSDDArchiveFinalStateAuthorityContract(t *testing.T) {
 		}
 	}
 }
+
+func TestSharedSkillFileNamesReturnsAllEmbeddedFiles(t *testing.T) {
+	names, err := SharedSkillFileNames()
+	if err != nil {
+		t.Fatalf("SharedSkillFileNames() error = %v", err)
+	}
+	if len(names) != 8 {
+		t.Fatalf("SharedSkillFileNames() returned %d files, want 8: %v", len(names), names)
+	}
+	want := []string{
+		"SKILL.md",
+		"engram-convention.md",
+		"openspec-convention.md",
+		"persistence-contract.md",
+		"review-ledger-contract.md",
+		"sdd-phase-common.md",
+		"sdd-status-contract.md",
+		"skill-resolver.md",
+	}
+	for i, name := range names {
+		if name != want[i] {
+			t.Fatalf("names[%d] = %q, want %q", i, name, want[i])
+		}
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1790,8 +1790,7 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if adapter.SupportsSkills() {
 				skillDir := adapter.SkillsDir(targetDir)
 				if skillDir != "" {
-					sharedNames, _ := assets.SharedSkillFileNames()
-					for _, name := range sharedNames {
+					for _, name := range assets.MustSharedSkillFileNames() {
 						paths = append(paths, filepath.Join(skillDir, "_shared", name))
 					}
 					paths = append(paths,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1790,13 +1790,11 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if adapter.SupportsSkills() {
 				skillDir := adapter.SkillsDir(targetDir)
 				if skillDir != "" {
+					sharedNames, _ := assets.SharedSkillFileNames()
+					for _, name := range sharedNames {
+						paths = append(paths, filepath.Join(skillDir, "_shared", name))
+					}
 					paths = append(paths,
-						filepath.Join(skillDir, "_shared", "persistence-contract.md"),
-						filepath.Join(skillDir, "_shared", "engram-convention.md"),
-						filepath.Join(skillDir, "_shared", "openspec-convention.md"),
-						filepath.Join(skillDir, "_shared", "sdd-phase-common.md"),
-						filepath.Join(skillDir, "_shared", "sdd-status-contract.md"),
-						filepath.Join(skillDir, "_shared", "skill-resolver.md"),
 						filepath.Join(skillDir, "sdd-init", "SKILL.md"),
 						filepath.Join(skillDir, "sdd-explore", "SKILL.md"),
 						filepath.Join(skillDir, "sdd-propose", "SKILL.md"),

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -494,14 +494,9 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	if adapter.SupportsSkills() {
 		skillDir := adapter.SkillsDir(homeDir)
 		if skillDir != "" {
-			sharedFiles := []string{
-				"SKILL.md",
-				"persistence-contract.md",
-				"engram-convention.md",
-				"openspec-convention.md",
-				"sdd-phase-common.md",
-				"sdd-status-contract.md",
-				"skill-resolver.md",
+			sharedFiles, err := assets.SharedSkillFileNames()
+			if err != nil {
+				return InjectionResult{}, fmt.Errorf("read embedded _shared skill file names: %w", err)
 			}
 			sddSkillIDs := []model.SkillID{
 				"sdd-init", "sdd-explore", "sdd-propose", "sdd-spec",

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -276,15 +276,9 @@ func managedSkillBackupPaths(homeDir string, adapter agents.Adapter, diagnostics
 		})
 	}
 
-	for _, relPath := range []string{
-		"_shared/persistence-contract.md",
-		"_shared/engram-convention.md",
-		"_shared/openspec-convention.md",
-		"_shared/sdd-phase-common.md",
-		"_shared/sdd-status-contract.md",
-		"_shared/skill-resolver.md",
-	} {
-		paths = append(paths, filepath.Join(skillDir, relPath))
+	sharedNames, _ := assets.SharedSkillFileNames()
+	for _, name := range sharedNames {
+		paths = append(paths, filepath.Join(skillDir, "_shared", name))
 	}
 
 	return paths

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -276,8 +276,7 @@ func managedSkillBackupPaths(homeDir string, adapter agents.Adapter, diagnostics
 		})
 	}
 
-	sharedNames, _ := assets.SharedSkillFileNames()
-	for _, name := range sharedNames {
+	for _, name := range assets.MustSharedSkillFileNames() {
 		paths = append(paths, filepath.Join(skillDir, "_shared", name))
 	}
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1806

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

The `_shared` skill file lists in `gentle-ai doctor` (`internal/cli/run.go`), `gentle-ai upgrade` backup (`internal/update/upgrade/executor.go`), and SDD component injection (`internal/components/sdd/inject.go`) were hardcoded independently and had drifted apart, skipping `review-ledger-contract.md` and `SKILL.md` in health verification and backups.

This PR exports `SharedSkillFileNames()` in `internal/assets` to dynamically discover all files in `skills/_shared/` at runtime, unifying shared skill file resolution across doctor checks, upgrade backups, and SDD skill injection.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/assets.go` | Export `SharedSkillFileNames()` to read and return all file basenames in `skills/_shared/` dynamically |
| `internal/assets/assets.go` | Add `TestSharedSkillFileNamesReturnsAllEmbeddedFiles` unit test |
| `internal/cli/run.go` | Use `SharedSkillFileNames()` in `componentPathsWithWorkspaceScoped` for doctor health checks |
| `internal/update/upgrade/executor.go` | Use `SharedSkillFileNames()` in `managedSkillBackupPaths` for pre-upgrade backups |
| `internal/components/sdd/inject.go` | Use `SharedSkillFileNames()` for SDD shared skill file injection |

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/assets/... ./internal/components/sdd/... ./internal/update/upgrade/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared skill markdown files are now discovered automatically from embedded skill assets.
  * Skill installation and workspace setup now include all available shared files dynamically (no predefined list needed).

* **Bug Fixes**
  * Skill upgrade backups now include the complete set of embedded shared files, preserving newly added shared content.

* **Tests**
  * Added coverage to confirm the embedded shared skill filenames are detected correctly (including strict ordering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->