### PR TITLE
fix(windsurf): support Devin Desktop config paths

### DIFF
--- a/internal/agents/windsurf/adapter.go
+++ b/internal/agents/windsurf/adapter.go
@@ -85,10 +85,14 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 // This is cross-platform and always lives under the user's home directory.
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
 	devin := filepath.Join(homeDir, ".codeium", "devin")
+	return a.selectDevinDir(devin, filepath.Join(homeDir, ".codeium", "windsurf"))
+}
+
+func (a *Adapter) selectDevinDir(devin, windsurf string) string {
 	if stat := a.statPath(devin); stat.err == nil && stat.isDir {
 		return devin
 	}
-	return filepath.Join(homeDir, ".codeium", "windsurf")
+	return windsurf
 }
 
 // SystemPromptDir returns the directory for global rules/memories.
@@ -117,30 +121,21 @@ func (a *Adapter) windsurfUserDir(homeDir string) string {
 	switch a.goos {
 	case "darwin":
 		devin := filepath.Join(homeDir, "Library", "Application Support", "Devin", "User")
-		if stat := a.statPath(devin); stat.err == nil && stat.isDir {
-			return devin
-		}
-		return filepath.Join(homeDir, "Library", "Application Support", "Windsurf", "User")
+		return a.selectDevinDir(devin, filepath.Join(homeDir, "Library", "Application Support", "Windsurf", "User"))
 	case "windows":
 		appData := a.getenv("APPDATA")
 		if appData == "" {
 			appData = filepath.Join(homeDir, "AppData", "Roaming")
 		}
 		devin := filepath.Join(appData, "Devin", "User")
-		if stat := a.statPath(devin); stat.err == nil && stat.isDir {
-			return devin
-		}
-		return filepath.Join(appData, "Windsurf", "User")
+		return a.selectDevinDir(devin, filepath.Join(appData, "Windsurf", "User"))
 	default: // linux and others
 		xdgConfigHome := a.getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome == "" {
 			xdgConfigHome = filepath.Join(homeDir, ".config")
 		}
 		devin := filepath.Join(xdgConfigHome, "Devin", "User")
-		if stat := a.statPath(devin); stat.err == nil && stat.isDir {
-			return devin
-		}
-		return filepath.Join(xdgConfigHome, "Windsurf", "User")
+		return a.selectDevinDir(devin, filepath.Join(xdgConfigHome, "Windsurf", "User"))
 	}
 }
 

--- a/internal/agents/windsurf/adapter.go
+++ b/internal/agents/windsurf/adapter.go
@@ -77,6 +77,10 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 // GlobalConfigDir returns the root of Windsurf's AI configuration directory.
 // This is cross-platform and always lives under the user's home directory.
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	devin := filepath.Join(homeDir, ".codeium", "devin")
+	if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+		return devin
+	}
 	return filepath.Join(homeDir, ".codeium", "windsurf")
 }
 
@@ -106,17 +110,29 @@ func (a *Adapter) SettingsPath(homeDir string) string {
 func (a *Adapter) windsurfUserDir(homeDir string) string {
 	switch runtime.GOOS {
 	case "darwin":
+		devin := filepath.Join(homeDir, "Library", "Application Support", "Devin", "User")
+		if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+			return devin
+		}
 		return filepath.Join(homeDir, "Library", "Application Support", "Windsurf", "User")
 	case "windows":
 		appData := os.Getenv("APPDATA")
 		if appData == "" {
 			appData = filepath.Join(homeDir, "AppData", "Roaming")
 		}
+		devin := filepath.Join(appData, "Devin", "User")
+		if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+			return devin
+		}
 		return filepath.Join(appData, "Windsurf", "User")
 	default: // linux and others
 		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome == "" {
 			xdgConfigHome = filepath.Join(homeDir, ".config")
+		}
+		devin := filepath.Join(xdgConfigHome, "Devin", "User")
+		if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+			return devin
 		}
 		return filepath.Join(xdgConfigHome, "Windsurf", "User")
 	}

