### PR TITLE
fix(review): consult the kill switch before pre-PR receipt composition

### DIFF
--- a/internal/cli/review_disabled_prepr_composition_test.go
+++ b/internal/cli/review_disabled_prepr_composition_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// reviewPrePRHistoricalAuthorityRepo builds the exact shape issue-1878 reports:
+// a repository that already carries compact review authority from earlier work,
+// plus a later commit no receipt covers. Selector-free pre-PR reaches compact
+// chain composition on this shape, which is what makes it the useful fixture
+// for both halves of the kill-switch decision.
+func reviewPrePRHistoricalAuthorityRepo(t *testing.T) string {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("published base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "published base")
+	// The remote is pinned here, so pre-PR derives its publication base from
+	// this commit.
+	configureCLIReviewPublicationRemote(t, repo, branch)
+
+	// Two reviewed lineages. Composition is only attempted from two compact
+	// stores upward (compact_chain.go: len(stores) < 2 is not applicable), so a
+	// single receipt would never exercise the path this issue is about.
+	for _, step := range []string{"first reviewed slice", "second reviewed slice"} {
+		base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+		if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte(step+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runReviewCLIGit(t, repo, "add", "tracked.txt")
+		runReviewCLIGit(t, repo, "commit", "-qm", step)
+		finalizeFacadeReviewForRepo(t, repo, "--base-ref", base, "--committed-only")
+	}
+	return repo
+}
+
+// TestReviewValidateReportsDisabledUnmanagedDeliveryAtPrePRWithHistoricalAuthority
+// closes issue-1878. pre-PR was the one gate that vetoed delivery while the
+// user's kill switch was off: selector-free composition ran before the disabled
+// branch, so an `invalid-chain` denial returned before `disabled/unmanaged`
+// could ever be reported. pre-commit and pre-push on this same repository
+// already report; pre-PR must now agree with them.
+func TestReviewValidateReportsDisabledUnmanagedDeliveryAtPrePRWithHistoricalAuthority(t *testing.T) {
+	reviewModeHome(t)
+	repo := reviewPrePRHistoricalAuthorityRepo(t)
+
+	disableReviewForClone(t, repo)
+
+	// Work authored and committed while disabled. No receipt can cover it, so
+	// the composed chain cannot reach HEAD — the exact denial the user hits.
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("work authored while disabled\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "authored while disabled")
+
+	var output bytes.Buffer
+	err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePR)}, &output)
+	// The gate reports; it does not veto.
+	if err != nil {
+		t.Fatalf("disabled pre-PR vetoed delivery instead of reporting it: %v\n%s", err, output.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Schema != ReviewValidateSchema {
+		t.Fatalf("disabled pre-PR left the typed gate schema = %q", result.Schema)
+	}
+	if result.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
+		t.Fatalf("disabled pre-PR delivery = %q, want %q", result.Delivery, reviewtransaction.RDDDeliveryDisabledUnmanaged)
+	}
+	// Unmanaged by choice is neither an approval nor a fault.
+	if result.Allowed || result.Result == reviewtransaction.GateAllow {
+		t.Fatalf("disabled pre-PR fabricated an approval: %#v", result)
+	}
+	var denied ReviewGateDeniedError
+	if errors.As(err, &denied) {
+		t.Fatalf("disabled pre-PR was reported as a denial: %#v", denied)
+	}
+	// The defect signature must be gone: composition never ran, so no
+	// receipt-composition denial can be what the user is shown.
+	if result.Context.Denial != nil && result.Context.Denial.Stage == "receipt-composition" {
+		t.Fatalf("disabled pre-PR still entered receipt composition: %#v", result.Context.Denial)
+	}
+	if strings.Contains(result.Reason, "compact receipt graph contains a cycle") {
+		t.Fatalf("disabled pre-PR reported a composition cycle: %q", result.Reason)
+	}
+
+	// The report is an observation: replaying returns the same bytes and
+	// composition never mutated authority.
+	var replay bytes.Buffer
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePR)}, &replay); err != nil {
+		t.Fatalf("replayed disabled pre-PR gate: %v\n%s", err, replay.String())
+	}
+	if !bytes.Equal(replay.Bytes(), output.Bytes()) {
+		t.Fatalf("disabled pre-PR report is not replay stable:\nfirst:\n%s\nreplay:\n%s", output.String(), replay.String())
+	}
+}
+
+// TestReviewValidatePrePRKeepsComposingHistoricalAuthorityWhileEnabled is the
+// enabled half. The fix must remove composition only while the switch is off:
+// with reviews on, the identical repository keeps today's composition, today's
+// denial, today's exit status and today's exact field set.
+func TestReviewValidatePrePRKeepsComposingHistoricalAuthorityWhileEnabled(t *testing.T) {
+	reviewModeHome(t)
+	repo := reviewPrePRHistoricalAuthorityRepo(t)
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unreviewed work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "unreviewed work")
+
+	var output bytes.Buffer
+	err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePR)}, &output)
+	var denied ReviewGateDeniedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("enabled pre-PR over uncovered work error = %T %v\n%s", err, err, output.String())
+	}
+	if fields := strictReviewJSONFields(t, output.Bytes()); !reflect.DeepEqual(fields, wantEnabledReviewGateFields) {
+		t.Fatalf("enabled pre-PR gate fields = %v, want %v", fields, wantEnabledReviewGateFields)
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Delivery != "" {
+		t.Fatalf("an enabled switch reported a delivery disposition: %#v", result)
+	}
+	if result.Allowed || result.Result == reviewtransaction.GateAllow {
+		t.Fatalf("enabled pre-PR approved uncovered work: %#v", result)
+	}
+	// Composition still runs with the switch on: this is the exact denial the
+	// disabled half must no longer produce, so asserting it here is what proves
+	// the fix removed composition only while reviews are off.
+	if result.Context.Denial == nil || result.Context.Denial.Stage != "receipt-composition" ||
+		result.Context.Denial.Code != "invalid-chain" {
+		t.Fatalf("enabled pre-PR denial = %#v, want receipt-composition/invalid-chain", result.Context.Denial)
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2906,16 +2906,29 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 		input.IntendedUntracked = append([]string(nil), compactRecord.State.InitialSnapshot.IntendedUntracked...)
 		evaluation := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, input)
 		if gateInput.Gate == reviewtransaction.GatePrePR && strings.TrimSpace(*lineage) == "" &&
-			evaluation.Context.Denial != nil && evaluation.Context.Denial.Stage == "receipt-binding" && evaluation.Context.Denial.Code == "base-mismatch" {
+			evaluation.Context.Denial != nil && evaluation.Context.Denial.Stage == "receipt-binding" && evaluation.Context.Denial.Code == "base-mismatch" &&
+			!reviewDrivenDevelopmentDisabled(ctx, root) {
 			if composed, attempted := reviewtransaction.EvaluateCompactPrePRChain(ctx, root, gateInput); attempted {
 				return emitFacadeGateEvaluationNegotiated(stdout, composed, negotiated, *contract)
 			}
 		}
 		return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated, *contract)
 	}
