### PR TITLE
fix(cli): answer --help with derived usage instead of an opaque sentinel

### DIFF
--- a/internal/cli/help_request.go
+++ b/internal/cli/help_request.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// helpRequestError carries the usage block the flag package derived from a
+// command's own registered flags. It exists because several parse functions
+// (ParseInstallFlags, ParseUninstallFlags) own no writer, so they cannot print
+// usage themselves; they return this instead and the caller that does own a
+// writer answers it through writeHelpRequest.
+type helpRequestError struct {
+	usage string
+}
+
+func (e *helpRequestError) Error() string {
+	return e.usage
+}
+
+// parseCommandFlags parses args while preserving the usage the flag package
+// generates from fs's registered flags, so no command has to restate its own
+// flag documentation and none can drift from it.
+//
+// It draws one distinction the standard library leaves to the caller:
+// flag.ErrHelp is a sentinel meaning "the operator asked for help", not a
+// failure. Returning it verbatim renders an explicit request as an opaque
+// error with a nonzero exit and no flag names, which is the defect this
+// replaces. A genuine parse error stays an error and is wrapped together with
+// the same derived usage, so the refusal names a continuation.
+func parseCommandFlags(fs *flag.FlagSet, args []string) error {
+	var usage bytes.Buffer
+	fs.SetOutput(&usage)
+	err := fs.Parse(args)
+	if err == nil {
+		return nil
+	}
+	text := derivedUsageText(&usage)
+	if errors.Is(err, flag.ErrHelp) {
+		return &helpRequestError{usage: text}
+	}
+	if text == "" {
+		return err
+	}
+	return fmt.Errorf("%w — run `gentle-ai %s --help` for the supported flags:\n%s", err, fs.Name(), text)
+}
+
+// writeHelpRequest answers a help request by printing the derived usage and
+// reporting success. Any other error passes through untouched, so callers can
+// wrap this around an existing parse result without changing failure handling.
+func writeHelpRequest(err error, stdout io.Writer) error {
+	var request *helpRequestError
+	if errors.As(err, &request) {
+		_, _ = fmt.Fprintln(stdout, request.usage)
+		return nil
+	}
+	return err
+}
+
+// derivedUsageText trims the flag package's duplicated error line so the usage
+// block is not preceded by the same message its caller is about to report.
+func derivedUsageText(usage *bytes.Buffer) string {
+	text := usage.String()
+	if index := strings.Index(text, "Usage of "); index >= 0 {
+		text = text[index:]
+	}
+	return strings.TrimRight(text, "\n")
+}

