### PR TITLE
feat(releaseartifact): add the release-artifact contract, canonical encoder and manifest

### DIFF
--- a/contracts/release-artifact/v1/fixtures/artifact-manifest-unsupported-major.fixture.json
+++ b/contracts/release-artifact/v1/fixtures/artifact-manifest-unsupported-major.fixture.json
@@ -1,0 +1,63 @@
+{
+  "schema": "gentle-ai.release-artifact-manifest/v2",
+  "contract": {
+    "id": "gentle-ai.release-artifact",
+    "major": 2,
+    "minor": 0,
+    "schema_id": "https://gentle-ai.dev/contracts/release-artifact/v2/schemas/artifact-manifest.schema.json",
+    "schema_path": "contracts/release-artifact/v2/schemas/artifact-manifest.schema.json"
+  },
+  "release": {
+    "repository": "Gentleman-Programming/gentle-ai",
+    "tag": "v2.3.0",
+    "version": "2.3.0",
+    "commit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "layout": { "version": 1 },
+  "archive": {
+    "asset": "gentle-ai_2.3.0_assets.tar.gz",
+    "digest_source": "signed-checksums.txt"
+  },
+  "references": {
+    "semantic_snapshots": [
+      {
+        "contract": "gentle-ai.review-integration/v2",
+        "path": "capabilities/review-integration-v2.semantic.json",
+        "schema": "gentle-ai.release-semantic-capabilities/v1"
+      }
+    ],
+    "contracts": [
+      { "id": "gentle-ai.review-integration/v1", "root": "contracts/review-integration/v1" },
+      { "id": "gentle-ai.review-integration/v2", "root": "contracts/review-integration/v2" }
+    ]
+  },
+  "tree": {
+    "algorithm": "sha256",
+    "canonicalization": "gentle-ai.release-artifact-tree/v1",
+    "manifest_included": false,
+    "digest": "sha256:2f4f2adad5eca6ce59b38a44ea88682827b430e70d843ed830c2f095d69fa645"
+  },
+  "compatibility": {
+    "minimum_contract_major": 1,
+    "maximum_contract_major": 1,
+    "additive_minor_policy": "optional-fields-only",
+    "unknown_mandatory": "reject",
+    "unknown_optional": "ignore"
+  },
+  "entries": [
+    {
+      "path": "capabilities/review-integration-v2.semantic.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 128,
+      "digest": "sha256:b78faae1fd74197a64a757d9535bb27dfdddff2b54089d300b6c2a5079b40c05"
+    },
+    {
+      "path": "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 256,
+      "digest": "sha256:160414be7f99faec1b12c8c0def67b454172bc31bd3a0f6afb6e7f885faefa95"
+    }
+  ]
+}

--- a/contracts/release-artifact/v1/fixtures/artifact-manifest.fixture.json
+++ b/contracts/release-artifact/v1/fixtures/artifact-manifest.fixture.json
@@ -1,0 +1,63 @@
+{
+  "schema": "gentle-ai.release-artifact-manifest/v1",
+  "contract": {
+    "id": "gentle-ai.release-artifact",
+    "major": 1,
+    "minor": 0,
+    "schema_id": "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+    "schema_path": "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json"
+  },
+  "release": {
+    "repository": "Gentleman-Programming/gentle-ai",
+    "tag": "v2.3.0",
+    "version": "2.3.0",
+    "commit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "layout": { "version": 1 },
+  "archive": {
+    "asset": "gentle-ai_2.3.0_assets.tar.gz",
+    "digest_source": "signed-checksums.txt"
+  },
+  "references": {
+    "semantic_snapshots": [
+      {
+        "contract": "gentle-ai.review-integration/v2",
+        "path": "capabilities/review-integration-v2.semantic.json",
+        "schema": "gentle-ai.release-semantic-capabilities/v1"
+      }
+    ],
+    "contracts": [
+      { "id": "gentle-ai.review-integration/v1", "root": "contracts/review-integration/v1" },
+      { "id": "gentle-ai.review-integration/v2", "root": "contracts/review-integration/v2" }
+    ]
+  },
+  "tree": {
+    "algorithm": "sha256",
+    "canonicalization": "gentle-ai.release-artifact-tree/v1",
+    "manifest_included": false,
+    "digest": "sha256:2f4f2adad5eca6ce59b38a44ea88682827b430e70d843ed830c2f095d69fa645"
+  },
+  "compatibility": {
+    "minimum_contract_major": 1,
+    "maximum_contract_major": 1,
+    "additive_minor_policy": "optional-fields-only",
+    "unknown_mandatory": "reject",
+    "unknown_optional": "ignore"
+  },
+  "entries": [
+    {
+      "path": "capabilities/review-integration-v2.semantic.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 128,
+      "digest": "sha256:b78faae1fd74197a64a757d9535bb27dfdddff2b54089d300b6c2a5079b40c05"
+    },
+    {
+      "path": "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 256,
+      "digest": "sha256:160414be7f99faec1b12c8c0def67b454172bc31bd3a0f6afb6e7f885faefa95"
+    }
+  ]
+}

--- a/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json
+++ b/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+  "title": "Gentle AI release artifact manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "contract", "release", "layout", "archive", "references", "tree", "compatibility", "entries"
+  ],
+  "properties": {
+    "schema": {"const": "gentle-ai.release-artifact-manifest/v1"},
+    "contract": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "major", "minor", "schema_id", "schema_path"],
+      "properties": {
+        "id": {"const": "gentle-ai.release-artifact"},
+        "major": {"type": "integer", "minimum": 1},
+        "minor": {"type": "integer", "minimum": 0},
+        "schema_id": {"type": "string", "minLength": 1},
+        "schema_path": {"type": "string", "minLength": 1}
+      }
+    },
+    "release": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repository", "tag", "version", "commit"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+      }
+    },
+    "layout": {
+      "type": "object", "additionalProperties": false,
+      "required": ["version"],
+      "properties": {"version": {"type": "integer", "minimum": 1}}
+    },
+    "archive": {
+      "type": "object", "additionalProperties": false,
+      "required": ["asset", "digest_source"],
+      "properties": {
+        "asset": {"type": "string", "minLength": 1},
+        "digest_source": {"const": "signed-checksums.txt"}
+      }
+    },
+    "references": {
+      "type": "object", "additionalProperties": false,
+      "required": ["semantic_snapshots", "contracts"],
+      "properties": {
+        "semantic_snapshots": {
+          "type": "array", "minItems": 1,
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["contract", "path", "schema"],
+            "properties": {
+              "contract": {"type": "string", "minLength": 1},
+              "path": {"type": "string", "minLength": 1},
+              "schema": {"const": "gentle-ai.release-semantic-capabilities/v1"}
+            }
+          }
+        },
+        "contracts": {
+          "type": "array", "minItems": 1,
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["id", "root"],
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "root": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    },
+    "tree": {
+      "type": "object", "additionalProperties": false,
+      "required": ["algorithm", "canonicalization", "manifest_included", "digest"],
+      "properties": {
+        "algorithm": {"const": "sha256"},
+        "canonicalization": {"const": "gentle-ai.release-artifact-tree/v1"},
+        "manifest_included": {"const": false},
+        "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "compatibility": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "minimum_contract_major", "maximum_contract_major", "additive_minor_policy", "unknown_mandatory",
+        "unknown_optional"
+      ],
+      "properties": {
+        "minimum_contract_major": {"type": "integer", "minimum": 1},
+        "maximum_contract_major": {"type": "integer", "minimum": 1},
+        "additive_minor_policy": {"const": "optional-fields-only"},
+        "unknown_mandatory": {"const": "reject"},
+        "unknown_optional": {"const": "ignore"}
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["path", "type", "mode", "size", "digest"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1, "maxLength": 1024},
+          "type": {"const": "file"},
+          "mode": {"const": "0644"},
+          "size": {"type": "integer", "minimum": 0},
+          "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+        }
+      }
+    }
+  }
+}

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -1,0 +1,89 @@
+# Release Artifact Contract
+
+← [Back to README](../README.md)
+
+Gentle AI publishes a platform-independent assets archive with every release, described by a versioned, self-describing manifest. This is the synchronization artifact a consumer decodes to trust bundled contracts, schemas, and snapshots instead of hand-transcribing provider internals. The contract lives in its own namespace, independent of the runtime-negotiated `review-integration` contract, so a bootstrap-time archive trust decision and a live CLI negotiation can version on separate timelines.
+
+> This document currently covers only the manifest contract itself: its namespace, schema, fixtures, and canonicalization rules. The archive is not yet assembled or published — the staging generator, GoReleaser wiring, and downstream notification are tracked separately and will extend this document as they land.
+
+## Contract identity
+
+| Item | Value |
+| --- | --- |
+| Namespace | `contracts/release-artifact/v1/` |
+| Schema file | `schemas/artifact-manifest.schema.json` |
+| Schema `$id` | `https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json` |
+| Contract ID | `gentle-ai.release-artifact` (major `1`, minor `0`) |
+| Manifest schema identity | `gentle-ai.release-artifact-manifest/v1` |
+| Fixtures | `fixtures/artifact-manifest.fixture.json`, `fixtures/artifact-manifest-unsupported-major.fixture.json` |
+| Manifest member | `artifact-manifest.json`, at the archive root |
+| Semantic snapshot schema identity | `gentle-ai.release-semantic-capabilities/v1` |
+| Tree canonicalization identity | `gentle-ai.release-artifact-tree/v1` |
+| Go package | `internal/releaseartifact` (stdlib-only, no internal imports) |
+| Assets archive name | `gentle-ai_{version}_assets.tar.gz`, GoReleaser `id: assets` |
+
+A consumer that supports only contract major `1` MUST reject a manifest declaring any other major with an actionable error naming that major, before attempting any layout inference. The `unsupported-major` fixture is byte-identical to the valid fixture except for the fields that carry the major identity, so it proves rejection happens on the major alone.
+
+## Mandatory manifest field groups
+
+Every manifest carries, at minimum:
+
+| Field group | Carries |
+| --- | --- |
+| `contract` | Contract id, major, minor, schema id, and schema path — a complete decode without any external fetch. |
+| `release` | Repository, tag, semantic version, and immutable commit. |
+| `layout` | A layout version, independent of the release version. |
+| `archive` | The published asset name and its digest source (`signed-checksums.txt`; the manifest never carries an archive self-digest). |
+| `references` | `semantic_snapshots` (an array, so a future addition never forces a breaking singular-to-plural reshape) and `contracts`, naming every applicable provider contract bundled in the archive. |
+| `tree` | The non-recursive digest binding described below. |
+| `compatibility` | `unknown_mandatory: reject`, carried into the archive so a consumer never silently widens its supported set. |
+| `entries` | The ordered, canonical content list. |
+
+A manifest missing the release identity or layout identity group MUST fail closed with an actionable error naming the missing group. Every path a manifest references — `contract.schema_path`, each `references.semantic_snapshots[].path` — MUST resolve into `entries`; an unresolved reference is a validation failure.
+
+## Canonical entry records
+
+Each entry in `entries` carries a confined relative path, a type restricted to regular files, a normalized non-executable mode, and a `sha256:` content digest over exact file bytes:
+
+| Rule | Detail |
+| --- | --- |
+| Path | Relative, forward slashes only. Rejected: absolute paths, backslashes, `..`/`.`/empty segments, NUL or control bytes, paths over 1024 bytes, segments over 255 bytes. |
+| Uniqueness / order | Unique after validation; ascending **raw UTF-8 byte** order. No case folding, no Unicode normalization. |
+| Type | `"file"` only. Directories are implicit; the writer emits no directory members. Symlinks, hardlinks, devices, FIFOs, sockets, and any unknown type are rejected. |
+| Mode | Exactly `"0644"`. Any executable, setuid, setgid, or sticky bit is rejected at write and at read. |
+| Digest | `"sha256:"` followed by exactly 64 lowercase hex characters, over exact file bytes. |
+
+A path traversal attempt or a disallowed entry type MUST be rejected before extraction proceeds further. A digest mismatch between an entry's declared value and the extracted file's actual sha256 MUST be rejected with an actionable mismatch error.
+
+## The non-self-referential tree digest
+
+The manifest's `tree.digest` is computed only over the sorted canonical entries and deliberately **excludes the manifest file itself** — `tree.manifest_included` is always the constant `false`, and a decoder MUST reject `true` as an unknown layout.
+
+The preimage is the literal tag `"gentle-ai.release-artifact-tree/v1"`, a NUL byte, then per entry in ascending path order: `path "\x00" type "\x00" mode "\x00" size "\x00" digest "\n"`, using the exact manifest field strings so a consumer hashes what it actually read. `size` is decimal, unpadded. The digest is independent of the input slice's order — entries are always sorted before hashing.
+
+The **complete-archive** digest never comes from a field inside the manifest. It comes only from the externally signed `checksums.txt`/minisign envelope, which the manifest recursion would otherwise undermine.
+
+## Canonical JSON encoding (`EncodeCanonical`)
+
+Every canonical document in this contract — the manifest and the semantic snapshot it references — is encoded with the same rules:
+
+- UTF-8, no BOM, LF-only line endings, exactly one trailing newline.
+- Two-space indent, no HTML escaping.
+- Key order follows Go struct declaration order — never map-key sorting.
+- Empty collections encode as `[]`, never `null`.
+- Unknown fields are rejected everywhere: the schema declares `additionalProperties: false` at every level, and the Go decoder uses `DisallowUnknownFields`.
+- The minor-version policy is additive-fields-only; a new required field or a changed meaning is a major bump.
+
+## Checklist for a consumer
+
+- [ ] Reject an unsupported contract major before inferring any layout.
+- [ ] Validate the manifest against the bundled schema with unknown fields rejected.
+- [ ] Confirm every mandatory field group is present and every reference resolves into `entries`.
+- [ ] Recompute the tree digest from the archive's non-manifest entries and compare it to `tree.digest`.
+- [ ] Establish archive authenticity only from the signed `checksums.txt` envelope, never from a manifest-internal field.
+
+## Rolling changelog
+
+### Contract v1.0 (unreleased)
+
+Initial publish of the `gentle-ai.release-artifact` namespace: contract identity, the canonical JSON encoder, entry path/type/mode admission, the non-self-referential tree digest, and the manifest shape with its schema and fixtures. Nothing yet assembles or publishes the archive itself.

