### PR TITLE
fix(sdd): discover monorepo sub-projects during sdd-init

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -379,6 +379,19 @@ func TestSDDInitDiscoversMonorepoSubProjects(t *testing.T) {
 		"never \"unclassified\"",
 		"per sub-project",
 		"two or more project roots",
+		// A single nested marker used to match both the monorepo rule and the
+		// single-root gate; each layout needs its own unambiguous row.
+		"exactly one project root, at the workspace root",
+		"exactly one project root, in a sub-directory",
+		// The scan is depth-bounded, so the unclassified verdict may only speak
+		// for the depth it reached.
+		"no marker within the scanned depth",
+		// Assert the whole chain, not its parts: a fragment check passes even if
+		// the tiers get reordered, and the order is the contract.
+		"override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`",
+		// The gates table must carry the same workspace-default tier as the
+		// precedence chain, or an executor reading only the table skips it.
+		"no per-project marker/config but workspace default set",
 	} {
 		if !strings.Contains(skill, want) {
 			t.Fatalf("skills/sdd-init/SKILL.md missing monorepo contract %q", want)
@@ -393,6 +406,14 @@ func TestSDDInitDiscoversMonorepoSubProjects(t *testing.T) {
 		"node_modules",
 		"go.work",
 		"projects:",
+		// Relative-path naming is what keeps two `api` directories apart, and
+		// each entry carries its own capabilities so overrides cannot collapse.
+		"sub-project name is its path relative to the workspace root",
+		"testing:",
+		"strict_tdd:",
+		// Declared members bypass the depth and skip bounds; say so, or the two
+		// rules read as contradictory.
+		"Declared members outrank both bounds",
 	} {
 		if !strings.Contains(details, want) {
 			t.Fatalf("skills/sdd-init/references/init-details.md missing discovery rule %q", want)

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -367,6 +367,47 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 	}
 }
 
+// TestSDDInitDiscoversMonorepoSubProjects pins the multi-root detection
+// contract. A workspace whose stack markers live only in sub-directories used
+// to be classified as "unclassified" with no runner, because detection was
+// anchored at the workspace root (issue #810). The skill must discover every
+// project root and keep unlike sub-projects separable.
+func TestSDDInitDiscoversMonorepoSubProjects(t *testing.T) {
+	skill := MustRead("skills/sdd-init/SKILL.md")
+	for _, want := range []string{
+		"Discover every project root before classifying",
+		"never \"unclassified\"",
+		"per sub-project",
+		"two or more project roots",
+	} {
+		if !strings.Contains(skill, want) {
+			t.Fatalf("skills/sdd-init/SKILL.md missing monorepo contract %q", want)
+		}
+	}
+
+	details := MustRead("skills/sdd-init/references/init-details.md")
+	for _, want := range []string{
+		"Project Root Discovery",
+		"Cargo.toml",
+		"pyproject.toml",
+		"node_modules",
+		"go.work",
+		"projects:",
+	} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("skills/sdd-init/references/init-details.md missing discovery rule %q", want)
+		}
+	}
+
+	// The depth bound and the skip list are what keep the walk affordable on a
+	// large tree; losing either turns discovery into a full-repository scan.
+	for _, want := range []string{"two** directory levels", "ignored by `.gitignore`"} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("skills/sdd-init/references/init-details.md lost its scan bound %q", want)
+		}
+	}
+}
+
 func TestSDDVerifyAuthorityPreflightDenialEnvelopeContract(t *testing.T) {
 	const denialFields = `authority_only_failure: true
 missing_review_authority: true

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -35,7 +35,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
-- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers all live in sub-directories is a monorepo, never "unclassified".
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
 - In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
@@ -53,18 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| exactly one project root | Single-project layout: one context, one capability set. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
 | two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
-| no marker at any depth | Report unclassified **and** list the directories scanned, so the gap is diagnosable. |
-| strict TDD marker/config found | Use that value (per sub-project in a monorepo). |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
 1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
-3. Resolve Strict TDD per root from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers all live in sub-directories is a monorepo, never "unclassified".
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
+| exactly one project root | Single-project layout: one context, one capability set. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker at any depth | Report unclassified **and** list the directories scanned, so the gap is diagnosable. |
+| strict TDD marker/config found | Use that value (per sub-project in a monorepo). |
 | no marker/config but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -1,5 +1,24 @@
 # SDD Init Details
 
+## Project Root Discovery
+
+A workspace root without stack markers does not mean the workspace is unclassified — in a monorepo the markers live one or two levels down. Discover roots before classifying anything.
+
+- **Marker files** that define a project root: `package.json`, `go.mod`, `pyproject.toml`, `setup.py`, `requirements.txt`, `Cargo.toml`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `Gemfile`, `composer.json`, `*.csproj`, `*.sln`, `mix.exs`, `pubspec.yaml`.
+- **Depth**: scan the workspace root and up to **two** directory levels below it. Deeper nesting is reported as a limitation rather than scanned, so the cost stays bounded on large trees.
+- **Skip** directories that never hold a first-party project root: `node_modules`, `vendor`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `.git`, `.gradle`, `bin`, `obj`, and any path ignored by `.gitignore`.
+- **Workspace-manager roots count once**: when a root declares members (`workspaces` in `package.json`, `[workspace] members` in `Cargo.toml`, `pnpm-workspace.yaml`, `go.work`), use the declared members as the sub-project list instead of re-deriving it from the directory walk.
+- **Naming**: the sub-project name is its path relative to the workspace root (`services/api`), not just the leaf, so two `api` directories never collide.
+
+| Discovered | Layout | Persistence shape |
+|---|---|---|
+| marker at workspace root only | single project | one context, one capability set |
+| markers only in sub-directories | monorepo | one entry per sub-project, workspace recorded as the container |
+| marker at root **and** in sub-directories | monorepo with a root project | root project plus one entry per sub-project |
+| no marker at any scanned depth | unclassified | report the scanned directories and the skip list applied |
+
+Report per sub-project: relative path, language/stack, test runner, and resolved `strict_tdd`. Never average unlike sub-projects into a single verdict — a Python service with `pytest` and a Rust crate with `cargo test` are two answers, not one.
+
 ## Testing Capability Checklist
 
 - Test runner: `package.json` scripts/deps, `pyproject.toml`, `pytest.ini`, `go.mod`, `Cargo.toml`, `Makefile`.
@@ -39,6 +58,16 @@ mem_save title/topic_key: sdd/{project}/testing-capabilities
 type: config
 content: testing capabilities markdown
 capture_prompt: false when available
+```
+
+In a monorepo, save one capability observation per sub-project and keep the
+workspace-level key as the index that lists them:
+
+```text
+mem_save title/topic_key: sdd/{project}/{sub-project-path}/testing-capabilities
+type: config
+content: testing capabilities markdown for that sub-project
+capture_prompt: false when available
 
 mem_save title/topic_key: skill-registry
 type: config
@@ -57,6 +86,23 @@ openspec/
 ```
 
 `config.yaml` should include concise context, `strict_tdd`, testing capabilities, and phase rules for proposal/spec/design/tasks/apply/verify/archive. Keep `context:` under 10 lines.
+
+For a monorepo, keep the workspace-level `context:` under 10 lines and move the per-sub-project detail into a `projects:` list so unlike stacks stay separable:
+
+```yaml
+context: |
+  workspace is a monorepo with 2 sub-projects.
+strict_tdd: false          # workspace default; each project may override
+projects:
+  - path: a
+    stack: Python
+    testing: { unit: pytest, coverage: pytest-cov }
+    strict_tdd: true
+  - path: b
+    stack: Rust
+    testing: { unit: cargo test }
+    strict_tdd: true
+```
 
 ## Testing Capabilities Format
 

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -5,17 +5,19 @@
 A workspace root without stack markers does not mean the workspace is unclassified — in a monorepo the markers live one or two levels down. Discover roots before classifying anything.
 
 - **Marker files** that define a project root: `package.json`, `go.mod`, `pyproject.toml`, `setup.py`, `requirements.txt`, `Cargo.toml`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `Gemfile`, `composer.json`, `*.csproj`, `*.sln`, `mix.exs`, `pubspec.yaml`.
-- **Depth**: scan the workspace root and up to **two** directory levels below it. Deeper nesting is reported as a limitation rather than scanned, so the cost stays bounded on large trees.
+- **Depth**: scan the workspace root and up to **two** directory levels below it. Deeper nesting is reported as a limitation rather than scanned, so the cost stays bounded on large trees. A depth-bounded scan can never establish that no marker exists at any depth: report "no marker within the scanned depth" together with the directories actually scanned.
 - **Skip** directories that never hold a first-party project root: `node_modules`, `vendor`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `.git`, `.gradle`, `bin`, `obj`, and any path ignored by `.gitignore`.
 - **Workspace-manager roots count once**: when a root declares members (`workspaces` in `package.json`, `[workspace] members` in `Cargo.toml`, `pnpm-workspace.yaml`, `go.work`), use the declared members as the sub-project list instead of re-deriving it from the directory walk.
+- **Declared members outrank both bounds**: a declared member deeper than two levels is still discovered, because reading a declaration costs no walk, and a declared member under a skipped or gitignored path is still discovered, because an explicit declaration beats the heuristic skip list. The skip list still applies **inside** glob expansion, so `packages/*` never yields `packages/node_modules`. A declared member with no directory on disk is reported as a limitation, never dropped silently.
 - **Naming**: the sub-project name is its path relative to the workspace root (`services/api`), not just the leaf, so two `api` directories never collide.
 
 | Discovered | Layout | Persistence shape |
 |---|---|---|
 | marker at workspace root only | single project | one context, one capability set |
-| markers only in sub-directories | monorepo | one entry per sub-project, workspace recorded as the container |
+| exactly one marker, in a sub-directory | nested single project | one entry keyed by its relative path, workspace recorded as the container |
+| markers in two or more sub-directories | monorepo | one entry per sub-project, workspace recorded as the container |
 | marker at root **and** in sub-directories | monorepo with a root project | root project plus one entry per sub-project |
-| no marker at any scanned depth | unclassified | report the scanned directories and the skip list applied |
+| no marker within the scanned depth | unclassified | report the scanned directories, the depth bound reached, and the skip list applied |
 
 Report per sub-project: relative path, language/stack, test runner, and resolved `strict_tdd`. Never average unlike sub-projects into a single verdict — a Python service with `pytest` and a Rust crate with `cargo test` are two answers, not one.
 
@@ -103,6 +105,8 @@ projects:
     testing: { unit: cargo test }
     strict_tdd: true
 ```
+
+Resolution order for a sub-project's `strict_tdd`: its own entry value or agent marker → the workspace-level default → its detected test runner → `false`. Every entry under `projects:` carries its own `testing:` and `strict_tdd:`, so a workspace default never silently overwrites a sub-project that decided differently.
 
 ## Testing Capabilities Format
 

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -35,6 +35,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -51,15 +53,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #810

---

## 🏷️ PR Type

- [x] `type:bug`: Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

En palabras simples: si entras a una casa y no ves muebles en el hall, no significa que la casa este vacia.. significa que los muebles estan en las habitaciones. `sdd-init` miraba solo el hall.

Lo tecnico: la deteccion estaba anclada a la raiz del workspace. En el monorepo del issue los marcadores viven en `a/` (Python) y `b/` (Rust), y la raiz no tiene ninguno.. asi que la clasificacion daba "Unclassified software project / Detected markers: none / no test runner", y de ahi caia en cascada `strict_tdd: false`. El resultado era coherente con el contrato; el contrato era el que estaba mal.

Este PR hace la deteccion consciente de sub-proyectos, con limites explicitos para que no se vuelva un escaneo del repositorio entero.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `skills/sdd-init/SKILL.md` | Hard rule de descubrir todos los roots antes de clasificar y de detectar por sub-proyecto; nuevas filas en Decision Gates que separan un root en la raiz, un root anidado, dos o mas roots, y ninguno dentro de la profundidad escaneada; la tabla suma el nivel de default de workspace para `strict_tdd`; los pasos 1-3 de ejecucion operan por root |
| `skills/sdd-init/references/init-details.md` | Nueva seccion **Project Root Discovery**: lista de marcadores (suma `Cargo.toml`, `pom.xml`, `mix.exs`, `pubspec.yaml` y demas), tope de **dos niveles**, lista de directorios salteados, y manejo de workspace managers (`workspaces`, `[workspace] members`, `pnpm-workspace.yaml`, `go.work`) para no re-derivar miembros ya declarados. Tabla de layouts. Claves de Engram por sub-proyecto. Esqueleto de `config.yaml` con lista `projects:` |
| `internal/assets/assets_test.go` | `TestSDDInitDiscoversMonorepoSubProjects` fija el contrato: los roots se descubren, los sub-proyectos no se colapsan, y esto importa.. que no se pierdan **el tope de profundidad ni la lista de exclusion**, que son lo que mantiene el costo acotado. La cadena de precedencia de `strict_tdd` se afirma como **un solo substring contiguo**, para que un reordenamiento de sus niveles rompa el test |
| `testdata/golden/sdd-*-skill-sdd-init.golden` (8 archivos) | **Regenerados**, no editados a mano. Estos goldens espejan el cuerpo de `SKILL.md` por adapter, asi que cualquier cambio al skill los deja obsoletos y la CI se pone roja. Se regeneraron con el comando del propio repo: `go test ./internal/components/ -run TestGoldenSDD -update`. El diff de los ocho es identico entre si y al hunk de `SKILL.md`; no hay contenido escrito a mano ni divergencia por adapter |

Decisiones de diseño que vale la pena mirar:

- **Nombre por ruta relativa** (`services/api`), no por hoja, para que dos directorios `api` no colisionen.
- **Nunca promediar**: un servicio Python con `pytest` y un crate Rust con `cargo test` son dos respuestas, no una. `strict_tdd` se resuelve por sub-proyecto, con el valor del workspace como default.
- **Un "unclassified" ahora es diagnosticable**: reporta que directorios escaneo y que lista de salteo aplico, en vez de dejar al usuario adivinando como en el issue.

---

## 🧪 Test Plan

**La regresion falla sin el arreglo.** Las tres cadenas que afirma el test no existen en `main`:

```bash
$ git show origin/main:internal/assets/skills/sdd-init/SKILL.md | grep -c "exactly one project root, at the workspace root"
0
$ git show origin/main:internal/assets/skills/sdd-init/SKILL.md | grep -c "no marker within the scanned depth"
0
$ git show origin/main:internal/assets/skills/sdd-init/references/init-details.md | grep -c "Declared members outrank both bounds"
0
```

**Corrido en esta maquina (Windows):**

```bash
go test ./internal/assets/ -run TestSDDInitDiscoversMonorepoSubProjects -count=1   # ok
go test ./internal/assets/ ./internal/components/ -count=1                          # ok, ok
go run ./internal/gofmtcheck                                                        # limpio
```

- [x] `internal/assets` e `internal/components` pasan, incluidos los ocho goldens regenerados
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] `go test ./...` completo **no** corrio local: `internal/cli` supera el timeout por defecto de Go en esta maquina. Verifique que no es una regresion de este PR corriendo el mismo paquete en un worktree limpio sobre `origin/main`: falla identico a los 601s. CI queda como autoridad
- [ ] E2E tests (`cd e2e && ./docker-test.sh`) **no** corrieron local: no tengo Docker en esta maquina Windows. Corren en CI
- [x] Manually tested locally

**Validacion de benchmark: N/A.** Segun `CONTRIBUTING.md`, la validacion de benchmark aplica a cambios de review-lifecycle, gates, recovery, delivery, y a la implementacion, corpus o clasificador del propio benchmark. Este PR toca unicamente assets de instrucciones de `sdd-init`, su test de contrato y los goldens que los espejan.. ninguna de esas superficies.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#810)
- [x] PR stays within 400 changed lines.. **265** (220 + 45), de los cuales 136 son los ocho goldens regenerados
- [ ] `type:*` label: **la necesita un maintainer**. Los permisos de contribuidor no permiten aplicar labels; el cuerpo selecciona exactamente `type:bug`
- [x] Unit tests pass en los paquetes afectados (ver Test Plan para el alcance exacto y lo que no corrio)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`).. via CI, sin Docker local
- [x] Benchmark validation: N/A justificado en el Test Plan
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

