### PR TITLE
feat: add graph-first-retrieval skill and orchestrator injection

### DIFF
--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -430,8 +430,9 @@ MUST check if the project has a knowledge graph at `graphify-out/graph.json`. If
 inject graph-first retrieval so sub-agents query the graph before reading implementation files.
 
 **Detection**: Before a matching sub-agent launch, check whether `graphify-out/graph.json`
-exists relative to `cwd` (e.g. `ls graphify-out/graph.json 2>/dev/null`). Cache the result
-for the session. If the file does not exist, skip injection silently.
+exists relative to `cwd` (e.g. `ls graphify-out/graph.json 2>/dev/null`) AND `graphify`
+CLI is available on PATH (e.g. `command -v graphify`). Cache the result for the session.
+If either check fails, skip injection silently.
 
 | Phase | Reason |
 |---|---|

--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -422,3 +422,39 @@ When launching `sdd-apply` for a continuation batch:
 | Apply progress  | `sdd/{change-name}/apply-progress` |
 | Verify report   | `sdd/{change-name}/verify-report`  |
 | Archive report  | `sdd/{change-name}/archive-report` |
+
+#### Graph-First Retrieval Injection (MANDATORY when graph exists)
+
+When launching `sdd-explore`, `sdd-apply`, `sdd-design`, or `sdd-verify`, the orchestrator
+MUST check if the project has a knowledge graph at `graphify-out/graph.json`. If it does,
+inject graph-first retrieval so sub-agents query the graph before reading implementation files.
+
+**Detection**: Before a matching sub-agent launch, check whether `graphify-out/graph.json`
+exists relative to `cwd` (e.g. `ls graphify-out/graph.json 2>/dev/null`). Cache the result
+for the session. If the file does not exist, skip injection silently.
+
+| Phase | Reason |
+|---|---|
+| `sdd-explore` | Find relevant files before reading blindly |
+| `sdd-apply` | Locate exact files to change + related tests |
+| `sdd-design` | Understand coupling without reading everything |
+| `sdd-verify` | Find affected areas + test files |
+
+**Pre-4-file-rule optimization**: Before the 4-file rule fires (reading 4+ files triggers
+delegation), first run a quick `graphify query "<question>" --budget 400`. If the graph
+can answer the question directly or narrow it to 1-2 files, skip delegation entirely.
+
+**Injection**: Resolve the `graph-first-retrieval` skill path from the skill registry and
+include it in the sub-agent prompt under `## Skills to load before work`. Add the following
+instruction to the sub-agent prompt:
+
+```
+GRAPH-FIRST ACTIVE — graphify-out/graph.json exists in this project.
+Query the knowledge graph via `graphify query "<question>"` BEFORE reading files.
+After editing code, run `graphify update .` (AST-only, zero API cost).
+```
+
+**Fallback**: If the `graphify` CLI is unavailable or `graphify-out/graph.json` does not
+exist, skip injection silently. Do not fail the launch. The skill registry will not contain
+this entry if graphify is not installed, so the orchestrator's standard registry-based
+resolution handles the fallback transparently.

--- a/internal/assets/skills/graph-first-retrieval/SKILL.md
+++ b/internal/assets/skills/graph-first-retrieval/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: graph-first-retrieval
+description: "Trigger: sdd-explore, sdd-apply, sdd-design, sdd-verify when graphify-out/graph.json exists. Query the knowledge graph before reading files to minimize token waste."
+disable-model-invocation: true
+user-invocable: false
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+  delegate_only: false
+---
+
+## Graph-First Retrieval Protocol
+
+Load this skill when:
+- The project has `graphify-out/graph.json`
+- You are an SDD sub-agent that needs to understand the codebase
+- Phases: `sdd-explore`, `sdd-apply`, `sdd-design`, `sdd-verify`
+
+This protocol runs BEFORE you start reading implementation files.
+
+## Detection
+
+Check if `graphify-out/graph.json` exists relative to the project root (cwd).
+If it does NOT exist, skip this entire protocol and read files normally.
+
+## Instructions
+
+### 1. Formulate a Graph Query
+
+Replace `<question>` with a question about what you need to understand:
+
+| Situation | Command |
+|---|---|
+| Understand what files touch a concept | `graphify query "<topic>" --budget 600` |
+| Find the shortest path between two concepts | `graphify path "<A>" "<B>"` |
+| Get a plain-language explanation of a node | `graphify explain "<node-label>"` |
+
+Examples:
+- `graphify query "auth middleware, login session handling" --budget 600`
+- `graphify path "UserRepository" "NotificationService"`
+- `graphify explain "DatabaseModule"`
+
+### 2. Interpret the Subgraph
+
+The result contains:
+- `nodes` — entities in the codebase (files, modules, concepts)
+- `edges` — relationships (imports, calls, extends, implements)
+- `source_location` — exact file path for each node
+
+From this, build a list of files to read.
+
+### 3. Read ONLY What the Graph Signals
+
+If the graph points to 2 files, read 2 files. Do NOT grep the entire codebase.
+
+If the graph returns nothing useful, or `graphify` CLI is unavailable, fall back
+to normal file reading — the graph is a supplement, not a replacement.
+
+### 4. After Editing Code
+
+If you modified files, run:
+```bash
+graphify update .
+```
+
+This is AST-only, zero API cost. If `graphify` CLI is unavailable, skip silently.
+
+## Hard Rules
+
+- Always try the graph FIRST before reading files
+- If the graph returns a valid subgraph, read ONLY the files it signals
+- If the graph doesn't exist or the query fails, work normally (read files)
+- `graphify update .` runs only after EDITS, not in read-only phases
+- Never use the graph as the sole source of truth — always verify by reading
+  the files it signals
+- The fallback is silent — no warnings or errors if graph is unavailable

