### PR TITLE
fix(doctor): deduplicate symlinked PATH tools

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -275,15 +275,18 @@ func resolveDoctorTool(tool string) (string, string, error) {
 }
 
 func doctorToolCopies(tool string, pathDirs []string) []string {
-	seenDirs := make(map[string]struct{}, len(pathDirs))
+	seenCopies := make(map[string]struct{}, len(pathDirs))
 	copies := make([]string, 0, len(pathDirs))
 	for _, dir := range pathDirs {
-		cleanDir := filepath.Clean(dir)
-		if _, seen := seenDirs[cleanDir]; seen {
-			continue
-		}
 		if p := toolInDir(dir, tool); p != "" {
-			seenDirs[cleanDir] = struct{}{}
+			resolved, err := filepath.EvalSymlinks(p)
+			if err != nil {
+				resolved = filepath.Clean(p)
+			}
+			if _, seen := seenCopies[resolved]; seen {
+				continue
+			}
+			seenCopies[resolved] = struct{}{}
 			copies = append(copies, p)
 		}
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -75,6 +75,35 @@ func TestCheckOneTool_ShadowedBinary(t *testing.T) {
 	}
 }
 
+func TestDoctorToolCopies_DeduplicatesSymlinkedPathDirectories(t *testing.T) {
+	origExts := executableExtsFn
+	defer func() { executableExtsFn = origExts }()
+	executableExtsFn = func() []string { return []string{""} }
+
+	root := t.TempDir()
+	usrBin := filepath.Join(root, "usr", "bin")
+	if err := os.MkdirAll(usrBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	code := filepath.Join(usrBin, "code")
+	if err := os.WriteFile(code, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := filepath.Join(root, "bin")
+	if err := os.Symlink(usrBin, bin); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	got := doctorToolCopies("code", []string{bin, usrBin})
+	if len(got) != 1 {
+		t.Fatalf("copies = %v, want one copy", got)
+	}
+	if want := filepath.Join(bin, "code"); got[0] != want {
+		t.Fatalf("copies[0] = %q, want first PATH entry %q", got[0], want)
+	}
+}
+
 func TestCheckOneTool_OK(t *testing.T) {
 	orig := lookPathFn
 	defer func() { lookPathFn = orig }()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1664

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Canonicalize discovered doctor tool paths before counting PATH duplicates.
- Avoid false duplicate warnings when usrmerge aliases such as `/bin` and `/usr/bin` resolve to the same executable.
- Preserve first-PATH ordering and real duplicate detection, with regression coverage.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/doctor.go` | Deduplicate tool candidates by their symlink-resolved executable target, with a cleaned-path fallback. |
| `internal/cli/doctor_test.go` | Add an usrmerge-style symlink regression test that preserves the first PATH entry. |

---

## 🧪 Test Plan

- [x] Focused doctor tests pass: `go test ./internal/cli -run '^(TestDoctorToolCopies_DeduplicatesSymlinkedPathDirectories|TestCheckOneTool_(MissingBinary|ShadowedBinary|OK|ShadowedWindowsExt|WindowsPowerShellShimFallback|WindowsShimVariantsInSameDirAreNotDuplicates|DirectoryWithToolName_NotCountedAsDuplicate|FileWithoutExecBit_NotCountedAsDuplicate))$' -count=1 -v`
- [x] Package compiles: `go test ./internal/cli -run '^$' -count=1`
- [x] Go format passes: `go run ./internal/gofmtcheck`
- [ ] Full `go test ./internal/cli` suite — exceeded 10 minutes locally; CI is the authoritative full-suite run.
- [ ] E2E tests — not run; this bounded filesystem unit has no external runtime boundary.
- [ ] Manually tested locally — covered through deterministic filesystem tests.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added exactly one `type:*` label
- [ ] Full unit suite passes locally — focused tests pass; full package suite timed out
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — not applicable to this bounded unit
- [x] Documentation is not necessary for this internal diagnostic correction
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This changes duplicate accounting only. It is not a security, integrity, admission, repair, or governance guard, so no `guard:population` declaration or baseline update applies.

Receipt-driven development is disabled for this workspace; delivery follows the repository's ordinary unmanaged path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved doctor diagnostics to correctly identify duplicate tools when the same executable is available through multiple PATH entries or symlinked directories.
  * Prevents false duplicate warnings and selects the executable associated with the first matching PATH entry.

* **Tests**
  * Added coverage for duplicate detection involving symlinked directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->