### PR TITLE
feat(review): scope the RDD kill switch per worktree

### DIFF
--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -21,27 +21,33 @@ import (
 const ReviewModeSchema = "gentle-ai.review-mode/v1"
 
 const (
-	reviewModeScopeGlobal = "global"
-	reviewModeScopeClone  = "clone"
-	reviewModeScopeBoth   = "both"
+	reviewModeScopeGlobal   = "global"
+	reviewModeScopeClone    = "clone"
+	reviewModeScopeWorktree = "worktree"
+	reviewModeScopeBoth     = "both"
 )
 
 // ReviewModeResult reports what the command did and the resulting effective
-// mode with both of its sources. It carries no review outcome.
+// mode with both of its sources. It carries no review outcome. BlastRadius is
+// informational and only present when a clone-local override lives under a Git
+// common directory shared with other worktree checkouts.
 type ReviewModeResult struct {
-	Schema    string                          `json:"schema"`
-	Operation string                          `json:"operation"`
-	Scope     string                          `json:"scope"`
-	Status    reviewtransaction.RDDModeStatus `json:"status"`
+	Schema      string                          `json:"schema"`
+	Operation   string                          `json:"operation"`
+	Scope       string                          `json:"scope"`
+	Status      reviewtransaction.RDDModeStatus `json:"status"`
+	BlastRadius int                             `json:"blast_radius,omitempty"`
 }
 
 // RunReviewMode is the user-controlled receipt-driven-development kill switch.
 // The global mode lives in uncommitted user state; the clone-local override
-// lives under this clone's Git common directory and can only disable. Any off
-// wins, status never mutates, and re-enabling applies to future candidates only.
+// lives under this clone's Git common directory and the worktree-local override
+// lives under a linked worktree's own Git directory, and both can only disable.
+// Any off wins, status never mutates, and re-enabling applies to future
+// candidates only.
 func RunReviewMode(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review mode <enable|disable|status> [--cwd <repo>] [--scope <global|clone>] [--expected-revision <revision>] [--json]")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review mode <enable|disable|status> [--cwd <repo>] [--scope <global|clone|worktree>] [--expected-revision <revision>] [--json]")
 		_, _ = fmt.Fprintln(stdout, "User-owned kill switch. Any off wins: a repository may disable receipt-driven development for this clone but can never require it, and no other clone inherits the override. status is read-only and reports both sources plus the effective mode. Re-enabling applies to future candidates only.")
 		return nil
 	}
@@ -54,8 +60,8 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 
 	flags := newReviewFlagSet("review mode "+operation, stdout, "Read or set the user-controlled receipt-driven-development kill switch.")
 	cwd := flags.String("cwd", ".", "repository path")
-	scope := flags.String("scope", reviewModeScopeGlobal, "mode source to write: global or clone")
-	expectedRevision := flags.String("expected-revision", "", "exact clone-local revision this write replaces")
+	scope := flags.String("scope", reviewModeScopeGlobal, "mode source to write: global, clone, or worktree")
+	expectedRevision := flags.String("expected-revision", "", "exact local-override revision this write replaces (clone or worktree scope)")
 	emitJSON := flags.Bool("json", false, "emit the machine-readable review mode result")
 	if err := parseReviewFlags(flags, args[1:]); err != nil {
 		return err
@@ -68,7 +74,7 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 	}
 	selectedScope := strings.TrimSpace(*scope)
 	switch selectedScope {
-	case reviewModeScopeGlobal, reviewModeScopeClone:
+	case reviewModeScopeGlobal, reviewModeScopeClone, reviewModeScopeWorktree:
 	default:
 		return fmt.Errorf("unknown review mode scope %q", *scope)
 	}
@@ -85,6 +91,14 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 	if operation == "status" {
 		result.Scope = reviewModeScopeBoth
 		result.Status, err = reviewModeStatus(ctx, *cwd)
+		if err == nil && result.Status.Source == reviewtransaction.RDDModeSourceCloneLocal {
+			// A clone-local override lives under the shared Git common
+			// directory, so it may also govern every linked worktree. The
+			// announcement is informational and never changes the mode.
+			if shared, radiusErr := reviewtransaction.LinkedWorktreeBlastRadius(ctx, *cwd); radiusErr == nil && shared > 0 {
+				result.BlastRadius = shared
+			}
+		}
 	} else {
 		result.Status, err = applyReviewMode(ctx, *cwd, operation, selectedScope, *expectedRevision, revisionProvided)
 	}
