### PR TITLE
fix(sdd): normalize omitted cwd for review mode

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -306,7 +306,7 @@ invents a metric is worse than one that admits a gap.
    classifier reads a field other than exit code and denial shape, and widening
    it would let the product talk its way out of a denial.
 
-7. **The corpus is honest, not exhaustive.** Forty-eight core journeys that run
+7. **The corpus is honest, not exhaustive.** Forty-nine core journeys that run
    end to end, weighted toward failure paths because that is where friction
    lives. Testing-guide flows 1 (install) and 8 (no phantom SDD artifacts) are
    inspection steps rather than review-lifecycle friction and are not modelled.
@@ -388,7 +388,7 @@ invents a metric is worse than one that admits a gap.
     (cluttered repositories, interleaved lifecycles) governed by a different
     growth rule: community-reported shapes become journeys, so its size tracks
     community reports, not releases, and folding it into the core would make
-    "48 journeys" a moving claim. Two of its numbers need careful reading.
+    "49 journeys" a moving claim. Two of its numbers need careful reading.
     `rw01` pins issue #1881 while a product fix is in flight: a block there is
     the truth about today's build, not a permanent verdict, and the journey is
     kept precisely so the fix has a permanent pin. And the no-echo assertions
@@ -431,7 +431,7 @@ completed; nothing was unsupported. Re-running produces byte-identical numbers,
 
 Those numbers are the **14-journey** corpus against the binary named above,
 kept as-is because they belong to that named build. The corpus has since grown
-to 48 journeys; re-run `run` against your own binary rather than reading the
+to 49 journeys; re-run `run` against your own binary rather than reading the
 block above as current totals. The row labels moved too: `by_design` did not
 exist when this was recorded and is now printed as `4d`, next to the number it
 carves out of, with `dead_end` at `4e`.
@@ -565,7 +565,7 @@ cannot silently decay into the already-covered corrupt-record case.
 
 ### Wave 1 integration regressions (`journeys_wave1.go`)
 
-Journeys 44 to 48 pin fixes that internal tests already covered below the user
+Journeys 44 to 49 pin fixes that internal tests already covered below the user
 boundary. All remain core black-box journeys: fixtures create repository inputs,
 and every native authority state is reached through the measured binary.
 
@@ -576,6 +576,7 @@ and every native authority state is reached through the measured binary.
 | `j46-correction-required-staged-recovery` | correction-required base-diff authority, negotiated staged-overlay recovery, fresh successor review, exact pre-commit/pre-push/pre-PR delivery | issue #1921 |
 | `j47-disabled-mode-archives-discovered-invalidated-receipt` | enabled discovered invalidation, disabled/unmanaged archive without allow, explicit invalid receipt control, and re-enabled enforcement | issue #2128 |
 | `j48-recovered-workspace-preserves-full-candidate-scope` | two-path workspace candidate, strict-subset correction, complete terminal and recovered scope, immediate pre-commit allow, byte/path drift controls | issue #2090 |
+| `j49-status-without-cwd-honors-kill-switch` | clone-local mode disabled, explicit-CWD control, omitted-CWD status using the same repository identity, disabled/unmanaged archive without approval | issue #2129 |
 
 `j44` proves the linked checkout/common-dir topology and remote baseline before
 review starts, then proves the staged delivery tree equals the corrected receipt
@@ -590,7 +591,9 @@ authority revision while review mode is toggled, proving that only discovered
 governance steps aside and an explicit invalid receipt remains fail-closed.
 `j48` keeps one-path correction evidence local while corrected and recovered
 authority retain the complete two-path tree and manifest; exact pre-commit
-targets allow, while later byte and path drift still fail closed.
+targets allow, while later byte and path drift still fail closed. `j49` proves
+that explicit and omitted CWD status calls reach the same clone-local switch and
+the same archive-ready change without fabricating review authority.
 
 ## Opt-in axes
 
@@ -612,7 +615,7 @@ its own declaration.
 
 - **Nothing runs unless you name it.** Default is the core alone. `--axis all`
   takes everything registered. An unknown name is a hard error, because
