### PR TITLE
fix(sdd): add operation-specific CLI help

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -319,6 +319,20 @@ func TestRunArgsSDDAttemptIsDispatchedBeforePlatformValidation(t *testing.T) {
 	}
 }
 
+func TestRunArgsSDDAttemptHelpIsDispatchedBeforePlatformValidation(t *testing.T) {
+	origEnsure := ensureCurrentOSSupported
+	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
+	ensureCurrentOSSupported = func() error { return fmt.Errorf("unsupported platform") }
+
+	var output bytes.Buffer
+	if err := RunArgs([]string{"sdd-attempt", "--help", "--cwd", filepath.Join(t.TempDir(), "missing"), "--change", "help-contract"}, &output); err != nil {
+		t.Fatalf("RunArgs(sdd-attempt --help) error = %v", err)
+	}
+	if !strings.Contains(output.String(), "Usage: gentle-ai sdd-attempt <operation> [flags]") {
+		t.Fatalf("sdd-attempt help output:\n%s", output.String())
+	}
+}
+
 func TestRunArgsSDDContinueIsDispatchedBeforePlatformValidation(t *testing.T) {
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -20,6 +20,9 @@ func RunSDDAttempt(args []string, stdout io.Writer) error {
 }
 
 func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
+	if requested, operation := sddAttemptHelpRequest(args); requested {
+		return renderSDDAttemptHelp(operation, stdout)
+	}
 	if len(args) == 0 {
 		return fmt.Errorf("sdd-attempt requires %s", joinSDDAttemptOperations())
 	}
@@ -33,40 +36,21 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 
 	flags := flag.NewFlagSet("sdd-attempt "+operation, flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
-	cwd := flags.String("cwd", "", "repository path")
-	change := flags.String("change", "", "SDD change")
-	expected := flags.String("expected-revision", "", "exact native runtime revision")
-	token := flags.String("token", "", "opaque compact attempt continuation")
-	requestID := flags.String("request-id", "", "idempotency request identifier")
-	workUnit := flags.String("work-unit", "", "caller-facing work-unit label")
-	evidenceGoal := flags.String("evidence-goal", "", "stable runtime evidence objective")
-	maxAttempts := flags.Int("max-attempts", 0, "bounded attempts for a new objective")
-	maxChangedLines := flags.Int("max-changed-lines", 0, "bounded changed lines for a new objective")
-	outcome := flags.String("outcome", "", "failed, interrupted, or passed")
-	evidenceRevision := flags.String("evidence-revision", "", "native evidence revision")
-	diagnosis := flags.String("diagnosis", "", "proven runtime diagnosis")
-	harnessDisposition := flags.String("harness-disposition", "", "reused or invalidated")
-	cleanupEvidence := flags.String("cleanup-evidence", "", "bounded cleanup evidence")
-	processEvidence := flags.String("process-evidence", "", "bounded process evidence")
-	expectedBindingRevision := flags.String("expected-binding-revision", "", "exact populated binding revision for atomic remediation")
-	successorLineage := flags.String("successor-lineage", "", "approved compact recovery successor lineage")
-	remediatesEvidenceRevision := flags.String("remediates-evidence-revision", "", "failed evidence revision repaired by the successor")
-	reason := flags.String("reason", "", "explicit objective reset reason")
-	actor := flags.String("actor", "", "explicit reset actor")
+	values := registerSDDAttemptFlags(flags, operation)
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected sdd-attempt argument %q", flags.Arg(0))
 	}
-	if strings.TrimSpace(*cwd) == "" {
+	if strings.TrimSpace(values.string("cwd")) == "" {
 		return errors.New("sdd-attempt requires --cwd")
 	}
-	if strings.TrimSpace(*change) == "" {
+	if strings.TrimSpace(values.string("change")) == "" {
 		return errors.New("sdd-attempt requires --change")
 	}
 
-	store, err := sddstatus.OpenRuntimeStore(ctx, *cwd, *change)
+	store, err := sddstatus.OpenRuntimeStore(ctx, values.string("cwd"), values.string("change"))
 	if err != nil {
 		return fmt.Errorf("open native SDD runtime authority: %w", err)
 	}
@@ -74,7 +58,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	// knows how to read both of its sources. With reviews off, closing an
 	// attempt must not demand a review obligation the operator has no way to
 	// satisfy.
-	store.ReviewDisabled = reviewDrivenDevelopmentDisabled(ctx, *cwd)
+	store.ReviewDisabled = reviewDrivenDevelopmentDisabled(ctx, values.string("cwd"))
 	var result any
 	switch operation {
 	case "status":
@@ -84,8 +68,8 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			return fmt.Errorf("sdd-attempt begin requires %s", strings.Join(missing, ", "))
 		}
 		result, err = store.Begin(ctx, sddstatus.BeginAttemptRequest{
-			ExpectedRevision: *expected, RequestID: *requestID, WorkUnit: *workUnit, EvidenceGoal: *evidenceGoal,
-			MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines,
+			ExpectedRevision: values.string("expected-revision"), RequestID: values.string("request-id"), WorkUnit: values.string("work-unit"), EvidenceGoal: values.string("evidence-goal"),
+			MaxAttempts: values.integer("max-attempts"), MaxChangedLines: values.integer("max-changed-lines"),
 		})
 	case "finish":
 		if missing := missingSDDAttemptFlags(args[1:], "expected-revision", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence"); len(missing) != 0 {
@@ -96,38 +80,38 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			return errors.New("remediation successor requires --expected-binding-revision, --successor-lineage, and --remediates-evidence-revision together")
 		}
 		result, err = store.Finish(ctx, sddstatus.FinishAttemptRequest{
-			ExpectedRevision: *expected, RequestID: *requestID, Outcome: sddstatus.AttemptOutcome(*outcome),
-			EvidenceRevision: *evidenceRevision, Diagnosis: *diagnosis,
-			HarnessDisposition: sddstatus.HarnessDisposition(*harnessDisposition),
-			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
-			ExpectedBindingRevision: *expectedBindingRevision, SuccessorLineageID: *successorLineage,
-			RemediatesEvidenceRevision: *remediatesEvidenceRevision,
+			ExpectedRevision: values.string("expected-revision"), RequestID: values.string("request-id"), Outcome: sddstatus.AttemptOutcome(values.string("outcome")),
+			EvidenceRevision: values.string("evidence-revision"), Diagnosis: values.string("diagnosis"),
+			HarnessDisposition: sddstatus.HarnessDisposition(values.string("harness-disposition")),
+			CleanupEvidence:    values.string("cleanup-evidence"), ProcessEvidence: values.string("process-evidence"),
+			ExpectedBindingRevision: values.string("expected-binding-revision"), SuccessorLineageID: values.string("successor-lineage"),
+			RemediatesEvidenceRevision: values.string("remediates-evidence-revision"),
 		})
 	case "reset":
 		if missing := missingSDDAttemptFlags(args[1:], "expected-revision", "request-id", "reason", "actor"); len(missing) != 0 {
 			return fmt.Errorf("sdd-attempt reset requires %s", strings.Join(missing, ", "))
 		}
 		result, err = store.Reset(ctx, sddstatus.ResetObjectiveRequest{
-			ExpectedRevision: *expected, RequestID: *requestID, Reason: *reason, Actor: *actor,
+			ExpectedRevision: values.string("expected-revision"), RequestID: values.string("request-id"), Reason: values.string("reason"), Actor: values.string("actor"),
 		})
 	case "acquire":
 		if missing := missingSDDAttemptFlags(args[1:], "request-id", "work-unit", "evidence-goal"); len(missing) != 0 {
 			return fmt.Errorf("sdd-attempt acquire requires %s; rerun `gentle-ai sdd-attempt acquire` with those missing flags", strings.Join(missing, ", "))
 		}
 		result, err = store.Acquire(ctx, sddstatus.CompactAcquireRequest{
-			RequestID: *requestID, WorkUnit: *workUnit, EvidenceGoal: *evidenceGoal,
-			MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines,
+			RequestID: values.string("request-id"), WorkUnit: values.string("work-unit"), EvidenceGoal: values.string("evidence-goal"),
+			MaxAttempts: values.integer("max-attempts"), MaxChangedLines: values.integer("max-changed-lines"),
 		})
 	case "settle":
 		if missing := missingSDDAttemptFlags(args[1:], "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence"); len(missing) != 0 {
 			return fmt.Errorf("sdd-attempt settle requires %s; rerun `gentle-ai sdd-attempt settle` with those missing flags", strings.Join(missing, ", "))
 		}
 		result, err = store.Settle(ctx, sddstatus.CompactSettleRequest{
-			Token: *token, RequestID: *requestID, Outcome: sddstatus.AttemptOutcome(*outcome),
-			EvidenceRevision: *evidenceRevision, Diagnosis: *diagnosis,
-			HarnessDisposition: sddstatus.HarnessDisposition(*harnessDisposition),
-			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
-			SuccessorLineageID: *successorLineage, RemediatesEvidenceRevision: *remediatesEvidenceRevision,
+			Token: values.string("token"), RequestID: values.string("request-id"), Outcome: sddstatus.AttemptOutcome(values.string("outcome")),
+			EvidenceRevision: values.string("evidence-revision"), Diagnosis: values.string("diagnosis"),
+			HarnessDisposition: sddstatus.HarnessDisposition(values.string("harness-disposition")),
+			CleanupEvidence:    values.string("cleanup-evidence"), ProcessEvidence: values.string("process-evidence"),
+			SuccessorLineageID: values.string("successor-lineage"), RemediatesEvidenceRevision: values.string("remediates-evidence-revision"),
 		})
 	}
 	if err != nil {
@@ -145,6 +129,241 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 // Mirrors reviewIntegrationGatesInOrder / reviewIntegrationGateNames in
 // review_operation_contract.go.
 var sddAttemptOperationsInOrder = []string{"status", "begin", "finish", "reset", "acquire", "settle"}
+
+type sddAttemptFlagKind uint8
+
+const (
+	sddAttemptStringFlag sddAttemptFlagKind = iota
+	sddAttemptIntFlag
+)
+
+type sddAttemptFlagDefinition struct {
+	name        string
+	kind        sddAttemptFlagKind
+	usage       string
+	defaultText string
+}
+
+type sddAttemptOperationContract struct {
+	name    string
+	purpose string
+	flags   []sddAttemptFlagDefinition
+}
+
+var sddAttemptCommonFlags = []sddAttemptFlagDefinition{
+	{name: "cwd", usage: "repository path"},
+	{name: "change", usage: "SDD change name (lowercase hyphen identifier, up to 96 characters)"},
+}
+
+var sddAttemptOperationDefinitions = []sddAttemptOperationContract{
+	{name: "status", purpose: "show the current native runtime status"},
+	{
+		name: "begin", purpose: "start a bounded runtime attempt", flags: []sddAttemptFlagDefinition{
+			{name: "expected-revision", usage: "exact native runtime revision (empty only for initial begin)"},
+			{name: "request-id", usage: "idempotency request identifier (lowercase canonical ID, up to 128 characters)"},
+			{name: "work-unit", usage: "caller-facing work-unit label (up to 160 characters)"},
+			{name: "evidence-goal", usage: "stable runtime evidence objective (up to 240 characters)"},
+			{name: "max-attempts", kind: sddAttemptIntFlag, usage: "attempt limit in the range 1..100", defaultText: "default 2"},
+			{name: "max-changed-lines", kind: sddAttemptIntFlag, usage: "changed-line limit in the range 1..1000000", defaultText: "default 200"},
+		},
+	},
+	{
+		name: "finish", purpose: "close the active runtime attempt", flags: []sddAttemptFlagDefinition{
+			{name: "expected-revision", usage: "exact current native runtime revision (sha256:<64 lowercase hex>)"},
+			{name: "request-id", usage: "idempotency request identifier (lowercase canonical ID, up to 128 characters)"},
+			{name: "outcome", usage: "terminal outcome: failed|interrupted|passed"},
+			{name: "evidence-revision", usage: "required lowercase sha256:<64 lowercase hex>; the literal none is invalid"},
+			{name: "diagnosis", usage: "proven runtime diagnosis (up to 500 characters)"},
+			{name: "harness-disposition", usage: "harness disposition: reused|invalidated"},
+			{name: "cleanup-evidence", usage: "bounded cleanup evidence (up to 500 characters)"},
+			{name: "process-evidence", usage: "bounded process evidence (up to 500 characters)"},
+			{name: "expected-binding-revision", usage: "exact populated binding revision for passed remediation"},
+			{name: "successor-lineage", usage: "approved lowercase successor lineage (up to 128 characters)"},
+			{name: "remediates-evidence-revision", usage: "failed evidence revision repaired by a passed successor"},
+		},
+	},
+	{
+		name: "reset", purpose: "reset a decision-required runtime objective", flags: []sddAttemptFlagDefinition{
+			{name: "expected-revision", usage: "exact current native runtime revision (sha256:<64 lowercase hex>)"},
+			{name: "request-id", usage: "idempotency request identifier (lowercase canonical ID, up to 128 characters)"},
+			{name: "reason", usage: "explicit objective reset reason (up to 500 characters)"},
+			{name: "actor", usage: "explicit reset actor (up to 128 characters)"},
+		},
+	},
+	{
+		name: "acquire", purpose: "acquire a bounded attempt", flags: []sddAttemptFlagDefinition{
+			{name: "request-id", usage: "idempotency request identifier"},
+			{name: "work-unit", usage: "caller-facing work-unit label"},
+			{name: "evidence-goal", usage: "stable runtime evidence objective"},
+			{name: "max-attempts", kind: sddAttemptIntFlag, usage: "bounded attempts"},
+			{name: "max-changed-lines", kind: sddAttemptIntFlag, usage: "bounded changed lines"},
+		},
+	},
+	{
+		name: "settle", purpose: "settle a bounded attempt", flags: []sddAttemptFlagDefinition{
+			{name: "token", usage: "opaque compact attempt continuation"},
+			{name: "request-id", usage: "idempotency request identifier"},
+			{name: "outcome", usage: "terminal outcome"},
+			{name: "evidence-revision", usage: "native evidence revision"},
+			{name: "diagnosis", usage: "proven runtime diagnosis"},
+			{name: "harness-disposition", usage: "reused or invalidated"},
+			{name: "cleanup-evidence", usage: "bounded cleanup evidence"},
+			{name: "process-evidence", usage: "bounded process evidence"},
+			{name: "successor-lineage", usage: "approved compact recovery successor lineage"},
+			{name: "remediates-evidence-revision", usage: "failed evidence revision repaired by the successor"},
+		},
+	},
+}
+
+type sddAttemptFlagValues struct {
+	strings map[string]*string
+	ints    map[string]*int
+}
+
+func (values sddAttemptFlagValues) string(name string) string {
+	if value := values.strings[name]; value != nil {
+		return *value
+	}
+	return ""
+}
+
+func (values sddAttemptFlagValues) integer(name string) int {
+	if value := values.ints[name]; value != nil {
+		return *value
+	}
+	return 0
+}
+
+func sddAttemptOperationDefinition(operation string) (sddAttemptOperationContract, bool) {
+	for _, definition := range sddAttemptOperationDefinitions {
+		if definition.name == operation {
+			return definition, true
+		}
+	}
+	return sddAttemptOperationContract{}, false
+}
+
+func sddAttemptFlagsForOperation(operation string) []sddAttemptFlagDefinition {
+	definition, _ := sddAttemptOperationDefinition(operation)
+	flags := make([]sddAttemptFlagDefinition, 0, len(sddAttemptCommonFlags)+len(definition.flags))
+	flags = append(flags, sddAttemptCommonFlags...)
+	return append(flags, definition.flags...)
+}
+
+func registerSDDAttemptFlags(flags *flag.FlagSet, operation string) sddAttemptFlagValues {
+	values := sddAttemptFlagValues{strings: map[string]*string{}, ints: map[string]*int{}}
+	for _, definition := range sddAttemptFlagsForOperation(operation) {
+		switch definition.kind {
+		case sddAttemptIntFlag:
+			values.ints[definition.name] = flags.Int(definition.name, 0, definition.usage)
+		default:
+			values.strings[definition.name] = flags.String(definition.name, "", definition.usage)
+		}
+	}
+	return values
+}
+
+func sddAttemptHelpRequest(args []string) (bool, string) {
+	requested := false
+	operation := ""
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if argument == "-h" || argument == "--help" {
+			requested = true
+			continue
+		}
+		if strings.HasPrefix(argument, "--") {
+			name := strings.TrimPrefix(argument, "--")
+			if separator := strings.IndexByte(name, '='); separator >= 0 {
+				continue
+			}
+			if sddAttemptFlagTakesValue(name) {
+				index++
+			}
+			continue
+		}
+		if operation == "" && validSDDAttemptOperation(argument) && argument != "acquire" && argument != "settle" {
+			operation = argument
+		}
+	}
+	return requested, operation
+}
+
+func sddAttemptFlagTakesValue(name string) bool {
+	for _, operation := range sddAttemptOperationDefinitions {
+		for _, definition := range append(append([]sddAttemptFlagDefinition{}, sddAttemptCommonFlags...), operation.flags...) {
+			if definition.name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func renderSDDAttemptHelp(operation string, stdout io.Writer) error {
+	if operation == "" {
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai sdd-attempt <operation> [flags]")
+		_, _ = fmt.Fprintln(stdout, "\nOperations:")
+		for _, name := range sddAttemptOperationsInOrder {
+			definition, _ := sddAttemptOperationDefinition(name)
+			_, _ = fmt.Fprintf(stdout, "  %-7s %s\n", name, definition.purpose)
+		}
+		_, _ = fmt.Fprintln(stdout, "\nCommon flags:")
+		for _, definition := range sddAttemptCommonFlags {
+			renderSDDAttemptFlag(stdout, definition)
+		}
+		_, _ = fmt.Fprintf(stdout, "\nContract tokens: revision %s; request ID %s; change and lineage %s.\n", sddstatus.RuntimeRevisionPattern, sddstatus.RuntimeRequestIDPattern, sddstatus.RuntimeChangePattern)
+		_, _ = fmt.Fprintf(stdout, "Terminal outcomes: %s; harness dispositions: %s.\n", strings.Join(sddstatus.RuntimeTerminalOutcomes(), "|"), strings.Join(sddstatus.RuntimeHarnessDispositions(), "|"))
+		_, _ = fmt.Fprintln(stdout, "\nAcquire and settle are compact orchestration operations; their detailed flag contract is intentionally not part of top-level help.")
+		return nil
+	}
+
+	definition, ok := sddAttemptOperationDefinition(operation)
+	if !ok || operation == "acquire" || operation == "settle" {
+		return renderSDDAttemptHelp("", stdout)
+	}
+	_, _ = fmt.Fprintf(stdout, "Usage: gentle-ai sdd-attempt %s [flags]\n", operation)
+	_, _ = fmt.Fprintf(stdout, "\nPurpose: %s.\n\nFlags:\n", definition.purpose)
+	for _, flagDefinition := range sddAttemptFlagsForOperation(operation) {
+		renderSDDAttemptFlag(stdout, flagDefinition)
+	}
+	renderSDDAttemptOperationContract(stdout, operation)
+	return nil
+}
+
+func renderSDDAttemptFlag(stdout io.Writer, definition sddAttemptFlagDefinition) {
+	value := "<value>"
+	if definition.kind == sddAttemptIntFlag {
+		value = "<n>"
+	}
+	defaultText := ""
+	if definition.defaultText != "" {
+		defaultText = "; " + definition.defaultText
+	}
+	_, _ = fmt.Fprintf(stdout, "  --%-30s %s%s\n", definition.name+" "+value, definition.usage, defaultText)
+}
+
+func renderSDDAttemptOperationContract(stdout io.Writer, operation string) {
+	_, _ = fmt.Fprintln(stdout, "\nRuntime contract:")
+	switch operation {
+	case "status":
+		_, _ = fmt.Fprintln(stdout, "  RuntimeStatus.revision is the native CAS value; active_attempt identifies a running attempt.")
+	case "begin":
+		_, _ = fmt.Fprintln(stdout, "  --expected-revision is empty only for the initial begin; later calls use the exact current revision.")
+		_, _ = fmt.Fprintln(stdout, "  A non-nil RuntimeStatus.active_attempt blocks begin.")
+		_, _ = fmt.Fprintf(stdout, "  Revision matches %s; request IDs match %s; change and lineage identifiers match %s.\n", sddstatus.RuntimeRevisionPattern, sddstatus.RuntimeRequestIDPattern, sddstatus.RuntimeChangePattern)
+	case "finish":
+		_, _ = fmt.Fprintln(stdout, "  RuntimeStatus.revision is the finish CAS value; finish requires a non-nil, running RuntimeStatus.active_attempt.")
+		_, _ = fmt.Fprintln(stdout, "  RuntimeStatus.binding_revision/binding identify remediation authority; evidence_revision is the failed value to remediate.")
+		_, _ = fmt.Fprintf(stdout, "  Revision, evidence, and binding values use %s; lineages use %s.\n", sddstatus.RuntimeRevisionPattern, sddstatus.RuntimeLineagePattern)
+		_, _ = fmt.Fprintf(stdout, "  Outcomes are %s; dispositions are %s.\n", strings.Join(sddstatus.RuntimeTerminalOutcomes(), "|"), strings.Join(sddstatus.RuntimeHarnessDispositions(), "|"))
+		_, _ = fmt.Fprintln(stdout, "  The remediation flags are all-or-none and valid only for passed attempts; a nonempty evidence revision is required.")
+	case "reset":
+		_, _ = fmt.Fprintln(stdout, "  --expected-revision must equal the exact current RuntimeStatus.revision; reset is for decision-required or complete objectives.")
+		_, _ = fmt.Fprintln(stdout, "  A non-nil RuntimeStatus.active_attempt blocks reset.")
+		_, _ = fmt.Fprintf(stdout, "  Revision matches %s; request IDs match %s; change and lineage identifiers match %s.\n", sddstatus.RuntimeRevisionPattern, sddstatus.RuntimeRequestIDPattern, sddstatus.RuntimeChangePattern)
+	}
+}
 
 func validSDDAttemptOperation(operation string) bool {
 	for _, valid := range sddAttemptOperationsInOrder {
@@ -173,15 +392,9 @@ func joinSDDAttemptOperations() string {
 }
 
 func validateSDDAttemptOperationFlags(operation string, args []string) error {
-	allowed := map[string]bool{"cwd": true, "change": true}
-	for _, name := range map[string][]string{
-		"begin":   {"expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines"},
-		"finish":  {"expected-revision", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "expected-binding-revision", "successor-lineage", "remediates-evidence-revision"},
-		"reset":   {"expected-revision", "request-id", "reason", "actor"},
-		"acquire": {"request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines"},
-		"settle":  {"token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "successor-lineage", "remediates-evidence-revision"},
-	}[operation] {
-		allowed[name] = true
+	allowed := map[string]bool{}
+	for _, definition := range sddAttemptFlagsForOperation(operation) {
+		allowed[definition.name] = true
 	}
 	for index := 0; index < len(args); index++ {
 		argument := args[index]

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -108,6 +109,152 @@ func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T)
 	}
 	if got := joinSDDAttemptOperations(); got != "status, begin, finish, reset, acquire, or settle" {
 		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, reset, acquire, or settle")
+	}
+}
+
+func TestSDDAttemptRuntimeContractAuthority(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		valid   string
+		invalid string
+	}{
+		{name: "revision", pattern: sddstatus.RuntimeRevisionPattern, valid: cliAttemptHash('a'), invalid: "sha256:" + strings.Repeat("A", 64)},
+		{name: "request id", pattern: sddstatus.RuntimeRequestIDPattern, valid: "request-1.v2", invalid: "Request ID"},
+		{name: "change", pattern: sddstatus.RuntimeChangePattern, valid: "sdd-cli-help-contracts", invalid: "sdd_cli_help_contracts"},
+		{name: "lineage", pattern: sddstatus.RuntimeLineagePattern, valid: "review-successor", invalid: "ReviewSuccessor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pattern := regexp.MustCompile(tt.pattern)
+			if !pattern.MatchString(tt.valid) {
+				t.Fatalf("%s pattern %q rejected valid value %q", tt.name, tt.pattern, tt.valid)
+			}
+			if pattern.MatchString(tt.invalid) {
+				t.Fatalf("%s pattern %q accepted invalid value %q", tt.name, tt.pattern, tt.invalid)
+			}
+		})
+	}
+
+	if got, want := sddstatus.RuntimeDefaultAttemptLimit, 2; got != want {
+		t.Fatalf("default attempt limit = %d, want %d", got, want)
+	}
+	if got, want := sddstatus.RuntimeMaxAttemptLimit, 100; got != want {
+		t.Fatalf("max attempt limit = %d, want %d", got, want)
+	}
+	if got, want := sddstatus.RuntimeDefaultChangedLines, 200; got != want {
+		t.Fatalf("default changed lines = %d, want %d", got, want)
+	}
+	if got, want := sddstatus.RuntimeMaxChangedLines, 1_000_000; got != want {
+		t.Fatalf("max changed lines = %d, want %d", got, want)
+	}
+	for name, limits := range map[string][2]int{
+		"work unit":          {sddstatus.RuntimeWorkUnitLimit, 160},
+		"evidence goal":      {sddstatus.RuntimeEvidenceGoalLimit, 240},
+		"diagnosis":          {sddstatus.RuntimeDiagnosisLimit, 500},
+		"cleanup evidence":   {sddstatus.RuntimeCleanupEvidenceLimit, 500},
+		"process evidence":   {sddstatus.RuntimeProcessEvidenceLimit, 500},
+		"reset reason":       {sddstatus.RuntimeResetReasonLimit, 500},
+		"actor":              {sddstatus.RuntimeActorLimit, 128},
+		"change identifier":  {sddstatus.RuntimeChangeLimit, 96},
+		"lineage identifier": {sddstatus.RuntimeLineageLimit, 128},
+	} {
+		if limits[0] != limits[1] {
+			t.Fatalf("%s limit = %d, want %d", name, limits[0], limits[1])
+		}
+	}
+
+	if got, want := sddstatus.RuntimeTerminalOutcomes(), []string{"failed", "interrupted", "passed"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("terminal outcomes = %v, want %v", got, want)
+	}
+	if got, want := sddstatus.RuntimeHarnessDispositions(), []string{"reused", "invalidated"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("harness dispositions = %v, want %v", got, want)
+	}
+}
+
+func TestRunSDDAttemptHelpContracts(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		want     []string
+		unwanted []string
+	}{
+		{
+			name:     "top level short help",
+			args:     []string{"-h"},
+			want:     []string{"Usage: gentle-ai sdd-attempt <operation> [flags]", "status", "begin", "finish", "reset", "acquire", "settle", "--cwd", "--change", "acquire a bounded attempt", "settle a bounded attempt"},
+			unwanted: []string{"--token", "--successor-lineage", "--expected-binding-revision"},
+		},
+		{
+			name: "top level long help",
+			args: []string{"--help"},
+			want: []string{"Usage: gentle-ai sdd-attempt <operation> [flags]", "acquire", "settle"},
+		},
+		{
+			name:     "status",
+			args:     []string{"status", "--help"},
+			want:     []string{"Usage: gentle-ai sdd-attempt status [flags]", "--cwd", "--change", "revision", "active_attempt"},
+			unwanted: []string{"--outcome", "--reason", "--request-id"},
+		},
+		{
+			name:     "begin",
+			args:     []string{"begin", "--help"},
+			want:     []string{"Usage: gentle-ai sdd-attempt begin [flags]", "--expected-revision", "--request-id", "--work-unit", "--evidence-goal", "--max-attempts", "--max-changed-lines", "default 2", "default 200", "A non-nil RuntimeStatus.active_attempt blocks begin."},
+			unwanted: []string{"--outcome", "--reason", "--token"},
+		},
+		{
+			name:     "finish",
+			args:     []string{"finish", "--help"},
+			want:     []string{"Usage: gentle-ai sdd-attempt finish [flags]", "--expected-revision", "--request-id", "--outcome", "--evidence-revision", "--diagnosis", "--harness-disposition", "--cleanup-evidence", "--process-evidence", "--expected-binding-revision", "--successor-lineage", "--remediates-evidence-revision", "failed|interrupted|passed", "reused|invalidated", "sha256:", "active_attempt", "binding_revision", "evidence_revision", "finish requires a non-nil, running RuntimeStatus.active_attempt."},
+			unwanted: []string{"--max-attempts", "--reason", "planning relationship"},
+		},
+		{
+			name:     "reset",
+			args:     []string{"reset", "--help"},
+			want:     []string{"Usage: gentle-ai sdd-attempt reset [flags]", "--expected-revision", "--request-id", "--reason", "--actor", "A non-nil RuntimeStatus.active_attempt blocks reset."},
+			unwanted: []string{"--outcome", "--work-unit", "--token"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunSDDAttempt(tt.args, &output); err != nil {
+				t.Fatalf("RunSDDAttempt(%v) error = %v", tt.args, err)
+			}
+			text := output.String()
+			for _, want := range tt.want {
+				if !strings.Contains(text, want) {
+					t.Errorf("help missing %q:\n%s", want, text)
+				}
+			}
+			for _, unwanted := range tt.unwanted {
+				if strings.Contains(text, unwanted) {
+					t.Errorf("help unexpectedly contains %q:\n%s", unwanted, text)
+				}
+			}
+		})
+	}
+}
+
+func TestRunSDDAttemptHelpIsPositionIndependentAndDependencyFree(t *testing.T) {
+	missingRepo := filepath.Join(t.TempDir(), "does-not-exist")
+	for _, args := range [][]string{
+		{"--help", "status", "--cwd", missingRepo, "--change", "help-contract"},
+		{"status", "--cwd", missingRepo, "--help", "--change", "help-contract"},
+		{"--cwd", missingRepo, "--change", "help-contract", "status", "--help"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunSDDAttempt(args, &output); err != nil {
+				t.Fatalf("RunSDDAttempt(%v) error = %v", args, err)
+			}
+			if !strings.Contains(output.String(), "Usage: gentle-ai sdd-attempt status [flags]") {
+				t.Fatalf("status help not selected for %v:\n%s", args, output.String())
+			}
+			if _, err := os.Stat(missingRepo); !os.IsNotExist(err) {
+				t.Fatalf("help accessed or created nonexistent repository %q: %v", missingRepo, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/sdd_verify_validate.go
+++ b/internal/cli/sdd_verify_validate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
 )
 
-const maxVerifyReportBytes = 1 << 20
+const maxVerifyReportBytes = sddstatus.MaxVerifyReportBytes
 
 // RunSDDVerifyValidate validates a complete report without touching an artifact store.
 func RunSDDVerifyValidate(args []string, stdout io.Writer) error {
@@ -22,10 +22,18 @@ func RunSDDVerifyValidate(args []string, stdout io.Writer) error {
 func runSDDVerifyValidate(args []string, stdin io.Reader, stdout io.Writer) error {
 	flags := flag.NewFlagSet("sdd-verify-validate", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { renderSDDVerifyValidateHelp(stdout) }
+	if hasSDDVerifyValidateHelp(args) {
+		flags.Usage()
+		return nil
+	}
 	input := flags.String("input", "", "report path or - for stdin")
 	requirements := flags.Int("requirements", -2, "authoritative requirement count")
 	scenarios := flags.Int("scenarios", -2, "authoritative scenario count")
 	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return err
 	}
 	if flags.NArg() != 0 {
@@ -66,4 +74,26 @@ func runSDDVerifyValidate(args []string, stdin io.Reader, stdout io.Writer) erro
 	encoder := json.NewEncoder(stdout)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(admission)
+}
+
+func hasSDDVerifyValidateHelp(args []string) bool {
+	for _, argument := range args {
+		if argument == "-h" || argument == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderSDDVerifyValidateHelp(stdout io.Writer) {
+	_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai sdd-verify-validate [flags]")
+	_, _ = fmt.Fprintln(stdout, "\nFlags:")
+	_, _ = fmt.Fprintln(stdout, "  --input <path>         report path, or - for stdin")
+	_, _ = fmt.Fprintln(stdout, "  --requirements <n>     authoritative requirement count; must be nonnegative")
+	_, _ = fmt.Fprintln(stdout, "  --scenarios <n>        authoritative scenario count; must be nonnegative")
+	_, _ = fmt.Fprintln(stdout, "\nReport contract:")
+	_, _ = fmt.Fprintf(stdout, "  schema: %s\n", sddstatus.VerifyResultSchema)
+	_, _ = fmt.Fprintf(stdout, "  base envelope fields: %s\n", strings.Join(sddstatus.VerifyReportEnvelopeFields(), ", "))
+	_, _ = fmt.Fprintf(stdout, "  verdict: %s\n", strings.Join(sddstatus.VerifyVerdicts(), "|"))
+	_, _ = fmt.Fprintf(stdout, "  report limit: 1 MiB (%d bytes)\n", maxVerifyReportBytes)
 }

--- a/internal/cli/sdd_verify_validate_test.go
+++ b/internal/cli/sdd_verify_validate_test.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
 )
 
 func TestRunSDDVerifyValidate(t *testing.T) {
@@ -43,4 +47,57 @@ func TestRunSDDVerifyValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyValidateContractAuthority(t *testing.T) {
+	if got, want := sddstatus.MaxVerifyReportBytes, 1<<20; got != want {
+		t.Fatalf("maximum report bytes = %d, want %d", got, want)
+	}
+	if got, want := sddstatus.VerifyVerdicts(), []string{"pass", "pass_with_warnings", "fail"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("verdicts = %v, want %v", got, want)
+	}
+
+	counts := sddstatus.SpecCounts{Requirements: 2, Scenarios: 3}
+	if counts.Requirements != 2 || counts.Scenarios != 3 {
+		t.Fatalf("authoritative counts = %#v, want 2 requirements and 3 scenarios", counts)
+	}
+}
+
+func TestRunSDDVerifyValidateHelpIsSuccessfulAndInputFree(t *testing.T) {
+	for _, args := range [][]string{
+		{"-h"},
+		{"--help"},
+		{"--input", filepath.Join(t.TempDir(), "missing-report.md"), "--help"},
+		{"--help", "--input", "-", "--requirements", "1", "--scenarios", "1"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var output bytes.Buffer
+			if err := runSDDVerifyValidate(args, rejectingReader{}, &output); err != nil {
+				t.Fatalf("runSDDVerifyValidate(%v) error = %v", args, err)
+			}
+			text := output.String()
+			for _, want := range []string{
+				"Usage: gentle-ai sdd-verify-validate [flags]",
+				"--input",
+				"--requirements",
+				"--scenarios",
+				"- for stdin",
+				"gentle-ai.verify-result/v1",
+				"base envelope fields: schema, evidence_revision",
+				"pass|pass_with_warnings|fail",
+				"nonnegative",
+				"1 MiB",
+			} {
+				if !strings.Contains(text, want) {
+					t.Errorf("validator help missing %q:\n%s", want, text)
+				}
+			}
+		})
+	}
+}
+
+type rejectingReader struct{}
+
+func (rejectingReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("validator help must not read input")
 }

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pathidentity"
@@ -21,9 +20,6 @@ import (
 
 const reviewBindingSchema = "gentle-ai.sdd-review-binding/v1"
 
-var reviewBindingChange = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
-var reviewBindingLineage = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
-var reviewBindingHash = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 var bindingFinalAuthorizationHook = func() {}
 
 type ReviewBindingPublicationError struct{ Cause error }
@@ -766,11 +762,11 @@ func bindingDigest(b ReviewBinding) string {
 }
 
 func validReviewBindingChange(change string) bool {
-	return len(change) <= 96 && reviewBindingChange.MatchString(change)
+	return len(change) <= RuntimeChangeLimit && runtimeChangePattern.MatchString(change)
 }
 
 func validReviewBindingLineage(lineage string) bool {
-	return len(lineage) <= 128 && reviewBindingLineage.MatchString(lineage)
+	return len(lineage) <= RuntimeLineageLimit && runtimeLineagePattern.MatchString(lineage)
 }
 
 func bindingBytes(binding ReviewBinding) ([]byte, error) {
@@ -793,7 +789,7 @@ func parseBinding(payload []byte) (ReviewBinding, error) {
 		return ReviewBinding{}, errors.New("multiple binding values")
 	}
 	canonical, err := bindingBytes(binding)
-	if err != nil || !bytes.Equal(payload, canonical) || binding.Schema != reviewBindingSchema || !validReviewBindingChange(binding.Change) || !validReviewBindingLineage(binding.Lineage) || !reviewBindingHash.MatchString(binding.Revision) || !reviewBindingHash.MatchString(binding.AuthorityRevision) || !reviewBindingHash.MatchString(binding.ReceiptHash) || binding.Revision != bindingDigest(binding) || binding.GateContext.Gate != reviewtransaction.GatePostApply || binding.GateContext.LineageID != binding.Lineage || binding.GateContext.StoreRevision != binding.AuthorityRevision {
+	if err != nil || !bytes.Equal(payload, canonical) || binding.Schema != reviewBindingSchema || !validReviewBindingChange(binding.Change) || !validReviewBindingLineage(binding.Lineage) || !runtimeHashPattern.MatchString(binding.Revision) || !runtimeHashPattern.MatchString(binding.AuthorityRevision) || !runtimeHashPattern.MatchString(binding.ReceiptHash) || binding.Revision != bindingDigest(binding) || binding.GateContext.Gate != reviewtransaction.GatePostApply || binding.GateContext.LineageID != binding.Lineage || binding.GateContext.StoreRevision != binding.AuthorityRevision {
 		return ReviewBinding{}, errors.New("invalid binding")
 	}
 	return binding, nil

--- a/internal/sddstatus/runtime_contract.go
+++ b/internal/sddstatus/runtime_contract.go
@@ -1,0 +1,61 @@
+package sddstatus
+
+import "regexp"
+
+const (
+	RuntimeRequestIDPattern    = `^[a-z0-9][a-z0-9._-]{0,127}$`
+	RuntimeRevisionPattern     = `^sha256:[a-f0-9]{64}$`
+	RuntimeChangePattern       = `^[a-z0-9]+(?:-[a-z0-9]+)*$`
+	RuntimeLineagePattern      = `^[a-z0-9]+(?:-[a-z0-9]+)*$`
+	RuntimeDefaultAttemptLimit = 2
+	RuntimeMaxAttemptLimit     = 100
+	RuntimeDefaultChangedLines = 200
+	RuntimeMaxChangedLines     = 1_000_000
+	// Deprecated compatibility aliases retained for existing callers.
+	DefaultRuntimeAttemptLimit  = RuntimeDefaultAttemptLimit
+	DefaultRuntimeChangedLines  = RuntimeDefaultChangedLines
+	RuntimeChangeLimit          = 96
+	RuntimeLineageLimit         = 128
+	RuntimeWorkUnitLimit        = 160
+	RuntimeEvidenceGoalLimit    = 240
+	RuntimeDiagnosisLimit       = 500
+	RuntimeCleanupEvidenceLimit = 500
+	RuntimeProcessEvidenceLimit = 500
+	RuntimeResetReasonLimit     = 500
+	RuntimeActorLimit           = 128
+	MaxVerifyReportBytes        = 1 << 20
+	RuntimeOutcomeRunning       = "running"
+	RuntimeOutcomeFailed        = "failed"
+	RuntimeOutcomeInterrupted   = "interrupted"
+	RuntimeOutcomePassed        = "passed"
+
+	RuntimeDispositionReused      = "reused"
+	RuntimeDispositionInvalidated = "invalidated"
+
+	VerifyVerdictPass             = "pass"
+	VerifyVerdictPassWithWarnings = "pass_with_warnings"
+	VerifyVerdictFail             = "fail"
+)
+
+var (
+	runtimeRequestIDPattern = regexp.MustCompile(RuntimeRequestIDPattern)
+	runtimeRevisionPattern  = regexp.MustCompile(RuntimeRevisionPattern)
+	runtimeChangePattern    = regexp.MustCompile(RuntimeChangePattern)
+	runtimeLineagePattern   = regexp.MustCompile(RuntimeLineagePattern)
+	runtimeHashPattern      = regexp.MustCompile(RuntimeRevisionPattern)
+)
+
+func RuntimeTerminalOutcomes() []string {
+	return []string{RuntimeOutcomeFailed, RuntimeOutcomeInterrupted, RuntimeOutcomePassed}
+}
+func RuntimeHarnessDispositions() []string {
+	return []string{RuntimeDispositionReused, RuntimeDispositionInvalidated}
+}
+
+func VerifyVerdicts() []string {
+	return []string{VerifyVerdictPass, VerifyVerdictPassWithWarnings, VerifyVerdictFail}
+}
+
+func VerifyReportEnvelopeFields() []string {
+	return []string{"schema", "evidence_revision", "verdict", "blockers", "critical_findings", "requirements", "scenarios", "test_command", "test_exit_code", "test_output_hash", "build_command", "build_exit_code", "build_output_hash"}
+}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -22,10 +22,6 @@ const (
 	runtimeRecordSchema               = "gentle-ai.sdd-runtime-record/v1"
 	runtimeObjectiveSchema            = "gentle-ai.sdd-runtime-objective/v1"
 	runtimeObjectiveSchemaV2          = "gentle-ai.sdd-runtime-objective/v2"
-	DefaultRuntimeAttemptLimit        = 2
-	DefaultRuntimeChangedLines        = 200
-	maximumRuntimeAttemptLimit        = 100
-	maximumRuntimeChangedLines        = 1_000_000
 	maximumRuntimeRecordBytes         = 1 << 20
 	maximumRuntimeChainRecords        = 10_000
 	RuntimeActionBegin                = "begin"
@@ -90,9 +86,7 @@ var (
 	ErrRuntimeRemediationSuccessorRequired = errors.New("a bound passing SDD runtime attempt must also bind the approved review of its corrected candidate")
 	ErrBindingRevisionConflict             = errors.New("SDD review binding revision conflict")
 
-	runtimeRequestIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,127}$`)
-	runtimeRevisionPattern  = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
-	runtimeGitTreePattern   = regexp.MustCompile(`^[a-f0-9]{40}(?:[a-f0-9]{24})?$`)
+	runtimeGitTreePattern = regexp.MustCompile(`^[a-f0-9]{40}(?:[a-f0-9]{24})?$`)
 
 	runtimePublishRecord                     = reviewtransaction.PublishFileNoReplace
 	runtimeReplaceHead                       = reviewtransaction.ReplaceFileAtomic
@@ -146,17 +140,17 @@ func (err *RuntimePublicationError) Unwrap() error { return err.Cause }
 type AttemptOutcome string
 
 const (
-	AttemptRunning     AttemptOutcome = "running"
-	AttemptFailed      AttemptOutcome = "failed"
-	AttemptInterrupted AttemptOutcome = "interrupted"
-	AttemptPassed      AttemptOutcome = "passed"
+	AttemptRunning     AttemptOutcome = RuntimeOutcomeRunning
+	AttemptFailed      AttemptOutcome = RuntimeOutcomeFailed
+	AttemptInterrupted AttemptOutcome = RuntimeOutcomeInterrupted
+	AttemptPassed      AttemptOutcome = RuntimeOutcomePassed
 )
 
 type HarnessDisposition string
 
 const (
-	HarnessReused      HarnessDisposition = "reused"
-	HarnessInvalidated HarnessDisposition = "invalidated"
+	HarnessReused      HarnessDisposition = RuntimeDispositionReused
+	HarnessInvalidated HarnessDisposition = RuntimeDispositionInvalidated
 )
 
 type RuntimeObjective struct {
@@ -1253,9 +1247,9 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("invalid SDD runtime begin record shape")
 		}
 		event := record.Begin
-		if !runtimeRevisionPattern.MatchString(event.ObjectiveID) || event.ObjectiveGeneration < 0 || validateRuntimeText(event.WorkUnit, 160) != nil ||
-			validateRuntimeText(event.EvidenceGoal, 240) != nil || event.MaxAttempts < 1 || event.MaxAttempts > maximumRuntimeAttemptLimit ||
-			event.MaxChangedLines < 1 || event.MaxChangedLines > maximumRuntimeChangedLines || event.Ordinal < 1 ||
+		if !runtimeRevisionPattern.MatchString(event.ObjectiveID) || event.ObjectiveGeneration < 0 || validateRuntimeText(event.WorkUnit, RuntimeWorkUnitLimit) != nil ||
+			validateRuntimeText(event.EvidenceGoal, RuntimeEvidenceGoalLimit) != nil || event.MaxAttempts < 1 || event.MaxAttempts > RuntimeMaxAttemptLimit ||
+			event.MaxChangedLines < 1 || event.MaxChangedLines > RuntimeMaxChangedLines || event.Ordinal < 1 ||
 			!runtimeRevisionPattern.MatchString(event.BeginCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.BeginCandidateTree) {
 			return errors.New("invalid SDD runtime begin event")
 		}
@@ -1272,10 +1266,10 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		}
 		event := record.Finish
 		if event.Ordinal < 1 || !validTerminalAttemptOutcome(event.Outcome) || event.ChangedLines < 0 ||
-			event.ChangedLines > maximumRuntimeChangedLines || !runtimeRevisionPattern.MatchString(event.EvidenceRevision) ||
+			event.ChangedLines > RuntimeMaxChangedLines || !runtimeRevisionPattern.MatchString(event.EvidenceRevision) ||
 			!runtimeRevisionPattern.MatchString(event.FinishCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.FinishCandidateTree) ||
-			validateRuntimeText(event.Diagnosis, 500) != nil || !validHarnessDisposition(event.HarnessDisposition) ||
-			validateRuntimeText(event.CleanupEvidence, 500) != nil || validateRuntimeText(event.ProcessEvidence, 500) != nil ||
+			validateRuntimeText(event.Diagnosis, RuntimeDiagnosisLimit) != nil || !validHarnessDisposition(event.HarnessDisposition) ||
+			validateRuntimeText(event.CleanupEvidence, RuntimeCleanupEvidenceLimit) != nil || validateRuntimeText(event.ProcessEvidence, RuntimeProcessEvidenceLimit) != nil ||
 			event.RemediatesEvidenceRevision != "" {
 			return errors.New("invalid SDD runtime finish event")
 		}
@@ -1293,11 +1287,11 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		}
 		finish, binding := record.Finish, record.Binding
 		if finish.Ordinal < 1 || finish.Outcome != AttemptPassed || finish.ChangedLines < 0 ||
-			finish.ChangedLines > maximumRuntimeChangedLines || !runtimeRevisionPattern.MatchString(finish.EvidenceRevision) ||
+			finish.ChangedLines > RuntimeMaxChangedLines || !runtimeRevisionPattern.MatchString(finish.EvidenceRevision) ||
 			!runtimeRevisionPattern.MatchString(finish.RemediatesEvidenceRevision) ||
 			!runtimeRevisionPattern.MatchString(finish.FinishCandidateIdentity) || !runtimeGitTreePattern.MatchString(finish.FinishCandidateTree) ||
-			validateRuntimeText(finish.Diagnosis, 500) != nil || !validHarnessDisposition(finish.HarnessDisposition) ||
-			validateRuntimeText(finish.CleanupEvidence, 500) != nil || validateRuntimeText(finish.ProcessEvidence, 500) != nil {
+			validateRuntimeText(finish.Diagnosis, RuntimeDiagnosisLimit) != nil || !validHarnessDisposition(finish.HarnessDisposition) ||
+			validateRuntimeText(finish.CleanupEvidence, RuntimeCleanupEvidenceLimit) != nil || validateRuntimeText(finish.ProcessEvidence, RuntimeProcessEvidenceLimit) != nil {
 			return errors.New("invalid atomic SDD runtime remediation finish event")
 		}
 		if !runtimeRevisionPattern.MatchString(binding.ExpectedRevision) {
@@ -1333,7 +1327,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		event := record.Reset
 		if !runtimeRevisionPattern.MatchString(event.PreviousObjectiveID) || event.PreviousGeneration < 1 ||
 			!runtimeRevisionPattern.MatchString(event.ResetCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.ResetCandidateTree) ||
-			validateRuntimeText(event.Reason, 500) != nil || validateRuntimeText(event.Actor, 128) != nil {
+			validateRuntimeText(event.Reason, RuntimeResetReasonLimit) != nil || validateRuntimeText(event.Actor, RuntimeActorLimit) != nil {
 			return errors.New("invalid SDD runtime reset event")
 		}
 		request := ResetObjectiveRequest{
@@ -1382,23 +1376,23 @@ func normalizeBeginAttemptRequest(request BeginAttemptRequest) (BeginAttemptRequ
 	if !runtimeRequestIDPattern.MatchString(request.RequestID) {
 		return BeginAttemptRequest{}, errors.New("request_id must be a canonical lowercase identifier")
 	}
-	if err := validateRuntimeText(request.WorkUnit, 160); err != nil {
+	if err := validateRuntimeText(request.WorkUnit, RuntimeWorkUnitLimit); err != nil {
 		return BeginAttemptRequest{}, fmt.Errorf("invalid work_unit: %w", err)
 	}
-	if err := validateRuntimeText(request.EvidenceGoal, 240); err != nil {
+	if err := validateRuntimeText(request.EvidenceGoal, RuntimeEvidenceGoalLimit); err != nil {
 		return BeginAttemptRequest{}, fmt.Errorf("invalid evidence_goal: %w", err)
 	}
 	if request.MaxAttempts == 0 {
-		request.MaxAttempts = DefaultRuntimeAttemptLimit
+		request.MaxAttempts = RuntimeDefaultAttemptLimit
 	}
 	if request.MaxChangedLines == 0 {
-		request.MaxChangedLines = DefaultRuntimeChangedLines
+		request.MaxChangedLines = RuntimeDefaultChangedLines
 	}
-	if request.MaxAttempts < 1 || request.MaxAttempts > maximumRuntimeAttemptLimit {
-		return BeginAttemptRequest{}, fmt.Errorf("max_attempts must be within 1..%d", maximumRuntimeAttemptLimit)
+	if request.MaxAttempts < 1 || request.MaxAttempts > RuntimeMaxAttemptLimit {
+		return BeginAttemptRequest{}, fmt.Errorf("max_attempts must be within 1..%d", RuntimeMaxAttemptLimit)
 	}
-	if request.MaxChangedLines < 1 || request.MaxChangedLines > maximumRuntimeChangedLines {
-		return BeginAttemptRequest{}, fmt.Errorf("max_changed_lines must be within 1..%d", maximumRuntimeChangedLines)
+	if request.MaxChangedLines < 1 || request.MaxChangedLines > RuntimeMaxChangedLines {
+		return BeginAttemptRequest{}, fmt.Errorf("max_changed_lines must be within 1..%d", RuntimeMaxChangedLines)
 	}
 	return request, nil
 }
@@ -1416,16 +1410,16 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 	if !runtimeRevisionPattern.MatchString(request.EvidenceRevision) {
 		return FinishAttemptRequest{}, errors.New("evidence_revision must be sha256")
 	}
-	if err := validateRuntimeText(request.Diagnosis, 500); err != nil {
+	if err := validateRuntimeText(request.Diagnosis, RuntimeDiagnosisLimit); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid diagnosis: %w", err)
 	}
 	if !validHarnessDisposition(request.HarnessDisposition) {
 		return FinishAttemptRequest{}, errors.New("harness_disposition must be reused or invalidated")
 	}
-	if err := validateRuntimeText(request.CleanupEvidence, 500); err != nil {
+	if err := validateRuntimeText(request.CleanupEvidence, RuntimeCleanupEvidenceLimit); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid cleanup_evidence: %w", err)
 	}
-	if err := validateRuntimeText(request.ProcessEvidence, 500); err != nil {
+	if err := validateRuntimeText(request.ProcessEvidence, RuntimeProcessEvidenceLimit); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid process_evidence: %w", err)
 	}
 	remediationFields := 0
@@ -1465,10 +1459,10 @@ func normalizeResetObjectiveRequest(request ResetObjectiveRequest) (ResetObjecti
 	if !runtimeRequestIDPattern.MatchString(request.RequestID) {
 		return ResetObjectiveRequest{}, errors.New("request_id must be a canonical lowercase identifier")
 	}
-	if err := validateRuntimeText(request.Reason, 500); err != nil {
+	if err := validateRuntimeText(request.Reason, RuntimeResetReasonLimit); err != nil {
 		return ResetObjectiveRequest{}, fmt.Errorf("invalid reset reason: %w", err)
 	}
-	if err := validateRuntimeText(request.Actor, 128); err != nil {
+	if err := validateRuntimeText(request.Actor, RuntimeActorLimit); err != nil {
 		return ResetObjectiveRequest{}, fmt.Errorf("invalid reset actor: %w", err)
 	}
 	return request, nil

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -157,7 +157,7 @@ func parseVerifyReport(text string) (verifyReport, string) {
 	if reason != "" {
 		return verifyReport{}, reason
 	}
-	base := []string{"schema", "evidence_revision", "verdict", "blockers", "critical_findings", "requirements", "scenarios", "test_command", "test_exit_code", "test_output_hash", "build_command", "build_exit_code", "build_output_hash"}
+	base := VerifyReportEnvelopeFields()
 	extension := []string{"authority_only_failure", "missing_review_authority", "substantive_failure", "command_failed", "observed_authority_revision"}
 	allowed := make(map[string]bool, len(base)+len(extension))
 	for _, field := range append(base, extension...) {
@@ -214,7 +214,7 @@ func parseVerifyReport(text string) (verifyReport, string) {
 	if report.Scenarios, ok = parseVerifyCompletion(fields["scenarios"]); !ok {
 		return report, "invalid scenarios in verify result envelope"
 	}
-	if report.Verdict != "pass" && report.Verdict != "pass_with_warnings" && report.Verdict != "fail" {
+	if report.Verdict != VerifyVerdictPass && report.Verdict != VerifyVerdictPassWithWarnings && report.Verdict != VerifyVerdictFail {
 		return report, fmt.Sprintf("invalid verdict %s", report.Verdict)
 	}
 	if report.AuthorityOnly {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1937

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add position-independent, operation-specific help for `sdd-attempt`.
- Add input-free help for `sdd-verify validate` and centralize runtime contract descriptions.
- Strengthen regression coverage for help output, runtime status mappings, and dependency-free help paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/sdd_attempt.go` | Adds operation-specific help routing and contracts. |
| `internal/cli/sdd_verify_validate.go` | Adds dependency-free validator help. |
| `internal/sddstatus/` | Centralizes runtime status and operation contract metadata. |
| `internal/cli/*_test.go`, `internal/app/app_test.go` | Adds focused regression coverage. |

---

## 🧪 Test Plan

**Focused unit tests**
```bash
go test -timeout 3m ./internal/app ./internal/sddstatus
go test -timeout 3m ./internal/cli -run '^(TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently|TestSDDAttemptRuntimeContractAuthority|TestRunSDDAttemptHelpContracts|TestRunSDDAttemptHelpIsPositionIndependentAndDependencyFree|TestRunSDDVerifyValidateHelpIsSuccessfulAndInputFree|TestVerifyValidateContractAuthority)$'
```

**Static and build validation**
```bash
go vet ./internal/cli ./internal/app ./internal/sddstatus
git diff --check origin/main...HEAD
go build ./cmd/gentle-ai
```

- [x] Focused unit tests pass
- [x] Affected-package `go vet` passes
- [x] Build and diff checks pass
- [x] Manually tested CLI help locally
- [ ] Full unit, formatting, and E2E suites run in CI

Benchmark validation: N/A — this changes SDD CLI help contracts, not benchmark implementation, corpus, classifier, or claims.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | Maintainer-approved `size:exception` requested for the 702-line reviewed candidate. |
| Check Issue Reference | ⏳ | PR closes approved issue #1937. |
| Check Issue Has `status:approved` | ⏳ | Issue #1937 is approved. |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` is requested. |
| Unit Tests | ⏳ | Runs in CI. |
| Go Format | ⏳ | Runs in CI. |
| E2E Tests | ⏳ | Runs in CI. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer-approved `size:exception` is documented for this 702-line reviewed candidate
- [x] Exactly one appropriate `type:*` label is requested
- [ ] Full unit tests pass (`go test ./...`) — delegated to CI because the package suite is long-running
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — delegated to CI
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to CI
- [x] Benchmark validation is not applicable, as explained above
- [x] User-facing CLI help and regression coverage are updated together
- [x] Commit follows Conventional Commits format
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Native four-lens review approved frozen lineage `review-79012478e80e8951`; both `pre-push` and `pre-pr` gates returned ALLOW against `origin/main`.

The broad `internal/cli` suite is cumulatively slow and silent. Diagnostic execution confirmed the apparently hanging pre-PR test passes repeatedly in isolation; focused tests for this change pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive help output for `sdd-attempt`, including operation-specific options.
  * Added help support for `sdd-verify-validate`, including usage, schema details, verdicts, and report limits.
  * Help can now be displayed without requiring valid platform settings, repository access, input files, or report data.

* **Bug Fixes**
  * Standardized runtime validation rules, supported outcomes, dispositions, verdicts, and report limits.
  * Improved consistency of validation for runtime records and verification reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->