@@ -115,18 +129,22 @@ type ReviewModeUnreadableScope struct {
 }
 
 func (scope ReviewModeUnreadableScope) label() string {
-	if scope.Scope == reviewModeScopeClone {
+	switch scope.Scope {
+	case reviewModeScopeClone:
 		return "clone-local"
+	case reviewModeScopeWorktree:
+		return "worktree-local"
 	}
 	return "global"
 }
 
 // commands names the two invocations that overwrite this scope. Both are
-// complete as printed: the clone-local scope carries the repository it belongs
-// to, because a clone-local record is only reachable through its own clone.
+// complete as printed: the repository scopes carry the repository they belong
+// to, because a repository-scoped record is only reachable through its own
+// clone.
 func (scope ReviewModeUnreadableScope) commands() []string {
 	suffix := " --scope=" + scope.Scope
-	if scope.Scope == reviewModeScopeClone {
+	if scope.Scope == reviewModeScopeClone || scope.Scope == reviewModeScopeWorktree {
 		suffix += " --cwd " + scope.Repo
 	}
 	return []string{
@@ -201,11 +219,14 @@ func reviewModeUnreadable(
 			scopes = append(scopes, ReviewModeUnreadableScope{Scope: reviewModeScopeGlobal, Path: state.Path(home), Repo: repo})
 		}
 	}
-	// An unset global can never fail, so this isolates the clone-local source
-	// even when the global one already failed ahead of it.
+	// An unset global can never fail, so this isolates the repository-scoped
+	// sources even when the global one already failed ahead of it.
 	if _, cloneErr := reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{}); cloneErr != nil {
 		if path, pathErr := reviewtransaction.CloneLocalRDDModeRecordPath(ctx, repo); pathErr == nil && path != "" {
 			scopes = append(scopes, ReviewModeUnreadableScope{Scope: reviewModeScopeClone, Path: path, Repo: repo})
+		}
+		if path, pathErr := reviewtransaction.WorktreeLocalRDDModeRecordPath(ctx, repo); pathErr == nil && path != "" {
+			scopes = append(scopes, ReviewModeUnreadableScope{Scope: reviewModeScopeWorktree, Path: path, Repo: repo})
 		}
 	}
 	if len(scopes) == 0 {
@@ -272,19 +293,34 @@ func applyReviewMode(
 	}
 	mode := reviewtransaction.RDDModeOff
 	if operation == "enable" {
-		// The override is off-only, so enabling clears this clone's opinion
+		// The override is off-only, so enabling clears this scope's opinion
 		// instead of asserting on: a repository may never force review on.
 		mode = reviewtransaction.RDDModeUnset
 	}
 	if !revisionProvided {
-		// The compare-and-set token belongs to the clone-local source alone, so
-		// it is read with an unset global. Repairing this clone must not depend
-		// on the other source being readable, or a switch whose two records are
-		// both unreadable would have no repair command at all.
+		// The compare-and-set token belongs to the repository-scoped source
+		// alone, so it is read with an unset global. Repairing this scope must
+		// not depend on the other source being readable, or a switch whose two
+		// records are both unreadable would have no repair command at all.
 		current, resolveErr := reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
 		switch {
 		case resolveErr == nil:
 			expectedRevision = current.Revision
+			if scope == reviewModeScopeWorktree {
+				// On a linked worktree the write targets the private
+				// worktree-local head, whose token is WorktreeRevision. On the
+				// main checkout there is no distinct worktree-local storage, so
+				// the write targets the clone-local record and must carry its
+				// token.
+				lease, leaseErr := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
+				if leaseErr != nil {
+					return disabled, reviewModeUnreadable(ctx, repo, global, leaseErr)
+				}
+				identity := lease.Identity()
+				if identity.GitDir != identity.GitCommonDir {
+					expectedRevision = current.WorktreeRevision
+				}
+			}
 		case errors.Is(resolveErr, reviewtransaction.ErrRDDModeCorrupt):
 			// An unreadable head carries no revision to compare against, and
 			// replacing it is the whole point of this command.
@@ -292,6 +328,10 @@ func applyReviewMode(
 		default:
 			return disabled, reviewModeUnreadable(ctx, repo, global, resolveErr)
 		}
+	}
+	if scope == reviewModeScopeWorktree {
+		status, err := reviewtransaction.SetWorktreeLocalRDDMode(ctx, repo, mode, expectedRevision, global)
+		return status, reviewModeUnreadable(ctx, repo, global, err)
 	}
 	status, err := reviewtransaction.SetCloneLocalRDDMode(ctx, repo, mode, expectedRevision, global)
 	return status, reviewModeUnreadable(ctx, repo, global, err)
@@ -349,12 +389,23 @@ func emitReviewMode(stdout io.Writer, result ReviewModeResult, emitJSON bool) er
 	}
 	_, err := fmt.Fprintf(
 		stdout,
-		"receipt-driven development: %s (decided by %s)\n  global:      %s\n  clone-local: %s\n",
+		"receipt-driven development: %s (decided by %s)\n  %-14s %s\n  %-14s %s\n  %-14s %s\n",
 		reviewModeLabel(result.Status.Effective),
 		result.Status.Source,
-		reviewModeLabel(result.Status.Global),
-		reviewModeLabel(result.Status.CloneLocal),
+		"global:", reviewModeLabel(result.Status.Global),
+		"clone-local:", reviewModeLabel(result.Status.CloneLocal),
+		"worktree-local:", reviewModeLabel(result.Status.WorktreeLocal),
 	)
+	if err != nil {
+		return err
+	}
+	if result.BlastRadius > 0 {
+		_, err = fmt.Fprintf(
+			stdout,
+			"  note: %d other worktree checkout(s) share this clone-local override because it is stored under the shared Git common directory\n",
+			result.BlastRadius,
+		)
+	}
 	return err
 }
 

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -314,9 +314,9 @@ func applyReviewMode(
 			// keeps the storage-distinctness rule in one place.
 			token, tokenErr = reviewtransaction.WorktreeLocalRevision(ctx, repo)
 		} else {
-			var current reviewtransaction.RDDModeStatus
-			current, tokenErr = reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
-			token = current.Revision
+			// Scoped to clone-local storage alone, so an unreadable
+			// worktree-local record never blocks repairing this scope.
+			token, tokenErr = reviewtransaction.CloneLocalRevision(ctx, repo)
 		}
 		switch {
 		case tokenErr == nil:

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -48,7 +48,7 @@ type ReviewModeResult struct {
 func RunReviewMode(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
 		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review mode <enable|disable|status> [--cwd <repo>] [--scope <global|clone|worktree>] [--expected-revision <revision>] [--json]")
-		_, _ = fmt.Fprintln(stdout, "User-owned kill switch. Any off wins: a repository may disable receipt-driven development for this clone but can never require it, and no other clone inherits the override. status is read-only and reports both sources plus the effective mode. Re-enabling applies to future candidates only.")
+		_, _ = fmt.Fprintln(stdout, "User-owned kill switch. Any off wins: a repository may disable receipt-driven development for this clone but can never require it, and no other clone inherits the override. status is read-only and reports the effective mode plus all three sources (global, clone-local, worktree-local); the worktree scope isolates exactly one linked worktree. Re-enabling applies to future candidates only.")
 		return nil
 	}
 	operation := args[0]
@@ -91,10 +91,13 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 	if operation == "status" {
 		result.Scope = reviewModeScopeBoth
 		result.Status, err = reviewModeStatus(ctx, *cwd)
-		if err == nil && result.Status.Source == reviewtransaction.RDDModeSourceCloneLocal {
+		if err == nil && result.Status.CloneLocal == reviewtransaction.RDDModeOff {
 			// A clone-local override lives under the shared Git common
 			// directory, so it may also govern every linked worktree. The
-			// announcement is informational and never changes the mode.
+			// announcement is keyed on the clone-local state rather than the
+			// deciding source, so a worktree-local off shadowing the shared
+			// record still announces it. It is informational and never changes
+			// the mode.
 			if shared, radiusErr := reviewtransaction.LinkedWorktreeBlastRadius(ctx, *cwd); radiusErr == nil && shared > 0 {
 				result.BlastRadius = shared
 			}
@@ -302,31 +305,28 @@ func applyReviewMode(
 		// alone, so it is read with an unset global. Repairing this scope must
 		// not depend on the other source being readable, or a switch whose two
 		// records are both unreadable would have no repair command at all.
-		current, resolveErr := reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
+		var token string
+		var tokenErr error
+		if scope == reviewModeScopeWorktree {
+			// The worktree scope targets whatever storage the package resolves
+			// for this checkout: the worktree-local head on a linked worktree,
+			// and the clone-local head on the main checkout. Asking the package
+			// keeps the storage-distinctness rule in one place.
+			token, tokenErr = reviewtransaction.WorktreeLocalRevision(ctx, repo)
+		} else {
+			var current reviewtransaction.RDDModeStatus
+			current, tokenErr = reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
+			token = current.Revision
+		}
 		switch {
-		case resolveErr == nil:
-			expectedRevision = current.Revision
-			if scope == reviewModeScopeWorktree {
-				// On a linked worktree the write targets the private
-				// worktree-local head, whose token is WorktreeRevision. On the
-				// main checkout there is no distinct worktree-local storage, so
-				// the write targets the clone-local record and must carry its
-				// token.
-				lease, leaseErr := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
-				if leaseErr != nil {
-					return disabled, reviewModeUnreadable(ctx, repo, global, leaseErr)
-				}
-				identity := lease.Identity()
-				if identity.GitDir != identity.GitCommonDir {
-					expectedRevision = current.WorktreeRevision
-				}
-			}
-		case errors.Is(resolveErr, reviewtransaction.ErrRDDModeCorrupt):
+		case tokenErr == nil:
+			expectedRevision = token
+		case errors.Is(tokenErr, reviewtransaction.ErrRDDModeCorrupt):
 			// An unreadable head carries no revision to compare against, and
 			// replacing it is the whole point of this command.
 			expectedRevision = ""
 		default:
-			return disabled, reviewModeUnreadable(ctx, repo, global, resolveErr)
+			return disabled, reviewModeUnreadable(ctx, repo, global, tokenErr)
 		}
 	}
 	if scope == reviewModeScopeWorktree {

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -389,7 +389,7 @@ func emitReviewMode(stdout io.Writer, result ReviewModeResult, emitJSON bool) er
 	}
 	_, err := fmt.Fprintf(
 		stdout,
-		"receipt-driven development: %s (decided by %s)\n  %-14s %s\n  %-14s %s\n  %-14s %s\n",
+		"receipt-driven development: %s (decided by %s)\n  %-15s %s\n  %-15s %s\n  %-15s %s\n",
 		reviewModeLabel(result.Status.Effective),
 		result.Status.Source,
 		"global:", reviewModeLabel(result.Status.Global),

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -439,7 +439,7 @@ func emitReviewMode(stdout io.Writer, result ReviewModeResult, emitJSON bool) er
 	}
 	_, err := fmt.Fprintf(
 		stdout,
-		"receipt-driven development: %s (decided by %s)\n  %-14s %s\n  %-14s %s\n  %-14s %s\n",
+		"receipt-driven development: %s (decided by %s)\n  %-15s %s\n  %-15s %s\n  %-15s %s\n",
 		reviewModeLabel(result.Status.Effective),
 		result.Status.Source,
 		"global:", reviewModeLabel(result.Status.Global),

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -23,29 +23,34 @@ import (
 const ReviewModeSchema = "gentle-ai.review-mode/v1"
 
 const (
-	reviewModeScopeGlobal = "global"
-	reviewModeScopeClone  = "clone"
-	reviewModeScopeBoth   = "both"
+	reviewModeScopeGlobal   = "global"
+	reviewModeScopeClone    = "clone"
+	reviewModeScopeWorktree = "worktree"
+	reviewModeScopeBoth     = "both"
 )
 
 // ReviewModeResult reports what the command did and the resulting effective
-// mode with both of its sources. It carries no review outcome.
+// mode with both of its sources. It carries no review outcome. BlastRadius is
+// informational and only present when a clone-local override lives under a Git
+// common directory shared with other worktree checkouts.
 type ReviewModeResult struct {
-	Schema    string                          `json:"schema"`
-	Operation string                          `json:"operation"`
-	Scope     string                          `json:"scope"`
-	Status    reviewtransaction.RDDModeStatus `json:"status"`
+	Schema      string                          `json:"schema"`
+	Operation   string                          `json:"operation"`
+	Scope       string                          `json:"scope"`
+	Status      reviewtransaction.RDDModeStatus `json:"status"`
+	BlastRadius int                             `json:"blast_radius,omitempty"`
 }
 
 // RunReviewMode is the user-controlled receipt-driven-development switch.
 // Receipt-driven development is opt-in: with no source expressing an opinion it
 // resolves to off, and only an explicit global enable turns it on. The global
 // mode lives in uncommitted user state; the clone-local override lives under
-// this clone's Git common directory and can only disable. Any off wins, status
-// never mutates, and enabling applies to future candidates only.
+// this clone's Git common directory and the worktree-local override lives under
+// a linked worktree's own Git directory, and both can only disable. Any off
+// wins, status never mutates, and enabling applies to future candidates only.
 func RunReviewMode(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review mode <enable|disable|status> [--cwd <repo>] [--scope <global|clone>] [--expected-revision <revision>] [--json]")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review mode <enable|disable|status> [--cwd <repo>] [--scope <global|clone|worktree>] [--expected-revision <revision>] [--json]")
 		_, _ = fmt.Fprintln(stdout, "User-owned switch. Receipt-driven development is off until you enable it: run 'gentle-ai review mode enable --scope global' to opt in. Any off wins: a repository may disable it for this clone but can never require it, and no other clone inherits the override. status is read-only and reports both sources plus the effective mode. Enabling applies to future candidates only.")
 		return nil
 	}
@@ -58,8 +63,8 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 
 	flags := newReviewFlagSet("review mode "+operation, stdout, "Read or set the user-controlled receipt-driven-development kill switch.")
 	cwd := flags.String("cwd", ".", "repository path")
-	scope := flags.String("scope", reviewModeScopeGlobal, "mode source to write: global or clone")
-	expectedRevision := flags.String("expected-revision", "", "exact clone-local revision this write replaces")
+	scope := flags.String("scope", reviewModeScopeGlobal, "mode source to write: global, clone, or worktree")
+	expectedRevision := flags.String("expected-revision", "", "exact local-override revision this write replaces (clone or worktree scope)")
 	emitJSON := flags.Bool("json", false, "emit the machine-readable review mode result")
 	if err := parseReviewFlags(flags, args[1:]); err != nil {
 		return err
@@ -72,7 +77,7 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 	}
 	selectedScope := strings.TrimSpace(*scope)
 	switch selectedScope {
-	case reviewModeScopeGlobal, reviewModeScopeClone:
+	case reviewModeScopeGlobal, reviewModeScopeClone, reviewModeScopeWorktree:
 	default:
 		return fmt.Errorf("unknown review mode scope %q", *scope)
 	}
@@ -89,6 +94,14 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 	if operation == "status" {
 		result.Scope = reviewModeScopeBoth
 		result.Status, err = reviewModeStatus(ctx, *cwd)
+		if err == nil && result.Status.Source == reviewtransaction.RDDModeSourceCloneLocal {
+			// A clone-local override lives under the shared Git common
+			// directory, so it may also govern every linked worktree. The
+			// announcement is informational and never changes the mode.
+			if shared, radiusErr := reviewtransaction.LinkedWorktreeBlastRadius(ctx, *cwd); radiusErr == nil && shared > 0 {
+				result.BlastRadius = shared
+			}
+		}
 	} else {
 		result.Status, err = applyReviewMode(ctx, *cwd, operation, selectedScope, *expectedRevision, revisionProvided)
 	}
@@ -119,18 +132,22 @@ type ReviewModeUnreadableScope struct {
 }
 
 func (scope ReviewModeUnreadableScope) label() string {
-	if scope.Scope == reviewModeScopeClone {
+	switch scope.Scope {
+	case reviewModeScopeClone:
 		return "clone-local"
+	case reviewModeScopeWorktree:
+		return "worktree-local"
 	}
 	return "global"
 }
 
 // commands names the two invocations that overwrite this scope. Both are
-// complete as printed: the clone-local scope carries the repository it belongs
-// to, because a clone-local record is only reachable through its own clone.
+// complete as printed: the repository scopes carry the repository they belong
+// to, because a repository-scoped record is only reachable through its own
+// clone.
 func (scope ReviewModeUnreadableScope) commands() []string {
 	suffix := " --scope=" + scope.Scope
-	if scope.Scope == reviewModeScopeClone {
+	if scope.Scope == reviewModeScopeClone || scope.Scope == reviewModeScopeWorktree {
 		suffix += " --cwd " + scope.Repo
 	}
 	return []string{
@@ -273,11 +290,14 @@ func reviewModeUnreadable(
 			scopes = append(scopes, ReviewModeUnreadableScope{Scope: reviewModeScopeGlobal, Path: state.Path(home), Repo: repo})
 		}
 	}
-	// An unset global can never fail, so this isolates the clone-local source
-	// even when the global one already failed ahead of it.
+	// An unset global can never fail, so this isolates the repository-scoped
+	// sources even when the global one already failed ahead of it.
 	if _, cloneErr := reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{}); cloneErr != nil {
 		if path, pathErr := reviewtransaction.CloneLocalRDDModeRecordPath(ctx, repo); pathErr == nil && path != "" {
 			scopes = append(scopes, ReviewModeUnreadableScope{Scope: reviewModeScopeClone, Path: path, Repo: repo})
+		}
+		if path, pathErr := reviewtransaction.WorktreeLocalRDDModeRecordPath(ctx, repo); pathErr == nil && path != "" {
+			scopes = append(scopes, ReviewModeUnreadableScope{Scope: reviewModeScopeWorktree, Path: path, Repo: repo})
 		}
 	}
 	if len(scopes) == 0 {
@@ -323,19 +343,34 @@ func applyReviewMode(
 	}
 	mode := reviewtransaction.RDDModeOff
 	if operation == "enable" {
-		// The override is off-only, so enabling clears this clone's opinion
+		// The override is off-only, so enabling clears this scope's opinion
 		// instead of asserting on: a repository may never force review on.
 		mode = reviewtransaction.RDDModeUnset
 	}
 	if !revisionProvided {
-		// The compare-and-set token belongs to the clone-local source alone, so
-		// it is read with an unset global. Repairing this clone must not depend
-		// on the other source being readable, or a switch whose two records are
-		// both unreadable would have no repair command at all.
+		// The compare-and-set token belongs to the repository-scoped source
+		// alone, so it is read with an unset global. Repairing this scope must
+		// not depend on the other source being readable, or a switch whose two
+		// records are both unreadable would have no repair command at all.
 		current, resolveErr := reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
 		switch {
 		case resolveErr == nil:
 			expectedRevision = current.Revision
+			if scope == reviewModeScopeWorktree {
+				// On a linked worktree the write targets the private
+				// worktree-local head, whose token is WorktreeRevision. On the
+				// main checkout there is no distinct worktree-local storage, so
+				// the write targets the clone-local record and must carry its
+				// token.
+				lease, leaseErr := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
+				if leaseErr != nil {
+					return disabled, reviewModeUnreadable(ctx, repo, global, leaseErr)
+				}
+				identity := lease.Identity()
+				if identity.GitDir != identity.GitCommonDir {
+					expectedRevision = current.WorktreeRevision
+				}
+			}
 		case errors.Is(resolveErr, reviewtransaction.ErrRDDModeCorrupt):
 			// An unreadable head carries no revision to compare against, and
 			// replacing it is the whole point of this command.
@@ -343,6 +378,10 @@ func applyReviewMode(
 		default:
 			return disabled, reviewModeUnreadable(ctx, repo, global, resolveErr)
 		}
+	}
+	if scope == reviewModeScopeWorktree {
+		status, err := reviewtransaction.SetWorktreeLocalRDDMode(ctx, repo, mode, expectedRevision, global)
+		return status, reviewModeUnreadable(ctx, repo, global, err)
 	}
 	status, err := reviewtransaction.SetCloneLocalRDDMode(ctx, repo, mode, expectedRevision, global)
 	return status, reviewModeUnreadable(ctx, repo, global, err)
@@ -400,13 +439,27 @@ func emitReviewMode(stdout io.Writer, result ReviewModeResult, emitJSON bool) er
 	}
 	_, err := fmt.Fprintf(
 		stdout,
-		"receipt-driven development: %s (decided by %s)\n  global:      %s\n  clone-local: %s\n",
+		"receipt-driven development: %s (decided by %s)\n  %-14s %s\n  %-14s %s\n  %-14s %s\n",
 		reviewModeLabel(result.Status.Effective),
 		result.Status.Source,
-		reviewModeLabel(result.Status.Global),
-		reviewModeLabel(result.Status.CloneLocal),
+		"global:", reviewModeLabel(result.Status.Global),
+		"clone-local:", reviewModeLabel(result.Status.CloneLocal),
+		"worktree-local:", reviewModeLabel(result.Status.WorktreeLocal),
 	)
-	if err != nil || result.Status.Reach != reviewtransaction.RDDModeReachThisBuild {
+	if err != nil {
+		return err
+	}
+	if result.BlastRadius > 0 {
+		_, err = fmt.Fprintf(
+			stdout,
+			"  note: %d other worktree checkout(s) share this clone-local override because it is stored under the shared Git common directory\n",
+			result.BlastRadius,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	if result.Status.Reach != reviewtransaction.RDDModeReachThisBuild {
 		return err
 	}
 	// The switch is machine state. A write that reached only this build has to

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -51,7 +51,7 @@ type ReviewModeResult struct {
 func RunReviewMode(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
 		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review mode <enable|disable|status> [--cwd <repo>] [--scope <global|clone|worktree>] [--expected-revision <revision>] [--json]")
-		_, _ = fmt.Fprintln(stdout, "User-owned switch. Receipt-driven development is off until you enable it: run 'gentle-ai review mode enable --scope global' to opt in. Any off wins: a repository may disable it for this clone but can never require it, and no other clone inherits the override. status is read-only and reports both sources plus the effective mode. Enabling applies to future candidates only.")
+		_, _ = fmt.Fprintln(stdout, "User-owned switch. Receipt-driven development is off until you enable it: run 'gentle-ai review mode enable --scope global' to opt in. Any off wins: a repository may disable it for this clone but can never require it, and no other clone inherits the override. status is read-only and reports the effective mode plus all three sources (global, clone-local, worktree-local); the worktree scope isolates exactly one linked worktree. Re-enabling applies to future candidates only.")
 		return nil
 	}
 	operation := args[0]
@@ -94,10 +94,13 @@ func RunReviewMode(args []string, stdout io.Writer) error {
 	if operation == "status" {
 		result.Scope = reviewModeScopeBoth
 		result.Status, err = reviewModeStatus(ctx, *cwd)
-		if err == nil && result.Status.Source == reviewtransaction.RDDModeSourceCloneLocal {
+		if err == nil && result.Status.CloneLocal == reviewtransaction.RDDModeOff {
 			// A clone-local override lives under the shared Git common
 			// directory, so it may also govern every linked worktree. The
-			// announcement is informational and never changes the mode.
+			// announcement is keyed on the clone-local state rather than the
+			// deciding source, so a worktree-local off shadowing the shared
+			// record still announces it. It is informational and never changes
+			// the mode.
 			if shared, radiusErr := reviewtransaction.LinkedWorktreeBlastRadius(ctx, *cwd); radiusErr == nil && shared > 0 {
 				result.BlastRadius = shared
 			}
@@ -352,31 +355,28 @@ func applyReviewMode(
 		// alone, so it is read with an unset global. Repairing this scope must
 		// not depend on the other source being readable, or a switch whose two
 		// records are both unreadable would have no repair command at all.
-		current, resolveErr := reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
+		var token string
+		var tokenErr error
+		if scope == reviewModeScopeWorktree {
+			// The worktree scope targets whatever storage the package resolves
+			// for this checkout: the worktree-local head on a linked worktree,
+			// and the clone-local head on the main checkout. Asking the package
+			// keeps the storage-distinctness rule in one place.
+			token, tokenErr = reviewtransaction.WorktreeLocalRevision(ctx, repo)
+		} else {
+			var current reviewtransaction.RDDModeStatus
+			current, tokenErr = reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
+			token = current.Revision
+		}
 		switch {
-		case resolveErr == nil:
-			expectedRevision = current.Revision
-			if scope == reviewModeScopeWorktree {
-				// On a linked worktree the write targets the private
-				// worktree-local head, whose token is WorktreeRevision. On the
-				// main checkout there is no distinct worktree-local storage, so
-				// the write targets the clone-local record and must carry its
-				// token.
-				lease, leaseErr := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
-				if leaseErr != nil {
-					return disabled, reviewModeUnreadable(ctx, repo, global, leaseErr)
-				}
-				identity := lease.Identity()
-				if identity.GitDir != identity.GitCommonDir {
-					expectedRevision = current.WorktreeRevision
-				}
-			}
-		case errors.Is(resolveErr, reviewtransaction.ErrRDDModeCorrupt):
+		case tokenErr == nil:
+			expectedRevision = token
+		case errors.Is(tokenErr, reviewtransaction.ErrRDDModeCorrupt):
 			// An unreadable head carries no revision to compare against, and
 			// replacing it is the whole point of this command.
 			expectedRevision = ""
 		default:
-			return disabled, reviewModeUnreadable(ctx, repo, global, resolveErr)
+			return disabled, reviewModeUnreadable(ctx, repo, global, tokenErr)
 		}
 	}
 	if scope == reviewModeScopeWorktree {

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -364,9 +364,9 @@ func applyReviewMode(
 			// keeps the storage-distinctness rule in one place.
 			token, tokenErr = reviewtransaction.WorktreeLocalRevision(ctx, repo)
 		} else {
-			var current reviewtransaction.RDDModeStatus
-			current, tokenErr = reviewtransaction.ResolveRDDMode(ctx, repo, reviewtransaction.RDDGlobalMode{})
-			token = current.Revision
+			// Scoped to clone-local storage alone, so an unreadable
+			// worktree-local record never blocks repairing this scope.
+			token, tokenErr = reviewtransaction.CloneLocalRevision(ctx, repo)
 		}
 		switch {
 		case tokenErr == nil:

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -142,6 +142,20 @@ func TestReviewModeRejectsUnknownSubcommandAndScope(t *testing.T) {
 	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "worktree", "--json"}, &output); err != nil {
 		t.Fatalf("--scope worktree must be accepted: %v", err)
 	}
+	// On the main checkout the worktree scope has no distinct storage, so the
+	// write targets the shared clone-local record and must report clone_local
+	// with no worktree revision, and a following status must agree.
+	result := decodeReviewModeResult(t, output.Bytes())
+	if result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal || result.Status.WorktreeRevision != "" {
+		t.Fatalf("main-checkout worktree-scope write reported %#v; want clone_local and no worktree revision", result.Status)
+	}
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("status after main-checkout worktree-scope write: %v", err)
+	}
+	if status := decodeReviewModeResult(t, output.Bytes()); status.Status.Source != reviewtransaction.RDDModeSourceCloneLocal {
+		t.Fatalf("status after main-checkout worktree-scope write = %#v; want clone_local", status.Status)
+	}
 }
 
 // TestReviewModeWorktreeScopeDisablesOnlyThisWorktree locks issue #1973 from
@@ -221,6 +235,22 @@ func TestReviewModeStatusAnnouncesCloneBlastRadius(t *testing.T) {
 		if result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal || result.BlastRadius != 1 {
 			t.Fatalf("%s status = %#v, blast radius = %d; want clone_local and 1", name, result.Status, result.BlastRadius)
 		}
+	}
+
+	// A worktree-local off shadowing the shared clone-local off must still
+	// announce the clone-local blast radius: the announcement keys on the
+	// clone-local state, not on which source decided.
+	output.Reset()
+	if err := RunReviewMode([]string{"disable", "--cwd", linked, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(disable worktree) error = %v", err)
+	}
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", linked, "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(status shadowed) error = %v", err)
+	}
+	shadowed := decodeReviewModeResult(t, output.Bytes())
+	if shadowed.Status.Source != reviewtransaction.RDDModeSourceWorktreeLocal || shadowed.BlastRadius != 1 {
+		t.Fatalf("shadowed status = %#v, blast radius = %d; want worktree_local and 1", shadowed.Status, shadowed.BlastRadius)
 	}
 }
 

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -139,6 +139,89 @@ func TestReviewModeRejectsUnknownSubcommandAndScope(t *testing.T) {
 		!strings.Contains(err.Error(), "unknown review mode scope") {
 		t.Fatalf("unknown scope error = %v", err)
 	}
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("--scope worktree must be accepted: %v", err)
+	}
+}
+
+// TestReviewModeWorktreeScopeDisablesOnlyThisWorktree locks issue #1973 from
+// the CLI surface: --scope worktree inside a linked worktree writes a private
+// override that disables that worktree only, reports the worktree_local source,
+// and never touches the main clone. Status from the worktree must not announce
+// a blast radius for its private override.
+func TestReviewModeWorktreeScopeDisablesOnlyThisWorktree(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runReviewCLIGit(t, repo, "worktree", "add", "-b", "review-mode-linked", linked, "HEAD")
+	t.Cleanup(func() { runReviewCLIGit(t, repo, "worktree", "remove", "--force", linked) })
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", linked, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(disable worktree) error = %v", err)
+	}
+	result := decodeReviewModeResult(t, output.Bytes())
+	if result.Status.Effective != reviewtransaction.RDDModeOff ||
+		result.Status.Source != reviewtransaction.RDDModeSourceWorktreeLocal ||
+		result.Status.WorktreeRevision == "" ||
+		result.BlastRadius != 0 {
+		t.Fatalf("worktree disable result = %#v", result.Status)
+	}
+
+	// The main clone is unaffected.
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(status main) error = %v", err)
+	}
+	if main := decodeReviewModeResult(t, output.Bytes()); main.Status.Effective != reviewtransaction.RDDModeOn {
+		t.Fatalf("main clone inherited the worktree override: %#v", main.Status)
+	}
+
+	// Status inside the worktree reports the private source and no blast radius.
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", linked, "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(status linked) error = %v", err)
+	}
+	if linkedResult := decodeReviewModeResult(t, output.Bytes()); linkedResult.Status.Source != reviewtransaction.RDDModeSourceWorktreeLocal ||
+		linkedResult.BlastRadius != 0 {
+		t.Fatalf("linked status = %#v, blast radius = %d; want worktree_local and none", linkedResult.Status, linkedResult.BlastRadius)
+	}
+
+	// Re-enabling with the worktree scope clears only this worktree.
+	output.Reset()
+	if err := RunReviewMode([]string{"enable", "--cwd", linked, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(enable worktree) error = %v", err)
+	}
+	if result := decodeReviewModeResult(t, output.Bytes()); result.Status.Effective != reviewtransaction.RDDModeOn {
+		t.Fatalf("worktree enable result = %#v", result.Status)
+	}
+}
+
+// TestReviewModeStatusAnnouncesCloneBlastRadius locks the blast-radius
+// announcement (issue #1973): a clone-local override is stored under the shared
+// Git common directory, so status names how many other worktree checkouts share
+// it, from any checkout of the clone.
+func TestReviewModeStatusAnnouncesCloneBlastRadius(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runReviewCLIGit(t, repo, "worktree", "add", "-b", "review-mode-blast", linked, "HEAD")
+	t.Cleanup(func() { runReviewCLIGit(t, repo, "worktree", "remove", "--force", linked) })
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(disable clone) error = %v", err)
+	}
+	for name, checkout := range map[string]string{"main": repo, "linked": linked} {
+		output.Reset()
+		if err := RunReviewMode([]string{"status", "--cwd", checkout, "--json"}, &output); err != nil {
+			t.Fatalf("RunReviewMode(status %s) error = %v", name, err)
+		}
+		result := decodeReviewModeResult(t, output.Bytes())
+		if result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal || result.BlastRadius != 1 {
+			t.Fatalf("%s status = %#v, blast radius = %d; want clone_local and 1", name, result.Status, result.BlastRadius)
+		}
+	}
 }
 
 // TestReviewStartIsRejectedWhileTheKillSwitchIsOff proves that disabling freezes

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -441,6 +441,20 @@ func TestReviewModeRejectsUnknownSubcommandAndScope(t *testing.T) {
 	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "worktree", "--json"}, &output); err != nil {
 		t.Fatalf("--scope worktree must be accepted: %v", err)
 	}
+	// On the main checkout the worktree scope has no distinct storage, so the
+	// write targets the shared clone-local record and must report clone_local
+	// with no worktree revision, and a following status must agree.
+	result := decodeReviewModeResult(t, output.Bytes())
+	if result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal || result.Status.WorktreeRevision != "" {
+		t.Fatalf("main-checkout worktree-scope write reported %#v; want clone_local and no worktree revision", result.Status)
+	}
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("status after main-checkout worktree-scope write: %v", err)
+	}
+	if status := decodeReviewModeResult(t, output.Bytes()); status.Status.Source != reviewtransaction.RDDModeSourceCloneLocal {
+		t.Fatalf("status after main-checkout worktree-scope write = %#v; want clone_local", status.Status)
+	}
 }
 
 // TestReviewModeWorktreeScopeDisablesOnlyThisWorktree locks issue #1973 from
@@ -520,6 +534,22 @@ func TestReviewModeStatusAnnouncesCloneBlastRadius(t *testing.T) {
 		if result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal || result.BlastRadius != 1 {
 			t.Fatalf("%s status = %#v, blast radius = %d; want clone_local and 1", name, result.Status, result.BlastRadius)
 		}
+	}
+
+	// A worktree-local off shadowing the shared clone-local off must still
+	// announce the clone-local blast radius: the announcement keys on the
+	// clone-local state, not on which source decided.
+	output.Reset()
+	if err := RunReviewMode([]string{"disable", "--cwd", linked, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(disable worktree) error = %v", err)
+	}
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", linked, "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(status shadowed) error = %v", err)
+	}
+	shadowed := decodeReviewModeResult(t, output.Bytes())
+	if shadowed.Status.Source != reviewtransaction.RDDModeSourceWorktreeLocal || shadowed.BlastRadius != 1 {
+		t.Fatalf("shadowed status = %#v, blast radius = %d; want worktree_local and 1", shadowed.Status, shadowed.BlastRadius)
 	}
 }
 

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -463,7 +463,7 @@ func TestReviewModeRejectsUnknownSubcommandAndScope(t *testing.T) {
 // and never touches the main clone. Status from the worktree must not announce
 // a blast radius for its private override.
 func TestReviewModeWorktreeScopeDisablesOnlyThisWorktree(t *testing.T) {
-	reviewModeHome(t)
+	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)
 	linked := filepath.Join(t.TempDir(), "linked")
 	runReviewCLIGit(t, repo, "worktree", "add", "-b", "review-mode-linked", linked, "HEAD")

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -438,6 +438,89 @@ func TestReviewModeRejectsUnknownSubcommandAndScope(t *testing.T) {
 		!strings.Contains(err.Error(), "unknown review mode scope") {
 		t.Fatalf("unknown scope error = %v", err)
 	}
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("--scope worktree must be accepted: %v", err)
+	}
+}
+
+// TestReviewModeWorktreeScopeDisablesOnlyThisWorktree locks issue #1973 from
+// the CLI surface: --scope worktree inside a linked worktree writes a private
+// override that disables that worktree only, reports the worktree_local source,
+// and never touches the main clone. Status from the worktree must not announce
+// a blast radius for its private override.
+func TestReviewModeWorktreeScopeDisablesOnlyThisWorktree(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runReviewCLIGit(t, repo, "worktree", "add", "-b", "review-mode-linked", linked, "HEAD")
+	t.Cleanup(func() { runReviewCLIGit(t, repo, "worktree", "remove", "--force", linked) })
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", linked, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(disable worktree) error = %v", err)
+	}
+	result := decodeReviewModeResult(t, output.Bytes())
+	if result.Status.Effective != reviewtransaction.RDDModeOff ||
+		result.Status.Source != reviewtransaction.RDDModeSourceWorktreeLocal ||
+		result.Status.WorktreeRevision == "" ||
+		result.BlastRadius != 0 {
+		t.Fatalf("worktree disable result = %#v", result.Status)
+	}
+
+	// The main clone is unaffected.
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(status main) error = %v", err)
+	}
+	if main := decodeReviewModeResult(t, output.Bytes()); main.Status.Effective != reviewtransaction.RDDModeOn {
+		t.Fatalf("main clone inherited the worktree override: %#v", main.Status)
+	}
+
+	// Status inside the worktree reports the private source and no blast radius.
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", linked, "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(status linked) error = %v", err)
+	}
+	if linkedResult := decodeReviewModeResult(t, output.Bytes()); linkedResult.Status.Source != reviewtransaction.RDDModeSourceWorktreeLocal ||
+		linkedResult.BlastRadius != 0 {
+		t.Fatalf("linked status = %#v, blast radius = %d; want worktree_local and none", linkedResult.Status, linkedResult.BlastRadius)
+	}
+
+	// Re-enabling with the worktree scope clears only this worktree.
+	output.Reset()
+	if err := RunReviewMode([]string{"enable", "--cwd", linked, "--scope", "worktree", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(enable worktree) error = %v", err)
+	}
+	if result := decodeReviewModeResult(t, output.Bytes()); result.Status.Effective != reviewtransaction.RDDModeOn {
+		t.Fatalf("worktree enable result = %#v", result.Status)
+	}
+}
+
+// TestReviewModeStatusAnnouncesCloneBlastRadius locks the blast-radius
+// announcement (issue #1973): a clone-local override is stored under the shared
+// Git common directory, so status names how many other worktree checkouts share
+// it, from any checkout of the clone.
+func TestReviewModeStatusAnnouncesCloneBlastRadius(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runReviewCLIGit(t, repo, "worktree", "add", "-b", "review-mode-blast", linked, "HEAD")
+	t.Cleanup(func() { runReviewCLIGit(t, repo, "worktree", "remove", "--force", linked) })
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output); err != nil {
+		t.Fatalf("RunReviewMode(disable clone) error = %v", err)
+	}
+	for name, checkout := range map[string]string{"main": repo, "linked": linked} {
+		output.Reset()
+		if err := RunReviewMode([]string{"status", "--cwd", checkout, "--json"}, &output); err != nil {
+			t.Fatalf("RunReviewMode(status %s) error = %v", name, err)
+		}
+		result := decodeReviewModeResult(t, output.Bytes())
+		if result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal || result.BlastRadius != 1 {
+			t.Fatalf("%s status = %#v, blast radius = %d; want clone_local and 1", name, result.Status, result.BlastRadius)
+		}
+	}
 }
 
 // TestReviewStartIsRejectedWhileTheKillSwitchIsOff proves a disabled START

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -98,6 +98,10 @@ const (
 	RDDModeSourceGlobal RDDModeSource = "global"
 	// RDDModeSourceCloneLocal means this clone's Git-common-dir override decided.
 	RDDModeSourceCloneLocal RDDModeSource = "clone_local"
+	// RDDModeSourceWorktreeLocal means this linked worktree's private override
+	// decided. It exists only when the checkout is a linked worktree; on the
+	// main checkout there is no distinct worktree-local storage.
+	RDDModeSourceWorktreeLocal RDDModeSource = "worktree_local"
 )
 
 // RDDOperation classifies what an actor wants to do, so that disabling freezes
@@ -144,15 +148,19 @@ type RDDGlobalMode struct {
 }
 
 // RDDModeStatus is the read-only projection of both sources. Revision is the
-// clone-local compare-and-set token. The projection carries no time cutoff: it
-// answers "may review start now", never "which bytes are approved".
+// clone-local compare-and-set token and WorktreeRevision is the worktree-local
+// token; both are only populated by an override that actually exists on that
+// storage. The projection carries no time cutoff: it answers "may review start
+// now", never "which bytes are approved".
 type RDDModeStatus struct {
-	Schema     string        `json:"schema"`
-	Global     RDDMode       `json:"global"`
-	CloneLocal RDDMode       `json:"clone_local"`
-	Effective  RDDMode       `json:"effective"`
-	Source     RDDModeSource `json:"source"`
-	Revision   string        `json:"revision,omitempty"`
+	Schema          string        `json:"schema"`
+	Global          RDDMode       `json:"global"`
+	CloneLocal      RDDMode       `json:"clone_local"`
+	WorktreeLocal   RDDMode       `json:"worktree_local"`
+	Effective       RDDMode       `json:"effective"`
+	Source          RDDModeSource `json:"source"`
+	Revision        string        `json:"revision,omitempty"`
+	WorktreeRevision string       `json:"worktree_revision,omitempty"`
 }
 
 // Enabled reports whether new receipt-driven development may start.
@@ -211,6 +219,8 @@ func reviewModeScopeForSource(source RDDModeSource) string {
 		return "global"
 	case RDDModeSourceCloneLocal:
 		return "clone"
+	case RDDModeSourceWorktreeLocal:
+		return "worktree"
 	default:
 		return ""
 	}
@@ -219,8 +229,9 @@ func reviewModeScopeForSource(source RDDModeSource) string {
 func (err *RDDDisabledError) Unwrap() error { return ErrRDDDisabled }
 
 // ResolveRDDMode combines the global user mode with this clone's off-only
-// override. Any off wins, a repository can never force on, and every failure
-// projects a disabled status so a caller that drops the error still fails safe.
+// override and this linked worktree's private off-only override. Any off wins,
+// a repository can never force on, and every failure projects a disabled
+// status so a caller that drops the error still fails safe.
 func ResolveRDDMode(ctx context.Context, repo string, global RDDGlobalMode) (RDDModeStatus, error) {
 	if err := ctx.Err(); err != nil {
 		return failedClosedRDDModeStatus(RDDModeSourceDefault), err
@@ -229,11 +240,15 @@ func ResolveRDDMode(ctx context.Context, repo string, global RDDGlobalMode) (RDD
 	if globalErr != nil {
 		return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
 	}
-	override, present, overrideErr := readCloneLocalRDDOverride(ctx, repo)
-	if overrideErr != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), overrideErr
+	cloneOverride, clonePresent, cloneErr := readCloneLocalRDDOverride(ctx, repo)
+	if cloneErr != nil {
+		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), cloneErr
 	}
-	return rddModeStatus(globalMode, override, present), nil
+	worktreeOverride, worktreePresent, worktreeErr := readWorktreeLocalRDDOverride(ctx, repo)
+	if worktreeErr != nil {
+		return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), worktreeErr
+	}
+	return rddModeStatus(globalMode, cloneOverride, clonePresent, worktreeOverride, worktreePresent), nil
 }
 
 // SetCloneLocalRDDMode records this clone's off-only override under the Git
@@ -247,20 +262,76 @@ func SetCloneLocalRDDMode(
 	expectedRevision string,
 	global RDDGlobalMode,
 ) (RDDModeStatus, error) {
+	return setRDDModeOverride(ctx, repo, rddOverrideCloneLocal, mode, expectedRevision, global)
+}
+
+// SetWorktreeLocalRDDMode records one linked worktree's private off-only
+// override under that worktree's own Git directory, so it never bleeds into
+// the main checkout or any sibling worktree. On the main checkout (where GitDir
+// equals GitCommonDir) there is no distinct worktree-local storage, so the
+// write targets the shared clone-local record instead. expectedRevision is the
+// exact compare-and-set token returned by the previous read; "" expects no
+// record.
+func SetWorktreeLocalRDDMode(
+	ctx context.Context,
+	repo string,
+	mode RDDMode,
+	expectedRevision string,
+	global RDDGlobalMode,
+) (RDDModeStatus, error) {
+	return setRDDModeOverride(ctx, repo, rddOverrideWorktreeLocal, mode, expectedRevision, global)
+}
+
+// rddModeOverrideStorage names which storage scope a read or write targets.
+type rddModeOverrideStorage int
+
+const (
+	rddOverrideCloneLocal rddModeOverrideStorage = iota
+	rddOverrideWorktreeLocal
+)
+
+func rddOverrideSource(storage rddModeOverrideStorage) RDDModeSource {
+	if storage == rddOverrideWorktreeLocal {
+		return RDDModeSourceWorktreeLocal
+	}
+	return RDDModeSourceCloneLocal
+}
+
+// rddOverrideHeadLabel names one storage scope the way an operator would say
+// it in an error message.
+func rddOverrideHeadLabel(storage rddModeOverrideStorage) string {
+	if storage == rddOverrideWorktreeLocal {
+		return "worktree-local"
+	}
+	return "clone-local"
+}
+
+// setRDDModeOverride is the compare-and-set publish shared by both repository
+// scopes. The mechanism is identical for clone-local and worktree-local
+// storage; only where the generation records live differs.
+func setRDDModeOverride(
+	ctx context.Context,
+	repo string,
+	storage rddModeOverrideStorage,
+	mode RDDMode,
+	expectedRevision string,
+	global RDDGlobalMode,
+) (RDDModeStatus, error) {
+	source := rddOverrideSource(storage)
 	if err := ctx.Err(); err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
 	persisted, err := cloneLocalRDDOverrideValue(mode)
 	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
-	dir, err := cloneLocalRDDModeRoot(ctx, repo, true)
+	dir, _, err := rddModeStorageRoot(ctx, repo, true, storage)
 	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
 	lock, err := acquireRARAuthorityLock(ctx, filepath.Join(dir, rddModeLockName))
 	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
 	defer func() { _ = lock.release() }()
 
@@ -277,11 +348,11 @@ func SetCloneLocalRDDMode(
 		// unreadable generation: the repair writes the generation that
 		// supersedes it, so a lost race still cannot corrupt the head.
 		if !errors.Is(err, ErrRDDModeCorrupt) {
-			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+			return failedClosedRDDModeStatus(source), err
 		}
 		generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
 		if generationErr != nil {
-			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), generationErr
+			return failedClosedRDDModeStatus(source), generationErr
 		}
 		head, present = rddModeOverrideRecord{Generation: generation}, false
 	}
@@ -290,11 +361,12 @@ func SetCloneLocalRDDMode(
 		current = head.Revision
 	}
 	if strings.TrimSpace(expectedRevision) != current {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), fmt.Errorf(
-			"%w: expected %q but the clone-local head is %q", ErrRDDModeRevisionMismatch, expectedRevision, current)
+		return failedClosedRDDModeStatus(source), fmt.Errorf(
+			"%w: expected %q but the %s head is %q", ErrRDDModeRevisionMismatch, expectedRevision, rddOverrideHeadLabel(storage), current)
 	}
 	if head.Generation >= rddModeMaxGeneration {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), errors.New("clone-local review mode generation space is exhausted")
+		// refusal:by-design world-action: the exit is a filesystem repair (deleting superseded override generations to free a slot) that only the operator can perform; no gentle-ai command may rewrite authority history
+		return failedClosedRDDModeStatus(source), fmt.Errorf("%s review mode generation space is exhausted", rddOverrideHeadLabel(storage))
 	}
 
 	record := rddModeOverrideRecord{
@@ -305,23 +377,39 @@ func SetCloneLocalRDDMode(
 		RecordedAt:       time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	if record.Revision, err = rddModeOverrideDigest(record); err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
 	payload, err := canonicalRDDModeOverridePayload(record)
 	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
 	// The immutable no-replace publish is the fail-closed backstop: a writer
 	// that somehow bypassed the lock still cannot overwrite a published
 	// generation, so a lost race can never corrupt the head record.
 	if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		return failedClosedRDDModeStatus(source), err
 	}
 	globalMode, globalErr := normalizeRDDMode(global.Value)
 	if globalErr != nil {
 		return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
 	}
-	return rddModeStatus(globalMode, record, true), nil
+	// The reported status re-reads the sibling storage so the projection
+	// reflects the true combined precedence instead of only the record this
+	// writer just published: on a linked worktree a clone-scope write may be
+	// shadowed by an existing worktree-scope off, and vice versa.
+	cloneRecord, clonePresent, worktreeRecord, worktreePresent := rddModeOverrideRecord{}, false, rddModeOverrideRecord{}, false
+	if storage == rddOverrideCloneLocal {
+		cloneRecord, clonePresent = record, true
+		if worktreeRecord, worktreePresent, err = readWorktreeLocalRDDOverride(ctx, repo); err != nil {
+			return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), err
+		}
+	} else {
+		worktreeRecord, worktreePresent = record, true
+		if cloneRecord, clonePresent, err = readCloneLocalRDDOverride(ctx, repo); err != nil {
+			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+		}
+	}
+	return rddModeStatus(globalMode, cloneRecord, clonePresent, worktreeRecord, worktreePresent), nil
 }
 
 // AuthorizeRDDOperation is the single kill-switch gate. Reads always pass so
@@ -441,23 +529,34 @@ func RDDDeliveryDisposition(status RDDModeStatus, receiptPresent bool) RDDDelive
 
 func rddModeStatus(
 	globalMode RDDMode,
-	override rddModeOverrideRecord,
-	present bool,
+	cloneOverride rddModeOverrideRecord,
+	clonePresent bool,
+	worktreeOverride rddModeOverrideRecord,
+	worktreePresent bool,
 ) RDDModeStatus {
 	status := RDDModeStatus{
-		Schema:     RDDModeStatusSchema,
-		Global:     globalMode,
-		CloneLocal: RDDModeUnset,
-		Effective:  RDDModeOff,
-		Source:     RDDModeSourceDefault,
+		Schema:        RDDModeStatusSchema,
+		Global:        globalMode,
+		CloneLocal:    RDDModeUnset,
+		WorktreeLocal: RDDModeUnset,
+		Effective:     RDDModeOff,
+		Source:        RDDModeSourceDefault,
 	}
-	if present {
-		status.Revision = override.Revision
-		if override.Mode == string(RDDModeOff) {
+	if clonePresent {
+		status.Revision = cloneOverride.Revision
+		if cloneOverride.Mode == string(RDDModeOff) {
 			status.CloneLocal = RDDModeOff
 		}
 	}
+	if worktreePresent {
+		status.WorktreeRevision = worktreeOverride.Revision
+		if worktreeOverride.Mode == string(RDDModeOff) {
+			status.WorktreeLocal = RDDModeOff
+		}
+	}
 	switch {
+	case status.WorktreeLocal == RDDModeOff:
+		status.Effective, status.Source = RDDModeOff, RDDModeSourceWorktreeLocal
 	case status.CloneLocal == RDDModeOff:
 		status.Effective, status.Source = RDDModeOff, RDDModeSourceCloneLocal
 	case globalMode == RDDModeOff:
@@ -472,11 +571,12 @@ func rddModeStatus(
 
 func failedClosedRDDModeStatus(source RDDModeSource) RDDModeStatus {
 	return RDDModeStatus{
-		Schema:     RDDModeStatusSchema,
-		Global:     RDDModeUnset,
-		CloneLocal: RDDModeUnset,
-		Effective:  RDDModeOff,
-		Source:     source,
+		Schema:        RDDModeStatusSchema,
+		Global:        RDDModeUnset,
+		CloneLocal:    RDDModeUnset,
+		WorktreeLocal: RDDModeUnset,
+		Effective:     RDDModeOff,
+		Source:        source,
 	}
 }
 
@@ -515,11 +615,32 @@ func cloneLocalRDDOverrideValue(mode RDDMode) (string, error) {
 	}
 }
 
-// cloneLocalRDDModeRoot derives the override directory from the exact Git
-// common directory. It nests inside the already-validated owner-only review
-// authority root so that path safety, permissions, and private IO reuse the
-// existing helpers instead of inventing a second path policy.
+// cloneLocalRDDModeRoot derives the clone-local override directory from the
+// exact Git common directory. It nests inside the already-validated owner-only
+// review authority root so that path safety, permissions, and private IO reuse
+// the existing helpers instead of inventing a second path policy.
 func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, error) {
+	dir, _, err := rddModeStorageRoot(ctx, repo, create, rddOverrideCloneLocal)
+	return dir, err
+}
+
+// worktreeLocalRDDModeRoot derives the worktree-local override directory from
+// the exact Git directory of this checkout. A linked worktree's Git directory
+// is private to it, so an override stored there never bleeds into the main
+// checkout or any sibling worktree. distinct reports whether this checkout
+// actually has separate worktree-local storage; on the main checkout
+// (GitDir == GitCommonDir) the worktree scope has no distinct storage and
+// resolves to the same location as the clone-local scope.
+func worktreeLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, bool, error) {
+	return rddModeStorageRoot(ctx, repo, create, rddOverrideWorktreeLocal)
+}
+
+// rddModeStorageRoot decides where one override storage scope lives. Both
+// repository scopes share the same identity-based root decision: the clone-local
+// scope always roots under the shared Git common directory, while the
+// worktree-local scope roots under this worktree's own Git directory when that
+// differs (a linked worktree) and under the common directory otherwise.
+func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage rddModeOverrideStorage) (string, bool, error) {
 	lease, err := OpenRepositoryIdentityLease(ctx, repo)
 	if err != nil {
 		// A bare repository already states its own refusal and names its own
@@ -527,26 +648,34 @@ func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (strin
 		// failure to a kill switch the operator never touched.
 		var bare *BareRepositoryError
 		if errors.As(err, &bare) {
-			return "", err
+			return "", false, err
 		}
-		return "", fmt.Errorf("resolve review mode repository identity: %w", err)
+		return "", false, fmt.Errorf("resolve review mode repository identity: %w", err)
 	}
 	identity := reviewRepositoryIdentityRecordFromLease(lease)
+	baseRoot := identity.GitCommonDir
+	distinct := true
+	if storage == rddOverrideWorktreeLocal {
+		distinct = identity.GitDir != identity.GitCommonDir
+		if distinct {
+			baseRoot = identity.GitDir
+		}
+	}
 	base := filepath.Join(
-		identity.GitCommonDir,
+		baseRoot,
 		"gentle-ai",
 		"review-transactions",
 		rarAuthorityDirectory,
 		rarAuthorityVersion,
 	)
-	if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, create); err != nil {
-		return "", err
+	if err := ensureRARRepositoryRoot(baseRoot, base, create); err != nil {
+		return "", false, err
 	}
 	dir := filepath.Join(base, rddModeDirectory)
 	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
-		return "", err
+		return "", false, err
 	}
-	return dir, nil
+	return dir, distinct, nil
 }
 
 func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrideRecord, bool, error) {
@@ -560,13 +689,43 @@ func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrid
 	return readCloneLocalRDDOverrideHead(dir)
 }
 
+// readWorktreeLocalRDDOverride reads the worktree-local override. On the main
+// checkout the worktree scope has no distinct storage, so it expresses no
+// opinion: the override that exists there belongs to the clone-local scope and
+// is already reported by readCloneLocalRDDOverride.
+func readWorktreeLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrideRecord, bool, error) {
+	dir, distinct, err := worktreeLocalRDDModeRoot(ctx, repo, false)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return rddModeOverrideRecord{}, false, nil
+		}
+		return rddModeOverrideRecord{}, false, err
+	}
+	if !distinct {
+		return rddModeOverrideRecord{}, false, nil
+	}
+	return readCloneLocalRDDOverrideHead(dir)
+}
+
 // CloneLocalRDDModeRecordPath reports the clone-local override file that
 // currently decides this clone's mode, so a refusal can name the exact file
 // holding an unreadable value instead of merely describing it. It is strictly
 // read-only, never creates state, and reports "" when this clone holds no
 // override at all.
 func CloneLocalRDDModeRecordPath(ctx context.Context, repo string) (string, error) {
-	dir, err := cloneLocalRDDModeRoot(ctx, repo, false)
+	return rddModeRecordPath(ctx, repo, rddOverrideCloneLocal)
+}
+
+// WorktreeLocalRDDModeRecordPath reports the worktree-local override file that
+// currently decides this worktree's mode, so a refusal can name the exact file
+// holding an unreadable value. On the main checkout it reports the clone-local
+// file, because that is where the worktree scope actually stores its record.
+func WorktreeLocalRDDModeRecordPath(ctx context.Context, repo string) (string, error) {
+	return rddModeRecordPath(ctx, repo, rddOverrideWorktreeLocal)
+}
+
+func rddModeRecordPath(ctx context.Context, repo string, storage rddModeOverrideStorage) (string, error) {
+	dir, _, err := rddModeStorageRoot(ctx, repo, false, storage)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -724,6 +724,22 @@ func WorktreeLocalRevision(ctx context.Context, repo string) (string, error) {
 	return head.Revision, nil
 }
 
+// CloneLocalRevision returns the compare-and-set token for the clone-local
+// scope alone, independent of whether the worktree-local record is readable.
+// It reports "" when the clone-local storage holds no record, which is the
+// same position as an absent expected revision. It is strictly read-only and
+// never creates state.
+func CloneLocalRevision(ctx context.Context, repo string) (string, error) {
+	record, present, err := readCloneLocalRDDOverride(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	if !present {
+		return "", nil
+	}
+	return record.Revision, nil
+}
+
 // CloneLocalRDDModeRecordPath reports the clone-local override file that
 // currently decides this clone's mode, so a refusal can name the exact file
 // holding an unreadable value instead of merely describing it. It is strictly

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -153,14 +153,14 @@ type RDDGlobalMode struct {
 // storage. The projection carries no time cutoff: it answers "may review start
 // now", never "which bytes are approved".
 type RDDModeStatus struct {
-	Schema          string        `json:"schema"`
-	Global          RDDMode       `json:"global"`
-	CloneLocal      RDDMode       `json:"clone_local"`
-	WorktreeLocal   RDDMode       `json:"worktree_local"`
-	Effective       RDDMode       `json:"effective"`
-	Source          RDDModeSource `json:"source"`
-	Revision        string        `json:"revision,omitempty"`
-	WorktreeRevision string       `json:"worktree_revision,omitempty"`
+	Schema           string        `json:"schema"`
+	Global           RDDMode       `json:"global"`
+	CloneLocal       RDDMode       `json:"clone_local"`
+	WorktreeLocal    RDDMode       `json:"worktree_local"`
+	Effective        RDDMode       `json:"effective"`
+	Source           RDDModeSource `json:"source"`
+	Revision         string        `json:"revision,omitempty"`
+	WorktreeRevision string        `json:"worktree_revision,omitempty"`
 }
 
 // Enabled reports whether new receipt-driven development may start.
@@ -321,7 +321,7 @@ func setRDDModeOverride(
 	if err := ctx.Err(); err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
-	persisted, err := cloneLocalRDDOverrideValue(mode)
+	persisted, err := rddModeOverrideValue(mode)
 	if err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
@@ -389,27 +389,16 @@ func setRDDModeOverride(
 	if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
-	globalMode, globalErr := normalizeRDDMode(global.Value)
-	if globalErr != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
-	}
-	// The reported status re-reads the sibling storage so the projection
-	// reflects the true combined precedence instead of only the record this
-	// writer just published: on a linked worktree a clone-scope write may be
-	// shadowed by an existing worktree-scope off, and vice versa.
-	cloneRecord, clonePresent, worktreeRecord, worktreePresent := rddModeOverrideRecord{}, false, rddModeOverrideRecord{}, false
-	if storage == rddOverrideCloneLocal {
-		cloneRecord, clonePresent = record, true
-		if worktreeRecord, worktreePresent, err = readWorktreeLocalRDDOverride(ctx, repo); err != nil {
-			return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), err
-		}
-	} else {
-		worktreeRecord, worktreePresent = record, true
-		if cloneRecord, clonePresent, err = readCloneLocalRDDOverride(ctx, repo); err != nil {
-			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-		}
-	}
-	return rddModeStatus(globalMode, cloneRecord, clonePresent, worktreeRecord, worktreePresent), nil
+	// The reported status must agree with a later ResolveRDDMode on the same
+	// checkout, for both storages and on both the main checkout and linked
+	// worktrees. Re-resolving through the same distinct-aware readers as the
+	// canonical read path guarantees the write-time projection can never
+	// disagree with a subsequent status about which source decided: on the
+	// main checkout a worktree-scope write still reports clone_local, and a
+	// linked worktree's clone-scope write shadowed by a worktree-local off
+	// still reports worktree_local. Any read failure stays fail-closed with
+	// the source ResolveRDDMode names.
+	return ResolveRDDMode(ctx, repo, global)
 }
 
 // AuthorizeRDDOperation is the single kill-switch gate. Reads always pass so
@@ -602,7 +591,10 @@ func RDDModeValueUnintelligible(value string) bool {
 	return err != nil
 }
 
-func cloneLocalRDDOverrideValue(mode RDDMode) (string, error) {
+// rddModeOverrideValue validates the off-only rule shared by both repository
+// storage scopes: an override may disable (off) or record an explicit inherit,
+// but never force review on.
+func rddModeOverrideValue(mode RDDMode) (string, error) {
 	switch mode {
 	case RDDModeOff:
 		return string(RDDModeOff), nil
@@ -705,6 +697,31 @@ func readWorktreeLocalRDDOverride(ctx context.Context, repo string) (rddModeOver
 		return rddModeOverrideRecord{}, false, nil
 	}
 	return readCloneLocalRDDOverrideHead(dir)
+}
+
+// WorktreeLocalRevision returns the compare-and-set token the worktree scope
+// targets on this checkout: the worktree-local head's revision on a linked
+// worktree, and the clone-local head's revision on the main checkout, where
+// the worktree scope has no distinct storage and shares the clone-local
+// record. It reports "" when the target storage holds no record, which is the
+// same position as an absent expected revision. It is strictly read-only and
+// never creates state.
+func WorktreeLocalRevision(ctx context.Context, repo string) (string, error) {
+	dir, _, err := rddModeStorageRoot(ctx, repo, false, rddOverrideWorktreeLocal)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	if err != nil {
+		return "", err
+	}
+	if !present {
+		return "", nil
+	}
+	return head.Revision, nil
 }
 
 // CloneLocalRDDModeRecordPath reports the clone-local override file that

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -325,7 +325,12 @@ func setRDDModeOverride(
 	if err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
-	dir, _, err := rddModeStorageRoot(ctx, repo, true, storage)
+	var dir string
+	if storage == rddOverrideWorktreeLocal {
+		dir, _, err = worktreeLocalRDDModeRoot(ctx, repo, true)
+	} else {
+		dir, err = cloneLocalRDDModeRoot(ctx, repo, true)
+	}
 	if err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
@@ -335,7 +340,7 @@ func setRDDModeOverride(
 	}
 	defer func() { _ = lock.release() }()
 
-	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	head, present, err := readRDDOverrideHead(dir)
 	if err != nil {
 		// An unreadable head is precisely what this command exists to replace,
 		// so it must not be able to block its own repair -- that left the
@@ -350,7 +355,7 @@ func setRDDModeOverride(
 		if !errors.Is(err, ErrRDDModeCorrupt) {
 			return failedClosedRDDModeStatus(source), err
 		}
-		generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
+		generation, generationErr := rddOverrideHeadGeneration(dir)
 		if generationErr != nil {
 			return failedClosedRDDModeStatus(source), generationErr
 		}
@@ -610,10 +615,15 @@ func rddModeOverrideValue(mode RDDMode) (string, error) {
 // cloneLocalRDDModeRoot derives the clone-local override directory from the
 // exact Git common directory. It nests inside the already-validated owner-only
 // review authority root so that path safety, permissions, and private IO reuse
-// the existing helpers instead of inventing a second path policy.
+// the existing helpers instead of inventing a second path policy. The
+// clone-local scope always roots under the shared common directory, so it has
+// no meaningful distinct value to report.
 func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, error) {
-	dir, _, err := rddModeStorageRoot(ctx, repo, create, rddOverrideCloneLocal)
-	return dir, err
+	identity, err := rddModeStorageIdentity(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	return rddModeRootUnder(identity.GitCommonDir, create)
 }
 
 // worktreeLocalRDDModeRoot derives the worktree-local override directory from
@@ -624,35 +634,40 @@ func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (strin
 // (GitDir == GitCommonDir) the worktree scope has no distinct storage and
 // resolves to the same location as the clone-local scope.
 func worktreeLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, bool, error) {
-	return rddModeStorageRoot(ctx, repo, create, rddOverrideWorktreeLocal)
+	identity, err := rddModeStorageIdentity(ctx, repo)
+	if err != nil {
+		return "", false, err
+	}
+	baseRoot := identity.GitCommonDir
+	distinct := identity.GitDir != identity.GitCommonDir
+	if distinct {
+		baseRoot = identity.GitDir
+	}
+	dir, err := rddModeRootUnder(baseRoot, create)
+	return dir, distinct, err
 }
 
-// rddModeStorageRoot decides where one override storage scope lives. Both
-// repository scopes share the same identity-based root decision: the clone-local
-// scope always roots under the shared Git common directory, while the
-// worktree-local scope roots under this worktree's own Git directory when that
-// differs (a linked worktree) and under the common directory otherwise.
-func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage rddModeOverrideStorage) (string, bool, error) {
+// rddModeStorageIdentity resolves the repository identity both storage scopes
+// root under. A bare repository already states its own refusal and names its
+// own recovery, so its error is returned unchanged instead of being wrapped in
+// this internal concern and misattributing the failure to a kill switch the
+// operator never touched.
+func rddModeStorageIdentity(ctx context.Context, repo string) (reviewRepositoryIdentityRecord, error) {
 	lease, err := OpenRepositoryIdentityLease(ctx, repo)
 	if err != nil {
-		// A bare repository already states its own refusal and names its own
-		// recovery. Wrapping it in this internal concern would misattribute the
-		// failure to a kill switch the operator never touched.
 		var bare *BareRepositoryError
 		if errors.As(err, &bare) {
-			return "", false, err
+			return reviewRepositoryIdentityRecord{}, err
 		}
-		return "", false, fmt.Errorf("resolve review mode repository identity: %w", err)
+		return reviewRepositoryIdentityRecord{}, fmt.Errorf("resolve review mode repository identity: %w", err)
 	}
-	identity := reviewRepositoryIdentityRecordFromLease(lease)
-	baseRoot := identity.GitCommonDir
-	distinct := true
-	if storage == rddOverrideWorktreeLocal {
-		distinct = identity.GitDir != identity.GitCommonDir
-		if distinct {
-			baseRoot = identity.GitDir
-		}
-	}
+	return reviewRepositoryIdentityRecordFromLease(lease), nil
+}
+
+// rddModeRootUnder builds the rdd-mode override directory under one repository
+// root (the shared Git common directory or a worktree's private Git directory)
+// and returns its path.
+func rddModeRootUnder(baseRoot string, create bool) (string, error) {
 	base := filepath.Join(
 		baseRoot,
 		"gentle-ai",
@@ -661,13 +676,13 @@ func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage r
 		rarAuthorityVersion,
 	)
 	if err := ensureRARRepositoryRoot(baseRoot, base, create); err != nil {
-		return "", false, err
+		return "", err
 	}
 	dir := filepath.Join(base, rddModeDirectory)
 	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
-		return "", false, err
+		return "", err
 	}
-	return dir, distinct, nil
+	return dir, nil
 }
 
 func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrideRecord, bool, error) {
@@ -678,7 +693,7 @@ func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrid
 		}
 		return rddModeOverrideRecord{}, false, err
 	}
-	return readCloneLocalRDDOverrideHead(dir)
+	return readRDDOverrideHead(dir)
 }
 
 // readWorktreeLocalRDDOverride reads the worktree-local override. On the main
@@ -696,7 +711,7 @@ func readWorktreeLocalRDDOverride(ctx context.Context, repo string) (rddModeOver
 	if !distinct {
 		return rddModeOverrideRecord{}, false, nil
 	}
-	return readCloneLocalRDDOverrideHead(dir)
+	return readRDDOverrideHead(dir)
 }
 
 // WorktreeLocalRevision returns the compare-and-set token the worktree scope
@@ -707,14 +722,14 @@ func readWorktreeLocalRDDOverride(ctx context.Context, repo string) (rddModeOver
 // same position as an absent expected revision. It is strictly read-only and
 // never creates state.
 func WorktreeLocalRevision(ctx context.Context, repo string) (string, error) {
-	dir, _, err := rddModeStorageRoot(ctx, repo, false, rddOverrideWorktreeLocal)
+	dir, _, err := worktreeLocalRDDModeRoot(ctx, repo, false)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
 		}
 		return "", err
 	}
-	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	head, present, err := readRDDOverrideHead(dir)
 	if err != nil {
 		return "", err
 	}
@@ -758,25 +773,31 @@ func WorktreeLocalRDDModeRecordPath(ctx context.Context, repo string) (string, e
 }
 
 func rddModeRecordPath(ctx context.Context, repo string, storage rddModeOverrideStorage) (string, error) {
-	dir, _, err := rddModeStorageRoot(ctx, repo, false, storage)
+	var dir string
+	var err error
+	if storage == rddOverrideWorktreeLocal {
+		dir, _, err = worktreeLocalRDDModeRoot(ctx, repo, false)
+	} else {
+		dir, err = cloneLocalRDDModeRoot(ctx, repo, false)
+	}
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
 		}
 		return "", err
 	}
-	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
+	head, err := rddOverrideHeadGeneration(dir)
 	if err != nil || head == 0 {
 		return "", err
 	}
 	return filepath.Join(dir, rddModeGenerationName(head)), nil
 }
 
-// cloneLocalRDDOverrideHeadGeneration reports the highest published generation
+// rddOverrideHeadGeneration reports the highest published generation
 // without reading or parsing it. Naming and repairing an unreadable head need
 // the slot number and nothing else, and a record that cannot be parsed must not
 // be able to hide the slot that supersedes it.
-func cloneLocalRDDOverrideHeadGeneration(dir string) (int, error) {
+func rddOverrideHeadGeneration(dir string) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -797,8 +818,8 @@ func cloneLocalRDDOverrideHeadGeneration(dir string) (int, error) {
 	return head, nil
 }
 
-func readCloneLocalRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, error) {
-	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
+func readRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, error) {
+	head, err := rddOverrideHeadGeneration(dir)
 	if err != nil {
 		return rddModeOverrideRecord{}, false, err
 	}

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -104,6 +104,10 @@ const (
 	RDDModeSourceGlobal RDDModeSource = "global"
 	// RDDModeSourceCloneLocal means this clone's Git-common-dir override decided.
 	RDDModeSourceCloneLocal RDDModeSource = "clone_local"
+	// RDDModeSourceWorktreeLocal means this linked worktree's private override
+	// decided. It exists only when the checkout is a linked worktree; on the
+	// main checkout there is no distinct worktree-local storage.
+	RDDModeSourceWorktreeLocal RDDModeSource = "worktree_local"
 )
 
 // RDDOperation classifies what an actor wants to do, so that disabling freezes
@@ -184,13 +188,15 @@ const (
 // clone-local compare-and-set token. The projection carries no time cutoff: it
 // answers "may review start now", never "which bytes are approved".
 type RDDModeStatus struct {
-	Schema     string        `json:"schema"`
-	Global     RDDMode       `json:"global"`
-	CloneLocal RDDMode       `json:"clone_local"`
-	Effective  RDDMode       `json:"effective"`
-	Source     RDDModeSource `json:"source"`
-	Revision   string        `json:"revision,omitempty"`
-	Reach      RDDModeReach  `json:"reach,omitempty"`
+	Schema           string        `json:"schema"`
+	Global           RDDMode       `json:"global"`
+	CloneLocal       RDDMode       `json:"clone_local"`
+	WorktreeLocal    RDDMode       `json:"worktree_local"`
+	Effective        RDDMode       `json:"effective"`
+	Source           RDDModeSource `json:"source"`
+	Revision         string        `json:"revision,omitempty"`
+	WorktreeRevision string        `json:"worktree_revision,omitempty"`
+	Reach            RDDModeReach  `json:"reach,omitempty"`
 }
 
 // Enabled reports whether new receipt-driven development may start.
@@ -258,6 +264,23 @@ func reviewModeEnableForSource(source RDDModeSource) string {
 	return enable + "global"
 }
 
+// reviewModeScopeForSource maps the deciding source onto the --scope value of
+// `gentle-ai review mode enable`. The default source expresses no opinion, so
+// it can never be what keeps reviews off and gets no continuation rather than
+// a guessed one.
+func reviewModeScopeForSource(source RDDModeSource) string {
+	switch source {
+	case RDDModeSourceGlobal:
+		return "global"
+	case RDDModeSourceCloneLocal:
+		return "clone"
+	case RDDModeSourceWorktreeLocal:
+		return "worktree"
+	default:
+		return ""
+	}
+}
+
 func (err *RDDDisabledError) Unwrap() error { return ErrRDDDisabled }
 
 // RDDModePartialApplyError reports a clone-scope write that applied for this
@@ -306,11 +329,15 @@ func ResolveRDDMode(ctx context.Context, repo string, global RDDGlobalMode) (RDD
 	if globalErr != nil {
 		return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
 	}
-	override, present, overrideErr := readCloneLocalRDDOverride(ctx, repo)
-	if overrideErr != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), overrideErr
+	cloneOverride, clonePresent, cloneErr := readCloneLocalRDDOverride(ctx, repo)
+	if cloneErr != nil {
+		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), cloneErr
 	}
-	return rddModeStatus(globalMode, override, present), nil
+	worktreeOverride, worktreePresent, worktreeErr := readWorktreeLocalRDDOverride(ctx, repo)
+	if worktreeErr != nil {
+		return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), worktreeErr
+	}
+	return rddModeStatusWithWorktree(globalMode, cloneOverride, clonePresent, worktreeOverride, worktreePresent), nil
 }
 
 // SetCloneLocalRDDMode records this clone's off-only override under the Git
@@ -324,157 +351,41 @@ func SetCloneLocalRDDMode(
 	expectedRevision string,
 	global RDDGlobalMode,
 ) (RDDModeStatus, error) {
-	if err := ctx.Err(); err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	persisted, err := cloneLocalRDDOverrideValue(mode)
-	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	globalMode, globalErr := normalizeRDDMode(global.Value)
-	if globalErr != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
-	}
-	currentStatus, currentErr := ResolveRDDMode(ctx, repo, global)
-	if currentErr == nil && strings.TrimSpace(expectedRevision) != currentStatus.Revision {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), fmt.Errorf(
-			"%w: expected %q but the clone-local head is %q", ErrRDDModeRevisionMismatch, expectedRevision, currentStatus.Revision)
-	}
-	if currentErr == nil && mode == RDDModeUnset && globalMode == RDDModeOff {
-		// Clearing this clone's off-only override cannot enable review while the
-		// global source remains off, so refuse without publishing a generation.
-		return currentStatus, &RDDDisabledError{Operation: RDDOperationStart, Source: RDDModeSourceGlobal}
-	}
-	// A request that matches the mode this clone already carries publishes no
-	// new generation of its own -- but it is not finished until every gentle-ai
-	// on this machine carries it too, so it goes on to the mirror below rather
-	// than returning here.
-	alreadyDecided := currentErr == nil && ((mode == RDDModeOff && currentStatus.CloneLocal == RDDModeOff) ||
-		(mode == RDDModeUnset && currentStatus.CloneLocal == RDDModeUnset))
-	if alreadyDecided && currentStatus.Revision == "" {
-		// This clone holds no override in either location and is not being asked
-		// for one. There is no decision to record and none to mirror, so this
-		// stays the one path that creates nothing at all.
-		return currentStatus, nil
-	}
-	if currentErr != nil && !errors.Is(currentErr, ErrRDDModeCorrupt) {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), currentErr
-	}
-	dir, err := cloneLocalRDDModeRoot(ctx, repo, true)
-	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	lock, err := acquireRARAuthorityLock(ctx, filepath.Join(dir, rddModeLockName))
-	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	defer func() { _ = lock.release() }()
+	return setRDDModeOverride(ctx, repo, rddOverrideCloneLocal, mode, expectedRevision, global)
+}
 
