### PR TITLE
fix(reviewtransaction): surface git merge-tree --write-tree capability instead of masking it as a merge conflict

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ An issue **without** that label is usually waiting on information (`status:needs
 
 - Go 1.24+
 - Docker (for E2E tests)
-- Git
+- Git 2.38+ (the pre-PR compatible-base-advance gate and its tests use `git merge-tree --write-tree`)
 
 ### Clone and Build
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,6 +32,7 @@
 
 ### All platforms
 
+- Git 2.38+ (the pre-PR compatible-base-advance gate uses `git merge-tree --write-tree`).
 - Go 1.24+ (for building from source).
 - Node.js 18+ and npm: `gentle-ai install` checks these as required prerequisites on every platform and prints a warning with a distro-specific install hint (see above) if either is missing — regardless of which agents/components you select. It does not install them for you. They are strictly required if you select any agent or component installed via `npm install -g` (most agent integrations, plus the CodeGraph community tool).
 - Pi installed and available as `pi` on `PATH` if you select the Pi agent.

--- a/internal/reviewtransaction/compact_chain_test.go
+++ b/internal/reviewtransaction/compact_chain_test.go
@@ -488,6 +488,7 @@ func TestCompactPrePRChainRejectsIncompatibleSelectedBase(t *testing.T) {
 }
 
 func TestCompactPrePRChainRequiresSignedCompatibleBaseAdvance(t *testing.T) {
+	requireMergeTreeWriteTree(t)
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -533,6 +534,7 @@ func TestCompactPrePRChainRequiresSignedCompatibleBaseAdvance(t *testing.T) {
 }
 
 func TestCompactPrePRChainRejectsPredecessorTrustAfterCompatibleAdvanceRecoveryRotation(t *testing.T) {
+	requireMergeTreeWriteTree(t)
 	predecessorPublicKey, predecessorPrivateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -503,6 +503,7 @@ type attestedRecoveryAdvanceFixture struct {
 
 func newAttestedRecoveryAdvanceFixture(t *testing.T) *attestedRecoveryAdvanceFixture {
 	t.Helper()
+	requireMergeTreeWriteTree(t)
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -953,6 +953,7 @@ func newCompatiblePrePRFixture(t *testing.T, deliveryPath, basePath string) *com
 
 func newCompatiblePrePRFixtureMode(t *testing.T, deliveryPath, basePath string, mode Mode) *compatiblePrePRFixture {
 	t.Helper()
+	requireMergeTreeWriteTree(t)
 	repo := initSnapshotRepo(t)
 	baseCommit := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	gitSnapshot(t, repo, "branch", "main", baseCommit)

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -118,7 +118,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	}
 	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)
 	if err != nil {
-		return BaseAdvanceCompatibility{}, errors.New("merge against new base is not conflict-free")
+		return BaseAdvanceCompatibility{}, fmt.Errorf("merge against new base is not conflict-free (git merge-tree --write-tree requires Git 2.38+): %w", err)
 	}
 	mergedFields := strings.Fields(string(mergedOutput))
 	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {
@@ -220,7 +220,7 @@ func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string,
 	}
 	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)
 	if err != nil {
-		return BaseAdvanceCompatibility{}, errors.New("merge against the advanced boundary is not conflict-free")
+		return BaseAdvanceCompatibility{}, fmt.Errorf("merge against the advanced boundary is not conflict-free (git merge-tree --write-tree requires Git 2.38+): %w", err)
 	}
 	mergedFields := strings.Fields(string(mergedOutput))
 	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -22,6 +22,9 @@ var (
 	snapshotRepoTemplateOnce sync.Once
 	snapshotRepoTemplateDir  string
 	snapshotRepoTemplateErr  error
+
+	mergeTreeWriteTreeOnce      sync.Once
+	mergeTreeWriteTreeSupported bool
 )
 
 func TestMain(m *testing.M) {
@@ -1694,6 +1697,29 @@ func requireSnapshotGit(t *testing.T) {
 	}
 }
 
+// gitSupportsMergeTreeWriteTree reports whether the git binary on PATH
+// supports `git merge-tree --write-tree`, which was introduced in Git 2.38.
+// The repo must have a commit at HEAD; pre-2.38 git only understands the
+// legacy `merge-tree <base-tree> <branch1> <branch2>` mode and exits
+// non-zero on the --write-tree flag.
+func gitSupportsMergeTreeWriteTree(repo string) bool {
+	return gitSnapshotSucceeds(repo, "merge-tree", "--write-tree", "HEAD", "HEAD")
+}
+
+func requireMergeTreeWriteTree(t *testing.T) {
+	t.Helper()
+	mergeTreeWriteTreeOnce.Do(func() {
+		template, err := snapshotRepoTemplate()
+		if err != nil {
+			return
+		}
+		mergeTreeWriteTreeSupported = gitSupportsMergeTreeWriteTree(template)
+	})
+	if !mergeTreeWriteTreeSupported {
+		t.Skip("git on PATH does not support merge-tree --write-tree (requires Git 2.38+)")
+	}
+}
+
 func writeSnapshotFile(t *testing.T, repo, name, content string) {
 	t.Helper()
 	path := filepath.Join(repo, name)
@@ -1718,4 +1744,37 @@ func gitSnapshot(t *testing.T, repo string, args ...string) string {
 func gitSnapshotSucceeds(repo string, args ...string) bool {
 	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
 	return cmd.Run() == nil
+}
+
+func TestGitSupportsMergeTreeWriteTreeProbe(t *testing.T) {
+	requireSnapshotGit(t)
+	t.Run("legacy git without --write-tree reports unsupported", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("PATH stub script requires a POSIX shell")
+		}
+		stubDir := t.TempDir()
+		stub := "#!/bin/sh\n" +
+			"for arg in \"$@\"; do\n" +
+			"  case \"$arg\" in\n" +
+			"  --version) echo \"git version 2.34.1\"; exit 0 ;;\n" +
+			"  --write-tree) echo \"error: unknown option \\`write-tree'\" >&2; exit 129 ;;\n" +
+			"  esac\n" +
+			"done\n" +
+			"exit 0\n"
+		if err := os.WriteFile(filepath.Join(stubDir, "git"), []byte(stub), 0o755); err != nil {
+			t.Fatalf("WriteFile(stub git): %v", err)
+		}
+		t.Setenv("PATH", stubDir)
+		if gitSupportsMergeTreeWriteTree(t.TempDir()) {
+			t.Fatal("stubbed git 2.34 must report merge-tree --write-tree as unsupported")
+		}
+	})
+	t.Run("probe agrees with a direct merge-tree --write-tree invocation", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+		want := gitSnapshotSucceeds(repo, "merge-tree", "--write-tree", head, head)
+		if got := gitSupportsMergeTreeWriteTree(repo); got != want {
+			t.Fatalf("gitSupportsMergeTreeWriteTree = %t, direct git merge-tree --write-tree = %t", got, want)
+		}
+	})
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2051

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Stop masking an unsupported git binary as a merge conflict: the two runtime `git merge-tree --write-tree` sites in `prepr.go` now `%w`-wrap the typed `*GitCommandError` and name the Git 2.38+ requirement, instead of discarding the cause behind `errors.New("merge ... is not conflict-free")`.
- Add a `sync.Once` capability probe (`gitSupportsMergeTreeWriteTree`) plus a `requireMergeTreeWriteTree(t)` skip gate beside the existing `requireSnapshotGit` helper, applied to the four merge-tree-dependent test sites, so `go test ./...` skips with an actionable message on LTS-default git (e.g. Ubuntu 22.04's 2.34.1) instead of hard-failing — the failure mode that dead-ended a real review lineage via `procedural_tooling_failed` (see #2051, and #2052 for the unrecoverable terminal it exposed).
- Document the Git 2.38+ floor in `CONTRIBUTING.md` Prerequisites and `docs/quickstart.md`.

No gate semantics change: every caller of the two derive functions branches only on `err != nil`, and `compactGateInfrastructureFailure` is never applied to this error chain, so a genuine merge conflict cannot be reclassified.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/prepr.go` | Both merge-tree error sites wrap the typed `*GitCommandError` with `%w` and name the Git 2.38+ requirement (error-text-only change on already-failing paths). |
| `internal/reviewtransaction/snapshot_test.go` | `gitSupportsMergeTreeWriteTree` probe (`sync.Once`, exit-code-only, against the memoized template repo) + `requireMergeTreeWriteTree(t)` gate + probe self-test with a PATH-stubbed git 2.34 exercising the absent-capability branch hermetically. |
| `internal/reviewtransaction/compact_chain_test.go` | Gate the two tests invoking `merge-tree --write-tree` directly. |
| `internal/reviewtransaction/compact_recovery_binding_test.go` | Gate the shared `newAttestedRecoveryAdvanceFixture`. |
| `internal/reviewtransaction/gate_test.go` | Gate `newCompatiblePrePRFixtureMode` (its `mergeErr == nil` fallback previously hid the root cause while downstream tests still hit the failing runtime path). |
| `CONTRIBUTING.md`, `docs/quickstart.md` | One-line Git 2.38+ prerequisite each. |

`git diff --stat`: 7 files changed, 67 insertions(+), 3 deletions(-) — 70 changed lines, well under the 400-line budget.

---

## 🧪 Test Plan

**RED** (honest TDD red for the new probe — compile failure before the helper existed):

```text
$ go test ./internal/reviewtransaction -run TestGitSupportsMergeTreeWriteTreeProbe -count=1 -v
internal/reviewtransaction/snapshot_test.go:1742:6: undefined: gitSupportsMergeTreeWriteTree
```

**GREEN**:

```bash
go test ./internal/reviewtransaction -run 'TestGitSupportsMergeTreeWriteTreeProbe|TestCompactPrePRChainRequiresSignedCompatibleBaseAdvance|TestCompactPrePRChainRejectsPredecessorTrustAfterCompatibleAdvanceRecoveryRotation' -count=1 -v
go test ./internal/reviewtransaction -count=1   # ok, 166s
go vet ./internal/reviewtransaction             # clean
go run ./internal/gofmtcheck                    # clean
git diff --check                                # clean
```

Independent adversarial verification on this branch (host git 2.43.0):

- Full package suite passes on branch and on main; **SKIP count is 0 on both** — nothing that used to run is now skipped on capable git. PASS count 1917 vs 1914; the +3 delta is exactly the new probe test parent plus its two subtests.
- The absent-capability branch is genuinely exercised: mutating the stub git's `--write-tree` case to `exit 0` makes the legacy subtest fail, proving the assertion is not vacuous.
- The probe decides purely on exit code of `git merge-tree --write-tree HEAD HEAD` against a template repo with a guaranteed commit — no locale/stderr parsing; `TestMain` already redirects `HOME`/`USERPROFILE`, so user gitconfig cannot skew it. The single PATH-mutating subtest calls the probe function directly and never triggers the `sync.Once`, so no cross-test poisoning is possible.

- [x] Focused regression and probe tests pass.
- [x] Review transaction package tests pass (`-count=1`).
- [x] Go vet passes.
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; CI will run them.
- [x] Benchmark validation not applicable: no benchmark implementation, corpus, classifier, or claim changes; test-capability gating and error-text wrapping only.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #2051 (filed with full evidence; awaiting maintainer `status:approved` per the issue-first workflow — the corresponding check will stay red until then, which is expected).
- [x] PR stays within 400 changed lines (70).
- [ ] `type:bug` label — contributor permissions cannot apply upstream labels; maintainer action needed.
- [x] Relevant unit tests pass.
- [x] Go format passes.
- [x] Documentation updated (`CONTRIBUTING.md`, `docs/quickstart.md`).
- [x] My commits follow Conventional Commits format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## 💬 Notes for Reviewers

- No qualifying security/integrity/admission/repair/governance guard population changes: the runtime change preserves error values on already-failing paths (`%w` instead of `errors.New`), and no caller string-matches the old messages (`rg 'not conflict-free'` returns only the two rewritten sites). `.guard-population-baseline.txt` is untouched.
- The skip gate fires only when `git merge-tree --write-tree` is genuinely unsupported; on capable git all previously-running tests still run and pass.
- Known wording nit (flagged during self-review, left as-is for minimalism): the wrapped runtime error appends the Git 2.38+ hint even for genuine conflicts on modern git; the `%w`-wrapped `*GitCommandError` carries the real stderr for disambiguation. Happy to branch on the underlying exit status instead if preferred.
- The related-but-distinct unrecoverable terminal this failure mode exposes (`review/escalate-correction-verification` has no sanctioned retry) is filed separately as #2052 and intentionally NOT addressed here.

Review-driven development is disabled/unmanaged for this delivery; no review transaction was started or validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and quickstart documentation to require Git 2.38 or later.

* **Bug Fixes**
  * Improved error messages when Git lacks support for the required merge-tree functionality, including the minimum version requirement.

* **Tests**
  * Added capability detection and coverage for the required Git functionality.
  * Tests now skip gracefully when the installed Git version is unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->