--- a/internal/assets/skills/graph-first-retrieval/SKILL.md
+++ b/internal/assets/skills/graph-first-retrieval/SKILL.md
@@ -21,8 +21,9 @@ This protocol runs BEFORE you start reading implementation files.
 
 ## Detection
 
-Check if `graphify-out/graph.json` exists relative to the project root (cwd).
-If it does NOT exist, skip this entire protocol and read files normally.
+Check if `graphify-out/graph.json` exists relative to the project root (cwd)
+AND `graphify` CLI is available on PATH (e.g. `command -v graphify`).
+If either check fails, skip this entire protocol and read files normally.
 
 ## Instructions
 
@@ -50,9 +51,13 @@ The result contains:
 
 From this, build a list of files to read.
 
-### 3. Read ONLY What the Graph Signals
+### 3. Read What the Graph Signals
 
-If the graph points to 2 files, read 2 files. Do NOT grep the entire codebase.
+The graph signals the priority files. Start by reading those.
+
+If implementation evidence requires additional files (configuration, tests,
+contracts, dependencies), expand the reading scope as needed. The graph is
+a starting point, not a complete allowlist.
 
 If the graph returns nothing useful, or `graphify` CLI is unavailable, fall back
 to normal file reading — the graph is a supplement, not a replacement.
@@ -69,7 +74,8 @@ This is AST-only, zero API cost. If `graphify` CLI is unavailable, skip silently
 ## Hard Rules
 
 - Always try the graph FIRST before reading files
-- If the graph returns a valid subgraph, read ONLY the files it signals
+- If the graph returns a valid subgraph, prioritize those files but expand when
+  implementation evidence requires configuration, tests, or other dependencies
 - If the graph doesn't exist or the query fails, work normally (read files)
 - `graphify update .` runs only after EDITS, not in read-only phases
 - Never use the graph as the sole source of truth — always verify by reading

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -54,6 +54,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | strict TDD marker/config found | Use that value. |
 | no marker/config but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
+| **graphify-out/graph.json exists** | Wire graph-first retrieval into the project. |
 
 ## Execution Steps
 
@@ -62,8 +63,17 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+6. **Detect graphify knowledge graph and wire graph-first retrieval.**
+   - Check if `graphify-out/graph.json` exists in the project root.
+   - If found: add a `## Graph-First Retrieval` section to the project's `AGENTS.md`.
+     The section instructs the orchestrator to inject `graph-first-retrieval` as a
+     skill when launching `sdd-explore`, `sdd-apply`, `sdd-design`, or `sdd-verify`.
+   - The registry scan (step 5) already includes `~/.config/opencode/skills/` so the
+     graph-first-retrieval skill is discovered automatically.
+   - If `AGENTS.md` already has graph-first instructions, skip (idempotent).
+   - If `graphify-out/graph.json` does NOT exist, skip this step silently.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 


### PR DESCRIPTION
## Summary

When a project has a graphify knowledge graph (`graphify-out/graph.json`), the SDD orchestrator now injects `graph-first-retrieval` as a skill into `sdd-explore`, `sdd-apply`, `sdd-design`, and `sdd-verify` sub-agents. Sub-agents query the graph before reading implementation files, reducing token waste by identifying exactly which files to read.

## Changes

### New: `internal/assets/skills/graph-first-retrieval/SKILL.md`

Protocol that sub-agents load when graph-first retrieval is active:
1. Formulate a graph query (`graphify query`, `graphify path`, or `graphify explain`)
2. Interpret the subgraph result (nodes with `source_location`, edges with relationships)
3. Read ONLY the files the graph signals
4. After edits, run `graphify update .` (AST-only, zero API cost)

### Modified: `internal/assets/opencode/sdd-orchestrator.md`

Added **Graph-First Retrieval Injection** section after Engram Topic Key Format:
- Detection: check for `graphify-out/graph.json` before matching sub-agent launches
- Phase table: which phases get the injection and why
- Pre-4-file-rule optimization: quick graph query before triggering delegation
- Injection instructions with exact sub-agent prompt text
- Silent fallback when graphify is unavailable

### Modified: `internal/assets/skills/sdd-init/SKILL.md`

- New decision gate for graphify detection
- New execution step 6 that wires graph-first instructions into the project AGENTS.md when graphify is detected

## Why

A `graphify query` returns a scoped subgraph (~200-600 tokens) instead of reading 4+ files (~8-32K tokens). For projects with existing graphify knowledge graphs, this reduces the "understand the codebase" phase token cost by 60-75% while preserving accuracy through file-level verification.

## Testing

- Projects without graphify: no change in behavior (silent fallback)
- Projects with graphify: `sdd-init` auto-detects and wires instructions
- After `sdd-init`, project AGENTS.md contains the injection instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graph-first retrieval support for SDD exploration, design, implementation, and verification workflows.
  * Uses project knowledge graphs to identify relevant files before retrieval and can update graph data after edits.
  * Optimizes large changes by querying the graph before delegating work across multiple files.
  * Automatically configures projects for graph-based retrieval when a knowledge graph is available.

* **Bug Fixes**
  * Gracefully falls back to standard file retrieval when graph data or required tooling is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->