### PR TITLE
fix(review): batch per-path git queries during candidate construction

### DIFF
--- a/e2e/organicruntime/organic_lifecycle_hardening_test.go
+++ b/e2e/organicruntime/organic_lifecycle_hardening_test.go
@@ -37,33 +37,28 @@ func currentChangesTargetIdentity(t *testing.T, repo string) string {
 	return snapshot.Identity
 }
 
-// organicLargeWorkspaceE2EEnvironment gates the deliberately heavy
-// large-workspace review/start proof below. Building a several-thousand-file
-// candidate launches one Git subprocess per intended-untracked path
-// (untrackedProof) plus per-changed-path diff work, twice over (once for
-// this test's own target-identity precompute, once inside review/start
-// itself): that is what reliably pushes real candidate construction past
-// the shared 25s facade deadline without an artificial delay hook, but Git
-// subprocess-spawn throughput is wildly platform-dependent. At 5,000 files
-// it blew the Windows CI job budget even though the behavior it proved was
-// correct (community report on issue 1778's Windows CI leg). Keep it out of
-// the default CI path; opt in locally or from a dedicated job with
-// GENTLE_AI_LARGE_WORKSPACE_E2E=1. The always-on, deterministic proof of the
-// same deadline-selection wiring is TestReviewFacadeOperationDeadlineSelector
-// in internal/cli/review_facade_test.go: it asserts review.start resolves to
-// reviewFacadeStartOperationTimeout while every other operation keeps
-// reviewFacadeOperationTimeout, with no dependency on real elapsed time or
-// process-spawn throughput. That unit test alone catches a regression to the
-// deadline-selection wiring (e.g. review.start silently falling back to the
-// shared deadline); only this gated end-to-end test catches the original
-// 1778 symptom itself — a valid large candidate actually being cut off
-// mid-sweep — and only when it is run.
+// organicLargeWorkspaceE2EEnvironment gates the large-workspace review/start
+// proof below. Candidate construction now batches its per-intended-path Git
+// queries into whole-tree listings instead of spawning one Git subprocess per
+// path, so a several-thousand-file candidate no longer burns the Windows CI
+// job budget the way the per-path loops did (community report on issue 1778's
+// Windows CI leg); the fixture is still deliberately heavy, so keep it out of
+// the default CI path and opt in locally or from a dedicated job with
+// GENTLE_AI_LARGE_WORKSPACE_E2E=1. The always-on, deterministic proofs are
+// TestReviewFacadeOperationDeadlineSelector in internal/cli/review_facade_test.go
+// (review.start resolves to reviewFacadeStartOperationTimeout while every other
+// operation keeps reviewFacadeOperationTimeout) and
+// TestNegotiatedStartSurvivesSharedDeadline in internal/cli (a start that
+// outlives the shared deadline completes while status is still cut off). Only
+// this gated end-to-end test catches a regression back to per-path subprocess
+// loops on a real repository — and only when it is run.
 const organicLargeWorkspaceE2EEnvironment = "GENTLE_AI_LARGE_WORKSPACE_E2E"
 
