### PR TITLE
docs(contributing): add benchmark validation attestation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -93,7 +93,7 @@ The following checks run automatically on this PR:
 - [ ] Unit tests pass (`go test ./...`)
 - [ ] Go format passes (`go run ./internal/gofmtcheck`)
 - [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
-- [ ] Benchmark run completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
+- [ ] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
 - [ ] I have updated documentation if necessary
 - [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - [ ] My commits do not include `Co-Authored-By` trailers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,10 @@ go run ./internal/gofmtcheck
 cd e2e && ./docker-test.sh
 ```
 
+**Benchmark Validation**
+
+See the [benchmark guide](../bench/README.md). Benchmark validation applies to review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, and benchmark-claim changes. For unrelated changes, explain `N/A` in the Test Plan.
+
 - [ ] Unit tests pass (`go test ./...`)
 - [ ] Go format passes (`go run ./internal/gofmtcheck`)
 - [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
@@ -89,6 +93,7 @@ The following checks run automatically on this PR:
 - [ ] Unit tests pass (`go test ./...`)
 - [ ] Go format passes (`go run ./internal/gofmtcheck`)
 - [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
+- [ ] Benchmark run completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
 - [ ] I have updated documentation if necessary
 - [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - [ ] My commits do not include `Co-Authored-By` trailers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,18 @@ chmod +x docker-test.sh
 
 > ⚠️ E2E tests spin up containers to simulate real installation environments. They may take a few minutes to complete.
 
+### Benchmark Validation
+
+[`bench/`](bench/README.md) is a separate Go module, so root-module tests do not validate it. For benchmark-module changes, run these commands from `bench/`:
+
+```bash
+go build ./...
+go vet ./...
+go test ./...
+```
+
+For measured product-behavior changes, use driven mode and report the command, tested binary or commit, selected subset or axes, and result summary. Compare before and after only when claiming a measured friction change. For unrelated changes, mark benchmark validation `N/A` with a brief reason.
+
 ### Windows — Known Test Limitations
 
 Some unit tests require OS-level capabilities that are restricted on Windows by default.
@@ -289,6 +301,7 @@ Review feedback should be warm, direct, and useful quickly. Start with the actio
 - [ ] Commits are organized by deliverable work unit
 - [ ] All unit tests pass (`go test ./...`)
 - [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
+- [ ] Benchmark run completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
 - [ ] Commits follow Conventional Commits format
 - [ ] Code is self-reviewed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ go vet ./...
 go test ./...
 ```
 
-For measured product-behavior changes, use driven mode and report the command, tested binary or commit, selected subset or axes, and result summary. Compare before and after only when claiming a measured friction change. For unrelated changes, mark benchmark validation `N/A` with a brief reason.
+Benchmark validation applies to review-lifecycle, gate, recovery, delivery, benchmark implementation/corpus/classifier, and benchmark-claim changes. For measured product-behavior changes, use driven mode and report the command, tested binary or commit, selected subset or axes, and result summary. Compare before and after only when claiming a measured friction change. For unrelated changes, mark benchmark validation `N/A` with a brief reason.
 
 ### Windows — Known Test Limitations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,7 +301,7 @@ Review feedback should be warm, direct, and useful quickly. Start with the actio
 - [ ] Commits are organized by deliverable work unit
 - [ ] All unit tests pass (`go test ./...`)
 - [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
-- [ ] Benchmark run completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
+- [ ] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
 - [ ] Commits follow Conventional Commits format
 - [ ] Code is self-reviewed
 


### PR DESCRIPTION
## Linked Issue

Closes #1990

---

## PR Type

- [ ] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [x] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Add a benchmark validation attestation with an explicit not-applicable path to the pull request checklist.
- Document when the in-repository friction benchmark applies and what evidence contributors should report.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `.github/PULL_REQUEST_TEMPLATE.md` | Adds benchmark applicability guidance and one contributor attestation. |
| `CONTRIBUTING.md` | Documents the separate benchmark module, driven-mode evidence, comparisons, and N/A handling. |

---

## Test Plan

- [x] Structural readback completed for both edited sections.
- [x] `git diff --check` passes.
- [x] `cd bench && go build ./...` passes.
- [x] `cd bench && go vet ./...` passes.
- [ ] `cd bench && go test ./... -count=1` currently fails on Windows in three existing benchmark tests: `TestProbeCapabilityRejectsAMissingFlag`, `TestProbeAndHelpProbeDoNotShareACacheEntry`, and `TestReadBackBlanksGitTrace`.
- [ ] A driven run was attempted against the exact `c16a0640` Windows binary, but the benchmark preflight rejected the runnable `.exe` with `cannot execute binary`; no journeys started and no result JSON was produced.
- [x] Unit tests, Go formatting, and E2E: N/A, passive Markdown-only change.
- [x] Benchmark validation: N/A for measured outcomes because this PR changes contributor guidance only, not product behavior, benchmark semantics, corpus, classifier, or benchmark claims. The attempted Windows evidence is recorded above.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines.
- [x] The appropriate `type:docs` label is applied.
- [x] Validation is documented above.
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan).
- [x] Documentation is updated.
- [x] My commits follow Conventional Commits format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## Notes for Reviewers

This PR intentionally adds contributor guidance only. Automated checklist enforcement and the pre-existing Windows benchmark failures remain out of scope.