-	// Every clone-scope write also publishes into the pre-relocation location,
-	// because that is where the other gentle-ai installations on this machine
-	// read the switch. Writers from before the relocation lock that path;
-	// taking this build's root first and that one second serialises either
-	// version of gentle-ai without a lock-order cycle.
-	mirror := openCloneLocalRDDModeMirror(ctx, repo)
-	defer mirror.release()
+func SetWorktreeLocalRDDMode(
+	ctx context.Context,
+	repo string,
+	mode RDDMode,
+	expectedRevision string,
+	global RDDGlobalMode,
+) (RDDModeStatus, error) {
+	return setRDDModeOverride(ctx, repo, rddOverrideWorktreeLocal, mode, expectedRevision, global)
+}
 
-	head, present, err := readCloneLocalRDDOverrideHead(dir)
-	repairingCurrentHead := false
-	if err != nil {
-		// An unreadable head is precisely what this command exists to replace,
-		// so it must not be able to block its own repair -- that left the
-		// operator with a refusal and no runnable way out of it. It expresses
-		// no readable opinion and therefore carries no compare-and-set token,
-		// which is the same position as holding no record at all.
-		//
-		// Nothing is weakened. The lock still serialises writers, and the
-		// immutable no-replace publish still refuses to overwrite the
-		// unreadable generation: the repair writes the generation that
-		// supersedes it, so a lost race still cannot corrupt the head.
-		if !errors.Is(err, ErrRDDModeCorrupt) {
-			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-		}
-		generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
-		if generationErr != nil {
-			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), generationErr
-		}
-		head, present = rddModeOverrideRecord{Generation: generation}, false
-		repairingCurrentHead = true
-	}
-	if !present && !repairingCurrentHead && mirror.available {
-		// Legacy records are immutable forensic evidence. A valid one may advance
-		// only by publishing its successor in the switch-owned authority root;
-		// a damaged legacy record must never be shadowed by a fresh root.
-		if mirror.readErr != nil {
-			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), mirror.readErr
-		}
-		if mirror.present {
-			head, present = mirror.record, true
-		}
-	}
-	current := ""
-	if present {
-		current = head.Revision
-	}
-	if strings.TrimSpace(expectedRevision) != current {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), fmt.Errorf(
-			"%w: expected %q but the clone-local head is %q", ErrRDDModeRevisionMismatch, expectedRevision, current)
-	}
-	if alreadyDecided && (!mirror.available || mirror.decides(persisted)) {
-		// Both readable locations already carry this decision, or the other one
-		// cannot be reached at all and no write would change what it reports.
-		// Publishing another generation would move the compare-and-set token
-		// for nothing.
-		return rddModeWriteStatus(globalMode, head, present, mirror.reach()), nil
-	}
-	// The generation is a slot number in both locations, so it clears whichever
-	// of them has published further. A pre-relocation gentle-ai that wrote its
-	// own generations must not have one of them overwritten, and this build's
-	// own head must still advance.
-	generation := head.Generation + 1
-	if mirror.available && mirror.head >= generation {
-		generation = mirror.head + 1
-	}
-	if generation > rddModeMaxGeneration {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), errors.New("clone-local review mode generation space is exhausted")
-	}
+// rddModeOverrideStorage names which storage scope a read or write targets.
+type rddModeOverrideStorage int
 
