### PR TITLE
fix(sdd): advance to a distinct work unit after a passed objective

### DIFF
--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -78,22 +78,22 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 			return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 		}
 		if _, err := store.Begin(ctx, begin); err != nil {
-			return store.compactMutationFailure(err, false), nil
+			return store.compactMutationFailure(err, false, begin), nil
 		}
 		current, loadErr := store.load()
 		if loadErr != nil {
 			return compactBlocked(CompactBlockCorruptAuthority, ""), nil
 		}
-		return compactAcquireResult(current, receipt.Revision), nil
+		return compactAcquireResult(current, begin, receipt.Revision), nil
 	}
 
-	if result, terminal := compactAcquireBlock(replay); terminal {
+	if result, terminal := compactAcquireBlock(replay, begin); terminal {
 		return result, nil
 	}
 	begin.ExpectedRevision = replay.Status.Revision
 	started, err := store.Begin(ctx, begin)
 	if err != nil {
-		return store.compactMutationFailure(err, false), nil
+		return store.compactMutationFailure(err, false, begin), nil
 	}
 	return CompactAttemptResult{State: CompactStateProceed, Token: started.Revision}, nil
 }
@@ -120,7 +120,7 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 			return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 		}
 		if _, err := store.Finish(ctx, finish); err != nil {
-			return store.compactMutationFailure(err, true), nil
+			return store.compactMutationFailure(err, true, BeginAttemptRequest{}), nil
 		}
 		return store.compactSettleResult()
 	}
@@ -165,7 +165,7 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 	}
 	if _, err := store.Finish(ctx, finish); err != nil {
-		return store.compactMutationFailure(err, true), nil
+		return store.compactMutationFailure(err, true, BeginAttemptRequest{}), nil
 	}
 	return store.compactSettleResult()
 }