-// TestOrganicReviewStartDeadlineHeadroom proves Group E (1778): review/start
-// uses its own start-scoped deadline instead of the shared 25s facade
-// deadline, so a valid candidate whose construction takes longer than 25s
-// still completes instead of being cut off mid-sweep.
+// TestOrganicReviewStartDeadlineHeadroom proves Group E (1778): a negotiated
+// review/start on a valid large workspace completes within the platform
+// budget, because candidate construction batches its per-intended-path Git
+// queries into whole-tree listings instead of spawning one Git subprocess per
+// path.
 func TestOrganicReviewStartDeadlineHeadroom(t *testing.T) {
 	t.Run("issue-1778", func(t *testing.T) {
 		if os.Getenv(organicLargeWorkspaceE2EEnvironment) != "1" {
@@ -72,12 +67,10 @@ func TestOrganicReviewStartDeadlineHeadroom(t *testing.T) {
 		harness := newOrganicHarness(t)
 		lineage := "organic-start-deadline-headroom"
 
-		// The shared facade operation deadline every other operation keeps using
-		// is 25s. Real candidate construction is dominated by one Git subprocess
-		// per intended-untracked path (untrackedProof) plus per-changed-path diff
-		// work in the frozen candidate context, so a workspace with enough new
-		// files reliably pushes construction past that shared deadline without
-		// needing an artificial delay hook.
+		// A bounded large-workspace performance fixture: enough intended-
+		// untracked files that any regression back to per-path Git subprocess
+		// loops blows the explicit platform budget below, most visibly on
+		// Windows where process spawns are expensive.
 		const headroomFiles = 5000
 		files := make(map[string]string, headroomFiles)
 		for index := 0; index < headroomFiles; index++ {
@@ -109,15 +102,7 @@ func TestOrganicReviewStartDeadlineHeadroom(t *testing.T) {
 		if elapsed >= organicLocalTimeout {
 			t.Fatalf("negotiated review start took %s, want less than the harness local timeout %s", elapsed, organicLocalTimeout)
 		}
-		// No lower-bound elapsed assertion: this must never fail just because
-		// candidate construction got faster. Log instead, so a maintainer can
-		// tell whether headroomFiles still needs bumping to keep exercising
-		// the past-25s window this test exists to cover.
-		if elapsed <= 25*time.Second {
-			t.Logf("negotiated review start on a %d-file candidate completed in %s, at or under the shared 25s facade deadline: candidate construction got faster, so this run no longer proves start-scoped deadline headroom (consider raising headroomFiles)", headroomFiles, elapsed)
-		} else {
-			t.Logf("negotiated review start on a %d-file candidate completed in %s, past the shared 25s facade deadline and under the start-scoped deadline", headroomFiles, elapsed)
-		}
+		t.Logf("negotiated review start on a %d-file candidate completed in %s, under the platform budget %s", headroomFiles, elapsed, organicLocalTimeout)
 
 		harness.assertSingleReviewLineage(lineage)
 		harness.assertNoSDDArtifacts()

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -456,11 +456,11 @@ var reviewFacadeOperationTimeout = 25 * time.Second
 // reviewFacadeStartOperationTimeout is the deadline for review.start only.
 // START performs full candidate construction (snapshot, hashing, frozen
 // context) over the real workspace, which can exceed the shared 25s facade
-// deadline for a valid large candidate. It is a fixed constant, not a
+// deadline for a valid large candidate. It is a fixed deadline, not a
 // configurable timeout framework: every other operation keeps using
-// reviewFacadeOperationTimeout unchanged, including the two existing tests
-// that mutate that var directly.
-const reviewFacadeStartOperationTimeout = 120 * time.Second
+// reviewFacadeOperationTimeout unchanged, and tests mutate this var directly
+// exactly like reviewFacadeOperationTimeout.
+var reviewFacadeStartOperationTimeout = 120 * time.Second
 
 // reviewFacadeOperationDeadline selects the operation-scoped deadline.
 // review.start uses its own larger constant; every other operation keeps

--- a/internal/cli/review_facade_start_deadline_test.go
+++ b/internal/cli/review_facade_start_deadline_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestNegotiatedStartSurvivesSharedDeadline is the deterministic proof for
+// issue-1778's headroom invariant: a negotiated review.start whose native work
+// outlives the shared facade deadline still completes, because RunReview
+// selects the start-scoped deadline for it, while every other negotiated
+// operation subjected to the exact same delay is cut off by the shared
+// deadline. The e2e large-workspace journey
+// (TestOrganicReviewStartDeadlineHeadroom) no longer needs to burn real wall
+// clock past 25s to prove this.
+func TestNegotiatedStartSurvivesSharedDeadline(t *testing.T) {
+	originalRunner := reviewFacadeCommandRunner
+	originalTimeout := reviewFacadeOperationTimeout
+	originalStartTimeout := reviewFacadeStartOperationTimeout
+	t.Cleanup(func() {
+		reviewFacadeCommandRunner = originalRunner
+		reviewFacadeOperationTimeout = originalTimeout
+		reviewFacadeStartOperationTimeout = originalStartTimeout
+	})
+	reviewFacadeOperationTimeout = 100 * time.Millisecond
+	reviewFacadeStartOperationTimeout = 2 * time.Second
+	reviewFacadeCommandRunner = func(_ context.Context, _ []string, stdout io.Writer) error {
+		time.Sleep(500 * time.Millisecond)
+		_, err := io.WriteString(stdout, "native start completed\n")
+		return err
+	}
+
+	var startOutput bytes.Buffer
+	err := RunReview([]string{"start", "--contract", ReviewIntegrationContractV1, "--lineage", "start-deadline-headroom"}, &startOutput)
+	if err != nil {
+		t.Fatalf("negotiated start outliving the shared deadline failed under the start-scoped deadline: %v\n%s", err, startOutput.String())
+	}
+	if startOutput.String() != "native start completed\n" {
+		t.Fatalf("negotiated start output = %q, want the native worker's complete output", startOutput.String())
+	}
+
+	// Sanity: a non-start negotiated operation under the exact same native
+	// delay is killed by the shared deadline, so the start success above can
+	// only come from the start-scoped selection.
+	var statusOutput bytes.Buffer
+	err = RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--lineage", "start-deadline-headroom"}, &statusOutput)
+	if err == nil {
+		t.Fatalf("negotiated status outliving the shared deadline succeeded: %s", statusOutput.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, statusOutput.Bytes())
+	if failure.Code != "operation_timeout" {
+		t.Fatalf("negotiated status failure code = %q, want operation_timeout from the shared deadline", failure.Code)
+	}
+}

--- a/internal/reviewtransaction/compact_approved_invalidation_test.go
+++ b/internal/reviewtransaction/compact_approved_invalidation_test.go
@@ -158,7 +158,7 @@ func TestInvalidateApprovedCompactAuthorityPreservesAuthorityOnGitInfrastructure
 	t.Cleanup(func() { gitProcessTreeStarter = originalStarter })
 	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
 		for _, arg := range command.Args {
-			if arg == "--error-unmatch" {
+			if arg == "--cached" {
 				return nil, errors.New("job object creation rejected")
 			}
 		}

--- a/internal/reviewtransaction/compact_approved_invalidation_test.go
+++ b/internal/reviewtransaction/compact_approved_invalidation_test.go
@@ -157,8 +157,10 @@ func TestInvalidateApprovedCompactAuthorityPreservesAuthorityOnGitInfrastructure
 	originalStarter := gitProcessTreeStarter
 	t.Cleanup(func() { gitProcessTreeStarter = originalStarter })
 	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
-		for _, arg := range command.Args {
-			if arg == "--cached" {
+		// Match only the batched `ls-files -z --cached` invocation this test
+		// exercises; snapshot.go runs an unrelated `ls-files --cached -z`.
+		for i, arg := range command.Args {
+			if arg == "ls-files" && i+2 < len(command.Args) && command.Args[i+1] == "-z" && command.Args[i+2] == "--cached" {
 				return nil, errors.New("job object creation rejected")
 			}
 		}

--- a/internal/reviewtransaction/compact_approved_invalidation_test.go
+++ b/internal/reviewtransaction/compact_approved_invalidation_test.go
@@ -159,8 +159,10 @@ func TestInvalidateApprovedCompactAuthorityPreservesAuthorityOnGitInfrastructure
 	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
 		// Match only the batched `ls-files -z --cached` invocation this test
 		// exercises; snapshot.go runs an unrelated `ls-files --cached -z`.
+		// Require `--cached` to be the final argument so invocations with
+		// trailing flags or pathspecs never trip the injected failure.
 		for i, arg := range command.Args {
-			if arg == "ls-files" && i+2 < len(command.Args) && command.Args[i+1] == "-z" && command.Args[i+2] == "--cached" {
+			if arg == "ls-files" && i+2 == len(command.Args)-1 && command.Args[i+1] == "-z" && command.Args[i+2] == "--cached" {
 				return nil, errors.New("job object creation rejected")
 			}
 		}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -826,16 +826,18 @@ func buildCompactGateRequestWithPushBase(ctx context.Context, repo string, state
 // propagate so the gate fails instead of misclassifying scope.
 func compactStillUntrackedIntended(ctx context.Context, repo string, intended []string) ([]string, error) {
 	remaining := []string{}
+	if len(intended) == 0 {
+		return remaining, nil
+	}
+	output, err := runGit(ctx, repo, nil, nil, "ls-files", "-z", "--cached")
+	if err != nil {
+		return nil, fmt.Errorf("classify intended-untracked paths: %w", err)
+	}
+	tracked := nulSeparatedPathSet(output)
 	for _, logicalPath := range intended {
-		_, err := runGit(ctx, repo, nil, nil, "ls-files", "--error-unmatch", "--", literalPathspec(logicalPath))
-		if err == nil {
-			continue
+		if _, isTracked := tracked[logicalPath]; !isTracked {
+			remaining = append(remaining, logicalPath)
 		}
-		var lookup *GitCommandError
-		if !errors.As(err, &lookup) || lookup.ExitCode != 1 {
-			return nil, fmt.Errorf("classify intended-untracked path %q: %w", logicalPath, err)
-		}
-		remaining = append(remaining, logicalPath)
 	}
 	return remaining, nil
 }

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -741,7 +741,7 @@ func TestCompactCommittedNextSliceIntendedFilterPropagatesGitInfraFailure(t *tes
 	t.Cleanup(func() { gitProcessTreeStarter = originalStarter })
 	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
 		for _, arg := range command.Args {
-			if arg == "--error-unmatch" {
+			if arg == "--cached" {
 				return nil, errors.New("job object creation rejected")
 			}
 		}

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -742,8 +742,10 @@ func TestCompactCommittedNextSliceIntendedFilterPropagatesGitInfraFailure(t *tes
 	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
 		// Match only the batched `ls-files -z --cached` invocation this test
 		// exercises; snapshot.go runs an unrelated `ls-files --cached -z`.
+		// Require `--cached` to be the final argument so invocations with
+		// trailing flags or pathspecs never trip the injected failure.
 		for i, arg := range command.Args {
-			if arg == "ls-files" && i+2 < len(command.Args) && command.Args[i+1] == "-z" && command.Args[i+2] == "--cached" {
+			if arg == "ls-files" && i+2 == len(command.Args)-1 && command.Args[i+1] == "-z" && command.Args[i+2] == "--cached" {
 				return nil, errors.New("job object creation rejected")
 			}
 		}

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -740,8 +740,10 @@ func TestCompactCommittedNextSliceIntendedFilterPropagatesGitInfraFailure(t *tes
 	originalStarter := gitProcessTreeStarter
 	t.Cleanup(func() { gitProcessTreeStarter = originalStarter })
 	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
-		for _, arg := range command.Args {
-			if arg == "--cached" {
+		// Match only the batched `ls-files -z --cached` invocation this test
+		// exercises; snapshot.go runs an unrelated `ls-files --cached -z`.
+		for i, arg := range command.Args {
+			if arg == "ls-files" && i+2 < len(command.Args) && command.Args[i+1] == "-z" && command.Args[i+2] == "--cached" {
 				return nil, errors.New("job object creation rejected")
 			}
 		}

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -327,6 +327,7 @@ func (builder SnapshotBuilder) activePassiveContentPaths(ctx context.Context, sn
 		}
 		return active, nil
 	}
+	names := make([]string, 0, len(candidates)*2)
 	for _, stat := range candidates {
 		for _, version := range []struct {
 			tree string
@@ -335,17 +336,67 @@ func (builder SnapshotBuilder) activePassiveContentPaths(ctx context.Context, sn
 			if version.mode == "" || version.mode == "000000" {
 				continue
 			}
-			content, err := runGit(ctx, repo, nil, nil, "cat-file", "blob", version.tree+":"+stat.Path)
-			if err != nil {
-				return nil, fmt.Errorf("read immutable passive candidate %q: %w", stat.Path, err)
+			names = append(names, version.tree+":"+stat.Path)
+		}
+	}
+	contents, err := batchBlobContents(ctx, repo, names)
+	if err != nil {
+		return nil, err
+	}
+	for _, stat := range candidates {
+		for _, version := range []struct {
+			tree string
+			mode string
+		}{{tree: snapshot.BaseTree, mode: stat.OldMode}, {tree: snapshot.CandidateTree, mode: stat.NewMode}} {
+			if version.mode == "" || version.mode == "000000" {
+				continue
 			}
-			if !isPassiveDocumentContent(stat.Path, content) {
+			if !isPassiveDocumentContent(stat.Path, contents[version.tree+":"+stat.Path]) {
 				active[stat.Path] = struct{}{}
 				break
 			}
 		}
 	}
 	return active, nil
+}
+
+// batchBlobContents reads every named immutable blob through one cat-file
+// --batch subprocess instead of one subprocess per object. The caller bounds
+// the total content bytes before requesting them.
+func batchBlobContents(ctx context.Context, repo string, names []string) (map[string][]byte, error) {
+	contents := make(map[string][]byte, len(names))
+	if len(names) == 0 {
+		return contents, nil
+	}
+	stdin := make([]byte, 0, len(names)*64)
+	for _, name := range names {
+		stdin = append(stdin, name...)
+		stdin = append(stdin, '\n')
+	}
+	output, err := runGit(ctx, repo, nil, stdin, "cat-file", "--batch")
+	if err != nil {
+		return nil, err
+	}
+	rest := output
+	for _, name := range names {
+		newline := bytes.IndexByte(rest, '\n')
+		if newline < 0 {
+			return nil, fmt.Errorf("read immutable passive candidate %q: truncated cat-file batch header", name)
+		}
+		header := string(rest[:newline])
+		rest = rest[newline+1:]
+		fields := strings.Fields(header)
+		if len(fields) != 3 || fields[1] != "blob" {
+			return nil, fmt.Errorf("read immutable passive candidate %q: unexpected cat-file batch header %q", name, header)
+		}
+		size, parseErr := strconv.ParseInt(fields[2], 10, 64)
+		if parseErr != nil || size < 0 || int64(len(rest)) < size+1 {
+			return nil, fmt.Errorf("read immutable passive candidate %q: invalid cat-file batch content", name)
+		}
+		contents[name] = rest[:size]
+		rest = rest[size+1:]
+	}
+	return contents, nil
 }
 
 // isPassiveDocumentContent proves a document is inert from its own bytes.

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -205,13 +205,19 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 
 func (builder SnapshotBuilder) buildHeadWithIntended(ctx context.Context, intended []string) (string, string, error) {
 	tracked := 0
-	for _, logicalPath := range intended {
-		output, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", "HEAD", "--", literalPathspec(logicalPath))
+	if len(intended) > 0 {
+		output, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-r", "-z", "HEAD")
 		if err != nil {
 			return "", "", err
 		}
-		if len(output) > 0 {
-			tracked++
+		entries, err := parseTreeEntries(output)
+		if err != nil {
+			return "", "", err
+		}
+		for _, logicalPath := range intended {
+			if _, present := entries[logicalPath]; present {
+				tracked++
+			}
 		}
 	}
 	if tracked != 0 && tracked != len(intended) {
@@ -874,12 +880,19 @@ func (builder *SnapshotBuilder) buildCurrentChanges(ctx context.Context, intende
 	}
 
 	stagedIntended := 0
-	for _, logicalPath := range intended {
-		if _, err := runGit(ctx, builder.Repo, nil, nil, "ls-files", "--error-unmatch", "--", literalPathspec(logicalPath)); err == nil {
-			if !allowStagedIntended {
-				return "", "", "", fmt.Errorf("intended-untracked path %q is already tracked", logicalPath)
+	if len(intended) > 0 {
+		trackedOutput, err := runGit(ctx, builder.Repo, nil, nil, "ls-files", "-z")
+		if err != nil {
+			return "", "", "", err
+		}
+		tracked := nulSeparatedPathSet(trackedOutput)
+		for _, logicalPath := range intended {
+			if _, isTracked := tracked[logicalPath]; isTracked {
+				if !allowStagedIntended {
+					return "", "", "", fmt.Errorf("intended-untracked path %q is already tracked", logicalPath)
+				}
+				stagedIntended++
 			}
-			stagedIntended++
 		}
 	}
 	if stagedIntended > 0 && stagedIntended != len(intended) {
@@ -1076,14 +1089,26 @@ func (builder SnapshotBuilder) changedPaths(ctx context.Context, baseTree, candi
 }
 
 func (builder SnapshotBuilder) rejectIgnoredIntended(ctx context.Context, intended []string) error {
+	if len(intended) == 0 {
+		return nil
+	}
+	stdin := make([]byte, 0, len(intended)*32)
 	for _, logicalPath := range intended {
-		_, err := runGit(ctx, builder.Repo, nil, nil, "check-ignore", "--quiet", "--no-index", "--", logicalPath)
-		if err == nil {
-			return fmt.Errorf("intended-untracked path %q is ignored", logicalPath)
-		}
+		stdin = append(stdin, logicalPath...)
+		stdin = append(stdin, 0)
+	}
+	output, err := runGit(ctx, builder.Repo, nil, stdin, "check-ignore", "-z", "--stdin", "--no-index")
+	if err != nil {
 		var exitErr *exec.ExitError
-		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
-			return err
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		return err
+	}
+	ignored := nulSeparatedPathSet(output)
+	for _, logicalPath := range intended {
+		if _, isIgnored := ignored[logicalPath]; isIgnored {
+			return fmt.Errorf("intended-untracked path %q is ignored", logicalPath)
 		}
 	}
 	return nil
@@ -1092,18 +1117,58 @@ func (builder SnapshotBuilder) rejectIgnoredIntended(ctx context.Context, intend
 func (builder SnapshotBuilder) untrackedProof(ctx context.Context, candidateTree string, intended []string) (string, error) {
 	hash := sha256.New()
 	hash.Write([]byte("gentle-ai.intended-untracked/v1\x00"))
+	if len(intended) == 0 {
+		return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+	}
+	output, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-r", "-z", candidateTree)
+	if err != nil {
+		return "", err
+	}
+	entries, err := parseTreeEntries(output)
+	if err != nil {
+		return "", err
+	}
 	for _, logicalPath := range intended {
-		output, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", candidateTree, "--", literalPathspec(logicalPath))
-		if err != nil {
-			return "", err
-		}
-		if len(output) == 0 {
+		entry, present := entries[logicalPath]
+		if !present {
 			return "", fmt.Errorf("intended-untracked path %q is absent from candidate tree", logicalPath)
 		}
 		writeLengthPrefixed(hash, []byte(logicalPath))
-		writeLengthPrefixed(hash, output)
+		writeLengthPrefixed(hash, entry)
 	}
 	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// parseTreeEntries maps each path in NUL-terminated ls-tree output to its
+// complete entry bytes, including the terminating NUL, keyed by the path after
+// the first tab.
+func parseTreeEntries(output []byte) (map[string][]byte, error) {
+	records := bytes.Split(output, []byte{0})
+	entries := make(map[string][]byte, len(records))
+	for _, record := range records {
+		if len(record) == 0 {
+			continue
+		}
+		tab := bytes.IndexByte(record, '\t')
+		if tab < 0 {
+			return nil, fmt.Errorf("unexpected tree entry %q", record)
+		}
+		entry := make([]byte, 0, len(record)+1)
+		entry = append(append(entry, record...), 0)
+		entries[string(record[tab+1:])] = entry
+	}
+	return entries, nil
+}
+
+func nulSeparatedPathSet(output []byte) map[string]struct{} {
+	records := bytes.Split(output, []byte{0})
+	paths := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		if len(record) > 0 {
+			paths[string(record)] = struct{}{}
+		}
+	}
+	return paths
 }
 
 func literalPathspec(logicalPath string) string {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -3,6 +3,8 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -1436,6 +1438,84 @@ func TestSnapshotRepoTemplateInitializesOnceConcurrently(t *testing.T) {
 	}
 	if template == "" {
 		t.Fatal("snapshotRepoTemplate() returned an empty path")
+	}
+}
+
+// TestUntrackedProofBatchedListingMatchesPerPathReference proves the batched
+// single recursive ls-tree listing in untrackedProof reproduces the historical
+// per-path `ls-tree -z <tree> -- :(literal)<path>` algorithm byte for byte,
+// so snapshot identities never change across the batching (issue-1778).
+func TestUntrackedProofBatchedListingMatchesPerPathReference(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	intended := []string{"bulk/a.txt", "deep/nested/b.txt"}
+	for index := 0; index < 48; index++ {
+		intended = append(intended, fmt.Sprintf("bulk/reference-%02d.txt", index))
+	}
+	for _, logicalPath := range intended {
+		writeSnapshotFile(t, repo, logicalPath, "reference content for "+logicalPath+"\n")
+	}
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind:              TargetCurrentChanges,
+		IntendedUntracked: intended,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(snapshot.IntendedUntracked) != len(intended) {
+		t.Fatalf("IntendedUntracked = %d paths, want %d", len(snapshot.IntendedUntracked), len(intended))
+	}
+
+	hash := sha256.New()
+	hash.Write([]byte("gentle-ai.intended-untracked/v1\x00"))
+	for _, logicalPath := range snapshot.IntendedUntracked {
+		entry, err := runGit(context.Background(), repo, nil, nil, "ls-tree", "-z", snapshot.CandidateTree, "--", literalPathspec(logicalPath))
+		if err != nil {
+			t.Fatalf("per-path reference ls-tree for %q: %v", logicalPath, err)
+		}
+		if len(entry) == 0 {
+			t.Fatalf("per-path reference ls-tree for %q returned no entry", logicalPath)
+		}
+		writeLengthPrefixed(hash, []byte(logicalPath))
+		writeLengthPrefixed(hash, entry)
+	}
+	reference := "sha256:" + hex.EncodeToString(hash.Sum(nil))
+	if snapshot.IntendedUntrackedProof != reference {
+		t.Fatalf("batched untracked proof = %s, want per-path reference %s", snapshot.IntendedUntrackedProof, reference)
+	}
+}
+
+func TestUntrackedProofReportsFirstAbsentIntendedPath(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "bulk/a.txt", "present\n")
+	builder := SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), Target{
+		Kind:              TargetCurrentChanges,
+		IntendedUntracked: []string{"bulk/a.txt"},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	_, err = builder.untrackedProof(context.Background(), snapshot.CandidateTree, []string{"absent-a.txt", "absent-b.txt", "bulk/a.txt"})
+	if err == nil || !strings.Contains(err.Error(), `intended-untracked path "absent-a.txt" is absent from candidate tree`) {
+		t.Fatalf("untracked proof absent-path error = %v, want the first absent path in intended order", err)
+	}
+}
+
+func TestSnapshotBuilderRejectsFirstIgnoredIntendedPathInOrder(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, ".gitignore", "ignored-dir/\n")
+	writeSnapshotFile(t, repo, "ignored-dir/a.txt", "ignored a\n")
+	writeSnapshotFile(t, repo, "ignored-dir/b.txt", "ignored b\n")
+	_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind:              TargetCurrentChanges,
+		IntendedUntracked: []string{"ignored-dir/b.txt", "ignored-dir/a.txt"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `intended-untracked path "ignored-dir/a.txt" is ignored`) {
+		t.Fatalf("ignored intended path error = %v, want the first ignored path in intended order", err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1957

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

**En simple:** hoy, por cada archivo del workspace se abre un programa `git` aparte para hacerle una sola pregunta. Este PR junta esas preguntas: una sola lista completa por operacion en vez de miles de programas abriendose uno atras del otro. El costo deja de escalar con la cantidad de archivos y las operaciones del ciclo entran comodas en sus deadlines.

Es el fix candidato publicado en #1778 y re-scopeado en #1957: batchea los cuatro sitios per-path que quedaron vivos despues del deadline de 120s de START. Los detalles tecnicos:

- **`untrackedProof`** — una lista recursiva `ls-tree -r -z` filtrada, reconstruyendo por path los bytes exactos del comando historico para que el digest y la identidad del snapshot no cambien (lo prueba un test de equivalencia byte a byte contra el algoritmo viejo).
- **`rejectIgnoredIntended`** — un solo `check-ignore -z --stdin --no-index`.
- **`buildCurrentChanges` / `compactStillUntrackedIntended`** — un `ls-files -z --cached` completo.
- **`activePassiveContentPaths`** — un `cat-file --batch` (memoria acotada por el `processBoundaryScanByteLimit` existente).
- `reviewFacadeStartOperationTimeout` pasa de `const` a `var` (igual que su hermano compartido) para que el test deterministico nuevo pueda achicar ambos deadlines sin depender de wall clock real.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | Batching de untrackedProof, filtro de ignorados y membresia de indice |
| `internal/reviewtransaction/risk.go` | Contenido pasivo via `cat-file --batch` |
| `internal/reviewtransaction/compact_gate.go` | Membresia de indice batcheada en el camino compact |
| `internal/cli/review_facade.go` | const→var del start deadline para el test deterministico |
| `internal/cli/review_facade_start_deadline_test.go` | Nuevo: `TestNegotiatedStartSurvivesSharedDeadline` (0.6s, sin wall clock) |
| `e2e/organicruntime/organic_lifecycle_hardening_test.go` | El journey gateado de 5.000 archivos queda como perf test acotado al budget de plataforma |
| `*_test.go` (reviewtransaction) | Equivalencia byte a byte del proof, orden de rechazo, fixtures de infra-failure migrados al comando batcheado |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`) — suites completas de `internal/reviewtransaction` + `internal/cli` corridas sobre esta rama en Windows 11 amd64 / go1.26.2: los unicos FAIL son el set preexistente de esta maquina (identico con y sin el patch, verificado contra baseline limpio en su momento)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — sin Docker en esta maquina; queda al CI
- [x] Manually tested locally — e2e gateado (`GENTLE_AI_LARGE_WORKSPACE_E2E=1`) sobre esta rama: START negociado con 5.000 archivos intended-untracked completa en ~11s contra un budget de 90s. La historia completa del antes/despues esta en #1778: en el commit limpio del Refresh 8 el mismo fixture FALLABA contra el budget (301s de test); con este patch, PASS en 10.6s

---

## 💬 Notes for Reviewers

- El patch es el mismo publicado y retesteado en #1778 (aplico limpio en cada rebase desde el Refresh 7 hasta el main de hoy sin tocar una linea).
- La equivalencia byte a byte del proof es el corazon de la seguridad del cambio: el digest del snapshot no cambia, asi que no hay migracion de identidades.
- La evidencia de @edwinsaavedran en v2.2.0 (#1778) muestra el sintoma actual que este PR elimina: 15.089 subprocesos en un START y el capture muriendo con 3.013 — con el batching esos numeros colapsan a un puñado de invocaciones por operacion.
- Diff: 398 lineas (+319/−79), dentro del presupuesto de 400.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced repeated Git subprocesses during review snapshot and candidate processing by switching to bulk listings and batched blob reads for untracked evidence, ignored-path checks, and passive-content scanning.

- **Reliability**
  - Improved review-start timeout handling so start-scoped negotiated operations can complete even when shared deadlines are tight.
  - Enhanced untracked/ignored classification to produce clearer, batch-scoped error reporting.

- **Tests**
  - Added a deterministic CLI integration test for start-vs-shared deadline survival.
  - Added/expanded snapshot determinism and error-order tests, plus updated Git failure stubs to match batched invocations.
  - Refreshed end-to-end test logging/timing behavior for simpler elapsed-time reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->