### PR TITLE
fix(review): preserve declined candidate identity

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -388,7 +388,7 @@ invents a metric is worse than one that admits a gap.
     (cluttered repositories, interleaved lifecycles) governed by a different
     growth rule: community-reported shapes become journeys, so its size tracks
     community reports, not releases, and folding it into the core would make
-    "49 journeys" a moving claim. Two of its numbers need careful reading.
+    "50 journeys" a moving claim. Two of its numbers need careful reading.
     `rw01` pins issue #1881 while a product fix is in flight: a block there is
     the truth about today's build, not a permanent verdict, and the journey is
     kept precisely so the fix has a permanent pin. And the no-echo assertions
@@ -431,7 +431,7 @@ completed; nothing was unsupported. Re-running produces byte-identical numbers,
 
 Those numbers are the **14-journey** corpus against the binary named above,
 kept as-is because they belong to that named build. The corpus has since grown
-to 49 journeys; re-run `run` against your own binary rather than reading the
+to 50 journeys; re-run `run` against your own binary rather than reading the
 block above as current totals. The row labels moved too: `by_design` did not
 exist when this was recorded and is now printed as `4d`, next to the number it
 carves out of, with `dead_end` at `4e`.
@@ -565,7 +565,7 @@ cannot silently decay into the already-covered corrupt-record case.
 
 ### Wave 1 integration regressions (`journeys_wave1.go`)
 
-Journeys 44 to 49 pin fixes that internal tests already covered below the user
+Journeys 44 to 50 pin fixes that internal tests already covered below the user
 boundary. All remain core black-box journeys: fixtures create repository inputs,
 and every native authority state is reached through the measured binary.
 
@@ -577,6 +577,7 @@ and every native authority state is reached through the measured binary.
 | `j47-disabled-mode-archives-discovered-invalidated-receipt` | enabled discovered invalidation, disabled/unmanaged archive without allow, explicit invalid receipt control, and re-enabled enforcement | issue #2128 |
 | `j48-recovered-workspace-preserves-full-candidate-scope` | two-path workspace candidate, strict-subset correction, complete terminal and recovered scope, immediate pre-commit allow, byte/path drift controls | issue #2090 |
 | `j49-status-without-cwd-honors-kill-switch` | clone-local mode disabled, explicit-CWD control, omitted-CWD status using the same repository identity, disabled/unmanaged archive without approval | issue #2129 |
+| `j50-candidate-decline-preserves-frozen-delivery-identity` | status-derived v2 consent relay and decline, exact non-authorizing delivery identity, clean authority inventory, release and byte/path drift controls | issue #2045 |
 
 `j44` proves the linked checkout/common-dir topology and remote baseline before
 review starts, then proves the staged delivery tree equals the corrected receipt
@@ -593,7 +594,10 @@ governance steps aside and an explicit invalid receipt remains fail-closed.
 authority retain the complete two-path tree and manifest; exact pre-commit
 targets allow, while later byte and path drift still fail closed. `j49` proves
 that explicit and omitted CWD status calls reach the same clone-local switch and
-the same archive-ready change without fabricating review authority.
+the same archive-ready change without fabricating review authority. `j50`
+executes only provider-emitted START and decline invocations, then proves the
+unchanged staged candidate retains its base/tree/path identity without review
+authority while release, byte drift, and path drift cannot inherit the decline.
 
 ## Opt-in axes
 
@@ -615,7 +619,7 @@ its own declaration.
 
 - **Nothing runs unless you name it.** Default is the core alone. `--axis all`
   takes everything registered. An unknown name is a hard error, because
-  "49 journeys" and "49 journeys plus an axis" are different measurements and a
+  "50 journeys" and "50 journeys plus an axis" are different measurements and a
   typo must never silently produce the first.
 - **The core does not depend on any axis.** `rm bench/axis_damaged_store*.go`
   leaves the corpus compiling, testing and reporting exactly the numbers it

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -23,6 +23,12 @@ type statusEnvelope struct {
 		Revision  string `json:"revision"`
 	} `json:"authority"`
 	TargetIdentity string `json:"target_identity"`