-  "48 journeys" and "48 journeys plus an axis" are different measurements and a
+  "49 journeys" and "49 journeys plus an axis" are different measurements and a
   typo must never silently produce the first.
 - **The core does not depend on any axis.** `rm bench/axis_damaged_store*.go`
   leaves the corpus compiling, testing and reporting exactly the numbers it

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -830,6 +830,19 @@ func requireExplicitInvalidArchiveStatus(_ *Sandbox, observation Observation) er
 	})(nil, observation)
 }
 
+func requireDisabledUnmanagedArchiveStatus(name string) func(*Sandbox, Observation) error {
+	return sddStatusAssertion(name, func(status sddStatusV1) error {
+		if status.ReviewGate == nil || status.ReviewGate.Delivery != deliveryDisabledUnmanaged || status.ReviewGate.Result == "allow" {
+			return fmt.Errorf("reviewGate = %+v, want non-authorizing disabled/unmanaged delivery", status.ReviewGate)
+		}
+		if status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" || len(status.BlockedReasons) != 0 {
+			return fmt.Errorf("archive=%q next=%q blocked=%v, want ready/archive with no blockers",
+				status.Dependencies.Archive, status.NextRecommended, status.BlockedReasons)
+		}
+		return nil
+	})
+}
+
 func proveArchiveAuthorityUnchanged(sandbox *Sandbox) error {
 	head, err := proveAuthorities(sandbox)
 	if err != nil {
@@ -995,6 +1008,22 @@ func waveOneJourneys() []Journey {
 				}},
 				{Name: "fixture: add path outside recovered scope", Fixture: addFullScopePathDrift},
 				{Name: "path drift still fails closed", Requires: validateCapability, Args: productArgs("review", "validate", "--lineage", fullScopeSuccessor, "--gate", "pre-commit"), After: requireFullScopeDrift},
+			},
+		},
+		{
+			ID:     "j49-status-without-cwd-honors-kill-switch",
+			Title:  "SDD status without CWD: repository resolution and the kill switch share one workspace",
+			Source: "issue #2129",
+			Steps: []Step{
+				{Name: "fixture: archive-ready SDD change", Fixture: sddPlanningArtifacts(sddVerifyReport)},
+				{Name: "disable review mode for the clone", Requires: modeCapability,
+					Args: productArgs("review", "mode", "disable", "--scope", "clone", "--json")},
+				{Name: "explicit CWD honors disabled mode", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: requireDisabledUnmanagedArchiveStatus("explicit CWD control")},
+				{Name: "omitted CWD honors the same disabled mode", Requires: sddStatusCapability,
+					Args: func(*Sandbox) ([]string, error) {
+						return []string{"sdd-status", sddChange, "--json"}, nil
+					}, After: requireDisabledUnmanagedArchiveStatus("omitted CWD")},
 			},
 		},
 	}

--- a/internal/cli/sdd_status.go
+++ b/internal/cli/sdd_status.go
@@ -9,6 +9,10 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
 )
 
+func sddReviewDisabledForWorkspace(workspaceRoot string) bool {
+	return reviewDrivenDevelopmentDisabled(context.Background(), workspaceRoot)
+}
+
 // RunSDDStatus is the CLI entry point for `gentle-ai sdd-status [change]`.
 //
 // The kill switch reaches SDD status here, at the one layer that owns the
