### PR TITLE
feat(upgrade): show doctor advisory after successful upgrade

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -209,6 +209,12 @@ func RunArgs(args []string, stdout io.Writer) error {
 					_, _ = fmt.Fprintf(stdout, "Warning: failed to clear PendingSync flag: %v\n", writeErr)
 				}
 			}
+			// TUI self-update path: the previous launch completed a gentle-ai
+			// self-upgrade under the old binary and set PendingSync=true. We are
+			// now running under the new binary; print the doctor advisory so the
+			// user can verify ecosystem health against the post-upgrade state.
+			// Print regardless of sync outcome — the advisory is informational.
+			printPostUpgradeDoctorAdvisory(stdout)
 		}
 
 		m := tui.NewModel(result, Version, installedState)
@@ -511,7 +517,14 @@ func runUpgrade(ctx context.Context, args upgradeArgs, detection system.Detectio
 	}
 	if !dryRun {
 		if latestVersion, ok := gentleAIUpgradeSucceeded(report); ok {
-			return restartAfterGentleAIUpgrade(latestVersion, stdout)
+			if err := restartAfterGentleAIUpgrade(latestVersion, stdout); err != nil {
+				return err
+			}
+			// CLI upgrade path: print the doctor advisory so the user can verify
+			// ecosystem health against the post-upgrade state. Informational only;
+			// does not run any checks or change exit status.
+			printPostUpgradeDoctorAdvisory(stdout)
+			return nil
 		}
 	}
 	return nil

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2145,6 +2145,163 @@ func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
 	}
 }
 