--- a/internal/releaseartifact/canonical.go
+++ b/internal/releaseartifact/canonical.go
@@ -1,0 +1,34 @@
+// Package releaseartifact implements the gentle-ai.release-artifact contract
+// (see design D1-D3): the versioned, self-describing manifest bundled with
+// the platform-independent assets archive published on every release. This
+// package is stdlib-only and imports no other internal package, so it stays
+// safe to import from both internal/cli and the release tooling that must
+// remain dependency-free.
+package releaseartifact
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// EncodeCanonical encodes v per the gentle-ai.release-artifact-tree/v1
+// canonicalization rules (design D3): two-space indent, no HTML escaping,
+// UTF-8 with no BOM, LF-only line endings, and exactly one trailing
+// newline. Key order follows the Go struct declaration order of v — the
+// only fields this contract encodes are struct fields, never map keys, so
+// no additional ordering step is required.
+//
+// Callers that must render an empty collection as JSON's `[]` rather than
+// `null` MUST initialize that field with a non-nil, zero-length slice (for
+// example `make([]Entry, 0)` or `[]Entry{}`); encoding/json marshals a nil
+// slice as `null`, and this function performs no such rewrite.
+func EncodeCanonical(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/releaseartifact/canonical_test.go
+++ b/internal/releaseartifact/canonical_test.go
@@ -1,0 +1,80 @@
+package releaseartifact
+
+import (
+	"bytes"
+	"testing"
+)
+
+// canonicalFixture deliberately declares its fields out of alphabetical
+// order relative to their JSON tags so the byte assertion below proves key
+// order follows Go struct declaration order, not JSON tag name or map-key
+// sorting.
+type canonicalFixture struct {
+	Zeta  string   `json:"zeta"`
+	Alpha int      `json:"alpha"`
+	Empty []string `json:"empty"`
+	HTML  string   `json:"html"`
+}
+
+func TestEncodeCanonicalMatchesD3Rules(t *testing.T) {
+	fixture := canonicalFixture{
+		Zeta:  "z-value",
+		Alpha: 1,
+		Empty: []string{},
+		HTML:  `<tag>&"'</tag>`,
+	}
+
+	got, err := EncodeCanonical(fixture)
+	if err != nil {
+		t.Fatalf("EncodeCanonical() error = %v", err)
+	}
+
+	want := "{\n" +
+		"  \"zeta\": \"z-value\",\n" +
+		"  \"alpha\": 1,\n" +
+		"  \"empty\": [],\n" +
+		"  \"html\": \"<tag>&\\\"'</tag>\"\n" +
+		"}\n"
+	if string(got) != want {
+		t.Fatalf("EncodeCanonical() =\n%q\nwant\n%q", string(got), want)
+	}
+}
+
+func TestEncodeCanonicalHasNoBOMOrCarriageReturn(t *testing.T) {
+	fixture := canonicalFixture{Zeta: "v", Alpha: 1, Empty: []string{}, HTML: "plain"}
+
+	got, err := EncodeCanonical(fixture)
+	if err != nil {
+		t.Fatalf("EncodeCanonical() error = %v", err)
+	}
+
+	if bytes.HasPrefix(got, []byte{0xEF, 0xBB, 0xBF}) {
+		t.Fatal("EncodeCanonical() emitted a UTF-8 BOM")
+	}
+	if bytes.Contains(got, []byte("\r")) {
+		t.Fatal("EncodeCanonical() emitted a carriage return")
+	}
+}
+
+func TestEncodeCanonicalEndsWithExactlyOneTrailingLF(t *testing.T) {
+	fixture := canonicalFixture{Zeta: "v", Alpha: 1, Empty: []string{}, HTML: "plain"}
+
+	got, err := EncodeCanonical(fixture)
+	if err != nil {
+		t.Fatalf("EncodeCanonical() error = %v", err)
+	}
+
+	if len(got) == 0 || got[len(got)-1] != '\n' {
+		t.Fatalf("EncodeCanonical() must end with a trailing LF, got tail %q", tail(got))
+	}
+	if len(got) >= 2 && got[len(got)-2] == '\n' {
+		t.Fatalf("EncodeCanonical() must end with exactly one trailing LF, got tail %q", tail(got))
+	}
+}
+
+func tail(b []byte) []byte {
+	if len(b) <= 4 {
+		return b
+	}
+	return b[len(b)-4:]
+}

--- a/internal/releaseartifact/entry.go
+++ b/internal/releaseartifact/entry.go
@@ -1,0 +1,129 @@
+package releaseartifact
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	// EntryTypeFile is the only admitted release artifact entry type;
+	// directories are implicit and the writer never emits a directory
+	// member (design D3).
+	EntryTypeFile = "file"
+
+	// EntryMode is the only admitted release artifact entry mode. Any
+	// executable, setuid, setgid, or sticky bit is rejected at write and
+	// at read (design D3).
+	EntryMode = "0644"
+
+	// AssetsArchiveID is the GoReleaser `id:` bound to the release
+	// artifact assets archive (design D1). Duplicated as a bare string
+	// literal in internal/releasepolicy/policy.go, which must stay
+	// stdlib-only; A2 adds a cross-package equality guard.
+	AssetsArchiveID = "assets"
+
+	maxEntryPathBytes   = 1024
+	maxEntryPathSegment = 255
+)
+
+var entryDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// Entry is one canonical release artifact content record (design D3,
+// Interfaces/Contracts).
+type Entry struct {
+	Path   string `json:"path"`
+	Type   string `json:"type"`
+	Mode   string `json:"mode"`
+	Size   int64  `json:"size"`
+	Digest string `json:"digest"`
+}
+
+// ValidateEntryPath enforces the design D3 path rules: relative, forward
+// slashes only, no traversal, no control bytes, and bounded path/segment
+// length.
+func ValidateEntryPath(p string) error {
+	if p == "" {
+		return errors.New("release artifact entry path must not be empty")
+	}
+	if len(p) > maxEntryPathBytes {
+		return fmt.Errorf("release artifact entry path exceeds %d bytes: %q", maxEntryPathBytes, p)
+	}
+	if strings.HasPrefix(p, "/") {
+		return fmt.Errorf("release artifact entry path must be relative: %q", p)
+	}
+	if strings.Contains(p, `\`) {
+		return fmt.Errorf("release artifact entry path must use forward slashes only: %q", p)
+	}
+	for _, r := range p {
+		if r == 0 || r < 0x20 || r == 0x7f {
+			return fmt.Errorf("release artifact entry path contains a control byte: %q", p)
+		}
+	}
+	if path.Clean(p) != p {
+		return fmt.Errorf("release artifact entry path is not clean (traversal, redundant, or trailing separator): %q", p)
+	}
+	for _, segment := range strings.Split(p, "/") {
+		switch {
+		case segment == "":
+			return fmt.Errorf("release artifact entry path has an empty segment: %q", p)
+		case segment == ".", segment == "..":
+			return fmt.Errorf("release artifact entry path contains a traversal segment: %q", p)
+		case len(segment) > maxEntryPathSegment:
+			return fmt.Errorf("release artifact entry path segment exceeds %d bytes: %q", maxEntryPathSegment, p)
+		}
+	}
+	return nil
+}
+
+// validateEntry enforces path, type, mode, and digest-format admission for
+// one entry (design D3). It does not verify the digest against file bytes;
+// that is the extraction-time responsibility of a consumer.
+func validateEntry(e Entry) error {
+	if err := ValidateEntryPath(e.Path); err != nil {
+		return err
+	}
+	if e.Type != EntryTypeFile {
+		return fmt.Errorf("release artifact entry %q has disallowed type %q; only %q is admitted", e.Path, e.Type, EntryTypeFile)
+	}
+	if e.Mode != EntryMode {
+		return fmt.Errorf("release artifact entry %q has disallowed mode %q; only %q is admitted", e.Path, e.Mode, EntryMode)
+	}
+	if e.Size < 0 {
+		return fmt.Errorf("release artifact entry %q has a negative size %d", e.Path, e.Size)
+	}
+	if !entryDigestPattern.MatchString(e.Digest) {
+		return fmt.Errorf("release artifact entry %q has a malformed digest %q; want sha256:<64 lowercase hex>", e.Path, e.Digest)
+	}
+	return nil
+}
+
+// ValidateEntries validates every entry and rejects a duplicate path.
+// Ascending sort order is enforced separately by callers that need it via
+// SortEntries; ValidateEntries does not require entries to already be
+// sorted.
+func ValidateEntries(entries []Entry) error {
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if err := validateEntry(e); err != nil {
+			return err
+		}
+		if seen[e.Path] {
+			return fmt.Errorf("release artifact entries contain a duplicate path: %q", e.Path)
+		}
+		seen[e.Path] = true
+	}
+	return nil
+}
+
+// SortEntries orders entries ascending by raw UTF-8 byte order of Path,
+// using Go's native string comparison — no case folding, no Unicode
+// normalization (design D3).
+func SortEntries(entries []Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+}

--- a/internal/releaseartifact/entry_test.go
+++ b/internal/releaseartifact/entry_test.go
@@ -1,0 +1,139 @@
+package releaseartifact
+
+import (
+	"strings"
+	"testing"
+)
+
+func validDigest() string {
+	return "sha256:" + strings.Repeat("a", 64)
+}
+
+func TestValidateEntryPathRejectsInvalidPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "absolute path", path: "/etc/passwd"},
+		{name: "parent traversal segment", path: "../etc/passwd"},
+		{name: "embedded parent traversal segment", path: "contracts/../secrets"},
+		{name: "current directory segment", path: "contracts/./v1"},
+		{name: "backslash separator", path: `contracts\v1\schema.json`},
+		{name: "NUL byte", path: "contracts/v1\x00schema.json"},
+		{name: "control byte", path: "contracts/v1\x01schema.json"},
+		{name: "DEL byte", path: "contracts/v1\x7fschema.json"},
+		{name: "empty segment", path: "contracts//v1"},
+		{name: "empty path", path: ""},
+		{name: "path exceeding 1024 bytes", path: "contracts/" + strings.Repeat("a", 1024)},
+		{name: "segment exceeding 255 bytes", path: strings.Repeat("a", 256) + "/schema.json"},
+		{name: "trailing slash is not clean", path: "contracts/v1/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateEntryPath(tt.path); err == nil {
+				t.Fatalf("ValidateEntryPath(%q) = nil, want error", tt.path)
+			}
+		})
+	}
+}
+
+func TestValidateEntryPathAcceptsWellFormedRelativePaths(t *testing.T) {
+	tests := []string{
+		"artifact-manifest.json",
+		"contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+		"a",
+	}
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			if err := ValidateEntryPath(path); err != nil {
+				t.Fatalf("ValidateEntryPath(%q) = %v, want nil", path, err)
+			}
+		})
+	}
+}
+
+func TestValidateEntriesRejectsDisallowedTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryType string
+	}{
+		{name: "symlink", entryType: "symlink"},
+		{name: "hardlink", entryType: "hardlink"},
+		{name: "character device", entryType: "chardevice"},
+		{name: "block device", entryType: "blockdevice"},
+		{name: "FIFO", entryType: "fifo"},
+		{name: "socket", entryType: "socket"},
+		{name: "unknown type", entryType: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []Entry{{Path: "a.txt", Type: tt.entryType, Mode: EntryMode, Size: 1, Digest: validDigest()}}
+			if err := ValidateEntries(entries); err == nil {
+				t.Fatalf("ValidateEntries() with type %q = nil, want error", tt.entryType)
+			}
+		})
+	}
+}
+
+func TestValidateEntriesRejectsDisallowedModes(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "executable owner bit", mode: "0744"},
+		{name: "executable group bit", mode: "0654"},
+		{name: "executable other bit", mode: "0645"},
+		{name: "setuid", mode: "4644"},
+		{name: "setgid", mode: "2644"},
+		{name: "sticky", mode: "1644"},
+		{name: "world writable", mode: "0666"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []Entry{{Path: "a.txt", Type: EntryTypeFile, Mode: tt.mode, Size: 1, Digest: validDigest()}}
+			if err := ValidateEntries(entries); err == nil {
+				t.Fatalf("ValidateEntries() with mode %q = nil, want error", tt.mode)
+			}
+		})
+	}
+}
+
+func TestValidateEntriesRejectsDuplicatePaths(t *testing.T) {
+	entries := []Entry{
+		{Path: "a.txt", Type: EntryTypeFile, Mode: EntryMode, Size: 1, Digest: validDigest()},
+		{Path: "a.txt", Type: EntryTypeFile, Mode: EntryMode, Size: 2, Digest: validDigest()},
+	}
+	if err := ValidateEntries(entries); err == nil {
+		t.Fatal("ValidateEntries() with duplicate paths = nil, want error")
+	}
+}
+
+func TestValidateEntriesAcceptsWellFormedEntries(t *testing.T) {
+	entries := []Entry{
+		{Path: "a.txt", Type: EntryTypeFile, Mode: EntryMode, Size: 1, Digest: validDigest()},
+		{Path: "b.txt", Type: EntryTypeFile, Mode: EntryMode, Size: 2, Digest: validDigest()},
+	}
+	if err := ValidateEntries(entries); err != nil {
+		t.Fatalf("ValidateEntries() = %v, want nil", err)
+	}
+}
+
+func TestSortEntriesOrdersByAscendingRawUTF8Bytes(t *testing.T) {
+	entries := []Entry{
+		{Path: "z/file.txt"},
+		{Path: "a/file.txt"},
+		{Path: "M/file.txt"},
+		{Path: "m/file.txt"},
+	}
+	SortEntries(entries)
+
+	want := []string{"M/file.txt", "a/file.txt", "m/file.txt", "z/file.txt"}
+	if len(entries) != len(want) {
+		t.Fatalf("SortEntries() len = %d, want %d", len(entries), len(want))
+	}
+	for i, path := range want {
+		if entries[i].Path != path {
+			t.Fatalf("SortEntries()[%d].Path = %q, want %q", i, entries[i].Path, path)
+		}
+	}
+}

--- a/internal/releaseartifact/manifest.go
+++ b/internal/releaseartifact/manifest.go
@@ -1,0 +1,159 @@
+package releaseartifact
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Contract identity, schema identity, and file name constants for the
+// gentle-ai.release-artifact contract (design D1, Interfaces/Contracts).
+const (
+	ContractID       = "gentle-ai.release-artifact"
+	ContractMajor    = 1
+	ContractMinor    = 0
+	ManifestSchema   = "gentle-ai.release-artifact-manifest/v1"
+	ManifestSchemaID = "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json"
+	ManifestFileName = "artifact-manifest.json"
+	SnapshotSchema   = "gentle-ai.release-semantic-capabilities/v1"
+)
+
+// Manifest is the release artifact contract's self-describing top-level
+// document (design D1-D3, Worked Example). Field order matches the JSON
+// declaration order used by EncodeCanonical.
+type Manifest struct {
+	Schema        string                `json:"schema"`
+	Contract      ManifestContract      `json:"contract"`
+	Release       ManifestRelease       `json:"release"`
+	Layout        ManifestLayout        `json:"layout"`
+	Archive       ManifestArchive       `json:"archive"`
+	References    ManifestReferences    `json:"references"`
+	Tree          Tree                  `json:"tree"`
+	Compatibility ManifestCompatibility `json:"compatibility"`
+	Entries       []Entry               `json:"entries"`
+}
+
+// ManifestContract carries contract identity (design D2: "self-describing
+// decode without any external fetch").
+type ManifestContract struct {
+	ID         string `json:"id"`
+	Major      int    `json:"major"`
+	Minor      int    `json:"minor"`
+	SchemaID   string `json:"schema_id"`
+	SchemaPath string `json:"schema_path"`
+}
+
+// ManifestRelease carries release identity: repository, tag, semantic
+// version, and immutable commit.
+type ManifestRelease struct {
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit"`
+}
+
+// ManifestLayout carries layout identity, independent of release version.
+type ManifestLayout struct {
+	Version int `json:"version"`
+}
+
+// ManifestArchive names the published archive and where its digest comes
+// from. DigestSource is always "signed-checksums.txt" — the manifest never
+// carries an archive self-digest (design D2, spec "Archive authenticity
+// from signed envelope").
+type ManifestArchive struct {
+	Asset        string `json:"asset"`
+	DigestSource string `json:"digest_source"`
+}
+
+// ManifestReferences carries named semantic references to snapshot entries
+// and applicable provider contracts.
+type ManifestReferences struct {
+	SemanticSnapshots []ManifestSemanticSnapshotRef `json:"semantic_snapshots"`
+	Contracts         []ManifestContractRef         `json:"contracts"`
+}
+
+// ManifestSemanticSnapshotRef is one array element (design D2: array, not
+// singular, to avoid a guaranteed future major bump).
+type ManifestSemanticSnapshotRef struct {
+	Contract string `json:"contract"`
+	Path     string `json:"path"`
+	Schema   string `json:"schema"`
+}
+
+// ManifestContractRef names one applicable provider contract root bundled
+// in the archive.
+type ManifestContractRef struct {
+	ID   string `json:"id"`
+	Root string `json:"root"`
+}
+
+// ManifestCompatibility carries unknown_mandatory: reject into the archive
+// (design D2, spec "Mandatory Feature Rejection Preserved").
+type ManifestCompatibility struct {
+	MinimumContractMajor int    `json:"minimum_contract_major"`
+	MaximumContractMajor int    `json:"maximum_contract_major"`
+	AdditiveMinorPolicy  string `json:"additive_minor_policy"`
+	UnknownMandatory     string `json:"unknown_mandatory"`
+	UnknownOptional      string `json:"unknown_optional"`
+}
+
+// Validate enforces, in order: (1) contract major support — checked and
+// reported before any other structural inference, so an unsupported major
+// fails closed on the major alone (spec "Unsupported major fails closed");
+// (2) presence of every mandatory field group; (3) per-entry admission and
+// path uniqueness; (4) that every referenced entry path (contract schema
+// path, semantic snapshot paths) resolves into the entries list; and
+// (5) the non-self-referential tree digest.
+func (m Manifest) Validate() error {
+	if m.Contract.Major != ContractMajor {
+		return fmt.Errorf("release artifact contract major %d is not supported; this consumer supports major %d", m.Contract.Major, ContractMajor)
+	}
+	if m.Contract.ID != ContractID {
+		return fmt.Errorf("release artifact contract id %q is not supported; want %q", m.Contract.ID, ContractID)
+	}
+
+	if m.Release == (ManifestRelease{}) {
+		return errors.New("release artifact manifest is missing the mandatory release identity field group")
+	}
+	if m.Release.Repository == "" || m.Release.Tag == "" || m.Release.Version == "" || m.Release.Commit == "" {
+		return errors.New("release artifact manifest release identity field group is incomplete")
+	}
+	if m.Layout == (ManifestLayout{}) || m.Layout.Version < 1 {
+		return errors.New("release artifact manifest is missing the mandatory layout identity field group")
+	}
+	if len(m.Entries) == 0 {
+		return errors.New("release artifact manifest is missing the mandatory entries list")
+	}
+	if len(m.References.SemanticSnapshots) == 0 {
+		return errors.New("release artifact manifest is missing the mandatory semantic snapshot references")
+	}
+	if len(m.References.Contracts) == 0 {
+		return errors.New("release artifact manifest is missing the mandatory contract references")
+	}
+	if m.Compatibility.UnknownMandatory != "reject" {
+		return fmt.Errorf("release artifact manifest compatibility.unknown_mandatory = %q, must be %q", m.Compatibility.UnknownMandatory, "reject")
+	}
+
+	if err := ValidateEntries(m.Entries); err != nil {
+		return err
+	}
+
+	entryPaths := make(map[string]bool, len(m.Entries))
+	for _, e := range m.Entries {
+		entryPaths[e.Path] = true
+	}
+	if !entryPaths[m.Contract.SchemaPath] {
+		return fmt.Errorf("release artifact manifest contract.schema_path %q does not resolve into entries", m.Contract.SchemaPath)
+	}
+	for _, ref := range m.References.SemanticSnapshots {
+		if !entryPaths[ref.Path] {
+			return fmt.Errorf("release artifact manifest semantic snapshot reference %q does not resolve into entries", ref.Path)
+		}
+	}
+
+	if err := m.Tree.Validate(m.Entries); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/releaseartifact/manifest_test.go
+++ b/internal/releaseartifact/manifest_test.go
@@ -1,0 +1,165 @@
+package releaseartifact
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const manifestFixtureRoot = "../../contracts/release-artifact/v1"
+
+func readManifestFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(manifestFixtureRoot, "fixtures", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func compileManifestSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	schemaPayload, err := os.ReadFile(filepath.Join(manifestFixtureRoot, "schemas", "artifact-manifest.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(schemaPayload, &document); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(ManifestSchemaID, document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(ManifestSchemaID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+// TestReleaseArtifactManifestSchemaAndFixtureAreStrict mirrors
+// TestReviewCapabilitiesSchemaAndFixtureAreStrict (internal/cli): it
+// asserts the schema header identity and additionalProperties:false, then
+// decodes the valid fixture with DisallowUnknownFields, validates it
+// against the schema, and confirms it passes Manifest.Validate().
+func TestReleaseArtifactManifestSchemaAndFixtureAreStrict(t *testing.T) {
+	schemaPayload, err := os.ReadFile(filepath.Join(manifestFixtureRoot, "schemas", "artifact-manifest.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(schemaPayload, &schema); err != nil {
+		t.Fatal(err)
+	}
+	if schema["$schema"] != "https://json-schema.org/draft/2020-12/schema" || schema["$id"] != ManifestSchemaID || schema["additionalProperties"] != false {
+		t.Fatalf("artifact-manifest schema header = %#v", schema)
+	}
+
+	fixture := readManifestFixture(t, "artifact-manifest.fixture.json")
+	compiled := compileManifestSchema(t)
+	var instance any
+	if err := json.Unmarshal(fixture, &instance); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiled.Validate(instance); err != nil {
+		t.Fatalf("valid fixture failed schema validation: %v", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(fixture))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatalf("decode valid fixture: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("Manifest.Validate() on valid fixture = %v, want nil", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(fixture, &raw); err != nil {
+		t.Fatal(err)
+	}
+	raw["unknown"] = true
+	malformed, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder = json.NewDecoder(bytes.NewReader(malformed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&Manifest{}); err == nil {
+		t.Fatal("strict manifest decoder accepted an unknown top-level field")
+	}
+}
+
+func TestReleaseArtifactManifestRejectsUnsupportedMajorBeforeLayoutInference(t *testing.T) {
+	fixture := readManifestFixture(t, "artifact-manifest-unsupported-major.fixture.json")
+
+	decoder := json.NewDecoder(bytes.NewReader(fixture))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatalf("decode unsupported-major fixture: %v", err)
+	}
+
+	err := manifest.Validate()
+	if err == nil {
+		t.Fatal("Manifest.Validate() on unsupported-major fixture = nil, want error naming the major")
+	}
+	if !strings.Contains(err.Error(), "2") {
+		t.Fatalf("Manifest.Validate() error = %q, want it to name the unsupported major 2", err.Error())
+	}
+}
+
+func validManifest(t *testing.T) Manifest {
+	t.Helper()
+	fixture := readManifestFixture(t, "artifact-manifest.fixture.json")
+	var manifest Manifest
+	if err := json.Unmarshal(fixture, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func TestReleaseArtifactManifestRejectsMissingMandatoryFieldGroup(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(m *Manifest)
+	}{
+		{name: "missing release identity", mutate: func(m *Manifest) { m.Release = ManifestRelease{} }},
+		{name: "missing layout identity", mutate: func(m *Manifest) { m.Layout = ManifestLayout{} }},
+		{name: "missing entries", mutate: func(m *Manifest) { m.Entries = nil }},
+		{name: "missing semantic snapshot references", mutate: func(m *Manifest) { m.References.SemanticSnapshots = nil }},
+		{name: "unknown_mandatory not reject", mutate: func(m *Manifest) { m.Compatibility.UnknownMandatory = "ignore" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := validManifest(t)
+			tt.mutate(&manifest)
+			if err := manifest.Validate(); err == nil {
+				t.Fatalf("Manifest.Validate() with %s = nil, want error", tt.name)
+			}
+		})
+	}
+}
+
+func TestReleaseArtifactManifestRejectsUnresolvedReference(t *testing.T) {
+	manifest := validManifest(t)
+	manifest.References.SemanticSnapshots[0].Path = "capabilities/does-not-exist.json"
+	if err := manifest.Validate(); err == nil {
+		t.Fatal("Manifest.Validate() with an unresolved semantic snapshot reference = nil, want error")
+	}
+}
+
+func TestReleaseArtifactManifestRejectsTamperedEntryDigest(t *testing.T) {
+	manifest := validManifest(t)
+	manifest.Entries[0].Digest = "sha256:" + strings.Repeat("0", 64)
+	if err := manifest.Validate(); err == nil {
+		t.Fatal("Manifest.Validate() with a tampered entry digest = nil, want error (tree recompute must fail)")
+	}
+}

--- a/internal/releaseartifact/tree.go
+++ b/internal/releaseartifact/tree.go
@@ -1,0 +1,72 @@
+package releaseartifact
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// TreeCanonicalization identifies the exact preimage format TreeDigest
+// hashes over (design D3, D1).
+const TreeCanonicalization = "gentle-ai.release-artifact-tree/v1"
+
+// Tree is the manifest's `tree` field group: the non-recursive digest
+// binding over the sorted canonical entries, deliberately excluding the
+// manifest file itself (design D3, spec "Non-Self-Referential Digest
+// Binding").
+type Tree struct {
+	Algorithm        string `json:"algorithm"`
+	Canonicalization string `json:"canonicalization"`
+	ManifestIncluded bool   `json:"manifest_included"`
+	Digest           string `json:"digest"`
+}
+
+// Validate rejects manifest_included: true as an unknown layout, rejects
+// an unrecognized algorithm or canonicalization identity, and recomputes
+// the tree digest from entries to confirm it matches t.Digest.
+func (t Tree) Validate(entries []Entry) error {
+	if t.ManifestIncluded {
+		return errors.New("release artifact tree.manifest_included must be false; true is an unknown layout")
+	}
+	if t.Algorithm != "sha256" {
+		return fmt.Errorf("release artifact tree algorithm %q is not supported; want %q", t.Algorithm, "sha256")
+	}
+	if t.Canonicalization != TreeCanonicalization {
+		return fmt.Errorf("release artifact tree canonicalization %q is not supported; want %q", t.Canonicalization, TreeCanonicalization)
+	}
+	recomputed, err := TreeDigest(entries)
+	if err != nil {
+		return err
+	}
+	if recomputed != t.Digest {
+		return fmt.Errorf("release artifact tree digest mismatch: declared %q, recomputed %q", t.Digest, recomputed)
+	}
+	return nil
+}
+
+// TreeDigest computes the gentle-ai.release-artifact-tree/v1 digest over
+// entries. It sorts a copy internally (never mutating the caller's slice),
+// so the result is independent of input order, and validates each entry
+// before hashing so the manifest never signs an inadmissible member.
+//
+// Preimage (design D3): the literal tag "gentle-ai.release-artifact-tree/v1"
+// followed by a NUL byte, then per entry in ascending path order:
+// "path\x00type\x00mode\x00size\x00digest\n", using the exact manifest
+// field strings and a decimal, unpadded size.
+func TreeDigest(entries []Entry) (string, error) {
+	sorted := make([]Entry, len(entries))
+	copy(sorted, entries)
+	SortEntries(sorted)
+
+	h := sha256.New()
+	h.Write([]byte(TreeCanonicalization))
+	h.Write([]byte{0})
+	for _, e := range sorted {
+		if err := validateEntry(e); err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%s\x00%s\x00%s\x00%d\x00%s\n", e.Path, e.Type, e.Mode, e.Size, e.Digest)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/releaseartifact/tree_test.go
+++ b/internal/releaseartifact/tree_test.go
@@ -1,0 +1,114 @@
+package releaseartifact
+
+import "testing"
+
+// knownVectorEntries is a fixed, checked-in test vector for the
+// gentle-ai.release-artifact-tree/v1 preimage: the canonicalization tag,
+// then per entry in ascending path order, "path\x00type\x00mode\x00size\x00digest\n".
+// The expected hex below was computed independently (sha256 over that exact
+// byte sequence) and is checked in as a constant so an implementation
+// change to the preimage format shows up as a diff, not a silently
+// regenerated value.
+func knownVectorEntries() []Entry {
+	return []Entry{
+		// Declared out of sorted order on purpose: "z/file.txt" sorts
+		// after "a/file.txt", so TreeDigest must sort internally to
+		// reach the expected hash regardless of input order.
+		{Path: "z/file.txt", Type: "file", Mode: "0644", Size: 10, Digest: "sha256:" + repeat("a", 64)},
+		{Path: "a/file.txt", Type: "file", Mode: "0644", Size: 5, Digest: "sha256:" + repeat("b", 64)},
+	}
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, n*len(s))
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
+const knownVectorTreeDigest = "sha256:971ca2d598a9f6e517c00eee9581f40376f9fef61b8a905c310a2a8d71140844"
+
+func TestTreeDigestMatchesKnownVector(t *testing.T) {
+	got, err := TreeDigest(knownVectorEntries())
+	if err != nil {
+		t.Fatalf("TreeDigest() error = %v", err)
+	}
+	if got != knownVectorTreeDigest {
+		t.Fatalf("TreeDigest() = %q, want %q", got, knownVectorTreeDigest)
+	}
+}
+
+func TestTreeDigestIsInputOrderIndependent(t *testing.T) {
+	entries := knownVectorEntries()
+	reversed := []Entry{entries[1], entries[0]}
+
+	got, err := TreeDigest(reversed)
+	if err != nil {
+		t.Fatalf("TreeDigest() error = %v", err)
+	}
+	if got != knownVectorTreeDigest {
+		t.Fatalf("TreeDigest() with reversed input = %q, want %q (order must not affect the digest)", got, knownVectorTreeDigest)
+	}
+}
+
+func TestTreeDigestDoesNotMutateCallerSlice(t *testing.T) {
+	entries := knownVectorEntries()
+	original := append([]Entry(nil), entries...)
+
+	if _, err := TreeDigest(entries); err != nil {
+		t.Fatalf("TreeDigest() error = %v", err)
+	}
+	for i := range entries {
+		if entries[i] != original[i] {
+			t.Fatalf("TreeDigest() mutated caller slice at index %d: got %+v, want %+v", i, entries[i], original[i])
+		}
+	}
+}
+
+func TestTreeValidateRejectsManifestIncludedTrue(t *testing.T) {
+	entries := knownVectorEntries()
+	digest, err := TreeDigest(entries)
+	if err != nil {
+		t.Fatalf("TreeDigest() error = %v", err)
+	}
+	tree := Tree{
+		Algorithm:        "sha256",
+		Canonicalization: TreeCanonicalization,
+		ManifestIncluded: true,
+		Digest:           digest,
+	}
+	if err := tree.Validate(entries); err == nil {
+		t.Fatal("Tree.Validate() with manifest_included=true = nil, want error")
+	}
+}
+
+func TestTreeValidateAcceptsRecomputedDigest(t *testing.T) {
+	entries := knownVectorEntries()
+	digest, err := TreeDigest(entries)
+	if err != nil {
+		t.Fatalf("TreeDigest() error = %v", err)
+	}
+	tree := Tree{
+		Algorithm:        "sha256",
+		Canonicalization: TreeCanonicalization,
+		ManifestIncluded: false,
+		Digest:           digest,
+	}
+	if err := tree.Validate(entries); err != nil {
+		t.Fatalf("Tree.Validate() = %v, want nil", err)
+	}
+}
+
+func TestTreeValidateRejectsTamperedDigest(t *testing.T) {
+	entries := knownVectorEntries()
+	tree := Tree{
+		Algorithm:        "sha256",
+		Canonicalization: TreeCanonicalization,
+		ManifestIncluded: false,
+		Digest:           "sha256:" + repeat("0", 64),
+	}
+	if err := tree.Validate(entries); err == nil {
+		t.Fatal("Tree.Validate() with tampered digest = nil, want error")
+	}
+}

--- a/openspec/changes/publish-gentle-ai-release-artifacts/apply-progress.md
+++ b/openspec/changes/publish-gentle-ai-release-artifacts/apply-progress.md
@@ -1,0 +1,87 @@
+# Apply Progress: Publish Gentle AI Release Artifacts — Phase A1a
+
+**Change**: publish-gentle-ai-release-artifacts
+**Unit**: A1a — Contract Namespace, Canonical Encoder, Entry/Path/Mode/Tree, Manifest
+**Mode**: Strict TDD
+**Branch**: `feat/release-artifact-contract` (base: `feat/pi-parity-assets-artifact`)
+
+## Completed Tasks
+
+- [x] A1a.1 RED `internal/releaseartifact/canonical_test.go`
+- [x] A1a.2 GREEN `internal/releaseartifact/canonical.go`
+- [x] A1a.3 RED `internal/releaseartifact/entry_test.go`
+- [x] A1a.4 GREEN `internal/releaseartifact/entry.go`
+- [x] A1a.5 RED `internal/releaseartifact/tree_test.go`
+- [x] A1a.6 GREEN `internal/releaseartifact/tree.go`
+- [x] A1a.7 `contracts/release-artifact/v1/schemas/artifact-manifest.schema.json` + both fixtures
+- [x] A1a.8 RED `internal/releaseartifact/manifest_test.go`
+- [x] A1a.9 GREEN `internal/releaseartifact/manifest.go`
+- [x] A1a.10 `docs/release-artifact.md`
+
+All ten A1a tasks complete. Phases A1b, A2, A3 are out of scope for this batch and remain `[ ]` in `tasks.md`.
+
+## TDD Cycle Evidence
+
+| Task | RED (test written first, run, failed for the right reason) | GREEN (implementation, run, passed) | REFACTOR |
+|---|---|---|---|
+| A1a.1/2 canonical encoder | `go test ./internal/releaseartifact/...` → `undefined: EncodeCanonical` (compile failure, package had no source) | `go test ./internal/releaseartifact/... -run Canonical` → 3/3 PASS | None needed — `EncodeCanonical` is a thin `json.Encoder` wrapper; kept minimal per design D3. |
+| A1a.3/4 entry admission | `go test ./internal/releaseartifact/...` → `undefined: ValidateEntryPath / Entry / EntryMode / ValidateEntries` (compile failure) | `go test ./internal/releaseartifact/... -run "Entry\|Sort"` → all subtests PASS (13 path-rejection rows, 7 type-rejection rows, 7 mode-rejection rows, duplicate rejection, accept, sort) | Extracted unexported `validateEntry` shared by `ValidateEntries` and `TreeDigest`, avoiding duplicated path/type/mode/digest-format checks. |
+| A1a.5/6 tree digest | `go test ./internal/releaseartifact/...` → `undefined: TreeDigest / Tree / TreeCanonicalization` (compile failure) | `go test ./internal/releaseartifact/... -run Tree` → 6/6 PASS, including the checked-in known-vector hash `sha256:971ca2d598a9f6e517c00eee9581f40376f9fef61b8a905c310a2a8d71140844` computed independently (Python `hashlib.sha256` over the exact D3 preimage) before the Go implementation existed, and matched on the first GREEN run — confirms the preimage format was implemented correctly, not tuned to pass. | None. |
+| A1a.7 schema + fixtures | N/A — not RED/GREEN; artifact creation task. Verified with `python3 -m json.load` for JSON well-formedness before use. | — | — |
+| A1a.8/9 manifest | `go test ./internal/releaseartifact/...` → `undefined: Manifest / ManifestSchemaID / ManifestRelease / ManifestLayout` (compile failure) | `go test ./internal/releaseartifact/... -run Manifest` → 6/6 PASS (schema-header + strict-fixture test mirroring `TestReviewCapabilitiesSchemaAndFixtureAreStrict`; unsupported-major-names-the-major; 5 missing-mandatory-group subtests; unresolved-reference; tampered-digest) | None. |
+
+## Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and exact result | `go test ./internal/releaseartifact/... -run 'Canonical\|Entry\|Tree\|Manifest\|Sort'` → all PASS (matches the Suggested Work Units table's focused command for A1a) |
+| Full package result | `go test ./internal/releaseartifact/... -v` → 100% PASS, `gofmt -l` clean, `go vet ./internal/releaseartifact/...` clean |
+| Whole-repository regression check | `go test ./...` (full repo, ~90 packages) → all `ok`, zero failures, zero build errors |
+| Runtime harness command/scenario and exact result | N/A — per the design's Suggested Work Units table, A1a ships pure, unwired contract types; no command consumes them yet. The generator command that would exercise them end-to-end is A1b scope. |
+| Rollback boundary | Delete `contracts/release-artifact/v1/{schemas,fixtures}/` and `internal/releaseartifact/{canonical,entry,tree,manifest}{,_test}.go`; revert `docs/release-artifact.md` (new file) and the `tasks.md` checkbox edits. Nothing else in the repository imports or references these paths — `go build ./...` and `go test ./...` remain green with them absent. |
+
+## Commits (work-unit-commits skill)
+
+1. `feat(releaseartifact): add canonical JSON encoder for release artifact contract` — `canonical.go`, `canonical_test.go`
+2. `feat(releaseartifact): add entry admission, ordering, and tree digest` — `entry.go`, `entry_test.go`, `tree.go`, `tree_test.go`
+3. `feat(releaseartifact): add manifest contract schema, fixtures, and validation` — `manifest.go`, `manifest_test.go`, `contracts/release-artifact/v1/**`
+4. `docs(release-artifact): document the release artifact contract` — `docs/release-artifact.md`, `tasks.md` checkbox update
+
+Diff vs. tracker branch (`feat/pi-parity-assets-artifact..HEAD`): 13 files changed, 1231 insertions(+), 10 deletions(-). No `.goreleaser.yaml`, `.github/workflows/release.yml`, `internal/releasepolicy/policy.go`, or `scripts/verify-release-assets.sh` touched.
+
+## Deviations from Design
+
+None. Implementation follows D1-D3 and the Interfaces/Contracts section exactly, including:
+
+- Array (not singular) `references.semantic_snapshots`.
+- No `$schema` URL key inside the manifest's own top-level fields (the JSON Schema file itself carries `$schema`/`$id` as schema metadata, per the same convention as `capabilities.schema.json`; the manifest document has no `$schema` field).
+- `entries[].size` retained.
+- `RequiredFloor` is out of scope for A1a (A1b.5/A1b.6).
+- Tree digest is non-self-referential: `TreeDigest` and `Tree.Validate` operate only on `entries`, never on the manifest's own bytes.
+
+### One clarification made, not a deviation
+
+The design's Interfaces/Contracts snippet lists only `ValidateEntryPath`, `SortEntries`, `TreeDigest`, `EncodeCanonical`, and `Manifest.Validate` as the cross-file API. Task A1a.3 explicitly requires table rows for entry **type** rejection, entry **mode** rejection, and **duplicate**-path rejection — none of which fit `ValidateEntryPath(p string) error`'s signature (a bare path string). To satisfy that task without inventing an undeclared shape, I added:
+
+- unexported `validateEntry(e Entry) error` (path + type + mode + digest-format admission for one entry), and
+- exported `ValidateEntries(entries []Entry) error` (validates every entry and rejects duplicate paths).
+
+Both are additive, internally consistent with D3, and `Manifest.Validate()` (A1a.9, listed in the design) calls `ValidateEntries` to do the "groups present" entry-admission work the design assigns it. I did not invent an alternative to any decision the design actually settled.
+
+## Issues Found
+
+None.
+
+## Design point I want the orchestrator to weigh in on
+
+The design's `Tree` struct/`(t Tree) Validate(entries []Entry) error` is implied but not spelled out in the Interfaces/Contracts snippet (only `TreeCanonicalization` and the free function `TreeDigest` are listed there). Task A1a.5's RED test explicitly requires a `manifest_included: true` rejection case, which is a property of the `tree` field group as a whole, not of the entries list alone. I introduced `Tree` as a first-class type with its own `Validate` method so `Manifest.Validate()` has something concrete to call for "tree recompute" (per A1a.9's own description). This seems like the only coherent reading of the tasks, but flagging it since it is genuinely an addition to, not a restatement of, the design's explicit snippet.
+
+## Remaining Tasks (out of scope for this batch)
+
+- [ ] Phase A1b: Snapshot Projection, Generator Command, Golden (A1b.1-A1b.11)
+- [ ] Phase A2: Archive Assembly, Policy Amendment, Verify Script, Docs (A2.1-A2.10)
+- [ ] Phase A3: Downstream Notification (A3.1-A3.5)
+
+## Status
+
+10/10 Phase A1a tasks complete. Ready for `sdd-verify` on this work unit, then PR 1 of the feature-branch chain (base: `feat/pi-parity-assets-artifact`).

--- a/openspec/changes/publish-gentle-ai-release-artifacts/tasks.md
+++ b/openspec/changes/publish-gentle-ai-release-artifacts/tasks.md
@@ -29,16 +29,16 @@ Chain strategy: feature-branch-chain
 
 ## Phase A1a: Contract Namespace, Canonical Encoder, Entry/Path/Mode/Tree, Manifest
 
-- [ ] A1a.1 RED: `internal/releaseartifact/canonical_test.go` — byte assertion on a small fixed struct: 2-space indent, `SetEscapeHTML(false)`, `[]` not `null`, single trailing LF, no BOM, struct-declaration field order.
-- [ ] A1a.2 GREEN: `internal/releaseartifact/canonical.go` — `EncodeCanonical(v any) ([]byte, error)` per D3.
-- [ ] A1a.3 RED: `internal/releaseartifact/entry_test.go` — table rows: path rejection (absolute, `..`, backslash, NUL/control byte, empty segment, >1024/255-byte, duplicate); type rejection (symlink, hardlink, device, FIFO, socket, unknown); mode rejection (non-`0644`, exec/setuid/setgid/sticky); `SortEntries` ascending raw-UTF8-byte order.
-- [ ] A1a.4 GREEN: `internal/releaseartifact/entry.go` — `Entry` struct; `EntryTypeFile`, `EntryMode`, `AssetsArchiveID` constants; `ValidateEntryPath`; `SortEntries`.
-- [ ] A1a.5 RED: `internal/releaseartifact/tree_test.go` — checked-in expected hex over the known-vector preimage `"gentle-ai.release-artifact-tree/v1\x00"` + sorted `path\x00type\x00mode\x00size\x00digest\n`; input-order independence; `manifest_included: true` rejected.
-- [ ] A1a.6 GREEN: `internal/releaseartifact/tree.go` — `TreeDigest(entries []Entry) (string, error)`, `TreeCanonicalization` constant.
-- [ ] A1a.7 Create `contracts/release-artifact/v1/schemas/artifact-manifest.schema.json` (`$id`, `additionalProperties:false` throughout, mandatory field groups) and both fixtures — `artifact-manifest.fixture.json` and `artifact-manifest-unsupported-major.fixture.json` (byte-identical except `schema`/`contract.major`/`schema_id`/`schema_path`, per Worked Example).
-- [ ] A1a.8 RED: `internal/releaseartifact/manifest_test.go` mirroring `TestReviewCapabilitiesSchemaAndFixtureAreStrict` — schema header assertions; valid fixture decodes with `DisallowUnknownFields` and validates; unsupported-major fixture rejected naming the major (before layout inference); missing mandatory field group rejected; tampered digest / unresolved reference rejected.
-- [ ] A1a.9 GREEN: `internal/releaseartifact/manifest.go` — `Manifest` type; `ContractID`, `ContractMajor`, `ContractMinor`, schema constants; `(m Manifest) Validate() error` (groups present, references resolve into entries, tree recompute, `unknown_mandatory: reject`).
-- [ ] A1a.10 `docs/release-artifact.md` — create, contract section only (namespace, schema, fixtures, rolling-changelog header), `docs/review-integration.md` style.
+- [x] A1a.1 RED: `internal/releaseartifact/canonical_test.go` — byte assertion on a small fixed struct: 2-space indent, `SetEscapeHTML(false)`, `[]` not `null`, single trailing LF, no BOM, struct-declaration field order.
+- [x] A1a.2 GREEN: `internal/releaseartifact/canonical.go` — `EncodeCanonical(v any) ([]byte, error)` per D3.
+- [x] A1a.3 RED: `internal/releaseartifact/entry_test.go` — table rows: path rejection (absolute, `..`, backslash, NUL/control byte, empty segment, >1024/255-byte, duplicate); type rejection (symlink, hardlink, device, FIFO, socket, unknown); mode rejection (non-`0644`, exec/setuid/setgid/sticky); `SortEntries` ascending raw-UTF8-byte order.
+- [x] A1a.4 GREEN: `internal/releaseartifact/entry.go` — `Entry` struct; `EntryTypeFile`, `EntryMode`, `AssetsArchiveID` constants; `ValidateEntryPath`; `SortEntries`.
+- [x] A1a.5 RED: `internal/releaseartifact/tree_test.go` — checked-in expected hex over the known-vector preimage `"gentle-ai.release-artifact-tree/v1\x00"` + sorted `path\x00type\x00mode\x00size\x00digest\n`; input-order independence; `manifest_included: true` rejected.
+- [x] A1a.6 GREEN: `internal/releaseartifact/tree.go` — `TreeDigest(entries []Entry) (string, error)`, `TreeCanonicalization` constant.
+- [x] A1a.7 Create `contracts/release-artifact/v1/schemas/artifact-manifest.schema.json` (`$id`, `additionalProperties:false` throughout, mandatory field groups) and both fixtures — `artifact-manifest.fixture.json` and `artifact-manifest-unsupported-major.fixture.json` (byte-identical except `schema`/`contract.major`/`schema_id`/`schema_path`, per Worked Example).
+- [x] A1a.8 RED: `internal/releaseartifact/manifest_test.go` mirroring `TestReviewCapabilitiesSchemaAndFixtureAreStrict` — schema header assertions; valid fixture decodes with `DisallowUnknownFields` and validates; unsupported-major fixture rejected naming the major (before layout inference); missing mandatory field group rejected; tampered digest / unresolved reference rejected.
+- [x] A1a.9 GREEN: `internal/releaseartifact/manifest.go` — `Manifest` type; `ContractID`, `ContractMajor`, `ContractMinor`, schema constants; `(m Manifest) Validate() error` (groups present, references resolve into entries, tree recompute, `unknown_mandatory: reject`).
+- [x] A1a.10 `docs/release-artifact.md` — create, contract section only (namespace, schema, fixtures, rolling-changelog header), `docs/review-integration.md` style.
 
 ## Phase A1b: Snapshot Projection, Generator Command, Golden
 


### PR DESCRIPTION
Closes #2156

First slice of the provider chain. Purely additive: a new package, a new contract namespace, and a doc. Nothing existing is wired to it yet.

## What this establishes

This is the shape `gentle-pi`'s bootstrap decoder will target, so it is deliberately conservative.

- `internal/releaseartifact/canonical.go` — canonical JSON encoding: 2-space indent, no HTML escaping, empty slices as `[]` rather than `null`, single trailing LF, no BOM, struct-declaration field order.
- `internal/releaseartifact/entry.go` — entry admission and ordering. Rejects absolute paths, `..`, backslashes, NUL and control bytes, empty segments, oversized paths and duplicates; rejects every entry type except a regular file; rejects any mode other than `0644`, including exec, setuid, setgid and sticky.
- `internal/releaseartifact/tree.go` — the tree digest, computed over sorted entries and explicitly excluding the manifest itself, so the digest can never need to contain itself.
- `internal/releaseartifact/manifest.go` — the manifest type and `Validate()`: mandatory field groups present, references resolve into entries, tree recomputes, and `unknown_mandatory: reject` is carried forward.
- `contracts/release-artifact/v1/` — schema with `additionalProperties: false` throughout, plus a valid fixture and an unsupported-major fixture that differ only in the version fields.
- `docs/release-artifact.md` — contract section, in the rolling-changelog style of `docs/review-integration.md`.

## Two shape decisions worth flagging

**Semantic snapshot references are an array from day one.** A singular field would guarantee a major bump the first time a second snapshot ships. A one-element array with `minItems: 1` costs nothing now.

**`entries[].size` is kept.** The consumer needs to bound extraction before writing bytes; a digest check after the fact is too late against a decompression bomb.

## Tests

Strict TDD throughout. Every RED test failed to compile against a missing symbol before its implementation existed, so nothing was retrofitted to a passing implementation.

The tree-digest known vector was computed independently, outside Go, from the exact preimage before `TreeDigest` was written, and matched on the first green run. That is the difference between proving the preimage format and tuning a test until it passes.

`go test ./...` is green across the whole repository, verified independently of the implementing run.

## Deliberately not here

The snapshot projection and generator command are A1b. Archive assembly, the release-policy amendment and the verify-assets update are A2 — touching `.goreleaser.yaml` or `release.yml` here would fail CI closed, since `policy.go` byte-diffs both against embedded constants.

## Size

+1318 / -10 against the tracker, over the 400-line budget. The session's delivery strategy is `exception-ok`, and the bulk is schema JSON, fixtures and table-driven tests rather than branching logic. The design already split this unit once (A1a from A1b); splitting the canonical encoder from the entry rules from the manifest would produce slices that cannot be tested independently, since the manifest test needs all three.

## Rollback

Delete `internal/releaseartifact/` and `contracts/release-artifact/v1/`, revert the doc. Nothing references these paths, so the build stays green with them absent.
