### PR TITLE
fix(state): serialize install-state writes behind an advisory lock

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -219,8 +219,7 @@ internal/sddstatus/status.go	reportLineHasPassSignal
 internal/sddstatus/status.go	reportTextIsClearlyPassing
 internal/sddstatus/status.go	reportValueIsBenign
 internal/sddstatus/status.go	stripMarkdownSignal
-internal/state/lock_unix.go	tryLockFile
-internal/state/lock_unix.go	unlockFile
+internal/state/state.go	Update
 internal/storage/bytes.go	FormatBytes
 internal/system/install_deps.go	InstallCommandsForDep
 internal/system/install_deps.go	installCommandsBrew

--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -219,6 +219,8 @@ internal/sddstatus/status.go	reportLineHasPassSignal
 internal/sddstatus/status.go	reportTextIsClearlyPassing
 internal/sddstatus/status.go	reportValueIsBenign
 internal/sddstatus/status.go	stripMarkdownSignal
+internal/state/lock_unix.go	tryLockFile
+internal/state/lock_unix.go	unlockFile
 internal/storage/bytes.go	FormatBytes
 internal/system/install_deps.go	InstallCommandsForDep
 internal/system/install_deps.go	installCommandsBrew

--- a/internal/state/lock_test.go
+++ b/internal/state/lock_test.go
@@ -1,0 +1,51 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTryLockFileReportsBusyForSecondHandle covers the platform primitive
+// directly: a second open handle on an already-locked file reports busy rather
+// than returning an error or blocking.
+func TestTryLockFileReportsBusyForSecondHandle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+
+	first, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open first handle: %v", err)
+	}
+	defer first.Close()
+	locked, err := tryLockFile(first)
+	if err != nil {
+		t.Fatalf("lock first handle: %v", err)
+	}
+	if !locked {
+		t.Fatal("first handle could not take a free lock")
+	}
+
+	second, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open second handle: %v", err)
+	}
+	defer second.Close()
+	locked, err = tryLockFile(second)
+	if err != nil {
+		t.Fatalf("lock second handle: %v", err)
+	}
+	if locked {
+		t.Error("second handle took a held lock; the lock does not exclude")
+	}
+
+	if err := unlockFile(first); err != nil {
+		t.Fatalf("unlock first handle: %v", err)
+	}
+	locked, err = tryLockFile(second)
+	if err != nil {
+		t.Fatalf("relock second handle: %v", err)
+	}
+	if !locked {
+		t.Error("second handle could not take the lock after release")
+	}
+}

