### PR TITLE
feat(skills): filter injection by runtime capabilities

### DIFF
--- a/internal/catalog/skills.go
+++ b/internal/catalog/skills.go
@@ -1,12 +1,16 @@
 package catalog
 
-import "github.com/gentleman-programming/gentle-ai/v2/internal/model"
+import (
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
 
 type Skill struct {
-	ID       model.SkillID
-	Name     string
-	Category string
-	Priority string
+	ID                   model.SkillID
+	Name                 string
+	Category             string
+	Priority             string
+	RequiredCapabilities capabilitymanifest.AgentFeatureClaims
 }
 
 var mvpSkills = []Skill{

--- a/internal/catalog/skills_test.go
+++ b/internal/catalog/skills_test.go
@@ -1,8 +1,9 @@
-package catalog
+package catalog_test
 
 import (
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
@@ -13,7 +14,7 @@ import (
 // silently rejected by normalizeSkills in cli/validate.go.
 func TestMVPSkillsCoverAllPresetSkills(t *testing.T) {
 	catalogSet := make(map[model.SkillID]bool)
-	for _, s := range MVPSkills() {
+	for _, s := range catalog.MVPSkills() {
 		catalogSet[s.ID] = true
 	}
 
@@ -28,7 +29,7 @@ func TestMVPSkillsCoverAllPresetSkills(t *testing.T) {
 // TestMVPSkillsNoDuplicates ensures no skill is listed twice in mvpSkills.
 func TestMVPSkillsNoDuplicates(t *testing.T) {
 	seen := make(map[model.SkillID]bool)
-	for _, s := range MVPSkills() {
+	for _, s := range catalog.MVPSkills() {
 		if seen[s.ID] {
 			t.Errorf("duplicate skill %q in mvpSkills", s.ID)
 		}
@@ -48,7 +49,7 @@ func TestMVPSkillsIncludeRequestedBundledSkillsWithCanonicalNames(t *testing.T) 
 	}
 
 	found := make(map[model.SkillID]string)
-	for _, skill := range MVPSkills() {
+	for _, skill := range catalog.MVPSkills() {
 		found[skill.ID] = skill.Name
 		if skill.Name == "judgement-day" {
 			t.Fatalf("catalog uses non-canonical spelling %q; want judgment-day", skill.Name)

--- a/internal/components/skills/inject.go
+++ b/internal/components/skills/inject.go
@@ -51,9 +51,32 @@ func injectWithCatalog(homeDir string, adapter agents.Adapter, skillIDs []model.
 		skillsByID[skill.ID] = skill
 	}
 
+	needsManifest := false
 	for _, id := range skillIDs {
 		// SDD skills are written by the SDD component — skip to avoid conflicts
 		// unless a capability was specified (model-section extraction requested).
+		if IsSDDSkill(id) && capability == "" {
+			continue
+		}
+
+		skill, ok := skillsByID[id]
+		if ok && skill.RequiredCapabilities != (agents.AgentFeatureClaims{}) {
+			needsManifest = true
+			break
+		}
+	}
+
+	var provided agents.AgentFeatureClaims
+	if needsManifest {
+		manifest, manifestErr := agents.ResolveCapabilityManifest(adapter)
+		if manifestErr != nil {
+			return InjectionResult{}, fmt.Errorf("resolve capabilities for agent %q: %w", adapter.Agent(), manifestErr)
+		}
+		provided = manifest.Features
+	}
+
+	candidates := make([]catalog.Skill, 0, len(skillIDs))
+	for _, id := range skillIDs {
 		if IsSDDSkill(id) && capability == "" {
 			continue
 		}
@@ -64,17 +87,15 @@ func injectWithCatalog(homeDir string, adapter agents.Adapter, skillIDs []model.
 			skipped = append(skipped, id)
 			continue
 		}
-		if skill.RequiredCapabilities != (agents.AgentFeatureClaims{}) {
-			manifest, manifestErr := agents.ResolveCapabilityManifest(adapter)
-			if manifestErr != nil {
-				return InjectionResult{}, fmt.Errorf("resolve capabilities for agent %q: %w", adapter.Agent(), manifestErr)
-			}
-			if !isCompatible(skill.RequiredCapabilities, manifest.Features) {
-				skipped = append(skipped, id)
-				continue
-			}
+		if skill.RequiredCapabilities != (agents.AgentFeatureClaims{}) && !isCompatible(skill.RequiredCapabilities, provided) {
+			skipped = append(skipped, id)
+			continue
 		}
+		candidates = append(candidates, skill)
+	}
 
+	for _, skill := range candidates {
+		id := skill.ID
 		embedDir := "skills/" + string(id)
 		entries, readErr := fs.ReadDir(assets.FS, embedDir)
 		if readErr != nil {

--- a/internal/components/skills/inject.go
+++ b/internal/components/skills/inject.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
@@ -29,6 +30,10 @@ type InjectionResult struct {
 // InjectWithCapability writes skill files like Inject, but for SDD skills
 // it extracts only the section matching the given capability.
 func InjectWithCapability(homeDir string, adapter agents.Adapter, skillIDs []model.SkillID, capability string) (InjectionResult, error) {
+	return injectWithCatalog(homeDir, adapter, skillIDs, capability, catalog.MVPSkills())
+}
+
+func injectWithCatalog(homeDir string, adapter agents.Adapter, skillIDs []model.SkillID, capability string, availableSkills []catalog.Skill) (InjectionResult, error) {
 	if !adapter.SupportsSkills() {
 		return InjectionResult{Skipped: skillIDs}, nil
 	}
@@ -41,12 +46,33 @@ func InjectWithCapability(homeDir string, adapter agents.Adapter, skillIDs []mod
 	paths := make([]string, 0, len(skillIDs))
 	skipped := make([]model.SkillID, 0)
 	changed := false
+	skillsByID := make(map[model.SkillID]catalog.Skill, len(availableSkills))
+	for _, skill := range availableSkills {
+		skillsByID[skill.ID] = skill
+	}
 
 	for _, id := range skillIDs {
 		// SDD skills are written by the SDD component — skip to avoid conflicts
 		// unless a capability was specified (model-section extraction requested).
 		if IsSDDSkill(id) && capability == "" {
 			continue
+		}
+
+		skill, ok := skillsByID[id]
+		if !ok {
+			log.Printf("skills: skipping %q — skill is not in the catalog", id)
+			skipped = append(skipped, id)
+			continue
+		}
+		if skill.RequiredCapabilities != (agents.AgentFeatureClaims{}) {
+			manifest, manifestErr := agents.ResolveCapabilityManifest(adapter)
+			if manifestErr != nil {
+				return InjectionResult{}, fmt.Errorf("resolve capabilities for agent %q: %w", adapter.Agent(), manifestErr)
+			}
+			if !isCompatible(skill.RequiredCapabilities, manifest.Features) {
+				skipped = append(skipped, id)
+				continue
+			}
 		}
 
 		embedDir := "skills/" + string(id)
@@ -103,6 +129,18 @@ func InjectWithCapability(homeDir string, adapter agents.Adapter, skillIDs []mod
 	}
 
 	return InjectionResult{Changed: changed, Files: paths, Skipped: skipped}, nil
+}
+
+// isCompatible reports whether every required capability is provided.
+func isCompatible(required, provided agents.AgentFeatureClaims) bool {
+	return (!required.AutoInstall || provided.AutoInstall) &&
+		(!required.OutputStyles || provided.OutputStyles) &&
+		(!required.SlashCommands || provided.SlashCommands) &&
+		(!required.FileSubAgents || provided.FileSubAgents) &&
+		(!required.Skills || provided.Skills) &&
+		(!required.SystemPrompt || provided.SystemPrompt) &&
+		(!required.MCP || provided.MCP) &&
+		(!required.Workflows || provided.Workflows)
 }
 
 // Inject writes the embedded SKILL.md files for each requested skill

--- a/internal/components/skills/inject_test.go
+++ b/internal/components/skills/inject_test.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -251,6 +252,37 @@ func TestInjectFiltersSkillsByRequiredCapabilities(t *testing.T) {
 			}
 			assertNonEmptyFile(t, path)
 		})
+	}
+}
+
+type invalidManifestAdapter struct {
+	agents.Adapter
+}
+
+func (a invalidManifestAdapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifest {
+	return capabilitymanifest.AgentCapabilityManifest{}
+}
+
+func TestInjectPreflightsCapabilitiesBeforeWritingSkills(t *testing.T) {
+	home := t.TempDir()
+	adapter := invalidManifestAdapter{Adapter: claude.NewAdapter()}
+	available := []catalog.Skill{
+		{ID: model.SkillCreator, Name: "skill-creator"},
+		{
+			ID:                   model.SkillGoTesting,
+			Name:                 "go-testing",
+			RequiredCapabilities: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true},
+		},
+	}
+
+	_, err := injectWithCatalog(home, adapter, []model.SkillID{model.SkillCreator, model.SkillGoTesting}, "", available)
+	if !errors.Is(err, agents.ErrCapabilityManifestMismatch) {
+		t.Fatalf("injectWithCatalog() error = %v, want capability manifest mismatch", err)
+	}
+
+	earlierPath := SkillPathForAgent(home, adapter, model.SkillCreator)
+	if _, statErr := os.Stat(earlierPath); !os.IsNotExist(statErr) {
+		t.Fatalf("unannotated skill path stat error = %v, want not exist", statErr)
 	}
 }
 

--- a/internal/components/skills/inject_test.go
+++ b/internal/components/skills/inject_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/antigravity"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/vscode"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -192,6 +195,62 @@ func TestInjectSkipsUnknownSkillGracefully(t *testing.T) {
 
 	if result.Skipped[0] != "nonexistent-skill" {
 		t.Fatalf("Inject() skipped[0] = %q, want nonexistent-skill", result.Skipped[0])
+	}
+}
+
+func TestInjectFiltersSkillsByRequiredCapabilities(t *testing.T) {
+	tests := []struct {
+		name         string
+		adapter      agents.Adapter
+		requirements capabilitymanifest.AgentFeatureClaims
+		wantSkipped  bool
+	}{
+		{
+			name:         "annotated compatible runtime installs",
+			adapter:      claude.NewAdapter(),
+			requirements: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true},
+		},
+		{
+			name:         "annotated incompatible runtime skips",
+			adapter:      antigravity.NewAdapter(),
+			requirements: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true},
+			wantSkipped:  true,
+		},
+		{
+			name:    "unannotated skill fails open",
+			adapter: antigravity.NewAdapter(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			available := []catalog.Skill{{
+				ID:                   model.SkillCreator,
+				Name:                 "skill-creator",
+				RequiredCapabilities: tt.requirements,
+			}}
+			result, err := injectWithCatalog(home, tt.adapter, []model.SkillID{model.SkillCreator}, "", available)
+			if err != nil {
+				t.Fatalf("injectWithCatalog() error = %v", err)
+			}
+
+			path := SkillPathForAgent(home, tt.adapter, model.SkillCreator)
+			if tt.wantSkipped {
+				if len(result.Skipped) != 1 || result.Skipped[0] != model.SkillCreator {
+					t.Fatalf("injectWithCatalog() skipped = %v, want [%s]", result.Skipped, model.SkillCreator)
+				}
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("incompatible skill path stat error = %v, want not exist", statErr)
+				}
+				return
+			}
+
+			if len(result.Skipped) != 0 {
+				t.Fatalf("injectWithCatalog() skipped = %v, want none", result.Skipped)
+			}
+			assertNonEmptyFile(t, path)
+		})
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #128

---

## PR Type

- [ ] `type:bug` - Bug fix
- [x] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Adds optional typed capability requirements to catalog skills.
- Filters shared skill injection when every required capability is provided, while keeping unannotated skills fail-open.
- Records incompatible skills in `InjectionResult.Skipped` and covers compatible, incompatible, and unannotated runtimes.

---

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/catalog/skills.go` | Adds optional `RequiredCapabilities` metadata using existing typed manifest facts. |
| `internal/catalog/skills_test.go` | Preserves catalog coverage after the new injector dependency. |
| `internal/components/skills/inject.go` | Enforces capability compatibility through the shared injector. |
| `internal/components/skills/inject_test.go` | Proves compatible installation, incompatible skipping, and fail-open behavior. |

---

## Test Plan

**Passed locally**
```bash
go test ./internal/components/skills -run '^TestInjectFiltersSkillsByRequiredCapabilities$' -count=1
CGO_ENABLED=0 go vet ./...
CGO_ENABLED=0 go run ./internal/gofmtcheck
bash ./scripts/deadcode-ratchet.sh
```

The affected catalog and skills packages passed. A full `CGO_ENABLED=0 go test ./... -count=1` run exercised both changed packages successfully, but the repository-wide command remained red because of unrelated Windows and environment failures (symlink privileges, executable access denial, platform path assumptions, and timeouts). CI will provide the authoritative Linux and E2E results.

Benchmark validation: N/A. This change does not touch review lifecycle, gates, recovery, delivery, or benchmark code.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | 120 changed lines, below the 400-line limit |
| Check Issue Reference | Pending | `Closes #128` |
| Check Issue Has `status:approved` | Pending | Issue #128 is approved |
| Check PR Has `type:*` Label | Blocked | Maintainer action required: add `type:feature` |
| Unit Tests | Pending | Awaiting CI |
| Go Format | Pending | Passed locally; awaiting CI |
| E2E Tests | Pending | Awaiting CI |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] A maintainer needs to add the `type:feature` label (external contributors cannot apply repository labels)
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation is not necessary for this narrowly scoped internal slice
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

This deliberately does not introduce a binary delegation model or infer generic delegation or parallel execution from `FileSubAgents`. No production skill, including `judgment-day`, is annotated without an exact typed manifest guarantee.

PR #1359 also touches the shared injector for compatibility refresh behavior. This PR keeps its capability check narrowly before asset enumeration and does not modify #1359's refresh, backup, rollback, or compatibility-directory scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills are now installed only when the agent supports their required capabilities.
  * Skills without capability requirements continue to install normally.
  * Unsupported or unavailable skills are skipped automatically.
* **Bug Fixes**
  * Capability validation now occurs before installation, preventing partial skill deployments when requirements cannot be resolved.
  * Invalid skill requests no longer interrupt installation of other valid skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->