+	// Selector-free pre-PR composition traverses provider-owned historical
+	// authority to build a base-through-HEAD receipt chain. That traversal IS
+	// receipt-driven development doing work, so the kill switch has to be
+	// consulted before it runs, not after: composing first means a denial is
+	// emitted and returned before the disabled branch below can ever report
+	// `disabled/unmanaged`, which is what made pre-PR the one gate that vetoed
+	// delivery while reviews were off — pre-commit and pre-push reach that
+	// branch unchanged. Skipping composition here does not relax anything:
+	// reviewDrivenDevelopmentDisabled fails closed to enabled on an unreadable
+	// switch, and with reviews on every composition path is unchanged
+	// (issue-1878).
 	var compactDiscovery *ReviewReceiptDiscoveryError
 	if gateInput.Gate == reviewtransaction.GatePrePR && strings.TrimSpace(*lineage) == "" &&
-		errors.As(compactErr, &compactDiscovery) && compactDiscovery.Kind != ReviewAuthorityCorrupted && compactDiscovery.Kind != ReviewReceiptMissing {
+		errors.As(compactErr, &compactDiscovery) && compactDiscovery.Kind != ReviewAuthorityCorrupted && compactDiscovery.Kind != ReviewReceiptMissing &&
+		!reviewDrivenDevelopmentDisabled(ctx, root) {
 		if evaluation, attempted := reviewtransaction.EvaluateCompactPrePRChain(ctx, root, gateInput); attempted {
 			return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated, *contract)
 		}


### PR DESCRIPTION
Closes #1878

## Problem

pre-PR was the one lifecycle gate that vetoed delivery while the user's kill switch was off. Selector-free compact chain composition ran *before* the disabled branch, so an `invalid-chain` denial returned through `emitFacadeGateEvaluationNegotiated` before `emitDisabledUnmanagedDelivery` could ever be reached. pre-commit and pre-push on the same repository already reported `disabled/unmanaged` and exited 0.

That contradicted the comment sitting directly above the disabled branch, which states the kill switch is consulted for every discovery outcome.

## Change

Both composition call sites in `internal/cli/review_facade.go` are now guarded by the existing `reviewDrivenDevelopmentDisabled` helper:

- `2908-2913`, the discovery-success path, reached when an exact receipt is discovered and denies with `receipt-binding` / `base-mismatch`. This one was not covered by the analysis in the issue, and gating only the other call site leaves the defect reachable.
- `2917-2922`, the discovery-failure path originally reported.

Composition traverses provider-owned historical authority, so it is receipt-driven development doing work. With the switch off that work must not happen at all, and control flow then falls through to the existing disabled branch unchanged.

This cannot relax anything: `reviewDrivenDevelopmentDisabled` fails closed to enabled on an unreadable or tampered mode record, and with reviews on every composition path is byte-identical.

## Tests

`internal/cli/review_disabled_prepr_composition_test.go` adds both halves of the decision over one shared fixture:

- **disabled** — reports `disabled/unmanaged`, exits 0, fabricates no approval, emits no `receipt-composition` denial, and stays replay stable.
- **enabled** — the identical repository still composes and still denies with `receipt-composition` / `invalid-chain`, with today's exact field set, so the change cannot silently widen into the enabled path.

The fixture builds two reviewed lineages plus one commit no receipt covers. Two is load-bearing: `internal/reviewtransaction/compact_chain.go:155` returns not-applicable below two compact stores, so a single-receipt fixture never reaches composition and would pass with or without this fix.

Verified the disabled test fails on `main` with exactly the reported envelope:

```
review lifecycle gate denied: invalidated: compact pre-PR receipt composition denied:
no exact compact receipt chain covers the selected base through HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled reviews now correctly report as unmanaged without running receipt validation or blocking delivery.
  * Prevented composition errors and pre-PR denials when receipt-driven development is disabled.
  * Preserved existing receipt validation and invalid-chain behavior when reviews are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->