### PR TITLE
test(review): prove staged recovery ignores worktree bytes

### DIFF
--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -346,10 +346,24 @@ func TestBuildStagedWorkspaceOverlayRecoveryUsesOnlyTheRealIndex(t *testing.T) {
 		len(snapshot.IntendedUntracked) != 0 || len(snapshot.LedgerIDs) != 0 {
 		t.Fatalf("staged recovery snapshot = %#v", snapshot)
 	}
-	for _, path := range []string{"tracked.txt", "untracked.txt"} {
-		if gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":"+path) && path == "untracked.txt" {
-			t.Fatalf("staged recovery snapshot included %s", path)
-		}
+	if got := gitSnapshot(t, repo, "show", snapshot.CandidateTree+":reviewed.txt"); got != "reviewed\n" {
+		t.Fatalf("staged recovery snapshot reviewed.txt = %q, want authorized staged bytes", got)
+	}
+	if got := gitSnapshot(t, repo, "show", snapshot.CandidateTree+":tracked.txt"); got != "base\n" {
+		t.Fatalf("staged recovery snapshot tracked.txt = %q, want base index bytes", got)
+	}
+	if gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":untracked.txt") {
+		t.Fatal("staged recovery snapshot included unrelated untracked.txt")
+	}
+
+	writeSnapshotFile(t, repo, "tracked.txt", "more unstaged\n")
+	writeSnapshotFile(t, repo, "untracked.txt", "more untracked\n")
+	rebuilt, err := builder.BuildStagedWorkspaceOverlayRecovery(context.Background(), target)
+	if err != nil {
+		t.Fatalf("rebuild staged recovery snapshot: %v", err)
+	}
+	if rebuilt.CandidateTree != snapshot.CandidateTree || rebuilt.Identity != snapshot.Identity {
+		t.Fatalf("staged recovery identity changed with only worktree bytes: before=%#v after=%#v", snapshot, rebuilt)
 	}
 	if afterIndex := gitSnapshot(t, repo, "diff", "--cached", "--binary"); afterIndex != beforeIndex {
 		t.Fatal("staged recovery snapshot mutated the real index")


### PR DESCRIPTION
## Linked Issue

Closes #1948

---

## PR Type

- [x] type:chore - Maintenance/tooling

---

## Summary

- Strengthens the staged recovery regression to assert candidate content comes only from the real index.
- Verifies worktree-only tracked and untracked byte changes cannot alter the candidate tree or identity.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| internal/reviewtransaction/snapshot_test.go | Replaced a vacuous inclusion loop with direct content, exclusion, and stability assertions. |

---

## Test Plan

- [x] Focused regression passed: go test ./internal/reviewtransaction -run '^TestBuildStagedWorkspaceOverlayRecoveryUsesOnlyTheRealIndex$' -count=1
- [x] Go formatting check passed: gofmt -d internal/reviewtransaction/snapshot_test.go (no output)
- [x] Diff whitespace check passed: git diff --check
- [ ] Package check limitation: go test -timeout 60s ./internal/reviewtransaction timed out in unrelated TestAbandonCrashBeforeRenameLeavesPreparedRecordAndRetrySucceeds Git process I/O on Windows. Approved to proceed with this documented limitation.
- [x] Runtime harness: N/A; this is a test-only regression with no runtime behavior change.

---

## Contributor Checklist

- [x] PR is linked to approved issue #1948.
- [x] PR stays within 400 changed lines (22 total).
- [x] Exactly one type:* label is applied.
- [x] Commit follows Conventional Commits.
- [x] Commit has no Co-Authored-By trailers.

---

## Notes for Reviewers

- Delivery is ordinary disabled/unmanaged. Receipt-driven development is globally disabled; no receipt or review lifecycle was used.
- Rollback boundary: revert this single commit or remove only these strengthened assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation for staged workspace recovery snapshots.
  * Confirmed staged, tracked, and untracked file handling remains correct after worktree changes.
  * Verified rebuilt snapshots preserve candidate contents and identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->