### PR TITLE
fix(review): preserve completed retry successor authority

### DIFF
--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -80,6 +80,35 @@ func TestCompactEscalatedGateReasonFallsBackWithoutDerivableCause(t *testing.T) 
 	}
 }
 
+func TestFinalVerificationRetryTerminalReceiptsKeepNormalGateOutcomes(t *testing.T) {
+	for _, terminal := range []struct {
+		name     string
+		approved bool
+		want     GateResult
+	}{
+		{name: "approved", approved: true, want: GateAllow},
+		{name: "escalated", approved: false, want: GateEscalated},
+	} {
+		t.Run(terminal.name, func(t *testing.T) {
+			fixture, successor, store, receipt := terminalFinalVerificationRetryFixture(t, "gate-"+terminal.name, terminal.approved)
+			before := readRetryAuthorityBytes(t, store)
+			for _, gate := range []GateKind{GatePostApply, GatePreCommit} {
+				t.Run(string(gate), func(t *testing.T) {
+					got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{Gate: gate, LineageID: successor.State.LineageID})
+					if got.Result != terminal.want {
+						t.Fatalf("%s retry gate = %#v, want %q", terminal.name, got, terminal.want)
+					}
+				})
+			}
+			after := mustLoadCompactRecord(t, store)
+			if after.Revision != successor.Revision || !bytes.Equal(before["state"], readRetryAuthorityBytes(t, store)["state"]) ||
+				!bytes.Equal(before["receipt"], readRetryAuthorityBytes(t, store)["receipt"]) {
+				t.Fatal("gate evaluation rewrote retry authority state, receipt, or revision")
+			}
+		})
+	}
+}
+
 func TestLegacyCurrentChangesGateRejectsCallerProjectionMismatch(t *testing.T) {
 	for _, gate := range []GateKind{GatePostApply, GatePreCommit} {
 		t.Run(string(gate), func(t *testing.T) {

--- a/internal/reviewtransaction/compact_inspect_test.go
+++ b/internal/reviewtransaction/compact_inspect_test.go
@@ -1,6 +1,7 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/json"
@@ -93,6 +94,152 @@ func TestInspectCompactRecoveryEdges(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestFinalVerificationRetryTerminalAuthorityTraversesReadOnlyGraphSurfaces(t *testing.T) {
+	for _, terminal := range []struct {
+		name     string
+		approved bool
+	}{
+		{name: "approved", approved: true},
+		{name: "escalated", approved: false},
+	} {
+		t.Run(terminal.name, func(t *testing.T) {
+			fixture, successor, store, receipt := terminalFinalVerificationRetryFixture(t, terminal.name, terminal.approved)
+			beforeState := readRetryAuthorityBytes(t, store)
+			beforeRevision := successor.Revision
+
+			if err := validateCompactFinalVerificationRetryEdge(fixture.predecessor, successor.State); err != nil {
+				t.Fatalf("direct retry edge validation: %v", err)
+			}
+			inventory, err := InventoryAuthority(context.Background(), fixture.repo)
+			if err != nil || !inventory.Complete || !inventory.Authoritative {
+				t.Fatalf("authority inventory = %#v, %v", inventory, err)
+			}
+			leaves, err := CompactAuthorityLeaves(context.Background(), fixture.repo)
+			if err != nil || len(leaves) != 1 || leaves[0].lineageID != successor.State.LineageID {
+				t.Fatalf("authority leaves = %#v, %v", leaves, err)
+			}
+			inspection, err := InspectCompactRecoveryEdges(context.Background(), fixture.repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			edge := inspectedEdge(t, inspection, successor.State.LineageID)
+			if !edge.Valid || len(edge.AnomalyClasses) != 0 || len(edge.Problems) != 0 {
+				t.Fatalf("retry inspection edge = %#v", edge)
+			}
+			payload, err := os.ReadFile(store.ReceiptPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			discovered, err := ParseCompactReceipt(payload)
+			if err != nil || !compactReceiptEqual(discovered, receipt) {
+				t.Fatalf("discovered retry receipt = %#v, %v", discovered, err)
+			}
+			after := mustLoadCompactRecord(t, store)
+			if after.Revision != beforeRevision || !bytes.Equal(beforeState["state"], readRetryAuthorityBytes(t, store)["state"]) ||
+				!bytes.Equal(beforeState["receipt"], readRetryAuthorityBytes(t, store)["receipt"]) {
+				t.Fatal("read-only retry traversal rewrote authority state, receipt, or revision")
+			}
+		})
+	}
+}
+
+func TestFinalVerificationRetryCorruptionFailsClosedAcrossAuthoritySurfaces(t *testing.T) {
+	mutations := []struct {
+		name   string
+		mutate func(*CompactState)
+	}{
+		{name: "lifecycle", mutate: func(state *CompactState) { state.State = StateValidating }},
+		{name: "frozen policy", mutate: func(state *CompactState) { state.PolicyHash = payloadDigest([]byte("forged-policy")) }},
+		{name: "source proof", mutate: func(state *CompactState) {
+			state.Recovery.FinalVerificationRetry.FailedEvidenceHash = payloadDigest([]byte("forged-proof"))
+		}},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			fixture, successor, store, receipt := terminalFinalVerificationRetryFixture(t, "corrupted-"+strings.ReplaceAll(mutation.name, " ", "-"), true)
+			mutation.mutate(&successor.State)
+			_, payload, err := makeCompactRecord(successor.State)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			inventory, err := InventoryAuthority(context.Background(), fixture.repo)
+			quarantined := slices.ContainsFunc(inventory.Diagnostics, func(diagnostic AuthorityInventoryDiagnostic) bool {
+				return strings.Contains(diagnostic.Path, successor.State.LineageID)
+			})
+			if err != nil || inventory.Authoritative && !quarantined {
+				t.Fatalf("corrupted authority inventory = %#v, %v", inventory, err)
+			}
+			leaves, leafErr := CompactAuthorityLeaves(context.Background(), fixture.repo)
+			if leafErr == nil && slices.ContainsFunc(leaves, func(leaf CompactStore) bool { return leaf.lineageID == successor.State.LineageID }) {
+				t.Fatalf("corrupted retry authority was accepted as a leaf: %#v", leaves)
+			}
+			inspection, err := InspectCompactRecoveryEdges(context.Background(), fixture.repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, edge := range inspection.Edges {
+				if edge.SuccessorLineageID == successor.State.LineageID && edge.Valid {
+					t.Fatalf("corrupted retry inspection = %#v", inspection)
+				}
+			}
+			if len(inspection.Edges) == 0 && !slices.ContainsFunc(inspection.EntryDiagnostics, func(diagnostic CompactRecoveryEntryDiagnostic) bool {
+				return diagnostic.LineageID == successor.State.LineageID
+			}) {
+				t.Fatalf("corrupted retry was neither rejected nor diagnosed: %#v", inspection)
+			}
+			if gate := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: receipt.LineageID}); gate.Result != GateInvalidated {
+				t.Fatalf("corrupted retry gate = %#v", gate)
+			}
+		})
+	}
+}
+
+func terminalFinalVerificationRetryFixture(t *testing.T, suffix string, approved bool) (finalVerificationRetryFixture, CompactRecord, CompactStore, CompactReceipt) {
+	t.Helper()
+	fixture := newFinalVerificationRetryFixture(t, "retry-graph-source-"+suffix, "retry-graph-successor-"+suffix)
+	successor, err := RetryCompactFinalVerification(context.Background(), fixture.repo, fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := successor.State.CompleteVerification([]byte("retry terminal verification\n"), approved); err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), fixture.repo, successor.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace(successor.Revision, "review/complete-verification", successor.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor.Revision = revision
+	receipt, err := successor.State.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return fixture, successor, store, receipt
+}
+
+func readRetryAuthorityBytes(t *testing.T, store CompactStore) map[string][]byte {
+	t.Helper()
+	result := map[string][]byte{}
+	for name, path := range map[string]string{"state": store.StatePath(), "receipt": store.ReceiptPath()} {
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result[name] = payload
+	}
+	return result
 }
 func TestCompactRecoveryInspectionCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -463,6 +463,10 @@ func validateCompactFinalVerificationRetryProofShape(successor CompactState, rec
 	return nil
 }
 
+// validateAndNormalizeFinalVerificationRetrySuccessorLifecycle accepts validating
+// successors with empty evidence and approved or escalated successors with a valid
+// evidence hash. It returns a copy normalized to StateValidating with evidence
+// cleared for frozen-authority comparison.
 func validateAndNormalizeFinalVerificationRetrySuccessorLifecycle(successor CompactState) (CompactState, error) {
 	switch successor.State {
 	case StateValidating:

--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -441,6 +441,9 @@ func validateCompactFinalVerificationRetryProofShape(successor CompactState, rec
 		return errors.New("final-verification retry incident does not bind its source proof")
 	}
 	attempt := proof.SourceFinalizeAttempt
+	if err := validateFinalizeAttemptRequest(recovery.PredecessorLineageID, attempt.Request); err != nil {
+		return err
+	}
 	if !attempt.Completed || !attempt.ReceiptPublished || len(attempt.Transitions) == 0 || !finalVerificationAttemptHasRevisionContinuity(attempt) {
 		return errors.New("final-verification retry source FINALIZE attempt is incomplete")
 	}
@@ -492,7 +495,8 @@ func validateCompactFinalVerificationRetryEdge(predecessor CompactRecord, succes
 		return err
 	}
 	proof := recovery.FinalVerificationRetry
-	if proof.FailedEvidenceHash != predecessor.State.EvidenceHash || proof.TargetIdentity != predecessor.State.CurrentSnapshot.Identity ||
+	if recovery.PredecessorLineageID != predecessor.State.LineageID || recovery.PredecessorRevision != predecessor.Revision ||
+		proof.FailedEvidenceHash != predecessor.State.EvidenceHash || proof.TargetIdentity != predecessor.State.CurrentSnapshot.Identity ||
 		proof.TerminalRevision != predecessor.Revision {
 		return errors.New("final-verification retry proof does not bind its predecessor")
 	}
@@ -500,7 +504,7 @@ func validateCompactFinalVerificationRetryEdge(predecessor CompactRecord, succes
 	if err != nil {
 		return err
 	}
-	want.LineageID, want.Generation, want.State, want.EvidenceHash, want.Recovery = successor.LineageID, successor.Generation, StateValidating, "", successor.Recovery
+	want.LineageID, want.Generation, want.State, want.EvidenceHash, want.Recovery = successor.LineageID, predecessor.State.Generation+1, StateValidating, "", successor.Recovery
 	if !compactStateEqual(want, normalizedSuccessor) {
 		return errors.New("final-verification retry successor changed frozen authority or budget state")
 	}

--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -467,14 +467,14 @@ func validateAndNormalizeFinalVerificationRetrySuccessorLifecycle(successor Comp
 	switch successor.State {
 	case StateValidating:
 		if successor.EvidenceHash != "" {
-			return CompactState{}, errors.New("final-verification retry validating successor must not contain evidence")
+			return CompactState{}, errors.New("final-verification retry validating successor must not contain evidence") // refusal:by-design world-action: the persisted authority shape is invalid; no gentle-ai command can make forged authority valid
 		}
 	case StateApproved, StateEscalated:
 		if !validSHA256(successor.EvidenceHash) {
-			return CompactState{}, errors.New("final-verification retry terminal successor requires a valid evidence hash")
+			return CompactState{}, errors.New("final-verification retry terminal successor requires a valid evidence hash") // refusal:by-design world-action: the persisted authority shape is invalid; no gentle-ai command can make forged authority valid
 		}
 	default:
-		return CompactState{}, errors.New("final-verification retry successor has an unsupported lifecycle state")
+		return CompactState{}, errors.New("final-verification retry successor has an unsupported lifecycle state") // refusal:by-design world-action: the persisted authority shape is invalid; no gentle-ai command can make forged authority valid
 	}
 	successor.State = StateValidating
 	successor.EvidenceHash = ""

--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -460,6 +460,24 @@ func validateCompactFinalVerificationRetryProofShape(successor CompactState, rec
 	return nil
 }
 
+func validateAndNormalizeFinalVerificationRetrySuccessorLifecycle(successor CompactState) (CompactState, error) {
+	switch successor.State {
+	case StateValidating:
+		if successor.EvidenceHash != "" {
+			return CompactState{}, errors.New("final-verification retry validating successor must not contain evidence")
+		}
+	case StateApproved, StateEscalated:
+		if !validSHA256(successor.EvidenceHash) {
+			return CompactState{}, errors.New("final-verification retry terminal successor requires a valid evidence hash")
+		}
+	default:
+		return CompactState{}, errors.New("final-verification retry successor has an unsupported lifecycle state")
+	}
+	successor.State = StateValidating
+	successor.EvidenceHash = ""
+	return successor, nil
+}
+
 func validateCompactFinalVerificationRetryEdge(predecessor CompactRecord, successor CompactState) error {
 	recovery := successor.Recovery
 	if recovery == nil || recovery.Disposition != RecoveryFinalVerificationRetry || recovery.FinalVerificationRetry == nil ||
@@ -467,6 +485,10 @@ func validateCompactFinalVerificationRetryEdge(predecessor CompactRecord, succes
 		return errors.New("final-verification retry requires an escalated failed-verification predecessor")
 	}
 	if err := validateCompactFinalVerificationRetryProofShape(successor, *recovery); err != nil {
+		return err
+	}
+	normalizedSuccessor, err := validateAndNormalizeFinalVerificationRetrySuccessorLifecycle(successor)
+	if err != nil {
 		return err
 	}
 	proof := recovery.FinalVerificationRetry
@@ -479,7 +501,7 @@ func validateCompactFinalVerificationRetryEdge(predecessor CompactRecord, succes
 		return err
 	}
 	want.LineageID, want.Generation, want.State, want.EvidenceHash, want.Recovery = successor.LineageID, successor.Generation, StateValidating, "", successor.Recovery
-	if !compactStateEqual(want, successor) {
+	if !compactStateEqual(want, normalizedSuccessor) {
 		return errors.New("final-verification retry successor changed frozen authority or budget state")
 	}
 	return nil

--- a/internal/reviewtransaction/final_verification_retry_test.go
+++ b/internal/reviewtransaction/final_verification_retry_test.go
@@ -77,6 +77,55 @@ func TestRetryCompactFinalVerificationCreatesOnlyOneFrozenValidatingSuccessor(t 
 	}
 }
 
+func TestValidateCompactFinalVerificationRetryEdgeAcceptsOnlyExactLifecycleEvidencePairs(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		state     State
+		evidence  string
+		wantError bool
+	}{
+		{name: "validating with empty evidence", state: StateValidating, evidence: ""},
+		{name: "approved with valid evidence", state: StateApproved, evidence: hash("a")},
+		{name: "escalated with valid evidence", state: StateEscalated, evidence: hash("b")},
+		{name: "validating with evidence", state: StateValidating, evidence: hash("c"), wantError: true},
+		{name: "approved with empty evidence", state: StateApproved, evidence: "", wantError: true},
+		{name: "escalated with empty evidence", state: StateEscalated, evidence: "", wantError: true},
+		{name: "approved with malformed evidence", state: StateApproved, evidence: "sha256:not-a-digest", wantError: true},
+		{name: "escalated with uppercase evidence", state: StateEscalated, evidence: strings.ToUpper(hash("d")), wantError: true},
+		{name: "unsupported state with valid evidence", state: StateReviewing, evidence: hash("e"), wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newFinalVerificationRetryFixture(t, "retry-edge-source", "retry-edge-successor")
+			source, err := deriveFinalVerificationRetrySourceLocked(context.Background(), fixture.store, fixture.predecessor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			successor, err := finalVerificationRetrySuccessor(fixture.predecessor, fixture.request, source, fixture.request.RecoveredAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			successor.State = tt.state
+			successor.EvidenceHash = tt.evidence
+			if !tt.wantError {
+				normalized, err := validateAndNormalizeFinalVerificationRetrySuccessorLifecycle(successor)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := fixture.predecessor.State
+				want.LineageID, want.Generation, want.State, want.EvidenceHash, want.Recovery = successor.LineageID, successor.Generation, StateValidating, "", successor.Recovery
+				if !compactStateEqual(want, normalized) {
+					t.Fatalf("lifecycle normalization changed frozen authority\ngot=%#v\nwant=%#v", normalized, want)
+				}
+			}
+
+			err = validateCompactFinalVerificationRetryEdge(fixture.predecessor, successor)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("validateCompactFinalVerificationRetryEdge() error = %v, want error %t", err, tt.wantError)
+			}
+		})
+	}
+}
+
 func TestRetryCompactFinalVerificationUsesCorrectedCurrentSnapshot(t *testing.T) {
 	fixture := newCorrectedFinalVerificationRetryFixture(t, "retry-corrected-source", "retry-corrected-successor")
 	if snapshotsEqual(fixture.predecessor.State.InitialSnapshot, fixture.predecessor.State.CurrentSnapshot) {

--- a/internal/reviewtransaction/final_verification_retry_test.go
+++ b/internal/reviewtransaction/final_verification_retry_test.go
@@ -126,6 +126,105 @@ func TestValidateCompactFinalVerificationRetryEdgeAcceptsOnlyExactLifecycleEvide
 	}
 }
 
+func TestValidateCompactFinalVerificationRetryEdgeRejectsProtectedFieldMutationsAcrossAcceptedLifecycles(t *testing.T) {
+	baselines := []struct {
+		name     string
+		state    State
+		evidence string
+	}{
+		{name: "validating empty", state: StateValidating},
+		{name: "approved valid hash", state: StateApproved, evidence: hash("approved")},
+		{name: "escalated valid hash", state: StateEscalated, evidence: hash("escalated")},
+	}
+	mutations := []struct {
+		name   string
+		mutate func(*CompactState)
+	}{
+		{name: "snapshot target", mutate: func(state *CompactState) { state.InitialSnapshot.Identity = hash("forged-snapshot") }},
+		{name: "policy risk", mutate: func(state *CompactState) { state.PolicyHash = hash("forged-policy") }},
+		{name: "lenses results", mutate: func(state *CompactState) {
+			state.LensResults = append(state.LensResults, LensResult{Lens: "review-forged"})
+		}},
+		{name: "findings outcomes", mutate: func(state *CompactState) { state.Findings = append(state.Findings, Finding{ID: "forged-finding"}) }},
+		{name: "correction history budgets", mutate: func(state *CompactState) { state.CorrectionBudget++ }},
+		{name: "recovery proof authorization", mutate: func(state *CompactState) { state.Recovery.MaintainerAuthorization = "forged-authorization" }},
+		{name: "lineage generation", mutate: func(state *CompactState) { state.Generation++ }},
+	}
+
+	for _, baseline := range baselines {
+		for _, mutation := range mutations {
+			t.Run(baseline.name+"/"+mutation.name, func(t *testing.T) {
+				fixture := newFinalVerificationRetryFixture(t, "retry-mutation-source", "retry-mutation-successor")
+				source, err := deriveFinalVerificationRetrySourceLocked(context.Background(), fixture.store, fixture.predecessor)
+				if err != nil {
+					t.Fatal(err)
+				}
+				successor, err := finalVerificationRetrySuccessor(fixture.predecessor, fixture.request, source, fixture.request.RecoveredAt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				successor.State, successor.EvidenceHash = baseline.state, baseline.evidence
+				mutation.mutate(&successor)
+				if err := validateCompactFinalVerificationRetryEdge(fixture.predecessor, successor); err == nil {
+					t.Fatal("protected-field mutation was accepted")
+				}
+			})
+		}
+	}
+}
+
+func TestValidateCompactFinalVerificationRetryEdgeRejectsForgedSourceFinalizeAttempt(t *testing.T) {
+	mutations := []struct {
+		name   string
+		rehash bool
+		mutate func(*CompactFinalVerificationRetryProof)
+	}{
+		{name: "evidence digest", mutate: func(proof *CompactFinalVerificationRetryProof) {
+			proof.SourceFinalizeAttempt.Request.EvidenceDigest = hash("forged-evidence")
+		}},
+		{name: "request digest", mutate: func(proof *CompactFinalVerificationRetryProof) {
+			proof.SourceFinalizeAttempt.Request.RequestDigest = hash("forged-request")
+		}},
+		{name: "request lineage", mutate: func(proof *CompactFinalVerificationRetryProof) {
+			proof.SourceFinalizeAttempt.Request.LineageID = "forged-lineage"
+		}},
+		{name: "request lineage canonical", rehash: true, mutate: func(proof *CompactFinalVerificationRetryProof) {
+			proof.SourceFinalizeAttempt.Request.LineageID = "forged-lineage"
+		}},
+		{name: "candidate binding", mutate: func(proof *CompactFinalVerificationRetryProof) {
+			proof.SourceFinalizeAttempt.Request.CandidateDigest = hash("forged-candidate")
+		}},
+		{name: "failed binding", mutate: func(proof *CompactFinalVerificationRetryProof) {
+			proof.SourceFinalizeAttempt.Request.FailedDigest = hash("forged-failed")
+		}},
+	}
+
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			fixture := newFinalVerificationRetryFixture(t, "retry-proof-source", "retry-proof-successor")
+			source, err := deriveFinalVerificationRetrySourceLocked(context.Background(), fixture.store, fixture.predecessor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			successor, err := finalVerificationRetrySuccessor(fixture.predecessor, fixture.request, source, fixture.request.RecoveredAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mutation.mutate(successor.Recovery.FinalVerificationRetry)
+			if mutation.rehash {
+				proof := successor.Recovery.FinalVerificationRetry
+				proof.SourceFinalizeAttempt.Request.RequestDigest = FinalizeAttemptRequestDigest(proof.SourceFinalizeAttempt.Request)
+				proof.FinalizeRequestDigest = proof.SourceFinalizeAttempt.Request.RequestDigest
+				proof.Incident.FinalizeRequestDigest = proof.FinalizeRequestDigest
+				proof.IncidentDigest = FinalVerificationIncidentDigest(proof.Incident)
+			}
+			if err := validateCompactFinalVerificationRetryEdge(fixture.predecessor, successor); err == nil {
+				t.Fatal("forged source FINALIZE attempt was accepted")
+			}
+		})
+	}
+}
+
 func TestRetryCompactFinalVerificationUsesCorrectedCurrentSnapshot(t *testing.T) {
 	fixture := newCorrectedFinalVerificationRetryFixture(t, "retry-corrected-source", "retry-corrected-successor")
 	if snapshotsEqual(fixture.predecessor.State.InitialSnapshot, fixture.predecessor.State.CurrentSnapshot) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1915

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Preserve completed final-verification retry successor authority during offline replay.
- Derive successor generation and proof bindings from canonical predecessor authority while rejecting forged or malformed persisted state.
- Cover compact inspection, admission, lifecycle, and refusal classification paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/final_verification_retry.go` | Validates completed retry successors against canonical predecessor-derived authority and frozen lifecycle state. |
| `internal/reviewtransaction/final_verification_retry_test.go` | Covers accepted lifecycle states and forged authority, request, evidence, and proof mutations. |
| `internal/reviewtransaction/compact_inspect_test.go` | Verifies compact inspection traverses legitimate completed retry successors. |
| `internal/reviewtransaction/compact_gate_test.go` | Verifies compact admission accepts the repaired authority path. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Vet**
```bash
go vet ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go vet passes (`go vet ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Additional verification:

- Focused retry suite: 61 tests passed.
- Review transaction package: 1,942 tests passed.
- Anonymous real-authority A/B: the released v2.2.0 classified 19/20 recovery edges as valid and rejected one retry edge; this candidate classified 20/20 as valid from the same persisted graph with 168 entries and 20 recovery edges.
- A deterministic 39,851-entry path/type/mode/content manifest was identical before and after inspection. Authority, index, HEAD, and workspace state were unchanged.
- The E2E Docker suite was not run locally and will run in CI.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.

The integrity/admission guard accepts only `validating` successors with empty evidence, or `approved`/`escalated` successors with a valid evidence hash, when accompanied by the canonical request, predecessor-derived generation, deterministic proof bindings, and exhaustive frozen-state equality. Its negative population covers malformed lifecycle or evidence, forged generation or request bindings, and mutations to snapshots, policies, results, findings, budgets, or proof authorization.

A fully self-consistent historical mismatch that would require unavailable journal bytes remains outside the offline replay claim.

Review-driven development is disabled/unmanaged for this delivery; no review transaction was started or validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for final-verification retry successors and proof shapes, including stricter lifecycle/evidence matching.
  * Rejects forged or mutated successor recovery details and protected authority fields.
  * Preserves correct gate outcomes for terminal receipts and prevents retry authority state from being altered during inspection/traversal.
  * Ensures corrupted paths fail closed by quarantining invalid lineage and marking edges invalid.

* **Tests**
  * Added new cases covering lifecycle/evidence acceptance/rejection, protected-field integrity, forged source-finalize attempts, read-only traversal, and corruption handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->