### PR TITLE
docs(agent): document Hermes agent setup with MCP YAML strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,6 +328,26 @@ Resolves #42
 
 ---
 
+## Hermes — Knowledge-Layer Agent
+
+Hermes is a detect-only agent in the Gentle AI ecosystem. Unlike coding agents (Claude Code, OpenCode, Cursor), Hermes operates as a configuration and knowledge layer.
+
+**Capabilities:**
+- `SOUL.md` system prompt (`StrategyMarkdownSections` — marker-based injection)
+- YAML MCP config (`StrategyMergeIntoYAML` — merges MCP server blocks into `config.yaml`)
+- Skills directory support (`~/.hermes/skills/`)
+
+**Why it matters:**
+Hermes's YAML MCP strategy is the reference implementation for non-coding agents that still need MCP configuration. If you are building a knowledge-layer integration (MCP servers for context, memory, or retrieval), Hermes's YAML merge strategy is the adapter pattern to follow.
+
+**Contributing to Hermes:**
+- Hermes cannot be auto-installed — it must be installed manually before Gentle AI detects it.
+- Adapter location: `internal/agents/hermes/adapter.go`
+- All `SupportTier` methods return `TierFull` (display purposes only; no auto-install).
+- No subagents, no slash commands, no output styles.
+
+---
+
 ## Code of Conduct
 
 Be respectful. We're building something together.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -284,6 +284,7 @@ The full delegation decision table lives in `~/.hermes/skills/hermes-ephemeral-d
 - **Detection**: gentle-ai reports the `hermes` binary on `PATH` and the config root at `~/.hermes` independently; the config directory drives install detection (the binary can be absent and Hermes is still detected as configured).
 - **Install**: detect-only — gentle-ai cannot install Hermes. Install Hermes manually first, then run `gentle-ai install --agent hermes`.
 - **Config path**: `~/.hermes/` (config.yaml, SOUL.md, skills/)
+- **Architecture**: Knowledge-layer agent. Hermes's `StrategyMergeIntoYAML` is the reference implementation adapter pattern for non-coding agents that merge MCP server blocks into YAML rather than JSON.
 - **MCP config**: Engram and Context7 are injected as YAML blocks under `mcp_servers:` in `~/.hermes/config.yaml` (`StrategyMergeIntoYAML`). Pre-existing top-level keys (e.g. `model:`) are preserved verbatim.
 - **System prompt**: SDD orchestrator and persona are written to `~/.hermes/SOUL.md` via markdown section markers (`<!-- gentle-ai:sdd-orchestrator -->`, `<!-- gentle-ai:persona -->`).
 - **Skills**: `~/.hermes/skills/` — gentle-ai writes SDD phase skills; the skill registry also scans this path.


### PR DESCRIPTION
Closes #966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for the Hermes knowledge-layer agent, including capabilities, installation limitations, support behavior, and available integrations.
  * Documented the reference adapter pattern for merging MCP server configuration blocks into YAML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->