### PR TITLE
fix(manifest): disable static prompt injection for AgentPi (Slice A1)

### DIFF
--- a/internal/agents/capabilitymanifest/manifest.go
+++ b/internal/agents/capabilitymanifest/manifest.go
@@ -321,7 +321,7 @@ var featureClaimsByAgent = map[model.AgentID]AgentFeatureClaims{
 		SlashCommands: true, Skills: true, SystemPrompt: true, MCP: true,
 	},
 	model.AgentPi: {
-		SystemPrompt: true, MCP: true,
+		SystemPrompt: false, MCP: true,
 	},
 	model.AgentQwenCode: {
 		SlashCommands: true, Skills: true, SystemPrompt: true, MCP: true,

--- a/internal/agents/capabilitymanifest/manifest_test.go
+++ b/internal/agents/capabilitymanifest/manifest_test.go
@@ -141,7 +141,7 @@ func TestEveryManifestKeepsWorkRoutingDormantAndHashesCanonically(t *testing.T) 
 		model.AgentKiroIDE:       "sha256:3be196483ed199894062892c9367b3772bb66e18d6ec7b64e477ea201851a44a",
 		model.AgentOpenClaw:      "sha256:0fb9cb07a7be9174e93793678ad7cd4618c58c6a0d284be2fa1b6acd4d409014",
 		model.AgentOpenCode:      "sha256:3df2c0ee0a61774b7b7f0d547abed55721cc37ecc332c131935ce72fb142103f",
-		model.AgentPi:            "sha256:346579cb9f505086cb9e429a36e857ed7fa5880171af1ad55bf6d9a8a0d53fcd",
+		model.AgentPi:            "sha256:2c3a5912bff86ffdf785e32013e3e899d0ce9506fd733b7fad1e8f78a6036391",
 		model.AgentQwenCode:      "sha256:897dd9264f92356375d1255949e1170938222853524d4b65e62b642a04b41c52",
 		model.AgentTrae:          "sha256:65234f37e1142edae7fff865613970e6ab0433b783df2e4c05b0023fb1c31ffe",
 		model.AgentVSCodeCopilot: "sha256:d1ceedd93c41dc1c34cce4accef239ca4e1bf4a643f203d5b3f8d031c4b4117b",
@@ -210,33 +210,32 @@ func TestEveryManifestKeepsWorkRoutingDormantAndHashesCanonically(t *testing.T) 
 // TestEveryManifestDigestStaysByteStable pins that exactly 15 non-Pi agent rows
 // remain byte-stable when the Pi row is updated. The Pi row change is the only
 // expected delta from the capability flip; any other row changing is a regression.
-// This test passes against the current (pre-flip) manifest since it asserts only
-// the 15 non-Pi digests — the Pi row still carries its original hash here.
-// Commit 1 (this test) is intentionally RED-against-original-passing to establish
-// the baseline; Commit 2 flips SystemPrompt and updates the Pi digest, after
-// which both tests pass together.
+// Digests are pinned to the current rebased baseline (post-rebase onto main);
+// Commit 2 flips SystemPrompt for Pi and updates the Pi digest, after which
+// both this test and TestEveryManifestKeepsWorkRoutingDormantAndHashesCanonically
+// pass together.
 func TestEveryManifestDigestStaysByteStable(t *testing.T) {
 	t.Parallel()
 
-	// Digests computed from the current (pre-flip) manifest. These 15 rows must
-	// not change when the Pi row is updated — they are the stability contract.
+	// Digests pinned to the current (post-rebase) baseline. These 15 rows must
+	// not change when only the Pi row is updated — they are the stability contract.
 	wantNonPiDigests := map[model.AgentID]string{
-		model.AgentAntigravity: "sha256:2f72974f6abdce68ca28a585705227d37d1c64c965120281727455223d678394",
-		model.AgentClaudeCode:  "sha256:1954836303597cd9efc3e9736f2eb7c72d2c3b5107f6f36e0ca63d82c561c005",
-		model.AgentCodex:       "sha256:fd1ed4fc30881c9ce53550f4c57ad7bd007e1b76bba943510ef53840b2e43a16",
-		model.AgentCursor:      "sha256:5ec0323fd33720a5a99ec2ff8b876312f52aa6a588871a71920516f748f23f80",
-		model.AgentGeminiCLI:   "sha256:3d51601fb11f71e2cc22daba09fd19dfdf473fbcbf3b16d732d4100f0a09cbbb",
-		model.AgentHermes:      "sha256:00d1f1d2db659d33a032a97dae373a0f5e4a676921ef65d0f1162923e4758aa1",
-		model.AgentKilocode:    "sha256:5472e4fb098caa868c650cf0d065bf277e079ddb8d5b8996b0cd9e8faa72d381",
-		model.AgentKimi:        "sha256:20da639dbb4c852aef56c81e417641bc0b817a7fa41fd6aa2eecfe42aad9fafa",
-		model.AgentKiroIDE:     "sha256:00cec3beeaa3506476151a6aa19966a6b3bfe52c3648ecf2e9d1804adafb86c2",
-		model.AgentOpenClaw:    "sha256:e3dadd12614a5d27daf1c3fbdde875df5cb52888b7987ded87e5abd7bca8d49f",
-		model.AgentOpenCode:    "sha256:77b30ecfac3cd3a6d54db33328b9ddddd8db3f11fa19ddd5e3829c5a0a506b80",
+		model.AgentAntigravity:   "sha256:962eb63dc7f59a0b4c9c011dbb890aca1b40ecbfd3800c3e69b08f8b1639332c",
+		model.AgentClaudeCode:    "sha256:132b9219b222d35b0e4eafce3dae965c56eb8d79f07dff6d45c42c137e36fd9b",
+		model.AgentCodex:         "sha256:dbf94a3b7815cf68ccd6299c634f3e17be9abc305b3849adee382c65055c5ed9",
+		model.AgentCursor:        "sha256:2cf80b9bd4cdc9a9d3586e6d02dc2207f326841bba935c6f11f257a20756d821",
+		model.AgentGeminiCLI:     "sha256:463fdc93ad387c9b107c5f031f806dece9da3e2d47300b88d7640174bcb22a1e",
+		model.AgentHermes:        "sha256:ec03506bc4cb0d4850542412630ada103c882d61fa372075f5f8db209a301127",
+		model.AgentKilocode:      "sha256:08dc6df101bb042e2da1673a213032b12ecf49ef15fc463d856fecb0a052951e",
+		model.AgentKimi:          "sha256:565e369cacfdbc128166512040fe1b5a18eada11b333a9c153f85d6661762dc9",
+		model.AgentKiroIDE:       "sha256:3be196483ed199894062892c9367b3772bb66e18d6ec7b64e477ea201851a44a",
+		model.AgentOpenClaw:      "sha256:0fb9cb07a7be9174e93793678ad7cd4618c58c6a0d284be2fa1b6acd4d409014",
+		model.AgentOpenCode:      "sha256:3df2c0ee0a61774b7b7f0d547abed55721cc37ecc332c131935ce72fb142103f",
 		// Pi excluded intentionally — it changes in the next commit.
-		model.AgentQwenCode:      "sha256:def191f9b6ec065eda9fdd490817f27bbc89634b393db4bbbe9e81dffe1d9fba",
-		model.AgentTrae:          "sha256:aada07d8d187a2649cf18613c2ba4be6eefd1632c39a7e792c6ec23dcc8e803d",
-		model.AgentVSCodeCopilot: "sha256:3be9f31260509c10c8f4b2866c76f950ab4d2fabd8bf8684fd3af7a9b2391657",
-		model.AgentWindsurf:      "sha256:a8c46fa07497092005ce74cd3b71ef230704408ea035b08229ebd054f42794ae",
+		model.AgentQwenCode:      "sha256:897dd9264f92356375d1255949e1170938222853524d4b65e62b642a04b41c52",
+		model.AgentTrae:          "sha256:65234f37e1142edae7fff865613970e6ab0433b783df2e4c05b0023fb1c31ffe",
+		model.AgentVSCodeCopilot: "sha256:d1ceedd93c41dc1c34cce4accef239ca4e1bf4a643f203d5b3f8d031c4b4117b",
+		model.AgentWindsurf:      "sha256:660efc2939546f9e3517115aa1400af1d5e5f1d4d10bb4475f2569fba1267312",
 	}
 
 	nonPiAgents := make([]model.AgentID, 0, len(wantNonPiDigests))

--- a/internal/agents/capabilitymanifest/manifest_test.go
+++ b/internal/agents/capabilitymanifest/manifest_test.go
@@ -207,6 +207,65 @@ func TestEveryManifestKeepsWorkRoutingDormantAndHashesCanonically(t *testing.T) 
 	}
 }
 
