### PR TITLE
fix(review): bound and separate git command output

### DIFF
--- a/internal/reviewtransaction/git_output_test.go
+++ b/internal/reviewtransaction/git_output_test.go
@@ -12,12 +12,7 @@ import (
 )
 
 func TestRunGitCapturesBoundedSeparateOutput(t *testing.T) {
-	originalCommand := gitCommandContext
-	t.Cleanup(func() { gitCommandContext = originalCommand })
-	gitCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunGitOutputHelper$", "--")
-	}
-
+	// Keep these subtests sequential because gitCommandContext is package-global.
 	for _, tt := range []struct {
 		name       string
 		mode       string
@@ -27,11 +22,13 @@ func TestRunGitCapturesBoundedSeparateOutput(t *testing.T) {
 		wantActual []int
 		wantExit   int
 		wantStderr string
+		wantDiag   string
 	}{
 		{name: "ordinary success", mode: "stdout", wantOutput: "machine-output\n"},
 		{name: "ordinary stdout excludes diagnostics", mode: "stdout-stderr", wantOutput: "machine-output\n"},
 		{name: "isolated stdout excludes diagnostics", mode: "stdout-stderr", runner: "isolated", wantOutput: "machine-output\n"},
 		{name: "inventory default limit success", mode: "stdout", runner: "inventory", wantOutput: "machine-output\n"},
+		{name: "inventory diagnostics are typed", mode: "stdout-stderr", runner: "inventory", wantDiag: "diagnostic output"},
 		{name: "inventory default limit overflow", mode: "stdout-overflow", runner: "inventory", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}},
 		{name: "zero limit uses default", mode: "stdout-overflow", runner: "zero-limit", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}},
 		{name: "stdout overflow", mode: "stdout-overflow", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}},
@@ -42,6 +39,12 @@ func TestRunGitCapturesBoundedSeparateOutput(t *testing.T) {
 		{name: "failed command with simultaneous overflow", mode: "failure-both-overflow", wantLimits: []int{defaultGitOutputLimit, defaultGitStderrLimit}, wantActual: []int{defaultGitOutputLimit + 1, defaultGitStderrLimit + len("actionable failure\n") + 1}, wantExit: 7, wantStderr: "actionable failure"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			originalCommand := gitCommandContext
+			t.Cleanup(func() { gitCommandContext = originalCommand })
+			gitCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunGitOutputHelper$", "--")
+			}
+
 			extraEnv := []string{"GENTLE_AI_GIT_OUTPUT_HELPER=" + tt.mode}
 			var output []byte
 			var err error
@@ -72,6 +75,13 @@ func TestRunGitCapturesBoundedSeparateOutput(t *testing.T) {
 				}
 				return
 			}
+			if tt.wantDiag != "" {
+				var diagnosticErr *GitInventoryDiagnosticsError
+				if !errors.Is(err, ErrGitInventoryDiagnostics) || !errors.As(err, &diagnosticErr) || diagnosticErr.Diagnostics != tt.wantDiag || len(output) != 0 {
+					t.Fatalf("inventory diagnostic error = %T %#v", err, diagnosticErr)
+				}
+				return
+			}
 			if len(tt.wantLimits) != 0 {
 				return
 			}
@@ -79,6 +89,14 @@ func TestRunGitCapturesBoundedSeparateOutput(t *testing.T) {
 				t.Fatalf("runGit output = %q, error = %v", output, err)
 			}
 		})
+	}
+}
+
+func TestGitOutputOverflowReportsStderrCollectorLimit(t *testing.T) {
+	err := gitOutputOverflow([]string{"status"}, defaultGitOutputLimit, &boundedGitOutput{}, &boundedGitOutput{limit: 17, total: 18, exceeded: true}, true)
+	var overflow *GitOutputLimitError
+	if !errors.As(err, &overflow) || overflow.Limit != 17 || overflow.Actual != 18 {
+		t.Fatalf("stderr overflow = %T %#v", err, overflow)
 	}
 }
 

