### PR TITLE
fix(agent): protect non-json settings mutations

### DIFF
--- a/internal/agents/interface.go
+++ b/internal/agents/interface.go
@@ -14,6 +14,51 @@ const (
 	CapabilityAutoInstall Capability = "auto-install"
 )
 
+// SettingsFileFormat describes the syntax of an adapter's settings file.
+// Unknown formats must not be mutated as JSON objects.
+type SettingsFileFormat string
+
+const (
+	SettingsFileFormatUnknown    SettingsFileFormat = "unknown"
+	SettingsFileFormatJSONObject SettingsFileFormat = "json-object"
+	SettingsFileFormatTOML       SettingsFileFormat = "toml"
+	SettingsFileFormatYAML       SettingsFileFormat = "yaml"
+)
+
+var settingsFileFormats = map[model.AgentID]SettingsFileFormat{
+	model.AgentAntigravity:   SettingsFileFormatJSONObject,
+	model.AgentClaudeCode:    SettingsFileFormatJSONObject,
+	model.AgentCursor:        SettingsFileFormatJSONObject,
+	model.AgentGeminiCLI:     SettingsFileFormatJSONObject,
+	model.AgentHermes:        SettingsFileFormatYAML,
+	model.AgentKilocode:      SettingsFileFormatJSONObject,
+	model.AgentKimi:          SettingsFileFormatTOML,
+	model.AgentKiroIDE:       SettingsFileFormatJSONObject,
+	model.AgentOpenClaw:      SettingsFileFormatJSONObject,
+	model.AgentOpenCode:      SettingsFileFormatJSONObject,
+	model.AgentPi:            SettingsFileFormatJSONObject,
+	model.AgentQwenCode:      SettingsFileFormatJSONObject,
+	model.AgentTrae:          SettingsFileFormatJSONObject,
+	model.AgentVSCodeCopilot: SettingsFileFormatJSONObject,
+	model.AgentWindsurf:      SettingsFileFormatJSONObject,
+}
+
+// SettingsFileFormatFor returns the known settings syntax for an agent. A
+// missing entry intentionally remains unknown until its mutation semantics are
+// explicitly established.
+func SettingsFileFormatFor(agent model.AgentID) SettingsFileFormat {
+	if format, ok := settingsFileFormats[agent]; ok {
+		return format
+	}
+	return SettingsFileFormatUnknown
+}
+
+// SupportsJSONSettingsObjectMutation reports whether a settings file may be
+// safely treated as a JSON object by shared components.
+func SupportsJSONSettingsObjectMutation(adapter Adapter) bool {
+	return SettingsFileFormatFor(adapter.Agent()) == SettingsFileFormatJSONObject
+}
+
 // Adapter is the core abstraction for AI agent integration. Components use
 // adapter methods instead of switch statements on AgentID, making it trivial
 // to add new agents without modifying component code.

