### PR TITLE
fix(review): preserve full candidate scope after correction

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -306,7 +306,7 @@ invents a metric is worse than one that admits a gap.
    classifier reads a field other than exit code and denial shape, and widening
    it would let the product talk its way out of a denial.
 
-7. **The corpus is honest, not exhaustive.** Forty-seven core journeys that run
+7. **The corpus is honest, not exhaustive.** Forty-eight core journeys that run
    end to end, weighted toward failure paths because that is where friction
    lives. Testing-guide flows 1 (install) and 8 (no phantom SDD artifacts) are
    inspection steps rather than review-lifecycle friction and are not modelled.
@@ -388,7 +388,7 @@ invents a metric is worse than one that admits a gap.
     (cluttered repositories, interleaved lifecycles) governed by a different
     growth rule: community-reported shapes become journeys, so its size tracks
     community reports, not releases, and folding it into the core would make
-    "47 journeys" a moving claim. Two of its numbers need careful reading.
+    "48 journeys" a moving claim. Two of its numbers need careful reading.
     `rw01` pins issue #1881 while a product fix is in flight: a block there is
     the truth about today's build, not a permanent verdict, and the journey is
     kept precisely so the fix has a permanent pin. And the no-echo assertions
@@ -431,7 +431,7 @@ completed; nothing was unsupported. Re-running produces byte-identical numbers,
 
 Those numbers are the **14-journey** corpus against the binary named above,
 kept as-is because they belong to that named build. The corpus has since grown
-to 47 journeys; re-run `run` against your own binary rather than reading the
+to 48 journeys; re-run `run` against your own binary rather than reading the
 block above as current totals. The row labels moved too: `by_design` did not
 exist when this was recorded and is now printed as `4d`, next to the number it
 carves out of, with `dead_end` at `4e`.
@@ -565,7 +565,7 @@ cannot silently decay into the already-covered corrupt-record case.
 
 ### Wave 1 integration regressions (`journeys_wave1.go`)
 
-Journeys 44 to 47 pin fixes that internal tests already covered below the user
+Journeys 44 to 48 pin fixes that internal tests already covered below the user
 boundary. All remain core black-box journeys: fixtures create repository inputs,
 and every native authority state is reached through the measured binary.
 
@@ -575,6 +575,7 @@ and every native authority state is reached through the measured binary.
 | `j45-completed-final-verification-retry` | procedural final-verification failure, status-derived retry successor, successful completion, authoritative inventory and selector-free post-apply | issue #1915 + 3 |
 | `j46-correction-required-staged-recovery` | correction-required base-diff authority, negotiated staged-overlay recovery, fresh successor review, exact pre-commit/pre-push/pre-PR delivery | issue #1921 |
 | `j47-disabled-mode-archives-discovered-invalidated-receipt` | enabled discovered invalidation, disabled/unmanaged archive without allow, explicit invalid receipt control, and re-enabled enforcement | issue #2128 |
+| `j48-recovered-workspace-preserves-full-candidate-scope` | two-path workspace candidate, strict-subset correction, complete terminal and recovered scope, immediate pre-commit allow, byte/path drift controls | issue #2090 |
 
 `j44` proves the linked checkout/common-dir topology and remote baseline before
 review starts, then proves the staged delivery tree equals the corrected receipt
@@ -587,6 +588,9 @@ inventory as complete and authoritative before selector-free post-apply runs.
 delivers only through its fresh approved successor. `j47` preserves one native
 authority revision while review mode is toggled, proving that only discovered
 governance steps aside and an explicit invalid receipt remains fail-closed.
+`j48` keeps one-path correction evidence local while corrected and recovered
+authority retain the complete two-path tree and manifest; exact pre-commit
+targets allow, while later byte and path drift still fail closed.
 
 ## Opt-in axes
 
@@ -608,7 +612,7 @@ its own declaration.
 
 - **Nothing runs unless you name it.** Default is the core alone. `--axis all`
   takes everything registered. An unknown name is a hard error, because
-  "47 journeys" and "47 journeys plus an axis" are different measurements and a
+  "48 journeys" and "48 journeys plus an axis" are different measurements and a
   typo must never silently produce the first.
 - **The core does not depend on any axis.** `rm bench/axis_damaged_store*.go`
   leaves the corpus compiling, testing and reporting exactly the numbers it

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -17,6 +17,8 @@ const (
 	retrySuccessorLineage    = "wave-one-final-verification-successor"
 	stagedRecoveryLineage    = "wave-one-staged-recovery-source"
 	stagedSuccessorLineage   = "wave-one-staged-recovery-successor"
+	fullScopeLineage         = "wave-one-full-scope-source"
+	fullScopeSuccessor       = "wave-one-full-scope-successor"
 )
 
 var startNamedCapability = &Capability{Verb: []string{"review", "start"}, Flags: []string{"--cwd", "--lineage"}}
