### PR TITLE
fix(sdd): honor disabled archive mode for discovered receipts

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -306,7 +306,7 @@ invents a metric is worse than one that admits a gap.
    classifier reads a field other than exit code and denial shape, and widening
    it would let the product talk its way out of a denial.
 
-7. **The corpus is honest, not exhaustive.** Forty-five core journeys that run
+7. **The corpus is honest, not exhaustive.** Forty-seven core journeys that run
    end to end, weighted toward failure paths because that is where friction
    lives. Testing-guide flows 1 (install) and 8 (no phantom SDD artifacts) are
    inspection steps rather than review-lifecycle friction and are not modelled.
@@ -388,7 +388,7 @@ invents a metric is worse than one that admits a gap.
     (cluttered repositories, interleaved lifecycles) governed by a different
     growth rule: community-reported shapes become journeys, so its size tracks
     community reports, not releases, and folding it into the core would make
-    "45 journeys" a moving claim. Two of its numbers need careful reading.
+    "47 journeys" a moving claim. Two of its numbers need careful reading.
     `rw01` pins issue #1881 while a product fix is in flight: a block there is
     the truth about today's build, not a permanent verdict, and the journey is
     kept precisely so the fix has a permanent pin. And the no-echo assertions
@@ -431,7 +431,7 @@ completed; nothing was unsupported. Re-running produces byte-identical numbers,
 
 Those numbers are the **14-journey** corpus against the binary named above,
 kept as-is because they belong to that named build. The corpus has since grown
-to 45 journeys; re-run `run` against your own binary rather than reading the
+to 47 journeys; re-run `run` against your own binary rather than reading the
 block above as current totals. The row labels moved too: `by_design` did not
 exist when this was recorded and is now printed as `4d`, next to the number it
 carves out of, with `dead_end` at `4e`.
@@ -565,14 +565,16 @@ cannot silently decay into the already-covered corrupt-record case.
 
 ### Wave 1 integration regressions (`journeys_wave1.go`)
 
-Journeys 44 and 45 pin fixes that internal tests already covered below the user
-boundary. Both remain core black-box journeys: fixtures create only Git state,
-and every review state is reached through the measured binary.
+Journeys 44 to 47 pin fixes that internal tests already covered below the user
+boundary. All remain core black-box journeys: fixtures create repository inputs,
+and every native authority state is reached through the measured binary.
 
 | ID | Flow | Shape |
 |---|---|---|
 | `j44-corrected-current-changes-delivery` | corrected current-changes receipt in a proven linked worktree, exact one-commit delivery, selector-free pre-push discovery | issue #1819 + 3 |
 | `j45-completed-final-verification-retry` | procedural final-verification failure, status-derived retry successor, successful completion, authoritative inventory and selector-free post-apply | issue #1915 + 3 |
+| `j46-correction-required-staged-recovery` | correction-required base-diff authority, negotiated staged-overlay recovery, fresh successor review, exact pre-commit/pre-push/pre-PR delivery | issue #1921 |
+| `j47-disabled-mode-archives-discovered-invalidated-receipt` | enabled discovered invalidation, disabled/unmanaged archive without allow, explicit invalid receipt control, and re-enabled enforcement | issue #2128 |
 
 `j44` proves the linked checkout/common-dir topology and remote baseline before
 review starts, then proves the staged delivery tree equals the corrected receipt
@@ -581,6 +583,10 @@ and `HEAD` is exactly one clean commit above upstream before pre-push runs.
 from negotiated status fields, then requires the global inventory to report the
 predecessor as `superseded`, the approved successor as `recovered`, and the
 inventory as complete and authoritative before selector-free post-apply runs.
+`j46` proves the staged overlay is the exact authorized recovery target and
+delivers only through its fresh approved successor. `j47` preserves one native
+authority revision while review mode is toggled, proving that only discovered
+governance steps aside and an explicit invalid receipt remains fail-closed.
 
 ## Opt-in axes
 
@@ -602,7 +608,7 @@ its own declaration.
 
 - **Nothing runs unless you name it.** Default is the core alone. `--axis all`
   takes everything registered. An unknown name is a hard error, because
