### PR TITLE
fix(review): preserve advertised remote failures

### DIFF
--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -633,10 +633,6 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 	remotes := strings.Fields(string(output))
 	matches := []PrePRBoundarySelection{}
 	for _, remote := range remotes {
-		identity, identityErr := remoteRepositoryIdentity(ctx, repo, remote)
-		if identityErr != nil {
-			return PrePRBoundarySelection{}, identityErr
-		}
 		branch := selector
 		if strings.HasPrefix(selector, remote+"/") {
 			branch = strings.TrimPrefix(selector, remote+"/")
@@ -647,6 +643,10 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 			branch = ""
 		} else if _, err := runGit(ctx, repo, nil, nil, "check-ref-format", "--branch", branch); err != nil {
 			continue
+		}
+		identity, identityErr := remoteRepositoryIdentity(ctx, repo, remote)
+		if identityErr != nil {
+			return PrePRBoundarySelection{}, identityErr
 		}
 		remoteOutput, queryErr := runGit(ctx, repo, nil, nil, "ls-remote", "--heads", remote, branch)
 		if queryErr != nil {

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -635,7 +635,7 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 	for _, remote := range remotes {
 		identity, identityErr := remoteRepositoryIdentity(ctx, repo, remote)
 		if identityErr != nil {
-			continue
+			return PrePRBoundarySelection{}, identityErr
 		}
 		branch := selector
 		if strings.HasPrefix(selector, remote+"/") {
@@ -650,7 +650,7 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 		}
 		remoteOutput, queryErr := runGit(ctx, repo, nil, nil, "ls-remote", "--heads", remote, branch)
 		if queryErr != nil {
-			continue
+			return PrePRBoundarySelection{}, queryErr
 		}
 		for _, line := range strings.Split(string(remoteOutput), "\n") {
 			fields := strings.Fields(line)
@@ -692,7 +692,10 @@ func advertisedRemoteRef(ctx context.Context, repo, remote, ref, selector string
 
 func remoteRepositoryIdentity(ctx context.Context, repo, remote string) (string, error) {
 	output, err := runGit(ctx, repo, nil, nil, "config", "--get", "remote."+remote+".url")
-	if err != nil || strings.TrimSpace(string(output)) == "" {
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(string(output)) == "" {
 		return "", errors.New("publication remote URL is not configured")
 	}
 	return repositoryLocationIdentity(ctx, repo, strings.TrimSpace(string(output)))

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -728,6 +729,77 @@ func TestDefaultPrePushBaseKeepsInfrastructureErrorsUntyped(t *testing.T) {
 	_, _, _, upstreamErr := configuredUpstreamRef(ctx, repo, branch)
 	if !errors.Is(upstreamErr, context.Canceled) || errors.As(upstreamErr, &targetErr) {
 		t.Fatalf("cancelled upstream lookup error = %T %v", upstreamErr, upstreamErr)
+	}
+}
+
+func TestResolveAdvertisedSelectorPreservesRemoteIdentityFailure(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+
+	original := gitCommandContext
+	t.Setenv("GENTLE_AI_TEST_GIT_PATH_FAIL", "1")
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slicesContain(args, "config") && slicesContain(args, "remote.origin.url") {
+			return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$")
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	_, err := resolveAdvertisedSelector(context.Background(), repo, "origin/"+branch, PrePRBoundaryExplicit)
+	var gitErr *GitCommandError
+	var targetErr *GateTargetResolutionError
+	if !errors.As(err, &gitErr) || errors.As(err, &targetErr) {
+		t.Fatalf("remote identity error = %T %v, want operational GitCommandError", err, err)
+	}
+}
+
+func TestResolveAdvertisedSelectorPreservesRemoteQueryFailure(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "missing.git"))
+
+	_, err := resolveAdvertisedSelector(context.Background(), repo, "origin/"+branch, PrePRBoundaryExplicit)
+	var gitErr *GitCommandError
+	var targetErr *GateTargetResolutionError
+	if !errors.As(err, &gitErr) || errors.As(err, &targetErr) {
+		t.Fatalf("remote query error = %T %v, want operational GitCommandError", err, err)
+	}
+}
+
+func TestResolveAdvertisedSelectorClassifiesZeroAndMultipleMatches(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		selector  string
+		configure func(*testing.T, string, string)
+	}{
+		{name: "zero", selector: "missing"},
+		{name: "multiple", configure: func(t *testing.T, repo, branch string) {
+			upstream := filepath.Join(t.TempDir(), "upstream.git")
+			gitSnapshot(t, repo, "clone", "--bare", repo, upstream)
+			gitSnapshot(t, repo, "remote", "add", "upstream", upstream)
+		}, selector: "main"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			branch := currentBranch(context.Background(), repo)
+			configurePublicationRemote(t, repo, branch)
+			if tt.configure != nil {
+				tt.configure(t, repo, branch)
+			}
+			selector := tt.selector
+			if selector == "main" {
+				selector = branch
+			}
+
+			_, err := resolveAdvertisedSelector(context.Background(), repo, selector, PrePRBoundaryExplicit)
+			var targetErr *GateTargetResolutionError
+			if !errors.As(err, &targetErr) || targetErr.RequiredInput != "base_ref" {
+				t.Fatalf("%s selector error = %T %v, want semantic target resolution", tt.name, err, err)
+			}
+		})
 	}
 }
 

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -755,6 +755,31 @@ func TestResolveAdvertisedSelectorPreservesRemoteIdentityFailure(t *testing.T) {
 	}
 }
 
+func TestResolveAdvertisedSelectorSkipsUnselectedRemoteIdentityFailure(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "remote", "add", "backup", filepath.Join(t.TempDir(), "backup.git"))
+
+	original := gitCommandContext
+	t.Setenv("GENTLE_AI_TEST_GIT_PATH_FAIL", "1")
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slicesContain(args, "config") && slicesContain(args, "remote.backup.url") {
+			return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$")
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	selection, err := resolveAdvertisedSelector(context.Background(), repo, "origin/"+branch, PrePRBoundaryExplicit)
+	if err != nil {
+		t.Fatalf("explicit selected remote resolution error = %T %v", err, err)
+	}
+	if selection.Remote != "origin" || selection.RemoteRef != "refs/heads/"+branch {
+		t.Fatalf("selection = %#v, want origin/%s", selection, branch)
+	}
+}
+
 func TestResolveAdvertisedSelectorPreservesRemoteQueryFailure(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	branch := currentBranch(context.Background(), repo)
@@ -796,7 +821,9 @@ func TestResolveAdvertisedSelectorClassifiesZeroAndMultipleMatches(t *testing.T)
 
 			_, err := resolveAdvertisedSelector(context.Background(), repo, selector, PrePRBoundaryExplicit)
 			var targetErr *GateTargetResolutionError
-			if !errors.As(err, &targetErr) || targetErr.RequiredInput != "base_ref" {
+			var gitErr *GitCommandError
+			var processErr *GitProcessControlError
+			if !errors.As(err, &targetErr) || targetErr.RequiredInput != "base_ref" || errors.As(err, &gitErr) || errors.As(err, &processErr) {
 				t.Fatalf("%s selector error = %T %v, want semantic target resolution", tt.name, err, err)
 			}
 		})

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -792,6 +792,9 @@ func TestResolveAdvertisedSelectorPreservesRemoteQueryFailure(t *testing.T) {
 	if !errors.As(err, &gitErr) || errors.As(err, &targetErr) {
 		t.Fatalf("remote query error = %T %v, want operational GitCommandError", err, err)
 	}
+	if len(gitErr.Args) != 4 || gitErr.Args[0] != "ls-remote" || gitErr.Args[1] != "--heads" || gitErr.Args[2] != "origin" || gitErr.Args[3] != branch {
+		t.Fatalf("remote query git args = %q, want ls-remote --heads origin %q", gitErr.Args, branch)
+	}
 }
 
 func TestResolveAdvertisedSelectorClassifiesZeroAndMultipleMatches(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1890

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Preserve remote identity and `ls-remote` operational failures during advertised selector resolution.
- Keep successful zero/multiple matches as semantic target-resolution failures without fabricating a fallback.
- Add regressions for identity failures, query failures, and genuine zero/multiple advertised matches.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/gate.go` | Propagate causal Git failures from remote identity and advertised branch queries. |
| `internal/reviewtransaction/gate_test.go` | Cover operational error preservation and semantic match-count classifications. |

---

## 🧪 Test Plan

**Focused regression and package suite**
```bash
go test ./internal/reviewtransaction -run 'TestResolveAdvertisedSelector(PreservesRemoteIdentityFailure|PreservesRemoteQueryFailure|ClassifiesZeroAndMultipleMatches)$' -count=1
go test ./internal/reviewtransaction -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Focused regressions pass
- [x] `internal/reviewtransaction` package suite passes
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] Full `go test ./...` completed locally — the organic runtime installer exceeded the 10-minute local bound and its external client install subprocesses were killed
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Docker is unavailable in the local WSL distro; CI will run the repository harness
- [x] Manually verified zero/multiple matches remain typed semantic failures while Git subprocess failures remain operational

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 117 authored changed lines |
| Check Issue Reference | ⏳ | Links approved issue #1890 |
| Check Issue Has `status:approved` | ⏳ | Issue is approved |
| Check PR Has `type:*` Label | ⏳ | Maintainer must apply `type:bug`; contributors cannot add labels in this repository |
| Unit Tests | ⏳ | CI pending |
| Go Format | ⏳ | CI pending; local check passed |
| E2E Tests | ⏳ | CI pending |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Maintainer-applied `type:bug` label pending; GitHub rejected the contributor label mutation due to repository permissions
- [ ] Unit tests pass (`go test ./...`) — focused and package suites pass; full CI pending
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI pending
- [x] Documentation is not required for this internal error-classification fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The qualifying gate boundary is advertised remote selection. Trustworthy successful query results remain the only population admitted into match counting; identity, subprocess, timeout, and cancellation failures now fail closed as their causal operational errors instead of being reclassified as zero matches. No global target-kind or fallback behavior changed, and final live remote revalidation remains intact.

- [x] Challenged the qualifying gate predicate against the real-world failure reported in #1890.
- [x] Confirmed the legitimate population excludes failed or untrusted remote queries from semantic match counting.
- [x] `.guard-population-baseline.txt` is unchanged because this patch corrects error propagation rather than introducing a new guard declaration.
