### PR TITLE
fix(review): resolve nested cwd for status

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -926,7 +926,11 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 	if strings.TrimSpace(*lineage) != "" || strings.TrimSpace(*baseRef) != "" || strings.TrimSpace(*baseTree) != "" || *workspaceOverlay || *projection != string(reviewtransaction.ProjectionWorkspace) || *gate != string(reviewtransaction.GatePreCommit) || *recoverySuccessor != "" || *recoveryReason != "" || *recoveryActor != "" || *recoveryAuthorization != "" || *repairActor != "" || *repairReason != "" || *repairAuthorization != "" {
 		return errors.New(reviewStatusTargetSelectorsRequireContractReason)
 	}
-	report, err := reviewtransaction.InventoryAuthority(ctx, *cwd)
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	report, err := reviewtransaction.InventoryAuthority(ctx, root)
 	if err != nil {
 		return fmt.Errorf("inventory review authority: %w", err)
 	}

--- a/internal/cli/review_status_cwd_test.go
+++ b/internal/cli/review_status_cwd_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReviewStatusSelectorFreeResolvesRepositoryRoot(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate behavior\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	nested := filepath.Join(repo, "nested", "path")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	status := func(t *testing.T, cwd string) string {
+		t.Helper()
+		var output bytes.Buffer
+		if err := RunReview([]string{"status", "--cwd", cwd}, &output); err != nil {
+			t.Fatalf("review status --cwd %q: %v", cwd, err)
+		}
+		var report struct {
+			Entries []struct {
+				LineageID string `json:"lineage_id"`
+			} `json:"entries"`
+		}
+		if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if len(report.Entries) != 1 || report.Entries[0].LineageID != started.LineageID {
+			t.Fatalf("review status --cwd %q entries = %#v, want lineage %q", cwd, report.Entries, started.LineageID)
+		}
+		return output.String()
+	}
+
+	want := status(t, repo)
+	if got := status(t, nested); got != want {
+		t.Fatalf("nested review status differs from repository root:\nroot:   %s\nnested: %s", want, got)
+	}
+
+	t.Run("safe symlink", func(t *testing.T) {
+		symlink := filepath.Join(t.TempDir(), "repo-link")
+		if err := os.Symlink(repo, symlink); err != nil {
+			if errors.Is(err, os.ErrPermission) {
+				t.Skipf("creating a directory symlink is unavailable: %v", err)
+			}
+			t.Fatal(err)
+		}
+		if got := status(t, symlink); got != want {
+			t.Fatalf("symlink review status differs from repository root:\nroot:    %s\nsymlink: %s", want, got)
+		}
+	})
+
+	if err := RunReview([]string{"status", "--cwd", t.TempDir()}, &bytes.Buffer{}); err == nil {
+		t.Fatal("review status accepted a path outside a repository")
+	}
+
+	nestedRepository := filepath.Join(repo, "nested-repository")
+	if err := os.Mkdir(nestedRepository, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, nestedRepository, "init", "-q")
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", nestedRepository}, &output); err != nil {
+		t.Fatalf("review status in nested independent repository: %v", err)
+	}
+	var nestedReport struct {
+		Entries []struct {
+			LineageID string `json:"lineage_id"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &nestedReport); err != nil {
+		t.Fatal(err)
+	}
+	if len(nestedReport.Entries) != 0 {
+		t.Fatalf("nested independent repository inherited parent authority entries: %#v", nestedReport.Entries)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1862

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Canonicalize selector-free `review status --cwd` inputs before authority inventory.
- Keep repository routing consistent for root, nested-directory, and safe-symlink spellings.
- Preserve repository isolation for outside paths and nested independent repositories.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Resolve the canonical repository root before calling `InventoryAuthority`. |
| `internal/cli/review_status_cwd_test.go` | Add regression coverage for root, nested, symlink, outside, and nested-repository inputs. |

---

## 🧪 Test Plan

- [x] `go test -v ./internal/cli -run '^TestReviewStatusSelectorFreeResolvesRepositoryRoot$' -count=1`
- [x] `go test ./internal/cli -run '^TestReviewStatus' -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`
- [ ] Full `go test ./...` was not run locally; CI remains authoritative.
- [ ] E2E Docker tests were not run locally; this change is isolated to review STATUS routing.

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #1862.
- [x] PR stays within the 400-line review budget.
- [x] Exactly one `type:*` label is requested.
- [x] Focused unit and format checks pass.
- [x] Documentation changes are not required for this bug fix.
- [x] Commit follows Conventional Commits and has no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

This calls the existing hardened `ResolveRepositoryRoot` boundary before selector-free authority inventory. The regression exercises the legitimate input population (root, nested path, and safe symlink) and isolation controls (outside path and nested independent repository). No guard contract or `.guard-population-baseline.txt` change is intended.

Receipt-driven development was disabled globally, so local delivery is reported as `disabled/unmanaged`; focused verification passed before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review status behavior when run from nested directories within a repository.
  * Review status now works consistently when launched through a repository symlink.
  * Added clearer errors when the specified working directory is not inside a repository.
  * Prevented status results from incorrectly inheriting entries from unrelated nested repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->