-  "45 journeys" and "45 journeys plus an axis" are different measurements and a
+  "47 journeys" and "47 journeys plus an axis" are different measurements and a
   typo must never silently produce the first.
 - **The core does not depend on any axis.** `rm bench/axis_damaged_store*.go`
   leaves the corpus compiling, testing and reporting exactly the numbers it

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -643,6 +644,90 @@ func proveCompletedRetryInventory(_ *Sandbox, observation Observation) error {
 	return nil
 }
 
+func rememberArchiveAuthority(sandbox *Sandbox, observation Observation) error {
+	if err := rememberLineage(sandbox, observation); err != nil {
+		return err
+	}
+	if sandbox.Lineage == "" || sandbox.Revision == "" {
+		return errors.New("approved archive authority published no lineage or revision")
+	}
+	sandbox.Scratch["archive-authority-revision"] = sandbox.Revision
+	return nil
+}
+
+func requireDiscoveredArchivePremise(_ *Sandbox, observation Observation) error {
+	return sddStatusAssertion("discovered receipt premise", func(status sddStatusV1) error {
+		if status.ReviewGate == nil || status.ReviewGate.Result != "allow" || status.ReviewGate.Delivery != "" {
+			return fmt.Errorf("reviewGate = %+v, want discovered allow without a delivery override", status.ReviewGate)
+		}
+		if status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" || len(status.BlockedReasons) != 0 {
+			return fmt.Errorf("archive=%q next=%q blocked=%v, want ready/archive with no blockers",
+				status.Dependencies.Archive, status.NextRecommended, status.BlockedReasons)
+		}
+		return nil
+	})(nil, observation)
+}
+
+func requireDiscoveredArchiveStatus(disabled bool) func(*Sandbox, Observation) error {
+	return sddStatusAssertion("discovered invalidated archive authority", func(status sddStatusV1) error {
+		if status.ReviewGate == nil || status.ReviewGate.Result != "invalidated" {
+			return fmt.Errorf("reviewGate = %+v, want invalidated", status.ReviewGate)
+		}
+		if !strings.Contains(status.ReviewGate.Reason, "review receipt was invalidated") {
+			return fmt.Errorf("reviewGate.reason = %q, want the discovered authority reason", status.ReviewGate.Reason)
+		}
+		if disabled {
+			if status.ReviewGate.Delivery != deliveryDisabledUnmanaged || status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" {
+				return fmt.Errorf("disabled gate=%+v archive=%q next=%q, want invalidated disabled/unmanaged ready/archive",
+					status.ReviewGate, status.Dependencies.Archive, status.NextRecommended)
+			}
+			return nil
+		}
+		if status.ReviewGate.Delivery != "" || status.Dependencies.Archive != "blocked" || status.NextRecommended != "resolve-review" {
+			return fmt.Errorf("enabled gate=%+v archive=%q next=%q, want invalidated blocked/resolve-review",
+				status.ReviewGate, status.Dependencies.Archive, status.NextRecommended)
+		}
+		return nil
+	})
+}
+
+func introduceArchiveGateInvalidation(sandbox *Sandbox) error {
+	return sandbox.write(filepath.Join(sandbox.Repo, "outside-reviewed-scope.txt"), "unreviewed\n")
+}
+
+func writeExplicitInvalidArchiveReceipt(sandbox *Sandbox) error {
+	return sandbox.write(filepath.Join(sddChangeRoot(sandbox), "reviews", "receipt.json"), "{\n")
+}
+
+func requireExplicitInvalidArchiveStatus(_ *Sandbox, observation Observation) error {
+	return sddStatusAssertion("explicit invalid archive authority", func(status sddStatusV1) error {
+		if status.ReviewGate == nil || status.ReviewGate.Result != "invalidated" || status.ReviewGate.Delivery != "" {
+			return fmt.Errorf("reviewGate = %+v, want explicit invalidated without disabled delivery", status.ReviewGate)
+		}
+		if !strings.Contains(status.ReviewGate.Reason, "invalid or non-terminal") || status.Dependencies.Archive != "blocked" || status.NextRecommended != "resolve-review" {
+			return fmt.Errorf("explicit gate=%+v archive=%q next=%q, want fail-closed blocked/resolve-review",
+				status.ReviewGate, status.Dependencies.Archive, status.NextRecommended)
+		}
+		return nil
+	})(nil, observation)
+}
+
+func proveArchiveAuthorityUnchanged(sandbox *Sandbox) error {
+	head, err := proveAuthorities(sandbox)
+	if err != nil {
+		return err
+	}
+	for _, entry := range head.Entries {
+		if entry.LineageID == sandbox.Lineage {
+			if entry.State != "approved" || entry.Revision != sandbox.Scratch["archive-authority-revision"] {
+				return fmt.Errorf("archive authority changed to state=%q revision=%q", entry.State, entry.Revision)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("archive authority %q disappeared", sandbox.Lineage)
+}
+
 func waveOneJourneys() []Journey {
 	return []Journey{
 		{
@@ -732,6 +817,33 @@ func waveOneJourneys() []Journey {
 				{Name: "fixture: commit reviewed overlay and remove unstaged noise", Fixture: commitRecoveredStagedOverlay},
 				{Name: "gate recovered delivery at pre-push", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", stagedSuccessorLineage, "--gate", "pre-push"), After: requireStagedSuccessorGate},
 				{Name: "gate recovered delivery at pre-pr", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", stagedSuccessorLineage, "--gate", "pre-pr", "--base-ref", "origin/feature"), After: requireStagedSuccessorGate},
+			},
+		},
+		{
+			ID:     "j47-disabled-mode-archives-discovered-invalidated-receipt",
+			Title:  "Discovered invalidated archive receipt: disabled mode steps aside without weakening explicit authority",
+			Source: "issue #2128",
+			Steps: []Step{
+				{Name: "fixture: archive-ready SDD change", Fixture: sddPlanningArtifacts(sddVerifyReport)},
+				{Name: "fixture: stage the reviewed candidate", Fixture: stageProse("", "archive-authority")},
+				{Name: "review start", Requires: startCapability, Args: productArgs("review", "start")},
+				{Name: "review finalize", Requires: finalizeCapability, Args: productArgs("review", "finalize"), After: rememberArchiveAuthority},
+				{Name: "discovered receipt allows before invalidation", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: requireDiscoveredArchivePremise},
+				{Name: "fixture: add untracked content outside the reviewed scope", Fixture: introduceArchiveGateInvalidation},
+				{Name: "enabled discovered receipt blocks", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: requireDiscoveredArchiveStatus(false)},
+				{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+				{Name: "disabled discovered receipt closes unmanaged", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: requireDiscoveredArchiveStatus(true)},
+				{Name: "mode enable", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--json")},
+				{Name: "re-enabled discovered receipt blocks again", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: requireDiscoveredArchiveStatus(false)},
+				{Name: "fixture: write an explicit invalid receipt", Fixture: writeExplicitInvalidArchiveReceipt},
+				{Name: "mode disable with explicit receipt", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+				{Name: "disabled explicit invalid receipt still blocks", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: requireExplicitInvalidArchiveStatus},
+				{Name: "authority remained approved at its original revision", Fixture: proveArchiveAuthorityUnchanged},
 			},
 		},
 	}

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -287,9 +287,9 @@ type reviewAuthorityEvaluation struct {
 	Reason       string
 	CompactState *reviewtransaction.CompactState
 	// Absent reports that no review authority GOVERNS this change: the change
-	// supplied no review artifact, and discovery found either no terminal
-	// native receipt at all or only receipts that verifiably stopped covering
-	// the current repository state. That is the implicit demand the kill
+	// supplied no review artifact, and discovery found either no terminal native
+	// receipt or only receipts whose terminal evaluation cannot govern the
+	// current change. That is the implicit demand the kill
 	// switch removes — issue #1877's disabled window delivers under ordinary
 	// repository policy and is recorded as unmanaged, never blocked on a
 	// review the switch refuses to run. An explicit change-bound artifact that
@@ -324,10 +324,9 @@ func resolveCompactRemediationAuthority(ctx context.Context, repo, change string
 	return evaluation.CompactState
 }
 
-// errTerminalReceiptMissing is the one discovery outcome that means "no review
-// authority exists", as opposed to "a review authority exists and does not
-// govern these bytes". Only the first is the implicit demand the kill switch
-// removes, so it is a sentinel rather than a message to match on.
+// errTerminalReceiptMissing distinguishes an empty terminal inventory from
+// discovery failures that must remain fail-closed. It is a sentinel rather than
+// a message to match on so the empty-inventory reason can name a fresh review.
 var errTerminalReceiptMissing = errors.New("terminal review receipt is missing")
 
 // reviewGateDisabledUnmanagedReason names the situation before the mechanism:
@@ -433,11 +432,12 @@ func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptConte
 			Absent: !explicit,
 		}
 	}
-	// Escalations and validation failures block regardless of provenance: an
-	// artifact that asked receipt-driven development to act is validated in
-	// full even while the switch is off.
+	// Escalations and validation failures still block while review is enabled.
+	// While disabled, only an explicit artifact continues to govern the change.
 	if len(blockers) > 0 {
-		return blockers[0]
+		selected := blockers[0]
+		selected.Absent = !explicit
+		return selected
 	}
 	selected := stale[0]
 	// An empty-candidate receipt means the operator already ran the plain

--- a/internal/sddstatus/review_gate_disabled_test.go
+++ b/internal/sddstatus/review_gate_disabled_test.go
@@ -1,6 +1,8 @@
 package sddstatus
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -197,6 +199,99 @@ func TestDisabledArchiveGateStillValidatesAnExplicitReviewReceipt(t *testing.T) 
 	if status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "resolve-review" {
 		t.Fatalf("explicit receipt while disabled archive=%q next=%q, want blocked/resolve-review",
 			status.Dependencies.Archive, status.NextRecommended)
+	}
+}
+
+func TestDiscoveredTerminalBlockerRespectsReviewModeProvenance(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     reviewtransaction.GateResult
+		wantReason string
+	}{
+		{name: "invalidated", result: reviewtransaction.GateInvalidated, wantReason: "review receipt was invalidated"},
+		{name: "escalated", result: reviewtransaction.GateEscalated, wantReason: "escalated the receipt"},
+	}
+
+	original := evaluateNativeReviewGate
+	t.Cleanup(func() { evaluateNativeReviewGate = original })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedBoundedReadyChange(t, root)
+			writeApprovedReviewArtifacts(t, changeRoot)
+			receiptPath := filepath.Join(changeRoot, "reviews", "receipt.json")
+			receipt, err := os.ReadFile(receiptPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(receiptPath); err != nil {
+				t.Fatal(err)
+			}
+			store, err := reviewtransaction.AuthoritativeStore(context.Background(), root, "thin-lineage")
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err := store.LoadChain()
+			if err != nil {
+				t.Fatal(err)
+			}
+			evaluateNativeReviewGate = func(context.Context, string, reviewtransaction.Receipt, reviewtransaction.GateRequest) reviewtransaction.NativeGateEvaluation {
+				return reviewtransaction.NativeGateEvaluation{Result: tt.result}
+			}
+
+			assertBlocked := func(label string, status Status) {
+				t.Helper()
+				if status.ReviewGate == nil || status.ReviewGate.Result != tt.result || status.ReviewGate.Delivery != "" {
+					t.Fatalf("%s gate = %#v, want %q without delivery", label, status.ReviewGate, tt.result)
+				}
+				if status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "resolve-review" {
+					t.Fatalf("%s archive=%q next=%q, want blocked/resolve-review", label, status.Dependencies.Archive, status.NextRecommended)
+				}
+			}
+
+			enabled, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertBlocked("enabled discovered", enabled)
+
+			disabled, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", ReviewDisabled: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if disabled.ReviewGate == nil || disabled.ReviewGate.Result != tt.result || disabled.ReviewGate.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
+				t.Fatalf("disabled discovered gate = %#v, want %q disabled/unmanaged", disabled.ReviewGate, tt.result)
+			}
+			if disabled.Dependencies.Archive == DependencyBlocked || disabled.NextRecommended == "resolve-review" {
+				t.Fatalf("disabled discovered archive=%q next=%q, want unmanaged archive route", disabled.Dependencies.Archive, disabled.NextRecommended)
+			}
+			if !strings.Contains(disabled.ReviewGate.Reason, tt.wantReason) {
+				t.Fatalf("disabled discovered reason = %q, want underlying %q", disabled.ReviewGate.Reason, tt.wantReason)
+			}
+
+			reenabled, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertBlocked("re-enabled discovered", reenabled)
+
+			if err := os.WriteFile(receiptPath, receipt, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			explicit, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", ReviewDisabled: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertBlocked("disabled explicit", explicit)
+
+			after, err := store.LoadChain()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after.HeadRevision != before.HeadRevision {
+				t.Fatalf("authority revision changed from %q to %q", before.HeadRevision, after.HeadRevision)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #2128

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)

## Summary

- Preserve archive blocking for discovered invalidated or escalated receipts while review mode is enabled.
- Record `Absent = !explicit` on discovered terminal blockers: `Absent` describes provenance, meaning no explicit change-bound authority governs the candidate. When review mode is disabled, that discovered authority therefore yields `disabled/unmanaged`, never `allow`, and ordinary repository policy controls archive delivery.
- Keep explicit invalid authority and unreadable review mode fail-closed, without mutating native authority. Issue #2069's apply/pre-verify and remediation-routing behavior is intentionally excluded.

## Behavior Contract

| Authority and mode | Result |
|---|---|
| Discovered invalidated/escalated, enabled | Archive remains blocked and routes to `resolve-review`. |
| Discovered invalidated/escalated, disabled | Existing result and reason remain visible; delivery is `disabled/unmanaged`, never `allow`, and archive follows ordinary policy. |
| Same discovered authority after re-enable | Archive blocks again. |
| Explicit invalid authority, disabled | Remains fail-closed and blocked. |
| Unreadable mode authority | Remains fail-closed. |

The production change only annotates the selected discovered blocker with `Absent = !explicit`. It does not rewrite receipts, advance or repair authority, alter the authority head, or broaden the change into #2069.

## Changes

| File / Area | What Changed |
|---|---|
| `internal/sddstatus/review_gate.go` | Preserve blocker result/reason while carrying explicit-versus-discovered provenance into disabled-mode routing. |
| `internal/sddstatus/review_gate_disabled_test.go` | Cover invalidated and escalated blockers across enabled, disabled, re-enabled, discovered, and explicit authority, including authority immutability. |
| `bench/journeys_wave1.go` | Add j47 black-box evidence for the archive premise, invalidation, mode toggle, explicit control, re-enable behavior, and original authority revision. |
| `bench/README.md` | Document j46/j47 and the complete 47-journey core corpus. |

## j47 Evidence

`j47-disabled-mode-archives-discovered-invalidated-receipt` proves the process boundary in this order:

1. Establishes the premise before invalidation: the discovered receipt returns `allow`, archive is `ready`, next is `archive`, and there are no blockers or delivery override.
2. Adds untracked content outside the reviewed scope to invalidate discovery without mutating native authority.
3. Confirms enabled mode blocks archive.
4. Disables review mode and confirms the discovered authority reports `disabled/unmanaged`, archive-ready routing, and never `allow`.
5. Re-enables review mode and confirms the same discovered authority blocks again.
6. Supplies an explicit invalid receipt while disabled and confirms fail-closed blocking.
7. Confirms the native authority remains approved at its original revision.

## Review Boundary

The PR changes exactly four files and 249 lines: 231 additions and 18 deletions. The rollback boundary is this single commit: reverting it restores the prior blocker-provenance behavior and removes its focused tests, j47, and corpus documentation. There is no schema migration, persisted-authority mutation, or data rollback.

## Test Plan

Independent read-only revalidation passed on base `713604cd0ae49fd9166f1f559afe16a88a5db41a` with the exact patch SHA-256 `49b49f2c5fe21713ec7441e2786fe28dca34fa41620d1d2fbedbbdb771f0cce9`:

- Focused `sddstatus` and CLI tests passed.
- Uncached root `go test ./... -count=1` passed.
- Root `go vet ./...` passed.
- Bench tests, vet, and build passed.
- j47 completed twice with 10 measured commands, zero unsupported, and zero failed each time.
- The full 47-journey core corpus completed with zero unsupported and zero failed.
- `git diff --check` passed.

Delivery-time validation preserved that exact patch hash after staging. The selector-free `review validate --gate pre-commit` gate ran with effective review mode off and returned `delivery: disabled/unmanaged`, `allowed: false`, and ordinary repository policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review-status handling when required receipts are missing or invalid.
  - Disabled review mode now permits archive progression for implicitly discovered blockers while preserving their unmanaged status.
  - Explicitly supplied receipts remain enforced, and re-enabled review mode continues to block unresolved issues.
  - Preserved review authority and underlying diagnostic details during status changes.

- **Documentation**
  - Updated benchmark documentation to cover 47 core journeys, including staged recovery and disabled-mode handling of invalidated receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->