-	record := rddModeOverrideRecord{
-		Schema:           rddModeOverrideSchema,
-		Generation:       generation,
-		PreviousRevision: current,
-		Mode:             persisted,
-		RecordedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+const (
+	rddOverrideCloneLocal rddModeOverrideStorage = iota
+	rddOverrideWorktreeLocal
+)
+
+func rddOverrideSource(storage rddModeOverrideStorage) RDDModeSource {
+	if storage == rddOverrideWorktreeLocal {
+		return RDDModeSourceWorktreeLocal
 	}
-	if record.Revision, err = rddModeOverrideDigest(record); err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+	return RDDModeSourceCloneLocal
+}
+
+// rddOverrideHeadLabel names one storage scope the way an operator would say
+// it in an error message.
+func rddOverrideHeadLabel(storage rddModeOverrideStorage) string {
+	if storage == rddOverrideWorktreeLocal {
+		return "worktree-local"
 	}
-	payload, err := canonicalRDDModeOverridePayload(record)
-	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	// The immutable no-replace publish is the fail-closed backstop: a writer
-	// that somehow bypassed the lock still cannot overwrite a published
-	// generation, so a lost race can never corrupt the head record.
-	//
-	// This build's own root is published first and never waits on the other
-	// location's health. #2882 is exactly what happens when the switch can be
-	// held hostage by the review authority tree, and ordering the mirror ahead
-	// of it would reintroduce that through the back door.
-	if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	if !mirror.available {
-		return rddModeWriteStatus(globalMode, record, true, RDDModeReachThisBuild), nil
-	}
-	// The same exact bytes at the same slot: a pre-relocation gentle-ai parses,
-	// digests, and canonicalises this record identically, so the two locations
-	// hold one decision rather than two that have to be reconciled.
-	if err := publishPrivateRARImmutable(filepath.Join(mirror.dir, rddModeGenerationName(record.Generation)), payload); err != nil {
-		return rddModeWriteStatus(globalMode, record, true, RDDModeReachThisBuild),
-			&RDDModePartialApplyError{Mode: mode, Cause: err}
-	}
-	return rddModeWriteStatus(globalMode, record, true, RDDModeReachMachine), nil
+	return "clone-local"
 }
 
 // cloneLocalRDDModeMirror is the pre-relocation copy of this clone's override,
@@ -485,6 +396,198 @@ func SetCloneLocalRDDMode(
 // gentle-ai fails closed on, so refusing there would only re-close the exit
 // #2882 opened; a location that opens and then refuses the publish is a real
 // half-applied switch and is reported as one.
+
+func setRDDModeOverride(
+	ctx context.Context,
+	repo string,
+	storage rddModeOverrideStorage,
+	mode RDDMode,
+	expectedRevision string,
+	global RDDGlobalMode,
+) (RDDModeStatus, error) {
+	source := rddOverrideSource(storage)
+	if err := ctx.Err(); err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	persisted, err := cloneLocalRDDOverrideValue(mode)
+	if err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	globalMode, globalErr := normalizeRDDMode(global.Value)
+	if globalErr != nil {
+		return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
+	}
+	currentStatus, currentErr := ResolveRDDMode(ctx, repo, global)
+	if storage == rddOverrideCloneLocal {
+		if currentErr == nil && strings.TrimSpace(expectedRevision) != currentStatus.Revision {
+			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), fmt.Errorf(
+				"%w: expected %q but the clone-local head is %q", ErrRDDModeRevisionMismatch, expectedRevision, currentStatus.Revision)
+		}
+		if currentErr == nil && mode == RDDModeUnset && globalMode == RDDModeOff {
+			return currentStatus, &RDDDisabledError{Operation: RDDOperationStart, Source: RDDModeSourceGlobal}
+		}
+		alreadyDecided := currentErr == nil && ((mode == RDDModeOff && currentStatus.CloneLocal == RDDModeOff) ||
+			(mode == RDDModeUnset && currentStatus.CloneLocal == RDDModeUnset))
+		if alreadyDecided && currentStatus.Revision == "" {
+			return currentStatus, nil
+		}
+		if currentErr != nil && !errors.Is(currentErr, ErrRDDModeCorrupt) {
+			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), currentErr
+		}
+	} else {
+		if currentErr != nil && !errors.Is(currentErr, ErrRDDModeCorrupt) {
+			return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), currentErr
+		}
+		if currentErr == nil && mode == RDDModeUnset && globalMode == RDDModeOff {
+			return currentStatus, &RDDDisabledError{Operation: RDDOperationStart, Source: RDDModeSourceGlobal}
+		}
+	}
+	dir, _, err := rddModeStorageRoot(ctx, repo, true, storage)
+	if err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	lock, err := acquireRARAuthorityLock(ctx, filepath.Join(dir, rddModeLockName))
+	if err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	defer func() { _ = lock.release() }()
+
+	if storage == rddOverrideCloneLocal {
+		mirror := openCloneLocalRDDModeMirror(ctx, repo)
+		defer mirror.release()
+
+		head, present, err := readCloneLocalRDDOverrideHead(dir)
+		repairingCurrentHead := false
+		if err != nil {
+			if !errors.Is(err, ErrRDDModeCorrupt) {
+				return failedClosedRDDModeStatus(source), err
+			}
+			generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
+			if generationErr != nil {
+				return failedClosedRDDModeStatus(source), generationErr
+			}
+			head, present = rddModeOverrideRecord{Generation: generation}, false
+			repairingCurrentHead = true
+		}
+		if !present && !repairingCurrentHead && mirror.available {
+			if mirror.readErr != nil {
+				return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), mirror.readErr
+			}
+			if mirror.present {
+				head, present = mirror.record, true
+			}
+		}
+		current := ""
+		if present {
+			current = head.Revision
+		}
+		if strings.TrimSpace(expectedRevision) != current {
+			return failedClosedRDDModeStatus(source), fmt.Errorf(
+				"%w: expected %q but the %s head is %q", ErrRDDModeRevisionMismatch, expectedRevision, rddOverrideHeadLabel(storage), current)
+		}
+		alreadyDecided := currentErr == nil && ((mode == RDDModeOff && currentStatus.CloneLocal == RDDModeOff) ||
+			(mode == RDDModeUnset && currentStatus.CloneLocal == RDDModeUnset))
+		if alreadyDecided && (!mirror.available || mirror.decides(persisted)) {
+			worktreeRecord, worktreePresent, err := readWorktreeLocalRDDOverride(ctx, repo)
+			if err != nil {
+				return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), err
+			}
+			status := rddModeStatusWithWorktree(globalMode, head, present, worktreeRecord, worktreePresent)
+			status.Reach = mirror.reach()
+			return status, nil
+		}
+		generation := head.Generation + 1
+		if mirror.available && mirror.head >= generation {
+			generation = mirror.head + 1
+		}
+		if generation > rddModeMaxGeneration {
+			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), errors.New("clone-local review mode generation space is exhausted")
+		}
+		record := rddModeOverrideRecord{
+			Schema:           rddModeOverrideSchema,
+			Generation:       generation,
+			PreviousRevision: current,
+			Mode:             persisted,
+			RecordedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		if record.Revision, err = rddModeOverrideDigest(record); err != nil {
+			return failedClosedRDDModeStatus(source), err
+		}
+		payload, err := canonicalRDDModeOverridePayload(record)
+		if err != nil {
+			return failedClosedRDDModeStatus(source), err
+		}
+		if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
+			return failedClosedRDDModeStatus(source), err
+		}
+		if !mirror.available {
+			worktreeRecord, worktreePresent, err := readWorktreeLocalRDDOverride(ctx, repo)
+			if err != nil {
+				return failedClosedRDDModeStatus(RDDModeSourceWorktreeLocal), err
+			}
+			status := rddModeStatusWithWorktree(globalMode, record, true, worktreeRecord, worktreePresent)
+			status.Reach = RDDModeReachThisBuild
+			return status, nil
+		}
+		if err := publishPrivateRARImmutable(filepath.Join(mirror.dir, rddModeGenerationName(record.Generation)), payload); err != nil {
+			worktreeRecord, worktreePresent, _ := readWorktreeLocalRDDOverride(ctx, repo)
+			status := rddModeStatusWithWorktree(globalMode, record, true, worktreeRecord, worktreePresent)
+			status.Reach = RDDModeReachThisBuild
+			return status, &RDDModePartialApplyError{Mode: mode, Cause: err}
+		}
+		worktreeRecord, worktreePresent, _ := readWorktreeLocalRDDOverride(ctx, repo)
+		status := rddModeStatusWithWorktree(globalMode, record, true, worktreeRecord, worktreePresent)
+		status.Reach = RDDModeReachMachine
+		return status, nil
+	}
+	// worktreeLocal path (no mirror)
+	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	if err != nil {
+		if !errors.Is(err, ErrRDDModeCorrupt) {
+			return failedClosedRDDModeStatus(source), err
+		}
+		generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
+		if generationErr != nil {
+			return failedClosedRDDModeStatus(source), generationErr
+		}
+		head, present = rddModeOverrideRecord{Generation: generation}, false
+	}
+	current := ""
+	if present {
+		current = head.Revision
+	}
+	if strings.TrimSpace(expectedRevision) != current {
+		return failedClosedRDDModeStatus(source), fmt.Errorf(
+			"%w: expected %q but the %s head is %q", ErrRDDModeRevisionMismatch, expectedRevision, rddOverrideHeadLabel(storage), current)
+	}
+	if head.Generation >= rddModeMaxGeneration {
+		return failedClosedRDDModeStatus(source), fmt.Errorf("%s review mode generation space is exhausted", rddOverrideHeadLabel(storage))
+	}
+	record := rddModeOverrideRecord{
+		Schema:           rddModeOverrideSchema,
+		Generation:       head.Generation + 1,
+		PreviousRevision: current,
+		Mode:             persisted,
+		RecordedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if record.Revision, err = rddModeOverrideDigest(record); err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	payload, err := canonicalRDDModeOverridePayload(record)
+	if err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
+		return failedClosedRDDModeStatus(source), err
+	}
+	cloneRecord, clonePresent, err := readCloneLocalRDDOverride(ctx, repo)
+	if err != nil {
+		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
+	}
+	worktreeRecord, worktreePresent := record, true
+	return rddModeStatusWithWorktree(globalMode, cloneRecord, clonePresent, worktreeRecord, worktreePresent), nil
+}
+
 type cloneLocalRDDModeMirror struct {
 	dir       string
 	lock      *storeLock
@@ -683,20 +786,39 @@ func rddModeStatus(
 	override rddModeOverrideRecord,
 	present bool,
 ) RDDModeStatus {
+	return rddModeStatusWithWorktree(globalMode, override, present, rddModeOverrideRecord{}, false)
+}
+
+func rddModeStatusWithWorktree(
+	globalMode RDDMode,
+	cloneOverride rddModeOverrideRecord,
+	clonePresent bool,
+	worktreeOverride rddModeOverrideRecord,
+	worktreePresent bool,
+) RDDModeStatus {
 	status := RDDModeStatus{
-		Schema:     RDDModeStatusSchema,
-		Global:     globalMode,
-		CloneLocal: RDDModeUnset,
-		Effective:  RDDModeOff,
-		Source:     RDDModeSourceDefault,
+		Schema:        RDDModeStatusSchema,
+		Global:        globalMode,
+		CloneLocal:    RDDModeUnset,
+		WorktreeLocal: RDDModeUnset,
+		Effective:     RDDModeOff,
+		Source:        RDDModeSourceDefault,
 	}
-	if present {
-		status.Revision = override.Revision
-		if override.Mode == string(RDDModeOff) {
+	if clonePresent {
+		status.Revision = cloneOverride.Revision
+		if cloneOverride.Mode == string(RDDModeOff) {
 			status.CloneLocal = RDDModeOff
 		}
 	}
+	if worktreePresent {
+		status.WorktreeRevision = worktreeOverride.Revision
+		if worktreeOverride.Mode == string(RDDModeOff) {
+			status.WorktreeLocal = RDDModeOff
+		}
+	}
 	switch {
+	case status.WorktreeLocal == RDDModeOff:
+		status.Effective, status.Source = RDDModeOff, RDDModeSourceWorktreeLocal
 	case status.CloneLocal == RDDModeOff:
 		status.Effective, status.Source = RDDModeOff, RDDModeSourceCloneLocal
 	case globalMode == RDDModeOff:
@@ -721,18 +843,32 @@ func rddModeWriteStatus(
 	present bool,
 	reach RDDModeReach,
 ) RDDModeStatus {
-	status := rddModeStatus(globalMode, override, present)
+	status := rddModeStatusWithWorktree(globalMode, override, present, rddModeOverrideRecord{}, false)
+	status.Reach = reach
+	return status
+}
+
+func rddModeWriteStatusWithWorktree(
+	globalMode RDDMode,
+	cloneOverride rddModeOverrideRecord,
+	clonePresent bool,
+	worktreeOverride rddModeOverrideRecord,
+	worktreePresent bool,
+	reach RDDModeReach,
+) RDDModeStatus {
+	status := rddModeStatusWithWorktree(globalMode, cloneOverride, clonePresent, worktreeOverride, worktreePresent)
 	status.Reach = reach
 	return status
 }
 
 func failedClosedRDDModeStatus(source RDDModeSource) RDDModeStatus {
 	return RDDModeStatus{
-		Schema:     RDDModeStatusSchema,
-		Global:     RDDModeUnset,
-		CloneLocal: RDDModeUnset,
-		Effective:  RDDModeOff,
-		Source:     source,
+		Schema:        RDDModeStatusSchema,
+		Global:        RDDModeUnset,
+		CloneLocal:    RDDModeUnset,
+		WorktreeLocal: RDDModeUnset,
+		Effective:     RDDModeOff,
+		Source:        source,
 	}
 }
 
@@ -934,6 +1070,105 @@ func CloneLocalRDDModeRecordPath(ctx context.Context, repo string) (string, erro
 // without reading or parsing it. Naming and repairing an unreadable head need
 // the slot number and nothing else, and a record that cannot be parsed must not
 // be able to hide the slot that supersedes it.
+
+
+func readWorktreeLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrideRecord, bool, error) {
+	dir, distinct, err := worktreeLocalRDDModeRoot(ctx, repo, false)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return rddModeOverrideRecord{}, false, nil
+		}
+		return rddModeOverrideRecord{}, false, err
+	}
+	if !distinct {
+		return rddModeOverrideRecord{}, false, nil
+	}
+	return readCloneLocalRDDOverrideHead(dir)
+}
+
+func worktreeLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, bool, error) {
+	return rddModeStorageRoot(ctx, repo, create, rddOverrideWorktreeLocal)
+}
+
+func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage rddModeOverrideStorage) (string, bool, error) {
+	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	if err != nil {
+		var bare *BareRepositoryError
+		if errors.As(err, &bare) {
+			return "", false, err
+		}
+		return "", false, fmt.Errorf("resolve review mode repository identity: %w", err)
+	}
+	identity := reviewRepositoryIdentityRecordFromLease(lease)
+	baseRoot := identity.GitCommonDir
+	distinct := true
+	switchDir := rddModeSwitchDirectory
+	if storage == rddOverrideWorktreeLocal {
+		distinct = identity.GitDir != identity.GitCommonDir
+		if distinct {
+			baseRoot = identity.GitDir
+		}
+		switchDir = rddModeLegacySwitchDirectory
+	}
+	base := filepath.Join(
+		baseRoot,
+		"gentle-ai",
+		switchDir,
+		rarAuthorityDirectory,
+		rarAuthorityVersion,
+	)
+	if storage == rddOverrideCloneLocal {
+		if err := ensureRARSwitchRoot(baseRoot, base, create); err != nil {
+			return "", false, err
+		}
+	} else {
+		if err := ensureRARRepositoryRoot(baseRoot, base, create); err != nil {
+			return "", false, err
+		}
+	}
+	dir := filepath.Join(base, rddModeDirectory)
+	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
+		return "", false, err
+	}
+	return dir, distinct, nil
+}
+
+func WorktreeLocalRDDModeRecordPath(ctx context.Context, repo string) (string, error) {
+	return rddModeRecordPath(ctx, repo, rddOverrideWorktreeLocal)
+}
+
+func rddModeRecordPath(ctx context.Context, repo string, storage rddModeOverrideStorage) (string, error) {
+	dir, _, err := rddModeStorageRoot(ctx, repo, false, storage)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	if dir == "" {
+		return "", nil
+	}
+	// For worktreeLocal on main checkout, there is no distinct storage, so no record
+	if storage == rddOverrideWorktreeLocal {
+		lease, err := OpenRepositoryIdentityLease(ctx, repo)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return "", nil
+			}
+			return "", err
+		}
+		identity := reviewRepositoryIdentityRecordFromLease(lease)
+		if identity.GitDir == identity.GitCommonDir {
+			return "", nil
+		}
+	}
+	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
+	if err != nil || head == 0 {
+		return "", err
+	}
+	return filepath.Join(dir, rddModeGenerationName(head)), nil
+}
+
 func cloneLocalRDDOverrideHeadGeneration(dir string) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -1165,6 +1165,32 @@ func WorktreeLocalRevision(ctx context.Context, repo string) (string, error) {
 	return head.Revision, nil
 }
 
