### PR TITLE
docs(opencode): document readonly task workaround

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -107,6 +107,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - Multi-mode prerequisite: connect your AI providers first, then run `opencode models --refresh`
 - Gentle AI sets OpenCode SDD agent sharing to `disabled` by default for privacy; existing user-managed `share` values such as `manual` or `auto` are preserved.
 - OpenCode Desktop SDD commands resolve the project with `git rev-parse --show-toplevel || pwd` before acting, avoiding Electron current-working-directory drift.
+- If review launch fails with `Attempted to assign to readonly property`, follow the [OpenCode readonly task-argument recovery](review-integration.md#restart-opencode-after-a-readonly-task-argument-failure).
 
 ### Kilo Code
 

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -136,6 +136,26 @@ Reviewer results must echo the exact `subject_hash` and report structured `inspe
 
 The managed OpenCode result-artifact plugin replaces caller-authored task prose with the provider-issued binding and preflight context. It validates the subject, trees, lens slot, and canonical ordered manifest before launching the reviewer; it never transports a patch or candidate bytes. OpenCode reviewers receive only the narrow read-only Git allowlist above. Managed runtimes that cannot enforce that per-command boundary receive no shell and must report incomplete inspection rather than substitute live files or receive an inline patch fallback.
 
+### Restart OpenCode after a readonly task-argument failure
+
+If OpenCode reports `Attempted to assign to readonly property` while launching a Gentle AI reviewer, fully quit OpenCode and restart it with the parent experimental flag disabled:
+
+```bash
+OPENCODE_EXPERIMENTAL=false opencode
+```
+
+You may reopen the same persisted OpenCode session. Then refresh native review authority:
+
+```bash
+gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --next-transition
+```
+
+Follow only the refreshed `next_transition` and relaunch only the exact pending slot it reoffers. With `OPENCODE_EXPERIMENTAL=true`, OpenCode's v2 event system can freeze task arguments before Gentle AI's `tool.execute.before` hook injects the reviewer prompt. The launch then produces no reviewer result, so the native slot remains pending.
+
+Setting only `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM=false` is insufficient while the parent `OPENCODE_EXPERIMENTAL` flag remains true. Do not use `OPENCODE_PURE=1` for this recovery: it disables the Gentle AI plugin required for reviewer capture.
+
+The behavior is tracked in [upstream issue #25873](https://github.com/anomalyco/opencode/issues/25873). [Proposed fix PR #25867](https://github.com/anomalyco/opencode/pull/25867) closed without merge, so it does not establish that OpenCode has fixed the issue.
+
 Durable controllers capture each result with exact lineage, target, lens, selected order, authority revision, and provider-issued repository context. Current captures emit pathless manifests with opaque references; the provider can discover every canonical result with `--captured-results`, or controllers can write each emitted manifest to its own file and pass those files to FINALIZE in selected-lens order with repeatable `--result-artifact-file <path>` flags. A `--result-artifact-file -` occurrence reads exactly one manifest from stdin; because FINALIZE has one shared stdin, `-` may appear only once across reviewer results, artifact manifests, validation, refuter outcomes, and evidence.
 
 Windows PowerShell 5.1 should use file transport because native argument reconstruction does not preserve dynamic inline JSON reliably. Write BOM-less UTF-8 so the strict JSON decoder receives the manifest bytes directly:


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2065

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Documents the confirmed `OPENCODE_EXPERIMENTAL=false opencode` workaround for readonly reviewer-task failures.
- Explains full-process restart, same-session recovery, and exact native STATUS refresh.
- Warns against ineffective or destructive alternatives and links the unresolved upstream OpenCode defect.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `docs/review-integration.md` | Adds action-first OpenCode readonly-task troubleshooting and recovery. |
| `docs/agents.md` | Adds a discoverability link from the OpenCode agent notes. |

---

## 🧪 Test Plan

- [x] Structural readback completed
- [x] Local path and GFM anchor validated
- [x] Upstream issue and closed PR links verified
- [x] Focused review documentation guards pass
- [x] `git diff --check` passes
- [x] Runtime/E2E validation is N/A for this passive documentation-only change

The broader `scripts/test-review-contract-package.sh` currently fails against pre-existing inventory drift unrelated to these two documentation files.

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #2065
- [x] PR stays within the 400 changed-line review budget
- [x] Exactly one `type:*` label will be applied
- [x] Documentation validation passes for the changed contract text
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Review the quick path first. It intentionally recommends disabling the parent experimental flag and restarting OpenCode, not pure mode, because pure mode also disables the Gentle AI review plugin required for capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for recovering from readonly task-argument errors when launching AI reviews.
  * Documented the required restart and session-recovery steps, including how to refresh review status and relaunch pending reviews.
  * Clarified environment-variable limitations and linked to relevant upstream OpenCode resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->