### PR TITLE
fix(cli): normalize consent fixture paths on Windows

### DIFF
--- a/internal/cli/review_consent_relay_test.go
+++ b/internal/cli/review_consent_relay_test.go
@@ -424,6 +424,10 @@ func TestConsentQuestionMatchesVersionedFixture(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reviewModeHome(t)
 			repo := initReviewCLIRepo(t)
+			root, err := resolveReviewMutationRoot(context.Background(), repo)
+			if err != nil {
+				t.Fatalf("resolve fixture repository root: %v", err)
+			}
 			stubReviewConsole(t, false, "")
 			writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
 
@@ -435,7 +439,14 @@ func TestConsentQuestionMatchesVersionedFixture(t *testing.T) {
 			if err := question.Validate(); err != nil {
 				t.Fatal(err)
 			}
-			normalized := bytes.ReplaceAll(output.Bytes(), []byte(repo), []byte("/repo"))
+			// The command is JSON-encoded, and Git may resolve a Windows 8.3 temp
+			// path to its long form. Normalize the encoded resolved root instead of
+			// the caller's raw t.TempDir spelling.
+			encodedRoot, err := json.Marshal(root)
+			if err != nil {
+				t.Fatalf("encode fixture repository root: %v", err)
+			}
+			normalized := bytes.ReplaceAll(output.Bytes(), encodedRoot[1:len(encodedRoot)-1], []byte("/repo"))
 			fixturePath := filepath.Join("..", "..", "contracts", "review-integration", tt.version, "fixtures", "consent.fixture.json")
 			if os.Getenv("GENTLE_AI_CONSENT_FIXTURE_UPDATE") == "1" {
 				if err := os.WriteFile(fixturePath, normalized, 0o644); err != nil {


### PR DESCRIPTION
## Summary
- normalize the resolved repository root after JSON escaping before comparing consent contract fixtures
- keep the versioned fixture placeholder stable when Windows expands an 8.3 temporary path

## Why
The consent relay test passes the raw `t.TempDir()` spelling to the CLI, but Git resolves the repository root before it appears in the JSON invocation. On Windows those can differ (`RUNNER~1` versus `runneradmin`), and backslashes are escaped in JSON, so the existing replacement never matched.

## Validation
- `go test ./internal/cli -run TestConsentQuestionMatchesVersionedFixture -count=1 -timeout=10m -v`

Part of #1983.