El cambio es de **contrato**, no de codigo Go: `sdd-init` es un skill ejecutado por el agente, asi que el defecto vivia en las instrucciones y ahi es donde se arregla. Por eso el test fija texto.. es la unica superficie verificable de un contrato de instrucciones, y es el patron que el repo ya usa en `TestSDDVerifyAuthorityPreflightDenialEnvelopeContract`.

Mantuve `SKILL.md` delgado a proposito (el criterio LLM-First del propio repo pide 180-450 tokens de cuerpo) y puse todo el peso en `references/init-details.md`, que es donde el skill ya manda a buscar el detalle.

**Sobre los ocho goldens**: son artefactos derivados, no fuente. Los regenere con el comando del repo y no toque una sola linea a mano. Si preferis que los goldens viajen en su propio commit para que el diff de revision quede en tres archivos, lo separo sin problema.

**Sobre el tamaño**: el PR crecio de 100 a 265 lineas al responder los cinco hallazgos de CodeRabbit del 30/7 y al regenerar los goldens que ese cambio dejo obsoletos. Sigue bajo el tope de 400. El contenido escrito a mano son tres archivos; los otros ocho son espejo mecanico.

Lo que este PR **no** hace, por si abre debate: no toca como las fases posteriores (`sdd-explore`, `sdd-apply`) consumen la lista `projects:`. Eso es superficie aparte y merece su propio issue si hace falta.

Queda ademas un detalle que prefiero declarar antes de que aparezca en review: la fila `two or more project roots` de la tabla de Decision Gates dice "record the root as the workspace", que describe el monorepo puro de subdirectorios. Para el caso con marcador en la raiz **y** en subdirectorios, `init-details.md` si lo distingue como "monorepo with a root project". Si preferis que esa fila tambien se parta, lo hago en este PR o en uno chico aparte.