@@ -52,14 +54,17 @@ type waveCorrectionStatus struct {
 	Action            string `json:"action"`
 	ActionDisposition string `json:"action_disposition"`
 	Projection        struct {
-		Kind                    string `json:"kind"`
-		InitialSnapshotIdentity string `json:"initial_snapshot_identity"`
-		CurrentSnapshotIdentity string `json:"current_snapshot_identity"`
-		CurrentCandidateTree    string `json:"current_candidate_tree"`
+		Kind                    string   `json:"kind"`
+		InitialSnapshotIdentity string   `json:"initial_snapshot_identity"`
+		CurrentSnapshotIdentity string   `json:"current_snapshot_identity"`
+		CurrentCandidateTree    string   `json:"current_candidate_tree"`
+		PathsDigest             string   `json:"paths_digest"`
+		Paths                   []string `json:"paths"`
 	} `json:"projection"`
 	ValidationRequest *struct {
 		RequestHash              string `json:"request_hash"`
 		CorrectionTargetIdentity string `json:"correction_target_identity"`
+		CorrectionPathsDigest    string `json:"correction_paths_digest"`
 	} `json:"validation_request"`
 	NextTransition *struct {
 		Kind       string `json:"kind"`
@@ -112,6 +117,10 @@ type waveGateResult struct {
 	Context struct {
 		LineageID             string `json:"lineage_id"`
 		BaseRelationshipValid bool   `json:"base_relationship_valid"`
+		Denial                *struct {
+			Stage string `json:"stage"`
+			Code  string `json:"code"`
+		} `json:"denial"`
 	} `json:"context"`
 }
 
@@ -196,6 +205,23 @@ func stageWaveCandidate(sandbox *Sandbox) error {
 	}
 	if paths != "candidate.go" || staged+"\n" != candidate {
 		return fmt.Errorf("fixture did not stage only the exact candidate: paths %q, content %q", paths, staged)
+	}
+	return nil
+}
+
+func stageFullScopeCandidate(sandbox *Sandbox) error {
+	if err := stageWaveCandidate(sandbox); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "companion.txt"), "reviewed companion\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "companion.txt"); err != nil {
+		return err
+	}
+	paths, err := gitOut(sandbox, sandbox.Repo, "diff", "--cached", "--name-only")
+	if err != nil || paths != "candidate.go\ncompanion.txt" {
+		return fmt.Errorf("full-scope fixture paths = %q, %v", paths, err)
 	}
 	return nil
 }
