### PR TITLE
fix(sdd): accept every change identity sdd-status resolves

### DIFF
--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -21,7 +21,15 @@ import (
 
 const reviewBindingSchema = "gentle-ai.sdd-review-binding/v1"
 
-var reviewBindingChange = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+// A change identity is whatever sdd-status already resolves: an OpenSpec
+// directory name or an Engram change ID such as DEC-EXAMPLE-CHANGE. It stays
+// path-safe by construction, since alphanumeric segments joined by single
+// hyphens or underscores can express neither a separator nor a dot segment.
+var reviewBindingChange = regexp.MustCompile(`^[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*$`)
+
+// legacyRuntimeChange is the shape the runtime ledger stored directly at
+// v1/<change> before identities widened. It must never change.
+var legacyRuntimeChange = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 var reviewBindingLineage = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 var reviewBindingHash = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 var bindingFinalAuthorizationHook = func() {}
@@ -767,6 +775,12 @@ func bindingDigest(b ReviewBinding) string {
 
 func validReviewBindingChange(change string) bool {
 	return len(change) <= 96 && reviewBindingChange.MatchString(change)
+}
+
+// legacyRuntimeChangeDir reports whether a change identity is one the runtime
+// ledger has always stored directly at v1/<change>.
+func legacyRuntimeChangeDir(change string) bool {
+	return len(change) <= 96 && legacyRuntimeChange.MatchString(change)
 }
 
 func validReviewBindingLineage(lineage string) bool {

--- a/internal/sddstatus/runtime_change_identity_test.go
+++ b/internal/sddstatus/runtime_change_identity_test.go
@@ -1,0 +1,119 @@
+package sddstatus
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The native runtime authority must accept every change identity that
+// sdd-status already resolves. Rejecting an Engram identity such as
+// DEC-EXAMPLE-CHANGE stalls the whole attempt gate for a change whose
+// artifacts resolve normally.
+func TestOpenRuntimeStoreAcceptsChangeIdentitiesResolvedBySDDStatus(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	for _, change := range []string{
+		"DEC-EXAMPLE-CHANGE",
+		"Add-User-Auth",
+		"add_user_auth",
+		"2116-fix-sdd-attempt",
+		"MixedCase_And-Digits2",
+	} {
+		store, err := OpenRuntimeStore(context.Background(), repo, change)
+		if err != nil {
+			t.Fatalf("OpenRuntimeStore(%q) error = %v, want accepted", change, err)
+		}
+		if store.Change != change {
+			t.Fatalf("OpenRuntimeStore(%q).Change = %q, want the identity preserved verbatim", change, store.Change)
+		}
+	}
+}
+
+// Widening the accepted identity must not widen what reaches the filesystem.
+func TestOpenRuntimeStoreRejectsUnsafeChangeName(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	for _, change := range []string{
+		"",
+		".",
+		"..",
+		"../escape",
+		"nested/change",
+		`nested\change`,
+		"-leading",
+		"trailing-",
+		"double--hyphen",
+		".hidden",
+		"has space",
+		"has:colon",
+		strings.Repeat("a", 97),
+	} {
+		if _, err := OpenRuntimeStore(context.Background(), repo, change); err == nil {
+			t.Fatalf("OpenRuntimeStore(%q) error = nil, want rejection", change)
+		}
+	}
+}
+
+// The rejection has to say which value failed and what shape is expected,
+// otherwise callers are left guessing the flag contract.
+func TestOpenRuntimeStoreRejectionNamesValueAndShape(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	_, err := OpenRuntimeStore(context.Background(), repo, "nested/change")
+	if err == nil {
+		t.Fatal("OpenRuntimeStore error = nil, want rejection")
+	}
+	message := err.Error()
+	if !strings.Contains(message, `"nested/change"`) {
+		t.Fatalf("error %q does not name the rejected value", message)
+	}
+	if !strings.Contains(message, "letters, digits") {
+		t.Fatalf("error %q does not state the expected shape", message)
+	}
+}
+
+// Ledgers already on disk live at v1/<change>. A kebab-case identity must keep
+// resolving to that exact directory or every existing attempt chain is orphaned.
+func TestOpenRuntimeStoreKeepsLegacyDirectoryForKebabChange(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "legacy-kebab-change")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(store.Dir) != "legacy-kebab-change" || filepath.Base(filepath.Dir(store.Dir)) != "v1" {
+		t.Fatalf("legacy ledger directory = %q, want v1/legacy-kebab-change", store.Dir)
+	}
+}
+
+// On case-insensitive filesystems two identities differing only in case would
+// share one ledger directory, silently merging unrelated attempt chains.
+func TestOpenRuntimeStoreSeparatesCaseVariantChangeDirectories(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	upper, err := OpenRuntimeStore(context.Background(), repo, "Case-Variant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lower, err := OpenRuntimeStore(context.Background(), repo, "case-variant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.EqualFold(upper.Dir, lower.Dir) {
+		t.Fatalf("case variants share ledger directory %q on a case-insensitive filesystem", upper.Dir)
+	}
+}
+
+// The encoded namespace must be unreachable as a legacy identity, so an
+// encoded directory can never collide with a kebab-case change's ledger.
+func TestOpenRuntimeStoreEncodedNamespaceIsNotAValidLegacyIdentity(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "DEC-EXAMPLE-CHANGE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	namespace := filepath.Base(filepath.Dir(store.Dir))
+	if namespace == "v1" {
+		t.Fatalf("encoded identity reused the legacy namespace at %q", store.Dir)
+	}
+	if legacyRuntimeChangeDir(namespace) {
+		t.Fatalf("encoded namespace %q is also a valid legacy change name", namespace)
+	}
+}

--- a/internal/sddstatus/runtime_change_identity_test.go
+++ b/internal/sddstatus/runtime_change_identity_test.go
@@ -74,11 +74,12 @@ func TestOpenRuntimeStoreRejectionNamesValueAndShape(t *testing.T) {
 	}
 }
 
-// The encoded suffix is the only thing keeping two identities with the same
-// lowercased form apart. Truncating it far enough to make a birthday search
-// practical would let crafted case variants share one ledger directory, so the
-// width is pinned here rather than left to a future edit.
-func TestOpenRuntimeStoreEncodedSuffixKeepsCollisionResistantWidth(t *testing.T) {
+// The encoded suffix is squeezed from both sides, so the width is pinned here
+// rather than left to a future edit. Narrower and a birthday search over
+// crafted case variants becomes practical, letting two identities share one
+// ledger directory. Wider and the leaf stops being addressable on Windows,
+// where an identity at the length limit already crowds the path ceiling.
+func TestOpenRuntimeStoreEncodedSuffixKeepsItsPinnedWidth(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	store, err := OpenRuntimeStore(context.Background(), repo, "DEC-EXAMPLE-CHANGE")
 	if err != nil {
@@ -86,8 +87,8 @@ func TestOpenRuntimeStoreEncodedSuffixKeepsCollisionResistantWidth(t *testing.T)
 	}
 	leaf := filepath.Base(store.Dir)
 	suffix := leaf[strings.LastIndex(leaf, "-")+1:]
-	if len(suffix) < 32 {
-		t.Fatalf("encoded suffix %q is %d hex characters, want at least 32 (128 bits)", suffix, len(suffix))
+	if len(suffix) != 32 {
+		t.Fatalf("encoded suffix %q is %d hex characters, want exactly 32 (128 bits)", suffix, len(suffix))
 	}
 	if strings.Trim(suffix, "0123456789abcdef") != "" {
 		t.Fatalf("encoded suffix %q is not lowercase hex", suffix)

--- a/internal/sddstatus/runtime_change_identity_test.go
+++ b/internal/sddstatus/runtime_change_identity_test.go
@@ -69,6 +69,29 @@ func TestOpenRuntimeStoreRejectionNamesValueAndShape(t *testing.T) {
 	if !strings.Contains(message, "letters, digits") {
 		t.Fatalf("error %q does not state the expected shape", message)
 	}
+	if !strings.Contains(message, "gentle-ai sdd-status") {
+		t.Fatalf("error %q does not name the command that reveals the resolved identity", message)
+	}
+}
+
+// The encoded suffix is the only thing keeping two identities with the same
+// lowercased form apart. Truncating it far enough to make a birthday search
+// practical would let crafted case variants share one ledger directory, so the
+// width is pinned here rather than left to a future edit.
+func TestOpenRuntimeStoreEncodedSuffixKeepsCollisionResistantWidth(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "DEC-EXAMPLE-CHANGE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf := filepath.Base(store.Dir)
+	suffix := leaf[strings.LastIndex(leaf, "-")+1:]
+	if len(suffix) < 32 {
+		t.Fatalf("encoded suffix %q is %d hex characters, want at least 32 (128 bits)", suffix, len(suffix))
+	}
+	if strings.Trim(suffix, "0123456789abcdef") != "" {
+		t.Fatalf("encoded suffix %q is not lowercase hex", suffix)
+	}
 }
 
 // Ledgers already on disk live at v1/<change>. A kebab-case identity must keep

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -399,12 +399,22 @@ const encodedRuntimeChangeNamespace = "_encoded"
 // silently merge two unrelated attempt chains. Lowercasing makes the path
 // stable across those filesystems and the digest of the verbatim identity keeps
 // the case variants apart.
+//
+// The suffix keeps 128 bits rather than the whole digest. Every identity that
+// shares a lowercased form differs only in case, so a name with k letters has
+// 2^k variants to search: at 64 bits a birthday collision costs about 2^32
+// candidates, which is reachable, while 128 bits puts it at 2^64. The remaining
+// half is dropped because the leaf must stay addressable on Windows, where an
+// identity at the 96-character limit plus a full 64-character digest crowds the
+// 260-character path ceiling that this issue's original reporter was hitting.
+const encodedRuntimeChangeDigestWidth = 32
+
 func runtimeChangeLedgerDir(base, change string) string {
 	if legacyRuntimeChangeDir(change) {
 		return filepath.Join(base, "v1", change)
 	}
 	digest := strings.TrimPrefix(runtimeValueHash("gentle-ai.sdd-runtime-change-identity/v1", change), "sha256:")
-	return filepath.Join(base, "v1", encodedRuntimeChangeNamespace, strings.ToLower(change)+"-"+digest[:16])
+	return filepath.Join(base, "v1", encodedRuntimeChangeNamespace, strings.ToLower(change)+"-"+digest[:encodedRuntimeChangeDigestWidth])
 }
 
 func (store RuntimeStore) Status() (RuntimeStatus, error) {

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -362,7 +362,7 @@ type runtimeReplay struct {
 
 func OpenRuntimeStore(ctx context.Context, repo, change string) (RuntimeStore, error) {
 	if !validReviewBindingChange(change) {
-		return RuntimeStore{}, errors.New("invalid SDD change name")
+		return RuntimeStore{}, fmt.Errorf("invalid SDD change name %q; want letters, digits, and single hyphens or underscores between them, at most 96 characters; run `gentle-ai sdd-status --cwd <repo> --json` to read the resolved changeName", change)
 	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
 	if err != nil {
@@ -381,8 +381,30 @@ func OpenRuntimeStore(ctx context.Context, repo, change string) (RuntimeStore, e
 		return RuntimeStore{}, err
 	}
 	commonDir := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(probe.Dir))))
-	dir := filepath.Join(commonDir, "gentle-ai", "sdd-runtime", "v1", change)
+	dir := runtimeChangeLedgerDir(filepath.Join(commonDir, "gentle-ai", "sdd-runtime"), change)
 	return RuntimeStore{Dir: dir, Repo: root, Workspace: workspace, Change: change, commonDir: commonDir}, nil
+}
+
+// encodedRuntimeChangeNamespace holds identities that cannot be a directory
+// name verbatim. A leading underscore is unreachable for a legacy identity, so
+// the namespace can never collide with a kebab-case change's own ledger.
+const encodedRuntimeChangeNamespace = "_encoded"
+
+// runtimeChangeLedgerDir derives the ledger directory for a change identity.
+//
+// A legacy kebab-case identity keeps its exact v1/<change> directory, so every
+// attempt chain written by an earlier version stays reachable. Anything else is
+// encoded, because the directory name alone cannot carry the identity: on a
+// case-insensitive filesystem "DEC-X" and "dec-x" would share one directory and
+// silently merge two unrelated attempt chains. Lowercasing makes the path
+// stable across those filesystems and the digest of the verbatim identity keeps
+// the case variants apart.
+func runtimeChangeLedgerDir(base, change string) string {
+	if legacyRuntimeChangeDir(change) {
+		return filepath.Join(base, "v1", change)
+	}
+	digest := strings.TrimPrefix(runtimeValueHash("gentle-ai.sdd-runtime-change-identity/v1", change), "sha256:")
+	return filepath.Join(base, "v1", encodedRuntimeChangeNamespace, strings.ToLower(change)+"-"+digest[:16])
 }
 
 func (store RuntimeStore) Status() (RuntimeStatus, error) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2116

> Heads up for maintainers: #2116 does not carry `status:approved` yet, so the approval check will fail until it is labeled. Root cause and evidence are in [this comment](https://github.com/Gentleman-Programming/gentle-ai/issues/2116#issuecomment-5153151471).

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- `sdd-attempt acquire/status` rejected every change name outside lowercase kebab-case, so an Engram identity such as `DEC-EXAMPLE-CHANGE` failed with `invalid SDD change name` even though `sdd-status` resolved the same name into a populated `changeRoot`. The native attempt gate was unreachable for those changes.
- The accepted identity now covers what `sdd-status` already resolves, and the ledger directory is derived separately so existing attempt chains stay reachable and case variants cannot collide.
- The rejection now names the value it refused and the shape it expects.

### Root cause

`OpenRuntimeStore` validated the change through `validReviewBindingChange`, whose pattern was `^[a-z0-9]+(?:-[a-z0-9]+)*$`. `sdd-status` applies no shape validation at all: it resolves any directory under `openspec/changes/` or any Engram identity, and `loadNativeRuntimeStatus` swallowed the very same error, so it still exited 0. Two commands, two identity contracts for one change.

### Why widening the pattern alone was not enough

`change` is used as a filesystem path segment (`<common-dir>/gentle-ai/sdd-runtime/v1/<change>`), and `ReviewBinding.Change` is hashed into `bindingDigest`. Two constraints follow:

- On a case-insensitive filesystem (macOS, Windows) `DEC-X` and `dec-x` would share one ledger directory and silently merge two unrelated attempt chains.
- Normalizing the stored name would invalidate every existing binding.

So the identity is persisted verbatim and only the directory is derived. A legacy kebab-case identity keeps its exact `v1/<change>` path, which leaves ledgers written by earlier versions reachable. Anything else lands under `_encoded`, a namespace no legacy identity can name because it starts with an underscore, with a digest of the verbatim identity appended to keep case variants apart.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/review_binding.go` | Widened `reviewBindingChange` to alphanumeric segments joined by single hyphens or underscores; froze the historical shape as `legacyRuntimeChange` and exposed it via `legacyRuntimeChangeDir` |
| `internal/sddstatus/runtime_ledger.go` | Added `runtimeChangeLedgerDir` and the `_encoded` namespace for the ledger path; made the `OpenRuntimeStore` rejection name the rejected value, the expected shape, and a concrete continuation |
| `internal/sddstatus/runtime_change_identity_test.go` | New: accepted identities, unsafe names still refused, legacy path preserved, case variants separated, encoded namespace unreachable as a legacy identity |

The widened pattern stays path-safe by construction: alphanumeric segments joined by a single `-` or `_` can express neither a separator nor a dot segment. `../escape`, `nested/change`, `.hidden`, `double--hyphen`, `has space` and over-length names remain refused, and that is covered by a test.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Manual end-to-end**, against a repo with an `openspec/changes/DEC-EXAMPLE-CHANGE/` scaffold:

```
$ gentle-ai sdd-attempt acquire --cwd . --change DEC-EXAMPLE-CHANGE \
    --request-id req-1 --work-unit apply-slice --evidence-goal "prove apply" \
    --max-attempts 3 --max-changed-lines 400
{ "state": "proceed", "token": "sha256:2a42f9d7..." }
```

Before the fix that exact invocation exited 1 with `open native SDD runtime authority: invalid SDD change name`. A kebab-case change still resolves to its original ledger directory, and `nested/change` is still refused:

```
Error: open native SDD runtime authority: invalid SDD change name "nested/change"; want letters, digits, and single hyphens or underscores between them, at most 96 characters; run `gentle-ai sdd-status --cwd <repo> --json` to read the resolved changeName
```

**Benchmark validation**: N/A. This change touches SDD runtime change-identity resolution only. It does not alter review lifecycle, gates, recovery, delivery, or any benchmark implementation, corpus, classifier, or claim.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally, no Docker available in this environment; leaving it to CI
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — #2116 is linked but not yet labeled `status:approved`
- [x] PR stays within 400 changed lines (161 changed lines)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — see Test Plan
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan)
- [x] I have updated documentation if necessary — no user-facing documented behavior changed beyond the widened identity, which the error message now states
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The guard here is `validReviewBindingChange`, and its legitimate input population genuinely widened: the real-world evidence is in #2116, where an Engram-backed change identity and an OpenSpec directory name both resolve through `sdd-status` but were refused by the attempt authority. The population it must still exclude is unchanged, namely anything that could escape or alias a ledger directory, and `TestOpenRuntimeStoreRejectsUnsafeChangeName` pins that boundary. `.guard-population-baseline.txt` needed no change, since the guard's declared contract direction did not move.

Two things deliberately left out of scope, both worth their own issue:

1. `loadNativeRuntimeStatus` swallowing the runtime-authority error is what let `sdd-status` exit 0 while `sdd-attempt` exited 1. That masking is a separate defect.
2. The flag-contract asymmetry reported in #2116 is real: `sdd-status` takes the change positionally, `sdd-attempt` only via `--change`. Unifying that is a CLI contract change, not a fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Change identities now support uppercase letters, numbers, and underscores.
  * Improved validation messages provide clearer guidance when an identity is invalid.
  * Prevented case-variant identities from colliding in runtime storage.
  * Preserved compatibility with existing lowercase, hyphenated change directories.
  * Improved handling of encoded identities to keep similarly named changes separate and avoid unintended runtime-store conflicts.
  * Added clearer guidance for resolving invalid change identities through the status command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->