+// CloneLocalRevision returns the compare-and-set token for the clone-local
+// scope alone, independent of whether the worktree-local record is readable.
+// It reports "" when the clone-local storage holds no record, which is the
+// same position as an absent expected revision. It is strictly read-only and
+// never creates state.
+func CloneLocalRevision(ctx context.Context, repo string) (string, error) {
+	record, present, err := readCloneLocalRDDOverride(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	if !present {
+		return "", nil
+	}
+	return record.Revision, nil
+}
+
+// CloneLocalRDDModeRecordPath reports the clone-local override file that
+// currently decides this clone's mode, so a refusal can name the exact file
+// holding an unreadable value instead of merely describing it. It is strictly
+// read-only, never creates state, and reports "" when this clone holds no
+// override at all.
+
+// WorktreeLocalRDDModeRecordPath reports the worktree-local override file that
+// currently decides this worktree's mode, so a refusal can name the exact file
+// holding an unreadable value. On the main checkout it reports the clone-local
+// file, because that is where the worktree scope actually stores its record.
 func WorktreeLocalRDDModeRecordPath(ctx context.Context, repo string) (string, error) {
 	return rddModeRecordPath(ctx, repo, rddOverrideWorktreeLocal)
 }

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -409,7 +409,7 @@ func setRDDModeOverride(
 	if err := ctx.Err(); err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
-	persisted, err := cloneLocalRDDOverrideValue(mode)
+	persisted, err := rddModeOverrideValue(mode)
 	if err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
@@ -580,12 +580,16 @@ func setRDDModeOverride(
 	if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
-	cloneRecord, clonePresent, err := readCloneLocalRDDOverride(ctx, repo)
-	if err != nil {
-		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
-	}
-	worktreeRecord, worktreePresent := record, true
-	return rddModeStatusWithWorktree(globalMode, cloneRecord, clonePresent, worktreeRecord, worktreePresent), nil
+	// The reported status must agree with a later ResolveRDDMode on the same
+	// checkout, for both storages and on both the main checkout and linked
+	// worktrees. Re-resolving through the same distinct-aware readers as the
+	// canonical read path guarantees the write-time projection can never
+	// disagree with a subsequent status about which source decided: on the
+	// main checkout a worktree-scope write still reports clone_local, and a
+	// linked worktree's clone-scope write shadowed by a worktree-local off
+	// still reports worktree_local. Any read failure stays fail-closed with
+	// the source ResolveRDDMode names.
+	return ResolveRDDMode(ctx, repo, global)
 }
 
 type cloneLocalRDDModeMirror struct {
@@ -894,7 +898,10 @@ func RDDModeValueUnintelligible(value string) bool {
 	return err != nil
 }
 
-func cloneLocalRDDOverrideValue(mode RDDMode) (string, error) {
+// rddModeOverrideValue validates the off-only rule shared by both repository
+// storage scopes: an override may disable (off) or record an explicit inherit,
+// but never force review on.
+func rddModeOverrideValue(mode RDDMode) (string, error) {
 	switch mode {
 	case RDDModeOff:
 		return string(RDDModeOff), nil
@@ -1131,6 +1138,31 @@ func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage r
 		return "", false, err
 	}
 	return dir, distinct, nil
+}
+
+// WorktreeLocalRevision returns the compare-and-set token the worktree scope
+// targets on this checkout: the worktree-local head's revision on a linked
+// worktree, and the clone-local head's revision on the main checkout, where
+// the worktree scope has no distinct storage and shares the clone-local
+// record. It reports "" when the target storage holds no record, which is the
+// same position as an absent expected revision. It is strictly read-only and
+// never creates state.
+func WorktreeLocalRevision(ctx context.Context, repo string) (string, error) {
+	dir, _, err := rddModeStorageRoot(ctx, repo, false, rddOverrideWorktreeLocal)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	if err != nil {
+		return "", err
+	}
+	if !present {
+		return "", nil
+	}
+	return head.Revision, nil
 }
 
 func WorktreeLocalRDDModeRecordPath(ctx context.Context, repo string) (string, error) {

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -261,6 +261,9 @@ func reviewModeEnableForSource(source RDDModeSource) string {
 	if source == RDDModeSourceCloneLocal {
 		return enable + "global then " + enable + "clone"
 	}
+	if source == RDDModeSourceWorktreeLocal {
+		return enable + "worktree"
+	}
 	return enable + "global"
 }
 
@@ -442,7 +445,12 @@ func setRDDModeOverride(
 			return currentStatus, &RDDDisabledError{Operation: RDDOperationStart, Source: RDDModeSourceGlobal}
 		}
 	}
-	dir, _, err := rddModeStorageRoot(ctx, repo, true, storage)
+	var dir string
+	if storage == rddOverrideWorktreeLocal {
+		dir, _, err = worktreeLocalRDDModeRoot(ctx, repo, true)
+	} else {
+		dir, err = cloneLocalRDDModeRoot(ctx, repo, true)
+	}
 	if err != nil {
 		return failedClosedRDDModeStatus(source), err
 	}
@@ -456,13 +464,13 @@ func setRDDModeOverride(
 		mirror := openCloneLocalRDDModeMirror(ctx, repo)
 		defer mirror.release()
 
-		head, present, err := readCloneLocalRDDOverrideHead(dir)
+		head, present, err := readRDDOverrideHead(dir)
 		repairingCurrentHead := false
 		if err != nil {
 			if !errors.Is(err, ErrRDDModeCorrupt) {
 				return failedClosedRDDModeStatus(source), err
 			}
-			generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
+			generation, generationErr := rddOverrideHeadGeneration(dir)
 			if generationErr != nil {
 				return failedClosedRDDModeStatus(source), generationErr
 			}
@@ -541,12 +549,12 @@ func setRDDModeOverride(
 		return status, nil
 	}
 	// worktreeLocal path (no mirror)
-	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	head, present, err := readRDDOverrideHead(dir)
 	if err != nil {
 		if !errors.Is(err, ErrRDDModeCorrupt) {
 			return failedClosedRDDModeStatus(source), err
 		}
-		generation, generationErr := cloneLocalRDDOverrideHeadGeneration(dir)
+		generation, generationErr := rddOverrideHeadGeneration(dir)
 		if generationErr != nil {
 			return failedClosedRDDModeStatus(source), generationErr
 		}
@@ -611,7 +619,7 @@ type cloneLocalRDDModeMirror struct {
 // validates and then refuses readdir(2) -- a permission change racing the
 // walk, EIO, or ESTALE on a network mount. Production always uses the real
 // scan.
-var cloneLocalRDDModeMirrorSlotScan = cloneLocalRDDOverrideHeadGeneration
+var cloneLocalRDDModeMirrorSlotScan = rddOverrideHeadGeneration
 
 func openCloneLocalRDDModeMirror(ctx context.Context, repo string) *cloneLocalRDDModeMirror {
 	mirror := &cloneLocalRDDModeMirror{}
@@ -654,7 +662,7 @@ func openCloneLocalRDDModeMirror(ctx context.Context, repo string) *cloneLocalRD
 		return mirror
 	}
 	mirror.head = head
-	mirror.record, mirror.present, mirror.readErr = readCloneLocalRDDOverrideHead(dir)
+	mirror.record, mirror.present, mirror.readErr = readRDDOverrideHead(dir)
 	return mirror
 }
 
@@ -938,23 +946,7 @@ const rddModeSwitchDirectory = "review-mode"
 // is a decision they never see (#3284).
 const rddModeLegacySwitchDirectory = "review-transactions"
 
-// cloneLocalRDDModeRoot derives the override directory from the exact Git
-// common directory, under the switch's own root.
-func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, error) {
-	identity, err := cloneLocalRDDModeIdentity(ctx, repo)
-	if err != nil {
-		return "", err
-	}
-	base := filepath.Join(identity.GitCommonDir, "gentle-ai", rddModeSwitchDirectory, rarAuthorityDirectory, rarAuthorityVersion)
-	if err := ensureRARSwitchRoot(identity.GitCommonDir, base, create); err != nil {
-		return "", err
-	}
-	dir := filepath.Join(base, rddModeDirectory)
-	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
-		return "", err
-	}
-	return dir, nil
-}
+
 
 // cloneLocalRDDModeLegacyRoot is the pre-#2882 location inside the review
 // authority tree. Reads pass create=false and are best-effort: overrides
@@ -1018,7 +1010,7 @@ func cloneLocalRDDModeReadRoot(ctx context.Context, repo string) (string, error)
 		return "", err
 	}
 	if err == nil {
-		head, headErr := cloneLocalRDDOverrideHeadGeneration(dir)
+		head, headErr := rddOverrideHeadGeneration(dir)
 		if headErr != nil {
 			return "", headErr
 		}
@@ -1030,7 +1022,7 @@ func cloneLocalRDDModeReadRoot(ctx context.Context, repo string) (string, error)
 	if legacyErr != nil {
 		return "", nil
 	}
-	if head, headErr := cloneLocalRDDOverrideHeadGeneration(legacy); headErr != nil || head == 0 {
+	if head, headErr := rddOverrideHeadGeneration(legacy); headErr != nil || head == 0 {
 		return "", nil
 	}
 	return legacy, nil
@@ -1047,7 +1039,7 @@ func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrid
 	if dir == "" {
 		return rddModeOverrideRecord{}, false, nil
 	}
-	return readCloneLocalRDDOverrideHead(dir)
+	return readRDDOverrideHead(dir)
 }
 
 // CloneLocalRDDModeRecordPath reports the clone-local override file that
@@ -1066,14 +1058,14 @@ func CloneLocalRDDModeRecordPath(ctx context.Context, repo string) (string, erro
 	if dir == "" {
 		return "", nil
 	}
-	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
+	head, err := rddOverrideHeadGeneration(dir)
 	if err != nil || head == 0 {
 		return "", err
 	}
 	return filepath.Join(dir, rddModeGenerationName(head)), nil
 }
 
-// cloneLocalRDDOverrideHeadGeneration reports the highest published generation
+// rddOverrideHeadGeneration reports the highest published generation
 // without reading or parsing it. Naming and repairing an unreadable head need
 // the slot number and nothing else, and a record that cannot be parsed must not
 // be able to hide the slot that supersedes it.
@@ -1090,54 +1082,72 @@ func readWorktreeLocalRDDOverride(ctx context.Context, repo string) (rddModeOver
 	if !distinct {
 		return rddModeOverrideRecord{}, false, nil
 	}
-	return readCloneLocalRDDOverrideHead(dir)
+	return readRDDOverrideHead(dir)
+}
+
+func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, error) {
+	identity, err := rddModeStorageIdentity(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	return rddModeRootUnder(identity.GitCommonDir, create)
 }
 
 func worktreeLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, bool, error) {
-	return rddModeStorageRoot(ctx, repo, create, rddOverrideWorktreeLocal)
-}
-
-func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage rddModeOverrideStorage) (string, bool, error) {
-	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	identity, err := rddModeStorageIdentity(ctx, repo)
 	if err != nil {
-		var bare *BareRepositoryError
-		if errors.As(err, &bare) {
-			return "", false, err
-		}
-		return "", false, fmt.Errorf("resolve review mode repository identity: %w", err)
+		return "", false, err
 	}
-	identity := reviewRepositoryIdentityRecordFromLease(lease)
 	baseRoot := identity.GitCommonDir
-	distinct := true
-	switchDir := rddModeSwitchDirectory
-	if storage == rddOverrideWorktreeLocal {
-		distinct = identity.GitDir != identity.GitCommonDir
-		if distinct {
-			baseRoot = identity.GitDir
-		}
-		switchDir = rddModeLegacySwitchDirectory
+	distinct := identity.GitDir != identity.GitCommonDir
+	if distinct {
+		baseRoot = identity.GitDir
 	}
 	base := filepath.Join(
 		baseRoot,
 		"gentle-ai",
-		switchDir,
+		rddModeLegacySwitchDirectory,
 		rarAuthorityDirectory,
 		rarAuthorityVersion,
 	)
-	if storage == rddOverrideCloneLocal {
-		if err := ensureRARSwitchRoot(baseRoot, base, create); err != nil {
-			return "", false, err
-		}
-	} else {
-		if err := ensureRARRepositoryRoot(baseRoot, base, create); err != nil {
-			return "", false, err
-		}
+	if err := ensureRARRepositoryRoot(baseRoot, base, create); err != nil {
+		return "", false, err
 	}
 	dir := filepath.Join(base, rddModeDirectory)
 	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
 		return "", false, err
 	}
 	return dir, distinct, nil
+}
+
+func rddModeStorageIdentity(ctx context.Context, repo string) (reviewRepositoryIdentityRecord, error) {
+	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	if err != nil {
+		var bare *BareRepositoryError
+		if errors.As(err, &bare) {
+			return reviewRepositoryIdentityRecord{}, err
+		}
+		return reviewRepositoryIdentityRecord{}, fmt.Errorf("resolve review mode repository identity: %w", err)
+	}
+	return reviewRepositoryIdentityRecordFromLease(lease), nil
+}
+
+func rddModeRootUnder(baseRoot string, create bool) (string, error) {
+	base := filepath.Join(
+		baseRoot,
+		"gentle-ai",
+		rddModeSwitchDirectory,
+		rarAuthorityDirectory,
+		rarAuthorityVersion,
+	)
+	if err := ensureRARSwitchRoot(baseRoot, base, create); err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, rddModeDirectory)
+	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
+		return "", err
+	}
+	return dir, nil
 }
 
 // WorktreeLocalRevision returns the compare-and-set token the worktree scope
@@ -1148,14 +1158,14 @@ func rddModeStorageRoot(ctx context.Context, repo string, create bool, storage r
 // same position as an absent expected revision. It is strictly read-only and
 // never creates state.
 func WorktreeLocalRevision(ctx context.Context, repo string) (string, error) {
-	dir, _, err := rddModeStorageRoot(ctx, repo, false, rddOverrideWorktreeLocal)
+	dir, _, err := worktreeLocalRDDModeRoot(ctx, repo, false)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
 		}
 		return "", err
 	}
-	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	head, present, err := readRDDOverrideHead(dir)
 	if err != nil {
 		return "", err
 	}
@@ -1196,7 +1206,13 @@ func WorktreeLocalRDDModeRecordPath(ctx context.Context, repo string) (string, e
 }
 
 func rddModeRecordPath(ctx context.Context, repo string, storage rddModeOverrideStorage) (string, error) {
-	dir, _, err := rddModeStorageRoot(ctx, repo, false, storage)
+	var dir string
+	var err error
+	if storage == rddOverrideWorktreeLocal {
+		dir, _, err = worktreeLocalRDDModeRoot(ctx, repo, false)
+	} else {
+		dir, err = cloneLocalRDDModeRoot(ctx, repo, false)
+	}
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
@@ -1220,14 +1236,14 @@ func rddModeRecordPath(ctx context.Context, repo string, storage rddModeOverride
 			return "", nil
 		}
 	}
-	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
+	head, err := rddOverrideHeadGeneration(dir)
 	if err != nil || head == 0 {
 		return "", err
 	}
 	return filepath.Join(dir, rddModeGenerationName(head)), nil
 }
 
-func cloneLocalRDDOverrideHeadGeneration(dir string) (int, error) {
+func rddOverrideHeadGeneration(dir string) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -1248,8 +1264,8 @@ func cloneLocalRDDOverrideHeadGeneration(dir string) (int, error) {
 	return head, nil
 }
 
-func readCloneLocalRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, error) {
-	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
+func readRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, error) {
+	head, err := rddOverrideHeadGeneration(dir)
 	if err != nil {
 		return rddModeOverrideRecord{}, false, err
 	}
@@ -1272,6 +1288,16 @@ func readCloneLocalRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, err
 		return rddModeOverrideRecord{}, false, fmt.Errorf("%w: generation %d is stored as %d", ErrRDDModeCorrupt, record.Generation, head)
 	}
 	return record, true, nil
+}
+
+// cloneLocalRDDOverrideHeadGeneration is deprecated, use rddOverrideHeadGeneration.
+func cloneLocalRDDOverrideHeadGeneration(dir string) (int, error) {
+	return rddOverrideHeadGeneration(dir)
+}
+
+// readCloneLocalRDDOverrideHead is deprecated, use readRDDOverrideHead.
+func readCloneLocalRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, error) {
+	return readRDDOverrideHead(dir)
 }
 
 // rddModeOverrideRecord is one immutable generation of the clone-local

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -456,12 +456,12 @@ func TestWorktreeLocalRDDOverrideStaysPrivateToItsWorktree(t *testing.T) {
 	}
 
 	for name, checkout := range map[string]string{"main": repo, "linkedB": linkedB} {
-		status, err := ResolveRDDMode(ctx, checkout, global)
+		siblingStatus, err := ResolveRDDMode(ctx, checkout, global)
 		if err != nil {
 			t.Fatalf("ResolveRDDMode(%s) error = %v", name, err)
 		}
-		if status.Effective != RDDModeOn || status.CloneLocal != RDDModeUnset || status.WorktreeLocal != RDDModeUnset {
-			t.Fatalf("%s inherited the worktree-local override: %#v", name, status)
+		if siblingStatus.Effective != RDDModeOn || siblingStatus.CloneLocal != RDDModeUnset || siblingStatus.WorktreeLocal != RDDModeUnset {
+			t.Fatalf("%s inherited the worktree-local override: %#v", name, siblingStatus)
 		}
 	}
 

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -398,5 +399,186 @@ func TestRDDDeliveryDispositionNeverFabricatesApproval(t *testing.T) {
 	}
 	if got := RDDDeliveryDisposition(enabled, true); got != RDDDeliveryReceiptGoverned {
 		t.Fatalf("enabled delivery with a receipt = %q, want %q", got, RDDDeliveryReceiptGoverned)
+	}
+}
+
+// TestWorktreeLocalRDDOverrideStaysPrivateToItsWorktree locks the core scope
+// property (issue #1973): a worktree-local override is stored under the linked
+// worktree's own Git directory, so it never bleeds into the main checkout or a
+// sibling worktree, and a start refusal inside the worktree names the
+// --scope=worktree continuation.
+func TestWorktreeLocalRDDOverrideStaysPrivateToItsWorktree(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	linkedA := filepath.Join(t.TempDir(), "linked-a")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-worktree-a", linkedA, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linkedA) })
+	linkedB := filepath.Join(t.TempDir(), "linked-b")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-worktree-b", linkedB, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linkedB) })
+
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+	disabled, err := SetWorktreeLocalRDDMode(ctx, linkedA, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) error = %v", err)
+	}
+	if disabled.Enabled() || disabled.Source != RDDModeSourceWorktreeLocal {
+		t.Fatalf("worktree-local disable did not take effect: %#v", disabled)
+	}
+
+	// The override lives under linkedA's private Git directory, never under the
+	// shared Git common directory.
+	lease, err := OpenRepositoryIdentityLease(ctx, linkedA)
+	if err != nil {
+		t.Fatalf("OpenRepositoryIdentityLease(linkedA) error = %v", err)
+	}
+	identity := lease.Identity()
+	overridePath := filepath.Join(identity.GitDir, "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if _, err := os.Stat(overridePath); err != nil {
+		t.Fatalf("worktree-local override is not stored under the worktree Git directory: %v", err)
+	}
+	sharedPath := filepath.Join(identity.GitCommonDir, "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if _, err := os.Stat(sharedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree-local override leaked into the shared Git common directory: %v", err)
+	}
+
+	status, err := ResolveRDDMode(ctx, linkedA, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(linkedA) error = %v", err)
+	}
+	if status.Effective != RDDModeOff || status.Source != RDDModeSourceWorktreeLocal ||
+		status.WorktreeLocal != RDDModeOff || status.WorktreeRevision == "" {
+		t.Fatalf("linkedA status = %#v", status)
+	}
+	if status.Revision != "" {
+		t.Fatalf("linkedA status carries a clone-local revision for an absent clone override: %#v", status)
+	}
+
+	for name, checkout := range map[string]string{"main": repo, "linkedB": linkedB} {
+		status, err := ResolveRDDMode(ctx, checkout, global)
+		if err != nil {
+			t.Fatalf("ResolveRDDMode(%s) error = %v", name, err)
+		}
+		if status.Effective != RDDModeOn || status.CloneLocal != RDDModeUnset || status.WorktreeLocal != RDDModeUnset {
+			t.Fatalf("%s inherited the worktree-local override: %#v", name, status)
+		}
+	}
+
+	// A start refusal inside the worktree names the exact scope that must be
+	// turned back on.
+	var stop *RDDDisabledError
+	err = AuthorizeRDDCandidate(status)
+	if !errors.As(err, &stop) || stop.Source != RDDModeSourceWorktreeLocal ||
+		!strings.Contains(stop.Error(), "gentle-ai review mode enable --scope=worktree") {
+		t.Fatalf("worktree-local refusal = %v, stop = %#v", err, stop)
+	}
+
+	// Re-enabling inside the worktree clears only its private record, leaving
+	// the main checkout and the sibling worktree untouched.
+	cleared, err := SetWorktreeLocalRDDMode(ctx, linkedA, RDDModeUnset, status.WorktreeRevision, global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(clear) error = %v", err)
+	}
+	if !cleared.Enabled() || cleared.Source != RDDModeSourceGlobal {
+		t.Fatalf("cleared worktree override did not re-enable linkedA: %#v", cleared)
+	}
+	for name, checkout := range map[string]string{"main": repo, "linkedA": linkedA, "linkedB": linkedB} {
+		status, err := ResolveRDDMode(ctx, checkout, global)
+		if err != nil {
+			t.Fatalf("ResolveRDDMode(%s) after clear error = %v", name, err)
+		}
+		if status.Effective != RDDModeOn {
+			t.Fatalf("%s stayed disabled after the worktree-local clear: %#v", name, status)
+		}
+	}
+
+	// The blast radius of a shared clone-local override is the sibling
+	// checkouts; the worktree-local override never widens it.
+	for name, checkout := range map[string]string{"main": repo, "linkedA": linkedA, "linkedB": linkedB} {
+		count, err := LinkedWorktreeBlastRadius(ctx, checkout)
+		if err != nil || count != 2 {
+			t.Fatalf("LinkedWorktreeBlastRadius(%s) = %d, %v; want 2", name, count, err)
+		}
+	}
+}
+
+// TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal pins the blast-radius
+// semantics (issue #1973): the clone-local override stays under the shared Git
+// common directory and governs every worktree of the clone, while the
+// worktree-local override wins inside exactly one worktree and never changes
+// the shared record.
+func TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-precedence", linked, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linked) })
+
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	for name, checkout := range map[string]string{"main": repo, "linked": linked} {
+		status, err := ResolveRDDMode(ctx, checkout, global)
+		if err != nil {
+			t.Fatalf("ResolveRDDMode(%s) error = %v", name, err)
+		}
+		if status.Effective != RDDModeOff || status.Source != RDDModeSourceCloneLocal || status.CloneLocal != RDDModeOff {
+			t.Fatalf("%s did not see the shared clone-local override: %#v", name, status)
+		}
+	}
+
+	// The worktree-local off wins over the shared clone-local off inside this
+	// worktree only.
+	worktreeOff, err := SetWorktreeLocalRDDMode(ctx, linked, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) error = %v", err)
+	}
+	if worktreeOff.Source != RDDModeSourceWorktreeLocal || worktreeOff.Effective != RDDModeOff {
+		t.Fatalf("worktree-scope disable reported %#v", worktreeOff)
+	}
+	status, err := ResolveRDDMode(ctx, linked, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(linked) error = %v", err)
+	}
+	if status.Effective != RDDModeOff || status.Source != RDDModeSourceWorktreeLocal {
+		t.Fatalf("worktree-local off did not win over clone-local off: %#v", status)
+	}
+	mainStatus, err := ResolveRDDMode(ctx, repo, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(main) error = %v", err)
+	}
+	if mainStatus.Effective != RDDModeOff || mainStatus.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("main checkout changed under a worktree-local override: %#v", mainStatus)
+	}
+
+	// A clone-scope write issued inside the linked worktree targets the shared
+	// common-dir head, never the private worktree head: its CAS token must be
+	// the clone-local revision, and the published record is visible in the main
+	// checkout (the blast radius is the whole clone family).
+	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, status.WorktreeRevision, global); !errors.Is(err, ErrRDDModeRevisionMismatch) {
+		t.Fatalf("clone-scope write with the worktree token error = %v, want ErrRDDModeRevisionMismatch", err)
+	}
+	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, mainStatus.Revision, global); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) inside linked worktree error = %v", err)
+	}
+	reShared, err := ResolveRDDMode(ctx, repo, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(main) after linked clone write error = %v", err)
+	}
+	if reShared.Effective != RDDModeOff || reShared.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("linked-worktree clone-scope write did not reach the shared record: %#v", reShared)
+	}
+
+	// Clearing the worktree scope re-exposes the shared clone-local off inside
+	// the linked worktree.
+	cleared, err := SetWorktreeLocalRDDMode(ctx, linked, RDDModeUnset, status.WorktreeRevision, global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(clear) error = %v", err)
+	}
+	if cleared.Effective != RDDModeOff || cleared.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("cleared worktree scope did not re-expose the shared clone-local off: %#v", cleared)
 	}
 }

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -561,8 +561,12 @@ func TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal(t *testing.T) {
 	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, status.WorktreeRevision, global); !errors.Is(err, ErrRDDModeRevisionMismatch) {
 		t.Fatalf("clone-scope write with the worktree token error = %v, want ErrRDDModeRevisionMismatch", err)
 	}
