### PR TITLE
fix(review): discover corrected current-changes delivery

### DIFF
--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -966,6 +966,12 @@ func TestReadFacadeReviewerResultsRejectsNonNativeFields(t *testing.T) {
 func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".remote", "origin")
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -1093,6 +1099,15 @@ func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *te
 	}
 	if committedReuse.Action != "reuse-receipt" || committedReuse.LensesRequired || committedReuse.LineageID != started.LineageID || committedReuse.State != reviewtransaction.StateApproved {
 		t.Fatalf("equivalent committed corrected target did not reuse receipt: %#v", committedReuse)
+	}
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePush)}, &output); err != nil {
+		t.Fatalf("selector-free corrected pre-push discovery: %v\n%s", err, output.String())
+	}
+	var delivery ReviewValidateResult
+	decodeStrictReviewJSON(t, output.Bytes(), &delivery)
+	if !delivery.Allowed || delivery.Context.LineageID != started.LineageID || !delivery.Context.BaseRelationshipValid {
+		t.Fatalf("selector-free corrected pre-push discovery = %#v", delivery)
 	}
 }
 

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -83,7 +83,7 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	strictBinding := request.Gate == GatePostApply || request.Gate == GatePreCommit ||
 		request.Gate == GatePrePush && state.InitialSnapshot.Kind != TargetCurrentChanges
 	pathsMatch := pathsAreSubset(snapshot.Paths, state.GenesisPaths) == nil
-	baseMatches := snapshot.BaseTree == state.CurrentSnapshot.BaseTree || request.Target.Kind == TargetFixDiff
+	baseMatches := snapshot.BaseTree == state.CurrentSnapshot.BaseTree || request.Target.Kind == TargetFixDiff || squashedFixDelivery
 	if strictBinding {
 		pathsMatch = snapshot.PathsDigest == state.CurrentSnapshot.PathsDigest || squashedFixDelivery
 		baseMatches = snapshot.BaseTree == state.CurrentSnapshot.BaseTree || squashedFixDelivery
@@ -318,7 +318,7 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	binding := record.State.CurrentSnapshot
 	squashedFixDelivery := compactSquashedFixDelivery(request.Gate, record.State, snapshot, resolvedPrePR, receipt.FinalCandidateTree)
 	strictBinding := request.Gate == GatePostApply || request.Gate == GatePreCommit || request.Gate == GatePrePush && record.State.InitialSnapshot.Kind != TargetCurrentChanges
-	baseRelationshipValid := snapshot.BaseTree == receipt.BaseTree || request.Target.Kind == TargetFixDiff
+	baseRelationshipValid := snapshot.BaseTree == receipt.BaseTree || request.Target.Kind == TargetFixDiff || squashedFixDelivery
 	if strictBinding {
 		baseRelationshipValid = snapshot.BaseTree == binding.BaseTree || squashedFixDelivery
 	}

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -1215,22 +1215,53 @@ func TestCompactCorrectedPreCommitBindsStagedIndexAndIgnoresWorkspace(t *testing
 }
 
 func TestCompactCorrectedCurrentChangesPrePushUsesFinalDeliveryBinding(t *testing.T) {
-	repo := initSnapshotRepo(t)
-	branch := currentBranch(context.Background(), repo)
-	configurePublicationRemote(t, repo, branch)
-	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
-	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
-	state := correctedCompactTestStateWithIntended(t, repo, "compact-corrected-current-delivery", []string{})
-	receipt := persistCorrectedCompactFixture(t, repo, state)
-	gitSnapshot(t, repo, "add", "tracked.txt")
-	gitSnapshot(t, repo, "commit", "-m", "corrected delivery")
-	input := NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: "origin/" + branch}
-	if got := EvaluateCompactGate(context.Background(), repo, receipt, input); got.Result != GateAllow {
-		t.Fatalf("one-commit corrected delivery = %#v", got)
+	tests := []struct {
+		name      string
+		mutate    func(t *testing.T, repo string)
+		wantExact bool
+		wantAllow bool
+	}{
+		{name: "exact squashed delivery", wantExact: true, wantAllow: true},
+		{name: "wrong candidate", mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "tracked.txt", "wrong corrected candidate\n")
+		}},
+		{name: "path drift", mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "extra.txt", "outside reviewed scope\n")
+		}},
+		{name: "non-squashed delivery", mutate: func(t *testing.T, repo string) {
+			gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "unreviewed extra commit")
+		}},
 	}