@@ -347,13 +373,21 @@ func writeCorrectedCandidate(sandbox *Sandbox) error {
 }
 
 func readCorrectionStatus(r *journeyRun) (waveCorrectionStatus, error) {
-	observation := r.run(productArgsFor(r, "review", "status", "--contract", reviewContract, "--next-transition", "--lineage", correctedDeliveryLineage), false)
+	return readCorrectionStatusFor(r, correctedDeliveryLineage)
+}
+
+func readCorrectionStatusFor(r *journeyRun, lineage string) (waveCorrectionStatus, error) {
+	observation := r.run(productArgsFor(r, "review", "status", "--contract", reviewContract, "--next-transition", "--lineage", lineage), false)
 	var status waveCorrectionStatus
 	return status, decodeWaveObservation(observation, &status, "corrected review status")
 }
 
 func capturePassedCorrectionEvidence(r *journeyRun) error {
-	status, err := readCorrectionStatus(r)
+	return capturePassedCorrectionEvidenceFor(r, correctedDeliveryLineage)
+}
+
+func capturePassedCorrectionEvidenceFor(r *journeyRun, lineage string) error {
+	status, err := readCorrectionStatusFor(r, lineage)
 	if err != nil {
 		return err
 	}
@@ -373,11 +407,16 @@ func capturePassedCorrectionEvidence(r *journeyRun) error {
 	}
 	r.sandbox.Scratch["validation-request"] = status.ValidationRequest.RequestHash
 	r.sandbox.Scratch["correction-target"] = status.ValidationRequest.CorrectionTargetIdentity
+	r.sandbox.Scratch["correction-paths"] = status.ValidationRequest.CorrectionPathsDigest
 	return nil
 }
 
 func completeCorrectedReview(r *journeyRun) error {
-	status, err := readCorrectionStatus(r)
+	return completeCorrectedReviewFor(r, correctedDeliveryLineage)
+}
+
+func completeCorrectedReviewFor(r *journeyRun, lineage string) error {
+	status, err := readCorrectionStatusFor(r, lineage)
 	if err != nil {
 		return err
 	}
@@ -400,13 +439,13 @@ func completeCorrectedReview(r *journeyRun) error {
 	if err != nil {
 		return err
 	}
-	observation := r.run(productArgsFor(r, "review", "finalize", "--lineage", correctedDeliveryLineage,
+	observation := r.run(productArgsFor(r, "review", "finalize", "--lineage", lineage,
 		"--validation", path, "--captured-evidence=true"), false)
 	result, err := decodeWaveOperation(observation, "corrected review finalize")
 	if err != nil {
 		return err
 	}
-	if result.State != "approved" || result.LineageID != correctedDeliveryLineage {
+	if result.State != "approved" || result.LineageID != lineage {
 		return fmt.Errorf("corrected review finalized as %+v", result)
 	}
 	return nil
@@ -437,6 +476,85 @@ func stageCorrectedTree(sandbox *Sandbox) error {
 	}
 	if tree != sandbox.Scratch["corrected-tree"] {
 		return fmt.Errorf("staged corrected tree %s does not match receipt tree %s", tree, sandbox.Scratch["corrected-tree"])
+	}
+	return nil
+}
+
+func stageFullCorrectedTree(sandbox *Sandbox) error {
+	if err := sandbox.git(sandbox.Repo, "add", "candidate.go"); err != nil {
+		return err
+	}
+	tree, err := gitOut(sandbox, sandbox.Repo, "write-tree")
+	if err == nil {
+		sandbox.Scratch["full-scope-tree"] = tree
+	}
+	return err
+}
+
+func proveFullScopeStatus(lineage, treeKey string) func(*Sandbox, Observation) error {
+	return func(sandbox *Sandbox, observation Observation) error {
+		var status waveCorrectionStatus
+		if err := decodeWaveObservation(observation, &status, "full-scope status"); err != nil {
+			return err
+		}
+		if status.Authority == nil || status.Authority.LineageID != lineage || status.Authority.State != "approved" ||
+			status.Receipt.Status != "present" || status.Projection.CurrentCandidateTree != sandbox.Scratch[treeKey] ||
+			strings.Join(status.Projection.Paths, "\x00") != "candidate.go\x00companion.txt" || status.Projection.PathsDigest == "" ||
+			status.Projection.PathsDigest == sandbox.Scratch["correction-paths"] {
+			return fmt.Errorf("full-scope authority was narrowed: %+v", status)
+		}
+		return nil
+	}
+}
+
+func driftFullScopeCandidate(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "companion.txt"), "reviewed companion after recovery\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "companion.txt"); err != nil {
+		return err
+	}
+	tree, err := gitOut(sandbox, sandbox.Repo, "write-tree")
+	if err == nil {
+		sandbox.Scratch["recovered-tree"] = tree
+	}
+	return err
+}
+
+func recoverFullScopeCandidate(r *journeyRun) error {
+	observation := r.run(productArgsFor(r, "review", "validate", "--lineage", fullScopeLineage, "--gate", "pre-commit"), false)
+	var denial gateDenial
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &denial); err != nil {
+		return fmt.Errorf("parse full-scope denial: %w", err)
+	}
+	change := denial.Context.ScopeChange
+	if denial.Result != "scope-changed" || change.PredecessorLineageID != fullScopeLineage || change.PredecessorRevision == "" {
+		return fmt.Errorf("full-scope drift did not negotiate recovery: %+v", denial)
+	}
+	result, err := decodeWaveOperation(r.run(productArgsFor(r, "review", "recover",
+		"--predecessor-lineage", change.PredecessorLineageID, "--expected-predecessor-revision", change.PredecessorRevision,
+		"--successor-lineage", fullScopeSuccessor, "--disposition", "scope_changed"), false), "full-scope recovery")
+	if err != nil || result.LineageID != fullScopeSuccessor || result.State != "reviewing" {
+		return fmt.Errorf("full-scope successor = %+v, %v", result, err)
+	}
+	return nil
+}
+
+func addFullScopePathDrift(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "outside.txt"), "outside reviewed scope\n"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "add", "outside.txt")
+}
+
+func requireFullScopeDrift(_ *Sandbox, observation Observation) error {
+	var gate waveGateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate); err != nil {
+		return fmt.Errorf("parse full-scope path drift: %w", err)
+	}
+	if gate.Allowed || gate.Result != "scope-changed" || gate.Context.Denial == nil ||
+		gate.Context.Denial.Stage != "receipt-binding" || gate.Context.Denial.Code != "candidate-or-paths-mismatch" {
+		return fmt.Errorf("path drift did not fail closed: %+v", gate)
 	}
 	return nil
 }
