### PR TITLE
fix(claude-code): add Engram read tools to sdd-explore frontmatter

### DIFF
--- a/internal/assets/claude/agents/sdd-explore.md
+++ b/internal/assets/claude/agents/sdd-explore.md
@@ -6,7 +6,7 @@ description: >
   clarify requirements — before any proposal or spec is written.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
-tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_save
+tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 
 You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further.

--- a/testdata/golden/sdd-claude-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-explore.golden
@@ -5,7 +5,7 @@ description: >
   a feature, investigate the codebase, understand current architecture, compare approaches, or
   clarify requirements — before any proposal or spec is written.
 model: sonnet
-tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_save
+tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 
 You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1976

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

`sdd-explore` was the only Claude SDD phase agent missing Engram read access. Its `tools:` frontmatter listed `mem_save` but neither `mem_search` nor `mem_get_observation`, so when `artifact_store_mode` is `engram` or `hybrid` the agent structurally cannot fetch the topic keys the orchestrator hands it during exploration.

Per the SDD Context Protocol, this falls back to the copied-artifact-body anti-pattern the protocol forbids. The failure mode is silent: the agent returns a confident, plausible exploration report grounded in whatever the orchestrator paraphrased into the prompt. Because explore is the first SDD phase, propose, spec, and design all build on that unverified foundation.

This PR aligns `sdd-explore` with its siblings (`sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-apply`, `sdd-verify`, `sdd-archive`), which all already expose the trio. The audit confirmed no other Claude SDD phase agent has this asymmetry — `sdd-apply` actually has a richer set including `mem_update`. Cursor, kiro, and kimi agents do not declare Engram tools at all and are out of scope.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/claude/agents/sdd-explore.md` | Insert `mcp__plugin_engram_engram__mem_search` and `mcp__plugin_engram_engram__mem_get_observation` before the existing `mem_save` in the `tools:` frontmatter line |
| `testdata/golden/sdd-claude-agent-sdd-explore.golden` | Refresh snapshot to match the updated `tools:` line |

Diff stats: `+2 / -2 across 2 files` (well within the 400-line review budget).

---

## 🧪 Test Plan

**Unit Tests**

```bash
go test ./internal/assets/... -count=1
```

Result: PASS in 1.8s.

```bash
go build ./... && go vet ./...
```

Result: clean across the whole repo.

```bash
go run ./internal/gofmtcheck
```

Result: clean (no output).

**E2E Tests** (Docker required)

Not run locally — this PR is a 2-line asset frontmatter change with no runtime behavior change in `internal/cli`, `internal/reviewtransaction`, or any other execution path. E2E coverage for asset embedding is exercised by the existing `assets_test.go` golden file test, which passes after the golden snapshot refresh. The maintainer-side `e2e/docker-test.sh` run on CI will gate the final merge.

**Benchmark Validation**

N/A — this is an asset frontmatter change, not in scope for the benchmark guide (review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark-claim changes).

- [x] Unit tests pass (`go test ./internal/assets/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — see note above
- [x] Manually tested locally (golden snapshot diff verified against expected tool-list ordering)

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#1976 was approved 2026-07-29 by `decode2` with explicit technical audit confirming the exact file/line)
- [x] PR stays within 400 changed lines (`+2 / -2`)
- [ ] I have added the appropriate `type:*` label to this PR — see Pending maintainer actions
- [x] Unit tests pass (`go test ./internal/assets/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — see note above
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (asset frontmatter change, no benchmark surface)
- [x] I have updated documentation if necessary (no behavior change, no docs needed)
- [x] My commits follow Conventional Commits format (`fix(claude-code): add Engram read tools to sdd-explore frontmatter`)
- [x] My commits do not include `Co-Authored-By` trailers

---

## Pending maintainer actions

Per `pr-check.yml` and CONTRIBUTING.md, the following are **maintainer-applied** (not contributor scope; `gh pr edit --add-label` returns GraphQL 403 `AddLabelsToLabelable` for external contributors):

- [ ] `type:bug` label applied to this PR — pending Alan
- [ ] Fork workflow approval if any runs reach `action_required` state

---

## 💬 Notes for Reviewers

- The change is mechanical: 2 tool names inserted into one frontmatter `tools:` line, mirroring the exact ordering already used by the 7 sibling SDD agents.
- Audit pass confirmed: no other Claude SDD phase agent has the same gap. `sdd-apply` has a richer set (`mem_search, mem_get_observation, mem_save, mem_update`) which makes sense — apply can mutate observations; explore should not, and this PR does not add `Edit`/`Write`/`Bash` to explore (it remains investigation-only).
- The non-Claude orchestrators (cursor, kiro, kimi) ship agent definitions that do not declare Engram tools at all. Those are out of scope for #1976 and belong with a separate cross-orchestrator audit if Engram coverage for them is desired.
- The fix touches an asset that is embedded into the shipped binary, so per the original bug report a local edit to `~/.claude/agents/sdd-explore.md` only lasts until the next `gentle-ai sync`. The release that ships this PR will be the canonical fix; until then, the workaround is to apply the same line edit manually to the deployed file and restart the Claude Code session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the SDD exploration assistant with access to memory search and observation retrieval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->