+// TestEveryManifestDigestStaysByteStable pins that exactly 15 non-Pi agent rows
+// remain byte-stable when the Pi row is updated. The Pi row change is the only
+// expected delta from the capability flip; any other row changing is a regression.
+// This test passes against the current (pre-flip) manifest since it asserts only
+// the 15 non-Pi digests — the Pi row still carries its original hash here.
+// Commit 1 (this test) is intentionally RED-against-original-passing to establish
+// the baseline; Commit 2 flips SystemPrompt and updates the Pi digest, after
+// which both tests pass together.
+func TestEveryManifestDigestStaysByteStable(t *testing.T) {
+	t.Parallel()
+
+	// Digests computed from the current (pre-flip) manifest. These 15 rows must
+	// not change when the Pi row is updated — they are the stability contract.
+	wantNonPiDigests := map[model.AgentID]string{
+		model.AgentAntigravity: "sha256:2f72974f6abdce68ca28a585705227d37d1c64c965120281727455223d678394",
+		model.AgentClaudeCode:  "sha256:1954836303597cd9efc3e9736f2eb7c72d2c3b5107f6f36e0ca63d82c561c005",
+		model.AgentCodex:       "sha256:fd1ed4fc30881c9ce53550f4c57ad7bd007e1b76bba943510ef53840b2e43a16",
+		model.AgentCursor:      "sha256:5ec0323fd33720a5a99ec2ff8b876312f52aa6a588871a71920516f748f23f80",
+		model.AgentGeminiCLI:   "sha256:3d51601fb11f71e2cc22daba09fd19dfdf473fbcbf3b16d732d4100f0a09cbbb",
+		model.AgentHermes:      "sha256:00d1f1d2db659d33a032a97dae373a0f5e4a676921ef65d0f1162923e4758aa1",
+		model.AgentKilocode:    "sha256:5472e4fb098caa868c650cf0d065bf277e079ddb8d5b8996b0cd9e8faa72d381",
+		model.AgentKimi:        "sha256:20da639dbb4c852aef56c81e417641bc0b817a7fa41fd6aa2eecfe42aad9fafa",
+		model.AgentKiroIDE:     "sha256:00cec3beeaa3506476151a6aa19966a6b3bfe52c3648ecf2e9d1804adafb86c2",
+		model.AgentOpenClaw:    "sha256:e3dadd12614a5d27daf1c3fbdde875df5cb52888b7987ded87e5abd7bca8d49f",
+		model.AgentOpenCode:    "sha256:77b30ecfac3cd3a6d54db33328b9ddddd8db3f11fa19ddd5e3829c5a0a506b80",
+		// Pi excluded intentionally — it changes in the next commit.
+		model.AgentQwenCode:      "sha256:def191f9b6ec065eda9fdd490817f27bbc89634b393db4bbbe9e81dffe1d9fba",
+		model.AgentTrae:          "sha256:aada07d8d187a2649cf18613c2ba4be6eefd1632c39a7e792c6ec23dcc8e803d",
+		model.AgentVSCodeCopilot: "sha256:3be9f31260509c10c8f4b2866c76f950ab4d2fabd8bf8684fd3af7a9b2391657",
+		model.AgentWindsurf:      "sha256:a8c46fa07497092005ce74cd3b71ef230704408ea035b08229ebd054f42794ae",
+	}
+
+	nonPiAgents := make([]model.AgentID, 0, len(wantNonPiDigests))
+	for agent := range wantNonPiDigests {
+		nonPiAgents = append(nonPiAgents, agent)
+	}
+
+	if got := len(nonPiAgents); got != 15 {
+		t.Fatalf("want 15 non-Pi agents, got %d", got)
+	}
+
+	for _, agent := range nonPiAgents {
+		agent := agent
+		wantDigest := wantNonPiDigests[agent]
+		t.Run(string(agent), func(t *testing.T) {
+			t.Parallel()
+
+			manifest := MustForAgent(agent)
+			gotDigest, err := manifest.Digest()
+			if err != nil {
+				t.Fatalf("Digest() error = %v", err)
+			}
+			if gotDigest != wantDigest {
+				t.Fatalf("Digest() = %q, want %q (byte-stable contract)", gotDigest, wantDigest)
+			}
+		})
+	}
+}
+
 func TestForAgentRejectsUnknownAgent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agents/capabilitymanifest/manifest_test.go
