### PR TITLE
docs: clarify beta upgrades and pre-squash archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ Workspace scope applies to selected agents for agent-scoped files such as system
 curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash -s -- --channel beta
 
 # Windows (PowerShell)
-$env:GENTLE_AI_CHANNEL="beta"; go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
+go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
 ```
 
-To check or upgrade the beta-selected managed tools later, set the channel in the
-current shell. PowerShell does not support the POSIX `NAME=value command` form:
+To check or upgrade the beta-selected managed tools later, pass the channel as a
+per-invocation override. The POSIX form does not change the current shell:
 
 ```bash
 # macOS / Linux
@@ -162,16 +162,26 @@ GENTLE_AI_CHANNEL=beta gentle-ai upgrade
 ```
 
 ```powershell
-# Windows PowerShell
-$env:GENTLE_AI_CHANNEL = "beta"; gentle-ai upgrade
+# Windows PowerShell: restore the previous value after this invocation
+$hadChannel = Test-Path Env:GENTLE_AI_CHANNEL
+$previousChannel = $env:GENTLE_AI_CHANNEL
+try {
+  $env:GENTLE_AI_CHANNEL = "beta"
+  gentle-ai upgrade
+} finally {
+  if ($hadChannel) {
+    $env:GENTLE_AI_CHANNEL = $previousChannel
+  } else {
+    Remove-Item Env:GENTLE_AI_CHANNEL -ErrorAction SilentlyContinue
+  }
+}
 ```
 
 `gentle-ai upgrade` checks the managed-tool cohort; it does not run `install` or
-`sync`. To explicitly refresh the main `gentle-ai` binary, use the `go install
-...@main` command above (or rerun the beta installer). If `proxy.golang.org` is
+`sync`. To explicitly refresh the main `gentle-ai` binary, use the `go install ...@main` command above (or rerun the beta installer). If `proxy.golang.org` is
 serving an older `main`, `go install` can succeed without changing the binary.
 See [beta upgrades and the Go module proxy](docs/usage.md#beta-upgrades-and-the-go-module-proxy)
-for the module-scoped direct-proxy workaround and release-tag alternative.
+for the temporary direct-proxy workaround and release-tag alternative.
 
 ### RDD version policy
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,26 @@ curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/mai
 $env:GENTLE_AI_CHANNEL="beta"; go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
 ```
 