+// TestRunArgs_PendingSync_PrintsDoctorAdvisory verifies the TUI self-update
+// deferred path: when the new binary starts and observes PendingSync=true, it
+// prints the doctor advisory after the deferred sync attempt (success or
+// failure). The advisory lets the user verify ecosystem health against the
+// post-upgrade state. Per #1901, this reuses the existing PendingSync signal
+// rather than introducing a new persisted flag.
+func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	deferredSyncFn = func() error {
+		return nil // successful sync
+	}
+
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Run 'gentle-ai doctor' to verify ecosystem health after upgrade") {
+		t.Errorf("stdout = %q, want doctor advisory when PendingSync=true on launch", out)
+	}
+}
+
+// TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure verifies that
+// the doctor advisory is printed regardless of deferred sync outcome. The
+// advisory is informational and complements the sync outcome (not a replacement).
+func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	deferredSyncFn = func() error {
+		return fmt.Errorf("simulated network error")
+	}
+
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v (deferred sync failure must be non-fatal)", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Run 'gentle-ai doctor' to verify ecosystem health after upgrade") {
+		t.Errorf("stdout = %q, want doctor advisory even when deferred sync fails", out)
+	}
+}
+
+// TestRunArgs_NoPendingSync_DoesNotPrintDoctorAdvisory verifies that the
+// doctor advisory is NOT printed on a normal launch where PendingSync=false.
+// The advisory is gated strictly on the post-upgrade signal.
+func TestRunArgs_NoPendingSync_DoesNotPrintDoctorAdvisory(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     false,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v", err)
+	}
+
+	if strings.Contains(buf.String(), "ecosystem health after upgrade") {
+		t.Errorf("stdout must NOT contain doctor advisory on a normal launch (PendingSync=false):\n%s", buf.String())
+	}
+}
+
 func TestCustomSyncClearsPersistedCodexOrchestratorAssignment(t *testing.T) {
 	home := t.TempDir()
 	if err := state.Write(home, state.InstallState{

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -208,3 +208,17 @@ func restartAfterGentleAIUpgrade(latestVersion string, stdout io.Writer) error {
 	_, _ = fmt.Fprintf(stdout, "Updated to v%s — restart gentle-ai to continue.\n", latestVersion)
 	return nil
 }
+
+// printPostUpgradeDoctorAdvisory prints a non-blocking informational advisory
+// suggesting the user run 'gentle-ai doctor' to verify ecosystem health after
+// a successful gentle-ai upgrade. It is purely informational: it does not run
+// any checks, does not change exit status, and does not block the upgrade.
+//
+// The advisory is shown in two places:
+//  1. After a successful `gentle-ai upgrade` CLI invocation (printed by runUpgrade).
+//  2. On the next launch under the new binary when PendingSync=true is observed
+//     (covers the TUI self-update path, where the new binary was not yet running
+//     when the upgrade completed).
+func printPostUpgradeDoctorAdvisory(stdout io.Writer) {
+	_, _ = fmt.Fprintf(stdout, "\n[info]    Run 'gentle-ai doctor' to verify ecosystem health after upgrade\n")
+}

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -280,3 +280,140 @@ func TestRunUpgrade_ForwardsParsedArgsOnceWithoutReparsing(t *testing.T) {
 		t.Errorf("upgradeExecuteWithOptions SkipBackup = false, want true (forwarded once)")
 	}
 }
+
+// TestPrintPostUpgradeDoctorAdvisory_OutputFormat verifies the advisory
+// message format: starts with a newline, has the [info] tag, and names the
+// `gentle-ai doctor` command. The exact wording is part of the public contract
+// because the issue (#1901) specifies the literal expected output.
+func TestPrintPostUpgradeDoctorAdvisory_OutputFormat(t *testing.T) {
+	var buf bytes.Buffer
+	printPostUpgradeDoctorAdvisory(&buf)
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "\n[info]") {
+		t.Errorf("output must start with newline + [info] tag, got %q", out)
+	}
+	if !strings.Contains(out, "gentle-ai doctor") {
+		t.Errorf("output must mention 'gentle-ai doctor', got %q", out)
+	}
+	if !strings.Contains(out, "ecosystem health") {
+		t.Errorf("output must mention ecosystem health context, got %q", out)
+	}
+}
+
+// TestRunUpgrade_PrintsDoctorAdvisoryAfterGentleAIUpgrade verifies that a
+// successful `gentle-ai upgrade` of the gentle-ai binary prints the doctor
+// advisory (per #1901). The advisory must appear AFTER the restart message
+// and must NOT appear in dry-run mode.
+func TestRunUpgrade_PrintsDoctorAdvisoryAfterGentleAIUpgrade(t *testing.T) {
+	unsetEnv(t, envSelfUpdateDone)
+
+	origCheckFiltered := updateCheckFiltered
+	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
+	t.Cleanup(func() {
+		updateCheckFiltered = origCheckFiltered
+		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
+	})
+
+	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
+		return []update.UpdateResult{{
+			Tool:             update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+			InstalledVersion: "1.36.1",
+			LatestVersion:    "1.36.2",
+			Status:           update.UpdateAvailable,
+		}}
+	}
+	upgradeExecuteWithOptions = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, upgrade.ExecuteOptions) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{{
+			ToolName:   "gentle-ai",
+			OldVersion: "1.36.1",
+			NewVersion: "1.36.2",
+			Status:     upgrade.UpgradeSucceeded,
+		}}}
+	}
+
+	var buf bytes.Buffer
+	err := runUpgrade(context.Background(), upgradeArgs{noBackup: true}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
+	if err != nil {
+		t.Fatalf("runUpgrade() error = %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "restart gentle-ai") {
+		t.Errorf("runUpgrade() output missing restart notice:\n%s", out)
+	}
+	if !strings.Contains(out, "Run 'gentle-ai doctor' to verify ecosystem health after upgrade") {
+		t.Errorf("runUpgrade() output missing post-upgrade doctor advisory:\n%s", out)
+	}
+	// Advisory must come AFTER the restart notice (lexicographic order in output).
+	restartIdx := strings.Index(out, "restart gentle-ai")
+	advisoryIdx := strings.Index(out, "gentle-ai doctor")
+	if restartIdx < 0 || advisoryIdx < 0 || advisoryIdx <= restartIdx {
+		t.Errorf("advisory must appear AFTER restart notice (restart=%d, advisory=%d):\n%s", restartIdx, advisoryIdx, out)
+	}
+}
+
+// TestRunUpgrade_DryRunDoesNotPrintDoctorAdvisory verifies that a dry-run
+// upgrade does NOT print the doctor advisory because no actual upgrade occurred.
+func TestRunUpgrade_DryRunDoesNotPrintDoctorAdvisory(t *testing.T) {
+	origCheckFiltered := updateCheckFiltered
+	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
+	t.Cleanup(func() {
+		updateCheckFiltered = origCheckFiltered
+		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
+	})
+
+	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
+		return []update.UpdateResult{{Tool: update.ToolInfo{Name: "gentle-ai"}, Status: update.UpdateAvailable}}
+	}
+	upgradeExecuteWithOptions = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, upgrade.ExecuteOptions) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{DryRun: true, Results: []upgrade.ToolUpgradeResult{{ToolName: "gentle-ai", NewVersion: "1.36.2", Status: upgrade.UpgradeSucceeded}}}
+	}
+
+	var buf bytes.Buffer
+	err := runUpgrade(context.Background(), upgradeArgs{dryRun: true}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", Supported: true}}}, &buf)
+	if err != nil {
+		t.Fatalf("runUpgrade() error = %v", err)
+	}
+	if strings.Contains(buf.String(), "gentle-ai doctor") {
+		t.Fatalf("dry-run output must NOT mention 'gentle-ai doctor' advisory:\n%s", buf.String())
+	}
+}
+
+// TestRunUpgrade_NonGentleAIUpgradeDoesNotPrintDoctorAdvisory verifies that
+// upgrading a tool other than gentle-ai (e.g. engram, gga) does NOT trigger
+// the doctor advisory. The advisory is gated on gentle-ai specifically.
+func TestRunUpgrade_NonGentleAIUpgradeDoesNotPrintDoctorAdvisory(t *testing.T) {
+	origCheckFiltered := updateCheckFiltered
+	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
+	t.Cleanup(func() {
+		updateCheckFiltered = origCheckFiltered
+		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
+	})
+
+	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
+		return []update.UpdateResult{{
+			Tool:             update.ToolInfo{Name: "engram", InstallMethod: update.InstallBinary},
+			InstalledVersion: "0.5.0",
+			LatestVersion:    "0.5.1",
+			Status:           update.UpdateAvailable,
+		}}
+	}
+	upgradeExecuteWithOptions = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, upgrade.ExecuteOptions) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{{
+			ToolName:   "engram",
+			OldVersion: "0.5.0",
+			NewVersion: "0.5.1",
+			Status:     upgrade.UpgradeSucceeded,
+		}}}
+	}
+
+	var buf bytes.Buffer
+	err := runUpgrade(context.Background(), upgradeArgs{}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
+	if err != nil {
+		t.Fatalf("runUpgrade() error = %v", err)
+	}
+	if strings.Contains(buf.String(), "ecosystem health after upgrade") {
+		t.Fatalf("non-gentle-ai upgrade must NOT print post-upgrade doctor advisory:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1901

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

## 📝 Summary

After a successful `gentle-ai upgrade` of the gentle-ai binary itself, the user receives a non-blocking informational advisory suggesting they run `gentle-ai doctor` to verify ecosystem health. The advisory is **purely informational**: it does not run any checks, does not change exit status, and does not block the upgrade.

The advisory surfaces in two paths:

1. **CLI path** — `gentle-ai upgrade` prints the advisory immediately after the existing restart notice, in the same process. Works because the doctor reads on-disk state, not in-memory process state, so it can verify the post-upgrade state even when invoked from the old process.
2. **TUI self-update path** — when the new binary starts and observes `PendingSync=true` in `state.json` (the existing next-launch signal left by the previous upgrade), it prints the advisory after the deferred sync attempt, regardless of whether the sync succeeded. The new binary is the one that knows the new state.

**Scope kept tight per issue's approved plan:**
- No in-process doctor run introduced
- No bounded fast-doctor timeout framework added
- No new persisted flag or lifecycle — reuses existing `PendingSync` next-launch signal
- `install` and read-only `update` commands are out of scope (install already has post-apply verification; update is read-only)
- Exit status unchanged — `gentle-ai upgrade` still exits 0 on success
- Dry-run does not print the advisory (no actual upgrade happened)

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/selfupdate.go` | New helper `printPostUpgradeDoctorAdvisory(stdout)` that prints the canonical advisory line. |
| `internal/app/app.go` | `runUpgrade` calls the advisory after `restartAfterGentleAIUpgrade` returns successfully. The deferred-sync block in `RunArgs` (TUI path) calls the advisory after the sync attempt when `PendingSync=true`. |
| `internal/app/update_test.go` | New tests: advisory format check; CLI upgrade prints advisory; dry-run does NOT print; non-gentle-ai upgrade does NOT print. |
| `internal/app/app_test.go` | New tests: TUI path prints advisory on success; TUI path prints advisory even on sync failure; normal launch (`PendingSync=false`) does NOT print. |

**Production diff:** +28 lines (helper + 2 integration points + comments). Test diff: +294 lines (7 new test cases).
**Total:** +322 / −1 = **321 net changed lines**, within the 400-line review budget.

## 🧪 Test Plan

**Unit Tests (new)**:
```bash
go test ./internal/app/ -run "TestPrintPostUpgradeDoctorAdvisory|TestRunUpgrade_|TestRunArgs_PendingSync" -count=1 -timeout 120s
# Result: PASS — 12 tests, 4.2s
```

**Full `internal/app` suite** (regression-relevant — the change touches `runUpgrade` and the deferred-sync block in `RunArgs`):
```bash
go test ./internal/app/ -count=1 -timeout 180s
# Result: ok  github.com/gentleman-programming/gentle-ai/v2/internal/app  23.379s
```

**Adjacent packages** (no source changes here, but `internal/components/sdd` re-imports the JD skill that touches similar plumbing, and `internal/state` is the home of `PendingSync`):
```bash
go test ./internal/state/ ./internal/components/sdd/ -count=1 -timeout 180s
# Result: ok  internal/state  1.544s
#         ok  internal/components/sdd  75.668s
```

**Build + vet**:
```bash
go build ./...
go vet ./...
# Result: both clean
```

**Go Format**:
```bash
go run ./internal/gofmtcheck
# Result: clean
```

**E2E Tests** (`cd e2e && ./docker-test.sh`): not run locally — the change is a print-string addition and an existing signal reuse; the E2E surface that exercises upgrade is not affected by the diff (the existing upgrade E2E is the same code path; the new advisory is asserted via unit tests above).

> **Known pre-existing failures (not introduced by this PR):** the pre-existing `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign` ratchet in `internal/cli/refusal_resolution_ratchet_test.go:404` did not fire on PR #2081 (last clean run). It may reappear on this PR; not in the diff path. Documented in `state.md`.

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | +321 / −1 — under 400-line budget |
| Check Issue Reference | ⏳ | `Closes #1901` |
| Check Issue Has `status:approved` | ⏳ | Linked issue has `status:approved`, `type:feature`, `priority:medium` |
| Check PR Has `type:*` Label | ⏳ | `type:feature` — pending Alan |
| Unit Tests | ⏳ | `go test ./internal/app/...` green locally |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` clean locally |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` — not run locally (out of scope for this diff) |

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#1901)
- [x] PR stays within 400 changed lines (321 net; 28 production + 294 test + 1 deletion)
- [ ] I have added the appropriate `type:*` label to this PR — *see Pending maintainer actions*
- [x] Unit tests pass (`go test ./internal/app/ -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — *not run locally; out of scope for this diff*
- [x] Benchmark validation: N/A — this change is a print-string addition and a signal reuse in the upgrade/TUI lifecycle. It does not touch review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark-claim surfaces.
- [x] I have updated documentation if necessary — no docs change required; the existing `gentle-ai upgrade` and `gentle-ai doctor` documentation remains valid.
- [x] My commits follow Conventional Commits format (`feat(upgrade): ...`)
- [x] My commits do not include `Co-Authored-By` trailers

## 💬 Notes for Reviewers

This is a single-commit, 4-file feature change. The implementation matches the issue's approved plan exactly:

- **Production code is tiny**: a 5-line helper plus two 5-line integration points with comments.
- **Reuses existing signal**: `state.PendingSync` is already the next-launch marker left by `selfupdate.go:184` after a successful self-upgrade. This PR only adds a reader side effect (the advisory print) to the two readers that already exist (`runUpgrade` and the deferred-sync block in `RunArgs`).
- **No persisted state change**: the diff does not touch `state.InstallState` or its JSON shape. The flag was already there.
- **No exit status change**: `restartAfterGentleAIUpgrade` still returns `nil`; `runUpgrade` returns `nil` after the advisory; deferred-sync failure path is unchanged. The advisory is `fmt.Fprint` to stdout, no mutation.
- **Gated correctly**:
  - Dry-run upgrade → no advisory (covered by `TestRunUpgrade_DryRunDoesNotPrintDoctorAdvisory`)
  - Non-gentle-ai upgrade (engram, gga, etc.) → no advisory (covered by `TestRunUpgrade_NonGentleAIUpgradeDoesNotPrintDoctorAdvisory`)
  - Normal launch with `PendingSync=false` → no advisory (covered by `TestRunArgs_NoPendingSync_DoesNotPrintDoctorAdvisory`)
  - TUI self-update next launch with `PendingSync=true` → advisory printed after sync attempt (covered by `TestRunArgs_PendingSync_PrintsDoctorAdvisory` and `TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure`)

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:feature` label applied to this PR — pending Alan (`gh pr edit --add-label` returns GraphQL 403 `AddLabelsToLabelable` for ardelperal; verified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational reminder to run the doctor check after successful upgrades.
  * The reminder also appears after deferred synchronization completes, including when synchronization reports an error.
  * Dry runs and upgrades for other tools do not display the reminder.

* **Bug Fixes**
  * Improved consistency of post-upgrade and post-synchronization guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->