### PR TITLE
fix(cli): refuse negotiated review start on an empty candidate

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1524,6 +1524,16 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		return reviewPreflightRefusal(reviewPreflightStaleTargetReason,
 			errors.New("review start target does not match the freshly built snapshot"))
 	}
+	// A negotiated TargetCurrentChanges candidate with zero changed paths
+	// (a clean, fully-committed worktree) would otherwise freeze as an empty
+	// candidate, pass risk assessment and consent, and only fail late and
+	// misleadingly at pre-push. Refuse it here, before any authority is
+	// created, and name --base-ref as the way to review committed work
+	// instead of silently deriving one.
+	if negotiated && snapshot.Kind == reviewtransaction.TargetCurrentChanges && len(snapshot.Paths) == 0 {
+		return reviewPreflightRefusal(reviewPreflightEmptyCandidateReason,
+			errors.New(reviewStartEmptyCandidateHint))
+	}
 	assessment, err := (reviewtransaction.SnapshotBuilder{Repo: root}).AssessSnapshotRisk(ctx, snapshot)
 	if err != nil {
 		return fmt.Errorf("classify facade review target: %w", err)

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -227,6 +227,21 @@ var reviewPreflightUntrackedScopeReason = reviewPreflightReason{
 	NextAction: "stop",
 }
 
+// reviewPreflightEmptyCandidateReason classifies a negotiated START whose
+// frozen TargetCurrentChanges candidate has zero changed paths (a clean,
+// fully-committed worktree). Left unguarded, this candidate would freeze as
+// base_tree == candidate_tree == HEAD, pass risk assessment and pre-commit,
+// then fail late and misleadingly at pre-push. `base_ref` is already in the
+// published required_inputs enum, and `next_action: correct_request` is
+// honest because the caller genuinely must supply it: the system never
+// auto-derives a base ref (e.g. HEAD~1) on the caller's behalf.
+var reviewPreflightEmptyCandidateReason = reviewPreflightReason{
+	Code:           "empty_candidate_scope",
+	Message:        "The review candidate has no pending changes to freeze; name the base to compare against before retrying.",
+	RequiredInputs: []string{"base_ref"},
+	NextAction:     "correct_request",
+}
+
 // reviewPreflightMissingInputsReason names the contract-level inputs a caller
 // must supply. Callers pass only inputs the published required_inputs enum
 // actually defines; a refusal whose missing inputs are not all expressible

--- a/internal/cli/review_start_empty_candidate_test.go
+++ b/internal/cli/review_start_empty_candidate_test.go
@@ -1,0 +1,146 @@
+package cli
+
+// Issue: negotiated `review.start` with TargetCurrentChanges on a clean,
+// fully-committed worktree freezes an EMPTY candidate (base_tree ==
+// candidate_tree == HEAD, paths: []), passes risk assessment and
+// pre-commit, then fails late and misleadingly at pre-push ("reviewed
+// delivery is not exactly one commit from its reviewed base"). These tests
+// pin a typed preflight refusal that stops this flow before any authority
+// is created, naming --base-ref as the resolution instead of silently
+// deriving one.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestNegotiatedReviewStartRefusesEmptyCandidateWithoutAuthority proves the
+// core fix: a clean, fully-committed worktree refuses negotiated START with
+// a typed, schema-valid preflight refusal, and persists nothing.
+func TestNegotiatedReviewStartRefusesEmptyCandidateWithoutAuthority(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", "empty-candidate",
+	}), &output)
+	if err == nil {
+		t.Fatalf("negotiated review start admitted an empty candidate:\n%s", output.String())
+	}
+
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	assertReviewFailureMatchesPublishedSchema(t, failure)
+
+	if failure.Code != "empty_candidate_scope" {
+		t.Fatalf("negotiated failure code = %q, want empty_candidate_scope\n%s", failure.Code, output.String())
+	}
+	if failure.Phase != "preflight" {
+		t.Fatalf("negotiated failure phase = %q, want preflight\n%s", failure.Phase, output.String())
+	}
+	if failure.MutationOutcome != ReviewMutationNotStarted {
+		t.Fatalf("negotiated failure mutation_outcome = %q, want not_started\n%s", failure.MutationOutcome, output.String())
+	}
+	if len(failure.RequiredInputs) != 1 || failure.RequiredInputs[0] != "base_ref" {
+		t.Fatalf("negotiated failure required_inputs = %v, want [base_ref]\n%s", failure.RequiredInputs, output.String())
+	}
+	if failure.NextAction != "correct_request" {
+		t.Fatalf("negotiated failure next_action = %q, want correct_request\n%s", failure.NextAction, output.String())
+	}
+
+	stores, discoverErr := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if discoverErr != nil {
+		t.Fatal(discoverErr)
+	}
+	if len(stores) != 0 {
+		t.Fatalf("refused empty-candidate START created authority: %#v", stores)
+	}
+}
+
+// TestNegotiatedEmptyCandidateRefusalNamesBaseRefWithoutDerivingIt proves the
+// refusal text names --base-ref as the way forward and never silently
+// derives or proposes a base ref such as HEAD~1.
+func TestNegotiatedEmptyCandidateRefusalNamesBaseRefWithoutDerivingIt(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", "empty-candidate-cause",
+	}), &output)
+	if err == nil {
+		t.Fatalf("negotiated review start admitted an empty candidate:\n%s", output.String())
+	}
+
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Cause != reviewStartEmptyCandidateHint {
+		t.Fatalf("negotiated failure cause = %q, want %q", failure.Cause, reviewStartEmptyCandidateHint)
+	}
+	if !strings.Contains(failure.Cause, "--base-ref") {
+		t.Fatalf("negotiated failure cause = %q, want it to name --base-ref", failure.Cause)
+	}
+	if strings.Contains(failure.Cause, "HEAD~1") || strings.Contains(failure.Cause, "HEAD^") {
+		t.Fatalf("negotiated failure cause auto-derives a base ref: %q", failure.Cause)
+	}
+}
+
+// TestNegotiatedStartWithExplicitBaseRefOverCommittedWorkStillStarts proves
+// the refusal only fires for an actually empty manifest: an explicit
+// --base-ref naming a real prior commit still builds a non-empty candidate
+// and proceeds normally.
+func TestNegotiatedStartWithExplicitBaseRefOverCommittedWorkStillStarts(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "tracked.txt", "second commit\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "second")
+
+	var output bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", "explicit-base-ref",
+		"--base-ref", "HEAD~1",
+	}), &output); err != nil {
+		t.Fatalf("negotiated start with an explicit base ref over committed work: %v\n%s", err, output.String())
+	}
+	result := decodeNegotiatedReviewStart(t, output.Bytes())
+	if result.ChangedFiles == 0 {
+		t.Fatalf("negotiated start with an explicit base ref over committed work produced an empty candidate: %#v", result)
+	}
+}
+
+// TestNegotiatedStartWithPendingChangesIsUnaffected proves the guard never
+// fires when the worktree actually has pending changes.
+func TestNegotiatedStartWithPendingChangesIsUnaffected(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "tracked.txt", "pending change\n", 0o644)
+
+	result := runNegotiatedReviewStart(t, repo, "pending-changes")
+	if result.ChangedFiles == 0 {
+		t.Fatalf("negotiated start with pending changes produced an empty candidate: %#v", result)
+	}
+}
+
+// TestUnnegotiatedEmptyCandidateStartKeepsItsHint is a regression pin: the
+// plain (non-negotiated) review start path on a clean tree must keep
+// emitting its existing hint unchanged by the negotiated-only guard added
+// by this change.
+func TestUnnegotiatedEmptyCandidateStartKeepsItsHint(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "unnegotiated-empty"}, &output); err != nil {
+		t.Fatalf("unnegotiated review start on a clean worktree: %v\n%s", err, output.String())
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	if started.ChangedFiles != 0 {
+		t.Fatalf("unnegotiated clean-worktree start changed_files = %d, want 0", started.ChangedFiles)
+	}
+	if started.Hint != reviewStartEmptyCandidateHint {
+		t.Fatalf("unnegotiated empty-candidate start hint = %q, want %q", started.Hint, reviewStartEmptyCandidateHint)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2172

> **Maintainer note, stated up front:** #2172 has no `status:approved` label yet, so `Check Issue Has status:approved` and `Check PR Has type:* Label` will both be red. A contributor account cannot apply repository labels (HTTP 403, admin-only), so neither is fixable from this side, and this PR discloses that rather than looking merge-ready. It is marked ready for review anyway so reviewers and automation can read it; hold or close it freely if the direction is wrong. I opened it before approval for the same reason as #2151: the refusal is easier to judge against real code than prose, and the change is 171 lines with a test that fails without it.
>
> Related but **not** fixed by this: #2090 (closed by #2169) shares the empty-receipt symptom while its freeze was correct and emptiness surfaced at validation. Here the freeze is born empty, with no correction and no recovery involved. #1203 fixed the `post-apply` variant of the same committed-clean-worktree family.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Negotiated `review.start` refuses an empty `current-changes` candidate instead of freezing an authority that no delivery gate can consume.
- The refusal names `--base-ref <commit>` and deliberately does not derive a base, because guessing one silently reviews the wrong scope.
- Nothing is persisted for the refused attempt: the guard runs before risk assessment, compact-state creation, and authority publication.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/cli/review_facade.go` | Preflight guard on the negotiated START path, immediately after the existing stale-target refusal and before `AssessSnapshotRisk`. |
| `internal/cli/review_operation_contract.go` | New `reviewPreflightEmptyCandidateReason`, following the shape of the two existing preflight reasons. |
| `internal/cli/review_start_empty_candidate_test.go` | Five tests: refusal, no persisted authority, `--base-ref` guidance without a derived base, explicit-base-ref success, and pins for the untouched unnegotiated path. |

---

## 🧠 Why this shape

**Why the CLI layer and not `reviewtransaction`.** The obvious place looks like `NewCompactState`, and it is wrong. A guard there breaks roughly thirty tests, because a degenerate scope (candidate tree equal to base tree) is *deliberately supported* for recovery successors — `TestCompactPrePRChainAllowsAcceptedDegenerateScopeRecovery` pins exactly that. Recovery reaches it through package-level calls that never touch this facade, so a CLI-layer guard cannot affect them.

**Why the predicate keys off `snapshot.Kind`.** `canonicalProjection` normalizes a workspace projection to the **empty string**, never to `ProjectionWorkspace`. A predicate comparing against that constant is dead code that passes tests by never executing. Gating on `Kind` plus an empty path manifest makes that trap structurally unreachable instead of merely avoided.

**Why negotiated-only.** Three shipped tests deliberately create empty-candidate reviews through the unnegotiated path, and two of them assert such a receipt must not count as archive coverage. They need to be able to create one, so that path is untouched. The unnegotiated path already emits the same `--base-ref` guidance as a hint.

**Why refuse rather than auto-propose a base.** The reporting branch had three commits. An auto-derived `--base-ref HEAD~1` would have frozen one third of the work while reporting success. Choosing the base is the caller's decision.

---

## 🧪 Test Plan

- [x] `go build ./...`
- [x] `go vet ./internal/cli`
- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./internal/cli` — passes with zero failures
- [x] `go test ./internal/reviewtransaction` — passes, degenerate-scope recovery unaffected
- [x] Clean-tree baseline measured first: both packages had **zero** pre-existing failures, so any red test is attributable to this change
- [x] Failing-test-first verified by reverting only the two production files and keeping the tests: `TestNegotiatedReviewStartRefusesEmptyCandidateWithoutAuthority` and `TestNegotiatedEmptyCandidateRefusalNamesBaseRefWithoutDerivingIt` fail, while the unnegotiated pin still passes. The package still compiles during that revert, because the tests assert the wire string `empty_candidate_scope` rather than a Go symbol, so the failure is behavioral rather than a compile artifact.
- [ ] Full Docker E2E suite (not applicable to this focused CLI change)

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 171 changed lines, within the 400 budget |
| Check Issue Reference | ⏳ | Body contains `Closes #2172` |
| Check Issue Has `status:approved` | ❌ | Blocked on maintainer; #2172 is unlabeled |
| Check PR Has `type:*` Label | ❌ | Blocked on maintainer; contributor cannot apply labels |
| Unit Tests | ⏳ | `go test ./...` |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` |

---

## ✅ Contributor Checklist

- [x] PR is linked to existing issue #2172.
- [ ] Issue has `status:approved` — blocked on maintainer.
- [ ] Exactly one `type:*` label is applied — blocked on maintainer, contributor accounts cannot apply repository labels.
- [x] Exactly one PR type is selected in the body.
- [x] Relevant unit tests, vet, and format checks pass.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

One accepted edge case, flagged rather than fixed: on an unborn `HEAD` with an empty index the refusal still advises `--base-ref`, and no commit is reachable to name. The message stays truthful, and the alternative (special-casing an unborn repository here) would widen this change without closing the reported defect.

Two known coverage gaps, both deliberate: nothing pins that an empty `TargetBaseDiff` candidate stays unrefused, which would guard against drifting toward a `BaseTree == CandidateTree` predicate; and the "the misleading pre-push message is now unreachable" criterion holds by implication (no authority is created, so no receipt reaches the gate) rather than by a direct end-to-end assertion.

The misleading `pre-push` wording itself (`reviewed delivery is not exactly one commit from its reviewed base`, emitted when the derived range holds **zero** commits) is left alone on purpose. It stays reachable through other paths, and rewording it widens the blast radius without closing this defect. Happy to open a separate issue for it if you want it tracked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Negotiated reviews now clearly refuse requests with no pending or selected changes.
  * The error directs committed-work reviews to provide an explicit `--base-ref`.
  * Refused requests no longer create review authority records.
  * Reviews with pending changes or an explicit base reference continue to start normally.

* **Tests**
  * Added coverage for empty worktrees, explicit base references, pending changes, and existing unnegotiated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->