### PR TITLE
fix(review): surface reviewer admission diagnostics

### DIFF
--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -286,10 +286,39 @@ function gitTrustRefusal(binding: ReviewBinding, cause: unknown): boolean {
 // binding", advice that deterministically fails: recapturing identical bytes
 // can never satisfy admission, only a relaunched reviewer can.
 const ADMISSION_REJECTION = /\breviewer artifact admission ([a-z_]+):/
+const ADMISSION_DIAGNOSTIC = /; admission_diagnostic=(\{[^\r\n]{1,1024}\})$/
+const ADMISSION_DIAGNOSTIC_REASONS = new Set([
+  "expected_path_and_line", "line_suffix_not_integer", "line_must_be_positive",
+  "path_must_be_repository_relative", "path_must_be_canonical", "line_not_changed_by_candidate",
+])
 
-function admissionRejection(cause: unknown): string | undefined {
-  const match = ADMISSION_REJECTION.exec(errorMessage(cause))
-  return match ? match[1] : undefined
+type AdmissionDiagnostic = {
+  code: "invalid_finding_location" | "candidate_causality_unproven"
+  finding_id: string
+  location: string
+  reason: string
+}
+
+function admissionRejection(cause: unknown): { decision: string, diagnostic?: AdmissionDiagnostic } | undefined {
+  const message = errorMessage(cause)
+  const match = ADMISSION_REJECTION.exec(message)
+  if (!match) return undefined
+  const detail = ADMISSION_DIAGNOSTIC.exec(message)
+  if (!detail) return { decision: match[1] }
+  try {
+    const parsed = JSON.parse(detail[1]) as Partial<AdmissionDiagnostic>
+    const safeLocation = typeof parsed.location === "string" && parsed.location.length <= 256 &&
+      !/[\u0000-\u001f\u007f\\]/.test(parsed.location) && !/^(?:[A-Za-z]:[\\/]|[\\/])/.test(parsed.location) &&
+      !parsed.location.split(":", 1)[0].split("/").includes("..")
+    const safeID = typeof parsed.finding_id === "string" && /^R[1-4]-[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(parsed.finding_id)
+    const safeCode = parsed.code === "invalid_finding_location" || parsed.code === "candidate_causality_unproven"
+    const safeReason = typeof parsed.reason === "string" && ADMISSION_DIAGNOSTIC_REASONS.has(parsed.reason)
+    return safeLocation && safeID && safeCode && safeReason
+      ? { decision: match[1], diagnostic: parsed as AdmissionDiagnostic }
+      : { decision: match[1] }
+  } catch {
+    return { decision: match[1] }
+  }
 }
 
 function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: string): string {
@@ -297,7 +326,10 @@ function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: strin
   if (gitTrustRefusal(binding, cause)) return GIT_TRUST_REFUSAL_MESSAGE
   const admission = admissionRejection(cause)
   if (admission) {
-    return `${code}: native admission rejected the reviewer result as ${admission}; ` +
+    const detail = admission.diagnostic
+      ? `; finding ${admission.diagnostic.finding_id} at ${JSON.stringify(admission.diagnostic.location)}: ${admission.diagnostic.reason}`
+      : ""
+    return `${code}: native admission rejected the reviewer result as ${admission.decision}${detail}; ` +
       "retrying capture with the same result cannot succeed; relaunch this lens reviewer to produce a corrected result"
   }
   return `${code}: provider-owned review operation failed; refresh the exact native next_transition or retry the same opaque binding`

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -342,6 +342,34 @@ func TestReviewPluginKeepsIncompleteAdmissionRecoveryNeutral(t *testing.T) {
 	}
 }
 
+func TestReviewPluginSurfacesStructuredLocationRecoveryDiagnostic(t *testing.T) {
+	native := `Error: reviewer artifact admission out_of_scope: reviewer finding location is invalid; ` +
+		`admission_diagnostic={"code":"invalid_finding_location","finding_id":"R3-001",` +
+		`"location":"internal/a.go:207-221","reason":"line_suffix_not_integer"}`
+	message := runReviewPluginScenarioWithNativeAndPreservation(
+		t, "after-opaque", "", native, `{"reference":"rinc1_safe"}`,
+	)
+	for _, want := range []string{
+		"rejected the reviewer result as out_of_scope",
+		`finding R3-001 at "internal/a.go:207-221": line_suffix_not_integer`,
+		"relaunch this lens reviewer",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("structured recovery message %q does not contain %q", message, want)
+		}
+	}
+	if strings.Contains(message, "reviewer finding location is invalid") {
+		t.Fatalf("structured recovery leaked native diagnostic prose: %s", message)
+	}
+	unsafe := strings.Replace(native, "internal/a.go:207-221", `C:\Users\private\repo\a.go:207-221`, 1)
+	message = runReviewPluginScenarioWithNativeAndPreservation(
+		t, "after-opaque", "", unsafe, `{"reference":"rinc1_safe"}`,
+	)
+	if strings.Contains(message, `C:\Users\private`) || strings.Contains(message, "finding R3-001") {
+		t.Fatalf("unsafe structured diagnostic escaped opaque filtering: %s", message)
+	}
+}
+
 // TestReviewPluginKeepsGenericOpaqueFailureOpaque proves the trust pass-through
 // is not a hole in the opaque path's path-safety rule: any other native failure
 // still collapses into the generic provider-owned message.

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -891,6 +891,9 @@ func verifiedCandidateCausalFindingIDs(ctx context.Context, repo string, snapsho
 		case reviewtransaction.CausalIntroduced, reviewtransaction.CausalBehaviorActivated, reviewtransaction.CausalWorsened:
 			changed, err := builder.CandidateLocationSupportsCausality(ctx, snapshot, finding.Location, finding.CausalDisposition)
 			if err != nil {
+				if errors.Is(err, reviewtransaction.ErrInvalidFindingLocation) {
+					return nil, reviewtransaction.NewArtifactLocationAdmissionError(finding.ID, finding.Location, err)
+				}
 				return nil, fmt.Errorf("verify candidate causality for finding %q: %w", finding.ID, err)
 			}
 			if changed {

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -255,6 +255,33 @@ func TestReviewCaptureResultIDLessCandidateCausalFinding(t *testing.T) {
 	}
 }
 
+func TestReviewCaptureResultRejectsInvalidLocationWithActionableDiagnostic(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, false)
+	result := admittedReviewerResultForTest(t, repo, record, record.State.SelectedLenses[0], 0)
+	result.Findings = []facadeFinding{{
+		ID: "R3-001", Location: "tracked.txt:1-2", Severity: "CRITICAL", Claim: "candidate failure",
+		ProofRefs: []string{"tracked.txt changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+		CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}
+	input := filepath.Join(t.TempDir(), "result.json")
+	writeReviewCLIJSON(t, input, result)
+
+	err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+		"--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input,
+	}, io.Discard)
+	var admissionErr *reviewtransaction.ArtifactAdmissionError
+	var locationErr *reviewtransaction.FindingLocationError
+	if !errors.As(err, &admissionErr) || !errors.As(err, &locationErr) {
+		t.Fatalf("capture-result error = %v; want typed admission and location errors", err)
+	}
+	if admissionErr.Diagnostic == nil || admissionErr.Diagnostic.FindingID != "R3-001" ||
+		admissionErr.Diagnostic.Location != "tracked.txt:1-2" ||
+		admissionErr.Diagnostic.Reason != "line_suffix_not_integer" {
+		t.Fatalf("capture diagnostic = %#v", admissionErr.Diagnostic)
+	}
+}
+
 func TestReviewCaptureResultFinalizePreservesCausalClassification(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -67,11 +67,59 @@ type ArtifactAdmissionRequest struct {
 // ArtifactAdmissionError exposes the stable native decision without requiring
 // callers to parse diagnostic prose.
 type ArtifactAdmissionError struct {
-	Admission ArtifactAdmission
+	Admission  ArtifactAdmission
+	Diagnostic *ArtifactAdmissionDiagnostic
+	cause      error
 }
 
 func (err *ArtifactAdmissionError) Error() string {
-	return fmt.Sprintf("reviewer artifact admission %s: %s", err.Admission.Decision, err.Admission.Diagnostic)
+	message := fmt.Sprintf("reviewer artifact admission %s: %s", err.Admission.Decision, err.Admission.Diagnostic)
+	if err.Diagnostic != nil {
+		encoded, _ := json.Marshal(err.Diagnostic)
+		message += "; admission_diagnostic=" + string(encoded)
+	}
+	return message
+}
+
+func (err *ArtifactAdmissionError) Unwrap() error { return err.cause }
+
+// ArtifactAdmissionDiagnostic contains bounded, non-sensitive recovery fields.
+type ArtifactAdmissionDiagnostic struct {
+	Code      string `json:"code"`
+	FindingID string `json:"finding_id,omitempty"`
+	Location  string `json:"location,omitempty"`
+	Reason    string `json:"reason"`
+}
+
+func boundedAdmissionField(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if len(value) > limit {
+		return value[:limit]
+	}
+	return value
+}
+
+func findingAdmissionDiagnostic(code, findingID, location, reason string) *ArtifactAdmissionDiagnostic {
+	return &ArtifactAdmissionDiagnostic{
+		Code: code, FindingID: boundedAdmissionField(findingID, 128),
+		Location: boundedAdmissionField(location, 256), Reason: reason,
+	}
+}
+
+// NewArtifactLocationAdmissionError preserves a typed location cause while
+// exposing the stable admission decision and bounded recovery details.
+func NewArtifactLocationAdmissionError(findingID, location string, cause error) error {
+	var locationErr *FindingLocationError
+	reason := "invalid_location"
+	if errors.As(cause, &locationErr) {
+		reason = string(locationErr.Reason)
+	}
+	admission := ArtifactAdmission{Decision: ArtifactAdmissionOutOfScope, Diagnostic: "reviewer finding location is invalid"}
+	return &ArtifactAdmissionError{
+		Admission:  admission,
+		Diagnostic: findingAdmissionDiagnostic("invalid_finding_location", findingID, location, reason),
+		cause:      cause,
+	}
 }
 
 func (admission ArtifactAdmission) Validate(subject ArtifactSubject) error {
@@ -115,6 +163,10 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 	fail := func(decision ArtifactAdmissionDecision, diagnostic string) (LensResult, ArtifactAdmission, error) {
 		admission.Decision, admission.Diagnostic = decision, diagnostic
 		return LensResult{}, admission, &ArtifactAdmissionError{Admission: admission}
+	}
+	failFinding := func(decision ArtifactAdmissionDecision, diagnostic string, detail *ArtifactAdmissionDiagnostic, cause error) (LensResult, ArtifactAdmission, error) {
+		admission.Decision, admission.Diagnostic = decision, diagnostic
+		return LensResult{}, admission, &ArtifactAdmissionError{Admission: admission, Diagnostic: detail, cause: cause}
 	}
 	if err := ValidateArtifactSubject(request.ExpectedSubject); err != nil {
 		return fail(ArtifactAdmissionBindingMismatch, err.Error())
@@ -227,7 +279,14 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 			return fail(ArtifactAdmissionAmbiguous, "reviewer result repeats a finding ID")
 		}
 		seenFindingIDs[finding.ID] = struct{}{}
-		if !findingLocationInGenesis(finding.Location, wantPaths) {
+		logicalPath, _, locationErr := parseFindingLocation(finding.Location)
+		if locationErr != nil {
+			var typedLocationErr *FindingLocationError
+			errors.As(locationErr, &typedLocationErr)
+			return failFinding(ArtifactAdmissionOutOfScope, "reviewer finding location is invalid",
+				findingAdmissionDiagnostic("invalid_finding_location", finding.ID, finding.Location, string(typedLocationErr.Reason)), locationErr)
+		}
+		if stringIndex(wantPaths, logicalPath) < 0 {
 			return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
 		}
 		for _, proof := range finding.ProofRefs {
@@ -263,7 +322,16 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 	// non-canonical formatting must still admit, since admission persists the
 	// canonical form below rather than the caller's raw bytes.
 	if !equalStrings(verifiedIDs, wantCandidateCausalIDs) {
-		return fail(ArtifactAdmissionOutOfScope, "candidate-causal findings are not proven by repository-derived changed-line evidence")
+		var findingID, location string
+		for _, finding := range canonical.Findings {
+			if stringIndex(wantCandidateCausalIDs, finding.ID) >= 0 && stringIndex(verifiedIDs, finding.ID) < 0 {
+				findingID, location = finding.ID, finding.Location
+				break
+			}
+		}
+		return failFinding(ArtifactAdmissionOutOfScope,
+			"candidate-causal findings are not proven by repository-derived changed-line evidence",
+			findingAdmissionDiagnostic("candidate_causality_unproven", findingID, location, "line_not_changed_by_candidate"), nil)
 	}
 	admission.Decision, admission.ResultHash = ArtifactAdmissionCompleted, canonical.ResultHash
 	admission.CandidateCausalFindingIDs = verifiedIDs

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -1,6 +1,7 @@
 package reviewtransaction
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -277,7 +278,36 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope || admission.Diagnostic != wantMessage {
 			t.Fatalf("AdmitArtifact() = %q, %q, %v; want out-of-scope %q", admission.Decision, admission.Diagnostic, err, wantMessage)
 		}
+		var admissionErr *ArtifactAdmissionError
+		if !errors.As(err, &admissionErr) || admissionErr.Diagnostic == nil {
+			t.Fatalf("candidate-causal error = %v; want structured diagnostic", err)
+		}
+		if admissionErr.Diagnostic.FindingID != "R3-001" ||
+			admissionErr.Diagnostic.Location != "internal/a.go:7" ||
+			admissionErr.Diagnostic.Reason != "line_not_changed_by_candidate" {
+			t.Fatalf("candidate-causal diagnostic = %#v", admissionErr.Diagnostic)
+		}
 	})
+}
+
+func TestAdmitArtifactReturnsStructuredInvalidLocationDiagnostic(t *testing.T) {
+	request := admittedCandidateCausalArtifactFixture(t)
+	request.Result.Findings[0].Location = "internal/a.go:7-9"
+
+	_, admission, err := AdmitArtifact(t.Context(), request)
+	var admissionErr *ArtifactAdmissionError
+	var locationErr *FindingLocationError
+	if admission.Decision != ArtifactAdmissionOutOfScope ||
+		!errors.As(err, &admissionErr) || !errors.As(err, &locationErr) {
+		t.Fatalf("AdmitArtifact() = %#v, %v; want typed location refusal", admission, err)
+	}
+	if admissionErr.Diagnostic == nil ||
+		admissionErr.Diagnostic.Code != "invalid_finding_location" ||
+		admissionErr.Diagnostic.FindingID != "R3-001" ||
+		admissionErr.Diagnostic.Location != "internal/a.go:7-9" ||
+		admissionErr.Diagnostic.Reason != "line_suffix_not_integer" {
+		t.Fatalf("structured diagnostic = %#v", admissionErr.Diagnostic)
+	}
 }
 
 // TestAdmitArtifactOmittedSubjectDiagnosticNamesContinuation pins the

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -1006,28 +1007,69 @@ func (state *CompactState) CompleteReview(input CompactReviewInput) error {
 }
 
 func findingLocationInGenesis(location string, genesisPaths []string) bool {
+	logicalPath, _, err := parseFindingLocation(location)
+	return err == nil && stringIndex(genesisPaths, logicalPath) >= 0
+}
+
+// ErrInvalidFindingLocation identifies reviewer locations that cannot be used
+// as repository line evidence.
+var ErrInvalidFindingLocation = errors.New("invalid reviewer finding location; correct it to repository/path:<positive-line> before running gentle-ai review capture-result again")
+
+// FindingLocationErrorReason is a stable machine-readable validation reason.
+type FindingLocationErrorReason string
+
+const (
+	FindingLocationExpectedPathAndLine FindingLocationErrorReason = "expected_path_and_line"
+	FindingLocationLineNotInteger      FindingLocationErrorReason = "line_suffix_not_integer"
+	FindingLocationLineNotPositive     FindingLocationErrorReason = "line_must_be_positive"
+	FindingLocationPathNotRelative     FindingLocationErrorReason = "path_must_be_repository_relative"
+	FindingLocationPathNotCanonical    FindingLocationErrorReason = "path_must_be_canonical"
+)
+
+// FindingLocationError describes why a reviewer location is invalid.
+type FindingLocationError struct {
+	Location string
+	Reason   FindingLocationErrorReason
+}
+
+func (err *FindingLocationError) Error() string {
+	return fmt.Sprintf("%v %q: %s", ErrInvalidFindingLocation, err.Location, err.Reason)
+}
+
+func (err *FindingLocationError) Unwrap() error { return ErrInvalidFindingLocation }
+
+func parseFindingLocation(location string) (string, int, error) {
 	separator := strings.LastIndexByte(location, ':')
 	if separator <= 0 || separator == len(location)-1 {
-		return false
+		return "", 0, &FindingLocationError{Location: location, Reason: FindingLocationExpectedPathAndLine}
 	}
-	line := location[separator+1:]
-	nonzero := false
-	for index := range line {
-		if line[index] < '0' || line[index] > '9' {
-			return false
+	lineSuffix := location[separator+1:]
+	line, err := strconv.Atoi(lineSuffix)
+	if err != nil {
+		return "", 0, &FindingLocationError{Location: location, Reason: FindingLocationLineNotInteger}
+	}
+	for index := range lineSuffix {
+		if lineSuffix[index] < '0' || lineSuffix[index] > '9' {
+			reason := FindingLocationLineNotInteger
+			if line <= 0 {
+				reason = FindingLocationLineNotPositive
+			}
+			return "", 0, &FindingLocationError{Location: location, Reason: reason}
 		}
-		nonzero = nonzero || line[index] != '0'
+	}
+	if line <= 0 {
+		return "", 0, &FindingLocationError{Location: location, Reason: FindingLocationLineNotPositive}
 	}
 	logicalPath := location[:separator]
 	if len(logicalPath) >= 3 && logicalPath[1] == ':' && logicalPath[2] == '/' &&
 		((logicalPath[0] >= 'A' && logicalPath[0] <= 'Z') || (logicalPath[0] >= 'a' && logicalPath[0] <= 'z')) {
-		return false
+		return "", 0, &FindingLocationError{Location: location, Reason: FindingLocationPathNotRelative}
 	}
-	canonical, err := normalizeLogicalPath(logicalPath)
-	if err != nil || canonical != logicalPath || !nonzero {
-		return false
+	canonical, pathErr := normalizeLogicalPath(logicalPath)
+	if pathErr != nil || canonical != logicalPath {
+		return "", 0, &FindingLocationError{Location: location, Reason: FindingLocationPathNotCanonical}
 	}
-	return stringIndex(genesisPaths, canonical) >= 0
+	return canonical, line, nil
 }
 
 func (state *CompactState) Invalidate(reason string) error {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -2628,11 +2628,18 @@ func TestSnapshotCandidateLocationSupportsStructuredCausality(t *testing.T) {
 		location  string
 		causality CausalDisposition
 		want      bool
-	}{{"introduced replacement", "tracked.txt:2", CausalIntroduced, true}, {"introduced addition", "tracked.txt:5", CausalIntroduced, true}, {"introduced deletion", "deleted.txt:1", CausalIntroduced, false}, {"old-side deletion collision", "tracked.txt:4", CausalIntroduced, false}, {"introduced unchanged", "tracked.txt:1", CausalIntroduced, false}, {"worsened changed", "tracked.txt:2", CausalWorsened, true}, {"worsened unchanged", "tracked.txt:1", CausalWorsened, false}, {"activated unchanged", "tracked.txt:1", CausalBehaviorActivated, true}, {"activated deletion", "deleted.txt:1", CausalBehaviorActivated, false}, {"activated out of range", "tracked.txt:99", CausalBehaviorActivated, false}, {"outside genesis", "other.txt:1", CausalBehaviorActivated, false}, {"zero", "tracked.txt:0", CausalIntroduced, false}, {"malformed", "tracked.txt", CausalWorsened, false}} {
+		wantError FindingLocationErrorReason
+	}{{"introduced replacement", "tracked.txt:2", CausalIntroduced, true, ""}, {"introduced addition", "tracked.txt:5", CausalIntroduced, true, ""}, {"introduced deletion", "deleted.txt:1", CausalIntroduced, false, ""}, {"old-side deletion collision", "tracked.txt:4", CausalIntroduced, false, ""}, {"introduced unchanged", "tracked.txt:1", CausalIntroduced, false, ""}, {"worsened changed", "tracked.txt:2", CausalWorsened, true, ""}, {"worsened unchanged", "tracked.txt:1", CausalWorsened, false, ""}, {"activated unchanged", "tracked.txt:1", CausalBehaviorActivated, true, ""}, {"activated deletion", "deleted.txt:1", CausalBehaviorActivated, false, ""}, {"activated out of range", "tracked.txt:99", CausalBehaviorActivated, false, ""}, {"outside genesis", "other.txt:1", CausalBehaviorActivated, false, ""}, {"range", "tracked.txt:1-2", CausalIntroduced, false, "line_suffix_not_integer"}, {"non-numeric", "tracked.txt:one", CausalIntroduced, false, "line_suffix_not_integer"}, {"overflow", "tracked.txt:" + strings.Repeat("9", 64), CausalIntroduced, false, "line_suffix_not_integer"}, {"leading plus", "tracked.txt:+1", CausalIntroduced, false, "line_suffix_not_integer"}, {"zero", "tracked.txt:0", CausalIntroduced, false, "line_must_be_positive"}, {"negative", "tracked.txt:-1", CausalIntroduced, false, "line_must_be_positive"}, {"missing suffix", "tracked.txt:", CausalWorsened, false, "expected_path_and_line"}, {"malformed", "tracked.txt", CausalWorsened, false, "expected_path_and_line"}} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := (SnapshotBuilder{Repo: repo}).CandidateLocationSupportsCausality(context.Background(), snapshot, tt.location, tt.causality)
-			if err != nil || got != tt.want {
+			if tt.wantError == "" && (err != nil || got != tt.want) {
 				t.Fatalf("CandidateLocationSupportsCausality(%q, %q) = %t, %v", tt.location, tt.causality, got, err)
+			}
+			if tt.wantError != "" {
+				var locationErr *FindingLocationError
+				if got || !errors.Is(err, ErrInvalidFindingLocation) || !errors.As(err, &locationErr) || locationErr.Reason != tt.wantError {
+					t.Fatalf("CandidateLocationSupportsCausality(%q) = %t, %v; want typed %q", tt.location, got, err, tt.wantError)
+				}
 			}
 		})
 	}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -310,12 +310,13 @@ func (builder SnapshotBuilder) CandidateLocationSupportsCausality(ctx context.Co
 	if err := builder.ValidateEvidence(ctx, snapshot); err != nil {
 		return false, err
 	}
-	separator := strings.LastIndex(location, ":")
-	if !findingLocationInGenesis(location, snapshot.Paths) {
+	logicalPath, line, err := parseFindingLocation(location)
+	if err != nil {
+		return false, err
+	}
+	if stringIndex(snapshot.Paths, logicalPath) < 0 {
 		return false, nil
 	}
-	logicalPath := location[:separator]
-	line, _ := strconv.Atoi(location[separator+1:])
 	if causality == CausalBehaviorActivated {
 		entry, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", snapshot.CandidateTree, "--", literalPathspec(logicalPath))
 		if err != nil || len(entry) == 0 {


### PR DESCRIPTION
## Linked Issue

Closes #2028

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

Maintainer action required: apply exactly the `type:bug` label. GitHub does not grant fork authors permission to label upstream pull requests.

## Summary

- Validate reviewer finding locations with typed errors instead of silently parsing malformed line suffixes as line zero.
- Return bounded structured admission diagnostics containing actionable finding and location details.
- Surface only allowlisted recovery diagnostics through the OpenCode adapter while preserving opaque path filtering and fail-closed candidate causality.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Added typed location validation, structured admission diagnostics, and fail-closed tests. |
| `internal/cli` | Propagated typed location failures through reviewer result capture. |
| `internal/assets/opencode` | Exposed allowlisted recovery details and rejected unsafe diagnostic content. |

## Test Plan

### Focused tests

- [x] Focused `internal/reviewtransaction` issue #2028 tests pass.
- [x] Focused `internal/cli` capture and refusal-policy tests pass.
- [x] `node --experimental-strip-types --check internal/assets/opencode/plugins/review-result-artifacts.ts`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`

### Broad validation

- [ ] `go test ./...` did not complete on Windows. `e2e/organicruntime` and a later `internal/cli` test timed out. The candidate-caused refusal-policy failure found before the timeout was fixed, and its exact test plus affected focused packages pass.
- [x] `cd bench && go build ./...`
- [x] `cd bench && go vet ./...`
- [ ] `cd bench && go test ./...` fails three Windows-only shell fixture tests that create extensionless `#!/bin/sh` executables.
- [ ] Docker E2E was not run from this Windows checkout.

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | 290 changed lines |
| Check Issue Reference | Pending | `Closes #2028` |
| Check Issue Has `status:approved` | Pending | Approved before implementation |
| Check PR Has `type:*` Label | Pending | Maintainer must apply exactly `type:bug` |
| Unit Tests | Pending | Awaiting Linux CI |
| Go Format | Pending | Local check passed |
| E2E Tests | Pending | Awaiting CI |

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is applied, maintainer permission is required
- [ ] Full unit suite passes locally, see Windows limitations above
- [x] Go format passes
- [ ] E2E tests pass locally, awaiting CI
- [ ] Benchmark tests pass locally, see Windows shell limitation above
- [x] Documentation is not required for this internal recovery behavior
- [x] Commit follows Conventional Commits format
- [x] Commit does not include `Co-Authored-By` trailers

## Notes for Reviewers

Please challenge the admission guard with real input populations: canonical repository-relative single-line locations remain accepted, malformed ranges, text, zero, and negative lines are rejected with typed reasons, and candidate-causal findings on unchanged lines remain `out_of_scope`.

- [x] Reviewed the integrity and admission guard against legitimate and invalid populations.
- [x] No `guard:population` direction or baseline change was required; the existing fail-closed direction remains unchanged.
- [x] `.guard-population-baseline.txt` is unchanged.

Receipt-driven development was disabled globally, so the native lifecycle did not start and delivery is recorded as `disabled/unmanaged`. No review PASS is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review artifact rejection messages with clear, structured diagnostics for invalid finding locations.
  * Added actionable details such as the affected finding, location, and validation reason.
  * Invalid or unsafe diagnostic content is now filtered to prevent exposing sensitive native error details.
  * Malformed locations—including absolute paths, non-canonical paths, and invalid line numbers—are rejected consistently.
  * Existing fallback behavior remains available when diagnostic details cannot be safely parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->