-	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "unreviewed extra commit")
-	if got := EvaluateCompactGate(context.Background(), repo, receipt, input); got.Result == GateAllow {
-		t.Fatalf("multi-commit current-changes delivery = %#v", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			branch := currentBranch(context.Background(), repo)
+			configurePublicationRemote(t, repo, branch)
+			gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+			gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+			state := correctedCompactTestStateWithIntended(t, repo, "compact-corrected-current-delivery-"+strings.ReplaceAll(tt.name, " ", "-"), []string{})
+			receipt := persistCorrectedCompactFixture(t, repo, state)
+			if tt.mutate != nil {
+				tt.mutate(t, repo)
+			}
+			gitSnapshot(t, repo, "add", "-A")
+			gitSnapshot(t, repo, "commit", "-m", "corrected delivery")
+			input := NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: "origin/" + branch}
+			assessment, err := AssessCompactGateTarget(context.Background(), repo, state, input)
+			if tt.wantExact && (err != nil || assessment.Applicability != CompactGateTargetExact) {
+				t.Fatalf("delivery assessment = %#v, %v", assessment, err)
+			}
+			if !tt.wantExact && err == nil && assessment.Applicability == CompactGateTargetExact {
+				t.Fatalf("inexact delivery assessment = %#v", assessment)
+			}
+			got := EvaluateCompactGate(context.Background(), repo, receipt, input)
+			if tt.wantAllow && (got.Result != GateAllow || !got.Context.BaseRelationshipValid) {
+				t.Fatalf("exact squashed delivery = %#v", got)
+			}
+			if !tt.wantAllow && got.Result == GateAllow {
+				t.Fatalf("inexact delivery = %#v", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #1819

## Summary

- Let the existing exact `compactSquashedFixDelivery` proof satisfy selector-free corrected `current-changes` receipt discovery and authorization.
- Keep wrong-candidate, path-drift, and non-squashed deliveries fail-closed.
- Add facade-level coverage for the real `review validate --gate pre-push` boundary.

## Test Plan

### RED — baseline `354c5b50`

```bash
go test ./internal/cli -run '^TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState$' -count=1 -v
```

Failed with `receipt_unrelated`: `no terminal review receipt governs this candidate`.

### GREEN

```bash
go test ./internal/cli -run '^TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState$' -count=1 -v
go test ./internal/reviewtransaction -run '^TestCompactCorrectedCurrentChangesPrePushUsesFinalDeliveryBinding$' -count=1 -v
go test ./internal/reviewtransaction -count=1
go run ./internal/gofmtcheck
git diff --check
```

All passed. The compact-gate controls cover the exact delivery, wrong candidate, path drift, and a non-squashed delivery.

### Benchmark validation

```bash
cd bench
go build ./... && go vet ./... && go test ./...
gentle-ai-bench run --binary <baseline> --only j06-pre-push-after-publication --out before.json
gentle-ai-bench run --binary <patched> --only j06-pre-push-after-publication --out after.json
gentle-ai-bench compare --before before.json --after after.json
```

Both runs completed with 5 commands, 0 blocks, and 0 failed journeys. Every measured comparison delta was 0.

### Full suite note

`go test ./...` reached the unchanged `internal/cli` refusal-resolution ratchet and failed on `internal/cli/review_facade.go:456`. The changed `internal/reviewtransaction` package passed in that run. CI remains authoritative for the current upstream tree.

## PR Type

- [x] Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for corrected changes delivered as a squashed commit.
  * Corrected pre-push checks now recognize valid base relationships and allow approved deliveries to proceed.
  * Added safeguards to reject deliveries with altered reviewed paths, incorrect contents, or unexpected additional commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->