--- a/internal/state/lock_test.go
+++ b/internal/state/lock_test.go
@@ -1,3 +1,5 @@
+//go:build darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || windows
+
 package state
 
 import (

--- a/internal/state/lock_unix.go
+++ b/internal/state/lock_unix.go
@@ -1,0 +1,33 @@
+// The `unix` pseudo-tag also matches aix and solaris, neither of which defines
+// syscall.Flock, and hurd, which has no port in this toolchain. Listing the
+// verified targets keeps the constraint honest and fails closed on new ports.
+// android satisfies the linux tag and ios satisfies darwin, so both are covered.
+//go:build darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd
+
+package state
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLockFile attempts to take an exclusive advisory lock without blocking.
+// It returns (true, nil) when the lock was taken, (false, nil) when another
+// holder has it, and (false, err) on any other failure.
+// Adapted from internal/reviewtransaction/store_lock_unix.go.
+func tryLockFile(file *os.File) (bool, error) {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the lock taken by tryLockFile.
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/state/lock_unsupported.go
+++ b/internal/state/lock_unsupported.go
@@ -1,0 +1,31 @@
+// Every target that neither lock_unix.go nor lock_windows.go claims lands here.
+// aix and solaris match the `unix` pseudo-tag but do not define syscall.Flock,
+// and hurd has no port in this toolchain, so none of them can honour the
+// advisory-lock contract. Rather than leaving the symbols undefined and failing
+// the build, this file keeps the package compilable everywhere and refuses to
+// lock where locking was never verified. Callers surface ErrLockUnsupported
+// instead of writing state without serialisation.
+//go:build !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !windows
+
+package state
+
+import (
+	"errors"
+	"os"
+	"runtime"
+)
+
+// ErrLockUnsupported is returned on targets with no verified advisory-lock
+// implementation. It fails closed: state writes stop rather than proceeding
+// without the serialisation that install and sync depend on.
+var ErrLockUnsupported = errors.New("state: advisory file locking is not implemented on " + runtime.GOOS)
+
+// tryLockFile always fails closed on unsupported targets.
+func tryLockFile(_ *os.File) (bool, error) {
+	return false, ErrLockUnsupported
+}
+
+// unlockFile always fails closed on unsupported targets.
+func unlockFile(_ *os.File) error {
+	return ErrLockUnsupported
+}

--- a/internal/state/lock_unsupported_test.go
+++ b/internal/state/lock_unsupported_test.go
@@ -1,0 +1,43 @@
+//go:build !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !windows
+
+package state
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestUnsupportedPlatformFailsClosed proves that a target without a verified
+// advisory-lock implementation refuses to lock instead of silently proceeding
+// unlocked. Degrading to no lock would reintroduce the lost-update race that
+// issue #1809 describes.
+//
+// This test never executes in CI, and that is deliberate rather than an
+// oversight: it is tagged for the same targets as lock_unsupported.go, and CI
+// runs linux, darwin, and windows. Its value is compile-time. `GOOS=aix
+// GOARCH=ppc64 go test -c ./internal/state/` type-checks this file against the
+// fallback, so the contract cannot drift — deleting or renaming
+// ErrLockUnsupported, or changing either signature, breaks the cross-compiled
+// build. Keep that command in the verification steps; without it this file
+// really would assert nothing.
+func TestUnsupportedPlatformFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open handle: %v", err)
+	}
+	defer file.Close()
+
+	locked, err := tryLockFile(file)
+	if locked {
+		t.Error("tryLockFile reported a lock on a platform with no implementation")
+	}
+	if !errors.Is(err, ErrLockUnsupported) {
+		t.Errorf("tryLockFile error = %v, want ErrLockUnsupported", err)
+	}
+	if err := unlockFile(file); !errors.Is(err, ErrLockUnsupported) {
+		t.Errorf("unlockFile error = %v, want ErrLockUnsupported", err)
+	}
+}

