### PR TITLE
feat(update): register codegraph with npm registry version detection

### DIFF
--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -81,7 +81,7 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 
 	go func() {
 		defer wg.Done()
-		if strings.TrimSpace(tool.NpmPackage) != "" {
+		if usesOpenCodePluginDetection(tool) {
 			localVersion, pluginRegistered = detectOpenCodePluginPackage(tool.NpmPackage)
 			return
 		}
@@ -118,7 +118,7 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 
 	// Determine status based on local version.
 	if localVersion == "" {
-		if strings.TrimSpace(tool.NpmPackage) != "" {
+		if usesOpenCodePluginDetection(tool) {
 			if pluginRegistered {
 				result.Status = RegisteredNotMaterialized
 				result.UpdateHint = openCodeRegisteredNotMaterializedHint(tool)
@@ -276,7 +276,18 @@ func shortCommit(sha string) string {
 	return sha[:12]
 }
 
+// usesOpenCodePluginDetection reports whether a tool's local version is read
+// from the OpenCode plugin package layout under ~/.config/opencode. npm-global
+// tools also declare NpmPackage (for registry lookups and upgrades) but detect
+// their installed version via DetectCmd like any other CLI binary.
+func usesOpenCodePluginDetection(tool ToolInfo) bool {
+	return strings.TrimSpace(tool.NpmPackage) != "" && tool.InstallMethod != InstallNpmGlobal
+}
+
 func fetchLatestReleaseForTool(ctx context.Context, tool ToolInfo) (githubRelease, error) {
+	if tool.InstallMethod == InstallNpmGlobal {
+		return fetchLatestNpmRelease(ctx, tool.NpmPackage)
+	}
 	if pattern := strings.TrimSpace(tool.ReleaseTagPattern); pattern != "" {
 		return fetchLatestReleaseMatchingPattern(ctx, tool.Owner, tool.Repo, pattern)
 	}

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -781,6 +781,12 @@ func TestCheckAll(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		path := r.URL.Path
+		// codegraph is an npm-global tool: its "latest version" document comes
+		// from the npm registry shape ({"version": ...}), not a GitHub release.
+		if contains(path, "@colbymchenry/codegraph") {
+			json.NewEncoder(w).Encode(map[string]string{"version": "1.5.0"})
+			return
+		}
 		var release githubRelease
 		switch {
 		case contains(path, "gentle-ai"):
@@ -835,8 +841,8 @@ func TestCheckAll(t *testing.T) {
 	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}
 	results := CheckAll(context.Background(), "1.5.0", profile)
 
-	if len(results) != 5 {
-		t.Fatalf("len(results) = %d, want 5", len(results))
+	if len(results) != 6 {
+		t.Fatalf("len(results) = %d, want 6", len(results))
 	}
 
 	// gentle-ai: 1.5.0 local == 1.5.0 remote → UpToDate
@@ -849,6 +855,10 @@ func TestCheckAll(t *testing.T) {
 	assertResult(t, results[2], "gga", NotInstalled, "", "2.0.0")
 	assertResult(t, results[3], "opencode-subagent-statusline", NotInstalled, "", "0.4.0")
 	assertResult(t, results[4], "opencode-sdd-engram-manage", NotInstalled, "", "1.1.7")
+
+	// codegraph: npm-global tool, binary not on PATH → NotInstalled,
+	// latest version resolved from the npm registry document.
+	assertResult(t, results[5], "codegraph", NotInstalled, "", "1.5.0")
 }
 
 func TestCheckSingleTool_EngramUsesBinaryReleaseChannel(t *testing.T) {
@@ -1249,8 +1259,8 @@ func TestParseVersionFromOutput(t *testing.T) {
 
 // TestRegistryContents verifies the registry has all expected tools.
 func TestRegistryContents(t *testing.T) {
-	if len(Tools) != 5 {
-		t.Fatalf("len(Tools) = %d, want 5", len(Tools))
+	if len(Tools) != 6 {
+		t.Fatalf("len(Tools) = %d, want 6", len(Tools))
 	}
 
 	expected := map[string]struct {
@@ -1262,6 +1272,7 @@ func TestRegistryContents(t *testing.T) {
 		"gga":                          {owner: "Gentleman-Programming", repo: "gentleman-guardian-angel"},
 		"opencode-subagent-statusline": {owner: "Joaquinvesapa", repo: "sub-agent-statusline"},
 		"opencode-sdd-engram-manage":   {owner: "j0k3r-dev-rgl", repo: "sdd-engram-plugin"},
+		"codegraph":                    {owner: "colbymchenry", repo: "codegraph"},
 	}
 
 	for _, tool := range Tools {

--- a/internal/update/detect.go
+++ b/internal/update/detect.go
@@ -34,7 +34,7 @@ var devVersionRegexp = regexp.MustCompile(`(?i)(?:^|\s)dev(?:$|\s)`)
 // For tools with nil DetectCmd (gentle-ai), returns currentBuildVersion.
 // For other tools, checks LookPath then runs the detect command.
 func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVersion string) string {
-	if strings.TrimSpace(tool.NpmPackage) != "" {
+	if usesOpenCodePluginDetection(tool) {
 		return detectNpmPackageVersion(tool.NpmPackage)
 	}
 

--- a/internal/update/instructions.go
+++ b/internal/update/instructions.go
@@ -33,6 +33,8 @@ func updateHint(tool ToolInfo, profile system.PlatformProfile) string {
 		return ggaHint(profile)
 	case "opencode-subagent-statusline", "opencode-sdd-engram-manage":
 		return "gentle-ai upgrade updates ~/.config/opencode npm deps, clears this plugin's @latest cache, then requires OpenCode restart/reload"
+	case "codegraph":
+		return "npm install -g @colbymchenry/codegraph@latest"
 	default:
 		return ""
 	}

--- a/internal/update/npm.go
+++ b/internal/update/npm.go
@@ -1,0 +1,67 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// npmRegistryBaseURL is the base URL of the npm registry used to resolve the
+// latest published version of npm-global tools. Package-level var so tests can
+// point it at an httptest server.
+var npmRegistryBaseURL = "https://registry.npmjs.org"
+
+// npmLatestResponse is the subset of the npm registry /<pkg>/latest response
+// that the update check needs.
+type npmLatestResponse struct {
+	Version string `json:"version"`
+}
+
+// fetchLatestNpmRelease resolves the latest published version of an npm package
+// via a direct HTTPS call to the npm registry — deliberately NOT via an
+// `npm view` subprocess, so the check does not depend on a local npm install.
+// The result is adapted to the githubRelease shape so the rest of the update
+// check pipeline (version normalization, comparison, result rendering) works
+// unchanged for npm-global tools.
+func fetchLatestNpmRelease(ctx context.Context, pkg string) (githubRelease, error) {
+	pkg = strings.TrimSpace(pkg)
+	if pkg == "" {
+		return githubRelease{}, fmt.Errorf("npm package name must not be empty")
+	}
+
+	// Scoped packages keep their slash: /@scope/name/latest is the canonical
+	// registry endpoint for the "latest" dist-tag document.
+	url := fmt.Sprintf("%s/%s/latest", strings.TrimRight(npmRegistryBaseURL, "/"), pkg)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("build npm registry request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "gentle-ai-update-check")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("npm registry request failed for %s: %w", pkg, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return githubRelease{}, fmt.Errorf("npm registry returned HTTP %d for %s", resp.StatusCode, pkg)
+	}
+
+	var latest npmLatestResponse
+	if err := json.NewDecoder(resp.Body).Decode(&latest); err != nil {
+		return githubRelease{}, fmt.Errorf("decode npm registry response for %s: %w", pkg, err)
+	}
+	if strings.TrimSpace(latest.Version) == "" {
+		return githubRelease{}, fmt.Errorf("npm registry response for %s has no version field", pkg)
+	}
+
+	return githubRelease{
+		TagName: latest.Version,
+		HTMLURL: fmt.Sprintf("https://www.npmjs.com/package/%s", pkg),
+	}, nil
+}

--- a/internal/update/npm_test.go
+++ b/internal/update/npm_test.go
@@ -1,0 +1,266 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+// --- TestFetchLatestNpmRelease ---
+
+func TestFetchLatestNpmRelease(t *testing.T) {
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		pkg         string
+		wantVersion string
+		wantErrPart string
+	}{
+		{
+			name: "success returns version from latest dist-tag document",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"name":"@colbymchenry/codegraph","version":"1.5.0"}`)
+			},
+			pkg:         "@colbymchenry/codegraph",
+			wantVersion: "1.5.0",
+		},
+		{
+			name: "non-200 status is an error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			pkg:         "@colbymchenry/codegraph",
+			wantErrPart: "HTTP 500",
+		},
+		{
+			name: "malformed JSON is an error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{not json`)
+			},
+			pkg:         "@colbymchenry/codegraph",
+			wantErrPart: "decode npm registry response",
+		},
+		{
+			name: "missing version field is an error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"name":"@colbymchenry/codegraph"}`)
+			},
+			pkg:         "@colbymchenry/codegraph",
+			wantErrPart: "no version field",
+		},
+		{
+			name:        "empty package name is an error",
+			handler:     func(w http.ResponseWriter, r *http.Request) {},
+			pkg:         "  ",
+			wantErrPart: "must not be empty",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			origBaseURL := npmRegistryBaseURL
+			t.Cleanup(func() { npmRegistryBaseURL = origBaseURL })
+			npmRegistryBaseURL = server.URL
+
+			release, err := fetchLatestNpmRelease(context.Background(), tc.pkg)
+			if tc.wantErrPart != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrPart) {
+					t.Fatalf("fetchLatestNpmRelease() err = %v, want error containing %q", err, tc.wantErrPart)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchLatestNpmRelease() unexpected error: %v", err)
+			}
+			if release.TagName != tc.wantVersion {
+				t.Fatalf("TagName = %q, want %q", release.TagName, tc.wantVersion)
+			}
+			if !strings.Contains(release.HTMLURL, tc.pkg) {
+				t.Fatalf("HTMLURL = %q, want it to reference package %q", release.HTMLURL, tc.pkg)
+			}
+		})
+	}
+}
+
+// TestFetchLatestNpmReleaseRequestPath verifies the fetcher hits the canonical
+// /<pkg>/latest endpoint, preserving the slash inside scoped package names.
+func TestFetchLatestNpmReleaseRequestPath(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"1.5.0"}`)
+	}))
+	defer server.Close()
+
+	origBaseURL := npmRegistryBaseURL
+	t.Cleanup(func() { npmRegistryBaseURL = origBaseURL })
+	npmRegistryBaseURL = server.URL
+
+	if _, err := fetchLatestNpmRelease(context.Background(), "@colbymchenry/codegraph"); err != nil {
+		t.Fatalf("fetchLatestNpmRelease() unexpected error: %v", err)
+	}
+	if want := "/@colbymchenry/codegraph/latest"; gotPath != want {
+		t.Fatalf("request path = %q, want %q", gotPath, want)
+	}
+}
+
+// --- TestCheckSingleToolNpmGlobal ---
+
+// TestCheckSingleToolNpmGlobal exercises the full check pipeline for an
+// npm-global tool: local detection via DetectCmd, remote resolution via the
+// npm registry fetcher, and version comparison.
+func TestCheckSingleToolNpmGlobal(t *testing.T) {
+	tool := ToolInfo{
+		Name:          "codegraph",
+		Owner:         "colbymchenry",
+		Repo:          "codegraph",
+		DetectCmd:     []string{"codegraph", "--version"},
+		VersionPrefix: "v",
+		InstallMethod: InstallNpmGlobal,
+		NpmPackage:    "@colbymchenry/codegraph",
+	}
+
+	tests := []struct {
+		name          string
+		localVersion  string // empty = binary not found on PATH
+		remoteVersion string
+		wantStatus    UpdateStatus
+		wantInstalled string
+		wantLatest    string
+	}{
+		{
+			name:          "up-to-date",
+			localVersion:  "1.5.0",
+			remoteVersion: "1.5.0",
+			wantStatus:    UpToDate,
+			wantInstalled: "1.5.0",
+			wantLatest:    "1.5.0",
+		},
+		{
+			name:          "update available",
+			localVersion:  "1.4.1",
+			remoteVersion: "1.5.0",
+			wantStatus:    UpdateAvailable,
+			wantInstalled: "1.4.1",
+			wantLatest:    "1.5.0",
+		},
+		{
+			name:          "not installed",
+			localVersion:  "",
+			remoteVersion: "1.5.0",
+			wantStatus:    NotInstalled,
+			wantInstalled: "",
+			wantLatest:    "1.5.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"version":%q}`, tc.remoteVersion)
+			}))
+			defer server.Close()
+
+			origBaseURL := npmRegistryBaseURL
+			origLookPath := lookPath
+			origExecCommand := execCommand
+			t.Cleanup(func() {
+				npmRegistryBaseURL = origBaseURL
+				lookPath = origLookPath
+				execCommand = origExecCommand
+			})
+
+			npmRegistryBaseURL = server.URL
+			if tc.localVersion == "" {
+				lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+				execCommand = func(name string, args ...string) *exec.Cmd { return mockCmd("false") }
+			} else {
+				lookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+				execCommand = func(name string, args ...string) *exec.Cmd {
+					return mockCmd("echo", tc.localVersion)
+				}
+			}
+
+			result := checkSingleTool(context.Background(), tool, "dev", system.PlatformProfile{OS: "linux", PackageManager: "apt"})
+			assertResult(t, result, "codegraph", tc.wantStatus, tc.wantInstalled, tc.wantLatest)
+		})
+	}
+}
+
+// TestCheckSingleToolNpmGlobalRegistryFailure verifies a remote fetch failure
+// surfaces as CheckFailed for npm-global tools.
+func TestCheckSingleToolNpmGlobalRegistryFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	origBaseURL := npmRegistryBaseURL
+	origLookPath := lookPath
+	origExecCommand := execCommand
+	t.Cleanup(func() {
+		npmRegistryBaseURL = origBaseURL
+		lookPath = origLookPath
+		execCommand = origExecCommand
+	})
+
+	npmRegistryBaseURL = server.URL
+	lookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+	execCommand = func(name string, args ...string) *exec.Cmd { return mockCmd("echo", "1.4.1") }
+
+	tool := ToolInfo{
+		Name:          "codegraph",
+		DetectCmd:     []string{"codegraph", "--version"},
+		InstallMethod: InstallNpmGlobal,
+		NpmPackage:    "@colbymchenry/codegraph",
+	}
+
+	result := checkSingleTool(context.Background(), tool, "dev", system.PlatformProfile{OS: "linux", PackageManager: "apt"})
+	if result.Status != CheckFailed {
+		t.Fatalf("status = %q, want %q", result.Status, CheckFailed)
+	}
+	if result.Err == nil {
+		t.Fatal("expected a fetch error, got nil")
+	}
+}
+
+// --- TestRegistryCodegraphEntry ---
+
+// TestRegistryCodegraphEntry pins the shipped codegraph registry declaration so
+// routing cannot drift away from the npm-global design (issue #984).
+func TestRegistryCodegraphEntry(t *testing.T) {
+	var found *ToolInfo
+	for i := range Tools {
+		if Tools[i].Name == "codegraph" {
+			found = &Tools[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("codegraph is missing from the tool registry")
+	}
+
+	if got, want := found.InstallMethod, InstallNpmGlobal; got != want {
+		t.Errorf("InstallMethod = %q, want %q", got, want)
+	}
+	if got, want := found.NpmPackage, "@colbymchenry/codegraph"; got != want {
+		t.Errorf("NpmPackage = %q, want %q", got, want)
+	}
+	if len(found.DetectCmd) != 2 || found.DetectCmd[0] != "codegraph" || found.DetectCmd[1] != "--version" {
+		t.Errorf("DetectCmd = %v, want [codegraph --version]", found.DetectCmd)
+	}
+}

--- a/internal/update/registry.go
+++ b/internal/update/registry.go
@@ -103,4 +103,16 @@ var Tools = []ToolInfo{
 		InstallMethod: InstallOpenCodePlugin,
 		NpmPackage:    "opencode-sdd-engram-manage",
 	},
+	{
+		Name:          "codegraph",
+		Owner:         "colbymchenry",
+		Repo:          "codegraph",
+		DetectCmd:     []string{"codegraph", "--version"},
+		VersionPrefix: "v",
+		// codegraph: globally-installed npm CLI. The latest version is resolved
+		// from the npm registry over HTTPS (not GitHub releases), and upgrades
+		// run `npm install -g @colbymchenry/codegraph@latest`.
+		InstallMethod: InstallNpmGlobal,
+		NpmPackage:    "@colbymchenry/codegraph",
+	},
 }

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -33,6 +33,10 @@ const (
 	// InstallOpenCodePlugin is a manual upgrade method: Gentle AI registers the
 	// package in tui.json, and OpenCode owns package resolution on restart/reload.
 	InstallOpenCodePlugin InstallMethod = "opencode-plugin"
+	// InstallNpmGlobal is for CLI tools installed globally via npm
+	// (`npm install -g <pkg>`). The latest version is resolved directly from the
+	// npm registry over HTTPS, and upgrades run `npm install -g <pkg>@latest`.
+	InstallNpmGlobal InstallMethod = "npm-global"
 )
 
 // ToolInfo describes a managed tool that can be checked for updates.
@@ -45,7 +49,7 @@ type ToolInfo struct {
 	ReleaseTagPattern string        // optional regexp for selecting the correct GitHub release channel
 	InstallMethod     InstallMethod // how this tool is installed (used by upgrade executor)
 	GoImportPath      string        // for go-install tools (e.g. "github.com/.../cmd/engram")
-	NpmPackage        string        // for OpenCode community plugins installed in ~/.config/opencode/node_modules
+	NpmPackage        string        // npm package name: for OpenCode community plugins (materialized in ~/.config/opencode/node_modules) and for npm-global tools (resolved on the npm registry)
 
 	// FallbackPaths returns a list of absolute paths to check when exec.LookPath
 	// fails. This covers the Windows scenario where AddToUserPath updates the


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #984

> ⚠️ **Stacked PR 1 of 9** (8 code slices + 1 docs PR) — this issue is delivered as a stack of focused PRs. Merging this PR will auto-close #984; please reopen it until the final PR lands. See **Chain Context** below.

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

First slice of #984: make CodeGraph version-aware by registering it in the update system.

- Registers CodeGraph (`codegraph` CLI, npm package `@colbymchenry/codegraph`) in `internal/update`'s tool registry.
- Resolves the latest published version via direct HTTPS to `registry.npmjs.org` (no `npm view` subprocess), matching the package's existing HTTP remote-check pattern (`github.go`).
- Local detection reuses the existing `DetectCmd` mechanism (`codegraph --version`, parsed by the existing semver regex).

This PR is detection-only: `gentle-ai upgrade` execution support lands in PR2, sync auto-upgrade in PR3b.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/types.go` | New `InstallNpmGlobal` install method; `NpmPackage` doc updated for dual purpose |
| `internal/update/registry.go` | CodeGraph registered as the 6th managed tool |
| `internal/update/npm.go` | **New** — npm registry latest-version fetcher (timeout, non-200/malformed-JSON handling, mockable base URL) |
| `internal/update/check.go`, `detect.go` | Route npm-global tools to the npm fetcher; `usesOpenCodePluginDetection()` gate preserves plugin behavior |
| `internal/update/instructions.go` | Update hint for codegraph (`npm install -g ...@latest`) |
| `internal/update/npm_test.go`, `check_test.go` | Fetcher table tests (httptest), end-to-end check scenarios, registry pinning |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/update/...   # ok — 13 new scenarios (fetcher, check wiring, registry)
go build ./...                  # ok
```

**Go Format**
```bash
go run ./internal/gofmtcheck    # clean
```

- [x] Unit tests pass (`go test ./internal/update/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run (Docker); remote fetch is covered by `httptest` mocks
- [x] Manually tested locally — `codegraph --version` output verified against the detection regex

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#984)
- [x] PR stays within 400 changed lines (391: +383/−8)
- [x] I have added the appropriate `type:*` label to this PR *(needs maintainer labeling — no triage access from fork)*
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass (see Test Plan)
- [x] I have updated documentation if necessary (SDD artifacts ride in a separate docs PR at the end of the stack — `feat/984-docs-sdd-artifacts`)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | codegraph-version-aware-upgrade (stacked to main, cross-repo from fork) |
| Tracker PR | Not needed — stacked strategy (no upstream branch push access) |
| Position | 1 of 9 (8 code slices + 1 docs PR) |
| Base | `main` |
| Depends on | None |
| Follow-up | PR2: npm-global upgrade strategy (`feat/984-pr2-npm-global-strategy`) |
| Review budget | 391 / 400 (+383/−8) |
| Starts at | `main` |
| Ends with | CodeGraph detectable by `internal/update` (installed vs latest); no behavior change to install/sync yet |

### Chain Overview

```text
main
 └── 📍 PR1: npm registry version detection
      └── PR2: npm-global upgrade strategy (gentle-ai upgrade)
           └── PR3a: community-tool upgrade core + rollback
                └── PR3b-1: sync auto-upgrade step
                     └── PR3b-2: sync report rendering + matrix tests
                          └── PR4a: --force-community-tools (install)
                               └── PR4b: --force-community-tools (sync gate)
                                    └── PR4: TUI version surfacing
                                         └── docs PR: SDD trail (`feat/984-docs-sdd-artifacts`, docs-only, requests `size:exception`)
```

### Scope
- Includes: version detection + npm registry fetch + registry wiring + tests.
- Excludes: upgrade execution (PR2), sync integration (PR3b), force flags and TUI (PR4).

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit

---

## 💬 Notes for Reviewers

- Design decision (approved in #984 discussion): remote check is HTTPS to the npm registry, not an `npm view` subprocess — consistent with `internal/update`'s existing HTTP remote-check architecture.
- `Owner`/`Repo` fields on the registry entry point to `colbymchenry/codegraph` as a best guess; `ReleaseURL` points to npmjs.com (CodeGraph is npm-published, not GitHub-released).
- Full SDD trail (proposal/spec/design/tasks/verify) lives in `openspec/changes/archive/2026-07-30-codegraph-version-aware-upgrade/`, delivered in a separate docs PR at the end of the stack (`feat/984-docs-sdd-artifacts`, docs-only, will request `size:exception`) — matching the repo's in-tree archive convention (`openspec/changes/archive/`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added update tracking for the CodeGraph command-line tool via global npm installs.
  - Added npm registry lookups to determine the latest available versions.
  - Expanded support to detect and update globally installed npm CLI tools.

- **Bug Fixes**
  - Improved version detection and update-status reporting for npm-global tools to avoid misclassifying them as plugin-related.
  - Refined handling of “not installed” and “registered but not materialized” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