+To check or upgrade the beta-selected managed tools later, set the channel in the
+current shell. PowerShell does not support the POSIX `NAME=value command` form:
+
+```bash
+# macOS / Linux
+GENTLE_AI_CHANNEL=beta gentle-ai upgrade
+```
+
+```powershell
+# Windows PowerShell
+$env:GENTLE_AI_CHANNEL = "beta"; gentle-ai upgrade
+```
+
+`gentle-ai upgrade` checks the managed-tool cohort; it does not run `install` or
+`sync`. To explicitly refresh the main `gentle-ai` binary, use the `go install
+...@main` command above (or rerun the beta installer). If `proxy.golang.org` is
+serving an older `main`, `go install` can succeed without changing the binary.
+See [beta upgrades and the Go module proxy](docs/usage.md#beta-upgrades-and-the-go-module-proxy)
+for the module-scoped direct-proxy workaround and release-tag alternative.
+
 ### RDD version policy
 
 Receipt-Driven Development (RDD) started in `gentle-ai` `v1.47.0` on 2026-07-10, with the first bounded native review transactions, and became the supported stable path in `v2.2.0`. The negotiated public review contract was published in `v2.1.6`.

--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ The managed installer tracks the channel's latest version and does not accept an
 
 > **Trust what the system can derive, not agent narration.** [Chapter 21 — Verifiable Trust](https://the-amazing-gentleman-programming-book.vercel.app/en/book/Chapter21_Verifiable-Trust) explains the mental model: agents assess the candidate; native authority and delivery gates independently derive what may be trusted.
 
-5. **Upgrade, then sync.** Refresh the binary and the managed agent assets together:
+5. **Refresh the binary, then sync.** Re-run the installer or use `go install ...@main` to refresh the binary, then sync the managed agent assets:
 
    ```bash
-   gentle-ai upgrade
+   go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
    gentle-ai sync
    ```
 

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -177,6 +177,33 @@ An exact no-input FINALIZE is eligible only when the frozen authority is low ris
 
 There is no `archive` gate. An advisory preflight is not delivery authorization; the native live gate result is authoritative.
 
+### Pre-squash SDD archive boundary
+
+For an SDD/OpenSpec change that will be squash-merged, complete archive before
+the squash merge while the reviewed target is still live. Use this order:
+
+1. Finish every source-mutating normalization, then freeze and finalize the
+   candidate through the native review lifecycle.
+2. Persist the required review transaction, frozen ledger, approved receipt,
+   and gate-context artifacts for that exact target.
+3. Run SDD verification and persist a passing `verify-report` plus its required
+   verification evidence.
+4. Re-read structured SDD status and obtain the applicable native live gate
+   result. Archive requires `reviewGate.result: allow`; a stale receipt,
+   advisory preflight, or copied status is not an allow result.
+5. Run archive and confirm that the archive report and final artifact state are
+   persisted while the reviewed target remains live.
+6. Only after archive is complete may the reviewed branch be squash-merged.
+
+If content, paths, modes, base, or other target identity changes before this
+sequence completes, stop and repeat the applicable native lifecycle for the new
+target. Do not carry the old receipt forward.
+
+A clean post-merge workspace with zero changed paths is a new unrelated target
+and remains fail-closed. It must not trigger a synthetic review, copied
+authority, or tree-match recovery, and this workflow provides no historical
+receipt recovery path.
+
 ### Unmanaged delivery windows and re-enabling (v2.2.0 boundary)
 
 Work delivered while the kill switch is off is recorded as unmanaged, and it stays recorded as unmanaged: gates and `sdd-status` report `disabled/unmanaged` at exit 0, the change closes under ordinary repository policy, and nothing — not a stale receipt, not a later empty-candidate approval — may ever make that window read as reviewed. Re-enabling re-validates the current state through one full fresh review, exactly as if receipt-driven development had never run: every downstream stop over unreviewed content names `gentle-ai review start` (with `--base-ref <commit>` when the delivered work is already committed), and completing that review is what unblocks the stop. The fresh review subsumes the unmanaged history; durable retroactive reconciliation — per-delivery dispositions, retroactive receipts, or any ledger that blesses past unmanaged deliveries — is deliberately not part of this release.

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -187,7 +187,11 @@ the squash merge while the reviewed target is still live. Use this order:
 2. Persist the required review transaction, frozen ledger, approved receipt,
    and gate-context artifacts for that exact target.
 3. Run SDD verification and persist a passing `verify-report` plus its required
-   verification evidence.
+   verification evidence as one target-bound proof. The report's evidence
+   revision and the evidence record's authority revision must identify the same
+   reviewed authority; that evidence must also bind the candidate identity,
+   canonical paths, and ledger IDs of that target. A report/evidence pair from a
+   different revision, candidate, path set, or ledger is not admissible.
 4. Re-read structured SDD status and obtain the applicable native live gate
    result. Archive requires `reviewGate.result: allow`; a stale receipt,
    advisory preflight, or copied status is not an allow result.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -209,8 +209,8 @@ brew upgrade engram
 ### Beta upgrades and the Go module proxy
 
 `GENTLE_AI_CHANNEL=beta` makes update checks compare the Gentle AI binary with
-the current `main` commit instead of only the latest release. Set it in the
-shell where you run the command:
+the current `main` commit instead of only the latest release. Use it as a
+per-invocation override; the POSIX form does not change the current shell:
 
 ```bash
 # macOS / Linux: check or upgrade the beta-selected managed tools
@@ -218,45 +218,65 @@ GENTLE_AI_CHANNEL=beta gentle-ai upgrade
 ```
 
 ```powershell
-# Windows PowerShell: the POSIX NAME=value command form is invalid here
-$env:GENTLE_AI_CHANNEL = "beta"; gentle-ai upgrade
+# Windows PowerShell: restore the previous value after this invocation
+$hadChannel = Test-Path Env:GENTLE_AI_CHANNEL
+$previousChannel = $env:GENTLE_AI_CHANNEL
+try {
+    $env:GENTLE_AI_CHANNEL = "beta"
+    gentle-ai upgrade
+} finally {
+    if ($hadChannel) {
+        $env:GENTLE_AI_CHANNEL = $previousChannel
+    } else {
+        Remove-Item Env:GENTLE_AI_CHANNEL -ErrorAction SilentlyContinue
+    }
+}
 ```
 
 The explicit binary refresh path is a source install from `main`, using the v2
-module path:
+module path. The `@main` suffix selects the beta source; `GENTLE_AI_CHANNEL` is
+not needed for this direct `go install` command. If the public module proxy is
+stale, override only `GOPROXY` for this invocation:
 
 ```bash
-GENTLE_AI_CHANNEL=beta \
 GOPROXY=direct \
-GONOSUMDB=github.com/gentleman-programming/gentle-ai/v2 \
-GOPRIVATE=github.com/gentleman-programming/gentle-ai/v2 \
-GONOPROXY=github.com/gentleman-programming/gentle-ai/v2 \
 go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
 ```
 
 ```powershell
-$env:GENTLE_AI_CHANNEL = "beta"
-$env:GOPROXY = "direct"
-$env:GONOSUMDB = "github.com/gentleman-programming/gentle-ai/v2"
-$env:GOPRIVATE = "github.com/gentleman-programming/gentle-ai/v2"
-$env:GONOPROXY = "github.com/gentleman-programming/gentle-ai/v2"
-go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
+$hadGoProxy = Test-Path Env:GOPROXY
+$previousGoProxy = $env:GOPROXY
+try {
+    $env:GOPROXY = "direct"
+    go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
+} finally {
+    if ($hadGoProxy) {
+        $env:GOPROXY = $previousGoProxy
+    } else {
+        Remove-Item Env:GOPROXY -ErrorAction SilentlyContinue
+    }
+}
 ```
 
-Use the direct-proxy settings only for this beta source install. If you have
-existing comma-separated `GONOSUMDB`, `GOPRIVATE`, or `GONOPROXY` patterns,
-append the Gentle AI module instead of replacing unrelated entries. The beta
-installer applies the same module-scoped bypass while preserving existing
-patterns.
+`GOPROXY=direct` controls module source lookup for this `go install` process;
+it is not a persistent setting and it is not scoped by `GONOPROXY`. Do not add
+the public Gentle AI module to `GONOSUMDB`, `GOPRIVATE`, or `GONOPROXY` merely
+to work around proxy lag: those variables control checksum or private-module
+behavior separately, and overwriting existing comma-separated values can break
+other modules. Leave existing values unchanged unless an explicit private
+module policy requires otherwise. The beta installers currently preserve
+existing patterns while preparing their own beta install and do not set
+`GOPROXY`; the manual command above intentionally keeps the normal public
+module checksum verification path.
 
 `proxy.golang.org` can lag behind a newly published `main`. A successful
 `go install ...@main` may therefore leave an older binary in place. Safe
 workarounds are:
 
 1. Retry after the proxy catches up, then verify with `gentle-ai version`.
-2. Use the module-scoped `GOPROXY=direct` command above for the beta `main`
-   build; do not disable proxy or checksum behavior globally for unrelated
-   modules.
+2. Use the command-scoped `GOPROXY=direct` command above for the beta `main`
+   build; do not persist the override or disable checksum behavior for this
+   public module.
 3. If a released build is sufficient, install an explicit released tag such as
    `@v2.2.2` with the normal proxy and checksum settings. A release tag is not
    the current `main` build.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,14 +147,34 @@ If no `--component` flag is provided for a partial uninstall, `gentle-ai` remove
 
 ### update / upgrade
 
-Check for and install new versions of `gentle-ai` itself. The pre-upgrade backup snapshot covers only the agents recorded in `state.InstalledAgents` (`~/.gentle-ai/state.json`) — not every agent config directory that exists on your machine.
+`gentle-ai upgrade` checks and applies updates for the managed-tool cohort. The
+current registry includes `gentle-ai`, `engram`, `gga`, and the registered
+OpenCode plugins `opencode-subagent-statusline` and
+`opencode-sdd-engram-manage`. It attempts entries reported as
+`update-available` or registered OpenCode plugins that are not yet materialized;
+up-to-date, missing, and failed-check entries are not upgraded.
+
+Upgrade uses each tool's effective installation method, such as Homebrew,
+authenticated release download, `go install`, the tool's installer, or npm for
+an OpenCode plugin. By default it snapshots only explicit Gentle AI-managed
+configuration paths for the agents recorded in `state.InstalledAgents`
+(`~/.gentle-ai/state.json`) before an executable upgrade, not every agent
+directory or conversation state on the machine. `--no-backup` skips that
+snapshot for the current invocation.
+
+`upgrade` does not run the `install` or `sync` pipelines. It does not refresh
+managed prompts, skills, MCP configuration, or SDD assets; run `gentle-ai sync`
+separately after the binary/tool upgrade.
 
 ```bash
 # Check if a newer version is available
 gentle-ai update
 
-# Upgrade to the latest release (downloads new binary, replaces current)
+# Upgrade eligible managed tools
 gentle-ai upgrade
+
+# Upgrade only one managed tool
+gentle-ai upgrade engram
 ```
 
 After upgrading, run `gentle-ai sync` to refresh all managed assets to the new version's content.
@@ -185,6 +205,72 @@ brew upgrade engram
 `GENTLE_AI_CONFIRM_UPDATE` was removed in slice 5. It is now ignored if set.
 
 `GENTLE_AI_SELF_UPDATE_DONE` is an internal loop guard and should not be set manually.
+
+### Beta upgrades and the Go module proxy
+
+`GENTLE_AI_CHANNEL=beta` makes update checks compare the Gentle AI binary with
+the current `main` commit instead of only the latest release. Set it in the
+shell where you run the command:
+
+```bash
+# macOS / Linux: check or upgrade the beta-selected managed tools
+GENTLE_AI_CHANNEL=beta gentle-ai upgrade
+```
+
+```powershell
+# Windows PowerShell: the POSIX NAME=value command form is invalid here
+$env:GENTLE_AI_CHANNEL = "beta"; gentle-ai upgrade
+```
+
+The explicit binary refresh path is a source install from `main`, using the v2
+module path:
+
+```bash
+GENTLE_AI_CHANNEL=beta \
+GOPROXY=direct \
+GONOSUMDB=github.com/gentleman-programming/gentle-ai/v2 \
+GOPRIVATE=github.com/gentleman-programming/gentle-ai/v2 \
+GONOPROXY=github.com/gentleman-programming/gentle-ai/v2 \
+go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
+```
+
+```powershell
+$env:GENTLE_AI_CHANNEL = "beta"
+$env:GOPROXY = "direct"
+$env:GONOSUMDB = "github.com/gentleman-programming/gentle-ai/v2"
+$env:GOPRIVATE = "github.com/gentleman-programming/gentle-ai/v2"
+$env:GONOPROXY = "github.com/gentleman-programming/gentle-ai/v2"
+go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
+```
+
+Use the direct-proxy settings only for this beta source install. If you have
+existing comma-separated `GONOSUMDB`, `GOPRIVATE`, or `GONOPROXY` patterns,
+append the Gentle AI module instead of replacing unrelated entries. The beta
+installer applies the same module-scoped bypass while preserving existing
+patterns.
+
+`proxy.golang.org` can lag behind a newly published `main`. A successful
+`go install ...@main` may therefore leave an older binary in place. Safe
+workarounds are:
+
+1. Retry after the proxy catches up, then verify with `gentle-ai version`.
+2. Use the module-scoped `GOPROXY=direct` command above for the beta `main`
+   build; do not disable proxy or checksum behavior globally for unrelated
+   modules.
+3. If a released build is sufficient, install an explicit released tag such as
+   `@v2.2.2` with the normal proxy and checksum settings. A release tag is not
+   the current `main` build.
+
+After any `go install`, confirm that the executable your shell resolves is the
+one Go updated:
+
+```bash
+gentle-ai version
+```
+
+On PowerShell, use the same commands. If the reported version is unchanged,
+check whether a stale executable earlier on `PATH` is shadowing the Go install
+destination.
 
 ### model assignment
 


### PR DESCRIPTION
## 🔗 Linked Issues

Closes #968
Closes #1927

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Documents beta-channel upgrade syntax for PowerShell and POSIX shells.
- Explains Go proxy staleness, module-scoped direct installation, and the actual `gentle-ai upgrade` scope.
- Documents the mandatory live review, verification, and archive sequence before squash merge, without introducing historical receipt recovery.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `README.md` | Adds concise cross-platform beta upgrade guidance |
| `docs/usage.md` | Documents managed-tool upgrades and safe beta binary refresh paths |
| `docs/review-integration.md` | Defines the required pre-squash archive boundary |

---

## 🧪 Test Plan

- [x] `git diff --check`
- [x] `go run ./internal/gofmtcheck`
- [x] `bash -n scripts/install.sh`
- [x] Focused beta, proxy, upgrade, CLI, docs-contract, and SDD archive/recovery tests
- [x] `go test ./internal/assets -count=1`
- [x] `go test ./internal/update/upgrade -count=1`
- [x] `go run ./cmd/gentle-ai --help`
- [x] Structural readback and local link/anchor validation
- [ ] `go test ./internal/update -count=1`, blocked locally by macOS Bash 3.2 lacking `declare -A` in an existing script
- [ ] PowerShell execution, unavailable on the local host; snippets were checked against source and repository tests
- [ ] Full E2E suite, not applicable to this documentation-only change and not run locally

Benchmark validation: N/A. No benchmark implementation, corpus, classifier, or claim changed.

The documentation candidate completed the native zero-lens structural review before RDD was disabled for this clone. Subsequent delivery is reported as `disabled/unmanaged`.

---

## ✅ Contributor Checklist

- [x] PR links approved issues
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is applied (maintainer action required: `type:docs`)
- [x] Documentation commands were checked against current behavior
- [x] Commits follow Conventional Commits and remain separated by issue
- [x] Commits contain no `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The #1927 section deliberately keeps clean post-merge workspaces fail-closed. It does not authorize synthetic review, copied authority, tree-match recovery, or historical receipt recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added beta-channel upgrade instructions for macOS/Linux and Windows PowerShell, including binary refresh guidance.
  * Clarified managed-tool upgrades, backup behavior, eligibility, installation methods, version verification, and PATH troubleshooting.
  * Added guidance for Go proxy/cache issues and released-tag alternatives.
  * Documented the required pre-squash review and archive workflow, including finalized artifacts, verification, completion, target stability, and identity-change handling.
  * Clarified that post-merge clean workspaces cannot recover or reuse prior review authority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->