### PR TITLE
fix(opencode): extract reviewer JSON from prose-prefixed output

### DIFF
--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -90,7 +90,7 @@ function reviewerResult(output: unknown): string {
   const envelope = TASK_RESULT.exec(trimmed)
   if (!envelope) {
     if (TASK_TAG.test(trimmed)) throw new Error("reviewer output contains a malformed task result envelope")
-    return trimmed
+    return extractReviewerJson(trimmed)
   }
   if (envelope[1].trim() === "") {
     throw Object.assign(new Error("reviewer task result is empty"), { reviewClass: "empty_result" })
@@ -98,7 +98,59 @@ function reviewerResult(output: unknown): string {
   if (TASK_TAG.test(envelope[1])) {
     throw Object.assign(new Error("reviewer task result contains a nested task envelope"), { reviewClass: "nested_envelope" })
   }
-  return envelope[1]
+  return extractReviewerJson(envelope[1])
+}
+
+// extractReviewerJson locates the single well-formed JSON object in reviewer
+// output that may start with explanatory prose or be wrapped in markdown
+// fences. Reviewers are instructed to return one JSON object and no prose, but
+// LLMs routinely prefix a preamble (or wrap the object in ```json fences)
+// anyway; forwarding the raw output makes the native strict decoder fail with
+// "invalid character ... looking for beginning of value" and strands the lens
+// result as a preserved incident (regression #1789). The object is located by
+// brace-depth scanning that respects string contents, and the candidate slice
+// is verified with JSON.parse, so the returned bytes are exactly the object
+// the reviewer produced — never surrounding prose, fences, or trailing text.
+function extractReviewerJson(body: string): string {
+  let candidate = body.trim()
+  const openingFence = /^```(?:json)?[ \t]*(?:\r?\n|$)/
+  if (openingFence.test(candidate)) candidate = candidate.replace(openingFence, "")
+  if (/```[ \t]*$/.test(candidate)) candidate = candidate.slice(0, candidate.lastIndexOf("```")).trim()
+  let start = -1
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let i = 0; i < candidate.length; i++) {
+    const ch = candidate[i]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (ch === "\\") escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') {
+      inString = true
+      continue
+    }
+    if (ch === "{") {
+      if (depth === 0) start = i
+      depth++
+      continue
+    }
+    if (ch === "}" && depth > 0) {
+      depth--
+      if (depth === 0 && start !== -1) {
+        const slice = candidate.slice(start, i + 1)
+        try {
+          const parsed = JSON.parse(slice)
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return slice
+        } catch {
+          // the balanced slice is not a JSON object; keep scanning for the next '{'
+        }
+      }
+    }
+  }
+  throw new Error("reviewer output contains no well-formed JSON object")
 }
 
 function extractionClass(cause: unknown): string | undefined {

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -107,46 +107,51 @@ function reviewerResult(output: unknown): string {
 // LLMs routinely prefix a preamble (or wrap the object in ```json fences)
 // anyway; forwarding the raw output makes the native strict decoder fail with
 // "invalid character ... looking for beginning of value" and strands the lens
-// result as a preserved incident (regression #1789). The object is located by
-// brace-depth scanning that respects string contents, and the candidate slice
-// is verified with JSON.parse, so the returned bytes are exactly the object
-// the reviewer produced — never surrounding prose, fences, or trailing text.
+// result as a preserved incident (regression #1789). Every '{' is scanned as
+// an independent candidate with fresh string state, so quotes or braces in the
+// leading prose can never corrupt the scan of the real object, and the
+// candidate slice is verified with JSON.parse, so the returned bytes are
+// exactly the object the reviewer produced — never surrounding prose, fences,
+// or trailing text.
 function extractReviewerJson(body: string): string {
   let candidate = body.trim()
   const openingFence = /^```(?:json)?[ \t]*(?:\r?\n|$)/
   if (openingFence.test(candidate)) candidate = candidate.replace(openingFence, "")
   if (/```[ \t]*$/.test(candidate)) candidate = candidate.slice(0, candidate.lastIndexOf("```")).trim()
-  let start = -1
-  let depth = 0
-  let inString = false
-  let escaped = false
-  for (let i = 0; i < candidate.length; i++) {
-    const ch = candidate[i]
-    if (inString) {
-      if (escaped) escaped = false
-      else if (ch === "\\") escaped = true
-      else if (ch === '"') inString = false
-      continue
+  for (let start = 0; start < candidate.length; start++) {
+    if (candidate[start] !== "{") continue
+    let depth = 1
+    let inString = false
+    let escaped = false
+    let i = start + 1
+    for (; i < candidate.length; i++) {
+      const ch = candidate[i]
+      if (inString) {
+        if (escaped) escaped = false
+        else if (ch === "\\") escaped = true
+        else if (ch === '"') inString = false
+        continue
+      }
+      if (ch === '"') {
+        inString = true
+        continue
+      }
+      if (ch === "{") {
+        depth++
+        continue
+      }
+      if (ch === "}") {
+        depth--
+        if (depth === 0) break
+      }
     }
-    if (ch === '"') {
-      inString = true
-      continue
-    }
-    if (ch === "{") {
-      if (depth === 0) start = i
-      depth++
-      continue
-    }
-    if (ch === "}" && depth > 0) {
-      depth--
-      if (depth === 0 && start !== -1) {
-        const slice = candidate.slice(start, i + 1)
-        try {
-          const parsed = JSON.parse(slice)
-          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return slice
-        } catch {
-          // the balanced slice is not a JSON object; keep scanning for the next '{'
-        }
+    if (depth === 0) {
+      const slice = candidate.slice(start, i + 1)
+      try {
+        const parsed = JSON.parse(slice)
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return slice
+      } catch {
+        // the balanced slice is not a JSON object; keep scanning for the next '{'
       }
     }
   }

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -42,9 +42,20 @@ try {
   } else {
     const input = { tool: "task", args: { subagent_type: "review-risk", prompt } }
     const incomplete = '{"subject_hash":"sha256:' + "c".repeat(64) + '","inspection":{"status":"incomplete","paths":[]},"findings":[],"evidence":["` + reviewPluginPayloadMarker + `"]}'
-    const output = { output: scenario === "after-incomplete" ? incomplete : '{"subject_hash":"sha256:x","findings":[],"evidence":["` + reviewPluginPayloadMarker + `"]}' }
+    const plain = '{"subject_hash":"sha256:x","findings":[],"evidence":["` + reviewPluginPayloadMarker + `"]}'
+    const prose = "Based on my inspection of the immutable candidate diff, I have verified the timeout math.\n\n" + plain + "\nThat completes the review."
+    const fenced = "` + "```" + `json\n" + plain + "\n` + "```" + `"
+    const enveloped = '<task id="review-reliability" state="completed">\n<task_result>\n' + prose + "\n</task_result>\n</task>"
+    let after: string
+    if (scenario === "after-incomplete") after = incomplete
+    else if (scenario === "after-prose") after = prose
+    else if (scenario === "after-fenced") after = fenced
+    else if (scenario === "after-envelope-prose") after = enveloped
+    else if (scenario.startsWith("after-prose-only")) after = "Based on my inspection of ` + reviewPluginPayloadMarker + `, every change is correct."
+    else after = plain
+    const output = { output: after }
     await hooks["tool.execute.after"](input, output)
-    console.log("NO_ERROR")
+    console.log(output.output === undefined || output.output === null ? "NO_ERROR" : String(output.output))
   }
 } catch (cause: unknown) {
   console.log(cause instanceof Error ? cause.message : String(cause))
@@ -76,6 +87,15 @@ func runReviewPluginScenarioWithNative(t *testing.T, scenario, nativeStdout, nat
 }
 
 func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, nativeStdout, nativeStderr, preserveStdout string) string {
+	return runReviewPluginStub(t, scenario, nativeStdout, nativeStderr, preserveStdout, "")
+}
+
+// runReviewPluginStub executes one plugin hook scenario against the stub
+// native binary. When expectStdin is non-empty, the stub verifies that
+// `review capture-result` received exactly those bytes and succeeds only on an
+// exact match, printing CAPTURED — so a test can prove the plugin forwarded
+// the precise extracted JSON, not the prose-wrapped reviewer output.
+func runReviewPluginStub(t *testing.T, scenario, nativeStdout, nativeStderr, preserveStdout, expectStdin string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub native binary requires a POSIX shell")
@@ -96,7 +116,12 @@ func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, na
 			t.Fatal(err)
 		}
 	}
-	stub := "#!/bin/sh\ncat >/dev/null\n" +
+	stub := "#!/bin/sh\n" +
+		"stdin=$(cat)\n" +
+		"if [ \"$2\" = \"capture-result\" ] && [ -n \"$GENTLE_AI_STUB_EXPECT_STDIN\" ]; then\n" +
+		"  if [ \"$stdin\" = \"$GENTLE_AI_STUB_EXPECT_STDIN\" ]; then printf 'CAPTURED\\n'; exit 0; fi\n" +
+		"  printf 'capture stdin mismatch\\n' >&2\n  exit 1\n" +
+		"fi\n" +
 		"if [ \"$2\" = \"preserve-result\" ] && [ -n \"$GENTLE_AI_STUB_PRESERVE_STDOUT\" ]; then printf '%s\\n' \"$GENTLE_AI_STUB_PRESERVE_STDOUT\"; exit 0; fi\n" +
 		"if [ -n \"$GENTLE_AI_STUB_STDOUT\" ]; then printf '%s\\n' \"$GENTLE_AI_STUB_STDOUT\"; exit 0; fi\n" +
 		"printf '%s\\n' \"$GENTLE_AI_STUB_STDERR\" >&2\nexit 1\n"
@@ -116,6 +141,7 @@ func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, na
 		"GENTLE_AI_STUB_STDOUT="+nativeStdout,
 		"GENTLE_AI_STUB_STDERR="+nativeStderr,
 		"GENTLE_AI_STUB_PRESERVE_STDOUT="+preserveStdout,
+		"GENTLE_AI_STUB_EXPECT_STDIN="+expectStdin,
 		"GENTLE_AI_REVIEW_CWD=",
 	)
 	output, err := command.CombinedOutput()
@@ -354,5 +380,74 @@ func TestReviewPluginKeepsGenericOpaqueFailureOpaque(t *testing.T) {
 	}
 	if !strings.Contains(message, "repository_context_preflight_failed") {
 		t.Fatalf("generic opaque failure lost its provider-owned code: %s", message)
+	}
+}
+
+// reviewPluginPlainResult is the exact well-formed reviewer envelope the
+// extraction must forward to `review capture-result` byte for byte.
+func reviewPluginPlainResult() string {
+	return `{"subject_hash":"sha256:x","findings":[],"evidence":["` + reviewPluginPayloadMarker + `"]}`
+}
+
+// TestReviewPluginStripsLeadingProseBeforeJSON pins the #1789 regression: a
+// reviewer that prefixes explanatory prose before the JSON object must still
+// capture — the plugin forwards exactly the extracted object, never the
+// prose-wrapped output that made the native strict decoder fail with
+// "invalid character 'B' looking for beginning of value".
+func TestReviewPluginStripsLeadingProseBeforeJSON(t *testing.T) {
+	message := runReviewPluginStub(t, "after-prose", "", "", "", reviewPluginPlainResult())
+	if message != "CAPTURED" {
+		t.Fatalf("capture after prose-prefixed output = %q, want CAPTURED (exact JSON forwarded)", message)
+	}
+}
+
+// TestReviewPluginStripsMarkdownFencesBeforeJSON pins the #1600 shape: the
+// JSON object wrapped in ```json code fences must also capture cleanly.
+func TestReviewPluginStripsMarkdownFencesBeforeJSON(t *testing.T) {
+	message := runReviewPluginStub(t, "after-fenced", "", "", "", reviewPluginPlainResult())
+	if message != "CAPTURED" {
+		t.Fatalf("capture after fenced output = %q, want CAPTURED (exact JSON forwarded)", message)
+	}
+}
+
+// TestReviewPluginExtractsJSONFromEnvelopedProse pins that the same extraction
+// applies inside a completed task envelope, whose inner body is subject to the
+// same LLM prose-prefix behavior.
+func TestReviewPluginExtractsJSONFromEnvelopedProse(t *testing.T) {
+	message := runReviewPluginStub(t, "after-envelope-prose", "", "", "", reviewPluginPlainResult())
+	if message != "CAPTURED" {
+		t.Fatalf("capture after enveloped prose output = %q, want CAPTURED (exact JSON forwarded)", message)
+	}
+}
+
+// TestReviewPluginPreservesProseOnlyOutput pins the fail-closed tail of the
+// extraction: output with no JSON object at all must not be forwarded; it is
+// preserved as an incident so the lens stays recoverable. The legacy --cwd
+// binding is used so the extraction cause message survives to the transcript
+// (the opaque provider-owned path deliberately collapses native detail).
+func TestReviewPluginPreservesProseOnlyOutput(t *testing.T) {
+	message := runReviewPluginScenario(t, "after-prose-only-legacy", "resolve failed")
+	if message == "NO_ERROR" {
+		t.Fatal("plugin did not fail despite prose-only reviewer output")
+	}
+	if !strings.Contains(message, "reviewer output contains no well-formed JSON object") {
+		t.Fatalf("prose-only output lost its extraction failure cause: %s", message)
+	}
+	if !strings.Contains(message, reviewPluginPayloadMarker) {
+		t.Fatalf("prose-only output was not preserved for recovery: %s", message)
+	}
+}
+
+// TestReviewPluginPreservesExtractedJSONNotProseOnCaptureFailure pins the
+// extraction boundary: when capture fails after successful extraction, the
+// preserved payload must be the extracted strict JSON (the only bytes replay
+// admission accepts), never the original prose-wrapped output.
+func TestReviewPluginPreservesExtractedJSONNotProseOnCaptureFailure(t *testing.T) {
+	message := runReviewPluginScenario(t, "after-prose", "resolve failed")
+	if !strings.Contains(message, reviewPluginPayloadMarker) {
+		t.Fatalf("capture failure lost the extracted reviewer payload: %s", message)
+	}
+	if strings.Contains(message, "Based on my inspection") {
+		t.Fatalf("capture failure preserved the prose-wrapped output instead of the extracted JSON: %s", message)
 	}
 }

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -43,7 +43,7 @@ try {
     const input = { tool: "task", args: { subagent_type: "review-risk", prompt } }
     const incomplete = '{"subject_hash":"sha256:' + "c".repeat(64) + '","inspection":{"status":"incomplete","paths":[]},"findings":[],"evidence":["` + reviewPluginPayloadMarker + `"]}'
     const plain = '{"subject_hash":"sha256:x","findings":[],"evidence":["` + reviewPluginPayloadMarker + `"]}'
-    const prose = "Based on my inspection of the immutable candidate diff, I have verified the timeout math.\n\n" + plain + "\nThat completes the review."
+    const prose = "Based on my inspection of the immutable candidate diff, I have verified the \"timeout math holds and {prose-braces} are harmless.\n\n" + plain + "\nThat completes the review."
     const fenced = "` + "```" + `json\n" + plain + "\n` + "```" + `"
     const enveloped = '<task id="review-reliability" state="completed">\n<task_result>\n' + prose + "\n</task_result>\n</task>"
     let after: string
@@ -93,8 +93,9 @@ func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, na
 // runReviewPluginStub executes one plugin hook scenario against the stub
 // native binary. When expectStdin is non-empty, the stub verifies that
 // `review capture-result` received exactly those bytes and succeeds only on an
-// exact match, printing CAPTURED — so a test can prove the plugin forwarded
-// the precise extracted JSON, not the prose-wrapped reviewer output.
+// exact byte-for-byte match (cmp against a file, so trailing newlines are not
+// stripped), printing CAPTURED — so a test can prove the plugin forwarded the
+// precise extracted JSON, not the prose-wrapped reviewer output.
 func runReviewPluginStub(t *testing.T, scenario, nativeStdout, nativeStderr, preserveStdout, expectStdin string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -117,11 +118,11 @@ func runReviewPluginStub(t *testing.T, scenario, nativeStdout, nativeStderr, pre
 		}
 	}
 	stub := "#!/bin/sh\n" +
-		"stdin=$(cat)\n" +
-		"if [ \"$2\" = \"capture-result\" ] && [ -n \"$GENTLE_AI_STUB_EXPECT_STDIN\" ]; then\n" +
-		"  if [ \"$stdin\" = \"$GENTLE_AI_STUB_EXPECT_STDIN\" ]; then printf 'CAPTURED\\n'; exit 0; fi\n" +
+		"if [ \"$2\" = \"capture-result\" ] && [ -n \"$GENTLE_AI_STUB_EXPECT_STDIN_FILE\" ]; then\n" +
+		"  if cmp -s \"$GENTLE_AI_STUB_EXPECT_STDIN_FILE\" -; then printf 'CAPTURED\\n'; exit 0; fi\n" +
 		"  printf 'capture stdin mismatch\\n' >&2\n  exit 1\n" +
 		"fi\n" +
+		"cat >/dev/null\n" +
 		"if [ \"$2\" = \"preserve-result\" ] && [ -n \"$GENTLE_AI_STUB_PRESERVE_STDOUT\" ]; then printf '%s\\n' \"$GENTLE_AI_STUB_PRESERVE_STDOUT\"; exit 0; fi\n" +
 		"if [ -n \"$GENTLE_AI_STUB_STDOUT\" ]; then printf '%s\\n' \"$GENTLE_AI_STUB_STDOUT\"; exit 0; fi\n" +
 		"printf '%s\\n' \"$GENTLE_AI_STUB_STDERR\" >&2\nexit 1\n"
@@ -134,6 +135,13 @@ func runReviewPluginStub(t *testing.T, scenario, nativeStdout, nativeStderr, pre
 	if err := os.WriteFile(filepath.Join(root, "harness.mts"), []byte(reviewPluginHarness), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	expectFile := ""
+	if expectStdin != "" {
+		expectFile = filepath.Join(root, "expect_stdin")
+		if err := os.WriteFile(expectFile, []byte(expectStdin), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
 	command := exec.Command(node, "harness.mts", scenario, workDir)
 	command.Dir = root
 	command.Env = append(os.Environ(),
@@ -141,7 +149,7 @@ func runReviewPluginStub(t *testing.T, scenario, nativeStdout, nativeStderr, pre
 		"GENTLE_AI_STUB_STDOUT="+nativeStdout,
 		"GENTLE_AI_STUB_STDERR="+nativeStderr,
 		"GENTLE_AI_STUB_PRESERVE_STDOUT="+preserveStdout,
-		"GENTLE_AI_STUB_EXPECT_STDIN="+expectStdin,
+		"GENTLE_AI_STUB_EXPECT_STDIN_FILE="+expectFile,
 		"GENTLE_AI_REVIEW_CWD=",
 	)
 	output, err := command.CombinedOutput()
@@ -393,7 +401,9 @@ func reviewPluginPlainResult() string {
 // reviewer that prefixes explanatory prose before the JSON object must still
 // capture — the plugin forwards exactly the extracted object, never the
 // prose-wrapped output that made the native strict decoder fail with
-// "invalid character 'B' looking for beginning of value".
+// "invalid character 'B' looking for beginning of value". The prose is
+// adversarial on purpose: it contains an unmatched double quote and stray
+// balanced braces before the object, which must not corrupt the scan.
 func TestReviewPluginStripsLeadingProseBeforeJSON(t *testing.T) {
 	message := runReviewPluginStub(t, "after-prose", "", "", "", reviewPluginPlainResult())
 	if message != "CAPTURED" {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1789

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

The managed OpenCode capture hook (`review-result-artifacts.ts`) forwarded reviewer output verbatim to `review capture-result`. When a reviewer prefixed explanatory prose before the JSON envelope (or wrapped it in ```json fences), the native strict decoder failed with `invalid character ... looking for beginning of value` and the lens result was stranded as a preserved `.raw` incident, blocking the review budget. This is the same root cause as #1579 (closed by #1550) regressed on v2.1.11.

The fix runs both the bare output and the extracted task-envelope body through a new `extractReviewerJson()` that strips markdown fences and locates the single well-formed JSON object via brace-depth scanning (string-aware), verified with `JSON.parse`. Output with no JSON object at all still fails closed and is preserved as an incident, so recovery behavior is unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/plugins/review-result-artifacts.ts` | `reviewerResult()` now extracts the JSON object from prose-prefixed/fenced output instead of forwarding it verbatim |
| `internal/assets/review_plugin_recovery_test.go` | Harness scenarios proving the exact extracted JSON reaches `capture-result` byte-for-byte (prose-prefixed, fenced, enveloped-prose) and that prose-only output stays preserved |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```
- `internal/assets`: 894 passed (5 new tests pin the #1789/#1600 shapes)
- Full suite: 8,938 passed; the 2 `e2e/organicruntime` failures are pre-existing environment failures (Claude Code installer) reproduced on clean `main`

**Go Format**
```bash
go run ./internal/gofmtcheck
```
- Passes

**E2E Tests** (Docker required)
- Not run (Docker unavailable locally)

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally (extraction verified against the preserved `.raw` incident from the report)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Review results now reliably extract valid JSON from task output, including responses preceded by explanatory text or wrapped in Markdown code fences.
  - Nested objects, quoted braces, and escaped characters are handled correctly during extraction.
  - Invalid, empty, or prose-only responses now fail safely instead of being forwarded as malformed review results.
  - Existing validation for malformed task envelopes and capture failures remains enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->