### PR TITLE
fix(sdd): keep stale verify evidence out of remediation

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -131,6 +131,9 @@ type sddStatusV1 struct {
 		Completed   int  `json:"completed"`
 		AllComplete bool `json:"allComplete"`
 	} `json:"taskProgress"`
+	RemediationState struct {
+		Required bool `json:"required"`
+	} `json:"remediationState"`
 }
 
 // gateResult is the subset of a lifecycle gate envelope the proofs read.
@@ -850,6 +853,43 @@ const sddFailedVerifyReport = "```yaml\n" +
 	"build_exit_code: 0\n" +
 	"build_output_hash: sha256:3333333333333333333333333333333333333333333333333333333333333333\n" +
 	"```\n"
+
+const sddHistoricalStalePassReport = "```yaml\n" +
+	"schema: gentle-ai.verify-result/v1\n" +
+	"evidence_revision: sha256:1111111111111111111111111111111111111111111111111111111111111111\n" +
+	"verdict: pass\n" +
+	"blockers: 0\n" +
+	"critical_findings: 0\n" +
+	"requirements: 0/0\n" +
+	"scenarios: 1/1\n" +
+	"test_command: go test ./internal/example\n" +
+	"test_exit_code: 0\n" +
+	"test_output_hash: sha256:2222222222222222222222222222222222222222222222222222222222222222\n" +
+	"build_command: go test ./cmd/gentle-ai\n" +
+	"build_exit_code: 0\n" +
+	"build_output_hash: sha256:3333333333333333333333333333333333333333333333333333333333333333\n" +
+	"```\n"
+
+// sddHistoricalStalePass creates a first-time component whose change-local
+// delta spec uses the valid historical requirement heading. The all-green report
+// predates that count and must re-enter fresh review routing, never remediation.
+func sddHistoricalStalePass(sandbox *Sandbox) error {
+	if err := sddPlanningArtifacts("")(sandbox); err != nil {
+		return err
+	}
+	root := sddChangeRoot(sandbox)
+	if err := sandbox.write(filepath.Join(root, "specs", "prose", "spec.md"),
+		"### REQ-1: prose exists\n#### Scenario: prose is present\n"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(root, "verify-report.md"), sddHistoricalStalePassReport); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "openspec"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "commit", "-qm", "historical SDD verification evidence")
+}
 
 // ---------------------------------------------------------------------------
 // Counted operator work