@@ -190,7 +190,7 @@ func normalizeCompactSettleRequest(request CompactSettleRequest) error {
 }
 
 func compactAcquireMatches(record runtimeRecord, request BeginAttemptRequest) bool {
-	if record.Operation != runtimeOperationBegin || record.Begin == nil {
+	if (record.Operation != runtimeOperationBegin && record.Operation != runtimeOperationAdvance) || record.Begin == nil {
 		return false
 	}
 	event := record.Begin
@@ -228,10 +228,16 @@ func compactSettleReplayRequest(replay runtimeReplay, record runtimeRecord, requ
 	return finish, matches
 }
 
-func compactAcquireBlock(replay runtimeReplay) (CompactAttemptResult, bool) {
+// compactAcquireBlock needs the request because completion is scoped to one
+// objective: a passed apply is terminal for its own work unit while remaining an
+// ordinary predecessor for the distinct verification the SDD graph still owes.
+func compactAcquireBlock(replay runtimeReplay, request BeginAttemptRequest) (CompactAttemptResult, bool) {
 	status := replay.Status
 	switch {
 	case status.Complete:
+		if runtimeObjectiveAdvanceAdmissible(status, request) {
+			return CompactAttemptResult{}, false
+		}
 		return CompactAttemptResult{State: CompactStateComplete}, true
 	case status.DecisionRequired:
 		return compactBlocked(CompactBlockMaintainerDecision, ""), true
@@ -242,8 +248,8 @@ func compactAcquireBlock(replay runtimeReplay) (CompactAttemptResult, bool) {
 	}
 }
 
-func compactAcquireResult(replay runtimeReplay, ownedToken string) CompactAttemptResult {
-	if result, terminal := compactAcquireBlock(replay); terminal {
+func compactAcquireResult(replay runtimeReplay, request BeginAttemptRequest, ownedToken string) CompactAttemptResult {
+	if result, terminal := compactAcquireBlock(replay, request); terminal {
 		if result.Reason == CompactBlockActiveAttempt && result.Token == ownedToken {
 			return CompactAttemptResult{State: CompactStateProceed, Token: ownedToken}
 		}
@@ -273,7 +279,7 @@ func (store RuntimeStore) compactSettleResult(expected ...string) (CompactAttemp
 	}
 }
 
-func (store RuntimeStore) compactMutationFailure(err error, settle bool) CompactAttemptResult {
+func (store RuntimeStore) compactMutationFailure(err error, settle bool, begin BeginAttemptRequest) CompactAttemptResult {
 	var publication *RuntimePublicationError
 	if errors.As(err, &publication) && publication.Committed {
 		if settle {
@@ -284,7 +290,7 @@ func (store RuntimeStore) compactMutationFailure(err error, settle bool) Compact
 		if loadErr != nil {
 			return compactBlocked(CompactBlockCorruptAuthority, "")
 		}
-		return compactAcquireResult(replay, publication.Revision)
+		return compactAcquireResult(replay, begin, publication.Revision)
 	}
 	switch {
 	case errors.Is(err, ErrRuntimeObjectiveDone):

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -36,6 +36,7 @@ const (
 	runtimeOperationFinish            = "attempt/finish"
 	runtimeOperationFinishRemediation = "attempt/finish-remediation"
 	runtimeOperationReset             = "objective/reset"
+	runtimeOperationAdvance           = "objective/advance"
 	runtimeOperationBind              = "binding/set"
 	runtimeLockAcquireAttempts        = 3
 
@@ -200,6 +201,20 @@ type RuntimeReset struct {
 	Actor                  string `json:"actor"`
 }
 
+// RuntimeAdvance records that a passed objective handed the change to a
+// distinct downstream work unit. It is deliberately not a RuntimeReset: reset
+// means a maintainer abandoned or re-scoped a terminal objective, while an
+// advance means the previous scope succeeded and its successor is the ordinary
+// next phase. It retains the completed objective's evidence revision because
+// the live per-objective field belongs to the successor from here on.
+type RuntimeAdvance struct {
+	Revision                 string `json:"revision"`
+	PreviousObjectiveID      string `json:"previous_objective_id"`
+	PreviousGeneration       int    `json:"previous_generation"`
+	PreviousWorkUnit         string `json:"previous_work_unit"`
+	PreviousEvidenceRevision string `json:"previous_evidence_revision"`
+}
+
 type RuntimeStatus struct {
 	Schema                 string            `json:"schema"`
 	Change                 string            `json:"change"`
@@ -218,6 +233,7 @@ type RuntimeStatus struct {
 	Complete               bool              `json:"complete"`
 	NextAction             string            `json:"next_action"`
 	LastReset              *RuntimeReset     `json:"last_reset,omitempty"`
+	LastAdvance            *RuntimeAdvance   `json:"last_advance,omitempty"`
 	BindingRevision        string            `json:"binding_revision"`
 	Binding                *ReviewBinding    `json:"binding,omitempty"`
 }
@@ -298,7 +314,17 @@ type runtimeRecord struct {
 	Begin            *runtimeBeginEvent   `json:"begin,omitempty"`
 	Finish           *runtimeFinishEvent  `json:"finish,omitempty"`
 	Reset            *runtimeResetEvent   `json:"reset,omitempty"`
+	Advance          *runtimeAdvanceEvent `json:"advance,omitempty"`
 	Binding          *runtimeBindingEvent `json:"binding,omitempty"`
+}
+
+// runtimeAdvanceEvent accompanies the successor's begin event in one atomic
+// record, so closing the passed objective and opening its successor can never
+// be observed apart.
+type runtimeAdvanceEvent struct {
+	PreviousObjectiveID string `json:"previous_objective_id"`
+	PreviousGeneration  int    `json:"previous_generation"`
+	PreviousWorkUnit    string `json:"previous_work_unit"`
 }
 
 type runtimeBeginEvent struct {
@@ -401,8 +427,16 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 		if status.ActiveAttempt != nil {
 			return runtimeRecord{}, ErrRuntimeAttemptActive
 		}
+		// A passed objective terminates its own scope, not the change. When the
+		// request names a distinct work unit, the ordinary continuation is the
+		// successor objective, not a maintainer reset that would discard the
+		// completed apply authority along with its evidence.
+		advancing := false
 		if status.Complete {
-			return runtimeRecord{}, ErrRuntimeObjectiveDone
+			if !runtimeObjectiveAdvanceAdmissible(status, request) {
+				return runtimeRecord{}, ErrRuntimeObjectiveDone
+			}
+			advancing = true
 		}
 		if status.DecisionRequired {
 			return runtimeRecord{}, ErrRuntimeBudgetExhausted
@@ -411,7 +445,7 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 		generation := status.ObjectiveGeneration + 1
 		var snapshot reviewtransaction.Snapshot
 		var err error
-		if status.Objective != nil {
+		if status.Objective != nil && !advancing {
 			generation = status.Objective.Generation
 			if request.WorkUnit != status.Objective.WorkUnit || request.EvidenceGoal != status.Objective.EvidenceGoal ||
 				request.MaxAttempts != status.Objective.MaxAttempts ||
@@ -437,16 +471,24 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate before launch: %w", err)
 		}
 		objectiveID := runtimeObjectiveID(store.Change, request.WorkUnit, request.EvidenceGoal, snapshot.Identity, generation)
-		if status.Objective != nil {
+		if status.Objective != nil && !advancing {
 			objectiveID = status.Objective.ID
 		}
-		if status.CumulativeAttempts >= request.MaxAttempts || status.CumulativeChangedLines >= request.MaxChangedLines {
+		// The successor opens a fresh per-objective budget, so the charges the
+		// completed scope accrued cannot exhaust it before its first attempt.
+		if !advancing && (status.CumulativeAttempts >= request.MaxAttempts || status.CumulativeChangedLines >= request.MaxChangedLines) {
 			return runtimeRecord{}, ErrRuntimeBudgetExhausted
 		}
 		event := &runtimeBeginEvent{
 			ObjectiveID: objectiveID, ObjectiveGeneration: generation, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal,
 			MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines,
 			Ordinal: status.NextOrdinal, BeginCandidateIdentity: snapshot.Identity, BeginCandidateTree: snapshot.CandidateTree,
+		}
+		if advancing {
+			return runtimeRecord{Operation: runtimeOperationAdvance, Begin: event, Advance: &runtimeAdvanceEvent{
+				PreviousObjectiveID: status.Objective.ID, PreviousGeneration: status.Objective.Generation,
+				PreviousWorkUnit: status.Objective.WorkUnit,
+			}}, nil
 		}
 		return runtimeRecord{Operation: runtimeOperationBegin, Begin: event}, nil
 	})
@@ -724,6 +766,30 @@ func (store RuntimeStore) runtimeObjectiveResetAdmissible(ctx context.Context, s
 		return false
 	}
 	return candidate.Identity != last.FinishCandidateIdentity || candidate.CandidateTree != last.FinishCandidateTree
+}
+
+// runtimeObjectiveAdvanceAdmissible answers whether a passed objective may hand
+// the change to the requested successor scope. It is deliberately narrower than
+// reset, which reopens any structurally terminal objective: advance requires the
+// previous objective to have PASSED and the request to name a different work
+// unit. Restating the settled work unit — even under a reworded evidence goal —
+// stays complete, because that objective really is done and a fresh budget for
+// it would be exactly the laundering the reset guard already refuses.
+//
+// It is read-only and fail-closed, and it applies the same rule the replay
+// validator re-checks, so an admitted advance can only be one the ledger
+// accepts.
+func runtimeObjectiveAdvanceAdmissible(status RuntimeStatus, request BeginAttemptRequest) bool {
+	if !status.Complete || status.DecisionRequired || status.ActiveAttempt != nil ||
+		status.Objective == nil || len(status.Attempts) == 0 {
+		return false
+	}
+	if request.WorkUnit == status.Objective.WorkUnit {
+		return false
+	}
+	last := status.Attempts[len(status.Attempts)-1]
+	return last.ObjectiveID == status.Objective.ID && last.Outcome == AttemptPassed &&
+		!last.ChangedLineBudgetExceeded && last.FinishCandidateIdentity != "" && last.FinishCandidateTree != ""
 }
 
 // Reset closes a terminal objective scope without deleting its immutable
@@ -1054,63 +1120,14 @@ func applyRuntimeRecord(replay *runtimeReplay, revision string, record runtimeRe
 	remediationPredecessorLineage := ""
 	switch record.Operation {
 	case runtimeOperationBegin:
-		event := record.Begin
-		generation := event.ObjectiveGeneration
-		if generation == 0 {
-			generation = replay.Status.ObjectiveGeneration + 1
-			if replay.Status.Objective != nil {
-				generation = replay.Status.Objective.Generation
-			}
+		if err := applyRuntimeBeginEvent(replay, revision, record); err != nil {
+			return err
 		}
-		if replay.Status.ActiveAttempt != nil || replay.Status.Complete || replay.Status.DecisionRequired {
-			return errors.New("begin record is not a valid successor")
+
+	case runtimeOperationAdvance:
+		if err := applyRuntimeAdvanceEvent(replay, revision, record); err != nil {
+			return err
 		}
-		if replay.Status.Objective == nil {
-			expectedObjectiveID := runtimeObjectiveID(record.Change, event.WorkUnit, event.EvidenceGoal, event.BeginCandidateIdentity, generation)
-			if event.ObjectiveGeneration == 0 {
-				expectedObjectiveID = legacyRuntimeObjectiveID(record.Change, event.EvidenceGoal)
-			}
-			legacyGeneratedID := runtimeObjectiveIDV1(record.Change, event.EvidenceGoal, event.BeginCandidateIdentity, generation)
-			validObjectiveID := event.ObjectiveID == expectedObjectiveID ||
-				event.ObjectiveGeneration != 0 && event.ObjectiveID == legacyGeneratedID
-			if event.Ordinal != replay.Status.NextOrdinal || generation != replay.Status.ObjectiveGeneration+1 || !validObjectiveID {
-				return errors.New("initial objective identity or ordinal is invalid")
-			}
-			replay.Status.Objective = &RuntimeObjective{
-				ID: event.ObjectiveID, Generation: generation, WorkUnit: event.WorkUnit, EvidenceGoal: event.EvidenceGoal,
-				InitialCandidateIdentity: event.BeginCandidateIdentity, InitialCandidateTree: event.BeginCandidateTree,
-				MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,
-			}
-			replay.Status.ObjectiveGeneration = generation
-		} else {
-			objective := replay.Status.Objective
-			if event.ObjectiveID != objective.ID || generation != objective.Generation || event.EvidenceGoal != objective.EvidenceGoal ||
-				event.WorkUnit != objective.WorkUnit ||
-				event.MaxAttempts != objective.MaxAttempts || event.MaxChangedLines != objective.MaxChangedLines ||
-				event.Ordinal != replay.Status.NextOrdinal {
-				return errors.New("begin record changes the active objective or ordinal")
-			}
-			if len(replay.Status.Attempts) == 0 ||
-				event.BeginCandidateTree != replay.Status.Attempts[len(replay.Status.Attempts)-1].FinishCandidateTree {
-				return errors.New("begin record does not continue the terminal candidate")
-			}
-		}
-		if replay.Status.CumulativeAttempts >= event.MaxAttempts || replay.Status.CumulativeChangedLines >= event.MaxChangedLines {
-			return errors.New("begin record exceeds the persisted objective budget")
-		}
-		attempt := RuntimeAttempt{
-			Ordinal: event.Ordinal, ObjectiveID: event.ObjectiveID, ObjectiveGeneration: generation,
-			WorkUnit: event.WorkUnit, BeginCandidateIdentity: event.BeginCandidateIdentity,
-			BeginCandidateTree: event.BeginCandidateTree, Outcome: AttemptRunning,
-		}
-		replay.Status.Attempts = append(replay.Status.Attempts, attempt)
-		replay.AttemptTokens[event.Ordinal] = revision
-		active := attempt
-		replay.Status.ActiveAttempt = &active
-		replay.Status.CumulativeAttempts++
-		replay.Status.LifetimeAttempts++
-		replay.Status.NextOrdinal = event.Ordinal + 1
-		replay.Status.NextAction = RuntimeActionFinish
 
 	case runtimeOperationFinish:
 		if err := applyRuntimeFinishEvent(replay, record.Finish); err != nil {
@@ -1183,6 +1200,107 @@ func applyRuntimeRecord(replay *runtimeReplay, revision string, record runtimeRe
 	return nil
 }
 
+func applyRuntimeBeginEvent(replay *runtimeReplay, revision string, record runtimeRecord) error {
+	event := record.Begin
+	generation := event.ObjectiveGeneration
+	if generation == 0 {
+		generation = replay.Status.ObjectiveGeneration + 1
+		if replay.Status.Objective != nil {
+			generation = replay.Status.Objective.Generation
+		}
+	}
+	if replay.Status.ActiveAttempt != nil || replay.Status.Complete || replay.Status.DecisionRequired {
+		return errors.New("begin record is not a valid successor")
+	}
+	if replay.Status.Objective == nil {
+		expectedObjectiveID := runtimeObjectiveID(record.Change, event.WorkUnit, event.EvidenceGoal, event.BeginCandidateIdentity, generation)
+		if event.ObjectiveGeneration == 0 {
+			expectedObjectiveID = legacyRuntimeObjectiveID(record.Change, event.EvidenceGoal)
+		}
+		legacyGeneratedID := runtimeObjectiveIDV1(record.Change, event.EvidenceGoal, event.BeginCandidateIdentity, generation)
+		validObjectiveID := event.ObjectiveID == expectedObjectiveID ||
+			event.ObjectiveGeneration != 0 && event.ObjectiveID == legacyGeneratedID
+		if event.Ordinal != replay.Status.NextOrdinal || generation != replay.Status.ObjectiveGeneration+1 || !validObjectiveID {
+			return errors.New("initial objective identity or ordinal is invalid")
+		}
+		replay.Status.Objective = &RuntimeObjective{
+			ID: event.ObjectiveID, Generation: generation, WorkUnit: event.WorkUnit, EvidenceGoal: event.EvidenceGoal,
+			InitialCandidateIdentity: event.BeginCandidateIdentity, InitialCandidateTree: event.BeginCandidateTree,
+			MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,
+		}
+		replay.Status.ObjectiveGeneration = generation
+	} else {
+		objective := replay.Status.Objective
+		if event.ObjectiveID != objective.ID || generation != objective.Generation || event.EvidenceGoal != objective.EvidenceGoal ||
+			event.WorkUnit != objective.WorkUnit ||
+			event.MaxAttempts != objective.MaxAttempts || event.MaxChangedLines != objective.MaxChangedLines ||
+			event.Ordinal != replay.Status.NextOrdinal {
+			return errors.New("begin record changes the active objective or ordinal")
+		}
+		if len(replay.Status.Attempts) == 0 ||
+			event.BeginCandidateTree != replay.Status.Attempts[len(replay.Status.Attempts)-1].FinishCandidateTree {
+			return errors.New("begin record does not continue the terminal candidate")
+		}
+	}
+	if replay.Status.CumulativeAttempts >= event.MaxAttempts || replay.Status.CumulativeChangedLines >= event.MaxChangedLines {
+		return errors.New("begin record exceeds the persisted objective budget")
+	}
+	attempt := RuntimeAttempt{
+		Ordinal: event.Ordinal, ObjectiveID: event.ObjectiveID, ObjectiveGeneration: generation,
+		WorkUnit: event.WorkUnit, BeginCandidateIdentity: event.BeginCandidateIdentity,
+		BeginCandidateTree: event.BeginCandidateTree, Outcome: AttemptRunning,
+	}
+	replay.Status.Attempts = append(replay.Status.Attempts, attempt)
+	replay.AttemptTokens[event.Ordinal] = revision
+	active := attempt
+	replay.Status.ActiveAttempt = &active
+	replay.Status.CumulativeAttempts++
+	replay.Status.LifetimeAttempts++
+	replay.Status.NextOrdinal = event.Ordinal + 1
+	replay.Status.NextAction = RuntimeActionFinish
+	return nil
+}
+
+// applyRuntimeAdvanceEvent closes a passed objective and opens its distinct
+// successor inside one record. It re-derives the same rule
+// runtimeObjectiveAdvanceAdmissible applied at write time, so a replayed chain
+// can never admit an advance the authority would have refused.
+func applyRuntimeAdvanceEvent(replay *runtimeReplay, revision string, record runtimeRecord) error {
+	event := record.Advance
+	objective := replay.Status.Objective
+	// Every refusal below re-checks an invariant the authority already enforced
+	// before publishing this record, so reaching one means the persisted chain
+	// was damaged or forged after the fact.
+	if replay.Status.ActiveAttempt != nil || objective == nil || !replay.Status.Complete || replay.Status.DecisionRequired {
+		return errors.New("objective advance is not a valid successor") // refusal:by-design world-action: a replayed chain that contradicts its own write-time state is damaged authority; the exit is restoring the Git-common-dir store, not a command
+	}
+	if event.PreviousObjectiveID != objective.ID || event.PreviousGeneration != objective.Generation ||
+		event.PreviousGeneration != replay.Status.ObjectiveGeneration || event.PreviousWorkUnit != objective.WorkUnit {
+		return errors.New("objective advance does not match the terminal objective") // refusal:by-design world-action: the predecessor identity was frozen at publication, so a mismatch is a mutated record and the exit is restoring the store
+	}
+	if len(replay.Status.Attempts) == 0 {
+		return errors.New("objective advance has no terminal candidate provenance") // refusal:by-design world-action: an advance can only follow a settled attempt, so an empty history is a truncated chain and the exit is restoring the store
+	}
+	last := replay.Status.Attempts[len(replay.Status.Attempts)-1]
+	if last.ObjectiveID != objective.ID || last.Outcome != AttemptPassed || last.ChangedLineBudgetExceeded ||
+		last.FinishCandidateIdentity == "" || last.FinishCandidateTree == "" {
+		return errors.New("objective advance does not follow a passed terminal objective") // refusal:by-design world-action: the passed predecessor was verified before publication, so this is a mutated record and the exit is restoring the store
+	}
+	if record.Begin.WorkUnit == objective.WorkUnit {
+		return errors.New("objective advance does not select a distinct work unit") // refusal:by-design world-action: same-scope advance is refused at write time, so observing one on replay is a forged record and the exit is restoring the store
+	}
+	replay.Status.LastAdvance = &RuntimeAdvance{
+		Revision: revision, PreviousObjectiveID: objective.ID, PreviousGeneration: objective.Generation,
+		PreviousWorkUnit: objective.WorkUnit, PreviousEvidenceRevision: replay.Status.EvidenceRevision,
+	}
+	replay.Status.Objective = nil
+	replay.Status.CumulativeAttempts = 0
+	replay.Status.CumulativeChangedLines = 0
+	replay.Status.EvidenceRevision = ""
+	replay.Status.Complete = false
+	return applyRuntimeBeginEvent(replay, revision, record)
+}
+
 func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent) error {
 	active := replay.Status.ActiveAttempt
 	if active == nil || active.Ordinal != event.Ordinal || len(replay.Status.Attempts) == 0 ||
@@ -1241,6 +1359,24 @@ func applyRuntimeBindingEvent(replay *runtimeReplay, event *runtimeBindingEvent)
 	return nil
 }
 
+func validateRuntimeBeginEvent(record runtimeRecord) error {
+	event := record.Begin
+	if !runtimeRevisionPattern.MatchString(event.ObjectiveID) || event.ObjectiveGeneration < 0 || validateRuntimeText(event.WorkUnit, 160) != nil ||
+		validateRuntimeText(event.EvidenceGoal, 240) != nil || event.MaxAttempts < 1 || event.MaxAttempts > maximumRuntimeAttemptLimit ||
+		event.MaxChangedLines < 1 || event.MaxChangedLines > maximumRuntimeChangedLines || event.Ordinal < 1 ||
+		!runtimeRevisionPattern.MatchString(event.BeginCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.BeginCandidateTree) {
+		return errors.New("invalid SDD runtime begin event")
+	}
+	request := BeginAttemptRequest{
+		ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID, WorkUnit: event.WorkUnit,
+		EvidenceGoal: event.EvidenceGoal, MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,
+	}
+	if runtimeValueHash("gentle-ai.sdd-runtime-begin-request/v1", request) != record.RequestDigest {
+		return errors.New("SDD runtime begin request digest does not match record")
+	}
+	return nil
+}
+
 func validateRuntimeRecordShape(record runtimeRecord) error {
 	if record.Schema != runtimeRecordSchema || !validReviewBindingChange(record.Change) ||
 		(record.PreviousRevision != "" && !runtimeRevisionPattern.MatchString(record.PreviousRevision)) ||
@@ -1249,25 +1385,28 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 	}
 	switch record.Operation {
 	case runtimeOperationBegin:
-		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Binding != nil {
+		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Binding != nil {
 			return errors.New("invalid SDD runtime begin record shape")
 		}
-		event := record.Begin
-		if !runtimeRevisionPattern.MatchString(event.ObjectiveID) || event.ObjectiveGeneration < 0 || validateRuntimeText(event.WorkUnit, 160) != nil ||
-			validateRuntimeText(event.EvidenceGoal, 240) != nil || event.MaxAttempts < 1 || event.MaxAttempts > maximumRuntimeAttemptLimit ||
-			event.MaxChangedLines < 1 || event.MaxChangedLines > maximumRuntimeChangedLines || event.Ordinal < 1 ||
-			!runtimeRevisionPattern.MatchString(event.BeginCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.BeginCandidateTree) {
-			return errors.New("invalid SDD runtime begin event")
+		if err := validateRuntimeBeginEvent(record); err != nil {
+			return err
 		}
-		request := BeginAttemptRequest{
-			ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID, WorkUnit: event.WorkUnit,
-			EvidenceGoal: event.EvidenceGoal, MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,
+	case runtimeOperationAdvance:
+		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Binding != nil {
+			return errors.New("invalid SDD runtime objective advance record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
-		if runtimeValueHash("gentle-ai.sdd-runtime-begin-request/v1", request) != record.RequestDigest {
-			return errors.New("SDD runtime begin request digest does not match record")
+		advance := record.Advance
+		if !runtimeRevisionPattern.MatchString(advance.PreviousObjectiveID) || advance.PreviousGeneration < 1 ||
+			validateRuntimeText(advance.PreviousWorkUnit, 160) != nil || advance.PreviousWorkUnit == record.Begin.WorkUnit {
+			return errors.New("invalid SDD runtime objective advance event") // refusal:by-design world-action: the advance event is derived from validated status, so a violation is a mutated record and the exit is restoring the store
+		}
+		// The successor carries an ordinary begin request, so its digest binds
+		// the same caller-visible request an ordinary begin would have bound.
+		if err := validateRuntimeBeginEvent(record); err != nil {
+			return err
 		}
 	case runtimeOperationFinish:
-		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Binding != nil {
+		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Advance != nil || record.Binding != nil {
 			return errors.New("invalid SDD runtime finish record shape")
 		}
 		event := record.Finish
@@ -1288,7 +1427,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime finish request digest does not match record")
 		}
 	case runtimeOperationFinishRemediation:
-		if record.Finish == nil || record.Binding == nil || record.Begin != nil || record.Reset != nil {
+		if record.Finish == nil || record.Binding == nil || record.Begin != nil || record.Reset != nil || record.Advance != nil {
 			return errors.New("invalid atomic SDD runtime remediation record shape")
 		}
 		finish, binding := record.Finish, record.Binding
@@ -1327,7 +1466,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("atomic SDD runtime remediation request digest does not match record")
 		}
 	case runtimeOperationReset:
-		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Binding != nil {
+		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Advance != nil || record.Binding != nil {
 			return errors.New("invalid SDD runtime reset record shape")
 		}
 		event := record.Reset
@@ -1343,7 +1482,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime reset request digest does not match record")
 		}
 	case runtimeOperationBind:
-		if record.Binding == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil {
+		if record.Binding == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil {
 			return errors.New("invalid SDD runtime binding record shape")
 		}
 		event := record.Binding

--- a/internal/sddstatus/runtime_objective_advance_test.go
+++ b/internal/sddstatus/runtime_objective_advance_test.go
@@ -1,0 +1,241 @@
+package sddstatus
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// runtimeAdvanceFixture settles one passed apply objective so each test starts
+// from the exact terminal state the reported deadlock reproduces.
+type runtimeAdvanceFixture struct {
+	repo   string
+	store  RuntimeStore
+	passed RuntimeStatus
+}
+
+const (
+	advanceApplyWorkUnit    = "migration-schema-implementation"
+	advanceApplyGoal        = "implement the migration schema"
+	advanceVerifyWorkUnit   = "requirements-runtime-verification"
+	advanceVerifyGoal       = "independently verify implementation against spec tasks"
+	advanceApplyMaxAttempts = 3
+	advanceApplyMaxLines    = 20
+)
+
+func newRuntimeAdvanceFixture(t *testing.T, change string) runtimeAdvanceFixture {
+	t.Helper()
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "advance-apply-begin", WorkUnit: advanceApplyWorkUnit,
+		EvidenceGoal: advanceApplyGoal, MaxAttempts: advanceApplyMaxAttempts, MaxChangedLines: advanceApplyMaxLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "migration-schema\n")
+	passed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "advance-apply-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "apply gates passed",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "apply cleanup completed",
+		ProcessEvidence: "apply process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !passed.Complete || passed.ActiveAttempt != nil || passed.NextAction != RuntimeActionComplete {
+		t.Fatalf("apply settlement did not reach the reported terminal state: %#v", passed)
+	}
+	return runtimeAdvanceFixture{repo: repo, store: store, passed: passed}
+}
+
+func (fixture runtimeAdvanceFixture) verifyRequest(requestID string) BeginAttemptRequest {
+	return BeginAttemptRequest{
+		ExpectedRevision: fixture.passed.Revision, RequestID: requestID, WorkUnit: advanceVerifyWorkUnit,
+		EvidenceGoal: advanceVerifyGoal, MaxAttempts: 2, MaxChangedLines: advanceApplyMaxLines,
+	}
+}
+
+// A passed apply objective must not make the change-level ledger terminal for a
+// distinct downstream work unit. The successor opens its own generation and
+// budget while the completed apply attempts stay immutable and uncharged twice.
+func TestRuntimeLedgerAdvancesDistinctWorkUnitAfterPassedObjective(t *testing.T) {
+	fixture := newRuntimeAdvanceFixture(t, "objective-advance")
+	before := countRuntimeRecords(t, fixture.store.Dir)
+	request := fixture.verifyRequest("advance-verify-begin")
+
+	advanced, err := fixture.store.Begin(context.Background(), request)
+	if err != nil {
+		t.Fatalf("distinct verification work unit was refused after a passed apply: %v", err)
+	}
+	if advanced.Complete || advanced.DecisionRequired || advanced.ActiveAttempt == nil ||
+		advanced.ActiveAttempt.Ordinal != 2 || advanced.NextAction != RuntimeActionFinish {
+		t.Fatalf("advanced status = %#v", advanced)
+	}
+	if advanced.Objective == nil || advanced.Objective.WorkUnit != advanceVerifyWorkUnit ||
+		advanced.Objective.EvidenceGoal != advanceVerifyGoal || advanced.Objective.Generation != 2 ||
+		advanced.Objective.ID == fixture.passed.Objective.ID || advanced.ObjectiveGeneration != 2 {
+		t.Fatalf("advanced objective = %#v", advanced.Objective)
+	}
+	if advanced.CumulativeAttempts != 1 || advanced.CumulativeChangedLines != 0 ||
+		advanced.LifetimeAttempts != 2 || advanced.LifetimeChangedLines != fixture.passed.LifetimeChangedLines {
+		t.Fatalf("advance laundered or double-charged budget: %#v", advanced)
+	}
+	if len(advanced.Attempts) != 2 || advanced.Attempts[0].Outcome != AttemptPassed ||
+		advanced.Attempts[0].WorkUnit != advanceApplyWorkUnit ||
+		advanced.Attempts[0].EvidenceRevision != runtimeTestHash('a') {
+		t.Fatalf("advance mutated completed apply attempts: %#v", advanced.Attempts)
+	}
+	// Reset is the maintainer abandonment path and must not be implied here,
+	// while the completed apply evidence stays auditable after the live
+	// per-objective field is cleared for the successor scope.
+	if advanced.LastReset != nil {
+		t.Fatalf("advance recorded a maintainer reset: %#v", advanced.LastReset)
+	}
+	if advanced.LastAdvance == nil || advanced.LastAdvance.PreviousObjectiveID != fixture.passed.Objective.ID ||
+		advanced.LastAdvance.PreviousGeneration != 1 || advanced.LastAdvance.PreviousWorkUnit != advanceApplyWorkUnit ||
+		advanced.LastAdvance.PreviousEvidenceRevision != runtimeTestHash('a') {
+		t.Fatalf("advance succession record = %#v", advanced.LastAdvance)
+	}
+	if advanced.EvidenceRevision != "" {
+		t.Fatalf("successor objective inherited apply evidence: %q", advanced.EvidenceRevision)
+	}
+	if countRuntimeRecords(t, fixture.store.Dir) != before+1 {
+		t.Fatalf("advance wrote %d records, want one", countRuntimeRecords(t, fixture.store.Dir)-before)
+	}
+
+	replayed, err := fixture.store.Begin(context.Background(), request)
+	if err != nil || replayed.Revision != advanced.Revision || countRuntimeRecords(t, fixture.store.Dir) != before+1 {
+		t.Fatalf("advance replay = %#v err=%v records=%d", replayed, err, countRuntimeRecords(t, fixture.store.Dir))
+	}
+}
+
+// Advance is strictly narrower than reset: it may not reopen the scope that
+// already passed, because that objective genuinely is complete.
+func TestRuntimeLedgerRefusesAdvanceIntoTheSameWorkUnit(t *testing.T) {
+	fixture := newRuntimeAdvanceFixture(t, "objective-advance-same-scope")
+	before := countRuntimeRecords(t, fixture.store.Dir)
+
+	for _, test := range []struct {
+		name    string
+		request BeginAttemptRequest
+	}{
+		{name: "identical scope", request: BeginAttemptRequest{
+			ExpectedRevision: fixture.passed.Revision, RequestID: "advance-same-scope", WorkUnit: advanceApplyWorkUnit,
+			EvidenceGoal: advanceApplyGoal, MaxAttempts: advanceApplyMaxAttempts, MaxChangedLines: advanceApplyMaxLines,
+		}},
+		{name: "restated evidence goal", request: BeginAttemptRequest{
+			ExpectedRevision: fixture.passed.Revision, RequestID: "advance-restated-goal", WorkUnit: advanceApplyWorkUnit,
+			EvidenceGoal: "implement the migration schema once more", MaxAttempts: advanceApplyMaxAttempts,
+			MaxChangedLines: advanceApplyMaxLines,
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := fixture.store.Begin(context.Background(), test.request)
+			if !errors.Is(err, ErrRuntimeObjectiveDone) {
+				t.Fatalf("same-work-unit advance error = %T %v, want ErrRuntimeObjectiveDone", err, err)
+			}
+			status, statusErr := fixture.store.Status()
+			if statusErr != nil || status.Revision != fixture.passed.Revision || !status.Complete ||
+				countRuntimeRecords(t, fixture.store.Dir) != before {
+				t.Fatalf("refused advance mutated authority: status=%#v err=%v records=%d",
+					status, statusErr, countRuntimeRecords(t, fixture.store.Dir))
+			}
+		})
+	}
+}
+
+// An exhausted or failed objective stays maintainer territory: advance never
+// launders a budget that decision_required is holding.
+func TestRuntimeLedgerRefusesAdvanceWhenDecisionIsRequired(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "objective-advance-exhausted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "exhausted-begin", WorkUnit: advanceApplyWorkUnit,
+		EvidenceGoal: advanceApplyGoal, MaxAttempts: 1, MaxChangedLines: advanceApplyMaxLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "partial\n")
+	exhausted, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "exhausted-finish", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "apply failed and exhausted its budget",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed",
+		ProcessEvidence: "process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exhausted.DecisionRequired || exhausted.Complete {
+		t.Fatalf("fixture did not reach decision_required: %#v", exhausted)
+	}
+	before := countRuntimeRecords(t, store.Dir)
+
+	_, err = store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: exhausted.Revision, RequestID: "exhausted-advance", WorkUnit: advanceVerifyWorkUnit,
+		EvidenceGoal: advanceVerifyGoal, MaxAttempts: 2, MaxChangedLines: advanceApplyMaxLines,
+	})
+	if !errors.Is(err, ErrRuntimeBudgetExhausted) {
+		t.Fatalf("advance past decision_required error = %T %v, want ErrRuntimeBudgetExhausted", err, err)
+	}
+	if countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("refused advance wrote %d records", countRuntimeRecords(t, store.Dir)-before)
+	}
+}
+
+// The reported defect surfaced through the compact projection: acquire returned
+// a bare `{"state":"complete"}` with no token, so the verifier could not launch.
+func TestCompactAcquireProceedsForDistinctWorkUnitAfterPassedObjective(t *testing.T) {
+	fixture := newRuntimeAdvanceFixture(t, "compact-objective-advance")
+	before := countRuntimeRecords(t, fixture.store.Dir)
+	request := CompactAcquireRequest{
+		RequestID: "compact-advance-verify", WorkUnit: advanceVerifyWorkUnit, EvidenceGoal: advanceVerifyGoal,
+		MaxAttempts: 2, MaxChangedLines: advanceApplyMaxLines,
+	}
+
+	result, err := fixture.store.Acquire(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != CompactStateProceed || result.Token == "" || result.Reason != "" {
+		t.Fatalf("verification acquire = %#v, want proceed with a token", result)
+	}
+	status, statusErr := fixture.store.Status()
+	if statusErr != nil {
+		t.Fatal(statusErr)
+	}
+	if status.ActiveAttempt == nil || status.ActiveAttempt.WorkUnit != advanceVerifyWorkUnit ||
+		result.Token != status.Revision || countRuntimeRecords(t, fixture.store.Dir) != before+1 {
+		t.Fatalf("acquire token/status = %#v %#v records=%d", result, status, countRuntimeRecords(t, fixture.store.Dir))
+	}
+
+	replayed, err := fixture.store.Acquire(context.Background(), request)
+	if err != nil || replayed != result || countRuntimeRecords(t, fixture.store.Dir) != before+1 {
+		t.Fatalf("acquire replay = %#v err=%v records=%d", replayed, err, countRuntimeRecords(t, fixture.store.Dir))
+	}
+}
+
+func TestCompactAcquireStaysCompleteForTheSettledWorkUnit(t *testing.T) {
+	fixture := newRuntimeAdvanceFixture(t, "compact-objective-advance-same-scope")
+	before := countRuntimeRecords(t, fixture.store.Dir)
+
+	result, err := fixture.store.Acquire(context.Background(), CompactAcquireRequest{
+		RequestID: "compact-advance-same-scope", WorkUnit: advanceApplyWorkUnit, EvidenceGoal: advanceApplyGoal,
+		MaxAttempts: advanceApplyMaxAttempts, MaxChangedLines: advanceApplyMaxLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != CompactStateComplete || result.Token != "" ||
+		countRuntimeRecords(t, fixture.store.Dir) != before {
+		t.Fatalf("settled-scope acquire = %#v records=%d", result, countRuntimeRecords(t, fixture.store.Dir))
+	}
+}

--- a/internal/sddstatus/runtime_objective_advance_test.go
+++ b/internal/sddstatus/runtime_objective_advance_test.go
@@ -21,6 +21,11 @@ const (
 	advanceVerifyGoal       = "independently verify implementation against spec tasks"
 	advanceApplyMaxAttempts = 3
 	advanceApplyMaxLines    = 20
+	// The successor budget deliberately differs from the apply budget in both
+	// dimensions, so an assertion on it cannot pass while the predecessor's
+	// budget is carried over.
+	advanceVerifyMaxAttempts = 2
+	advanceVerifyMaxLines    = 30
 )
 
 func newRuntimeAdvanceFixture(t *testing.T, change string) runtimeAdvanceFixture {
@@ -56,7 +61,7 @@ func newRuntimeAdvanceFixture(t *testing.T, change string) runtimeAdvanceFixture
 func (fixture runtimeAdvanceFixture) verifyRequest(requestID string) BeginAttemptRequest {
 	return BeginAttemptRequest{
 		ExpectedRevision: fixture.passed.Revision, RequestID: requestID, WorkUnit: advanceVerifyWorkUnit,
-		EvidenceGoal: advanceVerifyGoal, MaxAttempts: 2, MaxChangedLines: advanceApplyMaxLines,
+		EvidenceGoal: advanceVerifyGoal, MaxAttempts: advanceVerifyMaxAttempts, MaxChangedLines: advanceVerifyMaxLines,
 	}
 }
 
@@ -80,6 +85,13 @@ func TestRuntimeLedgerAdvancesDistinctWorkUnitAfterPassedObjective(t *testing.T)
 		advanced.Objective.EvidenceGoal != advanceVerifyGoal || advanced.Objective.Generation != 2 ||
 		advanced.Objective.ID == fixture.passed.Objective.ID || advanced.ObjectiveGeneration != 2 {
 		t.Fatalf("advanced objective = %#v", advanced.Objective)
+	}
+	// The successor must hold the budget IT requested, not the one the passed
+	// predecessor was bound to.
+	if advanced.Objective.MaxAttempts != advanceVerifyMaxAttempts || advanced.Objective.MaxChangedLines != advanceVerifyMaxLines ||
+		advanced.Objective.MaxAttempts == fixture.passed.Objective.MaxAttempts ||
+		advanced.Objective.MaxChangedLines == fixture.passed.Objective.MaxChangedLines {
+		t.Fatalf("successor inherited the predecessor budget: %#v", advanced.Objective)
 	}
 	if advanced.CumulativeAttempts != 1 || advanced.CumulativeChangedLines != 0 ||
 		advanced.LifetimeAttempts != 2 || advanced.LifetimeChangedLines != fixture.passed.LifetimeChangedLines {
@@ -181,7 +193,7 @@ func TestRuntimeLedgerRefusesAdvanceWhenDecisionIsRequired(t *testing.T) {
 
 	_, err = store.Begin(context.Background(), BeginAttemptRequest{
 		ExpectedRevision: exhausted.Revision, RequestID: "exhausted-advance", WorkUnit: advanceVerifyWorkUnit,
-		EvidenceGoal: advanceVerifyGoal, MaxAttempts: 2, MaxChangedLines: advanceApplyMaxLines,
+		EvidenceGoal: advanceVerifyGoal, MaxAttempts: advanceVerifyMaxAttempts, MaxChangedLines: advanceVerifyMaxLines,
 	})
 	if !errors.Is(err, ErrRuntimeBudgetExhausted) {
 		t.Fatalf("advance past decision_required error = %T %v, want ErrRuntimeBudgetExhausted", err, err)
@@ -198,7 +210,7 @@ func TestCompactAcquireProceedsForDistinctWorkUnitAfterPassedObjective(t *testin
 	before := countRuntimeRecords(t, fixture.store.Dir)
 	request := CompactAcquireRequest{
 		RequestID: "compact-advance-verify", WorkUnit: advanceVerifyWorkUnit, EvidenceGoal: advanceVerifyGoal,
-		MaxAttempts: 2, MaxChangedLines: advanceApplyMaxLines,
+		MaxAttempts: advanceVerifyMaxAttempts, MaxChangedLines: advanceVerifyMaxLines,
 	}
 
 	result, err := fixture.store.Acquire(context.Background(), request)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2133

Related: #1586 (the comment thread there carries three independent reproductions of the same deadlock, plus the [design rationale](https://github.com/Gentleman-Programming/gentle-ai/issues/1586#issuecomment-5150508746) for this implementation).

> **Maintainer note, stated up front:** I originally linked this to #1586 and CodeRabbit correctly pointed out that #2133 is the accurate issue. #2133's expected behavior asks for exactly what this implements: *"create a new bounded objective generation and return `state: proceed`"*. #2133 currently has no `status:approved` label, so the approval check will still fail. I opened this before approval because the design decision seemed easier to judge against real code than prose. Please treat it as a design proposal with an implementation attached.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- A passed SDD objective made the **change-level** attempt ledger terminal, so any distinct downstream work unit (a second apply work unit per #2133, or independent verification) got `{"state":"complete"}` with no token and could never launch. This is exactly the contradiction #2133 reports: the dispatcher says `applyState: ready` with 89 pending tasks, while `acquire` says `complete`.
- Adds an `objective/advance` record operation, emitted by `Begin` itself, that closes a passed objective and opens its distinct successor in one atomic record. `acquire` now returns `proceed` plus a token, matching what the dispatcher already reported.
- Deliberately narrower than the `reset` it replaces: restating the settled work unit still returns `complete`, and `reset` remains the maintainer path for abandoning or re-scoping a failed objective.

### Root cause

`applyRuntimeFinishEvent` sets `Complete` on the change-level status for any passed settlement (`runtime_ledger.go:1213` on main), but objectives are work-unit scoped. `Begin` then refuses with `ErrRuntimeObjectiveDone` at line 405, **before** the scope comparison at line 416 is ever reachable. So the requested work unit is never examined.

`reset` was not a usable escape: it zeroes `EvidenceRevision` (line 1161), which is exactly what `nativeRuntimeCompletesRemediation` reads to bind apply evidence. Resetting to unblock verification destroys the authority that verification exists to check, and records the passed apply as if a maintainer had abandoned it.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_ledger.go` | New `objective/advance` operation: `RuntimeAdvance` type, `LastAdvance` status field, `runtimeAdvanceEvent`, `runtimeObjectiveAdvanceAdmissible` admission predicate, `applyRuntimeAdvanceEvent` replay, and its record-shape validation. `Begin` emits an advance instead of refusing when the terminal objective passed and the request names a different work unit. |
| `internal/sddstatus/runtime_ledger.go` (refactor) | Extracted `applyRuntimeBeginEvent` and `validateRuntimeBeginEvent` verbatim out of the inline switch cases so the advance path reuses them. No behavior change; this is the bulk of the diff. |
| `internal/sddstatus/runtime_compact.go` | `compactAcquireBlock` / `compactAcquireResult` / `compactMutationFailure` now receive the `BeginAttemptRequest`, because completion is scoped to one objective. `compactAcquireMatches` accepts the advance operation so replayed acquires stay idempotent. |
| `internal/sddstatus/runtime_objective_advance_test.go` | Six new tests over the reported sequence. |

### Design properties

- **Atomic.** One record closes the passed objective and opens its successor, so they cannot be observed apart.
- **Non-destructive.** Attempts stay immutable, `LifetimeAttempts` and `LifetimeChangedLines` stay monotonic, and `LastAdvance` retains the previous objective's id, generation, work unit, and evidence revision. `LastReset` is not written, because it means something else.
- **Narrower than reset.** Same work unit stays `complete` even under a reworded evidence goal. The pre-existing same-scope `reset`-when-`Complete` path remains the wider door; I did not touch it, but it is worth a separate look.
- **Fail-closed replay.** `applyRuntimeAdvanceEvent` re-derives the same admission rule at replay time, so a mutated chain cannot smuggle in an advance the authority would have refused.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...          # 63 packages ok, 0 failures
go vet ./...           # clean
gofmt -l internal/     # clean
```

New coverage in `runtime_objective_advance_test.go`:

| Test | Proves |
|------|--------|
| `TestRuntimeLedgerAdvancesDistinctWorkUnitAfterPassedObjective` | Successor gets a new generation and its own budget (asserted against a successor budget that differs from the predecessor's in both dimensions, so inheriting it cannot pass); attempts, lifetime charges, and apply evidence provenance survive; replay is idempotent |
| `TestRuntimeLedgerRefusesAdvanceIntoTheSameWorkUnit` | Identical scope and restated evidence goal both stay `complete` and write zero records |
| `TestRuntimeLedgerRefusesAdvanceWhenDecisionIsRequired` | An exhausted objective stays maintainer territory (`ErrRuntimeBudgetExhausted`) |
| `TestCompactAcquireProceedsForDistinctWorkUnitAfterPassedObjective` | The reported call returns `proceed` with a token bound to the new attempt |
| `TestCompactAcquireStaysCompleteForTheSettledWorkUnit` | The settled scope still projects `complete` |

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — **not run**, Docker was not available in my environment. Flagging rather than checking a box I did not verify.
- [x] Manually tested locally

**Benchmark Validation:** N/A. This changes the SDD runtime attempt ledger, not the review lifecycle, gates, recovery, delivery, or the benchmark implementation/corpus/classifier, and makes no benchmark claim.

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — **no**. #2133 carries no labels yet. Deliberate, not an oversight; see the note at the top.
- [ ] PR stays within 400 changed lines — **no**, 473 insertions + 87 deletions = 560. Requesting maintainer-applied `size:exception`, rationale below.
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass — not run, see Test Plan
- [x] Benchmark validation not applicable, explained in the Test Plan
- [x] I have updated documentation if necessary (no user-facing surface changed)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

**`size:exception` rationale:** roughly 150 of the 560 lines are the verbatim extraction of `applyRuntimeBeginEvent` and `validateRuntimeBeginEvent` out of their switch cases, which git counts twice as moved code with zero behavior change. The remaining net-new logic is the advance operation plus 241 lines of tests. I am happy to split this into a mechanical-extraction PR followed by the feature instead. Say the word and I will chain them.

---

## 💬 Notes for Reviewers

**Compatibility, stated plainly.** The record schema stays `gentle-ai.sdd-runtime-record/v1`. The change is additive and an older binary rejects the unknown `objective/advance` operation rather than misreading it, so it fails closed. The real tradeoff: downgrading a binary after an advance has been written leaves that authority unreadable. If you would rather gate this behind a schema bump, that is a reasonable call and I will make it.

**Guard population.** `runtimeObjectiveAdvanceAdmissible` is an admission guard. Its legitimate input population is *terminal objectives that settled `passed` with intact candidate provenance, where the request names a different work unit*; failed, exhausted, active, and same-scope objectives are excluded. The declaration/registry check passes without a new `.guard-population-baseline.txt` entry, but per this template's own warning I am not treating that as proof the guard was correctly omitted. Please challenge that population directly.

**Two open questions I would rather you decide than me:**

1. Is "different `work_unit`" the right admission key, or should a differing `evidence_goal` alone also qualify? I chose the stricter rule on purpose, so a cosmetic goal rewording cannot buy a fresh budget.
2. Should the pre-existing same-scope `reset`-when-`Complete` path be tightened separately? It is a wider door than anything this PR opens, and it is out of scope here.

**Not verified against a live deadlocked worktree.** The reporter's worktree in #1586 is being preserved to reproduce the defect, and a successful `acquire` writes a record, so running it there would destroy the very state under investigation. Coverage is via fixtures that reconstruct the exact reported sequence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Completed objectives can advance to a distinct work unit with a fresh budget.
  - Advancement history, evidence, and audit details are preserved.
  - Previously completed work remains complete while eligible successor work proceeds.
  - Replay handling consistently validates objective advances and preserves request-specific behavior.

- **Bug Fixes**
  - Prevented advancement into the same work unit or when a decision is required.
  - Improved recovery and compact acquisition behavior for completed objectives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->