### PR TITLE
test(e2e): account for RDD workflow skill

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -665,15 +665,15 @@ test_cc_skills_minimal() {
 }
 
 test_cc_skills_full() {
-    log_test "Claude Code: skills injection (full-gentleman = 10 foundation skills)"
+    log_test "Claude Code: skills injection (full-gentleman = 11 foundation skills)"
     cleanup_test_env
 
     if $BINARY install --agent claude-code --component skills --preset full-gentleman --persona neutral 2>&1; then
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
-        # Full preset = 22 files: 10 SDD + judgment-day + 10 foundation + _shared/SKILL.md
-        assert_file_count "$skills_dir" "SKILL.md" 22 "Full preset: 22 skill files"
+        # Full preset = 23 files: 10 SDD + judgment-day + 11 foundation + _shared/SKILL.md
+        assert_file_count "$skills_dir" "SKILL.md" 23 "Full preset: 23 skill files"
 
         # Verify foundation skills exist
         assert_file_exists "$skills_dir/go-testing/SKILL.md" "go-testing SKILL.md"
@@ -694,15 +694,15 @@ test_cc_skills_full() {
 }
 
 test_cc_skills_ecosystem() {
-    log_test "Claude Code: skills injection (ecosystem-only = 10 foundation skills)"
+    log_test "Claude Code: skills injection (ecosystem-only = 11 foundation skills)"
     cleanup_test_env
 
     if $BINARY install --agent claude-code --component skills --preset ecosystem-only --persona neutral 2>&1; then
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
-        # ecosystem-only = 22 files: 10 SDD + judgment-day + 10 foundation + _shared/SKILL.md
-        assert_file_count "$skills_dir" "SKILL.md" 22 "Ecosystem preset: 22 skill files"
+        # ecosystem-only = 23 files: 10 SDD + judgment-day + 11 foundation + _shared/SKILL.md
+        assert_file_count "$skills_dir" "SKILL.md" 23 "Ecosystem preset: 23 skill files"
 
         # SDD skills present
         assert_file_exists "$skills_dir/sdd-init/SKILL.md" "SDD skills present"
@@ -932,13 +932,13 @@ test_oc_skills_minimal() {
 }
 
 test_oc_skills_full() {
-    log_test "OpenCode: skills injection (full-gentleman = 10 foundation skills)"
+    log_test "OpenCode: skills injection (full-gentleman = 11 foundation skills)"
     cleanup_test_env
 
     if $BINARY install --agent opencode --component skills --preset full-gentleman --persona neutral 2>&1; then
         local skill_dir="$HOME/.config/opencode/skills"
         assert_dir_exists "$skill_dir" "OpenCode skill directory"
-        assert_file_count "$skill_dir" "SKILL.md" 22 "Full preset: 22 skill files"
+        assert_file_count "$skill_dir" "SKILL.md" 23 "Full preset: 23 skill files"
         assert_file_exists "$skill_dir/go-testing/SKILL.md" "go-testing skill"
         assert_file_exists "$skill_dir/skill-creator/SKILL.md" "skill-creator skill"
         assert_file_exists "$skill_dir/branch-pr/SKILL.md" "branch-pr skill"


### PR DESCRIPTION
## Linked Issue

Closes #2163

## PR Type

- [x] `type:chore` - Maintenance/tooling

## Summary

- We own this maintainer regression: #2165 added `rdd-defect-workflow`, but we merged it with stale canonical E2E skill-count expectations.
- The shared preset now has 11 foundation skills. With 10 SDD skills, `judgment-day`, and `_shared`, Claude full-gentleman, Claude ecosystem-only, and OpenCode full-gentleman each install 23 `SKILL.md` files.
- This changes test assertions and descriptions only. There is no production behavior change.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `e2e/e2e_test.sh` | Align the three coupled preset assertions with 11 foundation skills and 23 total skill files. |

## Test Plan

- PASS: focused isolated-HOME installer harness for Claude full-gentleman, Claude ecosystem-only, and OpenCode full-gentleman on the exact patch.
- PASS: `go test ./... -count=1`
- PASS: `go vet ./...`
- PASS: `go run ./internal/gofmtcheck`
- PASS: `bash -n e2e/e2e_test.sh`
- PASS: `shellcheck -e SC1091,SC2001,SC2088 e2e/e2e_test.sh` (excludes existing findings outside edited lines)
- PASS: `git diff --check`
- PASS: staged RDD pre-commit validation returned `disabled/unmanaged`, so ordinary repository policy applies.
- Verified one file, 8 additions, 8 deletions, patch SHA-256 `2d68a9c28c17654b3133beac6b059413f474c7349312979d018beff1f2e34b5e`.
- Benchmark validation: N/A. This test-only count correction does not change review lifecycle, gates, recovery, delivery, benchmark implementation, corpus, classifier, or claims.

## Rollback

Revert commit `f8d7e83f27fee7d0f9bb19e8856c5e4b16910e99`. The rollback boundary is only `e2e/e2e_test.sh`; installer and catalog behavior remain untouched.

## Production Impact

None. This PR only corrects E2E expectations for behavior already shipped by #2165.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end skill injection tests to reflect the addition of a foundation skill.
  * Increased the expected skill-file count from 22 to 23 for Claude Code and OpenCode scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->