### PR TITLE
fix(review): scale immutable path admission

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -378,7 +378,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	if err != nil {
 		return reviewPreflightError(err)
 	}
-	_, admission, err := reviewtransaction.AdmitArtifact(reviewtransaction.ArtifactAdmissionRequest{
+	_, admission, err := reviewtransaction.AdmitArtifact(ctx, reviewtransaction.ArtifactAdmissionRequest{
 		ExpectedSubject: subject, FrozenContext: frozen, EchoedSubjectHash: result.SubjectHash,
 		Inspection: result.Inspection, Result: nativeResult, CandidateCausalFindingIDs: candidateCausalIDs,
 		RawPayload: rawPayload, CanonicalPayload: canonicalResult,
@@ -830,7 +830,7 @@ func decodeBoundAdmittedReviewerResult(ctx context.Context, repo string, payload
 	if err != nil {
 		return facadeReviewerResult{}, reviewtransaction.ArtifactSubject{}, err
 	}
-	result, err := decodeAdmittedReviewerResult(payload, expected, subjectFrozen)
+	result, err := decodeAdmittedReviewerResult(ctx, payload, expected, subjectFrozen)
 	if err != nil {
 		return facadeReviewerResult{}, reviewtransaction.ArtifactSubject{}, err
 	}
@@ -845,7 +845,7 @@ func decodeBoundAdmittedReviewerResult(ctx context.Context, repo string, payload
 	return result, expected, nil
 }
 
-func decodeAdmittedReviewerResult(payload []byte, expected reviewtransaction.ArtifactSubject, frozen reviewtransaction.FrozenCandidateContext) (facadeReviewerResult, error) {
+func decodeAdmittedReviewerResult(ctx context.Context, payload []byte, expected reviewtransaction.ArtifactSubject, frozen reviewtransaction.FrozenCandidateContext) (facadeReviewerResult, error) {
 	var envelope admittedReviewerResult
 	if err := decodeFacadeJSONBytes(payload, &envelope); err != nil {
 		return facadeReviewerResult{}, err
@@ -867,7 +867,7 @@ func decodeAdmittedReviewerResult(payload []byte, expected reviewtransaction.Art
 	canonical = append(canonical, '\n')
 	native := envelope.Result.nativeLensResult()
 	native.Lens = expected.Lens
-	result, revalidated, err := reviewtransaction.AdmitArtifact(reviewtransaction.ArtifactAdmissionRequest{
+	result, revalidated, err := reviewtransaction.AdmitArtifact(ctx, reviewtransaction.ArtifactAdmissionRequest{
 		ExpectedSubject: expected, FrozenContext: frozen, EchoedSubjectHash: envelope.Result.SubjectHash,
 		Inspection: envelope.Result.Inspection, Result: native,
 		CandidateCausalFindingIDs: envelope.Admission.CandidateCausalFindingIDs,

--- a/internal/cli/review_start_context_test.go
+++ b/internal/cli/review_start_context_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -113,6 +115,54 @@ func TestNegotiatedReviewStartContextCoversCreatedReuseAndRecovery(t *testing.T)
 			t.Fatalf("recovery START = %#v", recovery)
 		}
 	})
+}
+
+func TestNegotiatedReviewStartLargeRepositoryUsesBoundedReferenceAdmission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses real git commands and a repository tree larger than 4 MiB")
+	}
+	repo := initReviewCLIRepo(t)
+	baseCommit, supportingPath := installLargeReviewRepositoryHistory(t, repo)
+	lineage := "review-start-large-repository"
+	args := boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--lineage", lineage, "--base-ref", baseCommit,
+	})
+	var output bytes.Buffer
+	if err := RunReview(args, &output); err != nil {
+		t.Fatalf("START with a repository path inventory larger than 4 MiB: %v", err)
+	}
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	if started.Action != string(reviewtransaction.CompactStartCreated) || started.ChangedPathManifest == nil ||
+		len(*started.ChangedPathManifest) != 1 || (*started.ChangedPathManifest)[0].Path != "main.go" {
+		t.Fatalf("large-repository START = %#v", started)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(record.State.SelectedLenses) == 0 {
+		t.Fatalf("large-repository START selected no reviewer lenses: %#v", record.State)
+	}
+	result := admittedReviewerResultForTest(t, repo, record, record.State.SelectedLenses[0], 0)
+	input := filepath.Join(t.TempDir(), "reviewer.json")
+	captureArgs := []string{
+		"--cwd", repo, "--lineage", lineage, "--target", record.State.InitialSnapshot.Identity,
+		"--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input,
+	}
+	result.Evidence = []string{"fabricated proof: missing-inventory.go:1"}
+	writeReviewCLIJSON(t, input, result)
+	if err := RunReviewCaptureResult(captureArgs, io.Discard); err == nil || !strings.Contains(err.Error(), "outside the frozen repository") {
+		t.Fatalf("invalid immutable-tree reference admission error = %v", err)
+	}
+	result.Evidence = []string{"supporting proof: " + supportingPath + ":1"}
+	writeReviewCLIJSON(t, input, result)
+	if err := RunReviewCaptureResult(captureArgs, io.Discard); err != nil {
+		t.Fatalf("valid immutable-tree reference was rejected: %v", err)
+	}
 }
 
 func TestNegotiatedReviewStartContextValidationDistinguishesMissingAndEmpty(t *testing.T) {
@@ -308,4 +358,45 @@ func forceReviewStartContextFailure(forced error) func() {
 		return reviewtransaction.FrozenCandidateContext{}, forced
 	}
 	return func() { renderReviewStartFrozenCandidateContext = original }
+}
+
+func installLargeReviewRepositoryHistory(t *testing.T, repo string) (string, string) {
+	t.Helper()
+	sharedBlob := strings.TrimSpace(runReviewCLIGitInput(t, repo, []byte("package inventory\n"), "hash-object", "-w", "--stdin"))
+	baseBlob := strings.TrimSpace(runReviewCLIGitInput(t, repo, []byte("package main\n\nfunc value() int { return 1 }\n"), "hash-object", "-w", "--stdin"))
+	candidateBlob := strings.TrimSpace(runReviewCLIGitInput(t, repo, []byte("package main\n\nfunc value() int { return 2 }\n"), "hash-object", "-w", "--stdin"))
+	const inventoryEntries = 24_000
+	padding := strings.Repeat("x", 160)
+	paths := make([]string, inventoryEntries)
+	var baseTreeInput bytes.Buffer
+	var candidateTreeInput bytes.Buffer
+	for index := range paths {
+		paths[index] = fmt.Sprintf("inventory-%05d-%s.go", index, padding)
+		for _, tree := range []*bytes.Buffer{&baseTreeInput, &candidateTreeInput} {
+			fmt.Fprintf(tree, "100644 blob %s\t%s\x00", sharedBlob, paths[index])
+		}
+	}
+	fmt.Fprintf(&baseTreeInput, "100644 blob %s\tmain.go\x00", baseBlob)
+	fmt.Fprintf(&candidateTreeInput, "100644 blob %s\tmain.go\x00", candidateBlob)
+	baseTree := strings.TrimSpace(runReviewCLIGitInput(t, repo, baseTreeInput.Bytes(), "mktree", "-z"))
+	candidateTree := strings.TrimSpace(runReviewCLIGitInput(t, repo, candidateTreeInput.Bytes(), "mktree", "-z"))
+	baseCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "commit-tree", baseTree, "-m", "large base tree"))
+	candidateCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "commit-tree", candidateTree, "-p", baseCommit, "-m", "tiny candidate"))
+	runReviewCLIGit(t, repo, "update-ref", "HEAD", candidateCommit)
+	inventory := runReviewCLIGit(t, repo, "ls-tree", "-r", "-z", "--name-only", "--full-tree", baseTree)
+	if len(inventory) <= 4<<20 {
+		t.Fatalf("repository path inventory = %d bytes, want more than 4 MiB", len(inventory))
+	}
+	return baseCommit, paths[0]
+}
+
+func runReviewCLIGitInput(t *testing.T, repo string, input []byte, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	command.Stdin = bytes.NewReader(input)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, output)
+	}
+	return string(output)
 }

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -374,20 +374,28 @@ func (lookup *frozenRepositoryPathLookup) contains(logicalPath string) (bool, er
 	}
 	want := []byte(logicalPath + "\x00")
 	for _, tree := range lookup.trees {
-		output, err := runGitLimited(lookup.ctx, lookup.repo, lookup.isolation, nil, len(want),
-			"ls-tree", "-r", "-z", "--name-only", "--full-tree", tree, "--", ":(literal)"+logicalPath)
+		output, err := runGitLimited(lookup.ctx, lookup.repo, lookup.isolation, nil, len(logicalPath)+len("160000 commit ")+64+2,
+			"ls-tree", "-z", "--full-tree", tree, "--", ":(literal)"+logicalPath)
 		if err != nil {
 			return false, err
 		}
-		switch {
-		case len(output) == 0:
+		if len(output) == 0 {
 			continue
-		case bytes.Equal(output, want):
-			lookup.cache[logicalPath] = true
-			return true, nil
-		default:
+		}
+		header, path, found := bytes.Cut(output, []byte{'\t'})
+		fields := bytes.Split(header, []byte{' '})
+		if !found || !bytes.Equal(path, want) || len(fields) != 3 || !validGitTree(string(fields[2])) {
 			return false, errors.New("literal repository path lookup returned a non-exact result") // refusal:by-design world-action: contradictory Git plumbing output cannot establish immutable path authority
 		}
+		kind := string(fields[0]) + " " + string(fields[1])
+		if kind == "040000 tree" {
+			continue
+		}
+		if kind != "100644 blob" && kind != "100755 blob" && kind != "120000 blob" && kind != "160000 commit" {
+			return false, errors.New("literal repository path lookup returned an invalid file entry") // refusal:by-design world-action: contradictory Git mode and type cannot establish immutable path authority
+		}
+		lookup.cache[logicalPath] = true
+		return true, nil
 	}
 	lookup.cache[logicalPath] = false
 	return false, nil

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -2,6 +2,7 @@ package reviewtransaction
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -106,7 +107,7 @@ const artifactRecaptureContinuation = "the rejected admission did not consume th
 // AdmitArtifact performs the single provider-owned admission decision. It
 // validates subject echo, completed full-manifest inspection, result shape,
 // and candidate scope before returning a canonical lens result.
-func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmission, error) {
+func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensResult, ArtifactAdmission, error) {
 	admission := ArtifactAdmission{
 		Schema: ArtifactAdmissionSchema, SubjectHash: request.ExpectedSubject.SubjectHash,
 		RawSHA256: payloadSHA256(request.RawPayload), CanonicalSHA256: payloadSHA256(request.CanonicalPayload),
@@ -176,19 +177,6 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 		wantPaths[index] = entry.Path
 		allowed[entry.Path] = struct{}{}
 	}
-	repositoryPaths, err := canonicalPaths(request.FrozenContext.repositoryPaths)
-	if err != nil || request.FrozenContext.repositoryPaths == nil || !equalStrings(repositoryPaths, request.FrozenContext.repositoryPaths) {
-		return fail(ArtifactAdmissionBindingMismatch, "frozen repository path manifest is missing or non-canonical")
-	}
-	repository := make(map[string]struct{}, len(repositoryPaths))
-	for _, logicalPath := range repositoryPaths {
-		repository[logicalPath] = struct{}{}
-	}
-	for _, logicalPath := range wantPaths {
-		if _, ok := repository[logicalPath]; !ok {
-			return fail(ArtifactAdmissionBindingMismatch, "frozen changed path is absent from the repository path manifest")
-		}
-	}
 	if request.Inspection.Status != ArtifactInspectionCompleted {
 		return fail(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection")
 	}
@@ -208,6 +196,11 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 	if err != nil {
 		return fail(ArtifactAdmissionIncomplete, err.Error())
 	}
+	repository, cleanup, err := newFrozenRepositoryPathLookup(ctx, request.FrozenContext)
+	if err != nil {
+		return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup is unavailable")
+	}
+	defer cleanup()
 	wantPrefix := map[string]string{LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-"}[canonical.Lens]
 	seenFindingIDs := make(map[string]struct{}, len(canonical.Findings))
 	wantCandidateCausalIDs := make([]string, 0)
@@ -215,7 +208,11 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 		if evidenceReportsUnavailableInspection(evidence) {
 			return fail(ArtifactAdmissionIncomplete, "reviewer evidence reports that candidate inspection was unavailable")
 		}
-		if referenceOutsideRepository(evidence, repository) {
+		outside, lookupErr := referenceOutsideRepository(evidence, repository.contains)
+		if lookupErr != nil {
+			return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup failed")
+		}
+		if outside {
 			return fail(ArtifactAdmissionOutOfScope, "reviewer evidence references a path outside the frozen repository")
 		}
 	}
@@ -234,7 +231,11 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 			return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
 		}
 		for _, proof := range finding.ProofRefs {
-			if referenceOutsideRepository(proof, repository) {
+			outside, lookupErr := referenceOutsideRepository(proof, repository.contains)
+			if lookupErr != nil {
+				return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup failed")
+			}
+			if outside {
 				return fail(ArtifactAdmissionOutOfScope, "reviewer proof references a path outside the frozen repository")
 			}
 		}
@@ -339,25 +340,85 @@ type artifactReferenceToken struct {
 	quoted bool
 }
 
+type frozenRepositoryPathLookup struct {
+	ctx       context.Context
+	repo      string
+	isolation []string
+	trees     []string
+	cache     map[string]bool
+}
+
+func newFrozenRepositoryPathLookup(ctx context.Context, frozen FrozenCandidateContext) (*frozenRepositoryPathLookup, func(), error) {
+	if ctx == nil || frozen.repositoryRoot == "" || !validGitTree(frozen.BaseTree) || !validGitTree(frozen.CandidateTree) {
+		return nil, func() {}, errors.New("frozen repository identity is incomplete") // refusal:by-design world-action: provider-owned immutable context is incomplete and must be reconstructed from authority
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, func() {}, err
+	}
+	isolation, cleanup, err := isolatedImmutableTreeGit(ctx, frozen.repositoryRoot)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	trees := []string{frozen.BaseTree}
+	if frozen.CandidateTree != frozen.BaseTree {
+		trees = append(trees, frozen.CandidateTree)
+	}
+	return &frozenRepositoryPathLookup{
+		ctx: ctx, repo: frozen.repositoryRoot, isolation: isolation, trees: trees, cache: make(map[string]bool),
+	}, cleanup, nil
+}
+
+func (lookup *frozenRepositoryPathLookup) contains(logicalPath string) (bool, error) {
+	if known, ok := lookup.cache[logicalPath]; ok {
+		return known, nil
+	}
+	want := []byte(logicalPath + "\x00")
+	for _, tree := range lookup.trees {
+		output, err := runGitLimited(lookup.ctx, lookup.repo, lookup.isolation, nil, len(want),
+			"ls-tree", "-r", "-z", "--name-only", "--full-tree", tree, "--", ":(literal)"+logicalPath)
+		if err != nil {
+			return false, err
+		}
+		switch {
+		case len(output) == 0:
+			continue
+		case bytes.Equal(output, want):
+			lookup.cache[logicalPath] = true
+			return true, nil
+		default:
+			return false, errors.New("literal repository path lookup returned a non-exact result") // refusal:by-design world-action: contradictory Git plumbing output cannot establish immutable path authority
+		}
+	}
+	lookup.cache[logicalPath] = false
+	return false, nil
+}
+
 // referenceOutsideRepository recognizes canonical path:positive-line tokens
 // and requires each one to exist in the immutable base/candidate repository
 // universe. Bare root names need a dot; extensionless root paths remain
 // available through quoting. This keeps status:500 and digest/timestamp labels
 // out of the path grammar while rejecting malformed or unknown path claims.
-func referenceOutsideRepository(value string, repository map[string]struct{}) bool {
+func referenceOutsideRepository(value string, lookup func(string) (bool, error)) (bool, error) {
 	for _, token := range artifactReferenceTokens(value) {
-		path, known, malformed := artifactRepositoryPathReference(token, repository)
+		path, malformed := artifactRepositoryPathReference(token)
 		if malformed {
-			return true
+			return true, nil
 		}
-		if path != "" && !known {
-			return true
+		if path == "" {
+			continue
+		}
+		known, err := lookup(path)
+		if err != nil {
+			return false, err
+		}
+		if !known {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func artifactRepositoryPathReference(token artifactReferenceToken, repository map[string]struct{}) (string, bool, bool) {
+func artifactRepositoryPathReference(token artifactReferenceToken) (string, bool) {
 	value := token.value
 	if !token.quoted {
 		value = strings.TrimLeft(value, "([{<")
@@ -365,33 +426,32 @@ func artifactRepositoryPathReference(token artifactReferenceToken, repository ma
 	}
 	separator := strings.LastIndexByte(value, ':')
 	if separator <= 0 || separator == len(value)-1 {
-		return "", false, false
+		return "", false
 	}
 	line := value[separator+1:]
 	nonzero := false
 	for index := range line {
 		if line[index] < '0' || line[index] > '9' {
-			return "", false, false
+			return "", false
 		}
 		nonzero = nonzero || line[index] != '0'
 	}
 	if !nonzero {
-		return "", false, false
+		return "", false
 	}
 	logicalPath := value[:separator]
 	if strings.Contains(logicalPath, "://") {
-		return "", false, false
+		return "", false
 	}
 	pathLike := token.quoted || strings.Contains(logicalPath, "/") || strings.Contains(logicalPath, ".")
 	if !pathLike {
-		return "", false, false
+		return "", false
 	}
 	canonical, err := normalizeLogicalPath(logicalPath)
 	if err != nil || canonical != logicalPath {
-		return "", false, true
+		return "", true
 	}
-	_, known := repository[canonical]
-	return canonical, known, false
+	return canonical, false
 }
 
 func artifactReferenceTokens(value string) []artifactReferenceToken {

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -1,13 +1,42 @@
 package reviewtransaction
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func admittedArtifactFixture(t *testing.T) (ArtifactSubject, FrozenCandidateContext, ArtifactAdmissionRequest) {
 	t.Helper()
-	state, revision, context := artifactSubjectFixture(t)
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	for path, contents := range map[string]string{
+		"internal/a.go":      "package internal\n\nconst value = 1\n",
+		"internal/secret.go": "package internal\n",
+		"secret.go":          "package secret\n",
+	} {
+		writeSnapshotFile(t, repo, path, contents)
+	}
+	gitSnapshot(t, repo, "add", "-A", "--")
+	gitSnapshot(t, repo, "commit", "-m", "add admission fixtures")
+	writeSnapshotFile(t, repo, "internal/a.go", "package internal\n\nconst value = 2\n")
+	writeSnapshotFile(t, repo, "internal/b.go", "package internal\n")
+	gitSnapshot(t, repo, "add", "-A", "--")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	candidate := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(t.Context(), Target{Kind: TargetExactRevision, Revision: candidate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	context, err := (SnapshotBuilder{Repo: repo}).FrozenCandidateContext(t.Context(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := CompactState{
+		LineageID: "review-artifact-subject", SelectedLenses: []string{LensReliability, LensReadability}, InitialSnapshot: snapshot,
+	}
+	revision := "sha256:" + strings.Repeat("2", 64)
 	subject, err := NewArtifactSubject(state, revision, context, LensReliability, 0, "")
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +83,7 @@ func TestExtractBoundedSingleJSONObject(t *testing.T) {
 
 func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 	_, _, request := admittedArtifactFixture(t)
-	canonical, admission, err := AdmitArtifact(request)
+	canonical, admission, err := AdmitArtifact(t.Context(), request)
 	if err != nil {
 		t.Fatalf("AdmitArtifact() error = %v", err)
 	}
@@ -78,14 +107,8 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 			r.Result.Evidence = []string{"Inspection blocked: read access denied; no candidate contents were available."}
 		}, decision: ArtifactAdmissionIncomplete},
 		{name: "partial inspection", mutate: func(r *ArtifactAdmissionRequest) { r.Inspection.Paths = []string{"internal/a.go"} }, decision: ArtifactAdmissionIncomplete},
-		{name: "repository path manifest missing", mutate: func(r *ArtifactAdmissionRequest) {
-			r.FrozenContext.repositoryPaths = nil
-		}, decision: ArtifactAdmissionBindingMismatch},
-		{name: "repository path manifest non-canonical", mutate: func(r *ArtifactAdmissionRequest) {
-			r.FrozenContext.repositoryPaths = append([]string{"./not-canonical.go"}, r.FrozenContext.repositoryPaths...)
-		}, decision: ArtifactAdmissionBindingMismatch},
-		{name: "changed path absent from repository manifest", mutate: func(r *ArtifactAdmissionRequest) {
-			r.FrozenContext.repositoryPaths = []string{"internal/a.go"}
+		{name: "repository authority missing", mutate: func(r *ArtifactAdmissionRequest) {
+			r.FrozenContext.repositoryRoot = ""
 		}, decision: ArtifactAdmissionBindingMismatch},
 		{name: "out of scope finding", mutate: func(r *ArtifactAdmissionRequest) { r.Result.Findings[0].Location = "unrelated/old.go:3" }, decision: ArtifactAdmissionOutOfScope},
 		{name: "unknown repository proof", mutate: func(r *ArtifactAdmissionRequest) {
@@ -105,7 +128,7 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, candidate := admittedArtifactFixture(t)
 			tc.mutate(&candidate)
-			_, admission, err := AdmitArtifact(candidate)
+			_, admission, err := AdmitArtifact(t.Context(), candidate)
 			if err == nil || admission.Decision != tc.decision {
 				t.Fatalf("AdmitArtifact() decision = %q, error = %v; want %q", admission.Decision, err, tc.decision)
 			}
@@ -118,17 +141,23 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 // candidate diff rather than the frozen Git trees.
 func legacyAdmittedArtifactFixture(t *testing.T) ArtifactAdmissionRequest {
 	t.Helper()
-	state, revision, frozen := artifactSubjectFixture(t)
+	native, frozen, request := admittedArtifactFixture(t)
+	state := CompactState{
+		LineageID: native.LineageID, SelectedLenses: []string{LensReliability, LensReadability},
+		InitialSnapshot: Snapshot{
+			Identity: native.TargetIdentity, BaseTree: frozen.BaseTree, CandidateTree: frozen.CandidateTree,
+			Paths: manifestPaths(frozen.ChangedPathManifest),
+		},
+	}
 	diff, err := NewFrozenCandidateDiff([]byte("diff --git a/internal/a.go b/internal/a.go\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	frozen.LegacyCandidateDiff = &diff
-	subject, err := NewLegacyArtifactSubject(state, revision, frozen, LensReliability, 0, "")
+	subject, err := NewLegacyArtifactSubject(state, native.AuthorityRevision, frozen, LensReliability, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, request := admittedArtifactFixture(t)
 	request.ExpectedSubject, request.FrozenContext = subject, frozen
 	request.EchoedSubjectHash = subject.SubjectHash
 	return request
@@ -140,7 +169,7 @@ func legacyAdmittedArtifactFixture(t *testing.T) ArtifactAdmissionRequest {
 // slot, leaving the collect loop to re-offer the same slot forever.
 func TestAdmitArtifactBindsLegacySubjectByCandidateDiff(t *testing.T) {
 	request := legacyAdmittedArtifactFixture(t)
-	canonical, admission, err := AdmitArtifact(request)
+	canonical, admission, err := AdmitArtifact(t.Context(), request)
 	if err != nil {
 		t.Fatalf("AdmitArtifact() error = %v (decision %q, diagnostic %q)", err, admission.Decision, admission.Diagnostic)
 	}
@@ -170,7 +199,7 @@ func TestAdmitArtifactBindsLegacySubjectByCandidateDiff(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			candidate := legacyAdmittedArtifactFixture(t)
 			tc.mutate(&candidate)
-			_, admission, err := AdmitArtifact(candidate)
+			_, admission, err := AdmitArtifact(t.Context(), candidate)
 			if err == nil || admission.Decision != ArtifactAdmissionBindingMismatch {
 				t.Fatalf("AdmitArtifact() decision = %q, error = %v; want %q",
 					admission.Decision, err, ArtifactAdmissionBindingMismatch)
@@ -181,10 +210,16 @@ func TestAdmitArtifactBindsLegacySubjectByCandidateDiff(t *testing.T) {
 
 func TestAdmitArtifactAllowsSupportingProofOutsideChangedManifest(t *testing.T) {
 	_, _, request := admittedArtifactFixture(t)
+	if err := os.Remove(filepath.Join(request.FrozenContext.repositoryRoot, "secret.go")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(request.FrozenContext.repositoryRoot, "live-only.go"), []byte("package liveonly\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	request.Result.Evidence = append(request.Result.Evidence, "supporting implementation: internal/secret.go:7")
 	request.Result.Findings[0].ProofRefs = []string{"repository proof: secret.go:42"}
 
-	canonical, admission, err := AdmitArtifact(request)
+	canonical, admission, err := AdmitArtifact(t.Context(), request)
 	if err != nil || admission.Decision != ArtifactAdmissionCompleted {
 		t.Fatalf("AdmitArtifact() = %q, %v; want completed", admission.Decision, err)
 	}
@@ -194,8 +229,13 @@ func TestAdmitArtifactAllowsSupportingProofOutsideChangedManifest(t *testing.T) 
 	}
 
 	request.Inspection.Paths = append(request.Inspection.Paths, "internal/secret.go")
-	if _, rejected, err := AdmitArtifact(request); err == nil || rejected.Decision != ArtifactAdmissionOutOfScope {
+	if _, rejected, err := AdmitArtifact(t.Context(), request); err == nil || rejected.Decision != ArtifactAdmissionOutOfScope {
 		t.Fatalf("external proof path became an inspectable candidate path: decision=%q error=%v", rejected.Decision, err)
+	}
+	request.Inspection.Paths = []string{"internal/a.go", "internal/b.go"}
+	request.Result.Evidence = []string{"live-only proof: live-only.go:1"}
+	if _, rejected, err := AdmitArtifact(t.Context(), request); err == nil || rejected.Decision != ArtifactAdmissionOutOfScope {
+		t.Fatalf("live-worktree-only proof was admitted: decision=%q error=%v", rejected.Decision, err)
 	}
 }
 
@@ -221,7 +261,7 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 	t.Run("non-canonical submitted order still admits", func(t *testing.T) {
 		request := admittedCandidateCausalArtifactFixture(t)
 		request.CandidateCausalFindingIDs = []string{" R3-001 "}
-		_, admission, err := AdmitArtifact(request)
+		_, admission, err := AdmitArtifact(t.Context(), request)
 		if err != nil || admission.Decision != ArtifactAdmissionCompleted {
 			t.Fatalf("AdmitArtifact() = %q, %v; want completed", admission.Decision, err)
 		}
@@ -232,7 +272,7 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 	t.Run("canonicalization error becomes incomplete and names the offending id", func(t *testing.T) {
 		request := admittedCandidateCausalArtifactFixture(t)
 		request.CandidateCausalFindingIDs = []string{"R3-001", "R3-001"}
-		_, admission, err := AdmitArtifact(request)
+		_, admission, err := AdmitArtifact(t.Context(), request)
 		if err == nil || admission.Decision != ArtifactAdmissionIncomplete {
 			t.Fatalf("AdmitArtifact() = %q, %v; want incomplete", admission.Decision, err)
 		}
@@ -243,7 +283,7 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 	t.Run("real set mismatch stays out of scope byte-identical", func(t *testing.T) {
 		request := admittedCandidateCausalArtifactFixture(t)
 		request.CandidateCausalFindingIDs = []string{"R3-999"}
-		_, admission, err := AdmitArtifact(request)
+		_, admission, err := AdmitArtifact(t.Context(), request)
 		wantMessage := "candidate-causal findings are not proven by repository-derived changed-line evidence"
 		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope || admission.Diagnostic != wantMessage {
 			t.Fatalf("AdmitArtifact() = %q, %q, %v; want out-of-scope %q", admission.Decision, admission.Diagnostic, err, wantMessage)
@@ -260,7 +300,7 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 func TestAdmitArtifactOmittedSubjectDiagnosticNamesContinuation(t *testing.T) {
 	_, _, request := admittedArtifactFixture(t)
 	request.EchoedSubjectHash = ""
-	_, admission, err := AdmitArtifact(request)
+	_, admission, err := AdmitArtifact(t.Context(), request)
 	if err == nil || admission.Decision != ArtifactAdmissionIncomplete {
 		t.Fatalf("AdmitArtifact() decision = %q, error = %v; want incomplete", admission.Decision, err)
 	}
@@ -283,6 +323,10 @@ func TestReferenceOutsideRepositoryRecognizesOnlyCanonicalRepositoryPaths(t *tes
 		"internal/secret.go", "main.go", "secret.go", "sha256", "status",
 	} {
 		repository[logicalPath] = struct{}{}
+	}
+	lookup := func(logicalPath string) (bool, error) {
+		_, known := repository[logicalPath]
+		return known, nil
 	}
 	tests := []struct {
 		name    string
@@ -310,7 +354,11 @@ func TestReferenceOutsideRepositoryRecognizesOnlyCanonicalRepositoryPaths(t *tes
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := referenceOutsideRepository(tt.value, repository); got != tt.outside {
+			got, err := referenceOutsideRepository(tt.value, lookup)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.outside {
 				t.Fatalf("referenceOutsideRepository(%q) = %v, want %v", tt.value, got, tt.outside)
 			}
 		})

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -1,8 +1,6 @@
 package reviewtransaction
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -11,21 +9,16 @@ func admittedArtifactFixture(t *testing.T) (ArtifactSubject, FrozenCandidateCont
 	t.Helper()
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)
-	for path, contents := range map[string]string{
-		"internal/a.go":      "package internal\n\nconst value = 1\n",
-		"internal/secret.go": "package internal\n",
-		"secret.go":          "package secret\n",
-	} {
-		writeSnapshotFile(t, repo, path, contents)
-	}
+	writeSnapshotFile(t, repo, "internal/a.go", "package internal\n\nconst value = 1\n")
+	writeSnapshotFile(t, repo, "internal/secret.go", "package internal\n")
+	writeSnapshotFile(t, repo, "secret.go", "package secret\n")
 	gitSnapshot(t, repo, "add", "-A", "--")
 	gitSnapshot(t, repo, "commit", "-m", "add admission fixtures")
 	writeSnapshotFile(t, repo, "internal/a.go", "package internal\n\nconst value = 2\n")
 	writeSnapshotFile(t, repo, "internal/b.go", "package internal\n")
 	gitSnapshot(t, repo, "add", "-A", "--")
 	gitSnapshot(t, repo, "commit", "-m", "candidate")
-	candidate := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
-	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(t.Context(), Target{Kind: TargetExactRevision, Revision: candidate})
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(t.Context(), Target{Kind: TargetExactRevision, Revision: strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,11 +26,8 @@ func admittedArtifactFixture(t *testing.T) (ArtifactSubject, FrozenCandidateCont
 	if err != nil {
 		t.Fatal(err)
 	}
-	state := CompactState{
-		LineageID: "review-artifact-subject", SelectedLenses: []string{LensReliability, LensReadability}, InitialSnapshot: snapshot,
-	}
-	revision := "sha256:" + strings.Repeat("2", 64)
-	subject, err := NewArtifactSubject(state, revision, context, LensReliability, 0, "")
+	state := CompactState{LineageID: "review-artifact-subject", SelectedLenses: []string{LensReliability, LensReadability}, InitialSnapshot: snapshot}
+	subject, err := NewArtifactSubject(state, "sha256:"+strings.Repeat("2", 64), context, LensReliability, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,6 +106,9 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 		}, decision: ArtifactAdmissionOutOfScope},
 		{name: "unknown repository evidence", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Evidence = append(r.Result.Evidence, "diff: missing.go:42")
+		}, decision: ArtifactAdmissionOutOfScope},
+		{name: "directory repository evidence does not recurse", mutate: func(r *ArtifactAdmissionRequest) {
+			r.Result.Evidence = append(r.Result.Evidence, "directory: `internal:1`")
 		}, decision: ArtifactAdmissionOutOfScope},
 		{name: "non-canonical repository proof", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings[0].ProofRefs = []string{"diff: ./secret.go:42"}
@@ -210,12 +203,8 @@ func TestAdmitArtifactBindsLegacySubjectByCandidateDiff(t *testing.T) {
 
 func TestAdmitArtifactAllowsSupportingProofOutsideChangedManifest(t *testing.T) {
 	_, _, request := admittedArtifactFixture(t)
-	if err := os.Remove(filepath.Join(request.FrozenContext.repositoryRoot, "secret.go")); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(request.FrozenContext.repositoryRoot, "live-only.go"), []byte("package liveonly\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	gitSnapshot(t, request.FrozenContext.repositoryRoot, "rm", "--", "secret.go")
+	writeSnapshotFile(t, request.FrozenContext.repositoryRoot, "live-only.go", "package liveonly\n")
 	request.Result.Evidence = append(request.Result.Evidence, "supporting implementation: internal/secret.go:7")
 	request.Result.Findings[0].ProofRefs = []string{"repository proof: secret.go:42"}
 

--- a/internal/reviewtransaction/artifact_subject_test.go
+++ b/internal/reviewtransaction/artifact_subject_test.go
@@ -20,10 +20,6 @@ func artifactSubjectFixture(t *testing.T) (CompactState, string, FrozenCandidate
 			{Path: paths[0], Status: CandidatePathModified, OldMode: "100644", NewMode: "100644"},
 			{Path: paths[1], Status: CandidatePathAdded, OldMode: "000000", NewMode: "100644", IntendedUntracked: true},
 		},
-		repositoryPaths: []string{
-			"Dockerfile", "Makefile", "docs/naïve guide.md", "docs/秘密 guide.md", "internal/a.go", "internal/b.go",
-			"internal/secret.go", "main.go", "secret.go", "sha256", "status", "unrelated/old.go",
-		},
 	}
 	return state, "sha256:" + strings.Repeat("2", 64), context
 }

--- a/internal/reviewtransaction/compact_result_reopen.go
+++ b/internal/reviewtransaction/compact_result_reopen.go
@@ -219,7 +219,7 @@ func ReopenCompactReviewerResults(ctx context.Context, repo string, request Comp
 		} else if !os.IsNotExist(statErr) {
 			return statErr
 		}
-		quarantined, retained, inspectErr := classifyCompactResultReopenSlots(repository, store.Dir, record.State, frozen, plan.AuthorizedLenses)
+		quarantined, retained, inspectErr := classifyCompactResultReopenSlots(ctx, repository, store.Dir, record.State, frozen, plan.AuthorizedLenses)
 		if inspectErr != nil {
 			return inspectErr
 		}
@@ -301,7 +301,7 @@ func buildCompactResultReopenPlan(ctx context.Context, repository string, store 
 	if err != nil {
 		return CompactResultReopenPlan{}, err
 	}
-	quarantined, retained, err := classifyCompactResultReopenSlots(repository, store.Dir, state, frozen, authorizedLenses)
+	quarantined, retained, err := classifyCompactResultReopenSlots(ctx, repository, store.Dir, state, frozen, authorizedLenses)
 	if err != nil {
 		return CompactResultReopenPlan{}, err
 	}
@@ -322,7 +322,7 @@ func buildCompactResultReopenPlan(ctx context.Context, repository string, store 
 // reporting that candidate inspection was unavailable. authorizedLenses adds
 // the maintainer's explicitly named admitted slots — the one and only path by
 // which a structurally valid, provider-admitted result leaves its slot.
-func classifyCompactResultReopenSlots(repository, storeDir string, state CompactState, frozen FrozenCandidateContext, authorizedLenses []string) ([]CompactResultReopenSlot, []CompactResultReopenSlot, error) {
+func classifyCompactResultReopenSlots(ctx context.Context, repository, storeDir string, state CompactState, frozen FrozenCandidateContext, authorizedLenses []string) ([]CompactResultReopenSlot, []CompactResultReopenSlot, error) {
 	authorized := make(map[string]struct{}, len(authorizedLenses))
 	for _, lens := range authorizedLenses {
 		authorized[lens] = struct{}{}
@@ -330,7 +330,7 @@ func classifyCompactResultReopenSlots(repository, storeDir string, state Compact
 	quarantined := make([]CompactResultReopenSlot, 0)
 	retained := make([]CompactResultReopenSlot, 0)
 	for order, lens := range state.SelectedLenses {
-		slot, trusted, err := inspectCompactResultReopenSlot(repository, storeDir, state, frozen, order, lens)
+		slot, trusted, err := inspectCompactResultReopenSlot(ctx, repository, storeDir, state, frozen, order, lens)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -348,7 +348,7 @@ func classifyCompactResultReopenSlots(repository, storeDir string, state Compact
 	return quarantined, retained, nil
 }
 
-func inspectCompactResultReopenSlot(repository, storeDir string, state CompactState, frozen FrozenCandidateContext, order int, lens string) (CompactResultReopenSlot, bool, error) {
+func inspectCompactResultReopenSlot(ctx context.Context, repository, storeDir string, state CompactState, frozen FrozenCandidateContext, order int, lens string) (CompactResultReopenSlot, bool, error) {
 	if order >= len(state.LensResults) {
 		return CompactResultReopenSlot{}, false, errors.New("validating authority does not contain every selected lens result")
 	}
@@ -370,11 +370,11 @@ func inspectCompactResultReopenSlot(repository, storeDir string, state CompactSt
 	if err := decoder.Decode(&extra); err != io.EOF || envelope.Schema != admittedReviewerResultSchemaForSubject(envelope.Subject) || len(envelope.Result) == 0 {
 		return slot, false, nil
 	}
-	frozen, expected, err := artifactSubjectForSchema(context.Background(), SnapshotBuilder{Repo: repository}, state, envelope.Subject.AuthorityRevision, frozen, lens, order, envelope.Subject.CorrectionTargetIdentity, envelope.Subject.Schema)
+	frozen, expected, err := artifactSubjectForSchema(ctx, SnapshotBuilder{Repo: repository}, state, envelope.Subject.AuthorityRevision, frozen, lens, order, envelope.Subject.CorrectionTargetIdentity, envelope.Subject.Schema)
 	if err != nil || envelope.Subject != expected || envelope.Admission.Validate(expected) != nil {
 		return slot, false, nil
 	}
-	result, admitted := reAdmitCompactReviewerResult(envelope, expected, frozen)
+	result, admitted := reAdmitCompactReviewerResult(ctx, envelope, expected, frozen)
 	if !admitted || result.ResultHash != state.LensResults[order].ResultHash {
 		return slot, false, nil
 	}
@@ -382,7 +382,7 @@ func inspectCompactResultReopenSlot(repository, storeDir string, state CompactSt
 	return slot, true, nil
 }
 
-func reAdmitCompactReviewerResult(envelope compactAdmittedReviewerResult, expected ArtifactSubject, frozen FrozenCandidateContext) (LensResult, bool) {
+func reAdmitCompactReviewerResult(ctx context.Context, envelope compactAdmittedReviewerResult, expected ArtifactSubject, frozen FrozenCandidateContext) (LensResult, bool) {
 	decoder := json.NewDecoder(bytes.NewReader(envelope.Result))
 	decoder.DisallowUnknownFields()
 	var provider compactProviderReviewerResult
@@ -401,7 +401,7 @@ func reAdmitCompactReviewerResult(envelope compactAdmittedReviewerResult, expect
 		return LensResult{}, false
 	}
 	canonicalPayload = append(canonicalPayload, '\n')
-	result, admission, err := AdmitArtifact(ArtifactAdmissionRequest{
+	result, admission, err := AdmitArtifact(ctx, ArtifactAdmissionRequest{
 		ExpectedSubject: expected, FrozenContext: frozen, EchoedSubjectHash: provider.SubjectHash,
 		Inspection:                provider.Inspection,
 		Result:                    LensResult{Lens: expected.Lens, Findings: provider.Findings, Evidence: provider.Evidence},

--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -71,7 +71,7 @@ func (store CompactStore) ResolveAdmittedReviewerResult(ctx context.Context, exp
 		if err := decoder.Decode(&extra); err != io.EOF || envelope.Schema != admittedReviewerResultSchemaForSubject(expected) || envelope.Subject != expected || envelope.Admission.Validate(expected) != nil || len(envelope.Result) == 0 {
 			return errors.New("admitted reviewer result does not match locked authority")
 		}
-		result, found = reAdmitCompactReviewerResult(envelope, expected, nativeFrozen)
+		result, found = reAdmitCompactReviewerResult(ctx, envelope, expected, nativeFrozen)
 		if !found {
 			return errors.New("admitted reviewer result failed native re-admission")
 		}
@@ -168,6 +168,7 @@ func (store CompactStore) CaptureAdmittedReviewerResult(
 				)
 			}
 			admissionResult, admission, err := AdmitArtifact(
+				ctx,
 				ArtifactAdmissionRequest{
 					ExpectedSubject:           expected,
 					FrozenContext:             nativeContext,

--- a/internal/reviewtransaction/compact_reviewer_capture_test.go
+++ b/internal/reviewtransaction/compact_reviewer_capture_test.go
@@ -169,6 +169,7 @@ func TestCompactStoreCaptureAdmittedReviewerResultPublishesDurableExactReplay(
 		t.Fatalf("canonical provider result = %#v", provider)
 	}
 	reAdmitted, ok := reAdmitCompactReviewerResult(
+		t.Context(),
 		envelope,
 		fixture.request.ArtifactSubject,
 		fixture.request.FrozenContext,

--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -85,6 +85,7 @@ type ChangedPathManifestEntry struct {
 
 // FrozenCandidateContext is the deterministic reviewer input derived only
 // from the immutable Git trees and metadata persisted in a Snapshot.
+// Its repositoryRoot is provider-only local state, not reviewer-visible input.
 type FrozenCandidateContext struct {
 	BaseTree            string
 	CandidateTree       string

--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -1,7 +1,6 @@
 package reviewtransaction
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -10,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 )
 
@@ -92,7 +90,7 @@ type FrozenCandidateContext struct {
 	CandidateTree       string
 	LegacyCandidateDiff *FrozenCandidateDiff
 	ChangedPathManifest []ChangedPathManifestEntry
-	repositoryPaths     []string
+	repositoryRoot      string
 }
 
 // WithLegacyCandidateDiff adds the exact published v1 candidate transport.
@@ -188,13 +186,9 @@ func (builder SnapshotBuilder) FrozenCandidateContext(ctx context.Context, snaps
 		}
 		manifest = append(manifest, entry)
 	}
-	repositoryPaths, err := frozenRepositoryPathManifest(ctx, repo, isolation, snapshot.BaseTree, snapshot.CandidateTree)
-	if err != nil {
-		return FrozenCandidateContext{}, err
-	}
 	return FrozenCandidateContext{
 		BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree,
-		ChangedPathManifest: manifest, repositoryPaths: repositoryPaths,
+		ChangedPathManifest: manifest, repositoryRoot: repo,
 	}, nil
 }
 
@@ -246,44 +240,6 @@ func (builder SnapshotBuilder) InspectCandidate(ctx context.Context, snapshot Sn
 		return nil, fmt.Errorf("unknown candidate inspection operation %q", operation) // refusal:by-design operator-knowledge: the native CLI validates the closed operation enum before calling this boundary
 	}
 	return runGitLimited(ctx, repo, isolation, nil, MaxFrozenCandidateDiffBytes, args...)
-}
-
-// frozenRepositoryPathManifest returns the canonical logical paths present in
-// either immutable side of the review. Admission uses this private universe to
-// distinguish real repository path:line references from hashes, timestamps,
-// status labels, URLs, and other arbitrary colon-delimited prose.
-func frozenRepositoryPathManifest(ctx context.Context, repo string, isolation []string, trees ...string) ([]string, error) {
-	seen := make(map[string]struct{})
-	seenTrees := make(map[string]struct{}, len(trees))
-	for _, tree := range trees {
-		if _, duplicate := seenTrees[tree]; duplicate {
-			continue
-		}
-		seenTrees[tree] = struct{}{}
-		output, err := runGitLimited(ctx, repo, isolation, nil, maxFrozenCandidateManifestBytes,
-			"ls-tree", "-r", "-z", "--name-only", "--full-tree", tree)
-		if err != nil {
-			return nil, fmt.Errorf("render frozen repository path manifest: %w", err)
-		}
-		for _, rawPath := range bytes.Split(output, []byte{0}) {
-			if len(rawPath) == 0 {
-				continue
-			}
-			logicalPath, err := normalizeLogicalPath(string(rawPath))
-			if err != nil {
-				// Unsupported unchanged Git names cannot be emitted by the native
-				// changed-path manifest, so they are not valid reviewer references.
-				continue
-			}
-			seen[logicalPath] = struct{}{}
-		}
-	}
-	paths := make([]string, 0, len(seen))
-	for logicalPath := range seen {
-		paths = append(paths, logicalPath)
-	}
-	sort.Strings(paths)
-	return paths, nil
 }
 
 func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(), error) {

--- a/internal/reviewtransaction/frozen_candidate_context_test.go
+++ b/internal/reviewtransaction/frozen_candidate_context_test.go
@@ -73,11 +73,6 @@ func TestFrozenCandidateContextUsesImmutableTreesAndCanonicalManifest(t *testing
 	if !reflect.DeepEqual(manifestPaths(baseline.ChangedPathManifest), snapshot.Paths) {
 		t.Fatalf("manifest paths = %v, snapshot paths = %v", manifestPaths(baseline.ChangedPathManifest), snapshot.Paths)
 	}
-	for _, logicalPath := range []string{"added.txt", "deleted.txt", "docs/naïve guide.md", "tracked.txt"} {
-		if stringIndex(baseline.repositoryPaths, logicalPath) < 0 {
-			t.Fatalf("frozen repository path manifest omits %q: %v", logicalPath, baseline.repositoryPaths)
-		}
-	}
 	for _, marker := range []string{
 		"diff --git a/added.txt b/added.txt",
 		"GIT binary patch",

--- a/internal/reviewtransaction/reviewer_envelope_test.go
+++ b/internal/reviewtransaction/reviewer_envelope_test.go
@@ -69,13 +69,13 @@ func TestSchemaExampleShapedResultIsAdmitted(t *testing.T) {
 	request.Result = LensResult{Lens: LensReliability, Findings: []Finding{}, Evidence: evidence}
 	request.CandidateCausalFindingIDs = nil
 
-	_, admission, err := AdmitArtifact(request)
+	_, admission, err := AdmitArtifact(t.Context(), request)
 	if err != nil || admission.Decision != ArtifactAdmissionCompleted {
 		t.Fatalf("AdmitArtifact(schema-shaped result) decision = %q, error = %v; want completed", admission.Decision, err)
 	}
 
 	request.EchoedSubjectHash = ""
-	_, admission, err = AdmitArtifact(request)
+	_, admission, err = AdmitArtifact(t.Context(), request)
 	if err == nil || admission.Decision != ArtifactAdmissionIncomplete {
 		t.Fatalf("AdmitArtifact(no subject_hash) decision = %q, error = %v; want incomplete", admission.Decision, err)
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2058

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Removes the full-repository path inventory from frozen review-context construction.
- Validates only path-like evidence and proof references through cached literal lookups against the immutable base and candidate trees.
- Preserves fail-closed artifact admission while allowing small candidates in repositories whose path inventory exceeds 4 MiB.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/frozen_candidate_context.go` | Stops materializing every path from both immutable trees. |
| `internal/reviewtransaction/artifact_admission.go` | Resolves bounded reviewer references exactly against immutable trees with per-admission caching. |
| compact capture/reopen paths | Carry the immutable lookup boundary through native admission and replay. |
| focused CLI and transaction tests | Cover oversized repositories, valid supporting paths, fabricated paths, and legacy bindings. |

---

## 🧪 Test Plan

**Unit and integration tests**

```bash
go test ./internal/reviewtransaction -count=1
go test ./internal/cli -count=1
go test ./... -count=1
scripts/deadcode-ratchet.sh
```

**Go format and diff integrity**

```bash
go run ./internal/gofmtcheck
git diff --check
```

**Benchmark module**

```bash
cd bench
go build ./...
go vet ./...
go test ./... -count=1
```

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass in CI
- [x] Manually exercised the >4 MiB repository-path regression
- [x] Benchmark validation passes

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Candidate review recovery and scalable admission |
| Tracker PR | Not needed |
| Position | 2 of 2 |
| Base | `main` |
| Depends on | #2046, merged before publication |
| Follow-up | None |
| Review budget | 398 / 400 changed lines |
| Starts at | Merge commit `30cd2aad` from #2046 |
| Ends with | Repository-size-independent immutable evidence path admission |

### Chain Overview

```text
main
 └── #2046 Candidate decline authorization ✅ merged
      └── 📍 This PR: scalable immutable path admission
```

### Scope

- Includes: replacement of repository-wide path enumeration with exact bounded-reference validation.
- Excludes: candidate-decline behavior delivered by #2046 and unrelated review lifecycle changes.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover the work unit

---

## 🤖 Automated Checks

CI remains authoritative for supported-platform E2E and runtime coverage.

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #2058
- [x] PR stays within the 400 changed-line review budget
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass in CI
- [x] Benchmark validation completed
- [x] Documentation is not required; behavior and contract remain unchanged
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Please focus on the fail-closed population boundary: path-like evidence and proof references must resolve against at least one exact immutable tree, never the live worktree. The lookup cache is scoped to one admission request, and the changed-path manifest retains its existing independent 4 MiB bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review artifact admission for large repositories by validating repository references against immutable repository state at admission time.
  * Enhanced reliability by propagating execution context consistently through review capture, revalidation, and reopening.
  * Tightened evidence handling so invalid repository reference evidence is rejected, while valid immutable references are accepted.

* **Tests**
  * Added integration coverage for negotiated review starts on large repositories (large inventories), including acceptance/rejection scenarios for immutable-tree references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->