### PR TITLE
fix(uninstall): default profile removal to no cleanup

### DIFF
--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -288,11 +288,12 @@ func (s *Service) SetProfileNamesToRemove(profileNames []string) {
 }
 
 func (s *Service) SetEngramUninstallScope(scope model.EngramUninstallScope) {
-	if scope == model.EngramUninstallScopeProject {
-		s.engramUninstallScope = model.EngramUninstallScopeProject
-		return
+	switch scope {
+	case model.EngramUninstallScopeProject, model.EngramUninstallScopeGlobal, model.EngramUninstallScopeNone:
+		s.engramUninstallScope = scope
+	default:
+		s.engramUninstallScope = model.EngramUninstallScopeNone
 	}
-	s.engramUninstallScope = model.EngramUninstallScopeGlobal
 }
 
 func (s *Service) CompleteUninstall() (Result, error) {
@@ -330,6 +331,9 @@ func (s *Service) buildPlan(agentIDs []model.AgentID, componentIDs []model.Compo
 		}
 
 		for _, componentID := range componentIDs {
+			if componentID == model.ComponentEngram && s.engramUninstallScope == model.EngramUninstallScopeNone {
+				continue
+			}
 			ops, targets, err := s.componentOperations(adapter, componentID)
 			if err != nil {
 				return plan{}, fmt.Errorf("plan uninstall for %q/%q: %w", agentID, componentID, err)
@@ -511,6 +515,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 		targets = append(targets, context7Targets(adapter, homeDir)...)
 		ops = append(ops, context7Operations(adapter, homeDir)...)
 	case model.ComponentEngram:
+		if s.engramUninstallScope == model.EngramUninstallScopeNone {
+			break
+		}
 		if s.engramUninstallScope == model.EngramUninstallScopeProject {
 			projectDataPath := filepath.Join(s.workspaceDir, ".engram")
 			if strings.TrimSpace(s.workspaceDir) != "" {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1038,6 +1038,81 @@ func TestComponentOperationsEngram_GlobalScopeKeepsWorkspaceProjectData(t *testi
 	}
 }
 
+func TestPartialUninstallWithProfilesEngramScope(t *testing.T) {
+	tests := []struct {
+		name               string
+		scope              model.EngramUninstallScope
+		wantProjectRemoved bool
+		wantEngramConfig   bool
+	}{
+		{name: "no cleanup preserves all Engram data", scope: model.EngramUninstallScopeNone, wantEngramConfig: true},
+		{name: "project cleanup removes only workspace data", scope: model.EngramUninstallScopeProject, wantProjectRemoved: true, wantEngramConfig: true},
+		{name: "global cleanup removes integration", scope: model.EngramUninstallScopeGlobal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			workspaceDir := t.TempDir()
+			svc, err := NewService(homeDir, workspaceDir, "dev")
+			if err != nil {
+				t.Fatalf("NewService() error = %v", err)
+			}
+			svc.snapshotter = stubSnapshotter{}
+			svc.now = func() time.Time { return time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC) }
+
+			adapter, ok := svc.registry.Get(model.AgentOpenCode)
+			if !ok {
+				t.Fatal("OpenCode adapter not found")
+			}
+			settingsPath := adapter.SettingsPath(homeDir)
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(`{"mcp":{"engram":{"command":["engram"]}},"agent":{"sdd-orchestrator-cheap":{},"sdd-apply-cheap":{},"sdd-orchestrator-keep":{}}}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			projectData := filepath.Join(workspaceDir, ".engram", "memory.db")
+			if err := os.MkdirAll(filepath.Dir(projectData), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(projectData, []byte("memory"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := svc.PartialUninstallWithProfiles(
+				[]model.AgentID{model.AgentOpenCode},
+				[]model.ComponentID{model.ComponentSDD, model.ComponentEngram},
+				[]string{"cheap"},
+				tt.scope,
+			); err != nil {
+				t.Fatalf("PartialUninstallWithProfiles() error = %v", err)
+			}
+
+			root := map[string]any{}
+			if err := json.Unmarshal(mustReadServiceFile(t, settingsPath), &root); err != nil {
+				t.Fatalf("json.Unmarshal(settings) error = %v", err)
+			}
+			agents := root["agent"].(map[string]any)
+			if _, exists := agents["sdd-orchestrator-cheap"]; exists {
+				t.Fatalf("selected profile assets remain: %#v", agents)
+			}
+			if _, exists := agents["sdd-orchestrator-keep"]; !exists {
+				t.Fatalf("unselected profile assets removed: %#v", agents)
+			}
+			mcp, _ := root["mcp"].(map[string]any)
+			_, hasEngramConfig := mcp["engram"]
+			if hasEngramConfig != tt.wantEngramConfig {
+				t.Fatalf("Engram config present = %t, want %t", hasEngramConfig, tt.wantEngramConfig)
+			}
+			_, projectErr := os.Stat(projectData)
+			if gotRemoved := os.IsNotExist(projectErr); gotRemoved != tt.wantProjectRemoved {
+				t.Fatalf("project data removed = %t, want %t (err = %v)", gotRemoved, tt.wantProjectRemoved, projectErr)
+			}
+		})
+	}
+}
+
 // TestComponentOperationsEngram_CodexRemovesConsolidatedProtocolAssetsWithNoOrphans
 // is the task 2.9 regression assertion: the canonical-asset consolidation
 // (design.md Decision 3) renamed/removed the SOURCE assets

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -59,6 +59,7 @@ const (
 type EngramUninstallScope string
 
 const (
+	EngramUninstallScopeNone    EngramUninstallScope = "none"
 	EngramUninstallScopeGlobal  EngramUninstallScope = "global"
 	EngramUninstallScopeProject EngramUninstallScope = "project"
 )

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -673,7 +673,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		Detection:            detection,
 		UninstallAgents:      agents,
 		UninstallComponents:  defaultUninstallComponents(),
-		UninstallEngramScope: model.EngramUninstallScopeGlobal,
+		UninstallEngramScope: model.EngramUninstallScopeNone,
 		Progress: NewProgressState([]string{
 			"Install dependencies",
 			"Configure selected agents",
@@ -1139,7 +1139,7 @@ func (m Model) View() string {
 	case ScreenUninstallComponents:
 		return screens.RenderUninstallComponents(m.UninstallComponents, m.Cursor)
 	case ScreenUninstallProfiles:
-		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.UninstallEngramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
+		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.shouldShowUninstallEngramScopeSelection(), m.shouldOfferNoCleanupEngramScope(), m.UninstallEngramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
 	case ScreenUninstallConfirm:
 		return screens.RenderUninstallConfirm(m.UninstallMode, m.UninstallAgents, m.UninstallComponents, m.UninstallProfilesToRemove, m.UninstallEngramScope, m.UninstallEngramProjectScopeAvailable, m.Cursor, m.OperationRunning, m.SpinnerFrame)
 	case ScreenUninstallResult:
@@ -1753,6 +1753,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		switch {
 		case m.Cursor < len(options):
 			m.UninstallMode = options[m.Cursor].Mode
+			m.UninstallEngramScope = defaultUninstallEngramScope(m.UninstallMode)
 			switch m.UninstallMode {
 			case model.UninstallModePartial:
 				m.setScreen(ScreenUninstall)
@@ -1815,7 +1816,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		profileCount := len(m.UninstallProfilesAvailable)
 		engramScopeOptionCount := 0
 		if m.shouldShowUninstallEngramScopeSelection() {
-			engramScopeOptionCount = 2
+			engramScopeOptionCount = len(m.uninstallEngramScopeOptions())
 		}
 		continueIdx := profileCount + engramScopeOptionCount
 		switch {
@@ -2644,7 +2645,7 @@ func (m Model) withResetUninstallState() Model {
 	m.UninstallProfilesToRemove = nil
 	m.UninstallProfileSelection = false
 	m.UninstallEngramProjectScopeAvailable = false
-	m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+	m.UninstallEngramScope = model.EngramUninstallScopeNone
 	m.UninstallResult = componentuninstall.Result{}
 	m.UninstallErr = nil
 	m.SyncCleanInstallFiles = nil
@@ -2995,6 +2996,9 @@ func (m *Model) refreshUninstallProfiles() {
 		return
 	}
 	m.UninstallProfilesAvailable = profileNames(profiles)
+	if m.shouldOfferNoCleanupEngramScope() {
+		m.UninstallEngramScope = model.EngramUninstallScopeNone
+	}
 }
 
 func (m Model) detectProjectEngramData() bool {
@@ -3455,7 +3459,7 @@ func (m *Model) setScreen(next Screen) {
 		m.refreshUninstallProfiles()
 		m.UninstallProfilesToRemove = nil
 		m.UninstallProfileSelection = false
-		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+		m.UninstallEngramScope = defaultUninstallEngramScope(m.UninstallMode)
 	}
 }
 
@@ -3542,7 +3546,7 @@ func (m Model) optionCount() int {
 	case ScreenUninstallProfiles:
 		count := len(m.UninstallProfilesAvailable) + 2
 		if m.shouldShowUninstallEngramScopeSelection() {
-			count += 2
+			count += len(m.uninstallEngramScopeOptions())
 		}
 		return count
 	case ScreenUninstallConfirm:
@@ -3767,13 +3771,17 @@ func (m *Model) toggleCurrentUninstallEngramScope() {
 		return
 	}
 	idx := m.Cursor - profileCount
-	if idx == 0 {
-		m.UninstallEngramScope = model.EngramUninstallScopeProject
-		return
+	options := m.uninstallEngramScopeOptions()
+	if idx >= 0 && idx < len(options) {
+		m.UninstallEngramScope = options[idx].Scope
 	}
-	if idx == 1 {
-		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+}
+
+func defaultUninstallEngramScope(mode model.UninstallMode) model.EngramUninstallScope {
+	if mode == model.UninstallModeFull || mode == model.UninstallModeFullRemove || mode == model.UninstallModeCleanInstall {
+		return model.EngramUninstallScopeGlobal
 	}
+	return model.EngramUninstallScopeNone
 }
 
 func (m *Model) toggleCurrentSkill() {
@@ -4455,10 +4463,16 @@ func (m Model) shouldShowUninstallProfilesSelection() bool {
 }
 
 func (m Model) shouldShowUninstallEngramScopeSelection() bool {
-	if !hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
-		return false
-	}
-	return m.UninstallEngramProjectScopeAvailable
+	return hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) &&
+		(m.shouldShowUninstallProfilesSelection() || m.UninstallEngramProjectScopeAvailable)
+}
+
+func (m Model) shouldOfferNoCleanupEngramScope() bool {
+	return m.UninstallMode == model.UninstallModePartial && m.shouldShowUninstallProfilesSelection()
+}
+
+func (m Model) uninstallEngramScopeOptions() []screens.UninstallEngramScopeOption {
+	return screens.UninstallEngramScopeOptions(m.UninstallEngramProjectScopeAvailable, m.shouldOfferNoCleanupEngramScope())
 }
 
 func (m Model) shouldShowUninstallSubSelection() bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1927,6 +1927,9 @@ func TestUninstallModeScreen_FullWithProfilesNavigatesToProfileSelection(t *test
 	if !reflect.DeepEqual(state.UninstallProfilesToRemove, []string{"cheap", "fast"}) {
 		t.Fatalf("UninstallProfilesToRemove = %v, want [cheap fast]", state.UninstallProfilesToRemove)
 	}
+	if state.UninstallEngramScope != model.EngramUninstallScopeGlobal {
+		t.Fatalf("UninstallEngramScope = %q, want %q", state.UninstallEngramScope, model.EngramUninstallScopeGlobal)
+	}
 }
 
 func TestUninstallScreen_ContinueNavigatesToComponents(t *testing.T) {
@@ -1989,7 +1992,7 @@ func TestUninstallProfiles_ContinueNavigatesToConfirm(t *testing.T) {
 	m.Screen = ScreenUninstallProfiles
 	m.UninstallProfilesAvailable = []string{"cheap"}
 	m.UninstallProfilesToRemove = []string{"cheap"}
-	m.Cursor = len(m.UninstallProfilesAvailable)
+	m.Cursor = len(m.UninstallProfilesAvailable) + len(m.uninstallEngramScopeOptions())
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
@@ -2249,6 +2252,58 @@ func TestUninstallComponents_ContinueWithEngramProjectScopeNavigatesToSubSelecti
 	}
 	if state.UninstallEngramScope != model.EngramUninstallScopeGlobal {
 		t.Fatalf("UninstallEngramScope = %q, want %q", state.UninstallEngramScope, model.EngramUninstallScopeGlobal)
+	}
+}
+
+func TestUninstallProfileEngramScopeDefaultsAndRefreshes(t *testing.T) {
+	original := readProfilesFn
+	readProfilesFn = func(string) ([]model.Profile, error) { return []model.Profile{{Name: "cheap"}}, nil }
+	t.Cleanup(func() { readProfilesFn = original })
+
+	tests := []struct {
+		name string
+		mode model.UninstallMode
+		want model.EngramUninstallScope
+	}{
+		{name: "profile-only defaults to no cleanup", mode: model.UninstallModePartial, want: model.EngramUninstallScopeNone},
+		{name: "full uninstall keeps global cleanup", mode: model.UninstallModeFull, want: model.EngramUninstallScopeGlobal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{Configs: []system.ConfigState{{Agent: string(model.AgentOpenCode), Exists: true}}}, "dev")
+			m.UninstallMode = tt.mode
+			m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+			m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+			m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+			m.refreshUninstallProfiles()
+			if m.UninstallEngramScope != tt.want {
+				t.Fatalf("scope after refresh = %q, want %q", m.UninstallEngramScope, tt.want)
+			}
+			m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+			m.setScreen(ScreenUninstallMode)
+			if m.UninstallEngramScope != tt.want {
+				t.Fatalf("scope after re-entering uninstall = %q, want %q", m.UninstallEngramScope, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartUninstall_PassesNoCleanupProfileScope(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+	m.UninstallProfilesToRemove = []string{"cheap"}
+	m.UninstallEngramScope = model.EngramUninstallScopeNone
+	m.UninstallWithProfilesFn = func(_ []model.AgentID, _ []model.ComponentID, _ []string, scope model.EngramUninstallScope) (componentuninstall.Result, error) {
+		if scope != model.EngramUninstallScopeNone {
+			t.Fatalf("scope = %q, want %q", scope, model.EngramUninstallScopeNone)
+		}
+		return componentuninstall.Result{}, nil
+	}
+
+	if msg := m.startUninstall()().(UninstallDoneMsg); msg.Err != nil {
+		t.Fatalf("startUninstall() error = %v", msg.Err)
 	}
 }
 

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -171,8 +171,15 @@ func RenderUninstallComponents(selected []model.ComponentID, cursor int) string 
 	return b.String()
 }
 
-func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramScopeOption {
-	options := make([]UninstallEngramScopeOption, 0, 2)
+func UninstallEngramScopeOptions(projectScopeAvailable, includeNoCleanup bool) []UninstallEngramScopeOption {
+	options := make([]UninstallEngramScopeOption, 0, 3)
+	if includeNoCleanup {
+		options = append(options, UninstallEngramScopeOption{
+			Scope:       model.EngramUninstallScopeNone,
+			Label:       "No cleanup",
+			Description: "Keep all Engram data and configuration",
+		})
+	}
 	if projectScopeAvailable {
 		options = append(options, UninstallEngramScopeOption{
 			Scope:       model.EngramUninstallScopeProject,
@@ -188,7 +195,7 @@ func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramSc
 	return options
 }
 
-func RenderUninstallProfiles(available []string, selected []string, engramProjectScopeAvailable bool, selectedEngramScope model.EngramUninstallScope, cursor int) string {
+func RenderUninstallProfiles(available []string, selected []string, showEngramScope bool, includeNoCleanup bool, engramProjectScopeAvailable bool, selectedEngramScope model.EngramUninstallScope, cursor int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Uninstall Scope Selection"))
@@ -212,9 +219,9 @@ func RenderUninstallProfiles(available []string, selected []string, engramProjec
 		b.WriteString(renderCheckbox(profileName, checked, focused))
 	}
 
-	engramScopeOptions := uninstallEngramScopeOptions(engramProjectScopeAvailable)
+	engramScopeOptions := UninstallEngramScopeOptions(engramProjectScopeAvailable, includeNoCleanup)
 	engramScopeDisplayed := 0
-	if len(engramScopeOptions) > 1 {
+	if showEngramScope {
 		engramScopeDisplayed = len(engramScopeOptions)
 		if len(available) > 0 {
 			b.WriteString("\n")
@@ -315,11 +322,14 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 		b.WriteString("\n")
 		b.WriteString(styles.SubtextStyle.Render("Engram cleanup scope:"))
 		b.WriteString("\n")
-		scopeLabel := "Global"
-		detail := "  • Removes global Engram MCP/system prompt configuration"
+		scopeLabel := "No cleanup"
+		detail := "  • Keeps all Engram data and configuration"
 		if engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable {
 			scopeLabel = "Project-only"
 			detail = "  • Deletes .engram/ in the current project only"
+		} else if engramScope == model.EngramUninstallScopeGlobal {
+			scopeLabel = "Global"
+			detail = "  • Removes global Engram MCP/system prompt configuration"
 		}
 		b.WriteString(styles.UnselectedStyle.Render("  • " + scopeLabel))
 		b.WriteString("\n")

--- a/internal/tui/screens/uninstall_test.go
+++ b/internal/tui/screens/uninstall_test.go
@@ -1,0 +1,17 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func TestRenderUninstallProfilesShowsExplicitEngramChoices(t *testing.T) {
+	output := RenderUninstallProfiles([]string{"cheap"}, []string{"cheap"}, true, true, true, model.EngramUninstallScopeNone, 1)
+	for _, want := range []string{"No cleanup", "Keep all Engram data and configuration", "Project-only cleanup", "Global cleanup"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("RenderUninstallProfiles() missing %q:\n%s", want, output)
+		}
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #445

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

- Add an explicit no-cleanup Engram scope for profile-only uninstall.
- Default profile removal to preserving all Engram data and configuration.
- Keep project/global cleanup and full uninstall behavior explicit and unchanged.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model` | Added the no-cleanup uninstall scope. |
| `internal/components/uninstall` | Skips Engram planning for no-cleanup while removing selected profile assets. |
| `internal/tui` | Defaults, renders, and propagates no-cleanup/project/global choices safely. |

## 🧪 Test Plan

- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./internal/components/uninstall ./internal/tui ./internal/tui/screens -count=1 -timeout 180s`
- [x] `go vet ./internal/components/uninstall ./internal/tui ./internal/tui/screens`
- [x] Profile-only, project, global, refresh/re-entry, callback, and rendering scenarios pass
- [ ] Full `go test ./...` — CI is authoritative
- [ ] E2E Docker suite — focused service/TUI tests exercise the changed paths

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (233 authored lines)
- [x] Exactly one `type:*` label is requested
- [x] Documentation is not required for this TUI safety fix
- [x] Commit follows Conventional Commits
- [x] Commit contains no `Co-Authored-By` trailers

## Delivery

Receipt-driven development is disabled globally; pre-push reported `disabled/unmanaged`, so ordinary repository policy applies. Rebase if overlapping PRs #1507, #2251, #973, or #2100 land first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “No cleanup” option when partially uninstalling profiles.
  * Uninstall screens now show only the Engram cleanup choices relevant to the selected uninstall mode.
  * Full uninstall continues to default to global cleanup, while partial profile removal defaults to no cleanup.

* **Bug Fixes**
  * Invalid cleanup scope values now safely default to no cleanup.
  * Engram operations are skipped entirely when no cleanup is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->