+	Projection     struct {
+		BaseTree             string   `json:"base_tree"`
+		CurrentCandidateTree string   `json:"current_candidate_tree"`
+		PathsDigest          string   `json:"paths_digest"`
+		Paths                []string `json:"paths"`
+	} `json:"projection"`
 	NextTransition struct {
 		Kind    string `json:"kind"`
 		Collect struct {
@@ -44,6 +50,7 @@ type statusEnvelope struct {
 		} `json:"collect"`
 		Execute struct {
 			Operation string `json:"operation"`
+			Command   string `json:"command"`
 			Arguments []struct {
 				Name  string `json:"name"`
 				Value string `json:"value"`

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -19,6 +19,10 @@ const (
 	stagedSuccessorLineage   = "wave-one-staged-recovery-successor"
 	fullScopeLineage         = "wave-one-full-scope-source"
 	fullScopeSuccessor       = "wave-one-full-scope-successor"
+	declineCandidateLineage  = "wave-one-candidate-decline"
+	declineCandidatePath     = "scripts/deploy.sh"
+	declineCandidateContents = "#!/bin/sh\necho deploy\n"
+	reviewContractV2         = "gentle-ai.review-integration/v2"
 )
 
 var startNamedCapability = &Capability{Verb: []string{"review", "start"}, Flags: []string{"--cwd", "--lineage"}}
@@ -112,10 +116,25 @@ type waveFinalVerificationIncident struct {
 }
 
 type waveGateResult struct {
-	Result  string `json:"result"`
-	Allowed bool   `json:"allowed"`
-	Context struct {
+	Result   string `json:"result"`
+	Allowed  bool   `json:"allowed"`
+	Action   string `json:"action"`
+	Delivery string `json:"delivery"`
+	Context  struct {
 		LineageID             string `json:"lineage_id"`
+		Generation            int    `json:"generation"`
+		StoreRevision         string `json:"store_revision"`
+		GenesisRevision       string `json:"genesis_revision"`
+		ChainIdentity         string `json:"chain_identity"`
+		BundleDigest          string `json:"bundle_digest"`
+		BaseTree              string `json:"base_tree"`
+		CandidateTree         string `json:"candidate_tree"`
+		PathsDigest           string `json:"paths_digest"`
+		FixDeltaHash          string `json:"fix_delta_hash"`
+		PolicyHash            string `json:"policy_hash"`
+		LedgerHash            string `json:"ledger_hash"`
+		EvidenceHash          string `json:"evidence_hash"`
+		ReceiptBaseTree       string `json:"receipt_base_tree"`
 		BaseRelationshipValid bool   `json:"base_relationship_valid"`
 		Denial                *struct {
 			Stage string `json:"stage"`
@@ -134,12 +153,57 @@ type waveInventory struct {
 	} `json:"entries"`
 }
 
+type waveConsentResult struct {
+	Action         string `json:"action"`
+	TargetIdentity string `json:"target_identity"`
+	Choices        []struct {
+		Answer     string `json:"answer"`
+		Invocation string `json:"invocation"`
+	} `json:"choices"`
+}
+
+type waveDeclinedStart struct {
+	Action         string `json:"action"`
+	Consent        string `json:"consent"`
+	LineageID      string `json:"lineage_id"`
+	TargetIdentity string `json:"target_identity"`
+}
+
 func decodeWaveObservation(observation Observation, target any, label string) error {
 	if observation.ExitCode != 0 {
 		return fmt.Errorf("%s exited %d: %s", label, observation.ExitCode, firstLine(observation.Stderr))
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), target); err != nil {
 		return fmt.Errorf("parse %s: %w (stderr: %s)", label, err, firstLine(observation.Stderr))
+	}
+	return nil
+}
+
+func waveReviewInvocationArgs(invocation string) ([]string, error) {
+	fields := strings.Fields(strings.TrimSpace(invocation))
+	if len(fields) < 3 || fields[0] != "gentle-ai" || fields[1] != "review" {
+		return nil, fmt.Errorf("invalid emitted review invocation %q", invocation)
+	}
+	return fields[1:], nil
+}
+
+func requireCandidateDeclinedGate(sandbox *Sandbox, observation Observation) error {
+	var gate waveGateResult
+	if err := decodeWaveObservation(observation, &gate, "candidate-declined gate"); err != nil {
+		return err
+	}
+	context := gate.Context
+	if gate.Result != "invalidated" || gate.Allowed || gate.Action != "repository-policy" || gate.Delivery != "candidate_declined/unmanaged" ||
+		context.BaseTree == "" || context.BaseTree != sandbox.Scratch["decline-base"] ||
+		context.CandidateTree == "" || context.CandidateTree != sandbox.Scratch["decline-tree"] ||
+		context.PathsDigest == "" || context.PathsDigest != sandbox.Scratch["decline-paths"] ||
+		context.Denial == nil || context.Denial.Stage != "candidate-decline" || context.Denial.Code != "exact_candidate" {
+		return fmt.Errorf("candidate decline did not preserve exact unmanaged identity: %+v", gate)
+	}
+	if context.LineageID != "" || context.Generation != 0 || context.StoreRevision != "" || context.GenesisRevision != "" ||
+		context.ChainIdentity != "" || context.BundleDigest != "" || context.FixDeltaHash != "" || context.PolicyHash != "" ||
+		context.LedgerHash != "" || context.EvidenceHash != "" || context.ReceiptBaseTree != "" {
+		return fmt.Errorf("candidate decline fabricated review authority: %+v", context)
 	}
 	return nil
 }
@@ -859,6 +923,115 @@ func proveArchiveAuthorityUnchanged(sandbox *Sandbox) error {
 	return fmt.Errorf("archive authority %q disappeared", sandbox.Lineage)
 }
 
+func prepareDeclinedCandidate(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, declineCandidatePath), declineCandidateContents); err != nil {
+		return err
+	}
+	paths, err := gitOut(sandbox, sandbox.Repo, "ls-files", "--others", "--exclude-standard")
+	if err != nil || paths != declineCandidatePath {
+		return fmt.Errorf("decline fixture untracked paths = %q, %v", paths, err)
+	}
+	return nil
+}
+
+func declineCandidateFromStatus(r *journeyRun) error {
+	statusObservation := r.run(productArgsFor(r, "review", "status", "--contract", reviewContractV2,
+		"--next-transition", "--lineage", declineCandidateLineage), false)
+	var status statusEnvelope
+	if err := decodeWaveObservation(statusObservation, &status, "candidate decline status"); err != nil {
+		return err
+	}
+	projection := status.Projection
+	if status.TargetIdentity == "" || projection.BaseTree == "" || projection.CurrentCandidateTree == "" ||
+		projection.PathsDigest == "" || strings.Join(projection.Paths, "\x00") != declineCandidatePath ||
+		status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.start" || status.NextTransition.Execute.Command == "" {
+		return fmt.Errorf("status did not derive an exact v2 START: %+v", status)
+	}
+	r.sandbox.Scratch["decline-target"] = status.TargetIdentity
+	r.sandbox.Scratch["decline-base"] = projection.BaseTree
+	r.sandbox.Scratch["decline-tree"] = projection.CurrentCandidateTree
+	r.sandbox.Scratch["decline-paths"] = projection.PathsDigest
+
+	relayArgs, err := waveReviewInvocationArgs(status.NextTransition.Execute.Command)
+	if err != nil {
+		return err
+	}
+	var consent waveConsentResult
+	if err := decodeWaveObservation(r.run(relayArgs, false), &consent, "candidate consent relay"); err != nil {
+		return err
+	}
+	declineInvocation := ""
+	for _, choice := range consent.Choices {
+		if choice.Answer == "declined" {
+			declineInvocation = choice.Invocation
+		}
+	}
+	if consent.Action != "consent_required" || consent.TargetIdentity != status.TargetIdentity || declineInvocation == "" {
+		return fmt.Errorf("consent relay did not preserve the status target: %+v", consent)
+	}
+	declineArgs, err := waveReviewInvocationArgs(declineInvocation)
+	if err != nil {
+		return err
+	}
+	var declined waveDeclinedStart
+	if err := decodeWaveObservation(r.run(declineArgs, false), &declined, "candidate decline"); err != nil {
+		return err
+	}
+	if declined.Action != "declined" || declined.Consent != "declined_this_candidate" || declined.LineageID != "" || declined.TargetIdentity != status.TargetIdentity {
+		return fmt.Errorf("decline result created or changed authority: %+v", declined)
+	}
+	var inventory waveInventory
+	if err := decodeWaveObservation(r.run(productArgsFor(r, "review", "status"), false), &inventory, "post-decline authority inventory"); err != nil {
+		return err
+	}
+	if !inventory.Complete || !inventory.Authoritative || len(inventory.Entries) != 0 {
+		return fmt.Errorf("decline created review authority: %+v", inventory)
+	}
+	return nil
+}
+
+func stageDeclinedCandidate(sandbox *Sandbox) error {
+	if err := sandbox.git(sandbox.Repo, "add", declineCandidatePath); err != nil {
+		return err
+	}
+	tree, err := gitOut(sandbox, sandbox.Repo, "write-tree")
+	if err != nil || tree != sandbox.Scratch["decline-tree"] {
+		return fmt.Errorf("staged decline tree = %q, want %q: %v", tree, sandbox.Scratch["decline-tree"], err)
+	}
+	return nil
+}
+
+func driftDeclinedCandidate(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, declineCandidatePath), "#!/bin/sh\necho drift\n"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "add", declineCandidatePath)
+}
+
+func addDeclinedPathDrift(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, declineCandidatePath), declineCandidateContents); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "scripts/extra.sh"), "#!/bin/sh\necho extra\n"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "add", declineCandidatePath, "scripts/extra.sh")
+}
+
+func requireCandidateDeclineRejected(name string) func(*Sandbox, Observation) error {
+	return func(_ *Sandbox, observation Observation) error {
+		var gate waveGateResult
+		if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate); err != nil {
+			return fmt.Errorf("parse %s denial: %w", name, err)
+		}
+		if observation.ExitCode == 0 || gate.Allowed || gate.Result == "allow" || gate.Delivery != "" || gate.Action == "repository-policy" ||
+			gate.Context.Denial != nil && gate.Context.Denial.Stage == "candidate-decline" {
+			return fmt.Errorf("%s inherited candidate decline: exit=%d gate=%+v", name, observation.ExitCode, gate)
+		}
+		return nil
+	}
+}
+
 func waveOneJourneys() []Journey {
 	return []Journey{
 		{
@@ -1024,6 +1197,27 @@ func waveOneJourneys() []Journey {
 					Args: func(*Sandbox) ([]string, error) {
 						return []string{"sdd-status", sddChange, "--json"}, nil
 					}, After: requireDisabledUnmanagedArchiveStatus("omitted CWD")},
+			},
+		},
+		{
+			ID:     "j50-candidate-decline-preserves-frozen-delivery-identity",
+			Title:  "Candidate decline: exact frozen identity reaches delivery without creating review authority",
+			Source: "issue #2045",
+			Steps: []Step{
+				{Name: "fixture: repository", Fixture: baseRepo},
+				{Name: "fixture: high-risk candidate remains untracked", Fixture: prepareDeclinedCandidate},
+				{Name: "derive v2 START and execute emitted relay and decline", Requires: statusCapability, Composite: declineCandidateFromStatus},
+				{Name: "fixture: stage the exact unchanged declined candidate", Fixture: stageDeclinedCandidate},
+				{Name: "separate process preserves exact unmanaged identity", Requires: validateCapability,
+					Args: productArgs("review", "validate", "--gate", "pre-commit"), After: requireCandidateDeclinedGate},
+				{Name: "release cannot inherit candidate decline", Requires: validateCapability,
+					Args: productArgs("review", "validate", "--gate", "release"), After: requireCandidateDeclineRejected("release")},
+				{Name: "fixture: candidate bytes drift", Fixture: driftDeclinedCandidate},
+				{Name: "byte drift cannot inherit candidate decline", Requires: validateCapability,
+					Args: productArgs("review", "validate", "--gate", "pre-commit"), After: requireCandidateDeclineRejected("byte drift")},
+				{Name: "fixture: restore bytes and add path drift", Fixture: addDeclinedPathDrift},
+				{Name: "path drift cannot inherit candidate decline", Requires: validateCapability,
+					Args: productArgs("review", "validate", "--gate", "pre-commit"), After: requireCandidateDeclineRejected("path drift")},
 			},
 		},
 	}