--- a/internal/agents/interface_test.go
+++ b/internal/agents/interface_test.go
@@ -1,0 +1,29 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func TestSettingsFileFormatFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent model.AgentID
+		want  SettingsFileFormat
+	}{
+		{name: "Claude JSON", agent: model.AgentClaudeCode, want: SettingsFileFormatJSONObject},
+		{name: "OpenCode JSON", agent: model.AgentOpenCode, want: SettingsFileFormatJSONObject},
+		{name: "Kimi TOML", agent: model.AgentKimi, want: SettingsFileFormatTOML},
+		{name: "Hermes YAML", agent: model.AgentHermes, want: SettingsFileFormatYAML},
+		{name: "unknown agent", agent: model.AgentID("unknown"), want: SettingsFileFormatUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SettingsFileFormatFor(tt.agent); got != tt.want {
+				t.Fatalf("SettingsFileFormatFor(%q) = %q, want %q", tt.agent, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/components/theme/inject.go
+++ b/internal/components/theme/inject.go
@@ -40,6 +40,10 @@ var gentlemanClaudeTheme = claudeTheme{
 }
 
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	if !agents.SupportsJSONSettingsObjectMutation(adapter) {
+		return InjectionResult{}, nil
+	}
+
 	settingsPath := adapter.SettingsPath(homeDir)
 	if settingsPath == "" {
 		return InjectionResult{}, nil

--- a/internal/components/theme/inject_test.go
+++ b/internal/components/theme/inject_test.go
@@ -8,10 +8,14 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/hermes"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
+func hermesAdapter() agents.Adapter   { return hermes.NewAdapter() }
+func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 
 func TestInjectMergesThemeOverlayIntoAdapterSettings(t *testing.T) {
@@ -94,6 +98,54 @@ func TestInjectCreatesAdapterSettingsWhenMissing(t *testing.T) {
 	}
 	if root.Theme != "gentleman" {
 		t.Fatalf("theme = %q, want gentleman", root.Theme)
+	}
+}
+
+func TestInjectPreservesNonJSONSettings(t *testing.T) {
+	tests := []struct {
+		name    string
+		adapter agents.Adapter
+		content string
+	}{
+		{
+			name:    "Kimi TOML",
+			adapter: kimiAdapter(),
+			content: "default_model = \"kimi-k2\"\n",
+		},
+		{
+			name:    "Hermes YAML",
+			adapter: hermesAdapter(),
+			content: "model: hermes-3\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			settingsPath := tt.adapter.SettingsPath(home)
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(settings dir) error = %v", err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("WriteFile(settings) error = %v", err)
+			}
+
+			result, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+			if result.Changed || len(result.Files) != 0 {
+				t.Fatalf("Inject() = %#v, want no-op", result)
+			}
+
+			content, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("ReadFile(settings) error = %v", err)
+			}
+			if string(content) != tt.content {
+				t.Fatalf("settings = %q, want preserved %q", content, tt.content)
+			}
+		})
 	}
 }
 

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -499,7 +499,7 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			ops = append(ops, removeFile(path))
 			ops = append(ops, removeDirIfEmpty(adapter.OutputStyleDir(homeDir)))
 		}
-		if path := adapter.SettingsPath(homeDir); path != "" {
+		if path := adapter.SettingsPath(homeDir); path != "" && agents.SupportsJSONSettingsObjectMutation(adapter) {
 			targets = append(targets, path)
 			jsonPaths := []jsonPath{{"outputStyle"}}
 			if adapter.Agent() == model.AgentOpenCode {
@@ -544,7 +544,7 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			}
 		}
 	case model.ComponentTheme:
-		if path := adapter.SettingsPath(homeDir); path != "" {
+		if path := adapter.SettingsPath(homeDir); path != "" && agents.SupportsJSONSettingsObjectMutation(adapter) {
 			targets = append(targets, path)
 			ops = append(ops, rewriteJSONFile(path, jsonPath{"theme"}))
 		}

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -90,6 +90,54 @@ func mustReadServiceFile(t *testing.T, path string) []byte {
 	return data
 }
 
+func TestPartialUninstallPreservesKimiTOMLSettings(t *testing.T) {
+	homeDir := t.TempDir()
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+	adapter, ok := svc.registry.Get(model.AgentKimi)
+	if !ok {
+		t.Fatal("Kimi adapter not found in registry")
+	}
+
+	settingsPath := adapter.SettingsPath(homeDir)
+	settings := "default_model = \"kimi-k2\"\n"
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	promptPath := adapter.SystemPromptFile(homeDir)
+	prompt := "user instructions\n\n<!-- gentle-ai:persona -->\ngentle persona\n<!-- /gentle-ai:persona -->\n"
+	if err := os.WriteFile(promptPath, []byte(prompt), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt) error = %v", err)
+	}
+
+	result, err := svc.PartialUninstall(
+		[]model.AgentID{model.AgentKimi},
+		[]model.ComponentID{model.ComponentPersona, model.ComponentTheme},
+	)
+	if err != nil {
+		t.Fatalf("PartialUninstall() error = %v", err)
+	}
+	if !slices.Contains(result.ChangedFiles, promptPath) {
+		t.Fatalf("ChangedFiles = %v, want managed prompt %q removed", result.ChangedFiles, promptPath)
+	}
+
+	remainingPrompt := string(mustReadServiceFile(t, promptPath))
+	if strings.Contains(remainingPrompt, "gentle-ai:persona") || !strings.Contains(remainingPrompt, "user instructions") {
+		t.Fatalf("prompt after persona uninstall = %q, want user instructions without managed persona", remainingPrompt)
+	}
+
+	if got := string(mustReadServiceFile(t, settingsPath)); got != settings {
+		t.Fatalf("TOML settings = %q, want preserved %q", got, settings)
+	}
+}
+
 func TestExecutePlanPiUninstallPreservesPreexistingMarkedUserChildAndUserMCP(t *testing.T) {
 	homeDir := t.TempDir()
 	svc, err := NewService(homeDir, t.TempDir(), "dev")


### PR DESCRIPTION
## 🔗 Linked Issues

Closes #1828
Closes #1829

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes issues)

## 📝 Summary

- Add one fail-safe source of truth for agent settings formats.
- Preserve Kimi TOML and other non-JSON settings during uninstall.
- Prevent theme injection from replacing Kimi TOML or Hermes YAML with JSON.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents` | Classifies known settings formats; unknown formats deny JSON-object mutation. |
| `internal/components/uninstall` | Guards JSON rewrites while preserving managed persona cleanup. |
| `internal/components/theme` | Skips theme JSON merge for TOML, YAML, and unknown settings. |

## 🧪 Test Plan

- [x] `go run ./internal/gofmtcheck`
- [x] `go test -count=1 ./internal/agents ./internal/components/theme ./internal/components/uninstall`
- [x] `go vet ./internal/agents ./internal/components/theme ./internal/components/uninstall`
- [x] Dependency/import graph resolves without cycles
- [x] Kimi TOML and Hermes YAML preservation scenarios pass
- [ ] Full `go test ./...` — not claimed locally; CI is authoritative because unrelated Windows suites have known timeouts
- [ ] E2E Docker suite — not run; focused service tests execute the affected paths directly

## ✅ Contributor Checklist

- [x] PR is linked to approved issues
- [x] PR stays within 400 changed lines (182 authored lines)
- [x] Exactly one `type:*` label is requested
- [x] Documentation is not required for this internal safety fix
- [x] Commits follow Conventional Commits and preserve two work units
- [x] Commits contain no `Co-Authored-By` trailers

## Delivery

Receipt-driven development is disabled globally; pre-push reported `disabled/unmanaged`, so ordinary repository policy applies. PR #973 is semantic non-overlap; rebase this branch if it lands first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved TOML and YAML settings files when applying themes or performing partial uninstalls.
  * Continued removing managed content while leaving user instructions and unsupported settings formats unchanged.

* **Tests**
  * Added coverage for JSON, TOML, YAML, and unknown settings formats.
  * Added regression tests for theme injection and partial uninstall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->