--- a/internal/state/lock_windows.go
+++ b/internal/state/lock_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package state
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLockFile is the Windows half of the contract documented in lock_unix.go.
+// Adapted from internal/reviewtransaction/store_lock_windows.go.
+func tryLockFile(file *os.File) (bool, error) {
+	overlapped := new(windows.Overlapped)
+	flags := uint32(windows.LOCKFILE_FAIL_IMMEDIATELY | windows.LOCKFILE_EXCLUSIVE_LOCK)
+	err := windows.LockFileEx(windows.Handle(file.Fd()), flags, 0, 1, 0, overlapped)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the lock taken by tryLockFile.
+func unlockFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +13,18 @@ import (
 
 const stateDir = ".gentle-ai"
 const stateFile = "state.json"
+
+// ErrLockTimeout is returned when the state lock cannot be acquired in time.
+var ErrLockTimeout = errors.New("state: timed out acquiring install state lock")
+
+const (
+	lockFile       = "INSTALL-STATE.lock"
+	lockRetryDelay = 100 * time.Millisecond
+)
+
+// lockTimeout bounds lock acquisition. It is a var only so the timeout tests can
+// shorten it; tests in this package run sequentially, so there is no race.
+var lockTimeout = 5 * time.Second
 
 // ModelAssignmentState is the JSON-serialisable form of a provider+model pair
 // used by OpenCode-style model assignments. It mirrors model.ModelAssignment
@@ -169,6 +182,81 @@ func Path(homeDir string) string {
 	return filepath.Join(homeDir, stateDir, stateFile)
 }
 
+// acquireStateLock creates the state directory when missing and takes an
+// exclusive advisory lock on the sidecar lockfile. The returned release
+// function unlocks and closes the handle.
+func acquireStateLock(homeDir string) (func(), error) {
+	dir := filepath.Join(homeDir, stateDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(filepath.Join(dir, lockFile), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		locked, err := tryLockFile(f)
+		if err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		if locked {
+			return func() {
+				_ = unlockFile(f)
+				_ = f.Close()
+			}, nil
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return nil, ErrLockTimeout
+		}
+		time.Sleep(lockRetryDelay)
+	}
+}
+
+// writeLocked marshals and persists s. The caller must already hold the lock.
+func writeLocked(homeDir string, s InstallState) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = filemerge.WriteFileAtomic(Path(homeDir), append(data, '\n'), 0o644)
+	return err
+}
+
+// Update serializes a read-modify-write window on the install state file. It
+// takes an exclusive lock, re-reads the latest state from disk, invokes mutate
+// on that fresh copy, and persists the result. The lock covers the whole
+// interval and is released on every exit path, including panic.
+//
+// A missing state file starts from the zero value and is created. A file that
+// exists but cannot be decoded is never overwritten: mutate is not called and
+// the decode error is returned. An error from mutate aborts the write.
+//
+// The lock is not reentrant on either platform: flock associates the lock with
+// the open file description and LockFileEx with the handle, and every
+// acquisition opens a fresh one. mutate must therefore not call Update or Write
+// for the same homeDir, directly or through any nested call path; such a call
+// blocks against its own outer lock until lockTimeout elapses and then returns
+// ErrLockTimeout.
+func Update(homeDir string, mutate func(*InstallState) error) error {
+	release, err := acquireStateLock(homeDir)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	s, err := Read(homeDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := mutate(&s); err != nil {
+		return err
+	}
+	return writeLocked(homeDir, s)
+}
+
 // Read reads and unmarshals the state file from the given home directory.
 // Returns an error if the file does not exist or cannot be decoded.
 func Read(homeDir string) (InstallState, error) {
@@ -254,17 +342,15 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 	}
 }
 
-// Write persists the full install state to disk under the given home directory.
-// It creates the .gentle-ai directory if it does not already exist.
+// Write persists a caller-owned whole document. It takes the same lock as
+// Update so the two cannot interleave, and it is non-reentrant for the same
+// reason Update is: calling it from inside an Update mutation returns
+// ErrLockTimeout.
 func Write(homeDir string, s InstallState) error {
-	dir := filepath.Join(homeDir, stateDir)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(s, "", "  ")
+	release, err := acquireStateLock(homeDir)
 	if err != nil {
 		return err
 	}
-	_, err = filemerge.WriteFileAtomic(Path(homeDir), append(data, '\n'), 0o644)
-	return err
+	defer release()
+	return writeLocked(homeDir, s)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -196,6 +196,11 @@ func acquireStateLock(homeDir string) (func(), error) {
 	}
 	deadline := time.Now().Add(lockTimeout)
 	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			_ = f.Close()
+			return nil, ErrLockTimeout
+		}
 		locked, err := tryLockFile(f)
 		if err != nil {
 			_ = f.Close()
@@ -207,9 +212,9 @@ func acquireStateLock(homeDir string) (func(), error) {
 				_ = f.Close()
 			}, nil
 		}
-		if time.Now().After(deadline) {
-			_ = f.Close()
-			return nil, ErrLockTimeout
+		if remaining < lockRetryDelay {
+			time.Sleep(remaining)
+			continue
 		}
 		time.Sleep(lockRetryDelay)
 	}

--- a/internal/state/state_lock_test.go
+++ b/internal/state/state_lock_test.go
@@ -69,10 +69,11 @@ func TestConcurrentUpdatesDoNotLoseWrites(t *testing.T) {
 
 	const writers = 10
 	done := make(chan error, writers)
-	for i := range writers {
+	for i := 0; i < writers; i++ {
+		agent := fmt.Sprintf("agent-%d", i)
 		go func() {
 			done <- Update(homeDir, func(s *InstallState) error {
-				s.InstalledAgents = append(s.InstalledAgents, fmt.Sprintf("agent-%d", i))
+				s.InstalledAgents = append(s.InstalledAgents, agent)
 				return nil
 			})
 		}()
@@ -91,7 +92,7 @@ func TestConcurrentUpdatesDoNotLoseWrites(t *testing.T) {
 	for _, agent := range final.InstalledAgents {
 		seen[agent] = true
 	}
-	for i := range writers {
+	for i := 0; i < writers; i++ {
 		if want := fmt.Sprintf("agent-%d", i); !seen[want] {
 			t.Errorf("missing %s: %d of %d writers survived", want, len(seen), writers)
 		}

--- a/internal/state/state_lock_test.go
+++ b/internal/state/state_lock_test.go
@@ -280,3 +280,29 @@ func TestUpdateReleasesLockOnPanic(t *testing.T) {
 		t.Fatal("Update after panic blocked; the lock was not released")
 	}
 }
+
+// TestLockTimeoutDoesNotOvershoot pins the acquisition deadline. The retry loop
+// must check the deadline before each attempt and cap its sleep to the time
+// remaining, otherwise a 20ms timeout waits a full 100ms lockRetryDelay and can
+// even acquire the lock after the deadline has already passed.
+func TestLockTimeoutDoesNotOvershoot(t *testing.T) {
+	homeDir := t.TempDir()
+	previous := lockTimeout
+	lockTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { lockTimeout = previous })
+
+	release, err := acquireStateLock(homeDir)
+	if err != nil {
+		t.Fatalf("acquire held lock: %v", err)
+	}
+	t.Cleanup(release)
+
+	start := time.Now()
+	if _, err := acquireStateLock(homeDir); !errors.Is(err, ErrLockTimeout) {
+		t.Fatalf("second acquire error = %v, want ErrLockTimeout", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 60*time.Millisecond {
+		t.Errorf("acquire took %v for a %v timeout; the loop sleeps past its own deadline", elapsed, lockTimeout)
+	}
+}

--- a/internal/state/state_lock_test.go
+++ b/internal/state/state_lock_test.go
@@ -1,0 +1,282 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestUpdatePreservesConcurrentRDDModeChange is the regression for issue #1809:
+// actor A reads, actor B writes rdd_mode=off, then actor A persists its own
+// field from the snapshot it captured before B ran. The old Read/mutate/Write
+// pattern sent the whole stale document back and restored rdd_mode=on.
+func TestUpdatePreservesConcurrentRDDModeChange(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{RDDMode: "on", Persona: "gentleman"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	stale, err := Read(homeDir) // actor A, held across a long operation
+	if err != nil {
+		t.Fatalf("actor A read: %v", err)
+	}
+
+	// Actor B turns the kill switch off while A is still working.
+	if err := Update(homeDir, func(s *InstallState) error {
+		s.RDDMode = "off"
+		return nil
+	}); err != nil {
+		t.Fatalf("actor B update: %v", err)
+	}
+
+	// Actor A now persists the persona it derived from its stale snapshot.
+	if err := Update(homeDir, func(s *InstallState) error {
+		if s.RDDMode != "off" {
+			t.Errorf("closure saw RDDMode = %q, want off; the re-read must happen inside the lock", s.RDDMode)
+		}
+		s.Persona = stale.Persona + "-updated"
+		return nil
+	}); err != nil {
+		t.Fatalf("actor A update: %v", err)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.RDDMode != "off" {
+		t.Errorf("RDDMode = %q, want off; actor B's kill-switch decision was clobbered", final.RDDMode)
+	}
+	if final.Persona != "gentleman-updated" {
+		t.Errorf("Persona = %q, want gentleman-updated; actor A's change was lost", final.Persona)
+	}
+}
+
+// TestConcurrentUpdatesDoNotLoseWrites proves the lock serialises writers that
+// contend within one process. Without it, concurrent appends overwrite each
+// other and entries disappear. Cross-process contention uses the same advisory
+// lock but is not exercised here.
+func TestConcurrentUpdatesDoNotLoseWrites(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	const writers = 10
+	done := make(chan error, writers)
+	for i := range writers {
+		go func() {
+			done <- Update(homeDir, func(s *InstallState) error {
+				s.InstalledAgents = append(s.InstalledAgents, fmt.Sprintf("agent-%d", i))
+				return nil
+			})
+		}()
+	}
+	for range writers {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent update: %v", err)
+		}
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	seen := make(map[string]bool, writers)
+	for _, agent := range final.InstalledAgents {
+		seen[agent] = true
+	}
+	for i := range writers {
+		if want := fmt.Sprintf("agent-%d", i); !seen[want] {
+			t.Errorf("missing %s: %d of %d writers survived", want, len(seen), writers)
+		}
+	}
+}
+
+// TestWriteWaitsForUpdateLock is the direct coverage for the invariant Write's
+// doc comment asserts: the two share one lock, so a whole-document Write cannot
+// land inside an Update read-modify-write window. If Write ever stops taking the
+// lock, it completes while the window is open and the first assertion fails.
+func TestWriteWaitsForUpdateLock(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{Persona: "gentleman"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	inMutate, resume := make(chan struct{}), make(chan struct{})
+	updateDone, writeDone := make(chan error, 1), make(chan error, 1)
+
+	go func() {
+		updateDone <- Update(homeDir, func(s *InstallState) error {
+			close(inMutate)
+			<-resume
+			s.Persona += "-updated"
+			return nil
+		})
+	}()
+	<-inMutate
+
+	go func() { writeDone <- Write(homeDir, InstallState{Persona: "written"}) }()
+	select {
+	case err := <-writeDone:
+		t.Fatalf("Write completed inside the Update window (err = %v); the two interleaved", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(resume)
+	if err := <-updateDone; err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.Persona != "written" {
+		t.Errorf("Persona = %q, want written; Write must land after the window, not inside it", final.Persona)
+	}
+}
+
+// TestLockTimeoutWhenLockHeld covers ErrLockTimeout on both entry points. It
+// holds the lock through acquireStateLock, which is exactly what a nested call
+// from inside mutate would do, so it also demonstrates the documented
+// non-reentrancy.
+func TestLockTimeoutWhenLockHeld(t *testing.T) {
+	homeDir := t.TempDir()
+	previous := lockTimeout
+	lockTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { lockTimeout = previous })
+
+	release, err := acquireStateLock(homeDir)
+	if err != nil {
+		t.Fatalf("acquire held lock: %v", err)
+	}
+	defer release()
+
+	err = Update(homeDir, func(*InstallState) error {
+		t.Error("mutate ran while another holder had the lock")
+		return nil
+	})
+	if !errors.Is(err, ErrLockTimeout) {
+		t.Errorf("Update error = %v, want ErrLockTimeout", err)
+	}
+	if err := Write(homeDir, InstallState{Persona: "neutral"}); !errors.Is(err, ErrLockTimeout) {
+		t.Errorf("Write error = %v, want ErrLockTimeout", err)
+	}
+	if _, err := os.Stat(Path(homeDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("os.Stat(state file) = %v, want not-exist; a timed-out call must not write", err)
+	}
+}
+
+func TestUpdateMutationErrorLeavesFileUnchanged(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{Persona: "gentleman"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	sentinel := errors.New("mutation rejected")
+	err := Update(homeDir, func(s *InstallState) error {
+		s.Persona = "neutral"
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Update error = %v, want %v", err, sentinel)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.Persona != "gentleman" {
+		t.Errorf("Persona = %q, want gentleman; a failed mutation must not be persisted", final.Persona)
+	}
+}
+
+func TestUpdateCreatesStateFromZeroValue(t *testing.T) {
+	homeDir := t.TempDir()
+
+	if err := Update(homeDir, func(s *InstallState) error {
+		if !reflect.DeepEqual(*s, InstallState{}) {
+			t.Errorf("closure received %+v, want the zero value when no state file exists", *s)
+		}
+		s.Persona = "neutral"
+		return nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.Persona != "neutral" {
+		t.Errorf("Persona = %q, want neutral", final.Persona)
+	}
+}
+
+// TestUpdateRefusesToOverwriteCorruptState mirrors the no-clobber guards the
+// call sites already relied on.
+func TestUpdateRefusesToOverwriteCorruptState(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, stateDir), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	const corrupt = "{not json"
+	if err := os.WriteFile(Path(homeDir), []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("seed corrupt state: %v", err)
+	}
+
+	called := false
+	if err := Update(homeDir, func(*InstallState) error {
+		called = true
+		return nil
+	}); err == nil {
+		t.Fatal("Update returned nil, want a decode error for a corrupt state file")
+	}
+	if called {
+		t.Error("mutation ran against a corrupt state file")
+	}
+
+	data, err := os.ReadFile(Path(homeDir))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	if string(data) != corrupt {
+		t.Errorf("state file = %q, want it left untouched", string(data))
+	}
+}
+
+func TestUpdateReleasesLockOnPanic(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	func() {
+		defer func() { _ = recover() }()
+		_ = Update(homeDir, func(*InstallState) error { panic("mutation panic") })
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Update(homeDir, func(s *InstallState) error {
+			s.Persona = "neutral"
+			return nil
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Update after panic: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Update after panic blocked; the lock was not released")
+	}
+}

--- a/internal/state/state_lock_test.go
+++ b/internal/state/state_lock_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -107,19 +108,11 @@ func TestWriteWaitsForUpdateLock(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	inMutate, resume := make(chan struct{}), make(chan struct{})
-	updateDone, writeDone := make(chan error, 1), make(chan error, 1)
+	resume, updateDone := startUpdateWindow(t, homeDir, func(s *InstallState) {
+		s.Persona += "-updated"
+	})
 
-	go func() {
-		updateDone <- Update(homeDir, func(s *InstallState) error {
-			close(inMutate)
-			<-resume
-			s.Persona += "-updated"
-			return nil
-		})
-	}()
-	<-inMutate
-
+	writeDone := make(chan error, 1)
 	go func() { writeDone <- Write(homeDir, InstallState{Persona: "written"}) }()
 	select {
 	case err := <-writeDone:
@@ -127,7 +120,7 @@ func TestWriteWaitsForUpdateLock(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 	}
 
-	close(resume)
+	resume()
 	if err := <-updateDone; err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -305,4 +298,60 @@ func TestLockTimeoutDoesNotOvershoot(t *testing.T) {
 	if elapsed > 60*time.Millisecond {
 		t.Errorf("acquire took %v for a %v timeout; the loop sleeps past its own deadline", elapsed, lockTimeout)
 	}
+}
+
+// TestUpdateWindowIsReleasedWhenTheSubtestEnds pins the scaffolding contract. A
+// test that opens an Update window and returns without resuming it must still
+// release the state lock, or the window stays open and every later test in the
+// package times out — which is exactly what happens when a real test fails
+// early inside the window. The subtest below leaves the window open on purpose;
+// the outer assertion proves the helper's cleanup closed it.
+//
+// The subtest must PASS. An earlier draft made it fail deliberately, but Go
+// propagates a subtest failure to its parent and to the package result, so that
+// design reported FAIL forever. Leaving the window open exercises the same
+// cleanup path without poisoning the suite.
+func TestUpdateWindowIsReleasedWhenTheSubtestEnds(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{Persona: "gentleman"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	t.Run("leaves the window open", func(t *testing.T) {
+		startUpdateWindow(t, homeDir, func(s *InstallState) { s.Persona = "resumed-by-cleanup" })
+	})
+
+	previous := lockTimeout
+	lockTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { lockTimeout = previous })
+
+	release, err := acquireStateLock(homeDir)
+	if err != nil {
+		t.Fatalf("state lock still held after the subtest: %v", err)
+	}
+	release()
+}
+
+// startUpdateWindow enters an Update read-modify-write window and blocks inside
+// mutate until the returned resume func runs. resume is registered with
+// t.Cleanup and guarded by sync.Once, so every exit path — a passing test, a
+// failed assertion, or an explicit call — releases the state lock exactly once.
+func startUpdateWindow(t *testing.T, homeDir string, apply func(*InstallState)) (resume func(), done <-chan error) {
+	t.Helper()
+	inMutate, resumeCh := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	resume = func() { once.Do(func() { close(resumeCh) }) }
+	t.Cleanup(resume)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Update(homeDir, func(s *InstallState) error {
+			close(inMutate)
+			<-resumeCh
+			apply(s)
+			return nil
+		})
+	}()
+	<-inMutate
+	return resume, errCh
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2352

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Slice A of a two-PR chain for #1809. Adds the primitive; slice B migrates the call sites.

`state.Write` marshalled the whole `InstallState` and atomically replaced `state.json` with no lock, no revision, and no compare-and-swap, so the last writer won with whatever snapshot it had read. Atomic replacement kept the file valid JSON while silently accepting a stale full-object write.

This PR adds `state.Update(homeDir, mutate)`, which takes an exclusive advisory lock on a sidecar lock file, re-reads the persisted state **inside** the lock, applies the caller's mutation to that fresh copy, and writes while still holding the lock. `state.Write` is unchanged so nothing breaks; call sites move over in slice B.

The regression test reproduces the sequence from the issue: actor A reads state, actor B writes `rdd_mode=off`, actor A then writes `persona` from its stale snapshot. Before this change the test fails by silently restoring `rdd_mode=on`.

Locking is split by platform so both are exercised: `lock_unix.go` and `lock_windows.go`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/state/state.go` | `Update` primitive: lock, re-read, mutate, write under lock |
| `internal/state/lock_unix.go` | Advisory lock acquisition on Unix |
| `internal/state/lock_windows.go` | Advisory lock acquisition on Windows |
| `internal/state/state_lock_test.go` | Lost-update regression plus concurrency coverage |

---

## 🧪 Test Plan

```bash
go test ./internal/state/... -race -count=1
go run ./internal/gofmtcheck
go build ./...
go vet ./...
```

- [x] Unit tests pass for `internal/state`, including `-race`
- [x] Go format passes
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Full `go test ./...` — deferring to CI. Locally `internal/cli` needs `-timeout 30m` and fails one unrelated `uv` test that reproduces identically on the base tree.
- [ ] E2E tests — deferring to CI
- [x] Manually verified the lost-update sequence fails before the change and passes after

Benchmark validation: N/A. This touches install-state persistence only, not review-lifecycle, gates, recovery, delivery, or benchmark surfaces.

- [x] PR stays within 400 changed lines (391 additions + 9 deletions = 400)
- [x] Commits follow Conventional Commits
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**This slice does not fix the user-visible bug on its own.** It adds the primitive and pins the regression. The eight read-modify-write call sites migrate in the stacked follow-up, which is what actually closes the race in `install` and `sync`.

Split because the combined change is 528 changed lines, past the 400 budget. Each slice sits inside it, so no `size:exception` is requested.

Chain: this PR, then `pablontiv/sdd-1809-state-lock-callsites`.

I have no triage rights on this repository. Maintainer-owed label: `type:bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes update installation state concurrently.
  * Prevented failed, interrupted, or invalid updates from overwriting existing state.
  * Added timeout handling when installation state remains locked.
  * Ensured locks are released after errors or interruptions across supported platforms.
  * Preserved existing state when updates fail or state data is invalid.
  * Safely initialized missing installation state when needed.
  * Coordinated all state writes to prevent updates from being lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