+++ b/internal/agents/capabilitymanifest/manifest_test.go
@@ -220,17 +220,17 @@ func TestEveryManifestDigestStaysByteStable(t *testing.T) {
 	// Digests pinned to the current (post-rebase) baseline. These 15 rows must
 	// not change when only the Pi row is updated — they are the stability contract.
 	wantNonPiDigests := map[model.AgentID]string{
-		model.AgentAntigravity:   "sha256:962eb63dc7f59a0b4c9c011dbb890aca1b40ecbfd3800c3e69b08f8b1639332c",
-		model.AgentClaudeCode:    "sha256:132b9219b222d35b0e4eafce3dae965c56eb8d79f07dff6d45c42c137e36fd9b",
-		model.AgentCodex:         "sha256:dbf94a3b7815cf68ccd6299c634f3e17be9abc305b3849adee382c65055c5ed9",
-		model.AgentCursor:        "sha256:2cf80b9bd4cdc9a9d3586e6d02dc2207f326841bba935c6f11f257a20756d821",
-		model.AgentGeminiCLI:     "sha256:463fdc93ad387c9b107c5f031f806dece9da3e2d47300b88d7640174bcb22a1e",
-		model.AgentHermes:        "sha256:ec03506bc4cb0d4850542412630ada103c882d61fa372075f5f8db209a301127",
-		model.AgentKilocode:      "sha256:08dc6df101bb042e2da1673a213032b12ecf49ef15fc463d856fecb0a052951e",
-		model.AgentKimi:          "sha256:565e369cacfdbc128166512040fe1b5a18eada11b333a9c153f85d6661762dc9",
-		model.AgentKiroIDE:       "sha256:3be196483ed199894062892c9367b3772bb66e18d6ec7b64e477ea201851a44a",
-		model.AgentOpenClaw:      "sha256:0fb9cb07a7be9174e93793678ad7cd4618c58c6a0d284be2fa1b6acd4d409014",
-		model.AgentOpenCode:      "sha256:3df2c0ee0a61774b7b7f0d547abed55721cc37ecc332c131935ce72fb142103f",
+		model.AgentAntigravity: "sha256:962eb63dc7f59a0b4c9c011dbb890aca1b40ecbfd3800c3e69b08f8b1639332c",
+		model.AgentClaudeCode:  "sha256:132b9219b222d35b0e4eafce3dae965c56eb8d79f07dff6d45c42c137e36fd9b",
+		model.AgentCodex:       "sha256:dbf94a3b7815cf68ccd6299c634f3e17be9abc305b3849adee382c65055c5ed9",
+		model.AgentCursor:      "sha256:2cf80b9bd4cdc9a9d3586e6d02dc2207f326841bba935c6f11f257a20756d821",
+		model.AgentGeminiCLI:   "sha256:463fdc93ad387c9b107c5f031f806dece9da3e2d47300b88d7640174bcb22a1e",
+		model.AgentHermes:      "sha256:ec03506bc4cb0d4850542412630ada103c882d61fa372075f5f8db209a301127",
+		model.AgentKilocode:    "sha256:08dc6df101bb042e2da1673a213032b12ecf49ef15fc463d856fecb0a052951e",
+		model.AgentKimi:        "sha256:565e369cacfdbc128166512040fe1b5a18eada11b333a9c153f85d6661762dc9",
+		model.AgentKiroIDE:     "sha256:3be196483ed199894062892c9367b3772bb66e18d6ec7b64e477ea201851a44a",
+		model.AgentOpenClaw:    "sha256:0fb9cb07a7be9174e93793678ad7cd4618c58c6a0d284be2fa1b6acd4d409014",
+		model.AgentOpenCode:    "sha256:3df2c0ee0a61774b7b7f0d547abed55721cc37ecc332c131935ce72fb142103f",
 		// Pi excluded intentionally — it changes in the next commit.
 		model.AgentQwenCode:      "sha256:897dd9264f92356375d1255949e1170938222853524d4b65e62b642a04b41c52",
 		model.AgentTrae:          "sha256:65234f37e1142edae7fff865613970e6ab0433b783df2e4c05b0023fb1c31ffe",

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -31,7 +31,7 @@ func TestAdapterIdentityAndCapabilities(t *testing.T) {
 	}{
 		{"SupportsSkills", a.SupportsSkills(), false},
 		{"SupportsMCP", a.SupportsMCP(), true},
-		{"SupportsSystemPrompt", a.SupportsSystemPrompt(), true},
+		{"SupportsSystemPrompt", a.SupportsSystemPrompt(), false},
 		{"SupportsSlashCommands", a.SupportsSlashCommands(), false},
 		{"SupportsOutputStyles", a.SupportsOutputStyles(), false},
 		{"SupportsSubAgents", a.SupportsSubAgents(), false},


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1194

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Flip `SystemPrompt: false` for `AgentPi` in the canonical capability manifest (`internal/agents/capabilitymanifest/manifest.go`). The flip prevents the duplicate static-prompt-injection defect described in #1194. A new `TestEveryManifestDigestStaysByteStable` test pins 15 non-Pi agent row digests as byte-stable across the flip; the `TestAdapterIdentityAndCapabilities` expectation for `SupportsSystemPrompt` is updated to `false` to match the new contract.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/capabilitymanifest/manifest.go` | `SystemPrompt: true` → `false` for `model.AgentPi` (1-line flip) |
| `internal/agents/capabilitymanifest/manifest_test.go` | New `TestEveryManifestDigestStaysByteStable` (pins 15 non-Pi digests); updated Pi row digest in existing test |
| `internal/agents/pi/adapter_test.go` | `SupportsSystemPrompt` table expectation flipped `true` → `false` |

**Diff stats:** `3 files changed, 62 insertions(+), 3 deletions(-)` (well within 400-line budget)

---

## 🧪 Test Plan

**Unit tests (Slice A1 packages):**
```
go test -count=1 ./internal/agents/capabilitymanifest/... ./internal/agents/pi/...
# Result: ok × N (all PASS)
```

**Go vet:**
```
go vet ./internal/agents/...
# Result: no output (clean)
```

**Go fmt check:**
```
go run ./internal/gofmtcheck
# Result: no output (clean)
```

**Known pre-existing failures (not introduced by this slice):**
`internal/components/communitytool/pi_codegraph`, `internal/tui/sync`, and `internal/tui/sddmode` clusters present on `main` are not affected by Slice A1; verified identical via baseline inspection.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | :hour儿 | 62 lines — within 400-line budget |
| Check Issue Reference | :hour儿 | `Closes #1194` present |
| Check Issue Has `status:approved` | :hour儿 | Issue #1194 must have `status:approved` |
| Check PR Has `type:*` Label | :hour儿 | Maintainer applies `type:bug` label |
| Unit Tests | :hour儿 | `go test ./internal/agents/...` |
| Go Format | :hour儿 | `go run ./internal/gofmtcheck` |
| E2E Tests | :hour儿 | Full suite; pre-existing failures named above |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (issue #1194)
- [x] PR stays within 400 changed lines (62 lines — no `size:exception` needed)
- [ ] `type:bug` label applied — pending maintainer
- [x] Unit tests pass (`go test ./internal/agents/...` — all PASS)
- [x] Go format passes (`go run ./internal/gofmtcheck` — clean)
- [ ] E2E tests pass — pending CI
- [ ] Benchmark validation — N/A (not a benchmark change)
- [x] Documentation updated — N/A (capability manifest is self-documenting)
- [x] Commits follow Conventional Commits format (3 commits: `test(manifest):...`, `fix(manifest):...`, `test(adapter):...`)
- [x] No `Co-Authored-By` trailers

---

## 🔗 Chain Context

**5-slice Stacked-to-Main plan for #1194:**

```
Slice A1 ✅ (THIS PR): capability manifest flip — manifest.go + manifest_test.go + adapter_test.go
Slice A2: internal/components/uninstall/cleaners.go + cleaners_test.go        (~343 lines)
Slice A3: internal/cli/run.go + sync_test.go                                    (~76 lines)
Slice A4: internal/components/uninstall/service.go + service_test.go            (~193 lines)
Slice B:   docs/pi.md + communitytool contract + harness tests                   (~100 lines)
                                                                      Total: ~774 lines

pi-optional-codegraph-integration: INDEPENDENT — its review-gate invalidation is its owner's problem.
```

📍 **You are here: Slice A1** (capability manifest flip — 62 lines)

After merge of Slice A1, Slices A2–A4 land independently (stacked-to-main, each targeting `main`). Slice B lands last.

---

## 💬 Notes for Reviewers

- Slice A1 is intentionally scoped to only the capability manifest flip and its directly coupled tests. No other package is touched.
- Slices A2/A3/A4 and B are separate PRs landing independently from this one.
- The `pi-optional-codegraph-integration` feature branch is independent and its owner is responsible for managing any review-gate invalidation it causes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Pi’s reported capabilities to correctly indicate that system prompts are unsupported.
  * Preserved support for MCP functionality without affecting other capability declarations.

* **Tests**
  * Added coverage to ensure capability manifests remain stable across agents.
  * Updated Pi capability checks to reflect the corrected behavior.
  * Verified manifest digest consistency and byte stability across supported agent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->