### PR TITLE
fix(bench): reject empty explicit journey selections

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -73,6 +73,10 @@ It does not measure wall-clock time, real model tokens, or a composite score.
 }
 
 func commandRun(args []string) int {
+	return commandRunWith(args, executable, Journeys)
+}
+
+func commandRunWith(args []string, isExecutable func(string) bool, journeys func() []Journey) int {
 	flags := flag.NewFlagSet("run", flag.ExitOnError)
 	binary := flags.String("binary", "", "path to the gentle-ai binary to drive")
 	out := flags.String("out", "results.json", "where to write the machine-readable results")
@@ -87,7 +91,7 @@ func commandRun(args []string) int {
 		return 2
 	}
 	resolved, err := filepath.Abs(*binary)
-	if err != nil || !executable(resolved) {
+	if err != nil || !isExecutable(resolved) {
 		fmt.Fprintf(os.Stderr, "cannot execute binary %q\n", *binary)
 		return 2
 	}
@@ -103,7 +107,7 @@ func commandRun(args []string) int {
 	// would have quietly reported a number based on it must not start. The same
 	// applies to an axis, whose declaration is a claim about how its numbers
 	// were obtained.
-	core := Journeys()
+	core := journeys()
 	planned := append([]Journey{}, core...)
 	for _, axis := range axes {
 		planned = append(planned, axis.Journeys()...)
@@ -117,10 +121,15 @@ func commandRun(args []string) int {
 		return 2
 	}
 
+	requested := requestedJourneyIDs(*only)
 	selected := map[string]bool{}
-	for _, id := range strings.Split(*only, ",") {
-		if id = strings.TrimSpace(id); id != "" {
-			selected[id] = true
+	for _, id := range requested {
+		selected[id] = true
+	}
+	resolvedIDs := []string{}
+	for _, journey := range planned {
+		if selected[journey.ID] {
+			resolvedIDs = append(resolvedIDs, journey.ID)
 		}
 	}
 
@@ -129,6 +138,18 @@ func commandRun(args []string) int {
 		Mode:          ModeDriven,
 		Binary:        resolved,
 		BinaryVersion: binaryVersion(resolved),
+	}
+	if len(requested) > 0 && len(resolvedIDs) == 0 {
+		results.RequestedSelectors = requested
+		results.ResolvedIDs = &resolvedIDs
+		results.RunStatus = "failed"
+		results.FailureReason = "empty_selected_population"
+		if err := writeJSON(*out, results); err != nil {
+			fmt.Fprintf(os.Stderr, "write results: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "no journeys matched --only selectors: %s\n", strings.Join(requested, ", "))
+		return runExitCode(results)
 	}
 	run := func(journey Journey, axis string) bool {
 		if len(selected) > 0 && !selected[journey.ID] {
@@ -183,6 +204,16 @@ func commandRun(args []string) int {
 	return 0
 }
 
+func requestedJourneyIDs(value string) []string {
+	requested := []string{}
+	for _, id := range strings.Split(value, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			requested = append(requested, id)
+		}
+	}
+	return requested
+}
+
 // runExitCode is the fail-closed rule for `run`, pinned because community
 // issue #1883 found the opposite: a corpus run with failed journeys exited 0,
 // and a CI gate reading that exit saw success in a run that measured nothing
@@ -200,7 +231,7 @@ func commandRun(args []string) int {
 // comparison — the tool's whole reason to exist — impossible to script. The
 // summary line and the per-journey table keep the two impossible to conflate.
 func runExitCode(results Results) int {
-	if results.JourneysFailed > 0 {
+	if results.RunStatus == "failed" || results.JourneysFailed > 0 {
 		return 1
 	}
 	return 0

--- a/bench/main_test.go
+++ b/bench/main_test.go
@@ -1,6 +1,14 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 // Community issue #1883: a corpus run with failed journeys exited 0, so a CI
 // gate reading the exit code saw success in a run that measured nothing for
@@ -44,4 +52,127 @@ func TestRunExitsZeroWhenEverythingCompleted(t *testing.T) {
 	if exit := runExitCode(results); exit != 0 {
 		t.Fatalf("a clean run exited %d", exit)
 	}
+}
+
+func TestCommandRunSelection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a temporary executable to exercise the benchmark command boundary")
+	}
+
+	binary, invocations := benchmarkTestBinary(t)
+	journeys := func() []Journey {
+		return []Journey{{
+			ID: "known",
+			Steps: []Step{{
+				Name: "invoke test binary",
+				Fixture: func(sandbox *Sandbox) error {
+					return os.MkdirAll(sandbox.Repo, 0o755)
+				},
+				Args: func(*Sandbox) ([]string, error) {
+					return []string{"review"}, nil
+				},
+			}},
+		}}
+	}
+	for _, tt := range []struct {
+		name          string
+		only          string
+		includeOnly   bool
+		wantExit      int
+		wantJourneys  int
+		wantJourneyID string
+		wantFailure   bool
+	}{
+		{name: "omitted selector runs the default corpus", wantJourneys: 1, wantJourneyID: "known"},
+		{name: "empty selector runs the default corpus", only: " , ", includeOnly: true, wantJourneys: 1, wantJourneyID: "known"},
+		{name: "one exact known id runs one journey", only: "known", includeOnly: true, wantJourneys: 1, wantJourneyID: "known"},
+		{name: "unknown selector fails with a diagnostic envelope", only: "does-not-exist", includeOnly: true, wantExit: 1, wantFailure: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(invocations, nil, 0o644); err != nil {
+				t.Fatalf("reset invocation log: %v", err)
+			}
+			out := filepath.Join(t.TempDir(), "results.json")
+			args := []string{"--binary", binary, "--out", out}
+			if tt.includeOnly {
+				args = append(args, "--only", tt.only)
+			}
+			if exit := commandRunWith(args, func(string) bool { return true }, journeys); exit != tt.wantExit {
+				t.Fatalf("commandRunWith() exit = %d, want %d", exit, tt.wantExit)
+			}
+
+			content, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("read results: %v", err)
+			}
+			var results Results
+			if err := json.Unmarshal(content, &results); err != nil {
+				t.Fatalf("decode results: %v", err)
+			}
+			if tt.wantFailure {
+				if got := strings.Join(results.RequestedSelectors, ","); got != tt.only {
+					t.Fatalf("requested_selectors = %q, want %q", got, tt.only)
+				}
+				if results.ResolvedIDs == nil || len(*results.ResolvedIDs) != 0 {
+					t.Fatalf("resolved_ids = %#v, want []", results.ResolvedIDs)
+				}
+				if results.RunStatus != "failed" {
+					t.Fatalf("run_status = %q, want failed", results.RunStatus)
+				}
+				if results.FailureReason != "empty_selected_population" {
+					t.Fatalf("failure_reason = %q, want empty_selected_population", results.FailureReason)
+				}
+				calls, err := os.ReadFile(invocations)
+				if err != nil {
+					t.Fatalf("read invocation log: %v", err)
+				}
+				if got := strings.TrimSpace(string(calls)); got != "--version" {
+					t.Fatalf("journey execution calls = %q, want only --version", got)
+				}
+				return
+			}
+			if len(results.Journeys) != tt.wantJourneys {
+				t.Fatalf("journeys = %d, want %d", len(results.Journeys), tt.wantJourneys)
+			}
+			if tt.wantJourneyID != "" && results.Journeys[0].ID != tt.wantJourneyID {
+				t.Fatalf("journey id = %q, want %q", results.Journeys[0].ID, tt.wantJourneyID)
+			}
+		})
+	}
+}
+
+func benchmarkTestBinary(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	invocations := filepath.Join(dir, "invocations.log")
+	source := filepath.Join(dir, "main.go")
+	binary := filepath.Join(dir, "gentle-ai-test.exe")
+	program := `package main
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+func main() {
+	args := strings.Join(os.Args[1:], " ")
+	f, _ := os.OpenFile(` + strconv.Quote(invocations) + `, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if f != nil {
+		_, _ = fmt.Fprintln(f, args)
+		_ = f.Close()
+	}
+	if args == "--version" {
+		fmt.Println("test")
+		return
+	}
+	fmt.Fprintln(os.Stderr, ` + strconv.Quote(`unknown review command "review"`) + `)
+	os.Exit(1)
+}
+`
+	if err := os.WriteFile(source, []byte(program), 0o644); err != nil {
+		t.Fatalf("write test binary source: %v", err)
+	}
+	if output, err := exec.Command("go", "build", "-o", binary, source).CombinedOutput(); err != nil {
+		t.Fatalf("build test binary: %v\n%s", err, output)
+	}
+	return binary, invocations
 }

--- a/bench/metrics.go
+++ b/bench/metrics.go
@@ -151,6 +151,10 @@ type Results struct {
 	Mode                string          `json:"mode"` // driven | observed
 	Binary              string          `json:"binary"`
 	BinaryVersion       string          `json:"binary_version"`
+	RequestedSelectors  []string        `json:"requested_selectors,omitempty"`
+	ResolvedIDs         *[]string       `json:"resolved_ids,omitempty"`
+	RunStatus           string          `json:"run_status,omitempty"`
+	FailureReason       string          `json:"failure_reason,omitempty"`
 	Journeys            []JourneyResult `json:"journeys"`
 	Totals              MetricSet       `json:"totals"`
 	JourneysCounted     int             `json:"journeys_counted"`


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1883

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Resolve explicit `--only` selectors before any benchmark journey starts.
- Fail closed with a typed diagnostic result when a non-empty selector set resolves to zero journeys.
- Preserve the default corpus and exact-ID paths with command-boundary regression tests.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/main.go` | Resolves requested IDs before execution and rejects an empty resolved population. |
| `bench/metrics.go` | Adds requested/resolved selector fields and typed failure outcome fields. |
| `bench/main_test.go` | Covers omitted, empty, exact-known, and unknown selector behavior at the command boundary. |

---

## 🧪 Test Plan

- [x] Focused benchmark tests pass: `cd bench && go test . -run '^(TestCommandRunSelection|TestRunExitsNonzeroWhenAnyJourneyFailed|TestRunExitsZeroWhenJourneysAreOnlyUnsupported|TestRunExitsZeroWhenEverythingCompleted)$' -count=1`
- [x] Benchmark vet passes: `cd bench && go vet .`
- [x] Go format gate passes: `go run ./internal/gofmtcheck`
- [x] Diff validation passes: `git diff --check`
- [ ] Root unit suite: `go test ./...` timed out locally after 600 seconds without reporting a test failure; CI should provide the authoritative result.
- [ ] E2E Docker tests were not run locally because this bounded change is isolated to the nested benchmark module.
- [x] Manually verified the diagnostic envelope and that an unknown selector executes no journey step.

---

## 🤖 Automated Checks

The repository checks should validate issue linkage, cognitive load, labels, unit tests, formatting, and E2E behavior.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:bug` label to this PR
- [ ] Root unit suite passes locally; it timed out without a reported failure and is delegated to CI
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass locally; not run for this nested benchmark-only change
- [x] Documentation is not required for this bounded behavior correction
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please focus on the distinction between an omitted/empty `--only` value and a non-empty selector request that resolves to no exact journey IDs. Mixed known/unknown selectors remain outside issue #1883.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved `--only` selection handling for benchmark runs.
  - Results now record requested selectors, resolved journey IDs, run status, and failure reasons.

- **Bug Fixes**
  - Runs with selectors that match no journeys now fail clearly instead of completing silently.
  - Empty selections produce a nonzero exit code and identify the `empty_selected_population` failure reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->