### PR TITLE
fix(community-tool): attribute Pi MCP timeout phase

### DIFF
--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -528,16 +529,22 @@ func probePiCodeGraphMCPWithAgentDirContext(ctx context.Context, mcpPath, agentD
 	if err := command.Start(); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("start CodeGraph MCP server: %w", err)
 	}
+	return probePiCodeGraphMCPWithTransport(ctx, stdin, stdout, func() (error, error) {
+		return command.Process.Kill(), command.Wait()
+	})
+}
+
+func probePiCodeGraphMCPWithTransport(ctx context.Context, stdin io.WriteCloser, stdout io.Reader, cleanup func() (error, error)) (probeResult PiCodeGraphMCPProbeResult, returnErr error) {
+	phase := "MCP initialize"
 	defer func() {
 		_ = stdin.Close()
-		killErr := command.Process.Kill()
-		waitErr := command.Wait()
+		killErr, waitErr := cleanup()
 		if errors.Is(returnErr, context.DeadlineExceeded) {
 			return
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			probeResult = PiCodeGraphMCPProbeResult{}
-			returnErr = fmt.Errorf("wait for CodeGraph MCP server: %w", context.DeadlineExceeded)
+			returnErr = fmt.Errorf("%s: %w", phase, context.DeadlineExceeded)
 			return
 		}
 		if returnErr == nil && errors.Is(killErr, os.ErrProcessDone) && waitErr != nil {
@@ -565,6 +572,7 @@ func probePiCodeGraphMCPWithAgentDirContext(ctx context.Context, mcpPath, agentD
 	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized", "params": map[string]any{}}); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("send MCP initialized notification: %w", err)
 	}
+	phase = "MCP tools/list"
 	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}}); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("send MCP tools/list: %w", err)
 	}

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -1,9 +1,11 @@
 package communitytool
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -740,40 +742,29 @@ func TestPiCodeGraphProbeVerifiesDirectMCPWithoutPiProcess(t *testing.T) {
 
 func TestPiCodeGraphProbeClassifiesStalledMCPResponsesAsDeadlineExceeded(t *testing.T) {
 	for _, tt := range []struct {
-		name      string
-		script    string
-		wantPhase string
+		name               string
+		stallInitialize    bool
+		responseAtDeadline string
+		wantPhase          string
 	}{
 		{
-			name:      "initialize",
-			script:    `while IFS= read -r request; do while :; do :; done; done`,
-			wantPhase: "MCP initialize: read response",
+			name:            "initialize",
+			stallInitialize: true,
+			wantPhase:       "MCP initialize: read response",
 		},
 		{
-			name: "tools list",
-			script: `while IFS= read -r request; do
-  case "$request" in
-	    *'"id":1'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}' ;;
-    *'"id":2'*) while :; do :; done ;;
-  esac
-done`,
-			wantPhase: "MCP tools/list: read response",
+			name:               "tools list cleanup race",
+			responseAtDeadline: `{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}` + "\n",
+			wantPhase:          "MCP tools/list",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			home := t.TempDir()
-			agentDir := filepath.Join(home, "custom-agent")
-			mcpPath := filepath.Join(home, "project", ".mcp.json")
-			writePiFile(t, filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
-			if runtime.GOOS == "windows" {
-				installFakeCodeGraphHelper(t, "stall-"+strings.ReplaceAll(tt.name, " ", "-"))
-			} else {
-				installFakeCodeGraphScript(t, tt.script)
-			}
-
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
-			_, err := probePiCodeGraphMCPWithAgentDirContext(ctx, mcpPath, agentDir)
+			transport := &piCodeGraphStalledTransport{ctx: ctx, stallInitialize: tt.stallInitialize, responseAtDeadline: []byte(tt.responseAtDeadline)}
+			_, err := probePiCodeGraphMCPWithTransport(ctx, transport, transport, func() (error, error) {
+				return nil, nil
+			})
 			if !errors.Is(err, context.DeadlineExceeded) {
 				t.Fatalf("probe error = %v, want context deadline exceeded", err)
 			}
@@ -783,6 +774,38 @@ done`,
 		})
 	}
 }
+
+type piCodeGraphStalledTransport struct {
+	ctx                context.Context
+	response           bytes.Buffer
+	stallInitialize    bool
+	responseAtDeadline []byte
+}
+
+func (t *piCodeGraphStalledTransport) Write(request []byte) (int, error) {
+	if bytes.Contains(request, []byte(`"id":1`)) {
+		if t.stallInitialize {
+			return len(request), nil
+		}
+		t.response.WriteString(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}` + "\n")
+	}
+	return len(request), nil
+}
+
+func (t *piCodeGraphStalledTransport) Read(data []byte) (int, error) {
+	if t.response.Len() != 0 {
+		return t.response.Read(data)
+	}
+	<-t.ctx.Done()
+	if len(t.responseAtDeadline) != 0 {
+		t.response.Write(t.responseAtDeadline)
+		t.responseAtDeadline = nil
+		return t.response.Read(data)
+	}
+	return 0, io.EOF
+}
+
+func (*piCodeGraphStalledTransport) Close() error { return nil }
 
 func TestPiCodeGraphProbeRejectsInvalidInitializeResponses(t *testing.T) {
 	responses := []string{


### PR DESCRIPTION
## Linked Issue

Closes #1644

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Preserves the active Pi MCP request phase when the 100 ms probe deadline expires during cleanup.
- Adds a deterministic in-memory regression for stalled `initialize` and `tools/list` responses without relying on helper processes.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/communitytool/pi_codegraph.go` | Attribute cleanup-time deadline errors to the active MCP phase. |
| `internal/components/communitytool/pi_codegraph_test.go` | Cover deterministic in-memory 100 ms phase-attribution regressions. |

---

## Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

Passed focused checks:

- Timeout regression passed 20 repetitions using the deterministic in-memory 100 ms transport scenario.
- `go test -timeout 45s ./internal/components/communitytool -run '^TestPiCodeGraphProbe' -count=1`
- `go run ./internal/gofmtcheck`

Windows verification disclosure: the full `communitytool` package command did not terminate or emit Go timeout output locally. A later `go test ./...` completed with failures in unrelated or environment-sensitive packages including CLI, reviewtransaction, sddstatus, TUI, and update. Full-unit and E2E checks remain unchecked.

---

## Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | PR is within the 400 changed-line budget. |
| Check Issue Reference | Pending | PR body contains `Closes #1644`. |
| Check Issue Has `status:approved` | Pending | Linked issue was approved before work began. |
| Check PR Has `type:*` Label | Pending | Exactly one `type:*` label is applied. |
| Unit Tests | Pending | `go test ./...` must pass. |
| Go Format | Pending | `go run ./internal/gofmtcheck` must pass. |
| E2E Tests | Pending | `cd e2e && ./docker-test.sh` must pass. |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary - N/A: this is an internal error-classification fix with no user-facing documentation change.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The regression intentionally runs entirely in memory under the production 100 ms deadline so timeout attribution is deterministic across platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CodeGraph connection probing to handle stalled communication more reliably.
  * Timeout errors now identify the specific connection phase that failed, including initialization and tool listing.
  * Improved cleanup handling when probing processes encounter deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->