### PR TITLE
fix(review): accept completed retry successor lifecycle

### DIFF
--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -458,7 +458,11 @@ func validateCompactFinalVerificationRetryEdge(predecessor CompactRecord, succes
 	}
 	want.LineageID, want.Generation, want.State, want.EvidenceHash, want.Recovery = successor.LineageID, successor.Generation, StateValidating, "", successor.Recovery
 	want.EvidenceRecordDigest, want.EvidenceOutcome, want.EvidenceTargetIdentity, want.EvidenceAuthorityRevision = "", "", "", ""
-	if !compactStateEqual(want, successor) {
+	validLifecycle := successor.State == StateValidating && successor.EvidenceHash == "" ||
+		(successor.State == StateApproved || successor.State == StateEscalated) && validSHA256(successor.EvidenceHash)
+	normalized := successor
+	normalized.State, normalized.EvidenceHash = StateValidating, ""
+	if !validLifecycle || !compactStateEqual(want, normalized) {
 		return errors.New("final-verification retry successor changed frozen authority or budget state")
 	}
 	return nil

--- a/internal/reviewtransaction/final_verification_retry_test.go
+++ b/internal/reviewtransaction/final_verification_retry_test.go
@@ -80,6 +80,26 @@ func TestRetryCompactFinalVerificationCreatesOnlyOneFrozenValidatingSuccessor(t 
 	}
 }
 
+func TestFinalVerificationRetryEdgeAcceptsCompletedSuccessor(t *testing.T) {
+	fixture := newFinalVerificationRetryFixture(t, "retry-lifecycle-source", "retry-lifecycle-successor")
+	record, err := RetryCompactFinalVerification(context.Background(), fixture.repo, fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor := record.State
+	if err := successor.CompleteVerification([]byte("successful retry evidence\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateCompactFinalVerificationRetryEdge(fixture.predecessor, successor); err != nil {
+		t.Fatal(err)
+	}
+
+	successor.PolicyHash = hash("frozen-policy-changed")
+	if err := validateCompactFinalVerificationRetryEdge(fixture.predecessor, successor); err == nil || err.Error() != "final-verification retry successor changed frozen authority or budget state" {
+		t.Fatalf("changed frozen policy error = %v", err)
+	}
+}
+
 func TestRetryCompactFinalVerificationUsesCorrectedCurrentSnapshot(t *testing.T) {
 	fixture := newCorrectedFinalVerificationRetryFixture(t, "retry-corrected-source", "retry-corrected-successor")
 	if snapshotsEqual(fixture.predecessor.State.InitialSnapshot, fixture.predecessor.State.CurrentSnapshot) {


### PR DESCRIPTION
## Linked Issue

Closes #1915

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Admit a legitimate retry successor completed through the normal `CompleteVerification` lifecycle.
- Normalize only the copied `State` and `EvidenceHash` before the existing frozen-state comparison.
- Keep `compactStateEqual` unchanged, including rejection of a mutated `PolicyHash`.

This mechanism-only follow-up supersedes closed #1953 and directly follows maintainer feedback to begin with a failing regression and keep the fix focused. The diff is two files and +25/-1.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/final_verification_retry.go` | Accepts valid validating, approved, or escalated retry lifecycle representations by normalizing only copied lifecycle fields before frozen-state equality. |
| `internal/reviewtransaction/final_verification_retry_test.go` | Adds one completed-successor regression and one frozen-policy negative assertion. |

---

## Test Plan

**RED on current `main` (`d260cdbc8c4be083333cb8b0517ed125a450a411`) with the regression test only**

```bash
go test ./internal/reviewtransaction -run '^TestFinalVerificationRetryEdgeAcceptsCompletedSuccessor$' -count=1 -v
```

```text
=== RUN   TestFinalVerificationRetryEdgeAcceptsCompletedSuccessor
    final_verification_retry_test.go:94: final-verification retry successor changed frozen authority or budget state
--- FAIL: TestFinalVerificationRetryEdgeAcceptsCompletedSuccessor (0.51s)
FAIL
FAIL github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction 0.525s
FAIL
```

**GREEN with this change**

```bash
go test ./internal/reviewtransaction -run '^TestFinalVerificationRetryEdgeAcceptsCompletedSuccessor$' -count=1 -v
```

```text
Go test: 1 passed in 1 packages
```

**Retry-focused tests**

```bash
go test ./internal/reviewtransaction -run 'Retry.*FinalVerification|FinalVerification.*Retry' -count=1
```

```text
Go test: 47 passed in 1 packages
```

**Package, vet, format, and whitespace**

```bash
go test ./internal/reviewtransaction -count=1
go vet ./internal/reviewtransaction
go run ./internal/gofmtcheck
git diff --check
```

```text
Go test: 1915 passed in 1 packages
go vet: passed
gofmtcheck: passed
git diff --check: passed
```

- [x] Focused regression passes.
- [x] Retry-focused tests pass.
- [x] Review transaction package tests pass.
- [x] Go vet passes.
- [x] Go format passes.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`), not run locally; CI will run them.
- [x] Benchmark validation is not applicable to this focused lifecycle normalization; no benchmark implementation, corpus, classifier, or claim changes.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines (+25/-1).
- [ ] I have added the appropriate `type:*` label to this PR.
- [x] Relevant unit tests pass.
- [x] Go format passes.
- [ ] E2E tests pass, not run locally; CI will run them.
- [x] Documentation is not necessary for this mechanism-only fix.
- [x] My commits follow Conventional Commits format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## Notes for Reviewers

The legitimate population is a retry successor that has advanced from `validating` to `approved` or `escalated` through normal `CompleteVerification`, with a valid evidence hash. Validation copies the successor, normalizes only `State` and `EvidenceHash`, and then delegates to unchanged `compactStateEqual`; the focused negative assertion proves a `PolicyHash` mutation remains rejected.

Out of scope: generation/proof hardening, broad mutation matrices, inspection/gate integration, and migrations/repair/reconcile.

Review-driven development is disabled/unmanaged for this delivery. No review transaction was started or validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved final-verification retry validation to accept valid completed successors.
  * Preserved strict validation of authority, budget, and evidence data.
  * Added clearer rejection handling when protected successor state changes.

* **Tests**
  * Added coverage for successfully completed verification retries.
  * Added checks ensuring modified policy data is correctly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->