@@ -22,10 +26,10 @@ func RunSDDStatus(args []string, stdout io.Writer) error {
 	}
 
 	status, err := sddstatus.Resolve(sddstatus.ResolveOptions{
-		CWD:                 parsed.CWD,
-		ChangeName:          parsed.ChangeName,
-		IncludeInstructions: parsed.IncludeInstructions,
-		ReviewDisabled:      reviewDrivenDevelopmentDisabled(context.Background(), parsed.CWD),
+		CWD:                        parsed.CWD,
+		ChangeName:                 parsed.ChangeName,
+		IncludeInstructions:        parsed.IncludeInstructions,
+		ReviewDisabledForWorkspace: sddReviewDisabledForWorkspace,
 	})
 	if err != nil {
 		return fmt.Errorf("resolve sdd status: %w", err)
@@ -53,10 +57,10 @@ func RunSDDContinue(args []string, stdout io.Writer) error {
 	}
 
 	status, err := sddstatus.Resolve(sddstatus.ResolveOptions{
-		CWD:                 parsed.CWD,
-		ChangeName:          parsed.ChangeName,
-		IncludeInstructions: true,
-		ReviewDisabled:      reviewDrivenDevelopmentDisabled(context.Background(), parsed.CWD),
+		CWD:                        parsed.CWD,
+		ChangeName:                 parsed.ChangeName,
+		IncludeInstructions:        true,
+		ReviewDisabledForWorkspace: sddReviewDisabledForWorkspace,
 	})
 	if err != nil {
 		return fmt.Errorf("resolve sdd status: %w", err)

--- a/internal/cli/sdd_status_review_disabled_test.go
+++ b/internal/cli/sdd_status_review_disabled_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -53,17 +54,36 @@ func seedArchiveGatedSDDChange(t *testing.T, root string) {
 	runReviewCLIGit(t, root, "commit", "-qm", "base")
 }
 
-func resolveSDDStatusJSON(t *testing.T, root string) sddstatus.Status {
+func runSDDCommandJSON(t *testing.T, run func([]string, io.Writer) error, args ...string) sddstatus.Status {
 	t.Helper()
 	var stdout bytes.Buffer
-	if err := RunSDDStatus([]string{"thin", "--cwd", root, "--json"}, &stdout); err != nil {
-		t.Fatalf("RunSDDStatus() error = %v\n%s", err, stdout.String())
+	if err := run(args, &stdout); err != nil {
+		t.Fatalf("SDD command error = %v\n%s", err, stdout.String())
 	}
 	var status sddstatus.Status
 	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
 		t.Fatalf("decode sdd status: %v\n%s", err, stdout.String())
 	}
 	return status
+}
+
+func resolveSDDStatusJSON(t *testing.T, root string) sddstatus.Status {
+	t.Helper()
+	return runSDDCommandJSON(t, RunSDDStatus, "thin", "--cwd", root, "--json")
+}
+
+func requireDisabledUnmanagedSDDStatus(t *testing.T, status sddstatus.Status) {
+	t.Helper()
+	if status.Dependencies.Archive == sddstatus.DependencyBlocked || status.NextRecommended == "resolve-review" {
+		t.Fatalf("disabled archive=%q next=%q blocked=%v, want an unmanaged route to archive",
+			status.Dependencies.Archive, status.NextRecommended, status.BlockedReasons)
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
+		t.Fatalf("disabled reviewGate = %#v, want disabled/unmanaged", status.ReviewGate)
+	}
+	if status.ReviewGate.Result == reviewtransaction.GateAllow || status.ReviewTransaction != nil {
+		t.Fatalf("disabled status fabricated review authority: gate=%#v transaction=%#v", status.ReviewGate, status.ReviewTransaction)
+	}
 }
 
 // corruptCloneLocalReviewMode damages the clone-local override head record.
@@ -126,21 +146,47 @@ func TestSDDStatusArchiveGateCarriesOnWhileReviewIsDisabled(t *testing.T) {
 	disableReviewForClone(t, root)
 
 	status := resolveSDDStatusJSON(t, root)
-	if status.Dependencies.Archive == sddstatus.DependencyBlocked {
-		t.Fatalf("disabled archive = %q, want unblocked; blocked reasons = %v", status.Dependencies.Archive, status.BlockedReasons)
+	requireDisabledUnmanagedSDDStatus(t, status)
+}
+
+func TestSDDCommandsWithoutCWDHonorDisabledReviewMode(t *testing.T) {
+	reviewModeHome(t)
+	root := t.TempDir()
+	seedArchiveGatedSDDChange(t, root)
+	disableReviewForClone(t, root)
+	t.Chdir(root)
+
+	commands := []struct {
+		name string
+		run  func([]string, io.Writer) error
+	}{
+		{name: "status", run: RunSDDStatus},
+		{name: "continue", run: RunSDDContinue},
 	}
-	if status.NextRecommended == "resolve-review" {
-		t.Fatalf("disabled next = %q, want a route out of the resolve-review loop", status.NextRecommended)
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			status := runSDDCommandJSON(t, command.run, "thin", "--json")
+			requireDisabledUnmanagedSDDStatus(t, status)
+			if status.ActionContext.WorkspaceRoot != root {
+				t.Fatalf("workspace root = %q, want %q", status.ActionContext.WorkspaceRoot, root)
+			}
+		})
 	}
-	if status.ReviewGate == nil || status.ReviewGate.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
-		t.Fatalf("disabled reviewGate = %#v, want the disabled/unmanaged disposition on the wire", status.ReviewGate)
-	}
-	// A disabled run declines to manage. It never approves.
-	if status.ReviewGate.Result == reviewtransaction.GateAllow {
-		t.Fatalf("disabled reviewGate fabricated an approval: %#v", status.ReviewGate)
-	}
-	if status.ReviewTransaction != nil {
-		t.Fatalf("disabled run invented review authority: %#v", status.ReviewTransaction)
+}
+
+func TestSDDStatusWithoutCWDUsesLinkedWorktreeCommonDirMode(t *testing.T) {
+	reviewModeHome(t)
+	root := t.TempDir()
+	seedArchiveGatedSDDChange(t, root)
+	disableReviewForClone(t, root)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runReviewCLIGit(t, root, "worktree", "add", "-q", "-b", "linked-status", linked)
+	t.Chdir(linked)
+
+	status := runSDDCommandJSON(t, RunSDDStatus, "thin", "--json")
+	requireDisabledUnmanagedSDDStatus(t, status)
+	if status.ActionContext.WorkspaceRoot != linked {
+		t.Fatalf("workspace root = %q, want linked worktree %q", status.ActionContext.WorkspaceRoot, linked)
 	}
 }
 
@@ -157,11 +203,17 @@ func TestSDDStatusArchiveGateEnforcesWhenTheSwitchIsUnreadable(t *testing.T) {
 	if reviewDrivenDevelopmentDisabled(context.Background(), root) {
 		t.Fatal("an unreadable switch resolved to disabled; it must fail closed to enabled")
 	}
-	status := resolveSDDStatusJSON(t, root)
-	if status.ReviewGate == nil || status.ReviewGate.Delivery != "" {
-		t.Fatalf("unreadable-switch reviewGate = %#v, want the enforcing shape", status.ReviewGate)
-	}
-	if status.Dependencies.Archive != sddstatus.DependencyBlocked || status.NextRecommended != "resolve-review" {
-		t.Fatalf("unreadable-switch archive=%q next=%q, want blocked/resolve-review", status.Dependencies.Archive, status.NextRecommended)
+	t.Chdir(root)
+	for _, args := range [][]string{
+		{"thin", "--cwd", root, "--json"},
+		{"thin", "--json"},
+	} {
+		status := runSDDCommandJSON(t, RunSDDStatus, args...)
+		if status.ReviewGate == nil || status.ReviewGate.Delivery != "" {
+			t.Fatalf("unreadable-switch reviewGate = %#v, want the enforcing shape", status.ReviewGate)
+		}
+		if status.Dependencies.Archive != sddstatus.DependencyBlocked || status.NextRecommended != "resolve-review" {
+			t.Fatalf("unreadable-switch archive=%q next=%q, want blocked/resolve-review", status.Dependencies.Archive, status.NextRecommended)
+		}
 	}
 }

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -315,14 +315,6 @@ func validateStatusContract(contract string) error {
 	return fmt.Errorf("unsupported sdd-status contract %q; supported contract is %s", contract, StatusContractV1)
 }
 
-func ListActiveOpenSpecChanges(cwd string) ([]string, error) {
-	root, err := absOrCWD(cwd)
-	if err != nil {
-		return nil, err
-	}
-	return listActiveOpenSpecChanges(root)
-}
-
 func listActiveOpenSpecChanges(workspaceRoot string) ([]string, error) {
 	entries, err := os.ReadDir(filepath.Join(workspaceRoot, "openspec", "changes"))
 	if err != nil {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -240,6 +240,10 @@ type ResolveOptions struct {
 	// owns the single source of truth for both of its sources; an unreadable
 	// switch is not a disabled switch and resolves to false.
 	ReviewDisabled bool
+	// ReviewDisabledForWorkspace lets the composition root resolve the switch
+	// against the exact workspace normalized by Resolve. When set, it is called
+	// once and its result replaces ReviewDisabled for the whole status decision.
+	ReviewDisabledForWorkspace func(workspaceRoot string) bool
 }
 
 type CommandArgs struct {
@@ -316,7 +320,11 @@ func ListActiveOpenSpecChanges(cwd string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	entries, err := os.ReadDir(filepath.Join(root, "openspec", "changes"))
+	return listActiveOpenSpecChanges(root)
+}
+
+func listActiveOpenSpecChanges(workspaceRoot string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(workspaceRoot, "openspec", "changes"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return []string{}, nil
@@ -339,9 +347,13 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
+	reviewDisabled := options.ReviewDisabled
+	if options.ReviewDisabledForWorkspace != nil {
+		reviewDisabled = options.ReviewDisabledForWorkspace(workspaceRoot)
+	}
 	planningHome := filepath.Join(workspaceRoot, "openspec")
 	changesDir := filepath.Join(planningHome, "changes")
-	activeChanges, err := ListActiveOpenSpecChanges(workspaceRoot)
+	activeChanges, err := listActiveOpenSpecChanges(workspaceRoot)
 	if err != nil {
 		return Status{}, err
 	}
@@ -350,7 +362,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if changeName == "" {
 		switch len(activeChanges) {
 		case 0:
-			if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, options.ReviewDisabled); ok || err != nil {
+			if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, reviewDisabled); ok || err != nil {
 				return status, err
 			}
 			return blockedStatus(workspaceRoot, nil, nil, "sdd-new", []string{"No active OpenSpec changes found under openspec/changes."}, options.IncludeInstructions), nil
@@ -362,7 +374,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	}
 
 	if !contains(activeChanges, changeName) {
-		if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, options.ReviewDisabled); ok || err != nil {
+		if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, reviewDisabled); ok || err != nil {
 			return status, err
 		}
 		return blockedStatus(workspaceRoot, &changeName, nil, "sdd-new", []string{fmt.Sprintf("Active OpenSpec change not found: %s.", changeName)}, options.IncludeInstructions), nil
@@ -483,7 +495,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 		applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
 	}
 	if !bindingPresent && !bridge.Eligible && !bridge.Relevant {
-		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason, options.ReviewDisabled)
+		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason, reviewDisabled)
 	}
 
 	status := baseStatus(workspaceRoot, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))
@@ -505,7 +517,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 				workspaceRoot,
 				firstPath(artifactPaths.ReviewReceipt),
 				"",
-				options.ReviewDisabled,
+				reviewDisabled,
 			)
 		}
 	}

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -10,23 +10,6 @@ import (
 	"testing"
 )
 
-func TestListActiveOpenSpecChanges(t *testing.T) {
-	root := t.TempDir()
-	mkdir(t, filepath.Join(root, "openspec", "changes", "z-change"))
-	mkdir(t, filepath.Join(root, "openspec", "changes", "a-change"))
-	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2026-01-01-old"))
-
-	changes, err := ListActiveOpenSpecChanges(root)
-	if err != nil {
-		t.Fatalf("ListActiveOpenSpecChanges() error = %v", err)
-	}
-
-	want := []string{"a-change", "z-change"}
-	if !reflect.DeepEqual(changes, want) {
-		t.Fatalf("ListActiveOpenSpecChanges() = %v, want %v", changes, want)
-	}
-}
-
 func TestResolveSharesOneNormalizedWorkspaceWithReviewMode(t *testing.T) {
 	root := t.TempDir()
 	mkdir(t, filepath.Join(root, "openspec", "changes"))

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -27,6 +27,32 @@ func TestListActiveOpenSpecChanges(t *testing.T) {
 	}
 }
 
+func TestResolveSharesOneNormalizedWorkspaceWithReviewMode(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, "openspec", "changes"))
+	t.Chdir(root)
+
+	modeLookups := 0
+	status, err := Resolve(ResolveOptions{
+		ReviewDisabledForWorkspace: func(workspaceRoot string) bool {
+			modeLookups++
+			if workspaceRoot != root {
+				t.Fatalf("review mode workspace = %q, want %q", workspaceRoot, root)
+			}
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if modeLookups != 1 {
+		t.Fatalf("review mode lookups = %d, want 1", modeLookups)
+	}
+	if status.ActionContext.WorkspaceRoot != root {
+		t.Fatalf("status workspace = %q, want shared root %q", status.ActionContext.WorkspaceRoot, root)
+	}
+}
+
 func TestResolveUsesEngramArtifactsWhenOpenSpecIsAbsent(t *testing.T) {
 	root := t.TempDir()
 	mkdir(t, filepath.Join(root, ".engram"))


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2129

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Enforces one same-root invariant for SDD STATUS and CONTINUE: resolve the workspace once, then use that exact root for both active-change discovery and the review-mode kill-switch lookup.

This fixes omitted `--cwd` incorrectly failing closed to review-enabled while explicit `--cwd` honored the disabled clone-local mode. Disabled mode remains non-authorizing `disabled/unmanaged`; this PR does not change Gentle Pi, persisted mode storage, global/clone scope semantics, stale bindings, or review lifecycle behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus` | Resolves workspace identity once, reuses it for active-change lookup, invokes one workspace-scoped review-mode callback while preserving direct callers, and removes the genuinely unreachable `ListActiveOpenSpecChanges` wrapper and its wrapper-only test. |
| `internal/cli` | Routes both STATUS and CONTINUE through the same resolved-root callback. Adds explicit-CWD, omitted-CWD, linked-worktree/common-dir, and unreadable-switch controls. |
| `bench` | Adds black-box `j49-status-without-cwd-honors-kill-switch` and updates the honest core corpus count from 48 to 49. |

---

## 🧪 Test Plan

Validated independently at exact head `7308fb9b19d4eeee5a701cb08c99da3505d02e58` against the cumulative six-file PR diff from base `73b3a108f4a3901162bbafed3398772d3714dacb`, with cumulative patch SHA-256 `943e3e83d426a921aafb969d398acdb0bfcd48cf1008d3e8ccfcc3d86421e070`.

```bash
go test ./internal/sddstatus ./internal/cli
go vet ./internal/sddstatus ./internal/cli
go test -count=1 ./...
go vet ./...
go run ./internal/gofmtcheck
cd bench && go test ./... && go vet ./... && go build ./...
```

- [x] Focused and full root tests/vet pass.
- [x] Go format and diff checks pass.
- [x] Deadcode ratchet passes.
- [x] Bench tests/vet/build pass.
- [x] `j49-status-without-cwd-honors-kill-switch` completes twice with identical semantic results.
- [x] All 49 core journeys pass: 49 completed, 0 unsupported, 0 failed.
- [x] Independent read-only candidate validation: PASS with no blocker.
- [ ] Docker E2E suite was not rerun locally; the dedicated black-box runtime corpus covers this CLI boundary and CI remains authoritative.

---

## 📏 Budget And Rollback

Review budget is 6 files with 160 additions + 59 deletions = 219 changed lines, below the 400-line limit; no exception is required.

Rollback is the cumulative PR: revert both commits, `7308fb9b19d4eeee5a701cb08c99da3505d02e58` and `d8cc09c32fd648ec8aa6e2e6f2843a111382060b`, to restore the prior raw-`--cwd` lookup, the removed unreachable wrapper, and the 48-journey corpus. There is no migration, persisted-state change, Gentle Pi change, or mode-scope rollback dependency.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 219 changed lines, within the 400-line budget |
| Check Issue Reference | ✅ | `Closes #2129` |
| Check Issue Has `status:approved` | ✅ | Passed |
| Check PR Has `type:*` Label | ✅ | Exactly `type:bug` is applied |
| Unit Tests | ✅ | Passed in CI |
| Go Format | ✅ | Passed in CI |
| E2E Tests | ✅ | Passed in CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one appropriate `type:*` label is applied
- [x] Unit tests pass locally
- [x] Go format passes locally
- [x] Docker E2E checks pass in CI
- [x] Benchmark validation completed
- [x] Documentation is updated
- [x] Both commits follow Conventional Commits
- [x] Neither commit has a `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The qualifying governance guard remains fail-closed for unreadable mode state. The legitimate disabled input population is explicit CWD, omitted CWD, and linked worktrees sharing the clone common directory; all are covered without widening the switch or changing its scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SDD status and continue commands now consistently honor disabled review mode with or without a specified working directory.
  - Behavior is consistent across linked worktrees and workspace paths.
  - Unreadable review records now safely use the archive flow without granting review authority.

- **Documentation**
  - Updated benchmark documentation and journey counts to reflect the 49-journey baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->