### PR TITLE
fix(review): make admission recovery actionable

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -502,11 +502,12 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 		// envelope that `review capture-result --input` would reject on replay.
 		`result = reviewerResult(output.output)`,
 		`output.output = await captureResult(cwd, binding, result)`,
-		`throw await preservedCaptureFailure(cwd, binding, result, cause)`,
+		`throw await preservedCaptureFailure(cwd, binding, result, cause, admissionRecoveries)`,
 		// Envelope extraction itself can fail; only then is the raw envelope
 		// preserved, under a distinct extraction-failure cause.
 		`throw await preservedCaptureFailure(cwd, binding, output.output, cause)`,
-		`function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: string): string`,
+		`function sessionErrorMessage(`,
+		`admissionRecoveries?: Set<string>`,
 		`sessionErrorMessage(binding, cause, "repository_context_preflight_failed")`,
 		`parsed.reference`,
 		`raw reviewer result preserved for recovery`,

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -16,6 +16,11 @@ type ReviewBinding = {
   subject_hash?: string
 }
 
+type AdmissionRejection = {
+  decision: string
+  diagnostic?: { reason: "finding_location_invalid"; finding_id: string; location: string }
+}
+
 interface ReviewArtifactSubject {
   schema: string
   subject_hash: string
@@ -279,25 +284,58 @@ function gitTrustRefusal(binding: ReviewBinding, cause: unknown): boolean {
 
 // ADMISSION_REJECTION matches the typed decision the native CLI emits when it
 // refused the reviewer RESULT itself (`reviewer artifact admission <decision>:`
-// from internal/cli/review_artifact.go). Only the [a-z_]+ decision token is
-// forwarded — never the native diagnostic, which can embed payload text — so
-// the opaque path keeps its rule that no native prose reaches the transcript.
+// from internal/cli/review_artifact.go). Only the [a-z_]+ decision token and a
+// strictly validated malformed-location diagnostic are forwarded. All other
+// native diagnostic prose stays opaque because it can embed payload text.
 // Without this, an invalid result collapsed into "retry the same opaque
 // binding", advice that deterministically fails: recapturing identical bytes
 // can never satisfy admission, only a relaunched reviewer can.
-const ADMISSION_REJECTION = /\breviewer artifact admission ([a-z_]+):/
+const ADMISSION_REJECTION = /\breviewer artifact admission ([a-z_]+):(?: (\{[^\r\n]*\}))?/
 
-function admissionRejection(cause: unknown): string | undefined {
+function admissionRejection(cause: unknown): AdmissionRejection | undefined {
   const match = ADMISSION_REJECTION.exec(errorMessage(cause))
-  return match ? match[1] : undefined
+  if (!match) return undefined
+  const rejection: AdmissionRejection = { decision: match[1] }
+  if (!match[2]) return rejection
+  try {
+    const value = JSON.parse(match[2]) as Record<string, unknown>
+    if (Object.keys(value).sort().join(",") === "finding_id,location,reason" &&
+        value.reason === "finding_location_invalid" &&
+        typeof value.finding_id === "string" && /^[A-Za-z0-9._-]+$/.test(value.finding_id) &&
+        typeof value.location === "string" && value.location.length <= 1024 && !/[\r\n]/.test(value.location)) {
+      rejection.diagnostic = value as AdmissionRejection["diagnostic"]
+    }
+  } catch {
+    // Unrecognized native diagnostics remain opaque.
+  }
+  return rejection
 }
 
-function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: string): string {
+function recoveryKey(binding: ReviewBinding): string {
+  return `${binding.lineage}\0${binding.target}\0${binding.lens}\0${binding.order}`
+}
+
+function sessionErrorMessage(
+  binding: ReviewBinding, cause: unknown, code: string, admissionRecoveries?: Set<string>,
+): string {
   if (!binding.repository_context) return errorMessage(cause)
   if (gitTrustRefusal(binding, cause)) return GIT_TRUST_REFUSAL_MESSAGE
   const admission = admissionRejection(cause)
   if (admission) {
-    return `${code}: native admission rejected the reviewer result as ${admission}; ` +
+    if (admissionRecoveries) {
+      const key = recoveryKey(binding)
+      if (admissionRecoveries.has(key)) {
+        return `reviewer_admission_recovery_unavailable: corrected reviewer result was rejected as ${admission.decision}; ` +
+          "the single admission recovery relaunch is exhausted; stop relaunching this lens and surface the terminal failure"
+      }
+      if (admission.diagnostic) {
+        admissionRecoveries.add(key)
+        return `${code}: native admission rejected finding ${admission.diagnostic.finding_id} because location ` +
+          `${JSON.stringify(admission.diagnostic.location)} is malformed; use one repo-relative path followed by a final colon ` +
+          "and one positive integer line (for example path/to/file.go:207), then relaunch this lens reviewer exactly once"
+      }
+    }
+    return `${code}: native admission rejected the reviewer result as ${admission.decision}; ` +
       "retrying capture with the same result cannot succeed; relaunch this lens reviewer to produce a corrected result"
   }
   return `${code}: provider-owned review operation failed; refresh the exact native next_transition or retry the same opaque binding`
@@ -325,8 +363,10 @@ function embeddedRawPayload(raw: string): string {
   return `${raw.slice(0, PRESERVE_EMBED_LIMIT)}\n[truncated: first ${PRESERVE_EMBED_LIMIT} of ${raw.length} characters embedded]`
 }
 
-async function preservedCaptureFailure(cwd: string, binding: ReviewBinding, raw: unknown, cause: unknown): Promise<Error> {
-  const captureFailure = sessionErrorMessage(binding, cause, "repository_context_capture_failed")
+async function preservedCaptureFailure(
+  cwd: string, binding: ReviewBinding, raw: unknown, cause: unknown, admissionRecoveries?: Set<string>,
+): Promise<Error> {
+  const captureFailure = sessionErrorMessage(binding, cause, "repository_context_capture_failed", admissionRecoveries)
   if (typeof raw !== "string" || raw.trim() === "") {
     return new Error(`${captureFailure}; no raw reviewer result was available to preserve`)
   }
@@ -349,47 +389,50 @@ async function preservedCaptureFailure(cwd: string, binding: ReviewBinding, raw:
   }
 }
 
-const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => ({
-  "tool.execute.before": async (input, output) => {
-    if (input.tool !== "task" || typeof output.args?.subagent_type !== "string" ||
-        !REVIEW_AGENTS.has(output.args.subagent_type)) return
-    if (typeof output.args.prompt !== "string") {
-      throw new Error("review task is missing GENTLE_AI_REVIEW_BINDING")
-    }
-    if (output.args.background === true) {
-      throw new Error("bound review tasks must run in the foreground for native result capture")
-    }
-    output.args.prompt = await injectReviewerContext(
-      output.args.prompt,
-      output.args.subagent_type,
-      captureCwd(worktree, directory),
-    )
-  },
-  "tool.execute.after": async (input, output) => {
-    if (input.tool !== "task" || typeof input.args?.subagent_type !== "string" || !REVIEW_AGENTS.has(input.args.subagent_type)) return
-    if (typeof input.args.prompt !== "string" || !BINDING.test(input.args.prompt)) return
-    const lens = input.args.subagent_type
-    const binding = parseBinding(input.args.prompt, lens)
-    const cwd = captureCwd(worktree, directory)
-    // Extract the replayable payload exactly once, BEFORE capture: recovery
-    // re-runs `review capture-result --input <preserved file>`, whose strict
-    // decoder rejects the task envelope, so a capture failure must preserve
-    // the extracted strict JSON — never the enveloped output.output.
-    let result: string
-    try {
-      result = reviewerResult(output.output)
-    } catch (cause) {
-      // Extraction itself failed (malformed envelope): there is no extracted
-      // payload, so preserve the raw envelope under the distinct extraction
-      // cause for manual inspection.
-      throw await preservedCaptureFailure(cwd, binding, output.output, cause)
-    }
-    try {
-      output.output = await captureResult(cwd, binding, result)
-    } catch (cause) {
-      throw await preservedCaptureFailure(cwd, binding, result, cause)
-    }
-  },
-})
+const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => {
+  const admissionRecoveries = new Set<string>()
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "task" || typeof output.args?.subagent_type !== "string" ||
+          !REVIEW_AGENTS.has(output.args.subagent_type)) return
+      if (typeof output.args.prompt !== "string") {
+        throw new Error("review task is missing GENTLE_AI_REVIEW_BINDING")
+      }
+      if (output.args.background === true) {
+        throw new Error("bound review tasks must run in the foreground for native result capture")
+      }
+      output.args.prompt = await injectReviewerContext(
+        output.args.prompt,
+        output.args.subagent_type,
+        captureCwd(worktree, directory),
+      )
+    },
+    "tool.execute.after": async (input, output) => {
+      if (input.tool !== "task" || typeof input.args?.subagent_type !== "string" || !REVIEW_AGENTS.has(input.args.subagent_type)) return
+      if (typeof input.args.prompt !== "string" || !BINDING.test(input.args.prompt)) return
+      const lens = input.args.subagent_type
+      const binding = parseBinding(input.args.prompt, lens)
+      const cwd = captureCwd(worktree, directory)
+      // Extract the replayable payload exactly once, BEFORE capture: recovery
+      // re-runs `review capture-result --input <preserved file>`, whose strict
+      // decoder rejects the task envelope, so a capture failure must preserve
+      // the extracted strict JSON — never the enveloped output.output.
+      let result: string
+      try {
+        result = reviewerResult(output.output)
+      } catch (cause) {
+        // Extraction itself failed (malformed envelope): there is no extracted
+        // payload, so preserve the raw envelope under the distinct extraction
+        // cause for manual inspection.
+        throw await preservedCaptureFailure(cwd, binding, output.output, cause)
+      }
+      try {
+        output.output = await captureResult(cwd, binding, result)
+      } catch (cause) {
+        throw await preservedCaptureFailure(cwd, binding, result, cause, admissionRecoveries)
+      }
+    },
+  }
+}
 
 export default ReviewResultArtifactsPlugin

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -125,6 +125,47 @@ func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, na
 	return strings.TrimSpace(string(output))
 }
 
+func runReviewPluginDiagnosticScenario(t *testing.T, firstError, secondError string) string {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is unavailable")
+	}
+	source, err := Read("opencode/plugins/review-result-artifacts.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "plugin.mts"), []byte(source+"\nexport { sessionErrorMessage }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	harness := `import { sessionErrorMessage } from "./plugin.mts"
+const binding = {
+  lens: "review-risk", lineage: "trust-check", order: 0,
+  repository_context: "rctx1_" + "a".repeat(64),
+  revision: "sha256:" + "b".repeat(64), target: "sha256:" + "d".repeat(64),
+}
+const recoveries = new Set<string>()
+console.log(sessionErrorMessage(binding, new Error(process.env.GENTLE_AI_STUB_STDERR_FIRST), "repository_context_capture_failed", recoveries))
+console.log("---")
+console.log(sessionErrorMessage(binding, new Error(process.env.GENTLE_AI_STUB_STDERR_SECOND), "repository_context_capture_failed", recoveries))
+`
+	if err := os.WriteFile(filepath.Join(root, "harness.mts"), []byte(harness), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(node, "harness.mts")
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"GENTLE_AI_STUB_STDERR_FIRST="+firstError,
+		"GENTLE_AI_STUB_STDERR_SECOND="+secondError,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node could not execute plugin diagnostics (%v): %s", err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
 func TestReviewPluginRejectsInvalidBindingBeforeReviewerLaunch(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -339,6 +380,29 @@ func TestReviewPluginKeepsIncompleteAdmissionRecoveryNeutral(t *testing.T) {
 	}
 	if strings.Contains(message, reviewPluginPayloadMarker) {
 		t.Fatalf("incomplete admission leaked the rejected reviewer payload: %s", message)
+	}
+}
+
+func TestReviewPluginBoundsMalformedLocationRecovery(t *testing.T) {
+	first := `Error: reviewer artifact admission incomplete: {"reason":"finding_location_invalid","finding_id":"R1-007","location":"internal/review.go:207-221"}`
+	secondMarker := "SECOND-NATIVE-DIAGNOSTIC-MUST-STAY-OPAQUE"
+	second := "Error: reviewer artifact admission out_of_scope: " + secondMarker
+	message := runReviewPluginDiagnosticScenario(t, first, second)
+	parts := strings.Split(message, "\n---\n")
+	if len(parts) != 2 {
+		t.Fatalf("recovery attempts = %q", message)
+	}
+	for _, want := range []string{"R1-007", `internal/review.go:207-221`, "path/to/file.go:207", "exactly once"} {
+		if !strings.Contains(parts[0], want) {
+			t.Fatalf("first recovery omitted %q: %s", want, parts[0])
+		}
+	}
+	if !strings.Contains(parts[1], "reviewer_admission_recovery_unavailable") ||
+		!strings.Contains(parts[1], "single admission recovery relaunch is exhausted") {
+		t.Fatalf("second recovery was not terminal: %s", parts[1])
+	}
+	if strings.Contains(parts[1], secondMarker) {
+		t.Fatalf("terminal recovery leaked native diagnostic prose: %s", parts[1])
 	}
 }
 

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -165,6 +165,22 @@ type admittedReviewerResult struct {
 	Result    facadeReviewerResult                `json:"result"`
 }
 
+type reviewerAdmissionDiagnostic struct {
+	Reason    string `json:"reason"`
+	FindingID string `json:"finding_id"`
+	Location  string `json:"location"`
+}
+
+type reviewerAdmissionDiagnosticError struct {
+	Decision   reviewtransaction.ArtifactAdmissionDecision
+	Diagnostic reviewerAdmissionDiagnostic
+}
+
+func (err *reviewerAdmissionDiagnosticError) Error() string {
+	payload, _ := json.Marshal(err.Diagnostic)
+	return fmt.Sprintf("reviewer artifact admission %s: %s", err.Decision, payload)
+}
+
 type capturedArtifactBinding struct {
 	Subject   reviewtransaction.ArtifactSubject
 	Admission reviewtransaction.ArtifactAdmission
@@ -891,6 +907,15 @@ func verifiedCandidateCausalFindingIDs(ctx context.Context, repo string, snapsho
 		case reviewtransaction.CausalIntroduced, reviewtransaction.CausalBehaviorActivated, reviewtransaction.CausalWorsened:
 			changed, err := builder.CandidateLocationSupportsCausality(ctx, snapshot, finding.Location, finding.CausalDisposition)
 			if err != nil {
+				var locationErr *reviewtransaction.FindingLocationError
+				if errors.As(err, &locationErr) {
+					return nil, &reviewerAdmissionDiagnosticError{
+						Decision: reviewtransaction.ArtifactAdmissionIncomplete,
+						Diagnostic: reviewerAdmissionDiagnostic{
+							Reason: reviewtransaction.FindingLocationInvalidReason, FindingID: finding.ID, Location: locationErr.Location,
+						},
+					}
+				}
 				return nil, fmt.Errorf("verify candidate causality for finding %q: %w", finding.ID, err)
 			}
 			if changed {

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -150,6 +150,42 @@ func TestReviewCaptureResultRejectsSemanticAdmissionBeforePublication(t *testing
 	}
 }
 
+func TestReviewCaptureResultReportsMalformedCausalFindingLocation(t *testing.T) {
+	for _, location := range []string{"tracked.txt:1-2", "tracked.txt:+1", "tracked.txt"} {
+		t.Run(location, func(t *testing.T) {
+			repo, started, store, record := newArtifactReview(t, false)
+			lens := record.State.SelectedLenses[0]
+			prefix := map[string]string{
+				reviewtransaction.LensRisk: "R1-", reviewtransaction.LensReadability: "R2-",
+				reviewtransaction.LensReliability: "R3-", reviewtransaction.LensResilience: "R4-",
+			}[lens]
+			result := admittedReviewerResultForTest(t, repo, record, lens, 0)
+			result.Findings = []facadeFinding{{
+				ID: prefix + "001", Location: location, Severity: "CRITICAL", Claim: "candidate defect",
+				ProofRefs: []string{"tracked.txt:1 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+				CausalDisposition: reviewtransaction.CausalIntroduced,
+			}}
+			input := filepath.Join(t.TempDir(), "result.json")
+			writeReviewCLIJSON(t, input, result)
+			err := RunReviewCaptureResult([]string{
+				"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+				"--lens", lens, "--order", "0", "--input", input,
+			}, io.Discard)
+			var diagnostic *reviewerAdmissionDiagnosticError
+			if !errors.As(err, &diagnostic) || diagnostic.Decision != reviewtransaction.ArtifactAdmissionIncomplete ||
+				diagnostic.Diagnostic != (reviewerAdmissionDiagnostic{
+					Reason: reviewtransaction.FindingLocationInvalidReason, FindingID: prefix + "001", Location: location,
+				}) {
+				t.Fatalf("capture error = %#v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir)); !os.IsNotExist(statErr) {
+				t.Fatalf("malformed location consumed the immutable result slot: %v", statErr)
+			}
+			assertArtifactRevision(t, store, record.Revision)
+		})
+	}
+}
+
 func TestReviewCaptureResultPublishesExternalRepositoryProofExactlyOnce(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "support.go"), []byte("package support\n"), 0o644); err != nil {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -2628,9 +2628,16 @@ func TestSnapshotCandidateLocationSupportsStructuredCausality(t *testing.T) {
 		location  string
 		causality CausalDisposition
 		want      bool
-	}{{"introduced replacement", "tracked.txt:2", CausalIntroduced, true}, {"introduced addition", "tracked.txt:5", CausalIntroduced, true}, {"introduced deletion", "deleted.txt:1", CausalIntroduced, false}, {"old-side deletion collision", "tracked.txt:4", CausalIntroduced, false}, {"introduced unchanged", "tracked.txt:1", CausalIntroduced, false}, {"worsened changed", "tracked.txt:2", CausalWorsened, true}, {"worsened unchanged", "tracked.txt:1", CausalWorsened, false}, {"activated unchanged", "tracked.txt:1", CausalBehaviorActivated, true}, {"activated deletion", "deleted.txt:1", CausalBehaviorActivated, false}, {"activated out of range", "tracked.txt:99", CausalBehaviorActivated, false}, {"outside genesis", "other.txt:1", CausalBehaviorActivated, false}, {"zero", "tracked.txt:0", CausalIntroduced, false}, {"malformed", "tracked.txt", CausalWorsened, false}} {
+	}{{"introduced replacement", "tracked.txt:2", CausalIntroduced, true}, {"introduced addition", "tracked.txt:5", CausalIntroduced, true}, {"introduced deletion", "deleted.txt:1", CausalIntroduced, false}, {"old-side deletion collision", "tracked.txt:4", CausalIntroduced, false}, {"introduced unchanged", "tracked.txt:1", CausalIntroduced, false}, {"worsened changed", "tracked.txt:2", CausalWorsened, true}, {"worsened unchanged", "tracked.txt:1", CausalWorsened, false}, {"activated unchanged", "tracked.txt:1", CausalBehaviorActivated, true}, {"activated deletion", "deleted.txt:1", CausalBehaviorActivated, false}, {"activated out of range", "tracked.txt:99", CausalBehaviorActivated, false}, {"outside genesis", "other.txt:1", CausalBehaviorActivated, false}, {"zero", "tracked.txt:0", CausalIntroduced, false}, {"range", "tracked.txt:2-4", CausalIntroduced, false}, {"leading plus", "tracked.txt:+1", CausalIntroduced, false}, {"missing colon", "tracked.txt", CausalWorsened, false}} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := (SnapshotBuilder{Repo: repo}).CandidateLocationSupportsCausality(context.Background(), snapshot, tt.location, tt.causality)
+			if tt.name == "zero" || tt.name == "range" || tt.name == "leading plus" || tt.name == "missing colon" {
+				var locationErr *FindingLocationError
+				if got || !errors.As(err, &locationErr) || locationErr.Location != tt.location {
+					t.Fatalf("CandidateLocationSupportsCausality(%q, %q) = %t, %#v", tt.location, tt.causality, got, err)
+				}
+				return
+			}
 			if err != nil || got != tt.want {
 				t.Fatalf("CandidateLocationSupportsCausality(%q, %q) = %t, %v", tt.location, tt.causality, got, err)
 			}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -63,6 +63,16 @@ type SnapshotBuilder struct {
 	unbornHead bool
 }
 
+const FindingLocationInvalidReason = "finding_location_invalid"
+
+type FindingLocationError struct {
+	Location string
+}
+
+func (err *FindingLocationError) Error() string {
+	return "finding location must end with a positive integer line after its final colon"
+}
+
 var exactObjectPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$`)
 
 func (builder SnapshotBuilder) Build(ctx context.Context, target Target) (Snapshot, error) {
@@ -310,12 +320,16 @@ func (builder SnapshotBuilder) CandidateLocationSupportsCausality(ctx context.Co
 	if err := builder.ValidateEvidence(ctx, snapshot); err != nil {
 		return false, err
 	}
-	separator := strings.LastIndex(location, ":")
+	logicalPath, line, err := parseCandidateFindingLocation(location)
+	if err != nil {
+		if stringIndex(snapshot.Paths, logicalPath) >= 0 {
+			return false, err
+		}
+		return false, nil
+	}
 	if !findingLocationInGenesis(location, snapshot.Paths) {
 		return false, nil
 	}
-	logicalPath := location[:separator]
-	line, _ := strconv.Atoi(location[separator+1:])
 	if causality == CausalBehaviorActivated {
 		entry, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", snapshot.CandidateTree, "--", literalPathspec(logicalPath))
 		if err != nil || len(entry) == 0 {
@@ -355,6 +369,28 @@ func (builder SnapshotBuilder) CandidateLocationSupportsCausality(ctx context.Co
 		}
 	}
 	return false, nil
+}
+
+func parseCandidateFindingLocation(location string) (string, int, error) {
+	separator := strings.LastIndex(location, ":")
+	logicalPath := location
+	if separator >= 0 {
+		logicalPath = location[:separator]
+	}
+	if separator <= 0 || separator == len(location)-1 {
+		return logicalPath, 0, &FindingLocationError{Location: location}
+	}
+	lineText := location[separator+1:]
+	for index := range lineText {
+		if lineText[index] < '0' || lineText[index] > '9' {
+			return logicalPath, 0, &FindingLocationError{Location: location}
+		}
+	}
+	line, err := strconv.Atoi(lineText)
+	if err != nil || line <= 0 {
+		return logicalPath, 0, &FindingLocationError{Location: location}
+	}
+	return logicalPath, line, nil
 }
 
 func rebuildCurrentSnapshotEvidence(ctx context.Context, repo string, snapshot Snapshot) error {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -49,6 +49,37 @@ func TestCanonicalPathsRejectsDuplicateInput(t *testing.T) {
 	}
 }
 
+func TestParseCandidateFindingLocation(t *testing.T) {
+	tests := []struct {
+		name, location, wantPath string
+		wantLine                 int
+		wantErr                  bool
+	}{
+		{name: "single line", location: "internal/review.go:207", wantPath: "internal/review.go", wantLine: 207},
+		{name: "final colon after drive", location: `C:\repo\review.go:12`, wantPath: `C:\repo\review.go`, wantLine: 12},
+		{name: "range", location: "internal/review.go:207-221", wantPath: "internal/review.go", wantErr: true},
+		{name: "leading plus", location: "internal/review.go:+1", wantPath: "internal/review.go", wantErr: true},
+		{name: "zero", location: "internal/review.go:0", wantPath: "internal/review.go", wantErr: true},
+		{name: "missing line", location: "internal/review.go:", wantPath: "internal/review.go", wantErr: true},
+		{name: "missing colon", location: "internal/review.go", wantPath: "internal/review.go", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, line, err := parseCandidateFindingLocation(tt.location)
+			if tt.wantErr {
+				var locationErr *FindingLocationError
+				if !errors.As(err, &locationErr) || locationErr.Location != tt.location || path != tt.wantPath {
+					t.Fatalf("parseCandidateFindingLocation(%q) = %q, %d, %#v", tt.location, path, line, err)
+				}
+				return
+			}
+			if err != nil || path != tt.wantPath || line != tt.wantLine {
+				t.Fatalf("parseCandidateFindingLocation(%q) = %q, %d, %v", tt.location, path, line, err)
+			}
+		})
+	}
+}
+
 func TestSnapshotBuilderCurrentChangesIsCompleteAndPreservesRealIndex(t *testing.T) {
 	if testing.Short() {
 		t.Skip("uses real git commands")


### PR DESCRIPTION
## Linked Issue

Closes #2028

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)

---

## Summary

- Reject malformed candidate-causal finding locations with a safe typed diagnostic instead of silently dropping the finding.
- Relay allowlisted location details so the OpenCode adapter can request one corrected reviewer result.
- Stop after that single recovery relaunch with a typed terminal message, preserving opaque payload and frozen-authority boundaries.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Parse the final location colon strictly and report typed malformed-location errors. |
| `internal/cli` | Convert malformed causal locations into safe structured admission diagnostics. |
| `internal/assets` | Bound actionable plugin recovery to one relaunch and add executable regression coverage. |

---

## Test Plan

**Focused tests**
- [x] Candidate location parsing and causal admission tests pass.
- [x] Capture-result malformed-location diagnostic tests pass.
- [x] Embedded OpenCode plugin recovery tests pass.
- [x] `go test ./internal/assets -count=1`
- [x] `go vet ./internal/assets ./internal/cli ./internal/reviewtransaction`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`

**Broader validation**
- [ ] `go test ./...` - bounded Windows runs exceeded five minutes; focused affected-package coverage passed.
- [ ] E2E Docker suite - not run; this change is isolated to reviewer-result admission and the embedded plugin.
- [ ] Benchmark suite - build and vet passed, but Windows fake-executable tests are not portable and focused journey j12 is not semantically representative of malformed-location plugin recovery.

**Runtime harness**
- [x] Node-backed plugin harness proved one actionable relaunch followed by `reviewer_admission_recovery_unavailable`, without native diagnostic leakage.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is required; contributor permissions prevented applying `type:bug`
- [ ] Full unit suite passes (`go test ./...`) - see bounded-run note above
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass - not applicable to this isolated admission/plugin change
- [ ] Benchmark validation completed - attempted; platform and applicability limitations documented above
- [x] Documentation is not required; the user-facing recovery guidance is covered by executable asset tests
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The qualifying integrity/admission guard is the candidate-causal location parser. Its legitimate population is frozen genesis paths with a final positive integer line. The change keeps out-of-genesis findings non-admitted, reports malformed locations only when their logical path is in the frozen changed-path population, and does not modify `.guard-population-baseline.txt`.

Please pay particular attention to the diagnostic allowlist and the process-local one-relaunch key (`lineage`, `target`, `lens`, `order`).