--- a/bench/journeys_wave1_test.go
+++ b/bench/journeys_wave1_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWaveReviewInvocationArgs(t *testing.T) {
+	got, err := waveReviewInvocationArgs("gentle-ai review start --contract=gentle-ai.review-integration/v2 --consent=relay")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if joined := strings.Join(got, "\x00"); joined != "review\x00start\x00--contract=gentle-ai.review-integration/v2\x00--consent=relay" {
+		t.Fatalf("review invocation args = %q", joined)
+	}
+	for _, invalid := range []string{"", "other review start", "gentle-ai status"} {
+		if _, err := waveReviewInvocationArgs(invalid); err == nil {
+			t.Fatalf("accepted invalid review invocation %q", invalid)
+		}
+	}
+}
+
+func TestRequireCandidateDeclinedGate(t *testing.T) {
+	sandbox := &Sandbox{Scratch: map[string]string{
+		"decline-base":  "1111111111111111111111111111111111111111",
+		"decline-tree":  "2222222222222222222222222222222222222222",
+		"decline-paths": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+	}}
+	observation := Observation{Stdout: `{"result":"invalidated","allowed":false,"action":"repository-policy","delivery":"candidate_declined/unmanaged","context":{"lineage_id":"","base_tree":"1111111111111111111111111111111111111111","candidate_tree":"2222222222222222222222222222222222222222","paths_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","denial":{"stage":"candidate-decline","code":"exact_candidate"}}}`}
+	if err := requireCandidateDeclinedGate(sandbox, observation); err != nil {
+		t.Fatal(err)
+	}
+	observation.Stdout = strings.Replace(observation.Stdout, `"lineage_id":""`, `"lineage_id":"fabricated"`, 1)
+	if err := requireCandidateDeclinedGate(sandbox, observation); err == nil {
+		t.Fatal("accepted candidate-declined gate with fabricated lineage")
+	}
+}

