### PR TITLE
feat(judgment-day): bind judge/fix-actor roles to explicit subagent_type in SKILL.md

### DIFF
--- a/internal/assets/skills/judgment-day/SKILL.md
+++ b/internal/assets/skills/judgment-day/SKILL.md
@@ -13,11 +13,11 @@ Load only when the user explicitly requests Judgment Day or equivalent dual/adve
 
 ## Hard Rules
 
-- Resolve matching project skills before starting and pass the same paths to both judges and any fix actor.
+- Resolve matching project skills before starting and pass the same paths to both judges (`jd-judge-a`, `jd-judge-b`) and the fix actor (`jd-fix-agent`).
 - Build one complete immutable target, then launch two blind read-only judges in parallel with identical scope and criteria.
 - Each judge returns one neutral findings result and terminates. Wait for both; never accept a partial judgment.
 - Never launch `review-refuter`; two-judge agreement is the corroboration mechanism.
-- Only the parent orchestrator merges/persists findings, launches the fix actor, and launches scoped re-judgment.
+- Only the parent orchestrator merges/persists findings, launches the fix actor (`jd-fix-agent`), and launches scoped re-judgment.
 - Fix only severe findings confirmed by both judges. WARNING/SUGGESTION rows remain `info`.
 - Permit at most two fix rounds and two scoped re-judgments. Re-judgment sees only the frozen ledger plus fix delta and may record fix-caused defects.
 - The only terminal verdicts are `APPROVED | ESCALATED`; never reset or extend an exhausted round budget.
@@ -37,10 +37,10 @@ Load only when the user explicitly requests Judgment Day or equivalent dual/adve
 ## Execution Steps
 
 1. Build the complete immutable target and freeze the scope both judges will inspect.
-2. Launch both read-only judges against the same immutable target.
+2. Launch both read-only judges in parallel (`jd-judge-a`, `jd-judge-b`) against the same immutable target.
 3. Merge findings into the frozen ledger and persist it through the selected artifact store.
-4. Ask before round-one correction; run the fix actor only for confirmed severe IDs.
-5. Run both judges again only over the frozen ledger plus immutable fix delta.
+4. Ask before round-one correction; run the fix actor (`jd-fix-agent`) only for confirmed severe IDs.
+5. Run both judges again (`jd-judge-a`, `jd-judge-b`) only over the frozen ledger plus immutable fix delta.
 6. Repeat once at most, then run independent final verification and return the terminal verdict.
 
 ## Output Contract


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1923

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

## 📝 Summary

`judgment-day/SKILL.md` previously referenced the judges and fix actor with generic role language only ("Launch both read-only judges", "run the fix actor"). The literal agent identifiers (`jd-judge-a`, `jd-judge-b`, `jd-fix-agent`) that the orchestrator should pass as its `subagent_type` (or equivalent on other adapters) are now named inline at every role reference in the Hard Rules and Execution Steps.

This removes the structural gap that could let a context-pressured or nested-delegation orchestrator fall back to a generic agent instead of the dedicated JD agents defined in `internal/assets/{claude,kiro}/agents/jd-*.md`. The literal `subagent_type` names are now bound in the skill text itself, not just inferred from the agent catalog at runtime.

Scope is intentionally tight: Hard Rules and Execution Steps only (per the issue's explicit ask). Decision Gates and Output Contract unchanged.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/judgment-day/SKILL.md` | Binds literal `jd-judge-a` / `jd-judge-b` / `jd-fix-agent` to each role reference in Hard Rules (lines 16, 20) and Execution Steps (lines 39, 41, 42) |

`additions + deletions = 10` (well under the 400-line review budget).

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/sdd/ -count=1 -timeout 300s
# Result: ok  github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd  37.835s
```

**Targeted role-render tests** (regression-relevant for the JD skill):
```bash
go test ./internal/components/sdd/ -run "TestDedicatedReviewAndJudgment|TestBoundedReview|TestJudgmentDay" -count=1 -timeout 120s
# Result: ok  ... 2.438s
```

**Go Format**
```bash
go run ./internal/gofmtcheck
# Result: clean
```

**Full `go build ./...` and `go vet ./...`**: both clean.

**E2E Tests** (`cd e2e && ./docker-test.sh`): not run locally — this PR is docs/skill-only (no runtime behavior change), so the E2E layer is not affected by the diff.

> **Known pre-existing failures (not introduced by this PR):** `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign` in `internal/cli/refusal_resolution_ratchet_test.go:404` is a known ratchet on `main` (~4m20s) unrelated to the JD skill. Documented in `state.md`; remediation command available. Not in the diff path; not run as part of this PR's verification.

> **Test scope note:** the targeted role-render tests are the slice that asserts the JD assets still parse and bind correctly after the wording change. The full `./internal/...` suite was not run for this single-file docs change.

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#1923)
- [x] PR stays within 400 changed lines (10 lines changed; far under budget)
- [ ] I have added the appropriate `type:*` label to this PR — *see Pending maintainer actions*
- [x] Unit tests pass (`go test ./internal/components/sdd/ -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — *not run; docs-only change, no runtime effect*
- [x] Benchmark validation: N/A — this change does not touch review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark-claim surfaces.
- [x] I have updated documentation if necessary — this *is* the documentation change
- [x] My commits follow Conventional Commits format (`feat(judgment-day): ...`)
- [x] My commits do not include `Co-Authored-By` trailers

## 💬 Notes for Reviewers

Single-file, single-commit docs change. The literal `subagent_type` strings (`jd-judge-a`, `jd-judge-b`, `jd-fix-agent`) match the agent file names registered in `internal/assets/{claude,kiro}/agents/`. No runtime, no test, no schema touched.

The change is purely additive: every modification is inserting a parenthetical with the literal agent identifier next to the existing role name. No sentence is reworded; no clause is removed.

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:feature` label applied to this PR — pending Alan (`gh pr edit --add-label` returns GraphQL 403 `AddLabelsToLabelable` for ardelperal; verified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the roles involved in the skill workflow.
  * Documented that the two evaluation steps run in parallel.
  * Improved execution guidance for more consistent workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->