@@ -844,6 +962,39 @@ func waveOneJourneys() []Journey {
 				{Name: "disabled explicit invalid receipt still blocks", Requires: sddStatusCapability,
 					Args: productArgs("sdd-status", sddChange, "--json"), After: requireExplicitInvalidArchiveStatus},
 				{Name: "authority remained approved at its original revision", Fixture: proveArchiveAuthorityUnchanged},
+			},
+		},
+		{
+			ID:     "j48-recovered-workspace-preserves-full-candidate-scope",
+			Title:  "Recovered workspace correction: terminal authorities preserve the complete candidate scope",
+			Source: "issue #2090",
+			Steps: []Step{
+				{Name: "fixture: repository", Fixture: baseRepo},
+				{Name: "fixture: two-path candidate staged", Fixture: stageFullScopeCandidate},
+				{Name: "start two-path review", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", fullScopeLineage)},
+				{Name: "capture blocker and complete lenses", Requires: captureResultCapability, Composite: captureCorrectableFinding},
+				{Name: "enter correction-required", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", fullScopeLineage, "--captured-results=true")},
+				{Name: "forecast strict-subset correction", Requires: finalizeCorrectionCapability, Args: productArgs("review", "finalize", "--lineage", fullScopeLineage, "--correction-lines", "2")},
+				{Name: "fixture: correction touches only candidate.go", Fixture: writeCorrectedCandidate},
+				{Name: "capture correction-local repository evidence", Requires: captureOutcomeEvidenceCapability, Composite: func(r *journeyRun) error { return capturePassedCorrectionEvidenceFor(r, fullScopeLineage) }},
+				{Name: "approve corrected full candidate", Requires: finalizeValidationCapability, Composite: func(r *journeyRun) error { return completeCorrectedReviewFor(r, fullScopeLineage) }},
+				{Name: "fixture: stage exact corrected candidate", Fixture: stageFullCorrectedTree},
+				{Name: "corrected authority preserves full tree and paths", Requires: statusCapability, Args: productArgs("review", "status", "--contract", reviewContract, "--lineage", fullScopeLineage), After: proveFullScopeStatus(fullScopeLineage, "full-scope-tree")},
+				{Name: "immediate corrected pre-commit allows", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", fullScopeLineage, "--gate", "pre-commit"), After: func(_ *Sandbox, observation Observation) error {
+					return requireGateForLineage(observation, fullScopeLineage, false)
+				}},
+				{Name: "fixture: reviewed companion bytes drift", Fixture: driftFullScopeCandidate},
+				{Name: "follow scope denial into recovered successor", Requires: recoverCapability, Composite: recoverFullScopeCandidate},
+				{Name: "complete successor lenses", Requires: captureResultCapability, Composite: func(r *journeyRun) error { return captureAllLensesFor(r, "--lineage", fullScopeSuccessor) }},
+				{Name: "finish successor review", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", fullScopeSuccessor, "--captured-results=true")},
+				{Name: "capture successor verification", Requires: captureOutcomeEvidenceCapability, Composite: func(r *journeyRun) error { return captureFinalEvidenceFor(r, "--lineage", fullScopeSuccessor) }},
+				{Name: "approve recovered successor", Requires: finalizeEvidenceCapability, Args: productArgs("review", "finalize", "--lineage", fullScopeSuccessor, "--captured-evidence=true")},
+				{Name: "successor preserves full tree and paths", Requires: statusCapability, Args: productArgs("review", "status", "--contract", reviewContract, "--lineage", fullScopeSuccessor), After: proveFullScopeStatus(fullScopeSuccessor, "recovered-tree")},
+				{Name: "immediate successor pre-commit allows", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", fullScopeSuccessor, "--gate", "pre-commit"), After: func(_ *Sandbox, observation Observation) error {
+					return requireGateForLineage(observation, fullScopeSuccessor, false)
+				}},
+				{Name: "fixture: add path outside recovered scope", Fixture: addFullScopePathDrift},
+				{Name: "path drift still fails closed", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", fullScopeSuccessor, "--gate", "pre-commit"), After: requireFullScopeDrift},
 			},
 		},
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2526,14 +2526,18 @@ func prepareFacadeFinalizePlan(ctx context.Context, repo, revision string, state
 		if err != nil {
 			return plan, err
 		}
+		complete, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).BuildCorrectedCandidate(ctx, state.InitialSnapshot, fix)
+		if err != nil {
+			return plan, err
+		}
 		native, err := validation.compact(reviewtransaction.FixDeltaHashForSnapshot(fix), state.FixFindingIDs, request)
 		if err != nil {
 			return plan, err
 		}
-		if err := state.CompleteCorrectionVerification(fix, actual, native, captured.Record, captured.Payload); err != nil {
+		if err := state.CompleteCorrectionVerification(fix, actual, native, captured.Record, captured.Payload, complete); err != nil {
 			return plan, err
 		}
-		plan.Candidate = fix
+		plan.Candidate = complete
 		appendState("review/complete-correction-verification")
 	}
 	if state.State == reviewtransaction.StateValidating {

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -2049,11 +2049,12 @@ func TestCompactTransportAllowsCorrectedPrePushWithoutTransientBaseObject(t *tes
 	clone := filepath.Join(t.TempDir(), "clone")
 	runReviewCLIGit(t, source, "clone", "--no-local", source, clone)
 	runReviewCLIGit(t, source, "branch", "reviewed-base", "HEAD^")
-	for _, tree := range []string{initial.State.InitialSnapshot.CandidateTree, sourceRecord.State.CurrentSnapshot.BaseTree} {
-		command := exec.Command("git", "-C", clone, "cat-file", "-e", tree+"^{tree}")
-		if err := command.Run(); err == nil {
-			t.Fatalf("clean clone unexpectedly retained dangling intermediate tree %s", tree)
-		}
+	if sourceRecord.State.CurrentSnapshot.BaseTree != initial.State.InitialSnapshot.BaseTree {
+		t.Fatalf("corrected authority base = %s, want reviewed base %s", sourceRecord.State.CurrentSnapshot.BaseTree, initial.State.InitialSnapshot.BaseTree)
+	}
+	intermediate := initial.State.InitialSnapshot.CandidateTree
+	if err := exec.Command("git", "-C", clone, "cat-file", "-e", intermediate+"^{tree}").Run(); err == nil {
+		t.Fatalf("clean clone unexpectedly retained dangling intermediate tree %s", intermediate)
 	}
 	if err := RunReviewBundleImport([]string{"--cwd", clone, "--bundle", bundlePath}, io.Discard); err != nil {
 		t.Fatalf("corrected compact import: %v", err)

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -507,6 +507,8 @@ func validateCompactVerificationEvidence(state CompactState) error {
 	expectedTarget := state.CurrentSnapshot.Identity
 	if state.CorrectionVerificationTarget != nil {
 		expectedTarget = state.CorrectionVerificationTarget.Identity
+	} else if len(state.CorrectionAttempts) > 0 {
+		expectedTarget = state.CorrectionAttempts[len(state.CorrectionAttempts)-1].Snapshot.Identity
 	}
 	if !validSHA256(state.EvidenceHash) || !validSHA256(state.EvidenceRecordDigest) ||
 		!validSHA256(state.EvidenceTargetIdentity) || !validSHA256(state.EvidenceAuthorityRevision) ||
@@ -714,6 +716,7 @@ func validateCompactCorrection(state CompactState) error {
 		for _, attempt := range state.CorrectionAttempts {
 			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.Projection != state.InitialSnapshot.Projection || attempt.Snapshot.BaseTree != base ||
 				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.GenesisPaths) != nil ||
+				validateCompactSnapshot(attempt.Snapshot) != nil || validateCompactSnapshotMetadata(attempt.Snapshot) != nil ||
 				attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) {
 				return errors.New("compact correction attempt is outside frozen scope")
 			}
@@ -729,7 +732,9 @@ func validateCompactCorrection(state CompactState) error {
 			}
 			base, cumulative = attempt.Snapshot.CandidateTree, cumulative+attempt.ActualLines
 		}
-		if cumulative != state.CumulativeCorrectionLines || cumulative > state.CorrectionBudget && state.State != StateEscalated || !snapshotsEqual(state.CurrentSnapshot, state.CorrectionAttempts[len(state.CorrectionAttempts)-1].Snapshot) {
+		last := state.CorrectionAttempts[len(state.CorrectionAttempts)-1].Snapshot
+		if cumulative != state.CumulativeCorrectionLines || cumulative > state.CorrectionBudget && state.State != StateEscalated ||
+			!snapshotsEqual(state.CurrentSnapshot, last) && validateCompactCorrectedCandidate(state, last) != nil {
 			return errors.New("compact cumulative correction accounting is invalid")
 		}
 		if state.State == StateCorrectionRequired {
@@ -790,12 +795,16 @@ func validateCompactCorrection(state CompactState) error {
 	if state.ProposedCorrectionLines == nil || *state.ProposedCorrectionLines > state.CorrectionBudget || state.ActualCorrectionLines == nil {
 		return errors.New("completed compact correction requires in-budget forecast and actual size")
 	}
-	if state.CurrentSnapshot.Kind != TargetFixDiff || len(state.CorrectionAttempts) == 0 && state.CurrentSnapshot.BaseTree != state.InitialSnapshot.CandidateTree ||
-		!equalStrings(state.CurrentSnapshot.LedgerIDs, state.FixFindingIDs) ||
-		!equalStrings(state.CurrentSnapshot.IntendedUntracked, state.InitialSnapshot.IntendedUntracked) {
+	correction := state.CurrentSnapshot
+	if len(state.CorrectionAttempts) > 0 {
+		correction = state.CorrectionAttempts[len(state.CorrectionAttempts)-1].Snapshot
+	}
+	if correction.Kind != TargetFixDiff || len(state.CorrectionAttempts) == 0 && correction.BaseTree != state.InitialSnapshot.CandidateTree ||
+		!equalStrings(correction.LedgerIDs, state.FixFindingIDs) ||
+		!equalStrings(correction.IntendedUntracked, state.InitialSnapshot.IntendedUntracked) {
 		return errors.New("completed compact correction snapshot is not bound to the original candidate and causal findings")
 	}
-	if state.FixDeltaHash != FixDeltaHashForSnapshot(state.CurrentSnapshot) {
+	if state.FixDeltaHash != FixDeltaHashForSnapshot(correction) {
 		return errors.New("compact fix delta hash does not match the correction snapshot")
 	}
 	if state.OriginalCriteria == nil || state.CorrectionRegression == nil {
@@ -817,6 +826,18 @@ func validateCompactCorrection(state CompactState) error {
 	}
 	if (state.State == StateValidating || state.State == StateApproved) && (!state.OriginalCriteria.Passed || !state.CorrectionRegression.Passed) {
 		return errors.New("compact correction checks must both pass before validation or approval")
+	}
+	return nil
+}
+
+func validateCompactCorrectedCandidate(state CompactState, correction Snapshot) error {
+	current, initial := state.CurrentSnapshot, state.InitialSnapshot
+	if current.Kind != initial.Kind || current.Projection != initial.Projection || current.UnbornHead != correction.UnbornHead ||
+		current.BaseTree != initial.BaseTree || current.CandidateTree != correction.CandidateTree ||
+		current.IntendedUntrackedProof != correction.IntendedUntrackedProof ||
+		!equalStrings(current.IntendedUntracked, initial.IntendedUntracked) || !equalStrings(current.LedgerIDs, initial.LedgerIDs) ||
+		pathsAreSubset(current.Paths, state.GenesisPaths) != nil {
+		return errors.New("terminal correction authority does not preserve the complete reviewed candidate") // refusal:by-design world-action: contradictory persisted authority requires code or storage repair
 	}
 	return nil
 }
@@ -1320,7 +1341,10 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 // CompleteCorrectionVerification crosses the correction and repository
 // verification boundary in one state value. No correction accounting becomes
 // authoritative unless both candidate-bound checks pass.
-func (state *CompactState) CompleteCorrectionVerification(snapshot Snapshot, actual int, validation ScopedValidationResult, record VerificationEvidenceRecord, payload []byte) error {
+func (state *CompactState) CompleteCorrectionVerification(snapshot Snapshot, actual int, validation ScopedValidationResult, record VerificationEvidenceRecord, payload []byte, complete ...Snapshot) error {
+	if len(complete) > 1 {
+		return errors.New("compact correction accepts at most one complete candidate snapshot") // refusal:by-design world-action: provider code must submit one exact terminal authority
+	}
 	if record.Outcome != VerificationOutcomePassed {
 		return errors.New("compact correction repository verification must pass before acceptance") // refusal:by-design operator-knowledge: the caller must retain the open correction and submit only a passed candidate-bound verification bundle
 	}
@@ -1342,6 +1366,12 @@ func (state *CompactState) CompleteCorrectionVerification(snapshot Snapshot, act
 	}
 	if err := next.CompleteVerificationRecord(record, payload); err != nil {
 		return err
+	}
+	if len(complete) == 1 {
+		next.CurrentSnapshot = complete[0]
+		if err := next.Validate(); err != nil {
+			return err
+		}
 	}
 	*state = next
 	return nil
@@ -1501,11 +1531,15 @@ func (state CompactState) Receipt() (CompactReceipt, error) {
 	if evidence == "" {
 		evidence = EmptyFixDeltaHash
 	}
+	pathsDigest := state.CurrentSnapshot.PathsDigest
+	if state.CurrentSnapshot.Kind == TargetFixDiff {
+		pathsDigest = state.InitialSnapshot.PathsDigest
+	}
 	receipt := CompactReceipt{
 		Schema: CompactReceiptSchema, LineageID: state.LineageID, Generation: state.Generation,
 		Projection: state.InitialSnapshot.Projection,
 		BaseTree:   state.InitialSnapshot.BaseTree, InitialReviewTree: state.InitialSnapshot.CandidateTree,
-		FinalCandidateTree: state.CurrentSnapshot.CandidateTree, PathsDigest: state.InitialSnapshot.PathsDigest,
+		FinalCandidateTree: state.CurrentSnapshot.CandidateTree, PathsDigest: pathsDigest,
 		FixDeltaHash: state.FixDeltaHash, PolicyHash: state.PolicyHash, EvidenceHash: evidence,
 		EvidenceRecordDigest: state.EvidenceRecordDigest, EvidenceOutcome: state.EvidenceOutcome,
 		EvidenceTargetIdentity: state.EvidenceTargetIdentity, EvidenceAuthorityRevision: state.EvidenceAuthorityRevision,

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -1788,7 +1788,7 @@ func validateCompactRepositoryEvidence(ctx context.Context, repo string, current
 			return errors.New("compact risk inputs do not match repository evidence")
 		}
 	}
-	if operation == "review/complete-fix" {
+	if operation == "review/complete-fix" || operation == "review/complete-correction-verification" {
 		attempt := next.CorrectionAttempts[len(next.CorrectionAttempts)-1]
 		if err := builder.ValidateEvidence(ctx, attempt.Snapshot); err != nil {
 			return errors.New("compact correction snapshot is not repository-derived")
@@ -1796,6 +1796,11 @@ func validateCompactRepositoryEvidence(ctx context.Context, repo string, current
 		lines, err := builder.ChangedLines(ctx, attempt.Snapshot)
 		if err != nil || lines != attempt.ActualLines {
 			return errors.New("compact correction size does not match repository evidence")
+		}
+		if !snapshotsEqual(next.CurrentSnapshot, attempt.Snapshot) {
+			if err := builder.ValidateEvidence(ctx, next.CurrentSnapshot); err != nil {
+				return errors.New("complete corrected candidate is not repository-derived") // refusal:by-design world-action: repository drift requires rebuilding the candidate-bound finalize request
+			}
 		}
 	}
 	if operation == "review/complete-review" {
@@ -1887,7 +1892,7 @@ func validateCompactSuccessor(previousRevision string, previous, next CompactSta
 		}
 		if previous.State != StateCorrectionRequired || previous.ProposedCorrectionLines == nil || next.State != StateApproved ||
 			len(next.CorrectionAttempts) != len(previous.CorrectionAttempts)+1 || next.EvidenceOutcome != VerificationOutcomePassed ||
-			next.EvidenceAuthorityRevision != previousRevision || next.EvidenceTargetIdentity != next.CurrentSnapshot.Identity {
+			next.EvidenceAuthorityRevision != previousRevision || next.EvidenceTargetIdentity != next.CorrectionAttempts[len(next.CorrectionAttempts)-1].Snapshot.Identity {
 			return fmt.Errorf("%w: invalid atomic compact correction verification", ErrInvalidSuccessor)
 		}
 		if len(previous.CorrectionAttempts) > 0 && !reflect.DeepEqual(previous.CorrectionAttempts, next.CorrectionAttempts[:len(previous.CorrectionAttempts)]) {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -279,6 +279,42 @@ func (builder SnapshotBuilder) ValidateEvidence(ctx context.Context, snapshot Sn
 	return nil
 }
 
+// BuildCorrectedCandidate composes correction-local bytes onto the original
+// reviewed scope without rereading mutable workspace content.
+func (builder SnapshotBuilder) BuildCorrectedCandidate(ctx context.Context, initial, correction Snapshot) (Snapshot, error) {
+	if correction.Kind != TargetFixDiff || correction.Projection != initial.Projection ||
+		correction.BaseTree != initial.CandidateTree || correction.CandidateTree == correction.BaseTree ||
+		!equalStrings(correction.IntendedUntracked, initial.IntendedUntracked) {
+		return Snapshot{}, errors.New("corrected candidate requires an exact fix over the reviewed snapshot") // refusal:by-design world-action: provider code must rebuild both snapshots from one stable repository candidate
+	}
+	if err := builder.ValidateEvidence(ctx, initial); err != nil {
+		return Snapshot{}, err
+	}
+	if err := builder.ValidateEvidence(ctx, correction); err != nil {
+		return Snapshot{}, err
+	}
+	root, err := builder.repositoryRoot(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	builder.Repo = root
+	paths, err := builder.changedPaths(ctx, initial.BaseTree, correction.CandidateTree)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	complete := initial
+	complete.UnbornHead = correction.UnbornHead
+	complete.CandidateTree = correction.CandidateTree
+	complete.Paths, complete.PathsDigest = paths, digestPaths(paths)
+	complete.IntendedUntrackedProof = correction.IntendedUntrackedProof
+	complete.Identity = snapshotIdentityForProjection(complete.Kind, complete.Projection, complete.BaseTree, complete.CandidateTree,
+		complete.PathsDigest, complete.IntendedUntrackedProof, complete.IntendedUntracked, complete.LedgerIDs)
+	if err := builder.ValidateEvidence(ctx, complete); err != nil {
+		return Snapshot{}, err
+	}
+	return complete, nil
+}
+
 // ValidateLiveSnapshot proves that a frozen snapshot still describes its exact live target.
 func (builder SnapshotBuilder) ValidateLiveSnapshot(ctx context.Context, expected Snapshot) error {
 	if err := builder.ValidateEvidence(ctx, expected); err != nil {

--- a/internal/reviewtransaction/verification_evidence_test.go
+++ b/internal/reviewtransaction/verification_evidence_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -118,6 +119,108 @@ func TestCompleteCorrectionVerificationIsAtomicAndCandidateBound(t *testing.T) {
 	}
 	if _, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: before.CurrentSnapshot.CandidateTree, IntendedUntracked: before.InitialSnapshot.IntendedUntracked, LedgerIDs: before.FixFindingIDs}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCompleteCorrectionVerificationPreservesFullCandidateScope(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nwrong\n")
+	writeSnapshotFile(t, repo, "deleted.txt", "reviewed companion\n")
+	state := newCompactTestState(t, repo, "full-candidate-correction")
+	if !reflect.DeepEqual(state.GenesisPaths, []string{"deleted.txt", "tracked.txt"}) {
+		t.Fatalf("genesis paths = %v", state.GenesisPaths)
+	}
+	finding := Finding{ID: "R3-001", Lens: strings.TrimPrefix(state.SelectedLenses[0], "review-"), Location: "tracked.txt:2", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+		if index == 0 {
+			results[index].Findings = []Finding{finding}
+		}
+	}
+	if err := state.CompleteReview(CompactReviewInput{
+		LensResults:     results,
+		Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk causes failure"}},
+		RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfixed\n")
+	builder := SnapshotBuilder{Repo: repo}
+	fix, err := builder.Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	full, err := builder.BuildCorrectedCandidate(context.Background(), state.InitialSnapshot, fix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fix.Paths, []string{"tracked.txt"}) || !reflect.DeepEqual(full.Paths, state.GenesisPaths) || fix.PathsDigest == full.PathsDigest {
+		t.Fatalf("correction paths = %v (%s), full paths = %v (%s)", fix.Paths, fix.PathsDigest, full.Paths, full.PathsDigest)
+	}
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := bindTargetedValidationForTest(ScopedValidationResult{
+		LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+		OriginalCriteria:     ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: true},
+	}, fix)
+	payload := []byte("full candidate verification passed\n")
+	evidence, err := NewVerificationEvidenceRecord(state.LineageID, hash("a"), fix, payload, VerificationOutcomePassed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteCorrectionVerification(fix, 1, validation, evidence, payload, full); err != nil {
+		t.Fatal(err)
+	}
+	if !snapshotsEqual(state.CurrentSnapshot, full) || !snapshotsEqual(state.CorrectionAttempts[0].Snapshot, fix) || state.EvidenceTargetIdentity != fix.Identity {
+		t.Fatalf("terminal authority = %#v, correction = %#v", state.CurrentSnapshot, state.CorrectionAttempts[0].Snapshot)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.FinalCandidateTree != full.CandidateTree || receipt.PathsDigest != full.PathsDigest {
+		t.Fatalf("receipt tree/paths = %s/%s, want %s/%s", receipt.FinalCandidateTree, receipt.PathsDigest, full.CandidateTree, full.PathsDigest)
+	}
+	tampered := state
+	tampered.CorrectionAttempts = append([]CompactCorrectionAttempt(nil), state.CorrectionAttempts...)
+	tampered.CorrectionAttempts[0].Snapshot.PathsDigest = hash("b")
+	if _, err := tampered.Receipt(); err != nil {
+		t.Fatalf("full candidate receipt changed with correction metadata: %v", err)
+	}
+	_, tamperedPayload, err := makeCompactRecord(tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseCompactRecord(tamperedPayload, tampered.LineageID); err == nil {
+		t.Fatal("persisted record accepted tampered correction path metadata")
+	}
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	_, encoded, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "tracked.txt", "deleted.txt")
+	gate := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
+	if gate.Result != GateAllow {
+		t.Fatalf("unchanged full candidate pre-commit = %#v", gate)
+	}
+	writeSnapshotFile(t, repo, "deleted.txt", "unreviewed drift\n")
+	gitSnapshot(t, repo, "add", "deleted.txt")
+	if drift := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID}); drift.Result == GateAllow {
+		t.Fatalf("changed companion path was allowed: %#v", drift)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2090

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Correction verification deliberately binds its evidence to the correction-local `TargetFixDiff` snapshot. The completed authority previously also used that strict-subset snapshot as `CurrentSnapshot`, so its receipt could lose untouched paths from the original reviewed candidate.

This change keeps correction attempts, evidence, and validation targets correction-local while composing the immutable base-to-final candidate into the terminal `CurrentSnapshot` and receipt. Corrected authorities and recovered successors therefore preserve the complete candidate tree and path manifest.

Legacy callers and persisted records remain compatible: the complete snapshot argument is optional, existing correction-local terminal states still validate, and legacy `TargetFixDiff` receipts retain their original full paths digest behavior. Every persisted correction-attempt snapshot now also receives direct structural and canonical metadata validation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Compose and validate the complete corrected candidate while retaining correction-local attempts, evidence, compatibility, and direct persisted snapshot checks. |
| `internal/cli` | Build the complete terminal candidate during correction finalization and preserve compact transport behavior without transient tree assumptions. |
| `bench/journeys_wave1.go` | Add j48 for a two-path candidate, strict-subset correction, recovered successor, exact allows, byte drift, and path drift. |
| `bench/README.md` | Document j48 and the full 48-journey core corpus. |

---

## 🧪 Test Plan

**Independent final validation**

- Exact base: `7bbfe3b0ee6c969f6377853ef40bf576910463c3`
- Exact patch: 8 files, 368 additions and 30 deletions, 398/400 changed lines
- Patch SHA-256: `2e671ea393037871f84b0c154e6effadf60b5e21d7baf0ffe55a132f0f92c4ef`
- Final independent verdict: PASS

**Go validation**

```bash
go test -count=1 ./...
go vet ./...
go build ./cmd/gentle-ai
go run ./internal/gofmtcheck
```

Focused current and neighboring legacy correction/recovery tests passed. Uncached root tests, vet, product build, and format check passed.

**Benchmark validation**

Bench tests, vet, and build passed. j48 passed twice with 0 unsupported and 0 failed. The complete core corpus passed 48/48 with 0 unsupported and 0 failed.

The black-box journey proves that a strict-subset correction retains correction-local evidence while both the corrected authority and recovered successor bind the full candidate. Exact candidates allow; reviewed companion byte drift negotiates recovery; later path drift fails closed at receipt binding.

**Publication gate**

The staged selector-free pre-commit gate exited 0 with `delivery: disabled/unmanaged`, `allowed: false`, and ordinary repository-policy disposition. No review approval or receipt authority was created.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Docker E2E was not rerun; candidate-specific black-box j48 and the full core runtime corpus passed independently.
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | Exact candidate is 398/400 changed lines |
| Check Issue Reference | ⏳ | Body contains `Closes #2090` |
| Check Issue Has `status:approved` | ⏳ | Issue was approved before publication |
| Check PR Has `type:*` Label | ⏳ | Exactly one label: `type:bug` |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | Repository automation owns the Docker E2E run |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added exactly one appropriate `type:*` label
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to repository automation; independent black-box bench validation passed.
- [x] Benchmark validation completed
- [x] I have updated documentation
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The integrity boundary is intentional: correction evidence remains bound to the exact correction snapshot, but delivery authority binds the complete candidate. Please review the direct correction-attempt validation and the legacy `TargetFixDiff` compatibility path together with j48's strict-subset and recovered-successor controls.

Rollback is one focused revert of commit `131be7e1274daec1d8b1dee408831f1d492b100b`; it removes the snapshot composition, validation changes, j48, and corpus documentation as one independent behavior boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correction verification now preserves the full reviewed candidate, including unchanged companion paths.
  * Recovered corrections retain complete scope and reject unauthorized path drift.
  * Validation now rejects tampered correction metadata and requires repository-backed evidence.
  * Receipts and verification results accurately reflect the corrected candidate.

* **Tests**
  * Added coverage for recovered workspaces, scope preservation, pre-commit validation, and path-drift rejection.

* **Documentation**
  * Updated the benchmark corpus documentation to include the expanded 48-journey set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->