-	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, mainStatus.Revision, global); err != nil {
+	shadowed, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, mainStatus.Revision, global)
+	if err != nil {
 		t.Fatalf("SetCloneLocalRDDMode(off) inside linked worktree error = %v", err)
+	}
+	if shadowed.Effective != RDDModeOff || shadowed.Source != RDDModeSourceWorktreeLocal {
+		t.Fatalf("clone-scope write shadowed by the worktree-local off reported %#v; want worktree_local", shadowed)
 	}
 	reShared, err := ResolveRDDMode(ctx, repo, global)
 	if err != nil {
@@ -580,5 +584,33 @@ func TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal(t *testing.T) {
 	}
 	if cleared.Effective != RDDModeOff || cleared.Source != RDDModeSourceCloneLocal {
 		t.Fatalf("cleared worktree scope did not re-expose the shared clone-local off: %#v", cleared)
+	}
+}
+
+// TestWorktreeScopeOnMainCheckoutSharesCloneLocalStorage pins that a
+// worktree-scope write issued on the main checkout (GitDir == GitCommonDir)
+// targets the shared clone-local storage and reports clone_local, never
+// worktree_local, both in the write-time status and in a later resolve.
+func TestWorktreeScopeOnMainCheckoutSharesCloneLocalStorage(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+	written, err := SetWorktreeLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) on the main checkout error = %v", err)
+	}
+	if written.Effective != RDDModeOff || written.Source != RDDModeSourceCloneLocal ||
+		written.WorktreeLocal != RDDModeUnset || written.WorktreeRevision != "" {
+		t.Fatalf("main-checkout worktree write reported %#v; want clone_local off with no worktree revision", written)
+	}
+	if written.Revision == "" {
+		t.Fatalf("main-checkout worktree write carried no clone-local revision: %#v", written)
+	}
+	resolved, err := ResolveRDDMode(ctx, repo, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode error = %v", err)
+	}
+	if resolved.Source != RDDModeSourceCloneLocal || resolved.Revision != written.Revision {
+		t.Fatalf("write-time and subsequent status disagree: write=%#v resolve=%#v", written, resolved)
 	}
 }

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -614,3 +614,63 @@ func TestWorktreeScopeOnMainCheckoutSharesCloneLocalStorage(t *testing.T) {
 		t.Fatalf("write-time and subsequent status disagree: write=%#v resolve=%#v", written, resolved)
 	}
 }
