### PR TITLE
fix(review): classify FINALIZE parser failures

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1985,7 +1985,7 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	var resultArtifactFiles repeatedString
 	flags.Var(&resultArtifactFiles, "result-artifact-file", "native reviewer artifact manifest regular file or - for stdin; repeat in selected-lens order")
 	if err := parseReviewFlags(flags, args); err != nil {
-		return err
+		return reviewPreflightError(err)
 	}
 	if reviewHelpRequested(args) {
 		return nil

--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -121,16 +121,53 @@ func TestNegotiatedFinalizeParserFailuresArePreflight(t *testing.T) {
 	}
 
 	t.Run("equals boolean value reaches finalize processing", func(t *testing.T) {
-		var output bytes.Buffer
-		err := RunReview([]string{
-			"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", t.TempDir(), "--failed=true",
-		}, &output)
-		if err == nil {
-			t.Fatal("finalize outside a repository succeeded")
+		repo := initReviewCLIRepo(t)
+		if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\ncandidate\n"), 0o644); err != nil {
+			t.Fatal(err)
 		}
-		failure := decodeReviewIntegrationFailure(t, output.Bytes())
-		if failure.Code == "invalid_request" || strings.Contains(failure.Cause, "boolean flag --failed takes") {
-			t.Fatalf("--failed=true parser result = %#v", failure)
+		started := startFacadeReview(t, repo)
+		evidence := filepath.Join(t.TempDir(), "evidence.txt")
+		if err := os.WriteFile(evidence, []byte("focused verification failed\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := []string{
+			"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", started.LineageID,
+			"--evidence", evidence, "--failed=true",
+		}
+		args = append(args, facadeReviewerResultArgs(t, repo, started)...)
+		var output bytes.Buffer
+		if err := RunReview(args, &output); err != nil {
+			t.Fatalf("--failed=true finalize: %v\n%s", err, output.String())
+		}
+		var result ReviewFacadeFinalizeResult
+		decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+		if result.State != reviewtransaction.StateEscalated {
+			t.Fatalf("--failed=true finalize state = %q, want escalated", result.State)
+		}
+		record, err := store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.State.State != reviewtransaction.StateEscalated {
+			t.Fatalf("--failed=true authoritative state = %q, want escalated", record.State.State)
+		}
+		var journal struct {
+			Attempts []reviewtransaction.FinalizeAttempt `json:"attempts"`
+		}
+		payload, err := os.ReadFile(store.FinalizeAttemptJournalPath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(payload, &journal); err != nil {
+			t.Fatal(err)
+		}
+		if len(journal.Attempts) != 1 || journal.Attempts[0].Request.FailedDigest != reviewtransaction.FinalizeAttemptValueDigest("failed", true) {
+			t.Fatalf("--failed=true persisted finalize request = %#v", journal.Attempts)
 		}
 	})
 }

--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -88,6 +88,53 @@ func TestNegotiatedReviewContractFailuresArePreMutationAndLegacyErrorsStayCompat
 	}
 }
 
+func TestNegotiatedFinalizeParserFailuresArePreflight(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		args      []string
+		wantCause string
+	}{
+		{
+			name:      "unsupported flag",
+			args:      []string{"finalize", "--contract", ReviewIntegrationContractV1, "--base-ref", "origin/main"},
+			wantCause: "flag provided but not defined: -base-ref",
+		},
+		{
+			name:      "boolean flag has detached value",
+			args:      []string{"finalize", "--contract", ReviewIntegrationContractV1, "--failed", "true"},
+			wantCause: "boolean flag --failed takes --failed or --failed=true, not a separate value; got \"true\"",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunReview(tt.args, &output); err == nil {
+				t.Fatal("parser failure succeeded")
+			}
+			failure := decodeReviewIntegrationFailure(t, output.Bytes())
+			if failure.Operation != ReviewIntegrationOperationFinalize || failure.Phase != "preflight" ||
+				failure.Code != "invalid_request" || failure.MutationOutcome != ReviewMutationNotStarted ||
+				!failure.RetrySafe || failure.NextAction != "correct_request" ||
+				!strings.Contains(failure.Cause, tt.wantCause) {
+				t.Fatalf("parser failure = %#v", failure)
+			}
+		})
+	}
+
+	t.Run("equals boolean value reaches finalize processing", func(t *testing.T) {
+		var output bytes.Buffer
+		err := RunReview([]string{
+			"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", t.TempDir(), "--failed=true",
+		}, &output)
+		if err == nil {
+			t.Fatal("finalize outside a repository succeeded")
+		}
+		failure := decodeReviewIntegrationFailure(t, output.Bytes())
+		if failure.Code == "invalid_request" || strings.Contains(failure.Cause, "boolean flag --failed takes") {
+			t.Fatalf("--failed=true parser result = %#v", failure)
+		}
+	})
+}
+
 func TestNegotiatedReviewV2FailureUsesSuccessorEnvelope(t *testing.T) {
 	var output bytes.Buffer
 	err := RunReview([]string{"start", "--contract", ReviewIntegrationContractV2, "unexpected"}, &output)


### PR DESCRIPTION
## Linked Issue

Closes #1666

## PR Type

- [x] type:bug - Bug fix (non-breaking change that fixes an issue)
- [ ] type:feature - New feature (non-breaking change that adds functionality)
- [ ] type:docs - Documentation only
- [ ] type:refactor - Code refactoring (no functional changes)
- [ ] type:chore - Build, CI, or tooling changes
- [ ] type:breaking-change - Breaking change

## Summary

Classifies raw FINALIZE flag-parser failures as negotiated preflight errors before native review mutation. This preserves the invalid_request, not_started, retry-safe contract while allowing valid --failed=true input to reach normal FINALIZE processing.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| internal/cli/review_facade.go | Wrap FINALIZE flag parser errors with reviewPreflightError. |
| internal/cli/review_failure_contract_test.go | Cover unsupported --base-ref, detached --failed true, and valid --failed=true behavior. |

## Test Plan

- [x] go test ./internal/cli -run '^TestNegotiatedFinalizeParserFailuresArePreflight$' -count=1
- [x] go test ./internal/cli -run '^TestNegotiatedReviewContractFailuresArePreMutationAndLegacyErrorsStayCompatible$' -count=1
- [x] Check-only gofmt -d on both changed files
- [x] git diff --check
- [ ] Full unit suite (go test ./...)
- [ ] E2E suite (cd e2e && ./docker-test.sh)

## Contributor Checklist

- [x] PR is linked to an issue with status:approved
- [x] PR stays within the 400 changed-line review budget (49 lines)
- [x] I have added the appropriate type:* label to this PR
- [ ] Full unit suite passes (go test ./...)
- [ ] E2E suite passes (cd e2e && ./docker-test.sh)
- [x] Documentation is not necessary for this internal contract fix
- [x] My commit follows Conventional Commits format
- [x] My commit does not include Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `review finalize` handling for invalid command-line options.
  * Invalid options are now reported as preflight failures with clear guidance to correct the request.
  * Boolean options using equals syntax, such as `--failed=true`, are processed correctly.
  * Finalize requests with supported failure values now proceed correctly and record the resulting review state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->