--- a/internal/cli/review_candidate_decline_test.go
+++ b/internal/cli/review_candidate_decline_test.go
@@ -35,6 +35,12 @@ func TestRelayedCandidateDeclineAllowsOnlyExactPreCommitDelivery(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "v2", "review-candidate-decline", "receipt.json")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("declined candidate created receipt: %v", err)
 	}
+	declinedSnapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{"scripts/deploy.sh"},
+	})
+	if err != nil {
+		t.Fatalf("rebuild declined candidate: %v", err)
+	}
 
 	runReviewCLIGit(t, repo, "add", "scripts/deploy.sh")
 	var allowed bytes.Buffer
@@ -48,6 +54,11 @@ func TestRelayedCandidateDeclineAllowsOnlyExactPreCommitDelivery(t *testing.T) {
 	}
 	if result.Context.Denial == nil || result.Context.Denial.Stage != "candidate-decline" {
 		t.Fatalf("candidate-declined delivery did not expose its unmanaged choice: %#v", result.Context)
+	}
+	if result.Context.BaseTree != declinedSnapshot.BaseTree ||
+		result.Context.CandidateTree != declinedSnapshot.CandidateTree ||
+		result.Context.PathsDigest != declinedSnapshot.PathsDigest {
+		t.Fatalf("candidate-declined delivery lost frozen candidate identity:\ncontext=%#v\nwant=%#v", result.Context, declinedSnapshot)
 	}
 
 	if err := os.WriteFile(filepath.Join(repo, "scripts", "deploy.sh"), []byte("echo drift\n"), 0o644); err != nil {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -3850,8 +3850,11 @@ func emitCandidateDeclinedUnmanagedDelivery(stdout io.Writer, gate reviewtransac
 		Reason:   "review is unmanaged by candidate choice; ordinary repository policy governs this exact declined candidate",
 		Delivery: reviewtransaction.RDDDeliveryCandidateDeclinedUnmanaged,
 		Context: reviewtransaction.GateContext{
-			Gate:   gate,
-			Denial: &reviewtransaction.GateDenial{Stage: "candidate-decline", Code: "exact_candidate"},
+			Gate:          gate,
+			BaseTree:      decline.Snapshot.BaseTree,
+			CandidateTree: decline.Snapshot.CandidateTree,
+			PathsDigest:   decline.Snapshot.PathsDigest,
+			Denial:        &reviewtransaction.GateDenial{Stage: "candidate-decline", Code: "exact_candidate"},
 		},
 	}
 	// Keep the derived authorization live in this boundary: this guards against a

--- a/internal/reviewtransaction/candidate_decline_test.go
+++ b/internal/reviewtransaction/candidate_decline_test.go
@@ -36,6 +36,12 @@ func TestCandidateDeclineAuthorizationIsReplayableAndFailsClosed(t *testing.T) {
 	if err != nil || !found || resolved.Snapshot.Identity != snapshot.Identity {
 		t.Fatalf("exact staged delivery decline = %#v, found=%v, err=%v", resolved, found, err)
 	}
+	if resolved.Snapshot.BaseTree != snapshot.BaseTree ||
+		resolved.Snapshot.CandidateTree != snapshot.CandidateTree ||
+		resolved.Snapshot.PathsDigest != snapshot.PathsDigest ||
+		!equalStrings(resolved.Snapshot.Paths, snapshot.Paths) {
+		t.Fatalf("resolved decline lost frozen candidate identity:\nresolved=%#v\nwant=%#v", resolved.Snapshot, snapshot)
+	}
 
 	root, _, err := candidateDeclineRoot(ctx, repo, false)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2045

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Candidate-declined validation now exposes the exact frozen `base_tree`, `candidate_tree`, and `paths_digest` already persisted and revalidated by the provider. An unchanged declined candidate remains non-authorizing and delegates delivery to ordinary repository policy; no approval, receipt, lineage, or release authority is fabricated.

This preserves the candidate-scoped decline behavior merged in #2046. Release, byte drift, and path drift continue to fail closed without inheriting the decline disposition. Gentle Pi adoption and wrapper behavior are explicitly out of scope.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Projects the validated declined snapshot identity into the unmanaged gate context |
| `internal/cli/review_candidate_decline_test.go` | Pins exact runtime base/tree/path projection, no authority, and byte-drift refusal |
| `internal/reviewtransaction/candidate_decline_test.go` | Pins durable resolver preservation of the frozen candidate and path identity |
| `bench/journeys.go` | Reads provider-emitted v2 START command and projection fields |
| `bench/journeys_wave1.go` | Adds durable core j50 with release, byte-drift, and path-drift controls |
| `bench/journeys_wave1_test.go` | Tests emitted invocation parsing and rejects fabricated gate authority |
| `bench/README.md` | Documents the truthful 50-journey core corpus |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/reviewtransaction -run 'TestCandidateDecline' -count=1
go test ./internal/cli -run 'Test(RelayedCandidateDeclineAllowsOnlyExactPreCommitDelivery|CandidateDeclineAllowsExactPrePushAndPrePRButNotLaterCandidate|CandidateDeclineNeverAuthorizesRelease)$' -count=1
go test ./... -count=1
go vet ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

Docker E2E was not run locally; required CI remains authoritative. The root suite passed, including `e2e/organicruntime`.

**Benchmark Validation**

```bash
cd bench
go test ./... -count=1
go vet ./...
go build ./...
gentle-ai-bench run --binary /path/to/candidate --only j50-candidate-decline-preserves-frozen-delivery-identity --out j50.json
gentle-ai-bench run --binary /path/to/candidate --out full-50.json
```

- j50 completed twice with `0 unsupported, 0 failed`.
- Full core corpus completed with `50 completed, 0 unsupported, 0 failed`.
- Candidate is 7 files and 282 changed lines (`272 additions + 10 deletions`).
- Patch SHA-256 relative to `a13dd975518443aed2fd3b8116003a84c70cc084`: `72323d05536497ac535738f11935f666239bcc6d95a544c61ad72e8fc4188e83`.
- Disabled pre-commit validation returned `disabled/unmanaged` with no review authority.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Rollback is one commit: revert `fix(review): preserve declined candidate identity` to remove the provider projection, its regressions, j50, and the 50-corpus documentation together.

No new admission, security, integrity, repair, or governance guard is introduced. The existing provider resolver still validates persisted snapshot evidence, exact live candidate bytes, and path identity; this change only projects that already-validated identity into the non-authorizing result.

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added candidate-decline handling that preserves the original delivery snapshot throughout staging, review, and resolution.
  - Added validation to reject unmanaged deliveries and changes that occur after approval or release.
  - Expanded review results with clearer delivery, action, consent, and decline context.

- **Documentation**
  - Updated benchmark documentation and coverage to include the new candidate-decline journey.

- **Bug Fixes**
  - Improved protection against identity and content drift during candidate-decline workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->