### PR TITLE
fix(review): recover staged base-diff corrections

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -95,7 +95,12 @@ var captureEvidenceCapability = &Capability{
 // readStatus issues one `review status --next-transition`. The invocation is
 // counted: an agent driving this flow really does have to spend it.
 func readStatus(r *journeyRun) (statusEnvelope, error) {
-	observation := r.run([]string{"review", "status", "--cwd", r.sandbox.Repo, "--contract", reviewContract, "--next-transition"}, false)
+	return readStatusFor(r)
+}
+
+func readStatusFor(r *journeyRun, selectors ...string) (statusEnvelope, error) {
+	args := append([]string{"review", "status", "--cwd", r.sandbox.Repo, "--contract", reviewContract, "--next-transition"}, selectors...)
+	observation := r.run(args, false)
 	var envelope statusEnvelope
 	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &envelope); err != nil {
 		return envelope, fmt.Errorf("parse review status: %w (stderr: %s)", err, firstLine(observation.Stderr))
@@ -138,8 +143,12 @@ func writeScratch(sandbox *Sandbox, name string, content []byte) (string, error)
 // the next transition, synthesize the reviewer result it asks for, capture it,
 // repeat. Each capture counts as one model run.
 func captureAllLenses(r *journeyRun) error {
+	return captureAllLensesFor(r)
+}
+
+func captureAllLensesFor(r *journeyRun, selectors ...string) error {
 	for round := 0; round < 8; round++ {
-		envelope, err := readStatus(r)
+		envelope, err := readStatusFor(r, selectors...)
 		if err != nil {
 			return err
 		}
@@ -173,7 +182,11 @@ func captureAllLenses(r *journeyRun) error {
 
 // captureFinalEvidence answers the verification-evidence collect step.
 func captureFinalEvidence(r *journeyRun) error {
-	envelope, err := readStatus(r)
+	return captureFinalEvidenceFor(r)
+}
+
+func captureFinalEvidenceFor(r *journeyRun, selectors ...string) error {
+	envelope, err := readStatusFor(r, selectors...)
 	if err != nil {
 		return err
 	}

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -13,6 +14,8 @@ const (
 	correctedDeliveryLineage = "wave-one-corrected-delivery"
 	retrySourceLineage       = "wave-one-final-verification-source"
 	retrySuccessorLineage    = "wave-one-final-verification-successor"
+	stagedRecoveryLineage    = "wave-one-staged-recovery-source"
+	stagedSuccessorLineage   = "wave-one-staged-recovery-successor"
 )
 
 var startNamedCapability = &Capability{Verb: []string{"review", "start"}, Flags: []string{"--cwd", "--lineage"}}
@@ -35,7 +38,8 @@ type waveOperationResult struct {
 }
 
 type waveCorrectionStatus struct {
-	Authority *struct {
+	TargetIdentity string `json:"target_identity"`
+	Authority      *struct {
 		LineageID string `json:"lineage_id"`
 		State     string `json:"state"`
 		Revision  string `json:"revision"`
@@ -44,7 +48,9 @@ type waveCorrectionStatus struct {
 		Status   string `json:"status"`
 		Identity string `json:"identity"`
 	} `json:"receipt"`
-	Projection struct {
+	Action            string `json:"action"`
+	ActionDisposition string `json:"action_disposition"`
+	Projection        struct {
 		Kind                    string `json:"kind"`
 		InitialSnapshotIdentity string `json:"initial_snapshot_identity"`
 		CurrentSnapshotIdentity string `json:"current_snapshot_identity"`
@@ -193,8 +199,100 @@ func stageWaveCandidate(sandbox *Sandbox) error {
 	return nil
 }
 
+func commitStagedRecoveryCandidate(sandbox *Sandbox) error {
+	base, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["staged-recovery-base"] = base
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "candidate.go"), "package candidate\n\nfunc value() int {\n\treturn 1\n}\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "candidate.go"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "commit", "-qm", "feat: add reviewed candidate")
+}
+func stagedPredecessorSelectors(sandbox *Sandbox) []string {
+	return []string{"--lineage", stagedRecoveryLineage, "--base-ref", sandbox.Scratch["staged-recovery-base"]}
+}
+func stagedRecoverySelectors(sandbox *Sandbox) []string {
+	return []string{"--lineage", stagedSuccessorLineage, "--base-ref", sandbox.Scratch["staged-recovery-base"], "--projection", "staged", "--workspace-overlay"}
+}
+func stageExpandedCorrection(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "candidate.go"), "package candidate\n\nfunc value() int {\n\treturn 2\n}\n"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "migration.sql"), "CREATE TABLE recovered (id INTEGER);\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "candidate.go", "migration.sql"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "README.md"), "# unstaged noise\n"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "scratch.txt"), "untracked noise\n"); err != nil {
+		return err
+	}
+	tree, err := gitOut(sandbox, sandbox.Repo, "write-tree")
+	sandbox.Scratch["staged-recovery-tree"] = tree
+	return err
+}
+
+func recoverStagedCorrection(r *journeyRun) error {
+	selectors := stagedRecoverySelectors(r.sandbox)
+	selectors[1] = stagedRecoveryLineage
+	probeObservation := r.run(productArgsFor(r, append([]string{"review", "status", "--contract", reviewContract, "--next-transition", "--action-eligibility"}, selectors...)...), false)
+	var probe waveCorrectionStatus
+	if err := decodeWaveObservation(probeObservation, &probe, "staged recovery probe"); err != nil {
+		return err
+	}
+	if probe.Authority == nil || probe.Action != "recover" || probe.ActionDisposition != "scope_changed" || probe.NextTransition == nil || probe.NextTransition.Kind != "collect" {
+		return fmt.Errorf("staged recovery was not negotiated: %+v", probe)
+	}
+	const actor, reason = "bench-maintainer", "authorize staged correction scope expansion"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + stagedRecoveryLineage +
+		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
+		"\nsuccessor_lineage=" + stagedSuccessorLineage + "\nactor=" + actor + "\nreason=" + reason
+	authorized := append(selectors, "--recovery-successor-lineage", stagedSuccessorLineage, "--recovery-reason", reason,
+		"--recovery-actor", actor, "--recovery-authorization", authorization)
+	envelope, err := readStatusFor(r, authorized...)
+	if err != nil || envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
+		return fmt.Errorf("authorized staged recovery is not executable: %+v, %v", envelope.NextTransition, err)
+	}
+	args := []string{"review", "recover", "--cwd", r.sandbox.Repo}
+	for _, argument := range envelope.NextTransition.Execute.Arguments {
+		args = append(args, argument.Token)
+	}
+	result, err := decodeWaveOperation(r.run(args, false), "staged correction recovery")
+	if err != nil || result.LineageID != stagedSuccessorLineage || result.State != "reviewing" {
+		return fmt.Errorf("staged correction successor = %+v, %v", result, err)
+	}
+	fresh, err := readStatusFor(r, stagedRecoverySelectors(r.sandbox)...)
+	if err != nil || fresh.Authority.LineageID != stagedSuccessorLineage || fresh.Authority.State != "reviewing" ||
+		fresh.NextTransition.Kind != "collect" || strings.Join(fresh.paths(), "\x00") != "candidate.go\x00migration.sql" {
+		return fmt.Errorf("successor did not start a fresh exact-overlay review: %+v, %v", fresh, err)
+	}
+	return nil
+}
+
+func commitRecoveredStagedOverlay(sandbox *Sandbox) error {
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "fix: deliver staged recovery"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "restore", "README.md"); err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(sandbox.Repo, "scratch.txt"))
+}
+
 func captureCorrectableFinding(r *journeyRun) error {
-	envelope, err := readStatus(r)
+	return captureCorrectableFindingFor(r)
+}
+
+func captureCorrectableFindingFor(r *journeyRun, selectors ...string) error {
+	envelope, err := readStatusFor(r, selectors...)
 	if err != nil {
 		return err
 	}
@@ -229,7 +327,7 @@ func captureCorrectableFinding(r *journeyRun) error {
 	if observation.ExitCode != 0 {
 		return fmt.Errorf("capture blocking reviewer result: %s", firstLine(observation.Stderr))
 	}
-	return captureAllLenses(r)
+	return captureAllLensesFor(r, selectors...)
 }
 
 func writeCorrectedCandidate(sandbox *Sandbox) error {
@@ -381,6 +479,9 @@ func requireGateForLineage(observation Observation, lineage string, baseRelation
 		return fmt.Errorf("gate did not allow lineage %q with the required binding: %+v", lineage, gate)
 	}
 	return nil
+}
+func requireStagedSuccessorGate(_ *Sandbox, observation Observation) error {
+	return requireGateForLineage(observation, stagedSuccessorLineage, false)
 }
 
 func proveCorrectedPrePush(sandbox *Sandbox, observation Observation) error {
@@ -604,6 +705,33 @@ func waveOneJourneys() []Journey {
 					After: func(_ *Sandbox, observation Observation) error {
 						return requireGateForLineage(observation, retrySuccessorLineage, false)
 					}},
+			},
+		},
+		{
+			ID:     "j46-correction-required-staged-recovery",
+			Title:  "Correction-required base diff: negotiated staged recovery receives a fresh review and delivers",
+			Source: "issue #1921",
+			Steps: []Step{
+				{Name: "fixture: linked worktree and remote", Fixture: linkedWorktreeWithRemote},
+				{Name: "fixture: commit base-diff candidate", Fixture: commitStagedRecoveryCandidate},
+				{Name: "start workspace-projected base-diff review", Requires: startNamedCapability, Args: func(s *Sandbox) ([]string, error) {
+					return append([]string{"review", "start", "--lineage", stagedRecoveryLineage, "--base-ref", s.Scratch["staged-recovery-base"], "--committed-only"}, "--cwd", s.Repo), nil
+				}},
+				{Name: "capture blocker on predecessor", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
+					return captureCorrectableFindingFor(r, stagedPredecessorSelectors(r.sandbox)...)
+				}},
+				{Name: "enter correction-required", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", stagedRecoveryLineage, "--captured-results=true")},
+				{Name: "forecast correction", Requires: finalizeCorrectionCapability, Args: productArgs("review", "finalize", "--lineage", stagedRecoveryLineage, "--correction-lines", "3")},
+				{Name: "fixture: exact correction and migration staged with noise outside index", Fixture: stageExpandedCorrection},
+				{Name: "negotiate and execute staged recovery", Requires: recoverCapability, Composite: recoverStagedCorrection},
+				{Name: "fresh successor reviewer pass", Requires: captureResultCapability, Composite: func(r *journeyRun) error { return captureAllLensesFor(r, stagedRecoverySelectors(r.sandbox)...) }},
+				{Name: "finish successor review", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", stagedSuccessorLineage, "--captured-results=true")},
+				{Name: "capture successor verification", Requires: captureOutcomeEvidenceCapability, Composite: func(r *journeyRun) error { return captureFinalEvidenceFor(r, stagedRecoverySelectors(r.sandbox)...) }},
+				{Name: "approve fresh successor", Requires: finalizeEvidenceCapability, Args: productArgs("review", "finalize", "--lineage", stagedSuccessorLineage, "--captured-evidence=true")},
+				{Name: "gate exact staged candidate at pre-commit", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", stagedSuccessorLineage, "--gate", "pre-commit"), After: requireStagedSuccessorGate},
+				{Name: "fixture: commit reviewed overlay and remove unstaged noise", Fixture: commitRecoveredStagedOverlay},
+				{Name: "gate recovered delivery at pre-push", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", stagedSuccessorLineage, "--gate", "pre-push"), After: requireStagedSuccessorGate},
+				{Name: "gate recovered delivery at pre-pr", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", stagedSuccessorLineage, "--gate", "pre-pr", "--base-ref", "origin/feature"), After: requireStagedSuccessorGate},
 			},
 		},
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -863,7 +863,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 						}
 						stagedScopeRecovery := result.Action == reviewtransaction.TargetStatusActionRecover &&
 							result.ActionDisposition == reviewtransaction.RecoveryScopeChanged &&
-							record.State.State == reviewtransaction.StateApproved &&
+							(record.State.State == reviewtransaction.StateApproved || record.State.State == reviewtransaction.StateCorrectionRequired) &&
 							record.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseDiff &&
 							target.Kind == reviewtransaction.TargetBaseWorkspaceOverlay &&
 							selector.Projection == reviewtransaction.ProjectionStaged && selector.WorkspaceOverlay
@@ -1125,7 +1125,7 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 		*actor = reviewAuditActor(context.Background(), root)
 		*reason = reviewSelfRecoveryReason(shape)
 		successorForBinding := ""
-		if stagedScopeOverlay && predecessorRecord.State.State == reviewtransaction.StateApproved {
+		if stagedScopeOverlay && (predecessorRecord.State.State == reviewtransaction.StateApproved || predecessorRecord.State.State == reviewtransaction.StateCorrectionRequired) {
 			successorForBinding = *successor
 		}
 		*authorization = reviewTransitionRecoveryAuthorization(ReviewTransitionBinding{LineageID: *predecessor, Revision: *expected, TargetIdentity: snapshot.Identity}, successorForBinding, *actor, *reason)

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -326,6 +326,107 @@ func TestStatusRecoverTransitionExecutesApprovedStagedScopeExpansion(t *testing.
 	}
 }
 
+func TestStatusRecoverTransitionExecutesCorrectionRequiredStagedScopeExpansion(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int {\n\treturn 1\n}\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add reviewed candidate")
+
+	const predecessorLineage = "correction-staged-root"
+	var startedOut bytes.Buffer
+	if err := RunReviewFacadeStart([]string{
+		"--cwd", repo, "--lineage", predecessorLineage, "--base-ref", base, "--committed-only",
+	}, &startedOut); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, startedOut.Bytes(), &started)
+	if len(started.SelectedLenses) == 0 {
+		t.Fatal("base-diff fixture selected no reviewer lenses")
+	}
+	finalizeArgs := []string{"--cwd", repo, "--lineage", predecessorLineage}
+	for index, lens := range started.SelectedLenses {
+		result := facadeReviewerResult{Lens: lens, Findings: []facadeFinding{}, Evidence: []string{"reviewed exact base diff"}}
+		if index == 0 {
+			result.Findings = []facadeFinding{{
+				Location: "candidate.go:4", Severity: "CRITICAL", Claim: "candidate returns the wrong value",
+				ProofRefs: []string{"candidate.go:4 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+				CausalDisposition: reviewtransaction.CausalIntroduced,
+			}}
+		}
+		path := filepath.Join(t.TempDir(), "reviewer.json")
+		writeReviewCLIJSON(t, path, result)
+		finalizeArgs = append(finalizeArgs, "--result", path)
+	}
+	if err := finalizeReviewCLIArgs(t, repo, finalizeArgs, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{
+		"--cwd", repo, "--lineage", predecessorLineage, "--correction-lines", "3",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	predecessorStore, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, predecessorLineage)
+	predecessor, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateBefore, _ := os.ReadFile(predecessorStore.StatePath())
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int {\n\treturn 2\n}\n", 0o644)
+	writeReviewStartCandidate(t, repo, "migration.sql", "CREATE TABLE recovered (id INTEGER);\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go", "migration.sql")
+	writeReviewStartCandidate(t, repo, "tracked.txt", "unstaged divergence\n", 0o644)
+	writeReviewStartCandidate(t, repo, "scratch.txt", "untracked noise\n", 0o644)
+	wantTree := strings.TrimSpace(runReviewCLIGit(t, repo, "write-tree"))
+
+	selectors := []string{
+		"--lineage", predecessorLineage, "--base-ref", base, "--projection", "staged", "--workspace-overlay",
+	}
+	probe := selectorTransitionStatus(t, repo, selectors...)
+	if probe.Action != reviewtransaction.TargetStatusActionRecover || probe.ActionDisposition != reviewtransaction.RecoveryScopeChanged ||
+		probe.NextTransition == nil || probe.NextTransition.Collect == nil {
+		t.Fatalf("correction-required staged scope probe = %#v", probe)
+	}
+	const successor, actor, reason = "correction-staged-successor", "maintainer", "authorize staged correction scope expansion"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + predecessorLineage +
+		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
+		"\nsuccessor_lineage=" + successor + "\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo, append(selectors,
+		"--recovery-successor-lineage", successor, "--recovery-reason", reason,
+		"--recovery-actor", actor, "--recovery-authorization", authorization)...)
+	executeSelectorTransition(t, repo, status)
+
+	successorStore, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, successor)
+	recovered, err := successorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := recovered.State
+	if state.State != reviewtransaction.StateReviewing || state.InitialSnapshot.Kind != reviewtransaction.TargetBaseWorkspaceOverlay ||
+		state.InitialSnapshot.Projection != reviewtransaction.ProjectionStaged || state.InitialSnapshot.CandidateTree != wantTree ||
+		!reflect.DeepEqual(state.GenesisPaths, []string{"candidate.go", "migration.sql"}) {
+		t.Fatalf("recovered staged successor = %#v", state)
+	}
+	if state.CorrectionBudget != predecessor.State.CorrectionBudget ||
+		!state.CorrectionAttemptConsumed() || len(state.CorrectionAttempts) != 0 || state.CumulativeCorrectionLines != 0 ||
+		state.Recovery == nil || state.Recovery.ConsumedCorrectionAttempts != 1 || state.Recovery.ConsumedCorrectionLines != 3 {
+		t.Fatalf("recovered correction accounting = %#v, predecessor = %#v", state, predecessor.State)
+	}
+	if len(state.LensResults) != 0 || len(state.Findings) != 0 || state.EvidenceHash != "" || state.ProposedCorrectionLines != nil ||
+		state.ActualCorrectionLines != nil || state.CorrectionVerificationTarget != nil {
+		t.Fatalf("recovered successor inherited review or verification evidence: %#v", state)
+	}
+	if _, err := os.Stat(successorStore.ReceiptPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fresh correction successor receipt = %v", err)
+	}
+	stateAfter, _ := os.ReadFile(predecessorStore.StatePath())
+	if !bytes.Equal(stateBefore, stateAfter) || strings.TrimSpace(runReviewCLIGit(t, repo, "write-tree")) != wantTree {
+		t.Fatal("staged correction recovery mutated predecessor authority or index")
+	}
+}
+
 func TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -229,15 +229,17 @@ const (
 )
 
 type CompactRecoveryProvenance struct {
-	PredecessorLineageID    string                              `json:"predecessor_lineage_id"`
-	PredecessorRevision     string                              `json:"predecessor_revision"`
-	Disposition             RecoveryDisposition                 `json:"disposition"`
-	Reason                  string                              `json:"reason"`
-	Actor                   string                              `json:"actor"`
-	RecoveredAt             time.Time                           `json:"recovered_at"`
-	MaintainerAuthorization string                              `json:"maintainer_authorization,omitempty"`
-	Evidence                *CompactRecoveredEvidence           `json:"evidence,omitempty"`
-	FinalVerificationRetry  *CompactFinalVerificationRetryProof `json:"final_verification_retry,omitempty"`
+	PredecessorLineageID       string                              `json:"predecessor_lineage_id"`
+	PredecessorRevision        string                              `json:"predecessor_revision"`
+	Disposition                RecoveryDisposition                 `json:"disposition"`
+	Reason                     string                              `json:"reason"`
+	Actor                      string                              `json:"actor"`
+	RecoveredAt                time.Time                           `json:"recovered_at"`
+	MaintainerAuthorization    string                              `json:"maintainer_authorization,omitempty"`
+	ConsumedCorrectionAttempts int                                 `json:"consumed_correction_attempts,omitempty"`
+	ConsumedCorrectionLines    int                                 `json:"consumed_correction_lines,omitempty"`
+	Evidence                   *CompactRecoveredEvidence           `json:"evidence,omitempty"`
+	FinalVerificationRetry     *CompactFinalVerificationRetryProof `json:"final_verification_retry,omitempty"`
 }
 
 // CompactRecoveredEvidence is the self-contained provenance for the only
@@ -362,6 +364,14 @@ func (state CompactState) Validate() error {
 		if recovery.FinalVerificationRetry != nil && recovery.Disposition != RecoveryFinalVerificationRetry {
 			return errors.New("only final-verification retry recovery may carry final-verification source proof")
 		}
+		if recovery.ConsumedCorrectionAttempts < 0 || recovery.ConsumedCorrectionAttempts > MaxCompactCorrectionAttempts ||
+			recovery.ConsumedCorrectionLines < 0 || recovery.ConsumedCorrectionLines > state.CorrectionBudget ||
+			recovery.ConsumedCorrectionAttempts == 0 && recovery.ConsumedCorrectionLines != 0 {
+			return errors.New("compact recovery correction accounting is invalid") // refusal:by-design world-action: malformed persisted accounting cannot be repaired without replacing its provider-owned authority
+		}
+		if recovery.ConsumedCorrectionAttempts > 0 && recovery.Disposition != RecoveryScopeChanged {
+			return errors.New("only scope-changed recovery may preserve consumed correction accounting") // refusal:by-design world-action: contradictory persisted recovery provenance requires code or storage repair
+		}
 	}
 	if err := validateCompactResultDispositions(state); err != nil {
 		return err
@@ -421,7 +431,8 @@ func (state CompactState) Validate() error {
 		return errors.New("compact selected lenses are invalid")
 	}
 	wantBudget, err := CorrectionBudget(state.OriginalChangedLines)
-	if err != nil || state.CorrectionBudget != wantBudget {
+	preservedRecoveryBudget := state.Recovery != nil && state.Recovery.ConsumedCorrectionAttempts > 0
+	if err != nil || state.CorrectionBudget != wantBudget && !preservedRecoveryBudget {
 		return errors.New("compact correction budget does not match original changed lines")
 	}
 	if state.LensResults == nil || state.Findings == nil || state.Classifications == nil || state.Outcomes == nil || state.FixFindingIDs == nil || state.FollowUps == nil {
@@ -1234,7 +1245,11 @@ func compactPristineReviewing(state CompactState) bool {
 // ordinary correction append. Historical records may remain readable without
 // regaining permission to mutate their predecessor authority.
 func (state CompactState) CorrectionAttemptConsumed() bool {
-	return len(state.CorrectionAttempts) >= MaxCompactCorrectionAttempts
+	consumed := len(state.CorrectionAttempts)
+	if state.Recovery != nil {
+		consumed += state.Recovery.ConsumedCorrectionAttempts
+	}
+	return consumed >= MaxCompactCorrectionAttempts
 }
 
 func (state *CompactState) BeginCorrection(proposed int) error {
@@ -1398,6 +1413,9 @@ type CompactEscalationAccounting struct {
 // Validate() invariant is required.
 func (state CompactState) EscalationAccounting() CompactEscalationAccounting {
 	spent := state.CumulativeCorrectionLines
+	if state.Recovery != nil {
+		spent += state.Recovery.ConsumedCorrectionLines
+	}
 	// A correction forecast that never ran still crossed the budget:
 	// BeginCorrection escalates on CumulativeCorrectionLines+proposed and
 	// leaves ActualCorrectionLines nil, so for that shape the lines that

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -252,16 +252,21 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if predecessor.Revision != request.ExpectedPredecessorRevision {
 		return CompactRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
 	}
-	stagedScopeRecovery := request.Disposition == RecoveryScopeChanged &&
+	approvedStagedScopeRecovery := request.Disposition == RecoveryScopeChanged &&
 		compactApprovedStagedScopeRecoveryShape(predecessor.State, request.Successor.InitialSnapshot)
+	correctionStagedScopeRecovery := request.Disposition == RecoveryScopeChanged &&
+		compactCorrectionRequiredStagedScopeRecoveryShape(predecessor.State, request.Successor.InitialSnapshot)
+	stagedScopeRecovery := approvedStagedScopeRecovery || correctionStagedScopeRecovery
 	var predecessorReceipt compactTargetReceiptObservation
 	if stagedScopeRecovery {
 		if request.MaintainerAuthorization != compactApprovedStagedScopeRecoveryAuthorizationBinding(
 			request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity,
 			request.Successor.LineageID, request.Actor, request.Reason,
 		) {
-			return CompactRecord{}, errors.New("approved staged scope recovery requires an exact successor-bound maintainer authorization")
+			return CompactRecord{}, errors.New("staged scope recovery requires an exact successor-bound maintainer authorization") // refusal:by-design human-authority: only a maintainer can authorize this exact successor edge
 		}
+	}
+	if approvedStagedScopeRecovery {
 		predecessorReceipt, err = inspectCompactTargetReceipt(predecessorStore, predecessor.State)
 		if err != nil || !predecessorReceipt.published ||
 			!bytes.Equal(predecessorReceipt.artifact.content, predecessorReceipt.artifact.canonical) {
@@ -275,7 +280,18 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 			return CompactRecord{}, errors.New("approved staged scope recovery is not a complete same-base index expansion")
 		}
 	}
-	if predecessor.State.State == StateCorrectionRequired && request.Disposition != RecoveryEscalated && request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
+	correctionLines := 0
+	if correctionStagedScopeRecovery {
+		var eligible bool
+		correctionLines, eligible, err = compactCorrectionRequiredStagedScopeRecovery(ctx, successorStore.repo, predecessor.State, request.Successor.InitialSnapshot)
+		if err != nil {
+			return CompactRecord{}, err
+		}
+		if !eligible {
+			return CompactRecord{}, errors.New("correction-required staged scope recovery is not a complete same-base index expansion") // refusal:by-design world-action: the operator must restage the exact same-base correction scope before retrying
+		}
+	}
+	if predecessor.State.State == StateCorrectionRequired && request.Disposition != RecoveryEscalated && !correctionStagedScopeRecovery && request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
 		return CompactRecord{}, errors.New("correction-required scope recovery requires an exact maintainer authorization binding")
 	}
 	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) &&
@@ -312,6 +328,11 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 		PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
 		Disposition: request.Disposition, Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
 		RecoveredAt: request.RecoveredAt.UTC(), MaintainerAuthorization: strings.TrimSpace(request.MaintainerAuthorization),
+	}
+	if correctionStagedScopeRecovery {
+		request.Successor.CorrectionBudget = predecessor.State.CorrectionBudget
+		request.Successor.Recovery.ConsumedCorrectionAttempts = MaxCompactCorrectionAttempts
+		request.Successor.Recovery.ConsumedCorrectionLines = correctionLines
 	}
 	if request.Disposition == RecoveryEscalated {
 		evidence, eligible, evidenceErr := deriveCompactRecoveredEvidence(ctx, successorStore.repo, predecessorStore, predecessor, request.Successor)
@@ -371,7 +392,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if err := validateCompactRepositoryEvidence(ctx, successorStore.repo, nil, request.Successor, "review/start"); err != nil {
 		return CompactRecord{}, fmt.Errorf("%w: %v", ErrInvalidSuccessor, err)
 	}
-	if stagedScopeRecovery {
+	if approvedStagedScopeRecovery {
 		currentReceipt, receiptErr := inspectCompactTargetReceipt(predecessorStore, predecessor.State)
 		if receiptErr != nil || currentReceipt.published != predecessorReceipt.published ||
 			!compactTargetArtifactObservationsEqual(currentReceipt.artifact, predecessorReceipt.artifact) {
@@ -412,12 +433,21 @@ func compactRecoveryScopeChanged(previous, next Snapshot) bool {
 }
 
 func compactApprovedStagedScopeRecoveryShape(predecessor CompactState, next Snapshot) bool {
+	return predecessor.State == StateApproved && compactStagedScopeRecoverySnapshotShape(predecessor, next)
+}
+
+func compactCorrectionRequiredStagedScopeRecoveryShape(predecessor CompactState, next Snapshot) bool {
+	return predecessor.State == StateCorrectionRequired && predecessor.ProposedCorrectionLines != nil &&
+		!predecessor.CorrectionAttemptConsumed() && compactStagedScopeRecoverySnapshotShape(predecessor, next)
+}
+
+func compactStagedScopeRecoverySnapshotShape(predecessor CompactState, next Snapshot) bool {
 	initial := predecessor.InitialSnapshot
 	initialProjection := initial.Projection
 	if initialProjection == "" {
 		initialProjection = ProjectionWorkspace
 	}
-	return predecessor.State == StateApproved && initial.Kind == TargetBaseDiff &&
+	return initial.Kind == TargetBaseDiff &&
 		initialProjection == ProjectionWorkspace && next.Kind == TargetBaseWorkspaceOverlay &&
 		next.Projection == ProjectionStaged && next.BaseTree == initial.BaseTree &&
 		len(initial.IntendedUntracked) == 0 && len(initial.LedgerIDs) == 0 &&
@@ -431,6 +461,35 @@ func compactApprovedStagedScopeRecovery(ctx context.Context, repo string, predec
 	if !compactApprovedStagedScopeRecoveryShape(predecessor, next) {
 		return false, nil
 	}
+	return compactStagedScopeRecovery(ctx, repo, predecessor, next)
+}
+
+func compactCorrectionRequiredStagedScopeRecovery(ctx context.Context, repo string, predecessor CompactState, next Snapshot) (int, bool, error) {
+	if !compactCorrectionRequiredStagedScopeRecoveryShape(predecessor, next) {
+		return 0, false, nil
+	}
+	eligible, err := compactStagedScopeRecovery(ctx, repo, predecessor, next)
+	if err != nil || !eligible {
+		return 0, eligible, err
+	}
+	builder := SnapshotBuilder{Repo: repo}
+	paths, err := builder.changedPaths(ctx, predecessor.CurrentSnapshot.CandidateTree, next.CandidateTree)
+	if err != nil {
+		return 0, false, err
+	}
+	lines, err := builder.ChangedLines(ctx, Snapshot{
+		BaseTree: predecessor.CurrentSnapshot.CandidateTree, CandidateTree: next.CandidateTree, Paths: paths,
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if lines > predecessor.CorrectionBudget {
+		return 0, false, fmt.Errorf("staged correction is %d changed lines, exceeding the frozen budget of %d", lines, predecessor.CorrectionBudget) // refusal:by-design world-action: the staged correction must be reduced or receive a separate maintainer decision
+	}
+	return lines, true, nil
+}
+
+func compactStagedScopeRecovery(ctx context.Context, repo string, predecessor CompactState, next Snapshot) (bool, error) {
 	committed, err := (SnapshotBuilder{Repo: repo}).Build(ctx, Target{
 		Kind: TargetBaseDiff, Projection: ProjectionStaged,
 		BaseRef: predecessor.InitialSnapshot.BaseTree, IntendedUntracked: []string{},
@@ -483,8 +542,14 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 	if successor.Generation != predecessor.State.Generation+1 {
 		return errors.New("recovery successor generation must follow predecessor")
 	}
-	stagedScopeRecovery := recovery.Disposition == RecoveryScopeChanged &&
+	approvedStagedScopeRecovery := recovery.Disposition == RecoveryScopeChanged &&
 		compactApprovedStagedScopeRecoveryShape(predecessor.State, successor.InitialSnapshot)
+	correctionStagedScopeRecovery := recovery.Disposition == RecoveryScopeChanged &&
+		compactCorrectionRequiredStagedScopeRecoveryShape(predecessor.State, successor.InitialSnapshot)
+	stagedScopeRecovery := approvedStagedScopeRecovery || correctionStagedScopeRecovery
+	if recovery.ConsumedCorrectionAttempts > 0 && !correctionStagedScopeRecovery {
+		return errors.New("only correction-required staged recovery may preserve consumed correction accounting") // refusal:by-design world-action: forged cross-edge accounting cannot be rebound to a different recovery shape
+	}
 	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, successor.InitialSnapshot.Projection) &&
 		recovery.Disposition != RecoveryEscalated && !stagedScopeRecovery {
 		return errors.New("recovery successor must retain the predecessor projection")
@@ -516,6 +581,18 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 		case StateCorrectionRequired:
 			if strings.TrimSpace(recovery.MaintainerAuthorization) == "" {
 				return errors.New("correction-required scope recovery requires explicit maintainer authorization")
+			}
+			if correctionStagedScopeRecovery {
+				if recovery.MaintainerAuthorization != compactApprovedStagedScopeRecoveryAuthorizationBinding(
+					predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity,
+					successor.LineageID, recovery.Actor, recovery.Reason,
+				) {
+					return errors.New("correction-required staged scope recovery authorization is not successor-bound") // refusal:by-design human-authority: only a maintainer can issue the exact successor-bound authorization
+				}
+				if successor.CorrectionBudget != predecessor.State.CorrectionBudget ||
+					recovery.ConsumedCorrectionAttempts != MaxCompactCorrectionAttempts {
+					return errors.New("correction-required staged scope recovery did not preserve correction accounting") // refusal:by-design world-action: provider-built authority contradicted its predecessor and requires a code fix
+				}
 			}
 			if forgedSchemaAuthorization() {
 				return compactRecoveryAuthorizationError(successor.InitialSnapshot)

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -174,6 +174,17 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 				continue
 			}
 		}
+		if state.State == StateCorrectionRequired {
+			_, eligible, eligibilityErr := compactCorrectionRequiredStagedScopeRecovery(ctx, repo, state, live)
+			if eligibilityErr != nil {
+				return targetStatusFailure(base, eligibilityErr)
+			}
+			if eligible {
+				candidate.correctionRecovery, candidate.recoveryDisposition = true, RecoveryScopeChanged
+				candidates = append(candidates, candidate)
+				continue
+			}
+		}
 		// The same predicates START uses to refuse a fresh lineage against an
 		// approved predecessor: either the frozen delivery scope has a changed
 		// candidate, or a disjoint base advance preserves the exact feature patch.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1921

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Recover a `correction_required`, workspace-projected base-diff into a fresh successor bound to the same base and the exact staged workspace overlay.
- Preserve the predecessor correction budget and consumed correction accounting while excluding unstaged content and inherited approval, reviewer results, receipts, or verification evidence.
- Keep the boundary narrow: this PR explicitly excludes #1925 committed corrections and does not alter committed-correction reconstruction.

Authored change size: exactly 400 changed lines (374 additions and 26 deletions); no `size:exception` is required.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys.go` | Allow status, reviewer capture, and final evidence helpers to carry explicit selectors. |
| `bench/journeys_wave1.go` | Add `j46-correction-required-staged-recovery` across recover, fresh review, pre-commit, pre-push, and pre-PR. |
| `internal/cli/review_facade.go` | Route negotiated staged-overlay recovery for eligible `correction_required` base-diff predecessors. |
| `internal/cli/review_selector_transition_test.go` | Prove exact staged bytes, noise exclusion, accounting continuity, fresh successor state, and predecessor immutability. |
| `internal/reviewtransaction/compact.go` | Persist and validate consumed correction attempts and lines in recovery provenance. |
| `internal/reviewtransaction/compact_store.go` | Enforce same-base, exact-index, CAS-bound staged correction recovery and preserve correction accounting. |
| `internal/reviewtransaction/target_status.go` | Discover the eligible correction-required staged recovery transition. |

---

## 🧪 Test Plan

**Independent verification: PASS**

**Unit and static tests**
```bash
go test ./... -count=1
go vet ./...
```

**Benchmark module**
```bash
cd bench
go test ./...
go vet ./...
go build ./...
```

- Focused CLI recovery coverage and staged-overlay negative controls passed.
- `j46-correction-required-staged-recovery` ran twice; each run completed 20 commands, 0 blocks, and 2 reviewer proxies/model runs.
- The native `pre-commit` lifecycle gate exited successfully with `delivery: disabled/unmanaged` and `action: repository-policy`; no review transaction or approval was created.
- Delivery revalidated base `72f014561d0e6d62fb679176cc213dd31b8a7f35`, seven paths, 374 additions, 26 deletions, clean whitespace, and unchanged `100644` modes.
- Go format and Docker E2E were not rerun during delivery because source bytes were frozen; their PR checks remain authoritative.

- [x] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — pending PR check
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending PR check
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — pending PR check
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending PR check
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The recovery edge is intentionally limited to a `correction_required` workspace base-diff with a positive frozen forecast and an exact same-base staged-overlay expansion. Authorization is bound to the predecessor revision, successor lineage, target identity, actor, and reason; the successor starts a fresh review and consumes the predecessor's correction allowance.

This does not include #1925 committed corrections.

**Rollback boundary:** revert commit `f6b04e540dc03e65303887cd3605cac103171f38`. The revert removes only this staged-overlay recovery edge and its test/benchmark coverage, restoring the prior fail-closed behavior without changing #1925 committed-correction handling or persisted schemas outside the additive recovery-provenance fields.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [ ] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staged recovery for reviews requiring correction, including authorized scope expansion and successor review creation.
  * Added workflow support for capturing fresh evidence and delivering recovered changes while removing unrelated workspace changes.
  * Added validation for correction budgets, consumed attempts, changed lines, and successor authorization.

* **Bug Fixes**
  * Corrected recovery eligibility and status handling for correction-required reviews.
  * Improved isolation between predecessor and successor reviews, preventing inherited evidence or state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->