### PR TITLE
fix(opencode): prefer worktree over directory in skill-registry refresh

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -688,6 +688,14 @@ func TestSkillRegistryPluginContract(t *testing.T) {
 	if strings.Contains(src, "exec(") {
 		t.Fatal("skill-registry.ts must use execFile, not shell exec")
 	}
+	worktreeIdx := strings.Index(src, "input.worktree")
+	directoryIdx := strings.Index(src, "input.directory")
+	if worktreeIdx == -1 || directoryIdx == -1 {
+		t.Fatal("skill-registry.ts must contain both input.worktree and input.directory")
+	}
+	if worktreeIdx >= directoryIdx {
+		t.Errorf("skill-registry.ts must use input.worktree before input.directory; got worktree@%d >= directory@%d", worktreeIdx, directoryIdx)
+	}
 }
 
 func TestClaudeEmbeddedAssetLayout(t *testing.T) {

--- a/internal/assets/opencode/plugins/skill-registry.ts
+++ b/internal/assets/opencode/plugins/skill-registry.ts
@@ -15,7 +15,7 @@ const execFileAsync = promisify(execFile)
 
 export const SkillRegistryPlugin: Plugin = async (input) => {
   async function refreshSkillRegistry() {
-    const cwd = input.directory || input.worktree || process.cwd()
+    const cwd = input.worktree || input.directory || process.cwd()
 
     try {
       await execFileAsync(


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1731

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

> **Note:** Marking `[x]` here is the contributor's intent statement. The actual `type:*` label cannot be applied by external contributors (`gh pr edit --add-label` returns GraphQL 403). See `## Pending maintainer actions` below.

---

## 📝 Summary

The OpenCode `skill-registry` startup plugin chose `input.directory` before `input.worktree` when computing the `--cwd` passed to `gentle-ai skill-registry refresh`. When OpenCode was launched from a nested directory inside a Git worktree, that nested directory won over the worktree root, so the registry was written to the wrong location and missed root-level skills.

This PR flips the precedence to `input.worktree || input.directory || process.cwd()` and adds a contract test that asserts the source-level ordering, so the runtime path is locked in.

---

## 📂 Changes

| File / Area | What Changed | +/− |
|---|---|---|
| `internal/assets/opencode/plugins/skill-registry.ts` | Line 18: precedence flip from `input.directory \|\| input.worktree \|\| process.cwd()` to `input.worktree \|\| input.directory \|\| process.cwd()` | +1 / −1 |
| `internal/assets/assets_test.go` | `TestSkillRegistryPluginContract` (line 642): assert `input.worktree` appears before `input.directory` in the plugin source | +8 / −0 |

**Total:** 2 files, +9 / −1 = **10 changed lines** (well under the 400-line cognitive budget).

**Commits (work-unit sized):**

```
3b8c93f0 test(opencode): assert worktree-before-directory precedence in skill-registry contract
9857e0a5 fix(opencode): prefer worktree over directory in skill-registry refresh
```

No `Co-Authored-By` trailers (verified via `git log origin/main..HEAD --format='%(trailers)'`).

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/assets/... -run TestSkillRegistryPluginContract -v
```
Result: `PASS (0.00s)` — the new `worktreeIdx < directoryIdx` assertion holds.

**Targeted regression coverage**
```bash
go test ./internal/assets/... -count=1
```
Result: `ok internal/assets 1.646s` — the package's full test set passes.

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Result: clean (no output).

**Build / Vet**
```bash
go build ./...
go vet ./...
```
Result: clean.

**Pre-existing failures (not introduced by this PR, verified via detached-HEAD baseline on `origin/main`):**

> `internal/cli` fails `go test ./internal/cli/... -count=1` with `FAIL 64.237s` on this branch and **identically** on an `origin/main` worktree at `0126077c` (the merge that produced the current `main` HEAD). The diff in this PR touches only `internal/assets/opencode/plugins/skill-registry.ts` and `internal/assets/assets_test.go`, so it cannot affect `internal/cli`. This is the same `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign` failure observed in PRs #1978, #1988, #2021 on 2026-07-30. **Not blocking this PR.**

**E2E Tests (Docker required)**
Not run locally on Windows. The Docker-based E2E shell scripts target `installer` end-to-end flows; this PR touches one TypeScript asset file under `internal/assets/opencode/` and one Go test in `internal/assets/`. No installer-step or runtime path is changed, so the E2E suite is functionally orthogonal to this diff. CI will run it.

**Benchmark Validation**
N/A — this change is a single-line precedence flip in a startup plugin; it does not touch review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark claims. Per `bench/README.md`, unrelated changes mark `N/A` with a brief reason.

- [x] Unit tests pass (`go test ./internal/assets/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; CI will run
- [x] Manually tested locally (verified the new Go test asserts the new precedence and the targeted run is green)

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 10 changed lines, well under 400-line budget |
| Check Issue Reference | ⏳ | Body contains `Closes #1731` |
| Check Issue Has `status:approved` | ⏳ | Issue #1731 has `status:approved` from `dnlrsls` |
| Check PR Has `type:*` Label | ⏳ | Pending maintainer — see `## Pending maintainer actions` |
| Unit Tests | ⏳ | `internal/assets` PASS; pre-existing `internal/cli` failure is baseline-equivalent |
| Go Format | ⏳ | `gofmtcheck` clean |
| E2E Tests | ⏳ | CI will run |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#1731, approved by `dnlrsls`)
- [x] PR stays within 400 changed lines (10 lines)
- [ ] I have added the appropriate `type:*` label to this PR — **pending maintainer**, see below
- [x] Unit tests pass for the affected package (`go test ./internal/assets/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — not run locally; CI will run
- [x] Benchmark validation N/A (single-line precedence flip; unrelated to benchmark scope)
- [x] I have updated documentation if necessary — N/A (no public API change)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**Scope:** strictly the OpenCode `skill-registry` plugin precedence. Out of scope: `internal/components/sdd` (linked-worktree identity), other OpenCode plugins, the `gentle-ai skill-registry refresh` command itself.

**Single PR, ~10 lines.** No chain needed; the work is a one-line precedence flip + one targeted test.

**For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:** N/A — this PR does not touch those packages.

---

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:bug` label applied to this PR — pending Alan
- [ ] First-time fork workflow approval — `action_required` workflows on first cross-fork PR need a one-time maintainer approval before untrusted CI runs execute. This is the standard first-fork-PR gate per the `Workflow Approval Policy` documented in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skill registry commands now prioritize the correct worktree when one is available.
  * Existing directory fallbacks and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->