### PR TITLE
fix(tui): warn when custom models lack tool calls

### DIFF
--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -138,6 +138,7 @@ func NewModelPickerState(cachePath string, settingsPath string) ModelPickerState
 		customProviderIDs: customIDs,
 	}
 	state.refreshAvailableModels()
+	state.ConfigWarning = appendCustomProviderToolCallWarnings(state.ConfigWarning, providers, configProviders)
 	return state
 }
 
@@ -205,6 +206,42 @@ func (state *ModelPickerState) refreshAvailableModels() {
 	for _, id := range state.AvailableIDs {
 		state.SDDModels[id] = opencode.FilterModelsForSDD(state.Providers[id])
 	}
+}
+
+func appendCustomProviderToolCallWarnings(
+	existing string,
+	providers map[string]opencode.Provider,
+	configProviders map[string]opencode.ConfigProvider,
+) string {
+	ids := make([]string, 0, len(configProviders))
+	for id := range configProviders {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		configProvider := configProviders[id]
+		if len(configProvider.Models) == 0 {
+			continue
+		}
+
+		provider, ok := providers[id]
+		if !ok || len(opencode.FilterModelsForSDD(provider)) > 0 {
+			continue
+		}
+
+		name := provider.Name
+		if name == "" {
+			name = id
+		}
+		existing = appendConfigWarning(existing, fmt.Sprintf(
+			`Custom provider %q has models, but none declare tool_call: true. Add tool_call: true to at least one model in provider.%s.models.`,
+			name,
+			id,
+		))
+	}
+
+	return existing
 }
 
 func appendConfigWarning(existing, warning string) string {

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -194,7 +194,7 @@ func (state ModelPickerState) Update(msg tea.Msg) ModelPickerState {
 	state.customProviderIDs = append(state.customProviderIDs, "lmstudio")
 	state.refreshAvailableModels()
 	if len(discovery.Models) > 0 && len(opencode.FilterModelsForSDD(provider)) == 0 {
-		state.ConfigWarning = appendConfigWarning(state.ConfigWarning, "LM Studio models need tool_call: true in provider.lmstudio.models for SDD.")
+		state.ConfigWarning = appendConfigWarning(state.ConfigWarning, "LM Studio models need \"tool_call\": true in provider.lmstudio.models for SDD.")
 	}
 	return state
 }
@@ -235,7 +235,7 @@ func appendCustomProviderToolCallWarnings(
 			name = id
 		}
 		existing = appendConfigWarning(existing, fmt.Sprintf(
-			`Custom provider %q has models, but none declare tool_call: true. Add tool_call: true to at least one model in provider.%s.models.`,
+			`Custom provider %q has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.%s.models.`,
 			name,
 			id,
 		))

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -220,6 +220,9 @@ func appendCustomProviderToolCallWarnings(
 	sort.Strings(ids)
 
 	for _, id := range ids {
+		if id == "lmstudio" {
+			continue
+		}
 		configProvider := configProviders[id]
 		if len(configProvider.Models) == 0 {
 			continue
@@ -235,7 +238,7 @@ func appendCustomProviderToolCallWarnings(
 			name = id
 		}
 		existing = appendConfigWarning(existing, fmt.Sprintf(
-			`Custom provider %q has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.%s.models.`,
+			`Custom provider %q has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider[%q].models.`,
 			name,
 			id,
 		))

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -26,6 +26,8 @@ const (
 	ModeEffortSelect                          // Sub-mode: pick a reasoning effort level
 )
 
+const lmStudioToolCallWarning = `LM Studio models need "tool_call": true in provider.lmstudio.models for SDD.`
+
 // maxVisibleItems is the maximum number of items shown in scrollable sub-lists.
 const maxVisibleItems = 10
 const maxVisiblePhaseRows = 16
@@ -162,6 +164,7 @@ func (state ModelPickerState) Update(msg tea.Msg) ModelPickerState {
 	}
 	if discovery.Err != nil {
 		state.ConfigWarning = appendConfigWarning(state.ConfigWarning, "LM Studio discovery failed; using configured models.")
+		state.ConfigWarning = appendLMStudioToolCallWarning(state.ConfigWarning, state.Providers["lmstudio"], len(state.lmStudioConfig.Models))
 		return state
 	}
 
@@ -193,9 +196,7 @@ func (state ModelPickerState) Update(msg tea.Msg) ModelPickerState {
 	state.Providers["lmstudio"] = provider
 	state.customProviderIDs = append(state.customProviderIDs, "lmstudio")
 	state.refreshAvailableModels()
-	if len(discovery.Models) > 0 && len(opencode.FilterModelsForSDD(provider)) == 0 {
-		state.ConfigWarning = appendConfigWarning(state.ConfigWarning, "LM Studio models need \"tool_call\": true in provider.lmstudio.models for SDD.")
-	}
+	state.ConfigWarning = appendLMStudioToolCallWarning(state.ConfigWarning, provider, len(discovery.Models))
 	return state
 }
 
@@ -206,6 +207,13 @@ func (state *ModelPickerState) refreshAvailableModels() {
 	for _, id := range state.AvailableIDs {
 		state.SDDModels[id] = opencode.FilterModelsForSDD(state.Providers[id])
 	}
+}
+
+func appendLMStudioToolCallWarning(existing string, provider opencode.Provider, modelCount int) string {
+	if modelCount == 0 || len(opencode.FilterModelsForSDD(provider)) > 0 || strings.Contains(existing, lmStudioToolCallWarning) {
+		return existing
+	}
+	return appendConfigWarning(existing, lmStudioToolCallWarning)
 }
 
 func appendCustomProviderToolCallWarnings(

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1010,7 +1010,9 @@ func TestNewModelPickerState(t *testing.T) {
 		settingsContent   string   // non-empty means write settings file; empty means use missing path
 		wantProviderIDs   []string // provider IDs that must appear in Providers map
 		wantAvailable     int      // minimum number of AvailableIDs (custom providers always count)
+		wantUnavailable   []string // provider IDs that must not appear in AvailableIDs
 		wantConfigWarning bool     // whether ConfigWarning must be non-empty
+		wantWarningText   string   // substring expected in ConfigWarning and rendered output
 	}{
 		{
 			name:              "missing opencode.json falls back to catalog only",
@@ -1046,6 +1048,23 @@ func TestNewModelPickerState(t *testing.T) {
 			wantProviderIDs:   []string{"built-in", "custom-a", "custom-b"},
 			wantAvailable:     2, // custom-a and custom-b are always available as custom providers
 			wantConfigWarning: false,
+		},
+		{
+			name:         "custom provider without tool_call warns without becoming available",
+			cacheContent: catalogJSON,
+			settingsContent: `{
+				"provider": {
+					"custom-no-tools": {
+						"name": "Custom No Tools",
+						"models": {"model-a": {"name": "Model A"}}
+					}
+				}
+			}`,
+			wantProviderIDs:   []string{"built-in", "custom-no-tools"},
+			wantAvailable:     0,
+			wantUnavailable:   []string{"custom-no-tools"},
+			wantConfigWarning: true,
+			wantWarningText:   "provider.custom-no-tools.models",
 		},
 		{
 			name:         "name collision: custom provider wins over catalog",
@@ -1101,6 +1120,13 @@ func TestNewModelPickerState(t *testing.T) {
 				t.Errorf("AvailableIDs = %v (count %d), want at least %d",
 					state.AvailableIDs, len(state.AvailableIDs), tt.wantAvailable)
 			}
+			for _, unavailableID := range tt.wantUnavailable {
+				for _, availableID := range state.AvailableIDs {
+					if availableID == unavailableID {
+						t.Errorf("AvailableIDs = %v, must not include %q", state.AvailableIDs, unavailableID)
+					}
+				}
+			}
 
 			// ConfigWarning check.
 			if tt.wantConfigWarning && state.ConfigWarning == "" {
@@ -1108,6 +1134,14 @@ func TestNewModelPickerState(t *testing.T) {
 			}
 			if !tt.wantConfigWarning && state.ConfigWarning != "" {
 				t.Errorf("expected no ConfigWarning, got %q", state.ConfigWarning)
+			}
+			if tt.wantWarningText != "" {
+				if !strings.Contains(state.ConfigWarning, tt.wantWarningText) {
+					t.Errorf("ConfigWarning = %q, want substring %q", state.ConfigWarning, tt.wantWarningText)
+				}
+				if rendered := RenderModelPicker(nil, state, 0); !strings.Contains(rendered, tt.wantWarningText) {
+					t.Errorf("rendered picker missing warning substring %q:\n%s", tt.wantWarningText, rendered)
+				}
 			}
 		})
 	}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1009,7 +1009,7 @@ func TestNewModelPickerState(t *testing.T) {
 		cacheContent      string   // non-empty means write a cache file; empty means skip
 		settingsContent   string   // non-empty means write settings file; empty means use missing path
 		wantProviderIDs   []string // provider IDs that must appear in Providers map
-		wantAvailable     int      // minimum number of AvailableIDs (custom providers always count)
+		wantAvailable     int      // minimum number of AvailableIDs; custom providers count only with tool_call models
 		wantUnavailable   []string // provider IDs that must not appear in AvailableIDs
 		wantConfigWarning bool     // whether ConfigWarning must be non-empty
 		wantWarningText   string   // substring expected in ConfigWarning and rendered output
@@ -1064,7 +1064,7 @@ func TestNewModelPickerState(t *testing.T) {
 			wantAvailable:     0,
 			wantUnavailable:   []string{"custom-no-tools"},
 			wantConfigWarning: true,
-			wantWarningText:   "provider.custom-no-tools.models",
+			wantWarningText:   `"tool_call": true`,
 		},
 		{
 			name:         "name collision: custom provider wins over catalog",
@@ -1141,6 +1141,85 @@ func TestNewModelPickerState(t *testing.T) {
 				}
 				if rendered := RenderModelPicker(nil, state, 0); !strings.Contains(rendered, tt.wantWarningText) {
 					t.Errorf("rendered picker missing warning substring %q:\n%s", tt.wantWarningText, rendered)
+				}
+			}
+		})
+	}
+}
+
+func TestCustomProviderToolCallWarnings(t *testing.T) {
+	singleProvider := map[string]opencode.Provider{
+		"alpha": {
+			ID:   "alpha",
+			Name: "Alpha",
+			Models: map[string]opencode.Model{
+				"model": {ID: "model"},
+			},
+		},
+	}
+	singleConfigProvider := map[string]opencode.ConfigProvider{
+		"alpha": {
+			Models: map[string]opencode.ConfigModel{
+				"model": {},
+			},
+		},
+	}
+	customWarning := `Custom provider "Alpha" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.alpha.models.`
+
+	tests := []struct {
+		name            string
+		existingWarning string
+		providers       map[string]opencode.Provider
+		configProviders map[string]opencode.ConfigProvider
+		wantWarning     string
+	}{
+		{
+			name: "sorts multiple provider warnings by provider ID",
+			providers: map[string]opencode.Provider{
+				"zeta": {
+					ID:   "zeta",
+					Name: "Zeta",
+					Models: map[string]opencode.Model{
+						"model": {ID: "model"},
+					},
+				},
+				"alpha": singleProvider["alpha"],
+			},
+			configProviders: map[string]opencode.ConfigProvider{
+				"zeta": {
+					Models: map[string]opencode.ConfigModel{"model": {}},
+				},
+				"alpha": singleConfigProvider["alpha"],
+			},
+			wantWarning: `Custom provider "Alpha" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.alpha.models.
+Custom provider "Zeta" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.zeta.models.`,
+		},
+		{
+			name:            "preserves cache warning and renders both warnings",
+			existingWarning: "Could not load model cache: parse models cache: invalid character",
+			providers:       singleProvider,
+			configProviders: singleConfigProvider,
+			wantWarning:     "Could not load model cache: parse models cache: invalid character\n" + customWarning,
+		},
+		{
+			name:            "preserves config warning and renders both warnings",
+			existingWarning: "Could not load custom providers from opencode.json: parse opencode settings",
+			providers:       singleProvider,
+			configProviders: singleConfigProvider,
+			wantWarning:     "Could not load custom providers from opencode.json: parse opencode settings\n" + customWarning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendCustomProviderToolCallWarnings(tt.existingWarning, tt.providers, tt.configProviders)
+			if got != tt.wantWarning {
+				t.Fatalf("warning = %q, want %q", got, tt.wantWarning)
+			}
+			rendered := RenderModelPicker(nil, ModelPickerState{ConfigWarning: got}, 0)
+			for _, warning := range strings.Split(tt.wantWarning, "\n") {
+				if !strings.Contains(rendered, warning) {
+					t.Fatalf("rendered picker missing warning %q:\n%s", warning, rendered)
 				}
 			}
 		})
@@ -1225,7 +1304,7 @@ func TestLMStudioDiscovery(t *testing.T) {
 		t.Fatalf("unexpected models: %+v", lm.Models)
 	}
 	state = lmStudioState(t, `{}`, `{}`).Update(LMStudioDiscoveryMsg{BaseURL: "http://127.0.0.1:1234/v1", Models: []opencode.ConfigModel{{Name: "unknown"}}})
-	if len(state.AvailableIDs) != 0 || !strings.Contains(state.ConfigWarning, "tool_call: true") {
+	if len(state.AvailableIDs) != 0 || !strings.Contains(state.ConfigWarning, `"tool_call": true`) {
 		t.Fatalf("unsafe unknown model state: %+v", state)
 	}
 	state = lmStudioState(t, `{"lmstudio":{"models":{"catalog":{"id":"catalog","tool_call":true}}}}`, `{"provider":{"lmstudio":{"models":{"configured":{"tool_call":true}}}}}`)

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1240,6 +1240,31 @@ func TestLMStudioDiscoveryWarningIsNotDuplicated(t *testing.T) {
 	}
 }
 
+func TestLMStudioDiscoveryErrorWarnsOnceWhenConfiguredModelsLackToolCalls(t *testing.T) {
+	state := lmStudioState(t, `{}`, `{"provider":{"lmstudio":{"models":{"model":{"name":"Model"}}}}}`)
+	discovery := LMStudioDiscoveryMsg{
+		BaseURL: state.lmStudioURL,
+		Err:     errors.New("connection refused"),
+	}
+	state = state.Update(discovery)
+	state = state.Update(discovery)
+
+	if len(state.AvailableIDs) != 0 {
+		t.Fatalf("AvailableIDs = %v, want LM Studio excluded", state.AvailableIDs)
+	}
+
+	warning := lmStudioToolCallWarning
+	if got := strings.Count(state.ConfigWarning, warning); got != 1 {
+		t.Fatalf("LM Studio tool_call warning count = %d, want 1; warning = %q", got, state.ConfigWarning)
+	}
+	if !strings.Contains(state.ConfigWarning, "LM Studio discovery failed; using configured models.") {
+		t.Fatalf("discovery fallback warning missing: %q", state.ConfigWarning)
+	}
+	if got := strings.Count(RenderModelPicker(nil, state, 0), warning); got != 1 {
+		t.Fatalf("rendered LM Studio tool_call warning count = %d, want 1", got)
+	}
+}
+
 func TestNewModelPickerStateCacheErrorStillDiscovers(t *testing.T) {
 	state := NewModelPickerState(writeTempFile(t, "models.json", `{`), writeTempFile(t, "opencode.json", `{"provider":{"lmstudio":{"url":"http://gateway:1234/v1","models":{"model":{"tool_call":true}}}}}`))
 	if state.Providers == nil || state.lmStudioURL != "http://gateway:1234/v1" || len(state.AvailableIDs) != 1 || !strings.Contains(state.ConfigWarning, "model cache") || state.DiscoverLMStudioCmd() == nil {

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1064,7 +1064,7 @@ func TestNewModelPickerState(t *testing.T) {
 			wantAvailable:     0,
 			wantUnavailable:   []string{"custom-no-tools"},
 			wantConfigWarning: true,
-			wantWarningText:   `"tool_call": true`,
+			wantWarningText:   `provider["custom-no-tools"].models`,
 		},
 		{
 			name:         "name collision: custom provider wins over catalog",
@@ -1164,7 +1164,7 @@ func TestCustomProviderToolCallWarnings(t *testing.T) {
 			},
 		},
 	}
-	customWarning := `Custom provider "Alpha" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.alpha.models.`
+	customWarning := `Custom provider "Alpha" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider["alpha"].models.`
 
 	tests := []struct {
 		name            string
@@ -1191,8 +1191,9 @@ func TestCustomProviderToolCallWarnings(t *testing.T) {
 				},
 				"alpha": singleConfigProvider["alpha"],
 			},
-			wantWarning: `Custom provider "Alpha" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.alpha.models.
-Custom provider "Zeta" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider.zeta.models.`,
+			wantWarning: `Custom provider "Alpha" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider["alpha"].models.` +
+				"\n" +
+				`Custom provider "Zeta" has models, but none declare "tool_call": true. Add "tool_call": true to at least one model in provider["zeta"].models.`,
 		},
 		{
 			name:            "preserves cache warning and renders both warnings",
@@ -1223,6 +1224,19 @@ Custom provider "Zeta" has models, but none declare "tool_call": true. Add "tool
 				}
 			}
 		})
+	}
+}
+
+func TestLMStudioDiscoveryWarningIsNotDuplicated(t *testing.T) {
+	state := lmStudioState(t, `{}`, `{"provider":{"lmstudio":{"models":{"model":{}}}}}`)
+	state = state.Update(LMStudioDiscoveryMsg{
+		BaseURL: state.lmStudioURL,
+		Models:  []opencode.ConfigModel{{Name: "model"}},
+	})
+
+	warning := `LM Studio models need "tool_call": true in provider.lmstudio.models for SDD.`
+	if got := strings.Count(state.ConfigWarning, warning); got != 1 {
+		t.Fatalf("LM Studio warning count = %d, want 1; warning = %q", got, state.ConfigWarning)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #934

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Warns when a custom provider defines models but none declare `tool_call: true`.
- Keeps those models unavailable instead of weakening SDD capability filtering.
- Covers state and rendered warning behavior with focused tests.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/tui/screens/model_picker.go` | Adds deterministic non-blocking warnings for affected custom providers |
| `internal/tui/screens/model_picker_test.go` | Verifies warning rendering and that unsupported models remain unavailable |

---

## 🧪 Test Plan

- [x] `git diff --check`
- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./internal/tui/screens -run "^Test(NewModelPickerState|RenderModelPickerShowsConfigWarning)$" -count=1`
- [x] `go test ./internal/tui/screens`
- [x] `go test ./internal/opencode`
- [x] `go test ./... -run "^$"`
- [ ] Full E2E suite, not applicable to this focused TUI warning and not run locally

Benchmark validation: N/A. This change does not touch review lifecycle, gates, recovery, delivery, or benchmark code.

Receipt-driven development was disabled for this clone after the installed OpenCode reviewer transport returned `unsupported-capability`; delivery is therefore `disabled/unmanaged`. Focused verification and repository compilation passed.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is applied (maintainer action required: `type:bug`)
- [x] Go format passes
- [x] Documentation is unchanged because `tool_call` is already documented
- [x] Commits follow Conventional Commits
- [x] Commits contain no `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The warning is intentionally informational. It does not auto-enable models, infer model capabilities, query providers, or modify `FilterModelsForSDD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer configuration warnings when custom providers have models but none support the required tool-calling capability.
  * Providers without configured models or with at least one compatible model no longer generate unnecessary warnings.
  * Providers without compatible models remain listed but are marked unavailable.
  * Warnings are preserved alongside existing configuration notices and displayed consistently in a predictable order.
  * Clarified the LM Studio warning by specifying the required `"tool_call": true` setting and preventing duplicate notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->