### PR TITLE
fix(opencode): use neutral admission rejection guidance

### DIFF
--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -298,8 +298,7 @@ function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: strin
   const admission = admissionRejection(cause)
   if (admission) {
     return `${code}: native admission rejected the reviewer result as ${admission}; ` +
-      "retrying capture with the same result cannot succeed — relaunch this lens reviewer to produce a corrected result " +
-      "(severe findings must anchor to lines the frozen candidate actually changed)"
+      "retrying capture with the same result cannot succeed — relaunch this lens reviewer to produce a corrected result"
   }
   return `${code}: provider-owned review operation failed; refresh the exact native next_transition or retry the same opaque binding`
 }

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -276,25 +276,48 @@ func TestReviewPluginSurfacesNativeGitTrustRefusal(t *testing.T) {
 // relaunch the reviewer, while the native diagnostic prose (which can embed
 // payload text) stays out of the transcript.
 func TestReviewPluginSurfacesAdmissionRejectionClass(t *testing.T) {
-	native := "Error: reviewer artifact admission out_of_scope: candidate-causal findings are not proven by repository-derived changed-line evidence"
-	message := runReviewPluginScenario(t, "after-opaque", native)
-	if message == "NO_ERROR" {
-		t.Fatal("plugin did not fail despite an always-failing native binary")
+	tests := []struct {
+		name       string
+		decision   string
+		diagnostic string
+	}{
+		{
+			name:       "out-of-scope",
+			decision:   "out_of_scope",
+			diagnostic: "candidate-causal findings are not proven by repository-derived changed-line evidence",
+		},
+		{
+			name:       "incomplete-with-zero-findings",
+			decision:   "incomplete",
+			diagnostic: "zero-findings-native-diagnostic-must-stay-opaque",
+		},
 	}
-	if !strings.Contains(message, "rejected the reviewer result as out_of_scope") {
-		t.Fatalf("admission rejection lost its typed decision class: %s", message)
-	}
-	if !strings.Contains(message, "relaunch this lens reviewer") {
-		t.Fatalf("admission rejection carries no instruction that can actually succeed: %s", message)
-	}
-	if strings.Contains(message, "retry the same opaque binding") {
-		t.Fatalf("plugin still advises retrying a deterministically refused result: %s", message)
-	}
-	if strings.Contains(message, "changed-line evidence") {
-		t.Fatalf("plugin forwarded native admission diagnostic prose through an opaque binding: %s", message)
-	}
-	if !strings.Contains(message, reviewPluginPayloadMarker) {
-		t.Fatalf("admission rejection did not preserve the reviewer payload: %s", message)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			native := "Error: reviewer artifact admission " + tt.decision + ": " + tt.diagnostic
+			message := runReviewPluginScenario(t, "after-opaque", native)
+			if message == "NO_ERROR" {
+				t.Fatal("plugin did not fail despite an always-failing native binary")
+			}
+			if !strings.Contains(message, "rejected the reviewer result as "+tt.decision) {
+				t.Fatalf("admission rejection lost its typed decision class: %s", message)
+			}
+			if !strings.Contains(message, "relaunch this lens reviewer") {
+				t.Fatalf("admission rejection carries no instruction that can actually succeed: %s", message)
+			}
+			if strings.Contains(message, "retry the same opaque binding") {
+				t.Fatalf("plugin still advises retrying a deterministically refused result: %s", message)
+			}
+			if strings.Contains(message, tt.diagnostic) {
+				t.Fatalf("plugin forwarded native admission diagnostic prose through an opaque binding: %s", message)
+			}
+			if tt.decision == "incomplete" && strings.Contains(message, "severe findings must anchor") {
+				t.Fatalf("generic admission rejection included severe-finding-specific guidance: %s", message)
+			}
+			if !strings.Contains(message, reviewPluginPayloadMarker) {
+				t.Fatalf("admission rejection did not preserve the reviewer payload: %s", message)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2000

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Remove severe-finding-specific guidance from generic reviewer admission rejection errors.
- Preserve the typed decision, opaque native diagnostic boundary, relaunch instruction, and rejected payload recovery.
- Cover incomplete inspection with zero findings through the embedded OpenCode plugin harness.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/plugins/review-result-artifacts.ts` | Uses neutral recovery guidance for all typed admission rejections. |
| `internal/assets/review_plugin_recovery_test.go` | Covers `out_of_scope` and `incomplete` with zero findings while asserting diagnostic opacity and payload preservation. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/assets -count=1
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

E2E was not run locally because Docker is unavailable (`docker: command not found`). GitHub CI remains authoritative for the Docker run.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 62 changed lines, below the 400-line budget |
| Check Issue Reference | ⏳ | Closes approved issue #2000 |
| Check Issue Has `status:approved` | ⏳ | Issue #2000 is approved |
| Check PR Has `type:*` Label | ⏳ | Pending maintainer label application |
| Unit Tests | ⏳ | `go test ./...` |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation is not required for this diagnostic-only behavior correction
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The admission decision intentionally remains the only native detail surfaced through the opaque binding. This change removes an unsupported causal inference without exposing native diagnostic prose or altering capture, preservation, or retry semantics.

Receipt-driven development was disabled by maintainer decision after the existing local lineage became unrecoverable due to an artifact-subject schema mismatch. Delivery proceeds under ordinary repository policy; no review receipt is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified reviewer recovery guidance when a review result is rejected.
  * Improved handling of out-of-scope and incomplete review decisions.
  * Prevented internal diagnostic details and irrelevant guidance from appearing in recovery messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->