### PR TITLE
fix(sync): enumerate SDD nested skill assets and Codex hooks.json in managed paths

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -1837,25 +1838,36 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if adapter.SupportsSkills() {
 				skillDir := adapter.SkillsDir(targetDir)
 				if skillDir != "" {
-					paths = append(paths,
-						filepath.Join(skillDir, "_shared", "persistence-contract.md"),
-						filepath.Join(skillDir, "_shared", "engram-convention.md"),
-						filepath.Join(skillDir, "_shared", "openspec-convention.md"),
-						filepath.Join(skillDir, "_shared", "sdd-phase-common.md"),
-						filepath.Join(skillDir, "_shared", "sdd-status-contract.md"),
-						filepath.Join(skillDir, "_shared", "skill-resolver.md"),
-						filepath.Join(skillDir, "sdd-init", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-explore", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-propose", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-spec", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-design", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-tasks", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-apply", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-verify", "SKILL.md"),
-						filepath.Join(skillDir, "sdd-archive", "SKILL.md"),
-					)
+					// Path enumeration must mirror what sdd.Inject actually
+					// writes. sdd.Inject writes an explicit set of
+					// _shared/ files plus every file in each SDD phase
+					// skill dir via skills.InjectWithCapability. A
+					// hardcoded list here drifts the moment a phase
+					// adds a references/ doc or a strict-tdd variant,
+					// leaving the file outside the pre-sync backup
+					// snapshot and producing spurious "files changed"
+					// reports on repeat syncs (issue #2067). Derive the
+					// per-phase list from the same embedded FS that
+					// ships in the binary so it stays in sync; keep
+					// the _shared/ list explicit so we don't enumerate
+					// files the injector never ships (e.g. review-ledger
+					// -contract.md).
+					for _, fileName := range sharedSDDFiles() {
+						paths = append(paths, filepath.Join(skillDir, "_shared", fileName))
+					}
+					for _, id := range sddPhaseSkillIDs() {
+						paths = append(paths, walkEmbeddedAssetDir("skills/"+string(id), skillDir)...)
+					}
 					if adapter.Agent() == model.AgentClaudeCode {
 						paths = append(paths, filepath.Join(skillDir, "_shared", "sdd-orchestrator-workflow.md"))
+					}
+					if adapter.Agent() == model.AgentCodex {
+						// installSkillRegistryAutomation writes
+						// ~/.codex/hooks.json for the skill-registry
+						// startup refresh hook. Must be in the path
+						// enumeration or the pre-sync backup gap leaves
+						// it without a rollback target (issue #2067).
+						paths = append(paths, filepath.Join(adapter.GlobalConfigDir(targetDir), "hooks.json"))
 					}
 				}
 			}
@@ -2079,6 +2091,79 @@ func sddSubAgentPaths(homeDir string, adapter agents.Adapter) []string {
 	}
 
 	return paths
+}
+
+// walkEmbeddedAssetDir walks the embedded assets FS under embedDir and
+// returns the destination paths under targetDir for every regular file,
+// preserving embedDir's leaf component so the path matches what
+// sdd.Inject actually writes. For example, walking embedDir
+// "skills/sdd-init" with targetDir "~/.claude/skills" yields
+// "~/.claude/skills/sdd-init/SKILL.md" and
+// "~/.claude/skills/sdd-init/references/init-details.md".
+//
+// Directories are skipped. Returns nil if embedDir is missing or
+// unreadable — embedded assets are baked at build time and a missing
+// dir would be a build bug, not a runtime concern for path enumeration
+// (used by post-apply verification and pre-sync backup manifests).
+//
+// Mirrors the walk that skills.InjectWithCapability performs at write
+// time so the path enumeration cannot drift from the actual write set.
+func walkEmbeddedAssetDir(embedDir, targetDir string) []string {
+	var paths []string
+	err := fs.WalkDir(assets.FS, embedDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(filepath.FromSlash(embedDir), filepath.FromSlash(p))
+		if relErr != nil {
+			return relErr
+		}
+		// rel is the path inside embedDir. Prepend embedDir's leaf
+		// component so the destination matches the on-disk layout
+		// (e.g. skillDir/sdd-init/SKILL.md, not skillDir/SKILL.md).
+		leaf := filepath.Base(embedDir)
+		if rel == "." {
+			rel = ""
+		}
+		paths = append(paths, filepath.Join(targetDir, leaf, rel))
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+	return paths
+}
+
+// sddPhaseSkillIDs returns the embedded SDD phase skill directories whose
+// files sdd.Inject writes via skills.InjectWithCapability. Keep in sync
+// with the sddSkillIDs slice in internal/components/sdd/inject.go — any
+// new phase added there must be added here too.
+func sddPhaseSkillIDs() []model.SkillID {
+	return []model.SkillID{
+		"sdd-init", "sdd-explore", "sdd-propose", "sdd-spec",
+		"sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive",
+		"sdd-onboard", "judgment-day",
+	}
+}
+
+// sharedSDDFiles returns the _shared/ files sdd.Inject writes. Mirrors
+// the sharedFiles slice in internal/components/sdd/inject.go — keep in
+// sync. Not every embedded file under skills/_shared/ is shipped; for
+// example review-ledger-contract.md lives there as source but is
+// rendered into agent assets elsewhere, not copied as-is by Inject.
+func sharedSDDFiles() []string {
+	return []string{
+		"SKILL.md",
+		"persistence-contract.md",
+		"engram-convention.md",
+		"openspec-convention.md",
+		"sdd-phase-common.md",
+		"sdd-status-contract.md",
+		"skill-resolver.md",
+	}
 }
 
 func openCodeSDDPluginPaths(targetDir string) []string {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -943,3 +943,82 @@ func assertNoDuplicatePaths(t *testing.T, label string, paths []string) {
 		seen[path] = struct{}{}
 	}
 }
+
+// TestComponentPathsSDDCodexIncludesNestedSkillAssetsAndHooksJSON covers issue
+// #2067: a Codex install with ComponentSDD must enumerate every file the
+// sdd.Inject pass actually writes under ~/.codex/skills/ and the
+// Codex skill-registry hooks file. Previously the path list was a static
+// hardcoded enumeration that missed _shared/SKILL.md, every
+// <phase>/references/*.md doc, sdd-onboard, judgment-day, and
+// hooks.json — leaving those files outside the pre-sync backup snapshot
+// and producing spurious "files changed" reports on repeat syncs.
+//
+// Asserting the exact paths from the issue (plus a handful of
+// representative companions) locks in the fix and prevents the
+// enumeration from regressing if the static list is reintroduced.
+func TestComponentPathsSDDCodexIncludesNestedSkillAssetsAndHooksJSON(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentCodex})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentSDD)
+
+	want := []string{
+		// _shared/ files (was missing _shared/SKILL.md before the fix).
+		filepath.Join(home, ".codex", "skills", "_shared", "SKILL.md"),
+		filepath.Join(home, ".codex", "skills", "_shared", "persistence-contract.md"),
+		filepath.Join(home, ".codex", "skills", "_shared", "sdd-phase-common.md"),
+
+		// Phase skill dirs that were missed by the hardcoded list.
+		filepath.Join(home, ".codex", "skills", "sdd-onboard", "SKILL.md"),
+		filepath.Join(home, ".codex", "skills", "judgment-day", "SKILL.md"),
+
+		// Nested files that only fs.WalkDir over each phase dir can pick up.
+		filepath.Join(home, ".codex", "skills", "sdd-init", "references", "init-details.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-design", "references", "threat-matrix.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-apply", "strict-tdd.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-verify", "references", "report-format.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-verify", "strict-tdd-verify.md"),
+		filepath.Join(home, ".codex", "skills", "judgment-day", "references", "prompts-and-formats.md"),
+
+		// Codex skill-registry automation writes ~/.codex/hooks.json.
+		filepath.Join(home, ".codex", "hooks.json"),
+	}
+	for _, path := range want {
+		if !containsPath(paths, path) {
+			t.Fatalf("componentPaths(sdd,codex) missing %q\npaths=%v", path, paths)
+		}
+	}
+}
+
+// TestBackupTargetsSDDCodexIncludesNestedSkillAssetsAndHooksJSON verifies the
+// pre-sync backup snapshot (which feeds backupTargets → prepareBackupStep)
+// includes the same nested assets the post-apply verification covers. If
+// the backup snapshot omits any path the injector writes, a future sync
+// that damages that path has no rollback target — the safety-relevant
+// half of issue #2067.
+func TestBackupTargetsSDDCodexIncludesNestedSkillAssetsAndHooksJSON(t *testing.T) {
+	home := t.TempDir()
+	agentIDs := []model.AgentID{model.AgentCodex}
+	selection := model.Selection{
+		Agents:     agentIDs,
+		Components: []model.ComponentID{model.ComponentSDD},
+	}
+	resolved := planner.ResolvedPlan{Agents: agentIDs, OrderedComponents: selection.Components}
+
+	targets := backupTargets(home, "", ScopeGlobal, selection, resolved)
+
+	want := []string{
+		filepath.Join(home, ".codex", "skills", "_shared", "SKILL.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-init", "references", "init-details.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-apply", "strict-tdd.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-verify", "strict-tdd-verify.md"),
+		filepath.Join(home, ".codex", "skills", "sdd-onboard", "SKILL.md"),
+		filepath.Join(home, ".codex", "skills", "judgment-day", "references", "prompts-and-formats.md"),
+		filepath.Join(home, ".codex", "hooks.json"),
+	}
+	for _, path := range want {
+		if !containsPath(targets, path) {
+			t.Fatalf("backupTargets(sdd,codex) missing %q\ntargets=%v", path, targets)
+		}
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2067

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

For a Codex install with `persona: gentleman`, a second consecutive `gentle-ai sync` reported 9 byte-identical files as changed and the same 9 paths were absent from the pre-sync backup snapshot.

Root cause: `componentPathsWithWorkspaceScoped` listed SDD skill paths statically (`_shared/*.md`, 9 phase `SKILL.md` files), but `sdd.Inject` actually writes:

- **`_shared/`** — 7 files via an explicit `sharedFiles` slice (`SKILL.md` plus 6 conventions; `review-ledger-contract.md` is NOT in the set — it's rendered into agent assets elsewhere, never copied as-is by Inject).
- **Each of 11 phase skill dirs** (`sdd-init` through `sdd-archive`, plus `sdd-onboard` and `judgment-day`) — every file under the dir, via `skills.InjectWithCapability` which `fs.WalkDir`s.
- **`~/.codex/hooks.json`** — written by `installSkillRegistryAutomation`.

The static list missed `_shared/SKILL.md`, every `references/*.md`, `sdd-onboard/SKILL.md`, `judgment-day/SKILL.md`, the `strict-tdd*.md` variants, and `~/.codex/hooks.json`. `changedSyncFiles` then checked those candidates against the snapshot; with no baseline (paths absent from `rt.managedPaths`, which is also fed by `syncBackupTargets` → `prepareBackupStep`), `previous.exists` was false and the file was reported changed without its content ever being compared. Worse, those files were never captured by the pre-sync backup, so a sync that damaged them had no rollback target.

This PR fixes the path enumeration so it matches what `sdd.Inject` actually writes. The two halves of the issue (spurious "files changed" and the backup gap) share a single root cause and close together.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go` | Replaced the hardcoded `_shared/*.md` list in `componentPathsWithWorkspaceScoped` with the explicit 7-file `sharedSDDFiles()` set that mirrors `sdd.Inject`'s `sharedFiles` slice. Replaced the hardcoded 9-phase `SKILL.md` list with `fs.WalkDir` over each of the 11 phase skill dirs (`sddPhaseSkillIDs()`), preserving the leaf component so the destination matches the on-disk layout. Added `~/.codex/hooks.json` to the path enumeration for Codex. Added the `walkEmbeddedAssetDir`, `sddPhaseSkillIDs`, and `sharedSDDFiles` helpers next to the existing `sddSubAgentPaths`. |
| `internal/cli/run_component_paths_test.go` | Added `TestComponentPathsSDDCodexIncludesNestedSkillAssetsAndHooksJSON` (asserts the 9 missing paths are now in `componentPaths` for Codex) and `TestBackupTargetsSDDCodexIncludesNestedSkillAssetsAndHooksJSON` (asserts the same paths reach the pre-sync backup snapshot via `backupTargets`). |

Diff stats: `+181 / -17 across 2 files` (well within the 400-line review budget).

---

## 🧪 Test Plan

**Unit Tests**

```bash
go test ./internal/cli/... -count=1 -run "TestComponentPathsSDD|TestBackupTargetsSDD|TestComponentPathsBackup|TestRunSync_RestoresCodexCarrilAssignments|TestSyncBackupTargets"
```

Result: PASS in 7.9s. Includes the existing 7 `TestComponentPathsSDD*` tests still passing (verifies the static list → dynamic walk refactor didn't drop any previously-covered paths), the existing `TestRunSync_RestoresCodexCarrilAssignments` (the closest analog to the issue's reproduction, with `persona: neutral` and repeated codex syncs), and my 2 new regression tests.

```bash
go build ./... && go vet ./...
```

Result: clean across the whole repo.

```bash
go test ./internal/backup/... ./internal/components/... ./internal/assets/... -count=1
```

Result: PASS — confirms no other package regressed.

```bash
go run ./internal/gofmtcheck
```

Result: clean (no output).

**E2E Tests** (Docker required)

Not run locally — Windows without Docker. E2E coverage for sync idempotency is exercised by the existing `TestRunSync_RestoresCodexCarrilAssignments` test, which asserts `NoOp=true, FilesChanged=0` on the second consecutive `gentle-ai sync --agents codex`. The maintainer-side `e2e/docker-test.sh` run on CI will gate the final merge.

**Benchmark Validation**

N/A — this is a path enumeration refactor in `internal/cli`, not in scope for the benchmark guide (review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark-claim changes).

- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass — see note above (CI gate)
- [x] Manually tested locally — new tests cover the exact 9 paths from the bug report

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#2067 approved 2026-08-01 by `decode2` with explicit technical audit identifying the exact function and root cause)
- [x] PR stays within 400 changed lines (`+181 / -17`)
- [ ] I have added the appropriate `type:*` label to this PR — see Pending maintainer actions
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass — see note above
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (path enumeration refactor, no benchmark surface)
- [x] I have updated documentation if necessary (no behavior change, no docs needed)
- [x] My commits follow Conventional Commits format (`fix(sync): enumerate SDD nested skill assets and Codex hooks.json in managed paths`)
- [x] My commits do not include `Co-Authored-By` trailers

---

## Pending maintainer actions

Per `pr-check.yml` and CONTRIBUTING.md, the following are **maintainer-applied** (not contributor scope; `gh pr edit --add-label` returns GraphQL 403 `AddLabelsToLabelable` for external contributors):

- [ ] `type:bug` label applied to this PR — pending Alan

---

## 💬 Notes for Reviewers

- **Refactor over patch.** The minimal fix would be to add the 9 missing paths to the existing static list. I chose the refactor because the static list has already drifted once (this issue) and `sdd.Inject` uses `fs.WalkDir` for the per-phase enumeration, so any future addition of a `references/*.md` doc or `strict-tdd*.md` variant would re-introduce the same bug. The refactor makes the path enumeration derive from the embedded FS that ships in the binary, so it cannot drift from the actual write set on the per-phase side. The `_shared/` set is kept explicit because not every embedded file under `skills/_shared/` is shipped by `Inject` — `review-ledger-contract.md` is rendered into agent assets elsewhere and must NOT appear in this enumeration (the over-enumeration regression was caught and reverted during local testing).

- **Co-located helper placement.** `walkEmbeddedAssetDir`, `sddPhaseSkillIDs`, and `sharedSDDFiles` sit next to `sddSubAgentPaths` in `run.go`. All three helpers carry an inline "keep in sync with `internal/components/sdd/inject.go`" comment because the source of truth for the path sets lives in the SDD injector. The alternative — exporting them from the `sdd` package — would be the right long-term cleanup but is out of scope for this fix.

- **Codex-only `hooks.json` enumeration.** The bug report mentions Codex specifically (`.codex/hooks.json`). `installSkillRegistryAutomation` also writes `~/.claude/settings.json` for Claude Code via `ensureClaudeSkillRegistryHook`, but `settings.json` is already in the path enumeration through `ComponentEngram` and `ComponentSkills` (StrategyMergeIntoSettings). It is not enumerated under `ComponentSDD` for Claude, which is technically the same shape of gap but a different bug surface; not addressed here to keep the fix focused.

- **ComponentSkills analog.** `componentPathsWithWorkspaceScoped` for `ComponentSkills` still uses `SkillPathForAgent` (returns only `SKILL.md`), so non-SDD skill `references/*.md` files are also missing from that enumeration. Out of scope for #2067 (which only reports the SDD component path), but worth a follow-up issue if reported.

- **Local validation.** `go test ./internal/cli/...` includes a few pre-existing Windows-specific timeouts in `internal/reviewtransaction` that hang on `git` operations during symlink resolution (`TestCandidateDeclineNeverAuthorizesRelease`, `TestReviewCaptureResultRejectsNestedEnvelope`, `TestReviewFinalizeArtifactFileCancellationAndErrorPrivacy`, `TestReviewArtifactSubstitutionFailsBeforeMutation`). These are unrelated to this PR and are skipped in my local run; the maintainer-side CI runs them on Linux where they pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and verification coverage for SDD components, including nested skill assets, phase files, shared references, and Codex hook configuration.
  * Ensured all relevant embedded assets are discovered and included during synchronization.
* **Tests**
  * Added regression coverage to verify complete component path and backup target enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->