+
+// TestCloneLocalRevisionIgnoresCorruptWorktreeLocalRecord pins the repair
+// invariant: the clone-local CAS token must come from clone-local storage
+// alone, so an unreadable worktree-local record never blocks repairing the
+// clone scope. Before the reader was scoped, ResolveRDDMode failed closed on
+// the corrupt worktree record and the clone repair had no token to compare
+// against.
+func TestCloneLocalRevisionIgnoresCorruptWorktreeLocalRecord(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-repair-linked", linked, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linked) })
+
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+
+	// A healthy clone-local record on the main checkout.
+	written, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+
+	// A corrupt worktree-local record inside the linked worktree.
+	if _, err := SetWorktreeLocalRDDMode(ctx, linked, RDDModeOff, "", global); err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) error = %v", err)
+	}
+	lease, err := OpenRepositoryIdentityLease(ctx, linked)
+	if err != nil {
+		t.Fatalf("OpenRepositoryIdentityLease(linked) error = %v", err)
+	}
+	identity := lease.Identity()
+	corrupt := filepath.Join(identity.GitDir, "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	if err := os.WriteFile(corrupt, []byte("{not json}\n"), 0o600); err != nil {
+		t.Fatalf("corrupt worktree-local override: %v", err)
+	}
+
+	// The clone-local token is still readable even though resolving the full
+	// projection now fails closed.
+	if _, err := ResolveRDDMode(ctx, linked, global); !errors.Is(err, ErrRDDModeCorrupt) {
+		t.Fatalf("ResolveRDDMode on corrupt worktree record error = %v, want ErrRDDModeCorrupt", err)
+	}
+	token, err := CloneLocalRevision(ctx, repo)
+	if err != nil {
+		t.Fatalf("CloneLocalRevision error = %v, want the healthy clone-local token", err)
+	}
+	if token != written.Revision {
+		t.Fatalf("CloneLocalRevision = %q, want %q", token, written.Revision)
+	}
+
+	// The clone scope can be repaired from the main checkout with that token,
+	// independent of the sibling worktree's unreadable record.
+	cleared, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, token, global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(clear) with clone-local token error = %v", err)
+	}
+	if !cleared.Enabled() || cleared.CloneLocal != RDDModeUnset {
+		t.Fatalf("clone repair did not re-enable the clone: %#v", cleared)
+	}
+}

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -822,3 +822,63 @@ func TestWorktreeScopeOnMainCheckoutSharesCloneLocalStorage(t *testing.T) {
 		t.Fatalf("write-time and subsequent status disagree: write=%#v resolve=%#v", written, resolved)
 	}
 }
+
+// TestCloneLocalRevisionIgnoresCorruptWorktreeLocalRecord pins the repair
+// invariant: the clone-local CAS token must come from clone-local storage
+// alone, so an unreadable worktree-local record never blocks repairing the
+// clone scope. Before the reader was scoped, ResolveRDDMode failed closed on
+// the corrupt worktree record and the clone repair had no token to compare
+// against.
+func TestCloneLocalRevisionIgnoresCorruptWorktreeLocalRecord(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-repair-linked", linked, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linked) })
+
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+
+	// A healthy clone-local record on the main checkout.
+	written, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+
+	// A corrupt worktree-local record inside the linked worktree.
+	if _, err := SetWorktreeLocalRDDMode(ctx, linked, RDDModeOff, "", global); err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) error = %v", err)
+	}
+	lease, err := OpenRepositoryIdentityLease(ctx, linked)
+	if err != nil {
+		t.Fatalf("OpenRepositoryIdentityLease(linked) error = %v", err)
+	}
+	identity := lease.Identity()
+	corrupt := filepath.Join(identity.GitDir, "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	if err := os.WriteFile(corrupt, []byte("{not json}\n"), 0o600); err != nil {
+		t.Fatalf("corrupt worktree-local override: %v", err)
+	}
+
+	// The clone-local token is still readable even though resolving the full
+	// projection now fails closed.
+	if _, err := ResolveRDDMode(ctx, linked, global); !errors.Is(err, ErrRDDModeCorrupt) {
+		t.Fatalf("ResolveRDDMode on corrupt worktree record error = %v, want ErrRDDModeCorrupt", err)
+	}
+	token, err := CloneLocalRevision(ctx, repo)
+	if err != nil {
+		t.Fatalf("CloneLocalRevision error = %v, want the healthy clone-local token", err)
+	}
+	if token != written.Revision {
+		t.Fatalf("CloneLocalRevision = %q, want %q", token, written.Revision)
+	}
+
+	// The clone scope can be repaired from the main checkout with that token,
+	// independent of the sibling worktree's unreadable record.
+	cleared, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, token, global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(clear) with clone-local token error = %v", err)
+	}
+	if !cleared.Enabled() || cleared.CloneLocal != RDDModeUnset {
+		t.Fatalf("clone repair did not re-enable the clone: %#v", cleared)
+	}
+}

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -614,3 +614,180 @@ func TestResolveRDDModeUnsafePrivatePathIsNotACorruptHead(t *testing.T) {
 		t.Fatalf("unsafe private RAR path did not fail closed: %#v", status)
 	}
 }