--- a/internal/cli/help_request_test.go
+++ b/internal/cli/help_request_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// An explicit --help is a request, not a failure. Every command must answer it
+// with the usage the flag package derives from its own registered flags, and
+// must report success so a shell that checks the exit code is not told the
+// request failed.
+func TestHelpRequestPrintsDerivedUsageAndSucceeds(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		run     func(args []string, stdout *bytes.Buffer) error
+		expects []string
+	}{
+		{
+			name: "uninstall",
+			run: func(args []string, stdout *bytes.Buffer) error {
+				_, err := RunUninstall(args, stdout)
+				return err
+			},
+			expects: []string{"agent", "component", "all", "yes"},
+		},
+		{
+			name: "restore",
+			run: func(args []string, stdout *bytes.Buffer) error {
+				return RunRestore(args, stdout)
+			},
+			expects: []string{"list", "yes"},
+		},
+	} {
+		for _, flagName := range []string{"--help", "-h"} {
+			t.Run(test.name+" "+flagName, func(t *testing.T) {
+				var stdout bytes.Buffer
+				if err := test.run([]string{flagName}, &stdout); err != nil {
+					t.Fatalf("%s %s returned %v, want success", test.name, flagName, err)
+				}
+				output := stdout.String()
+				if strings.TrimSpace(output) == "" {
+					t.Fatalf("%s %s printed nothing", test.name, flagName)
+				}
+				for _, want := range test.expects {
+					if !strings.Contains(output, want) {
+						t.Fatalf("%s %s usage omits %q:\n%s", test.name, flagName, want, output)
+					}
+				}
+			})
+		}
+	}
+}
+
+// restore accepts a positional backup name before its flags, and flag.Parse
+// stops at the first non-flag token. A help request that follows the positional
+// must still be answered, and an unknown flag in that position must still fail
+// instead of being silently swallowed into a no-op success.
+func TestRestoreAnswersHelpAndRejectsUnknownFlagAfterPositional(t *testing.T) {
+	for _, flagName := range []string{"--help", "-h"} {
+		t.Run("help "+flagName, func(t *testing.T) {
+			var stdout bytes.Buffer
+			if err := RunRestore([]string{"backup-001", flagName}, &stdout); err != nil {
+				t.Fatalf("restore backup-001 %s returned %v, want success", flagName, err)
+			}
+			if !strings.Contains(stdout.String(), "list") || !strings.Contains(stdout.String(), "yes") {
+				t.Fatalf("restore backup-001 %s printed no usage: %q", flagName, stdout.String())
+			}
+		})
+	}
+
+	var stdout bytes.Buffer
+	err := RunRestore([]string{"backup-001", "--unknown"}, &stdout)
+	if err == nil {
+		t.Fatalf("restore backup-001 --unknown succeeded silently, output %q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("restore unknown-flag refusal does not name the flag: %v", err)
+	}
+}
+
+// A genuine parse failure must stay a failure, and it must carry the same
+// derived usage so the refusal names a continuation instead of only rejecting.
+// This is parseCommandFlags' other half: flag.ErrHelp becomes a success with
+// usage, everything else stays an error that now carries the same usage.
+func TestUnknownFlagStillFailsAndCarriesDerivedUsage(t *testing.T) {
+	var stdout bytes.Buffer
+	_, err := RunUninstall([]string{"--nonexistent-flag"}, &stdout)
+	if err == nil {
+		t.Fatal("unknown flag was accepted")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "agent") || !strings.Contains(message, "--help") {
+		t.Fatalf("unknown-flag refusal names no usage or continuation: %v", err)
+	}
+}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -69,10 +69,18 @@ func runRestoreWithHomeDir(args []string, restorer RestoreFunc, stdout io.Writer
 			if strings.HasPrefix(a, "-") {
 				// Unknown flag — surface error via flag.FlagSet for consistent messages.
 				fs := flag.NewFlagSet("restore", flag.ContinueOnError)
-				fs.SetOutput(ioDiscard{})
-				_ = fs.Bool("list", false, "")
-				_ = fs.Bool("yes", false, "")
-				if err := fs.Parse(args); err != nil {
+				// Descriptions are what the derived usage shows the operator,
+				// so they are the documentation rather than a placeholder.
+				_ = fs.Bool("list", false, "list available backups without restoring")
+				_ = fs.Bool("yes", false, "skip confirmation prompt")
+				// Parse only the flag actually detected. flag.Parse stops at
+				// the first non-flag token, so handing it the full args slice
+				// makes `restore <backup> --anything` return nil: the unknown
+				// flag is swallowed and the help request never seen.
+				if err := parseCommandFlags(fs, []string{a}); err != nil {
+					if writeHelpRequest(err, stdout) == nil {
+						return nil
+					}
 					return fmt.Errorf("parse restore flags: %w", err)
 				}
 				return nil

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -26,7 +26,6 @@ func ParseUninstallFlags(args []string) (UninstallFlags, error) {
 	var opts UninstallFlags
 
 	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
-	fs.SetOutput(ioDiscard{})
 	registerListFlag(fs, "agent", &opts.Agents)
 	registerListFlag(fs, "agents", &opts.Agents)
 	registerListFlag(fs, "component", &opts.Components)
@@ -35,7 +34,7 @@ func ParseUninstallFlags(args []string) (UninstallFlags, error) {
 	fs.BoolVar(&opts.Yes, "yes", false, "skip confirmation prompt")
 	fs.BoolVar(&opts.Yes, "y", false, "skip confirmation prompt")
 
-	if err := fs.Parse(args); err != nil {
+	if err := parseCommandFlags(fs, args); err != nil {
 		return UninstallFlags{}, err
 	}
 	if fs.NArg() > 0 {
@@ -112,7 +111,9 @@ func RenderUninstallReport(result componentuninstall.Result) string {
 func runUninstallWithInput(args []string, stdout io.Writer, stdin io.Reader) (componentuninstall.Result, error) {
 	flags, err := ParseUninstallFlags(args)
 	if err != nil {
-		return componentuninstall.Result{}, err
+		// An explicit help request is answered here, where a writer exists;
+		// ParseUninstallFlags owns none of its own.
+		return componentuninstall.Result{}, writeHelpRequest(err, stdout)
 	}
 
 	homeDir, err := osUserHomeDir()


### PR DESCRIPTION
Closes #2153

## Scope reduced — rebased onto current `main`

This branch originally covered four surfaces. Upstream has since implemented derived `--help` for two of them, **with a better design than this PR had**: `sddAttemptOperationDefinitions` carries per-operation flag contracts, where this branch only carried operation names.

Those parts are dropped. `internal/cli/sdd_attempt.go` and `internal/cli/sdd_verify_validate.go` are no longer touched, so the branch merges cleanly again.

| Surface | Status |
| --- | --- |
| `sdd-attempt` | dropped — upstream's derived help supersedes it |
| `sdd-verify-validate` | dropped — upstream's derived help supersedes it |
| `restore` | **still needed** |
| `uninstall` | **still needed** |

413 → 184 lines.

## The remaining defect

On current `main`:

```
$ gentle-ai restore --help
Error: parse restore flags: flag: help requested
```

An explicit `--help` is a request, not a failure. `restore` and `uninstall` returned `flag.ErrHelp` verbatim, which surfaces as an opaque error with a nonzero exit and no flag names.

`restore` had a second, quieter defect. `flag.Parse` stops at the first non-flag token, so with a positional backup name in front, the flag was never parsed at all:

```
$ gentle-ai restore backup-001 --anything-at-all
$ echo $?
0
```

The unknown flag was swallowed into a no-op success — a typo read as accepted.

## The fix

`parseCommandFlags` preserves the usage the `flag` package derives from each command's own registered flags, so no command restates its flag documentation and none can drift from it. It draws the distinction the standard library leaves to the caller: `flag.ErrHelp` is a request and becomes a success with usage; a genuine parse error stays an error and now carries the same usage, so the refusal names a continuation.

`writeHelpRequest` answers the request where a writer exists, because `ParseUninstallFlags` owns none.

`restore` additionally parses only the flag token it actually detected, rather than handing `flag.Parse` a slice it will abandon at the positional.

## Tests

- `TestHelpRequestPrintsDerivedUsageAndSucceeds` — `--help` and `-h` on `uninstall` and `restore` succeed and print usage naming their real flags
- `TestRestoreAnswersHelpAndRejectsUnknownFlagAfterPositional` — help after a positional is answered; an unknown flag in that same position still fails and names the flag
- `TestUnknownFlagStillFailsAndCarriesDerivedUsage` — `parseCommandFlags`' other half: a genuine parse failure stays a failure and carries the derived usage

The last test previously asserted this against `sdd-verify-validate`. Rather than drop the assertion along with that surface, it was rewritten against `uninstall`, which this PR still owns.

`requestsHelp` was removed: only `sdd-attempt`'s pre-dispatch path used it.

## Verification

- `gofmt -l ./internal/` — clean
- `go build ./...` — clean
- `go vet ./internal/cli/` — clean
- `go test ./internal/cli/` — **ok** (full package, 146s)
- No conflicts against `main` @ d299eb8a

## Rollback

Revert the single commit. Three files touched plus one new file and its test; no persisted state, schema, or lifecycle surface involved.

