### PR TITLE
fix(cli): declare inconclusive validation refusal by design

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -453,6 +453,7 @@ func (result facadeValidationResult) conclusive() error {
 		{name: "correction_regression", evidence: result.CorrectionRegression.Evidence},
 	} {
 		if reviewtransaction.InconclusiveValidationEvidence(check.evidence) {
+			// refusal:by-design world-action: validator access to the immutable frozen trees must be restored outside the local CLI before validation can be captured again
 			return fmt.Errorf("targeted validation is inconclusive: %s evidence reports the immutable candidate could not be inspected, so no verdict was produced and the correction attempt was not consumed; restore validator access to the frozen trees and capture the same validation again", check.name)
 		}
 	}


### PR DESCRIPTION
## Linked Issue

Closes #2049

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Declare the intentional inconclusive-validation refusal as a by-design `world-action` because restoring external validator access cannot be performed by the local CLI.
- Restore the shrink-only refusal ratchet without changing runtime behavior, error text, or either baseline.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Added one adjacent `refusal:by-design world-action` declaration to the existing inconclusive-validation refusal. |

---

## Test Plan

**Focused regression**
```bash
go test ./internal/cli -run '^TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign$' -count=1
```

The command failed deterministically on `upstream/main` at `internal/cli/review_facade.go:456` before the change and passes after the declaration.

**Relevant package**
```bash
go test ./internal/cli -count=1
```

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
gofmt -d internal/cli/review_facade.go
```

**Static Analysis**
```bash
go vet ./...
```

**E2E Tests**

Not run: the patch changes only a Go comment and cannot alter an executable runtime path. The root test suite, including `e2e/organicruntime`, passes.

**Benchmark Validation**

N/A: the patch does not change review-lifecycle behavior, benchmark implementation, corpus, classifier vocabulary, or claims. It only supplies the static declaration already required by the refusal ratchet.

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E Docker tests pass (`cd e2e && ./docker-test.sh`) - not applicable to this comment-only change
- [x] Manually verified the focused failure before the change and its success afterward

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | The change is one added line. |
| Check Issue Reference | Pending | The body contains `Closes #2049`. |
| Check Issue Has `status:approved` | Pending | Issue #2049 was approved before implementation. |
| Check PR Has `type:*` Label | Pending authorization | No PR labels were changed; `type:bug` requires separate explicit approval. |
| Unit Tests | Pending | `go test ./...` must pass in CI. |
| Go Format | Pending | `go run ./internal/gofmtcheck` must pass in CI. |
| E2E Tests | Pending | The repository workflow will run its configured E2E coverage. |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR - pending separate maintainer authorization for `type:bug`
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E Docker tests pass (`cd e2e && ./docker-test.sh`) - not applicable to this comment-only change
- [x] Benchmark validation is not applicable for the reason documented in the Test Plan
- [x] Documentation updates are unnecessary because runtime behavior and user-facing text are unchanged
- [x] My commit follows Conventional Commits format
- [x] My commit does not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The complete runtime-behavior evidence is the one-line diff: only an adjacent Go comment was added. The existing `fmt.Errorf` call and its message are byte-for-byte unchanged, and neither `.refusal-ratchet-baseline.txt` nor `.guard-population-baseline.txt` changed.

The existing inconclusive-validation guard and its legitimate input population are unchanged. This PR only classifies the already-intentional refusal for the static ratchet; it does not add, narrow, or widen an admission, integrity, repair, security, or governance guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification about validator refusal semantics in targeted validation handling.
  * No changes to validation behavior or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->