### PR TITLE
fix(engram): sync downloaded file and propagate close/sync errors

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -75,6 +75,17 @@ var (
 	}
 )
 
+// writeCloseSyncer abstracts *os.File for test seam injection.
+type writeCloseSyncer interface {
+	io.Writer
+	Sync() error
+	Close() error
+}
+
+var engramCreateFile = func(path string) (writeCloseSyncer, error) {
+	return os.Create(path)
+}
+
 func goPrivateModuleEnv(base []string, modulePath string) []string {
 	values := map[string]string{
 		"GONOSUMDB": modulePath,
@@ -514,17 +525,28 @@ func engramDownloadToFile(ctx context.Context, url string, outPath string) (hexD
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return "", fmt.Errorf("create dir: %w", err)
 	}
-	f, err := os.Create(outPath)
+	f, err := engramCreateFile(outPath)
 	if err != nil {
 		return "", fmt.Errorf("create %s: %w", outPath, err)
 	}
-	defer f.Close()
+	completed := false
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close %s: %w", outPath, closeErr)
+		}
+		if !completed || err != nil {
+			_ = os.Remove(outPath)
+		}
+	}()
 
 	h := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(f, h), resp.Body); err != nil {
 		return "", fmt.Errorf("write %s: %w", outPath, err)
 	}
-
+	if err := f.Sync(); err != nil {
+		return "", fmt.Errorf("sync %s: %w", outPath, err)
+	}
+	completed = true
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1455,3 +1455,182 @@ func TestSHA256ChecksumContract(t *testing.T) {
 	t.Logf("SHA256 contract: Go produces %q format (64 lowercase hex chars)", goDigest)
 	t.Logf("PowerShell fallback must produce identical format using .NET SHA256")
 }
