### PR TITLE
fix(skills): include content bytes in registry cache fingerprints

### DIFF
--- a/internal/skillregistry/registry.go
+++ b/internal/skillregistry/registry.go
@@ -18,7 +18,7 @@ import (
 const (
 	RegistryRelPath = ".atl/skill-registry.md"
 	CacheRelPath    = ".atl/.skill-registry.cache.json"
-	RegistrySchema  = 4
+	RegistrySchema  = 5
 	sectionMarker   = "## Skills"
 	atlIgnoreEntry  = ".atl/"
 )
@@ -226,7 +226,13 @@ func Fingerprint(files []string) string {
 			lines = append(lines, file+":missing")
 			continue
 		}
-		lines = append(lines, fmt.Sprintf("%s:%d:%d", file, info.ModTime().UnixNano(), info.Size()))
+		data, err := os.ReadFile(file)
+		if err != nil {
+			lines = append(lines, file+":unreadable")
+			continue
+		}
+		contentSum := sha1.Sum(data)
+		lines = append(lines, fmt.Sprintf("%s:%d:%d:%x", file, info.ModTime().UnixNano(), info.Size(), contentSum))
 	}
 	sort.Strings(lines)
 	sum := sha1.Sum([]byte(strings.Join(lines, "\n")))

--- a/internal/skillregistry/registry_test.go
+++ b/internal/skillregistry/registry_test.go
@@ -58,6 +58,77 @@ description: React patterns
 	}
 }
 
+func TestRegenerateContentOnlyMetadataPreservingChangeInvalidatesCache(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	skillPath := filepath.Join(cwd, "skills", "react", "SKILL.md")
+	firstContent := "---\nname: react\ndescription: first\n---\n"
+	secondContent := "---\nname: react\ndescription: other\n---\n"
+	writeSkill(t, skillPath, firstContent)
+
+	firstInfo, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatalf("stat original skill: %v", err)
+	}
+	first, err := Regenerate(cwd, home, false)
+	if err != nil {
+		t.Fatalf("first Regenerate() error = %v", err)
+	}
+	if !first.Regenerated || first.Reason != "fingerprint-changed" {
+		t.Fatalf("first result = %#v", first)
+	}
+
+	writeSkill(t, skillPath, secondContent)
+	if err := os.Chtimes(skillPath, firstInfo.ModTime(), firstInfo.ModTime()); err != nil {
+		t.Fatalf("restore skill timestamps: %v", err)
+	}
+	secondInfo, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatalf("stat changed skill: %v", err)
+	}
+	if secondInfo.Size() != firstInfo.Size() || !secondInfo.ModTime().Equal(firstInfo.ModTime()) {
+		t.Fatalf("test setup changed metadata: first=%+v second=%+v", firstInfo, secondInfo)
+	}
+
+	changed, err := Regenerate(cwd, home, false)
+	if err != nil {
+		t.Fatalf("changed Regenerate() error = %v", err)
+	}
+	if !changed.Regenerated || changed.Reason != "fingerprint-changed" {
+		t.Fatalf("changed result = %#v", changed)
+	}
+	if registry := readFile(t, filepath.Join(cwd, RegistryRelPath)); !strings.Contains(registry, "| `react` | other | project |") {
+		t.Fatalf("registry did not reflect changed skill content:\n%s", registry)
+	}
+
+	unchanged, err := Regenerate(cwd, home, false)
+	if err != nil {
+		t.Fatalf("unchanged Regenerate() error = %v", err)
+	}
+	if unchanged.Regenerated || unchanged.Reason != "cache-hit" {
+		t.Fatalf("unchanged result = %#v", unchanged)
+	}
+}
+
+func TestFingerprintChangesForFileSetAndIsOrderIndependent(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first", "SKILL.md")
+	secondPath := filepath.Join(dir, "second", "SKILL.md")
+	writeSkill(t, firstPath, "first")
+	writeSkill(t, secondPath, "second")
+
+	forward := Fingerprint([]string{firstPath, secondPath})
+	if reverse := Fingerprint([]string{secondPath, firstPath}); reverse != forward {
+		t.Fatalf("Fingerprint() depends on input order: forward=%s reverse=%s", forward, reverse)
+	}
+	if err := os.Remove(secondPath); err != nil {
+		t.Fatalf("remove skill: %v", err)
+	}
+	if withoutSecond := Fingerprint([]string{firstPath}); withoutSecond == forward {
+		t.Fatal("Fingerprint() did not change after deleting a skill")
+	}
+}
+
 func TestRegenerateForceBypassesCacheAndProjectSkillWins(t *testing.T) {
 	cwd := t.TempDir()
 	home := t.TempDir()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1732

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Make generated skill-registry cache fingerprints content-aware so metadata-preserving `SKILL.md` edits invalidate stale registries. The fingerprint remains deterministic and legacy metadata-only cache entries are invalidated once through the schema bump.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/skillregistry/registry.go` | Include each source file content digest in the fingerprint and bump the fingerprint schema. |
| `internal/skillregistry/registry_test.go` | Cover metadata-preserving content edits, unchanged cache hits, deleted files, and input-order determinism. |

## 🧪 Test Plan

**Unit Tests**

- [x] `go test ./internal/skillregistry -count=1`
- [x] Focused metadata-preserving content regression
- [x] Focused deletion and deterministic-order regression
- [ ] `go test ./...` — local Windows run failed in unrelated packages due timeouts and unavailable WSL/POSIX dependencies; CI must validate the Linux suite.

**Go Format**

- [x] `go run ./internal/gofmtcheck`

**E2E Tests**

- [ ] `cd e2e && ./docker-test.sh` — Docker is unavailable in the local environment, so no containers were created.

**Delivery verification**

- Receipt-driven development: `disabled/unmanaged` (global switch off).

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (81 additions + deletions)
- [x] I have added exactly one `type:*` label
- [ ] Full unit test suite passes locally (see environment limitation above)
- [ ] E2E tests pass locally (Docker unavailable)
- [x] Documentation update is not required for this internal cache-correctness fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skill registry caches now detect changes to file contents even when file timestamps remain unchanged.
  * Registry fingerprints reliably change when tracked files are added, removed, or modified.
  * Fingerprints remain consistent regardless of file ordering.
  * Unreadable skill files are handled explicitly during fingerprint generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->