--- a/internal/reviewtransaction/git_output_test.go
+++ b/internal/reviewtransaction/git_output_test.go
@@ -1,0 +1,145 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRunGitCapturesBoundedSeparateOutput(t *testing.T) {
+	originalCommand := gitCommandContext
+	t.Cleanup(func() { gitCommandContext = originalCommand })
+	gitCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunGitOutputHelper$", "--")
+	}
+
+	for _, tt := range []struct {
+		name       string
+		mode       string
+		runner     string
+		wantOutput string
+		wantLimits []int
+		wantActual []int
+		wantExit   int
+		wantStderr string
+	}{
+		{name: "ordinary success", mode: "stdout", wantOutput: "machine-output\n"},
+		{name: "ordinary stdout excludes diagnostics", mode: "stdout-stderr", wantOutput: "machine-output\n"},
+		{name: "isolated stdout excludes diagnostics", mode: "stdout-stderr", runner: "isolated", wantOutput: "machine-output\n"},
+		{name: "inventory default limit success", mode: "stdout", runner: "inventory", wantOutput: "machine-output\n"},
+		{name: "inventory default limit overflow", mode: "stdout-overflow", runner: "inventory", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}},
+		{name: "zero limit uses default", mode: "stdout-overflow", runner: "zero-limit", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}},
+		{name: "stdout overflow", mode: "stdout-overflow", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}},
+		{name: "stderr overflow", mode: "stderr-overflow", wantLimits: []int{defaultGitStderrLimit}, wantActual: []int{defaultGitStderrLimit + 1}},
+		{name: "failed command retains stderr", mode: "failure", wantExit: 7, wantStderr: "meaningful diagnostic"},
+		{name: "failed command with stdout overflow", mode: "failure-stdout-overflow", wantLimits: []int{defaultGitOutputLimit}, wantActual: []int{defaultGitOutputLimit + 1}, wantExit: 7, wantStderr: "actionable failure"},
+		{name: "failed command with stderr overflow", mode: "failure-stderr-overflow", wantLimits: []int{defaultGitStderrLimit}, wantActual: []int{defaultGitStderrLimit + len("actionable failure\n") + 1}, wantExit: 7, wantStderr: "actionable failure"},
+		{name: "failed command with simultaneous overflow", mode: "failure-both-overflow", wantLimits: []int{defaultGitOutputLimit, defaultGitStderrLimit}, wantActual: []int{defaultGitOutputLimit + 1, defaultGitStderrLimit + len("actionable failure\n") + 1}, wantExit: 7, wantStderr: "actionable failure"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			extraEnv := []string{"GENTLE_AI_GIT_OUTPUT_HELPER=" + tt.mode}
+			var output []byte
+			var err error
+			switch tt.runner {
+			case "isolated":
+				output, err = runGitIsolated(context.Background(), t.TempDir(), extraEnv, nil, "status")
+			case "inventory":
+				output, err = runGitInventoryWithEnv(context.Background(), t.TempDir(), extraEnv, "status")
+			case "zero-limit":
+				output, err = runGitCaptured(context.Background(), t.TempDir(), extraEnv, nil, 0, false, false, "status")
+			default:
+				output, err = runGit(context.Background(), t.TempDir(), extraEnv, nil, "status")
+			}
+			if len(tt.wantLimits) != 0 {
+				var firstOverflow *GitOutputLimitError
+				if !errors.Is(err, ErrGitOutputLimit) || !errors.As(err, &firstOverflow) || firstOverflow.Limit != tt.wantLimits[0] {
+					t.Fatalf("output overflow typing = %T %#v", err, firstOverflow)
+				}
+				limits, actual := gitOutputLimitDetails(err)
+				if !reflect.DeepEqual(limits, tt.wantLimits) || !reflect.DeepEqual(actual, tt.wantActual) {
+					t.Fatalf("output limits = %v/%v, want %v/%v", limits, actual, tt.wantLimits, tt.wantActual)
+				}
+			}
+			if tt.wantExit != 0 {
+				var commandErr *GitCommandError
+				if !errors.As(err, &commandErr) || commandErr.ExitCode != tt.wantExit || !strings.Contains(commandErr.Output, tt.wantStderr) || len(commandErr.Output) > defaultGitStderrLimit || strings.Contains(commandErr.Output, "machine-output") || len(output) != 0 {
+					t.Fatalf("command error = %T %#v", err, commandErr)
+				}
+				return
+			}
+			if len(tt.wantLimits) != 0 {
+				return
+			}
+			if err != nil || string(output) != tt.wantOutput {
+				t.Fatalf("runGit output = %q, error = %v", output, err)
+			}
+		})
+	}
+}
+
+func gitOutputLimitDetails(err error) (limits, actual []int) {
+	switch typed := err.(type) {
+	case *GitOutputLimitError:
+		return []int{typed.Limit}, []int{typed.Actual}
+	case interface{ Unwrap() []error }:
+		for _, cause := range typed.Unwrap() {
+			causeLimits, causeActual := gitOutputLimitDetails(cause)
+			limits, actual = append(limits, causeLimits...), append(actual, causeActual...)
+		}
+	case interface{ Unwrap() error }:
+		return gitOutputLimitDetails(typed.Unwrap())
+	}
+	return limits, actual
+}
+
+func TestRunGitTraceDoesNotContaminateMachineOutput(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	t.Setenv("GIT_TRACE", "1")
+
+	output, err := runGit(context.Background(), repo, nil, nil, "rev-parse", "--is-inside-work-tree")
+	if err != nil || string(output) != "true\n" {
+		t.Fatalf("traced rev-parse output = %q, error = %v", output, err)
+	}
+}
+
+func TestRunGitOutputHelper(t *testing.T) {
+	mode := os.Getenv("GENTLE_AI_GIT_OUTPUT_HELPER")
+	if mode == "" {
+		return
+	}
+	switch mode {
+	case "stdout":
+		fmt.Fprint(os.Stdout, "machine-output\n")
+	case "stdout-stderr":
+		fmt.Fprint(os.Stdout, "machine-output\n")
+		fmt.Fprint(os.Stderr, "diagnostic output\n")
+	case "stdout-overflow":
+		fmt.Fprint(os.Stdout, strings.Repeat("o", defaultGitOutputLimit+1))
+	case "stderr-overflow":
+		fmt.Fprint(os.Stderr, strings.Repeat("e", defaultGitStderrLimit+1))
+	case "failure":
+		fmt.Fprint(os.Stderr, "meaningful diagnostic\n")
+		os.Exit(7)
+	case "failure-stdout-overflow":
+		fmt.Fprint(os.Stdout, strings.Repeat("o", defaultGitOutputLimit+1))
+		fmt.Fprint(os.Stderr, "actionable failure\n")
+		os.Exit(7)
+	case "failure-stderr-overflow":
+		fmt.Fprint(os.Stdout, "machine-output\n")
+		fmt.Fprint(os.Stderr, "actionable failure\n")
+		fmt.Fprint(os.Stderr, strings.Repeat("e", defaultGitStderrLimit+1))
+		os.Exit(7)
+	case "failure-both-overflow":
+		fmt.Fprint(os.Stdout, strings.Repeat("o", defaultGitOutputLimit+1))
+		fmt.Fprint(os.Stderr, "actionable failure\n")
+		fmt.Fprint(os.Stderr, strings.Repeat("e", defaultGitStderrLimit+1))
+		os.Exit(7)
+	}
+	os.Exit(0)
+}

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -332,6 +332,7 @@ func (builder SnapshotBuilder) activePassiveContentPaths(ctx context.Context, sn
 		return active, nil
 	}
 	oids := make([]string, 0, len(candidates)*2)