+
+// fakeFile satisfies writeCloseSyncer for regression testing of engramDownloadToFile.
+type fakeFile struct {
+	writeErr error // returned by Write
+	syncErr  error // returned by Sync
+	closeErr error // returned by Close
+	written  []byte
+}
+
+func (f *fakeFile) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	f.written = append(f.written, p...)
+	return len(p), nil
+}
+func (f *fakeFile) Sync() error  { return f.syncErr }
+func (f *fakeFile) Close() error { return f.closeErr }
+
+// --- TestEngramDownloadToFile_SyncFailureReturnsErrorAndRemovesPartial ---
+
+func TestEngramDownloadToFile_SyncFailureReturnsErrorAndRemovesPartial(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test content"))
+	}))
+	defer server.Close()
+
+	origCreate := engramCreateFile
+	t.Cleanup(func() { engramCreateFile = origCreate })
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "out")
+
+	engramCreateFile = func(path string) (writeCloseSyncer, error) {
+		return &fakeFile{syncErr: errors.New("sync failed")}, nil
+	}
+
+	_, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "sync failed") {
+		t.Errorf("error = %v, want to contain 'sync failed'", err)
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Errorf("outPath stat = %v, want os.IsNotExist", statErr)
+	}
+}
+
+// --- TestEngramDownloadToFile_CloseFailureReturnsErrorAndRemovesPartial ---
+
+func TestEngramDownloadToFile_CloseFailureReturnsErrorAndRemovesPartial(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test content"))
+	}))
+	defer server.Close()
+
+	origCreate := engramCreateFile
+	t.Cleanup(func() { engramCreateFile = origCreate })
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "out")
+
+	engramCreateFile = func(path string) (writeCloseSyncer, error) {
+		return &fakeFile{closeErr: errors.New("close failed")}, nil
+	}
+
+	_, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "close failed") {
+		t.Errorf("error = %v, want to contain 'close failed'", err)
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Errorf("outPath stat = %v, want os.IsNotExist", statErr)
+	}
+}
+
+// --- TestEngramDownloadToFile_BothErrorsPropagatedNotDiscarded ---
+
+func TestEngramDownloadToFile_BothErrorsPropagatedNotDiscarded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test content"))
+	}))
+	defer server.Close()
+
+	origCreate := engramCreateFile
+	t.Cleanup(func() { engramCreateFile = origCreate })
+
+	// Variant 1: Sync fails first → Sync error is propagated (Close is shadowed by non-nil err).
+	t.Run("Sync error shadows Close error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outPath := filepath.Join(tmpDir, "out")
+		engramCreateFile = func(path string) (writeCloseSyncer, error) {
+			return &fakeFile{syncErr: errors.New("sync broken"), closeErr: errors.New("close broken")}, nil
+		}
+		_, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+		if err == nil {
+			t.Fatal("expected non-nil error, got nil")
+		}
+		if !strings.Contains(err.Error(), "sync broken") {
+			t.Errorf("error = %v, want to contain 'sync broken'", err)
+		}
+		if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+			t.Errorf("outPath stat = %v, want os.IsNotExist", statErr)
+		}
+	})
+
+	// Variant 2: Sync succeeds, Close fails → Close error is propagated.
+	t.Run("Close error after successful Sync", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outPath := filepath.Join(tmpDir, "out")
+		engramCreateFile = func(path string) (writeCloseSyncer, error) {
+			return &fakeFile{closeErr: errors.New("close broken")}, nil
+		}
+		_, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+		if err == nil {
+			t.Fatal("expected non-nil error, got nil")
+		}
+		if !strings.Contains(err.Error(), "close broken") {
+			t.Errorf("error = %v, want to contain 'close broken'", err)
+		}
+		if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+			t.Errorf("outPath stat = %v, want os.IsNotExist", statErr)
+		}
+	})
+}
+
+// --- TestEngramDownloadToFile_SuccessPathPersistsBytesAndDigest ---
+
+func TestEngramDownloadToFile_SuccessPathPersistsBytesAndDigest(t *testing.T) {
+	const content = "hello world from engram download test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(content))
+	}))
+	defer server.Close()
+
+	origCreate := engramCreateFile
+	t.Cleanup(func() { engramCreateFile = origCreate })
+
+	// Use the real os.Create via the default seam.
+	engramCreateFile = func(path string) (writeCloseSyncer, error) {
+		return os.Create(path)
+	}
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "out")
+
+	digest, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+	if err != nil {
+		t.Fatalf("engramDownloadToFile() error = %v", err)
+	}
+
+	// Digest must match sha256 of the content.
+	wantDigest := sha256Hex([]byte(content))
+	if digest != wantDigest {
+		t.Errorf("digest = %q, want %q", digest, wantDigest)
+	}
+
+	// On-disk file must contain the same bytes.
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outPath, err)
+	}
+	if string(onDisk) != content {
+		t.Errorf("on-disk content = %q, want %q", string(onDisk), content)
+	}
+
+	// On-disk sha256 must match the returned digest.
+	onDiskDigest := sha256Hex(onDisk)
+	if onDiskDigest != digest {
+		t.Errorf("on-disk digest = %q, returned digest = %q (mismatch means Sync/Close wrote different bytes)", onDiskDigest, digest)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #1998

## 🏷️ PR Type
- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary
Fixes a silent-corruption bug in `engramDownloadToFile` (`internal/components/engram/download.go`) where a write-back failure at file `Close` time is discarded, allowing an incomplete on-disk archive to pass checksum verification because the digest was computed from the in-memory stream rather than from the persisted bytes.

The change:

- Adds `f.Sync()` after the `io.Copy` completes, surfacing kernel write-back failures as a typed error (`sync %s: %w`).
- Replaces the discarded `defer f.Close()` with a defer-func that folds the close error into the named return when no prior error exists, and removes the partial output when the run did not reach the successful `completed = true` marker.
- Introduces an unexported `writeCloseSyncer` interface and a package-level `engramCreateFile` seam so tests can inject controllable files.
- Adds four regression tests at `internal/components/engram/download_test.go` exercising the seam for Sync failure, Close failure, both-error ordering, and the success-path byte/digest invariant.

The function signature and the digest computation are unchanged. No new exported symbols.

## 📂 Changes
| File | Change |
|------|--------|
| `internal/components/engram/download.go` | Added `writeCloseSyncer` interface, `engramCreateFile` seam, `f.Sync()` call, and the close-fold + partial-remove defer pattern in `engramDownloadToFile`. Function signature unchanged. |
| `internal/components/engram/download_test.go` | Added `fakeFile` test fixture and four regression tests (`TestEngramDownloadToFile_SyncFailure…`, `…CloseFailure…`, `…BothErrors…`, `…SuccessPath…`). |

Two work-unit commits:

1. `e262fcc2` — `fix(engram): sync downloaded file and propagate close/sync errors`
2. `cf6fe40e` — `test(engram): add regression tests for download close/sync error handling`

Total: **204 insertions, 3 deletions** across 2 files (well under the 400-line cognitive-load budget).

## 🧪 Test Plan
- [x] Unit tests pass (`go test ./internal/components/engram/... -count=1`) — 9.069s, all 4 new tests green
- [x] Go format passes (`go run ./internal/gofmtcheck`) — clean
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A for this fix (no Docker-touching changes); deferred to CI on `pr-check.yml`
- [x] Manually tested locally — covered by the new unit tests; no UI surface to exercise manually

```bash
$ go test ./internal/components/engram/... -run "TestEngramDownloadToFile" -v
=== RUN   TestEngramDownloadToFile_SyncFailureReturnsErrorAndRemovesPartial
--- PASS: ... (0.01s)
=== RUN   TestEngramDownloadToFile_CloseFailureReturnsErrorAndRemovesPartial
--- PASS: ... (0.01s)
=== RUN   TestEngramDownloadToFile_BothErrorsPropagatedNotDiscarded
=== RUN   TestEngramDownloadToFile_BothErrorsPropagatedNotDiscarded/Sync_error_shadows_Close_error
--- PASS: ... (0.00s)
=== RUN   TestEngramDownloadToFile_BothErrorsPropagatedNotDiscarded/Close_error_after_successful_Sync
--- PASS: ... (0.00s)
=== RUN   TestEngramDownloadToFile_SuccessPathPersistsBytesAndDigest
--- PASS: ... (0.03s)
PASS
ok  github.com/gentleman-programming/gentle-ai/v2/internal/components/engram  3.241s
```

### Pre-existing failures (not introduced by this PR, verified with `git stash` baseline on clean `main` @ `b6ecb3ef`)

The `gentle-ai-collab-perfect` skill names `internal/components/communitytool/pi_codegraph`, `internal/tui/sync`, and `internal/tui/sddmode` as pre-existing failures. Verified on current `main`:

- `pi_codegraph` lives **inside** the `communitytool` package (not a separate directory); the package passes in 51s on clean main. **Skill claim is stale.**
- `internal/tui/sync` and `internal/tui/sddmode` packages **do not exist** on main. **Skill claim is stale.**

The actual pre-existing failures on main (verified with `git stash push -- <files> && go test ./... && git stash pop`):

- `internal/update` — 9 failing tests (release/security/CI coverage, not related to this fix).
- `internal/update/upgrade` — `TestRunStrategyUsesCaskOwnershipAndMigrationGuidance`.
- `internal/reviewtransaction` — package-level timeout.
- `internal/sddstatus` — package-level timeout.

Additionally, `internal/cli.TestReviewCaptureResultConcurrentSelectedLenses` flakes under concurrent full-suite load but passes in isolation (12.3s). Verified identical flake on clean main.

## 🤖 Automated Checks
| Check | Status | Notes |
|-------|--------|-------|
| `Check PR Cognitive Load` | ⏳ | 204 +/− 3 = 207 lines, well under 400 |
| `Check Issue Reference` | ⏳ | `Closes #1998` |
| `Check Issue Has status:approved` | ⏳ | Issue has `status:approved` + `bug` labels |
| `Check PR Has type:* Label` | ⏳ | Awaiting maintainer action (see below) |

## ✅ Contributor Checklist
- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR — see Pending maintainer actions
- [x] Unit tests pass (`go test ./internal/components/engram/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A for this fix; deferred to CI
- [ ] Benchmark validation completed, or this change is not applicable to the benchmark — N/A (no benchmark impact)
- [x] I have updated documentation if necessary — N/A (no behavior change requiring docs)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and `CONTRIBUTING.md`** in this repo — not within contributor scope (verified empirically `gh pr edit --add-label` returns 403 `AddLabelsToLabelable` for `ardelperal`):

- [ ] `type:bug` label applied to this PR — pending Alan
- [ ] Fork workflow approval — first-push run(s) on `action_required` pending Alan

## 💬 Notes for Reviewers
- Two commits, work-unit split: fix first (`e262fcc2`), tests second (`cf6fe40e`). Each commit is independently reviewable; the fix commit alone keeps the package green.
- Reference pattern lifted from `internal/update/upgrade/download.go` lines 224-232 (the `completed` + defer-func + close-fold + partial-remove pattern), with one enhancement vs. the reference: `f.Sync()` is called explicitly before `Close` so kernel write-back failures surface as a typed error. The reference does not call `Sync`; the issue's "Expected Behavior" section calls for it.
- New test seam `engramCreateFile` and the `writeCloseSyncer` interface are unexported. No public API change.
- The four regression tests use `httptest.NewServer`, `t.TempDir()`, and `t.Cleanup`-restored package-level var swaps. Cross-platform (no symlinks, no OS-specific paths).
- CodeGraph flagged `engramDownloadToFile` as having no direct unit tests before this change (all coverage went through `DownloadLatestBinary` at the seam level). The new tests are the first direct unit coverage of the function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability by synchronizing files before completion.
  * Download failures now correctly propagate errors and remove incomplete output files.
  * File closing errors are surfaced to provide clearer failure reporting.
  * Successful downloads continue to persist complete data with the expected checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->