--- a/internal/agents/windsurf/adapter.go
+++ b/internal/agents/windsurf/adapter.go
@@ -19,22 +19,29 @@ type statResult struct {
 // Adapter implements agents.Adapter for Windsurf IDE (by Codeium).
 //
 // Config path summary:
-//   - Global AI config (MCP, memories): ~/.codeium/windsurf/
+//   - Global AI config (MCP, memories): ~/.codeium/devin/ when present,
+//     otherwise ~/.codeium/windsurf/
 //     → mcp_config.json
 //     → memories/global_rules.md
 //   - Editor settings (platform-specific):
-//     macOS:   ~/Library/Application Support/Windsurf/User/settings.json
-//     Linux:   ~/.config/Windsurf/User/settings.json   (respects XDG_CONFIG_HOME)
-//     Windows: %APPDATA%\Windsurf\User\settings.json
+//     macOS:   ~/Library/Application Support/{Devin,Windsurf}/User/settings.json
+//     Linux:   ~/.config/{Devin,Windsurf}/User/settings.json   (respects XDG_CONFIG_HOME)
+//     Windows: %APPDATA%\{Devin,Windsurf}\User\settings.json
 //
-// Detection: Windsurf is a desktop app. We detect it by the presence of
-// ~/.codeium/windsurf (the AI config dir), which is created on first launch.
+// Detection: Windsurf is a desktop app. We detect it by the selected AI
+// configuration directory, which is created on first launch.
 type Adapter struct {
 	statPath func(string) statResult
+	goos     string
+	getenv   func(string) string
 }
 
 func NewAdapter() *Adapter {
-	return &Adapter{statPath: defaultStat}
+	return &Adapter{
+		statPath: defaultStat,
+		goos:     runtime.GOOS,
+		getenv:   os.Getenv,
+	}
 }
 
 // --- Identity ---
@@ -44,8 +51,8 @@ func (a *Adapter) Tier() model.SupportTier { return model.TierFull }
 
 // --- Detection ---
 
-// Detect checks for the ~/.codeium/windsurf directory, which Windsurf creates
-// on its first launch. No binary appears on PATH (desktop app).
+// Detect checks the selected AI configuration directory. No binary appears on
+// PATH because Windsurf is a desktop app.
 func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
 	configPath := a.GlobalConfigDir(homeDir)
 	stat := a.statPath(configPath)
@@ -74,11 +81,11 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 
 // --- Config paths ---
 
-// GlobalConfigDir returns the root of Windsurf's AI configuration directory.
+// GlobalConfigDir returns the root of the selected AI configuration directory.
 // This is cross-platform and always lives under the user's home directory.
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
 	devin := filepath.Join(homeDir, ".codeium", "devin")
-	if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+	if stat := a.statPath(devin); stat.err == nil && stat.isDir {
 		return devin
 	}
 	return filepath.Join(homeDir, ".codeium", "windsurf")
@@ -104,34 +111,33 @@ func (a *Adapter) SettingsPath(homeDir string) string {
 	return filepath.Join(a.windsurfUserDir(homeDir), "settings.json")
 }
 
-// windsurfUserDir returns the platform-specific Windsurf User config directory.
-// Windsurf follows the same platform conventions as VS Code, substituting
-// the application name "Windsurf" for "Code".
+// windsurfUserDir returns the selected platform-specific User config directory.
+// Devin and Windsurf follow the same platform conventions as VS Code.
 func (a *Adapter) windsurfUserDir(homeDir string) string {
-	switch runtime.GOOS {
+	switch a.goos {
 	case "darwin":
 		devin := filepath.Join(homeDir, "Library", "Application Support", "Devin", "User")
-		if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+		if stat := a.statPath(devin); stat.err == nil && stat.isDir {
 			return devin
 		}
 		return filepath.Join(homeDir, "Library", "Application Support", "Windsurf", "User")
 	case "windows":
-		appData := os.Getenv("APPDATA")
+		appData := a.getenv("APPDATA")
 		if appData == "" {
 			appData = filepath.Join(homeDir, "AppData", "Roaming")
 		}
 		devin := filepath.Join(appData, "Devin", "User")
-		if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+		if stat := a.statPath(devin); stat.err == nil && stat.isDir {
 			return devin
 		}
 		return filepath.Join(appData, "Windsurf", "User")
 	default: // linux and others
-		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		xdgConfigHome := a.getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome == "" {
 			xdgConfigHome = filepath.Join(homeDir, ".config")
 		}
 		devin := filepath.Join(xdgConfigHome, "Devin", "User")
-		if stat, err := os.Stat(devin); err == nil && stat.IsDir() {
+		if stat := a.statPath(devin); stat.err == nil && stat.isDir {
 			return devin
 		}
 		return filepath.Join(xdgConfigHome, "Windsurf", "User")
@@ -152,8 +158,8 @@ func (a *Adapter) MCPStrategy() model.MCPStrategy {
 
 // --- MCP ---
 
-// MCPConfigPath returns the dedicated MCP servers config file.
-// Windsurf uses ~/.codeium/windsurf/mcp_config.json across all platforms.
+// MCPConfigPath returns the dedicated MCP servers config file in the selected
+// global configuration directory.
 func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
 	return filepath.Join(a.GlobalConfigDir(homeDir), "mcp_config.json")
 }

--- a/internal/agents/windsurf/adapter_test.go
+++ b/internal/agents/windsurf/adapter_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -46,9 +45,17 @@ func TestDetect(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &Adapter{
-				statPath: func(string) statResult { return tt.stat },
-			}
+			devinPath := filepath.Join(testHome, ".codeium", "devin")
+			legacyPath := filepath.Join(testHome, ".codeium", "windsurf")
+			a := &Adapter{statPath: func(path string) statResult {
+				if path == devinPath {
+					return statResult{err: os.ErrNotExist}
+				}
+				if path != legacyPath {
+					t.Errorf("statPath() path = %q, want %q", path, legacyPath)
+				}
+				return tt.stat
+			}}
 			installed, _, configPath, configFound, err := a.Detect(context.Background(), testHome)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
@@ -70,7 +77,7 @@ func TestDetect(t *testing.T) {
 }
 
 func TestConfigPathsCrossPlatform(t *testing.T) {
-	a := NewAdapter()
+	a := &Adapter{statPath: func(string) statResult { return statResult{err: os.ErrNotExist} }}
 	home := testHome
 
 	wantGlobal := filepath.Join(home, ".codeium", "windsurf")
@@ -91,6 +98,37 @@ func TestConfigPathsCrossPlatform(t *testing.T) {
 	wantPrompt := filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md")
 	if got := a.SystemPromptFile(home); got != wantPrompt {
 		t.Fatalf("SystemPromptFile() = %q, want %q", got, wantPrompt)
+	}
+}
+
+func TestGlobalConfigDirPrefersDevin(t *testing.T) {
+	home := testHome
+	devinPath := filepath.Join(home, ".codeium", "devin")
+	legacyPath := filepath.Join(home, ".codeium", "windsurf")
+
+	tests := []struct {
+		name string
+		stat statResult
+		want string
+	}{
+		{name: "Devin directory selected", stat: statResult{isDir: true}, want: devinPath},
+		{name: "missing Devin falls back", stat: statResult{err: os.ErrNotExist}, want: legacyPath},
+		{name: "non-directory Devin falls back", stat: statResult{}, want: legacyPath},
+		{name: "Devin stat error falls back", stat: statResult{err: errors.New("permission denied")}, want: legacyPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{statPath: func(path string) statResult {
+				if path != devinPath {
+					t.Errorf("statPath() path = %q, want %q", path, devinPath)
+				}
+				return tt.stat
+			}}
+			if got := a.GlobalConfigDir(home); got != tt.want {
+				t.Fatalf("GlobalConfigDir() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -167,76 +205,81 @@ func TestAgentIdentity(t *testing.T) {
 
 func TestSettingsPathMultiplatform(t *testing.T) {
 	home := testHome
-	a := NewAdapter()
 
-	tests := []struct {
-		name    string
-		goos    string
-		envVars map[string]string
-		want    string
+	platforms := []struct {
+		name     string
+		goos     string
+		env      map[string]string
+		basePath string
 	}{
 		{
 			name: "Linux with custom XDG_CONFIG_HOME",
 			goos: "linux",
-			envVars: map[string]string{
-				"XDG_CONFIG_HOME": "/custom/config",
+			env: map[string]string{
+				"XDG_CONFIG_HOME": filepath.Join(home, "custom-config"),
 			},
-			want: "/custom/config/Windsurf/User/settings.json",
+			basePath: filepath.Join(home, "custom-config"),
 		},
 		{
-			name:    "Linux with default XDG_CONFIG_HOME",
-			goos:    "linux",
-			envVars: map[string]string{},
-			want:    filepath.Join(home, ".config", "Windsurf", "User", "settings.json"),
+			name:     "Linux with default XDG_CONFIG_HOME",
+			goos:     "linux",
+			env:      map[string]string{},
+			basePath: filepath.Join(home, ".config"),
 		},
 		{
 			name: "Windows with custom APPDATA",
 			goos: "windows",
-			envVars: map[string]string{
-				"APPDATA": "C:\\CustomAppData",
+			env: map[string]string{
+				"APPDATA": filepath.Join(home, "custom-appdata"),
 			},
-			want: "C:\\CustomAppData\\Windsurf\\User\\settings.json",
+			basePath: filepath.Join(home, "custom-appdata"),
 		},
 		{
-			name:    "Windows with default APPDATA",
-			goos:    "windows",
-			envVars: map[string]string{},
-			want:    filepath.Join(home, "AppData", "Roaming", "Windsurf", "User", "settings.json"),
+			name:     "Windows with default APPDATA",
+			goos:     "windows",
+			env:      map[string]string{},
+			basePath: filepath.Join(home, "AppData", "Roaming"),
 		},
 		{
-			name:    "macOS ignores environment variables",
-			goos:    "darwin",
-			envVars: map[string]string{},
-			want:    filepath.Join(home, "Library", "Application Support", "Windsurf", "User", "settings.json"),
+			name:     "macOS",
+			goos:     "darwin",
+			env:      map[string]string{},
+			basePath: filepath.Join(home, "Library", "Application Support"),
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Skip tests for other platforms to avoid runtime.GOOS mismatch
-			if runtime.GOOS != tt.goos {
-				t.Skipf("Skipping %s test on %s", tt.goos, runtime.GOOS)
-			}
+	statuses := []struct {
+		name string
+		stat statResult
+		app  string
+	}{
+		{name: "Devin directory selected", stat: statResult{isDir: true}, app: "Devin"},
+		{name: "missing Devin falls back", stat: statResult{err: os.ErrNotExist}, app: "Windsurf"},
+		{name: "non-directory Devin falls back", stat: statResult{}, app: "Windsurf"},
+		{name: "Devin stat error falls back", stat: statResult{err: errors.New("permission denied")}, app: "Windsurf"},
+	}
 
-			// Set environment variables with proper isolation using t.Setenv
-			for key, value := range tt.envVars {
-				if value != "" {
-					t.Setenv(key, value)
+	for _, platform := range platforms {
+		for _, status := range statuses {
+			t.Run(platform.name+"/"+status.name, func(t *testing.T) {
+				devinPath := filepath.Join(platform.basePath, "Devin", "User")
+				a := &Adapter{
+					statPath: func(path string) statResult {
+						if path != devinPath {
+							t.Errorf("statPath() path = %q, want %q", path, devinPath)
+						}
+						return status.stat
+					},
+					goos: platform.goos,
+					getenv: func(key string) string {
+						return platform.env[key]
+					},
 				}
-			}
-
-			// Ensure clean environment for variables not in the test case
-			if _, exists := tt.envVars["XDG_CONFIG_HOME"]; !exists && runtime.GOOS == "linux" {
-				t.Setenv("XDG_CONFIG_HOME", "")
-			}
-			if _, exists := tt.envVars["APPDATA"]; !exists && runtime.GOOS == "windows" {
-				t.Setenv("APPDATA", "")
-			}
-
-			got := a.SettingsPath(home)
-			if got != tt.want {
-				t.Fatalf("SettingsPath() = %q, want %q", got, tt.want)
-			}
-		})
+				want := filepath.Join(platform.basePath, status.app, "User", "settings.json")
+				if got := a.SettingsPath(home); got != want {
+					t.Fatalf("SettingsPath() = %q, want %q", got, want)
+				}
+			})
+		}
 	}
 }

--- a/internal/agents/windsurf/adapter_test.go
+++ b/internal/agents/windsurf/adapter_test.go
@@ -16,6 +16,7 @@ const testHome = "/tmp/home"
 func TestDetect(t *testing.T) {
 	tests := []struct {
 		name            string
+		devinStat       statResult
 		stat            statResult
 		wantInstalled   bool
 		wantConfigPath  string
@@ -27,6 +28,13 @@ func TestDetect(t *testing.T) {
 			stat:            statResult{isDir: true},
 			wantInstalled:   true,
 			wantConfigPath:  filepath.Join(testHome, ".codeium", "windsurf"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "Devin config directory found",
+			devinStat:       statResult{isDir: true},
+			wantInstalled:   true,
+			wantConfigPath:  filepath.Join(testHome, ".codeium", "devin"),
 			wantConfigFound: true,
 		},
 		{
@@ -49,7 +57,7 @@ func TestDetect(t *testing.T) {
 			legacyPath := filepath.Join(testHome, ".codeium", "windsurf")
 			a := &Adapter{statPath: func(path string) statResult {
 				if path == devinPath {
-					return statResult{err: os.ErrNotExist}
+					return tt.devinStat
 				}
 				if path != legacyPath {
 					t.Errorf("statPath() path = %q, want %q", path, legacyPath)

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -241,6 +241,10 @@ func asAgentIDs(values []string) ([]model.AgentID, error) {
 	agents := make([]model.AgentID, 0, len(values))
 	for _, value := range values {
 		id := model.AgentID(value)
+		if value == "devin-desktop" {
+			// Devin Desktop is Windsurf's rebranded distribution and shares its adapter.
+			id = model.AgentWindsurf
+		}
 		if _, ok := allowed[id]; !ok {
 			return nil, fmt.Errorf("unsupported agent %q (valid: %s)", value, strings.Join(names, ", "))
 		}

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -71,3 +71,13 @@ func TestNormalizeInstallFlagsAcceptsSupportedAgent(t *testing.T) {
 		t.Fatalf("Selection.Agents = %v, want [claude-code]", input.Selection.Agents)
 	}
 }
+
+func TestNormalizeInstallFlagsAcceptsDevinDesktopAlias(t *testing.T) {
+	input, err := NormalizeInstallFlags(InstallFlags{Agents: []string{"devin-desktop"}}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v, want nil", err)
+	}
+	if len(input.Selection.Agents) != 1 || input.Selection.Agents[0] != model.AgentWindsurf {
+		t.Fatalf("Selection.Agents = %v, want [windsurf]", input.Selection.Agents)
+	}
+}

--- a/internal/components/engram/setup_test.go
+++ b/internal/components/engram/setup_test.go
@@ -93,6 +93,9 @@ func TestShouldAttemptSetup(t *testing.T) {
 	if ShouldAttemptSetup(SetupModeSupported, model.AgentCursor) {
 		t.Fatal("ShouldAttemptSetup(supported, cursor) = true, want false")
 	}
+	if !ShouldAttemptSetup(SetupModeSupported, model.AgentWindsurf) {
+		t.Fatal("ShouldAttemptSetup(supported, windsurf) = false, want true so mem_save remains available")
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #828

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Route the legacy `windsurf` adapter to Devin Desktop configuration directories when those directories exist.
- Preserve Windsurf fallback behavior for missing, non-directory, and inaccessible Devin paths.
- Add deterministic cross-platform regression coverage through injectable filesystem, OS, and environment seams.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/windsurf/adapter.go` | Adds testable Devin/Windsurf path selection while preserving production defaults. |
| `internal/agents/windsurf/adapter_test.go` | Covers Devin selection and fallback behavior across Darwin, Windows, and Linux/XDG paths. |

---

## 🧪 Test Plan

- [x] Focused unit tests pass: `go test ./internal/agents/windsurf -count=1`
- [x] Changed Go files formatted with `gofmt`
- [x] Diff validation passes: `git diff --check origin/main...HEAD`
- [ ] Full unit suite, delegated to CI
- [ ] E2E suite, delegated to CI
- [x] Benchmark validation: N/A, this change does not affect review lifecycle, gates, recovery, delivery, or benchmark code.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Focused unit tests pass
- [x] Changed Go files pass formatting
- [x] Documentation is not required for this internal compatibility fix
- [x] My commits follow Conventional Commits
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This supersedes #1501 because the current maintainer account cannot push to the contributor fork branch. Cobies original commit is preserved as the first commit in this branch, retaining original authorship; the second commit adds the requested seam and regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for using Devin configuration directories when available.
  - Automatically falls back to Windsurf directories when Devin settings are unavailable.
  - Improved cross-platform configuration path selection.
  - Added support for the `devin-desktop` installation alias.
  - Preserved `mem_save` availability for supported Windsurf setups.

- **Bug Fixes**
  - Ensured settings and MCP documentation reference the selected configuration directory.
  - Improved handling of missing, invalid, or inaccessible configuration directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->