### PR TITLE
feat(codex): discover installer models from CLI

### DIFF
--- a/internal/model/codex_catalog_internal_test.go
+++ b/internal/model/codex_catalog_internal_test.go
@@ -1,0 +1,137 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverCodexModels(t *testing.T) {
+	tests := []struct {
+		name         string
+		lookPathErr  error
+		command      func(context.Context, string, ...string) *exec.Cmd
+		want         []string
+		wantArgs     []string
+		wantLookPath bool
+	}{
+		{
+			name:        "missing executable",
+			lookPathErr: errors.New("codex not found"),
+			want:        CodexAvailableModels(),
+		},
+		{
+			name: "command failure",
+			command: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("false")
+			},
+			want:         CodexAvailableModels(),
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+		{
+			name: "invalid JSON",
+			command: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("printf", "%s", "not-json")
+			},
+			want:         CodexAvailableModels(),
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+		{
+			name: "empty output",
+			command: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("true")
+			},
+			want:         CodexAvailableModels(),
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+		{
+			name: "no selectable entries",
+			command: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("printf", "%s", `{"models":[{"slug":"hidden","visibility":"hide"},{"slug":"unsupported","supported_in_api":false}]}`)
+			},
+			want:         CodexAvailableModels(),
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+		{
+			name: "cancellation",
+			command: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "sleep", "1")
+			},
+			want:         CodexAvailableModels(),
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+		{
+			name: "output cap",
+			command: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("printf", "%s", strings.Repeat("x", codexModelDiscoveryOutputLimit+1))
+			},
+			want:         CodexAvailableModels(),
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+		{
+			name: "optional fields, whitespace, and duplicates",
+			command: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("printf", "%s", `{"models":[{"slug":"  gpt-5.6  "},{"slug":"gpt-5.6","visibility":"list","supported_in_api":true},{"slug":"legacy"},{"slug":"codex-auto-review","visibility":"hide","supported_in_api":true},{"slug":"hidden","visibility":"hide"},{"slug":"unsupported","supported_in_api":false},{"slug":"   "}]}`)
+			},
+			want:         []string{"gpt-5.6", "legacy"},
+			wantArgs:     []string{"/fake/bin/codex", "debug", "models"},
+			wantLookPath: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalLookPath := codexLookPath
+			originalCommand := codexCommand
+			t.Cleanup(func() {
+				codexLookPath = originalLookPath
+				codexCommand = originalCommand
+			})
+
+			called := false
+			var gotArgs []string
+			codexLookPath = func(string) (string, error) {
+				if tt.lookPathErr != nil {
+					return "", tt.lookPathErr
+				}
+				return "/fake/bin/codex", nil
+			}
+			codexCommand = func(ctx context.Context, path string, args ...string) *exec.Cmd {
+				called = true
+				gotArgs = append([]string{path}, args...)
+				if tt.command == nil {
+					return exec.CommandContext(ctx, "false")
+				}
+				return tt.command(ctx, path, args...)
+			}
+
+			ctx := context.Background()
+			if tt.name == "cancellation" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			got := DiscoverCodexModels(ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("DiscoverCodexModels() = %v, want %v", got, tt.want)
+			}
+			if called != tt.wantLookPath {
+				t.Fatalf("command called = %v, want %v", called, tt.wantLookPath)
+			}
+			if tt.wantArgs != nil {
+				if !reflect.DeepEqual(tt.wantArgs, gotArgs) {
+					t.Fatalf("command args = %v, want %v", gotArgs, tt.wantArgs)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -1,8 +1,13 @@
 package model
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os/exec"
 	"strings"
+	"time"
 )
 
 // codexModelCatalog is Gentle AI's curated selectable Codex model catalog for
@@ -29,16 +34,99 @@ func CodexAvailableModels() []string {
 	return out
 }
 
-// FilterCodexModels returns the subset of CodexAvailableModels whose ID contains
+const codexModelDiscoveryTimeout = 3 * time.Second
+const codexModelDiscoveryOutputLimit = 1 << 20
+
+var codexLookPath = exec.LookPath
+var codexCommand = exec.CommandContext
+
+type codexDiscoveryOutput struct {
+	data     strings.Builder
+	limit    int
+	overflow bool
+}
+
+func (w *codexDiscoveryOutput) Write(p []byte) (int, error) {
+	remaining := w.limit - w.data.Len()
+	if remaining <= 0 {
+		w.overflow = true
+		return 0, io.ErrShortWrite
+	}
+	if len(p) > remaining {
+		_, _ = w.data.Write(p[:remaining])
+		w.overflow = true
+		return remaining, io.ErrShortWrite
+	}
+	return w.data.Write(p)
+}
+
+type codexDiscoveredModelCatalog struct {
+	Models []codexCatalogModel `json:"models"`
+}
+
+type codexCatalogModel struct {
+	Slug           string `json:"slug"`
+	Visibility     string `json:"visibility"`
+	SupportedInAPI *bool  `json:"supported_in_api"`
+}
+
+// DiscoverCodexModels returns selectable models from the locally installed Codex
+// CLI. It falls back to the curated catalog if Codex is unavailable, times out,
+// returns invalid JSON, or reports no selectable models.
+func DiscoverCodexModels(ctx context.Context) []string {
+	discoveryCtx, cancel := context.WithTimeout(ctx, codexModelDiscoveryTimeout)
+	defer cancel()
+
+	codexPath, err := codexLookPath("codex")
+	if err != nil {
+		return CodexAvailableModels()
+	}
+	cmd := codexCommand(discoveryCtx, codexPath, "debug", "models")
+	output := &codexDiscoveryOutput{limit: codexModelDiscoveryOutputLimit}
+	cmd.Stdout = output
+	if err := cmd.Run(); err != nil || output.overflow {
+		return CodexAvailableModels()
+	}
+
+	var catalog codexDiscoveredModelCatalog
+	if err := json.Unmarshal([]byte(output.data.String()), &catalog); err != nil {
+		return CodexAvailableModels()
+	}
+
+	models := make([]string, 0, len(catalog.Models))
+	seen := make(map[string]struct{}, len(catalog.Models))
+	for _, entry := range catalog.Models {
+		slug := strings.TrimSpace(entry.Slug)
+		if slug == "" || (entry.Visibility != "" && entry.Visibility != "list") || (entry.SupportedInAPI != nil && !*entry.SupportedInAPI) {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		models = append(models, slug)
+	}
+	if len(models) == 0 {
+		return CodexAvailableModels()
+	}
+	return models
+}
+
+// FilterCodexModels returns the subset of the fallback catalog whose ID contains
 // query as a case-insensitive substring. An empty query returns all models.
 func FilterCodexModels(query string) []string {
-	all := CodexAvailableModels()
+	return FilterCodexModelList(CodexAvailableModels(), query)
+}
+
+// FilterCodexModelList returns the subset of models whose ID contains query as a
+// case-insensitive substring. An empty query returns a copy of models.
+func FilterCodexModelList(models []string, query string) []string {
 	if strings.TrimSpace(query) == "" {
-		return all
+		return append([]string(nil), models...)
 	}
 	q := strings.ToLower(query)
-	out := make([]string, 0, len(all))
-	for _, m := range all {
+	out := make([]string, 0, len(models))
+	for _, m := range models {
 		if strings.Contains(strings.ToLower(m), q) {
 			out = append(out, m)
 		}

--- a/internal/tui/screens/codex_model_picker.go
+++ b/internal/tui/screens/codex_model_picker.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"strings"
@@ -84,6 +85,7 @@ type CodexModelPickerState struct {
 	CustomModelCursor  int                              // cursor position in filtered model list
 	CustomEffortCursor int                              // cursor position in effort list
 	CustomPendingModel string                           // model ID selected in model-select (pending effort)
+	AvailableModels    []string                         // discovered model IDs for Custom mode
 	CustomAssignments  map[string]CodexCustomAssignment // phase → assignment
 	CustomConfirmed    bool                             // true after user presses Confirm
 }
@@ -92,6 +94,7 @@ type CodexModelPickerState struct {
 func NewCodexModelPickerState() CodexModelPickerState {
 	return CodexModelPickerState{
 		Preset:            CodexPresetRecommended,
+		AvailableModels:   model.CodexAvailableModels(),
 		CustomAssignments: make(map[string]CodexCustomAssignment),
 	}
 }
@@ -110,6 +113,7 @@ func NewCodexModelPickerStateFromAssignments(assignments map[string]model.CodexE
 		if codexAssignmentsEqual(constructor(), assignments) {
 			return CodexModelPickerState{
 				Preset:            preset,
+				AvailableModels:   model.CodexAvailableModels(),
 				CustomAssignments: make(map[string]CodexCustomAssignment),
 			}
 		}
@@ -117,6 +121,7 @@ func NewCodexModelPickerStateFromAssignments(assignments map[string]model.CodexE
 	// Unknown assignments → fall back to Recommended.
 	return CodexModelPickerState{
 		Preset:            CodexPresetRecommended,
+		AvailableModels:   model.CodexAvailableModels(),
 		CustomAssignments: make(map[string]CodexCustomAssignment),
 	}
 }
@@ -133,6 +138,14 @@ func codexAssignmentsEqual(a, b map[string]model.CodexEffort) bool {
 	return true
 }
 
+func filteredCodexModels(state CodexModelPickerState) []string {
+	models := state.AvailableModels
+	if len(models) == 0 {
+		models = model.CodexAvailableModels()
+	}
+	return model.FilterCodexModelList(models, state.CustomModelSearch)
+}
+
 // CodexModelPickerOptionCount returns the total number of selectable rows based
 // on the active sub-mode:
 //   - Main picker: 3 presets + Custom + Back = 5
@@ -144,7 +157,7 @@ func CodexModelPickerOptionCount(state CodexModelPickerState) int {
 	case CodexCustomModePhaseList:
 		return len(codexCustomPhases) + 1 // phases + Confirm
 	case CodexCustomModeModelSelect:
-		models := model.FilterCodexModels(state.CustomModelSearch)
+		models := filteredCodexModels(state)
 		if len(models) == 0 {
 			return 0
 		}
@@ -193,6 +206,7 @@ func HandleCodexModelPickerNav(
 
 	// Custom row: index len(codexPresetOrder) = 3.
 	if cursor == len(codexPresetOrder) {
+		state.AvailableModels = model.DiscoverCodexModels(context.Background())
 		state.CustomMode = CodexCustomModePhaseList
 		state.CustomPhaseIdx = 0
 		state.CustomModelSearch = ""
@@ -282,7 +296,7 @@ func handleCustomPhaseListNav(key string, state *CodexModelPickerState, cursor i
 }
 
 func handleCustomModelSelectNav(key string, state *CodexModelPickerState) (bool, map[string]model.CodexEffort) {
-	models := model.FilterCodexModels(state.CustomModelSearch)
+	models := filteredCodexModels(*state)
 
 	switch key {
 	case "up", "k":
@@ -483,7 +497,7 @@ func renderCodexCustomModelSelect(state CodexModelPickerState) string {
 	b.WriteString(styles.SubtextStyle.Render("Search: " + codexModelSearchDisplay(state.CustomModelSearch)))
 	b.WriteString("\n\n")
 
-	models := model.FilterCodexModels(state.CustomModelSearch)
+	models := filteredCodexModels(state)
 	cursor := state.CustomModelCursor
 	if cursor >= len(models) && len(models) > 0 {
 		cursor = len(models) - 1

--- a/internal/tui/screens/codex_model_picker_test.go
+++ b/internal/tui/screens/codex_model_picker_test.go
@@ -76,6 +76,17 @@ func TestCodexModelPickerOptionCount_PhaseListMode(t *testing.T) {
 	}
 }
 
+func TestCodexCustomModelSelect_UsesStateCatalog(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	state.CustomMode = screens.CodexCustomModeModelSelect
+	state.AvailableModels = []string{"gpt-5.6", "gpt-5.6-mini"}
+
+	out := screens.RenderCodexModelPicker(state, 0)
+	if !strings.Contains(out, "gpt-5.6") || strings.Contains(out, "gpt-5.5") {
+		t.Fatalf("custom model picker should use state catalog; output:\n%s", out)
+	}
+}
+
 func TestCodexModelPickerOptionCount_EffortMode(t *testing.T) {
 	// Effort-select mode: 4 effort levels
 	state := screens.NewCodexModelPickerState()


### PR DESCRIPTION
Closes #1087

## Summary
- Discover selectable Codex models from the installed CLI while retaining the curated catalog as a fallback.
- Bound command output, normalize and deduplicate slugs, and exclude hidden entries such as `codex-auto-review`.
- Store discovered models in Custom mode for search, navigation, rendering, and selection.

## Verification
- [x] `go test ./...` (8,945 tests across 66 packages)
- [x] `e2e/docker-test.sh` (Ubuntu, Arch, Fedora: 79 passed, 0 failed, 2 skipped per platform)
- [x] Receipt-Driven Development review completed and pre-PR/pre-push gates allowed delivery
- [x] `git diff --check`

## Scope
- Four files changed, 258 additions and 8 deletions.
- No generated pnpm files or unrelated changes included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Codex model selection now discovers available models from the local Codex CLI.
  - Custom model options refresh when entering Custom mode and reflect the current catalog.
  - Duplicate and unusable model entries are filtered automatically.
  - If discovery is unavailable, times out, or returns no usable results, the curated model list remains available.

- **Bug Fixes**
  - Updated model filtering and selection to use the current discovered catalog instead of outdated hardcoded entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->