@@ -2023,6 +2063,35 @@ func sddJourneys() []Journey {
 				{Name: "fixture: change the candidate, which is what all three asked for", Fixture: stageProse("", "changed")},
 				{Name: "recover, following exactly what the gate then names",
 					Requires: recoverCapability, Composite: recoverScopeChangeRoundTrip("review-guardrail-successor")},
+			},
+		},
+		{
+			ID:     "j44-sdd-historical-requirement-stale-pass",
+			Title:  "Historical change-local requirement heading: stale PASS restarts verification instead of failed remediation",
+			Source: "issue #2137 (historical OpenSpec requirement compatibility and stale verification routing)",
+			Steps: []Step{
+				{Name: "fixture: first-time component with historical requirement evidence", Fixture: sddHistoricalStalePass},
+				// Wave 4 S3 removed pre-verify review supervision: this fixture
+				// carries no review artifacts anywhere, so absent authority is
+				// decline-by-absence and the stale PASS re-enters verification
+				// directly (never review, never remediation). Archive stays
+				// blocked until that fresh verification lands. Mirrors
+				// TestEnabledStaleEvidenceWithNoReceiptRestartsVerification.
+				{Name: "sdd-status routes stale PASS to fresh verification", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: sddStatusAssertion("historical stale PASS routing", func(status sddStatusV1) error {
+						if status.NextRecommended != "verify" || status.Dependencies.Verify != "ready" || status.Dependencies.Archive != "blocked" {
+							return fmt.Errorf("nextRecommended=%q verify=%q archive=%q, want fresh verification before archive", status.NextRecommended, status.Dependencies.Verify, status.Dependencies.Archive)
+						}
+						if status.RemediationState.Required {
+							return errors.New("stale PASS entered failed-verification remediation")
+						}
+						for _, reason := range status.BlockedReasons {
+							if strings.Contains(reason, "bounded review transaction is missing") || strings.Contains(reason, "remediation") {
+								return fmt.Errorf("stale PASS exposed failed-evidence routing: %q", reason)
+							}
+						}
+						return nil
+					})},
 			},
 		},
 	}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 63 {
-		t.Errorf("core journey count = %d, want 63", got)
+	if got := len(seen); got != 64 {
+		t.Errorf("core journey count = %d, want 64", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -1077,6 +1077,123 @@ func TestResolveRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority(t
 	}
 }
 
+func TestResolveRoutesChangeLocalStalePassWithoutRemediation(t *testing.T) {
+	tests := []struct {
+		name              string
+		report            string
+		withAuthority     bool
+		blockingAuthority bool
+		explicitAuthority bool
+		reviewDisabled    bool
+		wantNext          string
+		wantVerify        DependencyState
+		wantRemediation   bool
+	}{
+		{
+			// Wave 4 S3 removed pre-verify review supervision: absent
+			// authority is decline-by-absence, so stale PASS evidence
+			// re-enters verification directly instead of demanding review.
+			name:            "historical requirement PASS mismatch restarts verification without review supervision",
+			report:          strings.Replace(boundedVerifyEnvelope(shaID("d"), "pass"), "requirements: 1/1", "requirements: 0/0", 1),
+			wantNext:        "verify",
+			wantVerify:      DependencyReady,
+			wantRemediation: false,
+		},
+		{
+			name:            "historical requirement PASS mismatch restarts verification while review is disabled",
+			report:          strings.Replace(boundedVerifyEnvelope(shaID("d"), "pass"), "requirements: 1/1", "requirements: 0/0", 1),
+			reviewDisabled:  true,
+			wantNext:        "verify",
+			wantVerify:      DependencyReady,
+			wantRemediation: false,
+		},
+		{
+			name:              "historical requirement PASS mismatch with discovered blocking authority resolves review",
+			report:            strings.Replace(boundedVerifyEnvelope(shaID("d"), "pass"), "requirements: 1/1", "requirements: 0/0", 1),
+			blockingAuthority: true,
+			wantNext:          "resolve-review",
+			wantVerify:        DependencyBlocked,
+			wantRemediation:   false,
+		},
+		{
+			name:              "historical requirement PASS mismatch with disabled discovered blocking authority restarts verification",
+			report:            strings.Replace(boundedVerifyEnvelope(shaID("d"), "pass"), "requirements: 1/1", "requirements: 0/0", 1),
+			blockingAuthority: true,
+			reviewDisabled:    true,
+			wantNext:          "verify",
+			wantVerify:        DependencyReady,
+			wantRemediation:   false,
+		},
+		{
+			// While the kill switch is off, zero review code executes:
+			// even an explicit escalated receipt never blocks SDD routing.
+			name:              "historical requirement PASS mismatch with disabled explicit blocking authority restarts verification",
+			report:            strings.Replace(boundedVerifyEnvelope(shaID("d"), "pass"), "requirements: 1/1", "requirements: 0/0", 1),
+			blockingAuthority: true,
+			explicitAuthority: true,
+			reviewDisabled:    true,
+			wantNext:          "verify",
+			wantVerify:        DependencyReady,
+			wantRemediation:   false,
+		},
+		{
+			name:            "genuine FAIL evidence keeps bounded remediation",
+			report:          strings.Replace(boundedVerifyEnvelope(shaID("d"), "fail"), "test_exit_code: 0", "test_exit_code: 1", 1),
+			withAuthority:   true,
+			wantNext:        "remediate",
+			wantVerify:      DependencyBlocked,
+			wantRemediation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### REQ-1: Auth\n#### Scenario: Valid login\n")
+			write(t, filepath.Join(changeRoot, "verify-report.md"), tt.report)
+			if tt.withAuthority {
+				writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+			}
+			if tt.blockingAuthority {
+				writeApprovedReviewArtifacts(t, changeRoot)
+				if !tt.explicitAuthority {
+					if err := os.RemoveAll(filepath.Join(changeRoot, "reviews")); err != nil {
+						t.Fatal(err)
+					}
+				} else if err := os.Remove(filepath.Join(changeRoot, "reviews", "transaction.json")); err != nil {
+					t.Fatal(err)
+				}
+				original := evaluateNativeReviewGate
+				evaluateNativeReviewGate = func(context.Context, string, reviewtransaction.Receipt, reviewtransaction.GateRequest) reviewtransaction.NativeGateEvaluation {
+					return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateEscalated}
+				}
+				t.Cleanup(func() { evaluateNativeReviewGate = original })
+			}
+
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", ReviewDisabled: tt.reviewDisabled})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.NextRecommended != tt.wantNext || status.Dependencies.Verify != tt.wantVerify || status.RemediationState.Required != tt.wantRemediation {
+				t.Fatalf("status = next %q verify %q remediation %#v, want %q/%q/remediation=%v", status.NextRecommended, status.Dependencies.Verify, status.RemediationState, tt.wantNext, tt.wantVerify, tt.wantRemediation)
+			}
+			if tt.blockingAuthority && !tt.reviewDisabled && (status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateEscalated) {
+				t.Fatalf("ReviewGate = %#v, want escalated blocking authority", status.ReviewGate)
+			}
+			if tt.reviewDisabled && status.ReviewGate != nil {
+				t.Fatalf("disabled ReviewGate = %#v, want structural absence while the switch is off", status.ReviewGate)
+			}
+			if !tt.wantRemediation {
+				reasons := strings.Join(status.BlockedReasons, "\n")
+				if strings.Contains(reasons, "bounded review transaction is missing") || strings.Contains(reasons, "remediation") {
+					t.Fatalf("stale PASS entered failed-evidence routing: %v", status.BlockedReasons)
+				}
+			}
+		})
+	}
+}
+
 func TestResolveRejectsForeignCompactAuthorityForStaleVerifyEvidence(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
@@ -1151,6 +1268,81 @@ func TestResolveEngramRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAutho
 	}
 	if status.RemediationState != (RemediationState{}) {
 		t.Fatalf("RemediationState = %#v, want empty for stale evidence", status.RemediationState)
+	}
+}
+
+func TestResolveEngramRoutesStalePassWithDisabledBlockingAuthority(t *testing.T) {
+	// While the kill switch is off, zero review code executes: neither
+	// discovered nor explicit review artifacts may block SDD routing or
+	// project a review gate, and stale PASS evidence re-enters verification.
+	tests := []struct {
+		name              string
+		explicitAuthority bool
+		wantNext          string
+		wantVerify        DependencyState
+	}{
+		{
+			name:       "discovered authority is unmanaged",
+			wantNext:   "verify",
+			wantVerify: DependencyReady,
+		},
+		{
+			name:              "explicit authority is unmanaged while disabled",
+			explicitAuthority: true,
+			wantNext:          "verify",
+			wantVerify:        DependencyReady,
+		},
+	}
+
+	original := evaluateNativeReviewGate
+	t.Cleanup(func() { evaluateNativeReviewGate = original })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("d"), "pass"))
+			writeApprovedReviewArtifacts(t, changeRoot)
+			receipt := readText(filepath.Join(changeRoot, "reviews", "receipt.json"))
+			if !tt.explicitAuthority {
+				if err := os.RemoveAll(filepath.Join(changeRoot, "reviews")); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.Remove(filepath.Join(changeRoot, "reviews", "transaction.json")); err != nil {
+				t.Fatal(err)
+			}
+			evaluateNativeReviewGate = func(context.Context, string, reviewtransaction.Receipt, reviewtransaction.GateRequest) reviewtransaction.NativeGateEvaluation {
+				return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateEscalated}
+			}
+
+			mkdir(t, filepath.Join(root, ".engram"))
+			project := strings.ToLower(filepath.Base(root))
+			observations := []engramObservation{
+				{Title: "sdd/thin/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+				{Title: "sdd/thin/spec", Content: "### REQ-1: Auth\n#### Scenario: Valid login\n", Project: project, Scope: "project"},
+				{Title: "sdd/thin/design", Content: "# Design\n", Project: project, Scope: "project"},
+				{Title: "sdd/thin/tasks", Content: "- [x] 1.1 Done\n", Project: project, Scope: "project"},
+				{Title: "sdd/thin/verify-report", Content: strings.Replace(boundedVerifyEnvelope(shaID("d"), "pass"), "requirements: 1/1", "requirements: 0/0", 1), Project: project, Scope: "project"},
+			}
+			if tt.explicitAuthority {
+				observations = append(observations, engramObservation{Title: "sdd/thin/review/receipt", Content: receipt, Project: project, Scope: "project"})
+			}
+			restore := stubEngramExport(t, observations)
+			defer restore()
+
+			status, ok, err := resolveEngramStatus(root, "thin", false, true)
+			if err != nil || !ok {
+				t.Fatalf("resolveEngramStatus() = ok %v, error %v", ok, err)
+			}
+			if status.NextRecommended != tt.wantNext || status.Dependencies.Verify != tt.wantVerify || status.Dependencies.Archive != DependencyBlocked {
+				t.Fatalf("status = next %q verify %q archive %q, want %q/%q/blocked", status.NextRecommended, status.Dependencies.Verify, status.Dependencies.Archive, tt.wantNext, tt.wantVerify)
+			}
+			if status.ReviewGate != nil {
+				t.Fatalf("disabled ReviewGate = %#v, want structural absence while the switch is off", status.ReviewGate)
+			}
+			if reasons := strings.Join(status.BlockedReasons, "\n"); strings.Contains(reasons, "escalated the receipt") || strings.Contains(reasons, "remediation") {
+				t.Fatalf("disabled BlockedReasons = %v, want no review or remediation blocking", status.BlockedReasons)
+			}
+		})
 	}
 }
 

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -343,6 +343,9 @@ type reviewAuthorityEvaluation struct {
 	Result       reviewtransaction.GateResult
 	Reason       string
 	CompactState *reviewtransaction.CompactState
+	// Blocking distinguishes a discovered non-allow authority from an absent
+	// governing receipt, so stale verification can preserve its resolution path.
+	Blocking bool
 	// Absent reports that no review authority GOVERNS this change: the change
 	// supplied no review artifact, and discovery found either no terminal native
 	// receipt or only receipts whose terminal evaluation cannot govern the
@@ -486,6 +489,10 @@ func applyReviewGateEvaluation(status *Status, evaluation reviewAuthorityEvaluat
 	if evaluation.Missing {
 		return
 	}
+	if status.Dependencies.Verify != DependencyAllDone {
+		status.ReviewGate = &ReviewGateState{Result: evaluation.Result, Reason: evaluation.Reason}
+		return
+	}
 	blockReviewGate(status, evaluation.Result, evaluation.Reason)
 }
 
@@ -559,6 +566,7 @@ func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptConte
 	if len(blockers) > 0 {
 		selected := blockers[0]
 		selected.Absent = !explicit
+		selected.Blocking = true
 		return selected
 	}
 	selected := stale[0]

--- a/internal/sddstatus/review_gate_disabled_test.go
+++ b/internal/sddstatus/review_gate_disabled_test.go
@@ -449,11 +449,13 @@ func seedStaleEvidenceReadyChange(t *testing.T, root string) string {
 	return changeRoot
 }
 
-// TestEnabledStaleEvidenceWithNoReceiptNamesReviewStart pins today's enabled
-// behaviour for the exact fixture the disabled test below relaxes: with no
-// governing receipt anywhere, the discovery walk finds nothing, and the
-// change is blocked pending a fresh review.
-func TestEnabledStaleEvidenceWithNoReceiptNamesReviewStart(t *testing.T) {
+// TestEnabledStaleEvidenceWithNoReceiptRestartsVerification covers the
+// enabled behaviour for the exact fixture the disabled test below relaxes:
+// with no governing receipt anywhere, the discovery walk finds nothing, and
+// absent authority is decline-by-absence (issue #2137): stale non-FAIL
+// evidence re-enters verification instead of blocking at resolve-review
+// demanding a bounded review transaction that never existed.
+func TestEnabledStaleEvidenceWithNoReceiptRestartsVerification(t *testing.T) {
 	root := t.TempDir()
 	seedStaleEvidenceReadyChange(t, root)
 
@@ -461,11 +463,11 @@ func TestEnabledStaleEvidenceWithNoReceiptNamesReviewStart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
-	if status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "resolve-review" {
-		t.Fatalf("enabled stale-evidence archive=%q next=%q, want blocked/resolve-review", status.Dependencies.Archive, status.NextRecommended)
+	if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+		t.Fatalf("enabled stale-evidence verify=%q archive=%q next=%q, want ready/blocked/verify", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
 	}
-	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "gentle-ai review start") {
-		t.Fatalf("enabled stale-evidence BlockedReasons = %v, want it to name the fresh review", status.BlockedReasons)
+	if reasons := strings.Join(status.BlockedReasons, "\n"); strings.Contains(reasons, "gentle-ai review start") || strings.Contains(reasons, "bounded review transaction is missing") {
+		t.Fatalf("enabled stale-evidence BlockedReasons = %v, want no review-start or missing-transaction demand", status.BlockedReasons)
 	}
 }
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -534,7 +534,9 @@ func Resolve(options ResolveOptions) (Status, error) {
 	// "archive consults no reviewGate structured status ... archive cannot
 	// fail or block for review reasons" requirement.
 	staleEvidenceCandidate := governingRef == nil && reviewState == nil && applyState == ApplyAllDone && artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale
+	var staleReviewAuthority *reviewAuthorityEvaluation
 	var staleAllowAuthority *reviewAuthorityEvaluation
+	staleAuthorityBlocked := false
 	// staleEvidenceUnmanaged is the disabled-mode analogue of
 	// staleAllowAuthority: internally-complete, non-failing evidence whose
 	// only defect is a totals mismatch needs a fresh verification either
@@ -548,14 +550,21 @@ func Resolve(options ResolveOptions) (Status, error) {
 	staleEvidenceUnmanaged := reviewDisabled && staleEvidenceCandidate
 	if !reviewDisabled && staleEvidenceCandidate {
 		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, firstPath(artifactPaths.ReviewReceipt), "", changeName)
+		staleReviewAuthority = &evaluation
 		if evaluation.Result == reviewtransaction.GateAllow {
 			staleAllowAuthority = &evaluation
 		} else {
-			blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
+			staleAuthorityBlocked = evaluation.Blocking
+			if staleAuthorityBlocked {
+				blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
+			}
 		}
 	}
 	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult, reviewDisabled)
-	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
+	// A complete non-FAIL report with only stale totals needs fresh verification,
+	// not remediation for failed evidence.
+	verifyReportCurrent := artifacts["verifyReport"] == ArtifactDone && !verifyResult.Stale
+	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && verifyReportCurrent && !verifyResult.Passing && applyState == ApplyAllDone
 	var compactRemediation *reviewtransaction.CompactState
 	if !reviewDisabled {
 		compactRemediation = resolveCompactRemediationAuthority(
@@ -572,8 +581,8 @@ func Resolve(options ResolveOptions) (Status, error) {
 		reviewStateReason,
 		readText(firstPath(artifactPaths.ApplyProgress)),
 	)
-	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
-	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
+	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyReportCurrent, verifyResult.Passing, remediationState.Complete)
+	nextRecommended := resolveNextRecommended(dependencies, applyState, verifyReportCurrent, remediationState)
 	if staleAllowAuthority != nil || staleEvidenceUnmanaged || (reviewDisabled && runtimeRemediationComplete) {
 		dependencies.Verify = DependencyReady
 		dependencies.Archive = DependencyBlocked
@@ -581,6 +590,11 @@ func Resolve(options ResolveOptions) (Status, error) {
 		if runtimeRemediationComplete {
 			remediationState = RemediationState{}
 		}
+	}
+	if staleAuthorityBlocked {
+		dependencies.Verify = DependencyBlocked
+		dependencies.Archive = DependencyBlocked
+		nextRecommended = "resolve-review"
 	}
 	var boundGate *ReviewGateState
 	bridge := compactPreVerifyBridge{}
@@ -647,8 +661,8 @@ func Resolve(options ResolveOptions) (Status, error) {
 	status.runtimeAttemptTokens = runtimeAttemptTokens
 	status.ReviewTransaction = reviewState
 	if governingRef == nil {
-		if staleAllowAuthority != nil {
-			status.ReviewGate = &ReviewGateState{Result: staleAllowAuthority.Result, Reason: staleAllowAuthority.Reason}
+		if staleReviewAuthority != nil {
+			applyReviewGateEvaluation(&status, *staleReviewAuthority)
 		} else {
 			applyReviewGate(
 				&status,
@@ -930,18 +944,27 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	// staleAllowAuthority granting the same "please re-verify" leniency with
 	// zero review consultation and zero blocked reasons).
 	staleEvidenceCandidate := governingRef == nil && reviewState == nil && applyState == ApplyAllDone && artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale
+	var staleReviewAuthority *reviewAuthorityEvaluation
 	var staleAllowAuthority *reviewAuthorityEvaluation
+	staleAuthorityBlocked := false
 	staleEvidenceUnmanaged := reviewDisabled && staleEvidenceCandidate
 	if !reviewDisabled && staleEvidenceCandidate {
 		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, "", artifactsByType["review/receipt"].Content, changeName)
+		staleReviewAuthority = &evaluation
 		if evaluation.Result == reviewtransaction.GateAllow {
 			staleAllowAuthority = &evaluation
 		} else {
-			blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
+			staleAuthorityBlocked = evaluation.Blocking
+			if staleAuthorityBlocked {
+				blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
+			}
 		}
 	}
 	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult, reviewDisabled)
-	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
+	// A complete non-FAIL report with only stale totals needs fresh verification,
+	// not remediation for failed evidence.
+	verifyReportCurrent := artifacts["verifyReport"] == ArtifactDone && !verifyResult.Stale
+	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && verifyReportCurrent && !verifyResult.Passing && applyState == ApplyAllDone
 	var compactRemediation *reviewtransaction.CompactState
 	if !reviewDisabled {
 		compactRemediation = resolveCompactRemediationAuthority(
@@ -961,8 +984,8 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	if remediationState.Reason != "" {
 		blockedReasons.genuine = append(blockedReasons.genuine, remediationState.Reason)
 	}
-	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
-	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
+	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyReportCurrent, verifyResult.Passing, remediationState.Complete)
+	nextRecommended := resolveNextRecommended(dependencies, applyState, verifyReportCurrent, remediationState)
 	if staleAllowAuthority != nil || staleEvidenceUnmanaged || (reviewDisabled && runtimeRemediationComplete) {
 		dependencies.Verify = DependencyReady
 		dependencies.Archive = DependencyBlocked
@@ -970,6 +993,11 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		if runtimeRemediationComplete {
 			remediationState = RemediationState{}
 		}
+	}
+	if staleAuthorityBlocked {
+		dependencies.Verify = DependencyBlocked
+		dependencies.Archive = DependencyBlocked
+		nextRecommended = "resolve-review"
 	}
 	var boundGate *ReviewGateState
 	if !reviewDisabled && governingRef != nil {
@@ -1011,8 +1039,8 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	status.runtimeAttemptTokens = runtimeAttemptTokens
 	status.ReviewTransaction = reviewState
 	if governingRef == nil {
-		if staleAllowAuthority != nil {
-			status.ReviewGate = &ReviewGateState{Result: staleAllowAuthority.Result, Reason: staleAllowAuthority.Reason}
+		if staleReviewAuthority != nil {
+			applyReviewGateEvaluation(&status, *staleReviewAuthority)
 		} else {
 			applyReviewGate(
 				&status,
@@ -1752,7 +1780,7 @@ func resolveApplyState(coreReady bool, taskProgress TaskProgress) ApplyState {
 	return ApplyReady
 }
 
-func resolveDependencies(artifacts map[string]ArtifactState, taskProgress TaskProgress, applyState ApplyState, coreReady bool, verifyReportPassing bool, remediationComplete bool) Dependencies {
+func resolveDependencies(artifacts map[string]ArtifactState, taskProgress TaskProgress, applyState ApplyState, coreReady, verifyReportCurrent, verifyReportPassing, remediationComplete bool) Dependencies {
 	dependencies := Dependencies{
 		Proposal: artifactDependency(artifacts["proposal"]),
 		Specs:    artifactDependency(artifacts["specs"]),
@@ -1768,10 +1796,9 @@ func resolveDependencies(artifacts map[string]ArtifactState, taskProgress TaskPr
 		dependencies.Apply = DependencyAllDone
 	}
 
-	verifyReportDone := artifacts["verifyReport"] == ArtifactDone
-	if verifyReportDone && coreReady && taskProgress.AllComplete && verifyReportPassing {
+	if verifyReportCurrent && coreReady && taskProgress.AllComplete && verifyReportPassing {
 		dependencies.Verify = DependencyAllDone
-	} else if coreReady && applyState == ApplyAllDone && (!verifyReportDone || remediationComplete) {
+	} else if coreReady && applyState == ApplyAllDone && (!verifyReportCurrent || remediationComplete) {
 		dependencies.Verify = DependencyReady
 	}
 	if dependencies.Verify == DependencyAllDone && taskProgress.AllComplete {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -49,7 +49,7 @@ type verifyReport struct {
 }
 
 var sha256IdentityPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-var requirementHeadingPattern = regexp.MustCompile(`(?m)^### Requirement:\s+\S`)
+var requirementHeadingPattern = regexp.MustCompile(`(?m)^### (?:Requirement|REQ-[0-9]+):\s+\S`)
 var scenarioHeadingPattern = regexp.MustCompile(`(?m)^#### Scenario:\s+\S`)
 
 func countSpecRequirementsAndScenarios(specs []string) SpecCounts {

--- a/internal/sddstatus/verification_test.go
+++ b/internal/sddstatus/verification_test.go
@@ -98,12 +98,42 @@ func TestValidateVerifyReportAdmission(t *testing.T) {
 }
 
 func TestCountSpecRequirementsAndScenariosUsesActualArtifacts(t *testing.T) {
-	counts := countSpecRequirementsAndScenarios([]string{
-		"### Requirement: First\n#### Scenario: A\n#### Scenario: B\n",
-		"### Requirement: Second\n#### Scenario: C\n",
-	})
-	if counts != (SpecCounts{Requirements: 2, Scenarios: 3}) {
-		t.Fatalf("counts = %#v, want 2 requirements and 3 scenarios", counts)
+	tests := []struct {
+		name  string
+		specs []string
+		want  SpecCounts
+	}{
+		{
+			name: "canonical Requirement headings",
+			specs: []string{
+				"### Requirement: First\n#### Scenario: A\n#### Scenario: B\n",
+				"### Requirement: Second\n#### Scenario: C\n",
+			},
+			want: SpecCounts{Requirements: 2, Scenarios: 3},
+		},
+		{
+			name: "historical numeric REQ headings",
+			specs: []string{
+				"### REQ-1: First\n#### Scenario: A\n",
+				"### REQ-12: Second\n#### Scenario: B\n",
+			},
+			want: SpecCounts{Requirements: 2, Scenarios: 2},
+		},
+		{
+			name: "malformed and arbitrary headings are excluded",
+			specs: []string{
+				"### REQ-: Missing number\n### REQ-ABC: Not historical\n### Requirements: Plural\n### Overview: Arbitrary\n#### Scenario: Covered\n",
+			},
+			want: SpecCounts{Requirements: 0, Scenarios: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countSpecRequirementsAndScenarios(tt.specs); got != tt.want {
+				t.Fatalf("counts = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2137

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Count historical numeric `### REQ-N:` OpenSpec headings alongside canonical `### Requirement:` headings.
- Treat complete non-FAIL totals mismatches as stale verification evidence instead of failed remediation.
- Preserve approved, foreign, explicit, and disabled review-authority routing, with focused regressions and benchmark journey j44.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/verification.go` | Adds conservative historical requirement-heading compatibility. |
| `internal/sddstatus/status.go` | Routes stale non-FAIL evidence through fresh review or verification without remediation. |
| `internal/sddstatus/review_gate.go` | Distinguishes blocking discovered authority from absent authority. |
| `internal/sddstatus/*_test.go` | Covers canonical/historical headings, stale PASS, genuine FAIL, and authority controls. |
| `bench/journeys_sdd.go` | Registers `j44-sdd-historical-requirement-stale-pass`. |

---

## 🧪 Test Plan

**Focused SDD status tests**
```bash
go test ./internal/sddstatus -run 'TestCountSpecRequirementsAndScenariosUsesActualArtifacts|TestResolveRoutesChangeLocalStalePassWithoutRemediation|TestResolveRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority|TestResolveRejectsForeignCompactAuthorityForStaleVerifyEvidence|TestResolveEngramRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority|TestResolveEngramRejectsForeignCompactAuthorityForStaleVerifyEvidence' -count=1
```
Result: PASS. Independent focused union including genuine FAIL, enabled, explicit, foreign, disabled/unmanaged, and archive controls also passed in 82.611s.

**Go format and build**
```bash
go run ./internal/gofmtcheck
go build -o <temp>/gentle-ai-2137.exe ./cmd/gentle-ai
git diff --check origin/main
```
Result: PASS.

**Benchmark validation**
```bash
go -C bench test -run '^TestCorpusDeclarationsAreValid$' -count=1
```
Result: PASS. The j44 declaration and causal fixture were independently inspected. Runtime execution is unavailable on this Windows host because the unchanged benchmark runner requires a POSIX execute bit; no framework-wide workaround was added.

The full `go test ./internal/sddstatus -count=1` check timed out once after 360 seconds and was not retried. Full repository unit and Docker E2E suites are left to CI.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 236 changed lines, below the 400-line limit |
| Check Issue Reference | ⏳ | `Closes #2137` |
| Check Issue Has `status:approved` | ⏳ | #2137 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` |
| Unit Tests | ⏳ | CI |
| Go Format | ⏳ | CI |
| E2E Tests | ⏳ | CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added exactly one `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed as described above
- [x] Documentation is not required for this internal compatibility fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The requirement-heading population is intentionally conservative: canonical `Requirement` and historical numeric `REQ-N` headings are accepted, while malformed, alphabetic, plural, and arbitrary H3 headings remain excluded. This change does not implement disabled/unmanaged FAIL remediation; that separate policy seam is tracked in #2182.

No new security, integrity, admission, repair, or governance guard is introduced. Existing explicit, foreign, approved, and disabled authority controls remain covered, and `.guard-population-baseline.txt` is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale verification reports now require fresh verification instead of remediation.
  * Outdated passing evidence can no longer complete verification or enable archiving.
  * Stale review blockers now route to review resolution, while allowed evidence proceeds to verification.
  * Historical numbered requirement headings are now recognized during specification counting.
* **Tests**
  * Added coverage for stale evidence, review routing, failed-evidence remediation, and supported requirement heading formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->