+
+func TestWorktreeLocalRDDOverrideStaysPrivateToItsWorktree(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	linkedA := filepath.Join(t.TempDir(), "linked-a")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-worktree-a", linkedA, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linkedA) })
+	linkedB := filepath.Join(t.TempDir(), "linked-b")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-worktree-b", linkedB, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linkedB) })
+
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+	disabled, err := SetWorktreeLocalRDDMode(ctx, linkedA, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) error = %v", err)
+	}
+	if disabled.Enabled() || disabled.Source != RDDModeSourceWorktreeLocal {
+		t.Fatalf("worktree-local disable did not take effect: %#v", disabled)
+	}
+
+	// The override lives under linkedA's private Git directory, never under the
+	// shared Git common directory.
+	lease, err := OpenRepositoryIdentityLease(ctx, linkedA)
+	if err != nil {
+		t.Fatalf("OpenRepositoryIdentityLease(linkedA) error = %v", err)
+	}
+	identity := lease.Identity()
+	overridePath := filepath.Join(identity.GitDir, "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if _, err := os.Stat(overridePath); err != nil {
+		t.Fatalf("worktree-local override is not stored under the worktree Git directory: %v", err)
+	}
+	sharedPath := filepath.Join(identity.GitCommonDir, "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if _, err := os.Stat(sharedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree-local override leaked into the shared Git common directory: %v", err)
+	}
+
+	status, err := ResolveRDDMode(ctx, linkedA, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(linkedA) error = %v", err)
+	}
+	if status.Effective != RDDModeOff || status.Source != RDDModeSourceWorktreeLocal ||
+		status.WorktreeLocal != RDDModeOff || status.WorktreeRevision == "" {
+		t.Fatalf("linkedA status = %#v", status)
+	}
+	if status.Revision != "" {
+		t.Fatalf("linkedA status carries a clone-local revision for an absent clone override: %#v", status)
+	}
+
+	for name, checkout := range map[string]string{"main": repo, "linkedB": linkedB} {
+		status, err := ResolveRDDMode(ctx, checkout, global)
+		if err != nil {
+			t.Fatalf("ResolveRDDMode(%s) error = %v", name, err)
+		}
+		if status.Effective != RDDModeOn || status.CloneLocal != RDDModeUnset || status.WorktreeLocal != RDDModeUnset {
+			t.Fatalf("%s inherited the worktree-local override: %#v", name, status)
+		}
+	}
+
+	// A start refusal inside the worktree names the exact scope that must be
+	// turned back on.
+	var stop *RDDDisabledError
+	err = AuthorizeRDDCandidate(status)
+	if !errors.As(err, &stop) || stop.Source != RDDModeSourceWorktreeLocal ||
+		!strings.Contains(stop.Error(), "gentle-ai review mode enable --scope=worktree") {
+		t.Fatalf("worktree-local refusal = %v, stop = %#v", err, stop)
+	}
+
+	// Re-enabling inside the worktree clears only its private record, leaving
+	// the main checkout and the sibling worktree untouched.
+	cleared, err := SetWorktreeLocalRDDMode(ctx, linkedA, RDDModeUnset, status.WorktreeRevision, global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(clear) error = %v", err)
+	}
+	if !cleared.Enabled() || cleared.Source != RDDModeSourceGlobal {
+		t.Fatalf("cleared worktree override did not re-enable linkedA: %#v", cleared)
+	}
+	for name, checkout := range map[string]string{"main": repo, "linkedA": linkedA, "linkedB": linkedB} {
+		status, err := ResolveRDDMode(ctx, checkout, global)
+		if err != nil {
+			t.Fatalf("ResolveRDDMode(%s) after clear error = %v", name, err)
+		}
+		if status.Effective != RDDModeOn {
+			t.Fatalf("%s stayed disabled after the worktree-local clear: %#v", name, status)
+		}
+	}
+
+	// The blast radius of a shared clone-local override is the sibling
+	// checkouts; the worktree-local override never widens it.
+	for name, checkout := range map[string]string{"main": repo, "linkedA": linkedA, "linkedB": linkedB} {
+		count, err := LinkedWorktreeBlastRadius(ctx, checkout)
+		if err != nil || count != 2 {
+			t.Fatalf("LinkedWorktreeBlastRadius(%s) = %d, %v; want 2", name, count, err)
+		}
+	}
+}
+
+// TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal pins the blast-radius
+// semantics (issue #1973): the clone-local override stays under the shared Git
+// common directory and governs every worktree of the clone, while the
+// worktree-local override wins inside exactly one worktree and never changes
+// the shared record.
+func TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	gitSnapshot(t, repo, "worktree", "add", "-b", "rdd-precedence", linked, "HEAD")
+	t.Cleanup(func() { _ = runSnapshotGit(repo, "worktree", "remove", "--force", linked) })
+
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	for name, checkout := range map[string]string{"main": repo, "linked": linked} {
+		status, err := ResolveRDDMode(ctx, checkout, global)
+		if err != nil {
+			t.Fatalf("ResolveRDDMode(%s) error = %v", name, err)
+		}
+		if status.Effective != RDDModeOff || status.Source != RDDModeSourceCloneLocal || status.CloneLocal != RDDModeOff {
+			t.Fatalf("%s did not see the shared clone-local override: %#v", name, status)
+		}
+	}
+
+	// The worktree-local off wins over the shared clone-local off inside this
+	// worktree only.
+	worktreeOff, err := SetWorktreeLocalRDDMode(ctx, linked, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) error = %v", err)
+	}
+	if worktreeOff.Source != RDDModeSourceWorktreeLocal || worktreeOff.Effective != RDDModeOff {
+		t.Fatalf("worktree-scope disable reported %#v", worktreeOff)
+	}
+	status, err := ResolveRDDMode(ctx, linked, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(linked) error = %v", err)
+	}
+	if status.Effective != RDDModeOff || status.Source != RDDModeSourceWorktreeLocal {
+		t.Fatalf("worktree-local off did not win over clone-local off: %#v", status)
+	}
+	mainStatus, err := ResolveRDDMode(ctx, repo, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(main) error = %v", err)
+	}
+	if mainStatus.Effective != RDDModeOff || mainStatus.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("main checkout changed under a worktree-local override: %#v", mainStatus)
+	}
+
+	// A clone-scope write issued inside the linked worktree targets the shared
+	// common-dir head, never the private worktree head: its CAS token must be
+	// the clone-local revision, and the published record is visible in the main
+	// checkout (the blast radius is the whole clone family).
+	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, status.WorktreeRevision, global); !errors.Is(err, ErrRDDModeRevisionMismatch) {
+		t.Fatalf("clone-scope write with the worktree token error = %v, want ErrRDDModeRevisionMismatch", err)
+	}
+	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, mainStatus.Revision, global); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) inside linked worktree error = %v", err)
+	}
+	reShared, err := ResolveRDDMode(ctx, repo, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode(main) after linked clone write error = %v", err)
+	}
+	if reShared.Effective != RDDModeOff || reShared.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("linked-worktree clone-scope write did not reach the shared record: %#v", reShared)
+	}
+
+	// Clearing the worktree scope re-exposes the shared clone-local off inside
+	// the linked worktree.
+	cleared, err := SetWorktreeLocalRDDMode(ctx, linked, RDDModeUnset, status.WorktreeRevision, global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(clear) error = %v", err)
+	}
+	if cleared.Effective != RDDModeOff || cleared.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("cleared worktree scope did not re-expose the shared clone-local off: %#v", cleared)
+	}
+}
+

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -664,12 +664,12 @@ func TestWorktreeLocalRDDOverrideStaysPrivateToItsWorktree(t *testing.T) {
 	}
 
 	for name, checkout := range map[string]string{"main": repo, "linkedB": linkedB} {
-		status, err := ResolveRDDMode(ctx, checkout, global)
+		siblingStatus, err := ResolveRDDMode(ctx, checkout, global)
 		if err != nil {
 			t.Fatalf("ResolveRDDMode(%s) error = %v", name, err)
 		}
-		if status.Effective != RDDModeOn || status.CloneLocal != RDDModeUnset || status.WorktreeLocal != RDDModeUnset {
-			t.Fatalf("%s inherited the worktree-local override: %#v", name, status)
+		if siblingStatus.Effective != RDDModeOn || siblingStatus.CloneLocal != RDDModeUnset || siblingStatus.WorktreeLocal != RDDModeUnset {
+			t.Fatalf("%s inherited the worktree-local override: %#v", name, siblingStatus)
 		}
 	}
 

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -769,8 +769,12 @@ func TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal(t *testing.T) {
 	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, status.WorktreeRevision, global); !errors.Is(err, ErrRDDModeRevisionMismatch) {
 		t.Fatalf("clone-scope write with the worktree token error = %v, want ErrRDDModeRevisionMismatch", err)
 	}
-	if _, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, mainStatus.Revision, global); err != nil {
+	shadowed, err := SetCloneLocalRDDMode(ctx, linked, RDDModeOff, mainStatus.Revision, global)
+	if err != nil {
 		t.Fatalf("SetCloneLocalRDDMode(off) inside linked worktree error = %v", err)
+	}
+	if shadowed.Effective != RDDModeOff || shadowed.Source != RDDModeSourceWorktreeLocal {
+		t.Fatalf("clone-scope write shadowed by the worktree-local off reported %#v; want worktree_local", shadowed)
 	}
 	reShared, err := ResolveRDDMode(ctx, repo, global)
 	if err != nil {
@@ -791,3 +795,30 @@ func TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal(t *testing.T) {
 	}
 }
 
+// TestWorktreeScopeOnMainCheckoutSharesCloneLocalStorage pins that a
+// worktree-scope write issued on the main checkout (GitDir == GitCommonDir)
+// targets the shared clone-local storage and reports clone_local, never
+// worktree_local, both in the write-time status and in a later resolve.
+func TestWorktreeScopeOnMainCheckoutSharesCloneLocalStorage(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+	written, err := SetWorktreeLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetWorktreeLocalRDDMode(off) on the main checkout error = %v", err)
+	}
+	if written.Effective != RDDModeOff || written.Source != RDDModeSourceCloneLocal ||
+		written.WorktreeLocal != RDDModeUnset || written.WorktreeRevision != "" {
+		t.Fatalf("main-checkout worktree write reported %#v; want clone_local off with no worktree revision", written)
+	}
+	if written.Revision == "" {
+		t.Fatalf("main-checkout worktree write carried no clone-local revision: %#v", written)
+	}
+	resolved, err := ResolveRDDMode(ctx, repo, global)
+	if err != nil {
+		t.Fatalf("ResolveRDDMode error = %v", err)
+	}
+	if resolved.Source != RDDModeSourceCloneLocal || resolved.Revision != written.Revision {
+		t.Fatalf("write-time and subsequent status disagree: write=%#v resolve=%#v", written, resolved)
+	}
+}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -714,6 +714,30 @@ func linkedWorktreeDirectories(ctx context.Context, root string) ([]string, erro
 	return directories, nil
 }
 
+// LinkedWorktreeBlastRadius reports how many other worktree checkouts share
+// this repository's Git common directory. A clone-local override is stored
+// under that common directory, so a status can announce exactly how wide the
+// blast radius of the deciding clone-local record is. It is strictly
+// informational: it never changes the resolved mode, and it reports 0 for a
+// checkout with no siblings.
+func LinkedWorktreeBlastRadius(ctx context.Context, repo string) (int, error) {
+	root, err := (SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return 0, err
+	}
+	directories, err := linkedWorktreeDirectories(ctx, root)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, directory := range directories {
+		if !pathidentity.SameDirectory(directory, root) {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // DiscoverTrackedAndUnignoredPaths returns the canonical Git-owned workspace
 // inventory: every cached path plus every unignored untracked path.
 func (builder SnapshotBuilder) DiscoverTrackedAndUnignoredPaths(ctx context.Context) ([]string, error) {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -714,12 +714,15 @@ func linkedWorktreeDirectories(ctx context.Context, root string) ([]string, erro
 	return directories, nil
 }
 
-// LinkedWorktreeBlastRadius reports how many other worktree checkouts share
-// this repository's Git common directory. A clone-local override is stored
-// under that common directory, so a status can announce exactly how wide the
-// blast radius of the deciding clone-local record is. It is strictly
-// informational: it never changes the resolved mode, and it reports 0 for a
-// checkout with no siblings.
+// LinkedWorktreeBlastRadius reports how many other checkouts of this
+// repository share its Git common directory. The count covers every other
+// checkout of the clone, including the main worktree when this is called from
+// a linked worktree, because git worktree list emits both the main and linked
+// checkouts and the caller is excluded. A clone-local override is stored under
+// that common directory, so a status can announce exactly how wide the blast
+// radius of the deciding clone-local record is. It is strictly informational:
+// it never changes the resolved mode, and it reports 0 for a checkout with no
+// siblings.
 func LinkedWorktreeBlastRadius(ctx context.Context, repo string) (int, error) {
 	root, err := (SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
 	if err != nil {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -804,6 +804,30 @@ func linkedWorktreeDirectories(ctx context.Context, root string) ([]string, erro
 	return directories, nil
 }
 
+// LinkedWorktreeBlastRadius reports how many other worktree checkouts share
+// this repository's Git common directory. A clone-local override is stored
+// under that common directory, so a status can announce exactly how wide the
+// blast radius of the deciding clone-local record is. It is strictly
+// informational: it never changes the resolved mode, and it reports 0 for a
+// checkout with no siblings.
+func LinkedWorktreeBlastRadius(ctx context.Context, repo string) (int, error) {
+	root, err := (SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return 0, err
+	}
+	directories, err := linkedWorktreeDirectories(ctx, root)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, directory := range directories {
+		if !pathidentity.SameDirectory(directory, root) {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // DiscoverTrackedAndUnignoredPaths returns the canonical Git-owned workspace
 // inventory: every cached path plus every unignored untracked path.
 func (builder SnapshotBuilder) DiscoverTrackedAndUnignoredPaths(ctx context.Context) ([]string, error) {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -804,12 +804,15 @@ func linkedWorktreeDirectories(ctx context.Context, root string) ([]string, erro
 	return directories, nil
 }
 
-// LinkedWorktreeBlastRadius reports how many other worktree checkouts share
-// this repository's Git common directory. A clone-local override is stored
-// under that common directory, so a status can announce exactly how wide the
-// blast radius of the deciding clone-local record is. It is strictly
-// informational: it never changes the resolved mode, and it reports 0 for a
-// checkout with no siblings.
+// LinkedWorktreeBlastRadius reports how many other checkouts of this
+// repository share its Git common directory. The count covers every other
+// checkout of the clone, including the main worktree when this is called from
+// a linked worktree, because git worktree list emits both the main and linked
+// checkouts and the caller is excluded. A clone-local override is stored under
+// that common directory, so a status can announce exactly how wide the blast
+// radius of the deciding clone-local record is. It is strictly informational:
+// it never changes the resolved mode, and it reports 0 for a checkout with no
+// siblings.
 func LinkedWorktreeBlastRadius(ctx context.Context, repo string) (int, error) {
 	root, err := (SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1973

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

The RDD kill switch (`gentle-ai review mode`) had exactly two scopes, `global` and `clone`, and the clone-local override is stored under the Git common directory — which every linked worktree shares. Several agents working in parallel, one worktree each, off a single clone, silently shared the override: disabling reviews in one worktree disabled them in all of them, with no warning.

This PR adds a `--scope worktree` option so an override inside a linked worktree is stored under that worktree's own Git directory and never bleeds into the main checkout or sibling worktrees. Status now also announces the blast radius of a clone-local override (how many other worktree checkouts share the common directory where the record lives), so an operator can see that the override is not scoped to just one checkout.

Precedence stays fail-closed: `worktree-local off` wins over `clone-local off`, which wins over `global off`. The CAS generation mechanism, the off-only rule, and fail-closed semantics are unchanged. On the main checkout the worktree scope resolves to the existing clone-local record, so behavior for ordinary repositories (no worktrees) is byte-for-byte unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/rdd_mode.go` | Added `RDDModeSourceWorktreeLocal`, `SetWorktreeLocalRDDMode`, shared `setRDDModeOverride` (single CAS/lock/publish path), `rddModeStorageRoot` deciding the storage base via `GitDir != GitCommonDir`, `WorktreeLocal`/`WorktreeRevision` status fields, and the extended precedence `worktree_local off > clone_local off > global off > global on > default`. |
| `internal/reviewtransaction/snapshot.go` | Added `LinkedWorktreeBlastRadius`, counting sibling checkouts via `git worktree list`. |
| `internal/cli/review_mode.go` | Accepts `--scope worktree`; JSON result carries an additive `blast_radius,omitempty`; human status output now shows all three sources plus a blast-radius note; unreadable-scope repair commands cover the worktree scope. |
| `internal/reviewtransaction/rdd_mode_test.go` | Added `TestWorktreeLocalRDDOverrideStaysPrivateToItsWorktree` (2 linked worktrees + main: override is private, never leaks, refusal names `--scope=worktree`) and `TestWorktreeLocalRDDOverrideWinsOverSharedCloneLocal` (precedence over a shared clone-local off, correct CAS token per storage). |
| `internal/cli/review_mode_test.go` | Added `TestReviewModeWorktreeScopeDisablesOnlyThisWorktree` and `TestReviewModeStatusAnnouncesCloneBlastRadius`; unknown-scope rejection now accepts `worktree`. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/reviewtransaction/ ./internal/cli/
```
Result: `ok` for both packages (the full 1780-test surface of these packages stays green).

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```
Not run locally (no Docker in this environment); the existing organic E2E kill-switch tests are untouched.

**Benchmark Validation**

`N/A` — no review-lifecycle gate, recovery, delivery, or benchmark code changed. This is a CLI/status scope addition.

- [x] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally, no Docker
- [x] Manually tested locally (unit tests create real linked worktrees via `git worktree add` and assert isolation)

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 667 changed lines — **above 400; requesting `size:exception`** (rationale below) |
| Check Issue Reference | ⏳ | `Closes #1973` present |
| Check Issue Has `status:approved` | ✅ | #1973 carries `status:approved` (also `help wanted`, `up-for-grabs`, `priority:high`) |
| Check PR Has `type:*` Label | ⏳ | `type:feature` requested (label applies on merge) |
| Unit Tests | ⏳ | Passed locally for both touched packages |
| Go Format | ⏳ | Pending CI |
| E2E Tests | ⏳ | Pending CI (Docker) |

**`size:exception` rationale:** the change is atomic by design — worktree-local storage is useless without the resolution precedence, the resolution is useless without the CLI scope, and the tests exercise the full chain. Splitting would produce intermediate states with broken invariants (the exact anti-pattern the work-unit commits skill warns against). The bulk is test code (265 of 667 lines); production changes are 318 lines across three files.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, **or** I have requested maintainer-applied `size:exception` with rationale documented above
- [x] I have added the appropriate `type:*` label to this PR (`type:feature` — applies on merge, contributor cannot label directly on the upstream repo)
- [x] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — CI will confirm
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI will confirm (no local Docker)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan)
- [x] I have updated documentation if necessary — help text for `review mode` updated in `review_mode.go`
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The storage root decision is in `rddModeStorageRoot` (`internal/reviewtransaction/rdd_mode.go`): a linked worktree (`GitDir != GitCommonDir`) roots the worktree-local override under its own GitDir; otherwise it falls back to the existing clone-local location, so no behavior change for ordinary repos.
- The CAS token is per storage: linked-worktree writes use `WorktreeRevision`, never `Revision`. The precedence test pins that using the wrong token yields `ErrRDDModeRevisionMismatch`.
- `LinkedWorktreeBlastRadius` is strictly informational: it never changes the resolved mode, and it is omitted from JSON when 0.
- No `guard:population` contract changed; the refusal-ratchet baseline was not modified.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence. (The kill-switch precedence and off-only rule are the qualifying guards; their population (worktree, clone, global) is unchanged in direction and now explicit for worktrees.)
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed. (Baseline untouched.)
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added worktree-local controls for review and RDD modes.
  * Worktree-specific settings remain isolated from the main clone and other linked worktrees.
  * Status now reports setting sources, revisions, and potential linked-worktree impact.
  * Added blast-radius information when shared settings affect linked worktrees.
  * Added repair commands and clearer diagnostics for worktree-local state.

* **Bug Fixes**
  * Improved precedence and restoration when worktree-local and shared settings overlap.
  * Main-checkout worktree-scoped changes correctly use shared clone settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->