+	batchOutputLimit := int64(0)
 	for _, stat := range candidates {
 		for _, version := range []struct {
 			tree string
@@ -344,10 +345,18 @@ func (builder SnapshotBuilder) activePassiveContentPaths(ctx context.Context, sn
 			if !present {
 				return nil, fmt.Errorf("read immutable passive candidate %q: blob is absent from tree inventory", stat.Path) // refusal:by-design world-action: contradictory immutable Git evidence cannot be repaired by a review command
 			}
+			recordBytes := catFileBatchRecordBytes(blob.oid, blob.size)
+			if recordBytes >= processBoundaryScanByteLimit-batchOutputLimit {
+				for _, logicalPath := range paths {
+					active[logicalPath] = struct{}{}
+				}
+				return active, nil
+			}
+			batchOutputLimit += recordBytes
 			oids = append(oids, blob.oid)
 		}
 	}
-	contents, err := batchBlobContents(ctx, repo, oids)
+	contents, err := batchBlobContents(ctx, repo, oids, int(batchOutputLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +380,7 @@ func (builder SnapshotBuilder) activePassiveContentPaths(ctx context.Context, sn
 
 // batchBlobContents reads exact OIDs rather than rev:path expressions, keeping
 // path bytes out of cat-file's line-delimited batch protocol.
-func batchBlobContents(ctx context.Context, repo string, oids []string) (map[string][]byte, error) {
+func batchBlobContents(ctx context.Context, repo string, oids []string, outputLimit int) (map[string][]byte, error) {
 	contents := make(map[string][]byte, len(oids))
 	if len(oids) == 0 {
 		return contents, nil
@@ -381,7 +390,7 @@ func batchBlobContents(ctx context.Context, repo string, oids []string) (map[str
 		stdin = append(stdin, oid...)
 		stdin = append(stdin, '\n')
 	}
-	output, err := runGitCaptured(ctx, repo, nil, stdin, 0, false, true, "cat-file", "--batch")
+	output, err := runGitCaptured(ctx, repo, nil, stdin, outputLimit, false, true, "cat-file", "--batch")
 	if err != nil {
 		return nil, fmt.Errorf("read immutable passive candidate blobs: %w", err)
 	}
@@ -407,6 +416,12 @@ func batchBlobContents(ctx context.Context, repo string, oids []string) (map[str
 		return nil, errors.New("read immutable passive candidate blobs: unexpected trailing cat-file batch output") // refusal:by-design world-action: malformed Git protocol output cannot be made trustworthy by a review command
 	}
 	return contents, nil
+}
+
+// catFileBatchRecordBytes accounts for Git's exact --batch framing:
+// "<oid> blob <decimal-size>\n<content>\n".
+func catFileBatchRecordBytes(oid string, size int64) int64 {
+	return int64(len(oid)+len(" blob ")+len(strconv.FormatInt(size, 10))+2) + size
 }
 
 // isPassiveDocumentContent proves a document is inert from its own bytes.

--- a/internal/reviewtransaction/risk_argv_batching_test.go
+++ b/internal/reviewtransaction/risk_argv_batching_test.go
@@ -356,7 +356,11 @@ func TestBatchBlobContentsPreservesBinaryObjectBoundariesAndErrors(t *testing.T)
 	for index, blob := range blobs {
 		oids[index] = blob.oid
 	}
-	got, err := batchBlobContents(context.Background(), repo, oids)
+	outputLimit := 0
+	for _, blob := range blobs {
+		outputLimit += int(catFileBatchRecordBytes(blob.oid, blob.size))
+	}
+	got, err := batchBlobContents(context.Background(), repo, oids, outputLimit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +369,25 @@ func TestBatchBlobContentsPreservesBinaryObjectBoundariesAndErrors(t *testing.T)
 			t.Fatalf("blob content for %q = %q, want %q", blob.path, got[blob.oid], contents[blob.path])
 		}
 	}
-	if _, err := batchBlobContents(context.Background(), repo, []string{strings.Repeat("0", 40)}); err == nil {
+	if _, err := batchBlobContents(context.Background(), repo, []string{strings.Repeat("0", 40)}, defaultGitOutputLimit); err == nil {
 		t.Fatal("missing batch object was accepted")
+	}
+}
+
+func TestCatFileBatchRecordBytesAccountsForProtocolFraming(t *testing.T) {
+	oid := strings.Repeat("a", 40)
+	for _, tt := range []struct {
+		name string
+		size int64
+		want int64
+	}{
+		{name: "empty blob", size: 0, want: 49},
+		{name: "two digit blob", size: 12, want: 62},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := catFileBatchRecordBytes(oid, tt.size); got != tt.want {
+				t.Fatalf("catFileBatchRecordBytes(%d) = %d, want %d", tt.size, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/reviewtransaction/risk_test.go
+++ b/internal/reviewtransaction/risk_test.go
@@ -744,6 +744,19 @@ func TestPassiveContentReadbackStaysBounded(t *testing.T) {
 	}
 }
 
+func TestPassiveContentReadbackReservesCatFileBatchFraming(t *testing.T) {
+	requireSnapshotGit(t)
+	content := "Ordinary prose.\n"
+	original := processBoundaryScanByteLimit
+	processBoundaryScanByteLimit = int64(len(content) + 1)
+	t.Cleanup(func() { processBoundaryScanByteLimit = original })
+
+	assessment := assessUntrackedCandidate(t, candidateFile{path: "docs/guide.md", content: content})
+	if assessment.Level == RiskLow {
+		t.Fatalf("candidate with %d content bytes under a %d-byte cap = %#v, want an escalated tier because cat-file framing exceeds the cap", len(content), processBoundaryScanByteLimit, assessment)
+	}
+}
+
 // TestTierTwoAlwaysNamesItsEvidence proves every escalation carries a reason a
 // human can read, because the consent prompt has to explain the cost.
 func TestTierTwoAlwaysNamesItsEvidence(t *testing.T) {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1442,6 +1442,20 @@ func (err *GitCommandError) Unwrap() error { return err.Cause }
 
 var ErrGitOutputLimit = errors.New("git output exceeded deterministic byte limit")
 
+var ErrGitInventoryDiagnostics = errors.New("git inventory produced diagnostics")
+
+// GitInventoryDiagnosticsError reports unexpected diagnostics from a Git
+// inventory command that otherwise completed successfully.
+type GitInventoryDiagnosticsError struct {
+	Diagnostics string
+}
+
+func (err *GitInventoryDiagnosticsError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrGitInventoryDiagnostics, err.Diagnostics)
+}
+
+func (err *GitInventoryDiagnosticsError) Unwrap() error { return ErrGitInventoryDiagnostics }
+
 // GitOutputLimitError reports that a bounded Git capture produced more bytes
 // than the caller permits. The capture retains at most Limit bytes while the
 // child is drained, so oversized output cannot grow process memory without
@@ -1592,7 +1606,7 @@ func runGitCapturedRange(ctx context.Context, repo string, extraEnv []string, st
 		return nil, 0, overflow
 	}
 	if rejectStderr && len(diagnostic) != 0 {
-		return nil, 0, fmt.Errorf("git inventory produced diagnostics: %s", strings.TrimSpace(string(diagnostic)))
+		return nil, 0, &GitInventoryDiagnosticsError{Diagnostics: strings.TrimSpace(string(diagnostic))}
 	}
 	return output, stdout.total, nil
 }
@@ -1607,7 +1621,7 @@ func gitOutputOverflow(args []string, outputLimit int, stdout, stderr *boundedGi
 		overflows = append(overflows, &GitOutputLimitError{Args: append([]string{}, args...), Limit: outputLimit, Actual: stdout.total})
 	}
 	if stderr.exceeded {
-		overflows = append(overflows, &GitOutputLimitError{Args: append([]string{}, args...), Limit: defaultGitStderrLimit, Actual: stderr.total})
+		overflows = append(overflows, &GitOutputLimitError{Args: append([]string{}, args...), Limit: stderr.limit, Actual: stderr.total})
 	}
 	if len(overflows) == 1 {
 		return overflows[0]

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1486,8 +1486,13 @@ var gitCommandWaitDelay = time.Second
 var gitCommandContext = exec.CommandContext
 var gitProcessTreeStarter = startGitProcessTree
 
+const (
+	defaultGitOutputLimit = 8 << 20
+	defaultGitStderrLimit = 64 << 10
+)
+
 func runGit(ctx context.Context, repo string, extraEnv []string, stdin []byte, args ...string) ([]byte, error) {
-	return runGitCaptured(ctx, repo, extraEnv, stdin, 0, false, false, args...)
+	return runGitCaptured(ctx, repo, extraEnv, stdin, defaultGitOutputLimit, false, false, args...)
 }
 
 func runGitInventory(ctx context.Context, repo string, args ...string) ([]byte, error) {
@@ -1495,11 +1500,11 @@ func runGitInventory(ctx context.Context, repo string, args ...string) ([]byte, 
 }
 
 func runGitInventoryWithEnv(ctx context.Context, repo string, extraEnv []string, args ...string) ([]byte, error) {
-	return runGitCaptured(ctx, repo, extraEnv, nil, 0, false, true, args...)
+	return runGitCaptured(ctx, repo, extraEnv, nil, defaultGitOutputLimit, false, true, args...)
 }
 
 func runGitIsolated(ctx context.Context, repo string, extraEnv []string, stdin []byte, args ...string) ([]byte, error) {
-	return runGitCaptured(ctx, repo, extraEnv, stdin, 0, true, false, args...)
+	return runGitCaptured(ctx, repo, extraEnv, stdin, defaultGitOutputLimit, true, false, args...)
 }
 
 func runGitLimited(ctx context.Context, repo string, extraEnv []string, stdin []byte, outputLimit int, args ...string) ([]byte, error) {
@@ -1529,17 +1534,12 @@ func runGitCapturedRange(ctx context.Context, repo string, extraEnv []string, st
 	if stdin != nil {
 		command.Stdin = bytes.NewReader(stdin)
 	}
-	var combined, machineStdout, machineStderr bytes.Buffer
-	var stdout, stderr *boundedGitOutput
-	if outputLimit > 0 {
-		stdout = &boundedGitOutput{offset: outputOffset, limit: outputLimit}
-		stderr = &boundedGitOutput{limit: 64 << 10}
-		command.Stdout, command.Stderr = stdout, stderr
-	} else if rejectStderr {
-		command.Stdout, command.Stderr = &machineStdout, &machineStderr
-	} else {
-		command.Stdout, command.Stderr = &combined, &combined
+	if outputLimit <= 0 {
+		outputLimit = defaultGitOutputLimit
 	}
+	stdout := &boundedGitOutput{offset: outputOffset, limit: outputLimit}
+	stderr := &boundedGitOutput{limit: defaultGitStderrLimit}
+	command.Stdout, command.Stderr = stdout, stderr
 	release, startErr := gitProcessTreeStarter(command)
 	err := startErr
 	if err == nil {
@@ -1559,15 +1559,11 @@ func runGitCapturedRange(ctx context.Context, repo string, extraEnv []string, st
 		_ = command.Process.Kill()
 		_ = command.Wait()
 	}
-	output, diagnostic := combined.Bytes(), combined.Bytes()
-	if stdout != nil {
-		output, diagnostic = stdout.Bytes(), stderr.Bytes()
-	} else if rejectStderr {
-		output, diagnostic = machineStdout.Bytes(), machineStderr.Bytes()
-	}
+	output, diagnostic := stdout.Bytes(), stderr.Bytes()
 	if errors.Is(err, exec.ErrWaitDelay) && commandContext.Err() == nil {
 		err = nil
 	}
+	overflow := gitOutputOverflow(args, outputLimit, stdout, stderr, rejectOverflow)
 	if err != nil {
 		if commandContext.Err() != nil {
 			cause := commandContext.Err()
@@ -1575,34 +1571,55 @@ func runGitCapturedRange(ctx context.Context, repo string, extraEnv []string, st
 			if aggregate {
 				cause = ctx.Err()
 			}
-			return nil, 0, &GitCommandTimeoutError{
+			return nil, 0, joinGitOutputOverflow(&GitCommandTimeoutError{
 				Args: append([]string{}, args...), Timeout: timeout, Remote: remote, Aggregate: aggregate, Cause: cause,
-			}
+			}, overflow)
 		}
 		if startErr != nil {
-			return nil, 0, &GitProcessControlError{Args: append([]string{}, args...), Cause: startErr}
+			return nil, 0, joinGitOutputOverflow(&GitProcessControlError{Args: append([]string{}, args...), Cause: startErr}, overflow)
 		}
 		exitCode := -1
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		}
-		return nil, 0, &GitCommandError{
+		return nil, 0, joinGitOutputOverflow(&GitCommandError{
 			Args: append([]string{}, args...), ExitCode: exitCode, Remote: remote, Cause: err,
 			Output: strings.TrimSpace(string(diagnostic)),
-		}
+		}, overflow)
 	}
-	if stdout != nil && stdout.exceeded && rejectOverflow {
-		return nil, 0, &GitOutputLimitError{Args: append([]string{}, args...), Limit: outputLimit, Actual: stdout.total}
+	if overflow != nil {
+		return nil, 0, overflow
 	}
 	if rejectStderr && len(diagnostic) != 0 {
 		return nil, 0, fmt.Errorf("git inventory produced diagnostics: %s", strings.TrimSpace(string(diagnostic)))
 	}
-	total := len(output)
-	if stdout != nil {
-		total = stdout.total
+	return output, stdout.total, nil
+}
+
+func gitOutputOverflow(args []string, outputLimit int, stdout, stderr *boundedGitOutput, rejectOverflow bool) error {
+	if !rejectOverflow {
+		return nil
 	}
-	return output, total, nil
+	var overflows []error
+	// Preserve stream order so errors.As deterministically finds stdout first.
+	if stdout.exceeded {
+		overflows = append(overflows, &GitOutputLimitError{Args: append([]string{}, args...), Limit: outputLimit, Actual: stdout.total})
+	}
+	if stderr.exceeded {
+		overflows = append(overflows, &GitOutputLimitError{Args: append([]string{}, args...), Limit: defaultGitStderrLimit, Actual: stderr.total})
+	}
+	if len(overflows) == 1 {
+		return overflows[0]
+	}
+	return errors.Join(overflows...)
+}
+
+func joinGitOutputOverflow(err, overflow error) error {
+	if overflow == nil {
+		return err
+	}
+	return errors.Join(err, overflow)
 }
 
 type boundedGitOutput struct {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1442,6 +1442,7 @@ func (err *GitCommandError) Unwrap() error { return err.Cause }
 
 var ErrGitOutputLimit = errors.New("git output exceeded deterministic byte limit")
 
+// refusal:by-design world-action: unexpected Git diagnostics require repairing the repository or its environment; no Gentle AI command can safely infer that repair.
 var ErrGitInventoryDiagnostics = errors.New("git inventory produced diagnostics")
 
 // GitInventoryDiagnosticsError reports unexpected diagnostics from a Git

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -1573,7 +1573,7 @@ func TestBatchGitProtocolReadersRejectDiagnostics(t *testing.T) {
 			return err
 		}},
 		{name: "cat-file-batch", run: func() error {
-			_, err := batchBlobContents(context.Background(), repo, []string{strings.Repeat("a", 40)})
+			_, err := batchBlobContents(context.Background(), repo, []string{strings.Repeat("a", 40)}, defaultGitOutputLimit)
 			return err
 		}},
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1717

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

- Bound ordinary Git stdout and stderr independently to prevent unbounded memory growth.
- Keep machine-readable stdout free from trace and diagnostic stderr.
- Preserve typed command, timeout, process-control, and output-limit errors together.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | Added bounded separate Git streams and deterministic typed overflow composition. |
| `internal/reviewtransaction/git_output_test.go` | Added success, tracing, overflow, failure, inventory, and zero-limit regressions. |

## 🧪 Test Plan

- [x] `go run ./internal/gofmtcheck`
- [x] Focused `runGit` tests pass
- [x] Dependent CLI typed-error contract passes
- [x] `go vet ./internal/reviewtransaction`
- [x] Real Git `GIT_TRACE=1` scenario preserves exact stdout
- [ ] Full `go test ./...` — not claimed locally; CI is authoritative because unrelated Windows suites have known timeouts
- [ ] E2E Docker suite — not run; no E2E fixture covers this internal Git boundary

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (222 authored lines)
- [x] Exactly one `type:*` label is requested
- [x] Documentation is not required for this internal compatibility-preserving fix
- [x] Commits follow Conventional Commits
- [x] Commits contain no `Co-Authored-By` trailers

## Delivery

Receipt-driven development is disabled globally; pre-push reported `disabled/unmanaged`, so ordinary repository policy applies. If PR #1556 lands first, preserve its independent `sysproc.HideConsole` hunk while rebasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git command handling by capturing standard output and error messages separately.
  - Added safeguards against excessively large command output, with clear overflow reporting and byte counts.
  - Preserved actionable error details when commands fail, time out, or encounter process-control issues.
  - Prevented trace information from contaminating machine-readable command output.
  - Improved reliability when both output streams exceed their limits simultaneously.
  - Improved reporting of inventory diagnostics from Git operations.
  - Prevented oversized content scans from exceeding configured limits, including protocol overhead, and ensured affected items are classified conservatively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->