### PR TITLE
refactor(state): migrate install-state call sites onto the advisory lock

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -202,6 +202,7 @@ internal/sddstatus/status.go	reportLineHasPassSignal
 internal/sddstatus/status.go	reportTextIsClearlyPassing
 internal/sddstatus/status.go	reportValueIsBenign
 internal/sddstatus/status.go	stripMarkdownSignal
+internal/state/state.go	Update
 internal/storage/bytes.go	FormatBytes
 internal/system/install_deps.go	InstallCommandsForDep
 internal/system/install_deps.go	installCommandsBrew

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -182,11 +182,14 @@ func RunArgs(args []string, stdout io.Writer) error {
 				_, _ = fmt.Fprintf(stdout, "Warning: deferred sync failed: %v\n", err)
 				// Leave PendingSync=true so the next launch retries.
 			} else {
-				installedState.PendingSync = false
-				if writeErr := state.Write(homeDir, installedState); writeErr != nil {
+				// Update owns PendingSync field only. Re-read inside lock ensures fresh state.
+				if updateErr := state.Update(homeDir, func(s *state.InstallState) error {
+					s.PendingSync = false
+					return nil
+				}); updateErr != nil {
 					// Best-effort: surface the failure so it's not silently swallowed.
 					// Idempotent re-sync on the next launch is acceptable.
-					_, _ = fmt.Fprintf(stdout, "Warning: failed to clear PendingSync flag: %v\n", writeErr)
+					_, _ = fmt.Fprintf(stdout, "Warning: failed to clear PendingSync flag: %v\n", updateErr)
 				}
 			}
 		}
@@ -831,72 +834,73 @@ func persistAssignments(homeDir string, selection model.Selection) error {
 	if len(selection.ClaudeModelAssignments) == 0 && len(selection.ClaudePhaseAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 && len(selection.CodexModelAssignments) == 0 && len(selection.CodexCarrilModelAssignments) == 0 && len(selection.CodexPhaseModelAssignments) == 0 && !hasAssignmentSignal {
 		return nil
 	}
-	current, err := state.Read(homeDir)
-	if err != nil {
-		// State file may not exist yet (e.g. pre-state users). Other read
-		// failures, such as invalid JSON, must not overwrite existing state.
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		current = state.InstallState{}
+	// A state file that exists but cannot be decoded must not be overwritten, and
+	// that case is not an install failure. Probe for it first so the Update error
+	// below can stay reserved for genuine write failures, which callers still see.
+	if _, readErr := state.Read(homeDir); readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return nil
 	}
-	if selection.ClaudeModelAssignments != nil {
-		if len(selection.ClaudeModelAssignments) > 0 {
-			current.ClaudeModelAssignments = claudeAliasesToStrings(selection.ClaudeModelAssignments)
-		} else {
+	// The closure owns every model-assignment field. Re-reading inside the lock
+	// keeps a concurrent writer's unrelated fields intact.
+	return state.Update(homeDir, func(current *state.InstallState) error {
+		if selection.ClaudeModelAssignments != nil {
+			if len(selection.ClaudeModelAssignments) > 0 {
+				current.ClaudeModelAssignments = claudeAliasesToStrings(selection.ClaudeModelAssignments)
+			} else {
+				current.ClaudeModelAssignments = nil
+			}
+		}
+		if selection.ClaudePhaseAssignments != nil {
+			if len(selection.ClaudePhaseAssignments) > 0 {
+				current.ClaudePhaseAssignments = claudePhaseAssignmentsToState(selection.ClaudePhaseAssignments)
+			} else {
+				current.ClaudePhaseAssignments = nil
+			}
 			current.ClaudeModelAssignments = nil
 		}
-	}
-	if selection.ClaudePhaseAssignments != nil {
-		if len(selection.ClaudePhaseAssignments) > 0 {
-			current.ClaudePhaseAssignments = claudePhaseAssignmentsToState(selection.ClaudePhaseAssignments)
-		} else {
-			current.ClaudePhaseAssignments = nil
+		if selection.KiroModelAssignments != nil {
+			if len(selection.KiroModelAssignments) > 0 {
+				current.KiroModelAssignments = kiroAliasesToStrings(selection.KiroModelAssignments)
+			} else {
+				current.KiroModelAssignments = nil
+			}
 		}
-		current.ClaudeModelAssignments = nil
-	}
-	if selection.KiroModelAssignments != nil {
-		if len(selection.KiroModelAssignments) > 0 {
-			current.KiroModelAssignments = kiroAliasesToStrings(selection.KiroModelAssignments)
-		} else {
-			current.KiroModelAssignments = nil
+		if selection.ClearCodexOrchestratorAssignment {
+			current.CodexOrchestratorAssignment = nil
+		} else if selection.CodexOrchestratorAssignment != nil {
+			current.CodexOrchestratorAssignment = codexOrchestratorToState(selection.CodexOrchestratorAssignment)
 		}
-	}
-	if selection.ClearCodexOrchestratorAssignment {
-		current.CodexOrchestratorAssignment = nil
-	} else if selection.CodexOrchestratorAssignment != nil {
-		current.CodexOrchestratorAssignment = codexOrchestratorToState(selection.CodexOrchestratorAssignment)
-	}
-	if selection.CodexModelAssignments != nil {
-		if len(selection.CodexModelAssignments) > 0 {
-			current.CodexModelAssignments = codexEffortsToStrings(selection.CodexModelAssignments)
-		} else {
-			current.CodexModelAssignments = nil
+		if selection.CodexModelAssignments != nil {
+			if len(selection.CodexModelAssignments) > 0 {
+				current.CodexModelAssignments = codexEffortsToStrings(selection.CodexModelAssignments)
+			} else {
+				current.CodexModelAssignments = nil
+			}
 		}
-	}
-	if selection.CodexCarrilModelAssignments != nil {
-		if len(selection.CodexCarrilModelAssignments) > 0 {
-			current.CodexCarrilModelAssignments = selection.CodexCarrilModelAssignments
-		} else {
-			current.CodexCarrilModelAssignments = nil
+		if selection.CodexCarrilModelAssignments != nil {
+			if len(selection.CodexCarrilModelAssignments) > 0 {
+				current.CodexCarrilModelAssignments = selection.CodexCarrilModelAssignments
+			} else {
+				current.CodexCarrilModelAssignments = nil
+			}
 		}
-	}
-	// non-nil, len > 0 → write; non-nil, len == 0 → clear (explicit preset signal); nil → leave untouched.
-	if selection.CodexPhaseModelAssignments != nil {
-		if len(selection.CodexPhaseModelAssignments) > 0 {
-			current.CodexPhaseModelAssignments = selection.CodexPhaseModelAssignments
-		} else {
-			current.CodexPhaseModelAssignments = nil
+		// non-nil, len > 0 → write; non-nil, len == 0 → clear (explicit preset signal); nil → leave untouched.
+		if selection.CodexPhaseModelAssignments != nil {
+			if len(selection.CodexPhaseModelAssignments) > 0 {
+				current.CodexPhaseModelAssignments = selection.CodexPhaseModelAssignments
+			} else {
+				current.CodexPhaseModelAssignments = nil
+			}
 		}
-	}
-	if selection.ModelAssignments != nil {
-		if len(selection.ModelAssignments) > 0 {
-			current.ModelAssignments = modelAssignmentsToState(selection.ModelAssignments)
-		} else {
-			current.ModelAssignments = nil
+		if selection.ModelAssignments != nil {
+			if len(selection.ModelAssignments) > 0 {
+				current.ModelAssignments = modelAssignmentsToState(selection.ModelAssignments)
+			} else {
+				current.ModelAssignments = nil
+			}
 		}
-	}
-	return state.Write(homeDir, current)
+		return nil
+	})
 }
 
 // claudeAliasesToStrings converts a typed ClaudeModelAlias map to plain strings

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -3,7 +3,6 @@ package app
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -176,14 +175,12 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 	// JSON, permission denied) means an existing file is present — do not
 	// overwrite it and risk dropping unrelated persisted fields.
 	if homeDir != "" {
-		s, readErr := state.Read(homeDir)
-		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-			// File exists but is unreadable/corrupt — skip this round to avoid
-			// clobbering installed_agents, model assignments, etc.
-		} else {
+		// Update owns PendingSync field only. Re-read inside lock ensures fresh state.
+		// Ignore errors; non-fatal.
+		_ = state.Update(homeDir, func(s *state.InstallState) error {
 			s.PendingSync = true
-			_ = state.Write(homeDir, s)
-		}
+			return nil
+		})
 	}
 
 	return restartAfterGentleAIUpgrade(target.LatestVersion, stdout)

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -321,18 +321,18 @@ func writeGlobalRDDMode(operation string) error {
 	if err != nil {
 		return fmt.Errorf("resolve user home directory: %w", err)
 	}
-	persisted, err := state.Read(home)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("read global review mode: %w", err)
-	}
-	mode := reviewtransaction.RDDModeOff
-	if operation == "enable" {
-		mode = reviewtransaction.RDDModeOn
-	}
-	recorded := time.Now().UTC()
-	persisted.RDDMode = string(mode)
-	persisted.RDDModeRecordedAt = &recorded
-	if err := state.Write(home, persisted); err != nil {
+	// Update owns RDDMode and RDDModeRecordedAt fields. Re-read inside lock
+	// ensures fresh state and prevents concurrent writes from clobbering the kill switch.
+	if err := state.Update(home, func(s *state.InstallState) error {
+		mode := reviewtransaction.RDDModeOff
+		if operation == "enable" {
+			mode = reviewtransaction.RDDModeOn
+		}
+		recorded := time.Now().UTC()
+		s.RDDMode = string(mode)
+		s.RDDModeRecordedAt = &recorded
+		return nil
+	}); err != nil {
 		return fmt.Errorf("persist global review mode: %w", err)
 	}
 	return nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1382,10 +1382,19 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	if !result.Verify.Ready {
 		return result, fmt.Errorf("post-sync verification failed:\n%s", verify.RenderReport(result.Verify))
 	}
-	if persistedStateErr == nil && !persistedState.CommunityToolsConfigured && selection.CommunityTools != nil {
-		persistedState.CommunityTools = communityToolIDsToStrings(selection.CommunityTools)
-		persistedState.CommunityToolsConfigured = true
-		if err := state.Write(homeDir, persistedState); err != nil {
+	// The closure owns CommunityTools and CommunityToolsConfigured. Re-reading
+	// inside the lock evaluates the "already configured" half of the guard against
+	// the current file rather than the snapshot taken before the pipeline ran.
+	// persistedStateErr still gates the whole block: an absent or undecodable
+	// state file is left alone here, exactly as before.
+	if persistedStateErr == nil && selection.CommunityTools != nil {
+		if err := state.Update(homeDir, func(s *state.InstallState) error {
+			if !s.CommunityToolsConfigured {
+				s.CommunityTools = communityToolIDsToStrings(selection.CommunityTools)
+				s.CommunityToolsConfigured = true
+			}
+			return nil
+		}); err != nil {
 			return result, fmt.Errorf("persist migrated community tool selection: %w", err)
 		}
 	}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -2,6 +2,7 @@ package uninstall
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -1367,36 +1368,43 @@ func updateStateAfterUninstall(homeDir string, toRemove []model.AgentID) ([]mode
 		return nil, nil
 	}
 
-	current, err := state.Read(homeDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+	// The closure owns InstalledAgents; removed is captured for the caller.
+	// errNoMatchingAgents aborts the write so that a run which removes nothing
+	// leaves the file untouched, and in particular does not create a state file
+	// that did not exist before.
+	errNoMatchingAgents := errors.New("no matching installed agents")
+	var removed []model.AgentID
+	err := state.Update(homeDir, func(s *state.InstallState) error {
+		removeSet := make(map[string]struct{}, len(toRemove))
+		for _, agentID := range toRemove {
+			removeSet[string(agentID)] = struct{}{}
 		}
-		return nil, fmt.Errorf("read install state: %w", err)
-	}
 
-	removeSet := make(map[string]struct{}, len(toRemove))
-	for _, agentID := range toRemove {
-		removeSet[string(agentID)] = struct{}{}
-	}
-
-	kept := make([]string, 0, len(current.InstalledAgents))
-	removed := make([]model.AgentID, 0, len(toRemove))
-	for _, installed := range current.InstalledAgents {
-		if _, ok := removeSet[installed]; ok {
-			removed = append(removed, model.AgentID(installed))
-			continue
+		kept := make([]string, 0, len(s.InstalledAgents))
+		removed = make([]model.AgentID, 0, len(toRemove))
+		for _, installed := range s.InstalledAgents {
+			if _, ok := removeSet[installed]; ok {
+				removed = append(removed, model.AgentID(installed))
+				continue
+			}
+			kept = append(kept, installed)
 		}
-		kept = append(kept, installed)
-	}
-	if len(removed) == 0 {
+
+		if len(removed) == 0 {
+			return errNoMatchingAgents
+		}
+
+		s.InstalledAgents = kept
+		return nil
+	})
+	switch {
+	case errors.Is(err, errNoMatchingAgents), errors.Is(err, os.ErrNotExist):
 		return nil, nil
-	}
-
-	updated := current
-	updated.InstalledAgents = kept
-	if err := state.Write(homeDir, updated); err != nil {
-		return nil, fmt.Errorf("write install state: %w", err)
+	case err != nil:
+		// Update folds the read and the write into one call, so this message
+		// covers both. It stays worded as a read failure because an undecodable
+		// state file is the case callers and tests actually pin.
+		return nil, fmt.Errorf("read install state: %w", err)
 	}
 	return removed, nil
 }

--- a/internal/state/lock_unix.go
+++ b/internal/state/lock_unix.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+package state
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLockFile attempts to take an exclusive advisory lock without blocking.
+// It returns (true, nil) when the lock was taken, (false, nil) when another
+// holder has it, and (false, err) on any other failure.
+// Adapted from internal/reviewtransaction/store_lock_unix.go.
+func tryLockFile(file *os.File) (bool, error) {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the lock taken by tryLockFile.
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/state/lock_windows.go
+++ b/internal/state/lock_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package state
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLockFile attempts to take an exclusive advisory lock without blocking.
+// It returns (true, nil) when the lock was taken, (false, nil) when another
+// holder has it, and (false, err) on any other failure.
+// Adapted from internal/reviewtransaction/store_lock_windows.go.
+func tryLockFile(file *os.File) (bool, error) {
+	overlapped := new(windows.Overlapped)
+	flags := uint32(windows.LOCKFILE_FAIL_IMMEDIATELY | windows.LOCKFILE_EXCLUSIVE_LOCK)
+	err := windows.LockFileEx(windows.Handle(file.Fd()), flags, 0, 1, 0, overlapped)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the lock taken by tryLockFile.
+func unlockFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+}

--- a/internal/state/lock_windows.go
+++ b/internal/state/lock_windows.go
@@ -9,9 +9,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// tryLockFile attempts to take an exclusive advisory lock without blocking.
-// It returns (true, nil) when the lock was taken, (false, nil) when another
-// holder has it, and (false, err) on any other failure.
+// tryLockFile is the Windows half of the contract documented in lock_unix.go.
 // Adapted from internal/reviewtransaction/store_lock_windows.go.
 func tryLockFile(file *os.File) (bool, error) {
 	overlapped := new(windows.Overlapped)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +13,15 @@ import (
 
 const stateDir = ".gentle-ai"
 const stateFile = "state.json"
+
+// ErrLockTimeout is returned when the state lock cannot be acquired in time.
+var ErrLockTimeout = errors.New("state: timed out acquiring install state lock")
+
+const (
+	lockFile       = "INSTALL-STATE.lock"
+	lockRetryDelay = 100 * time.Millisecond
+	lockTimeout    = 5 * time.Second
+)
 
 // ModelAssignmentState is the JSON-serialisable form of a provider+model pair
 // used by OpenCode-style model assignments. It mirrors model.ModelAssignment
@@ -136,6 +146,74 @@ func Path(homeDir string) string {
 	return filepath.Join(homeDir, stateDir, stateFile)
 }
 
+// acquireStateLock creates the state directory when missing and takes an
+// exclusive advisory lock on the sidecar lockfile. The returned release
+// function unlocks and closes the handle.
+func acquireStateLock(homeDir string) (func(), error) {
+	dir := filepath.Join(homeDir, stateDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(filepath.Join(dir, lockFile), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		locked, err := tryLockFile(f)
+		if err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		if locked {
+			return func() {
+				_ = unlockFile(f)
+				_ = f.Close()
+			}, nil
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return nil, ErrLockTimeout
+		}
+		time.Sleep(lockRetryDelay)
+	}
+}
+
+// writeLocked marshals and persists s. The caller must already hold the lock.
+func writeLocked(homeDir string, s InstallState) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = filemerge.WriteFileAtomic(Path(homeDir), append(data, '\n'), 0o644)
+	return err
+}
+
+// Update serializes a read-modify-write window on the install state file. It
+// takes an exclusive lock, re-reads the latest state from disk, invokes mutate
+// on that fresh copy, and persists the result. The lock covers the whole
+// interval and is released on every exit path, including panic.
+//
+// A missing state file starts from the zero value and is created. A file that
+// exists but cannot be decoded is never overwritten: mutate is not called and
+// the decode error is returned. An error from mutate aborts the write.
+func Update(homeDir string, mutate func(*InstallState) error) error {
+	release, err := acquireStateLock(homeDir)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	s, err := Read(homeDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := mutate(&s); err != nil {
+		return err
+	}
+	return writeLocked(homeDir, s)
+}
+
 // Read reads and unmarshals the state file from the given home directory.
 // Returns an error if the file does not exist or cannot be decoded.
 func Read(homeDir string) (InstallState, error) {
@@ -218,17 +296,13 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 	}
 }
 
-// Write persists the full install state to disk under the given home directory.
-// It creates the .gentle-ai directory if it does not already exist.
+// Write persists a caller-owned whole document. It takes the same lock as
+// Update so the two cannot interleave.
 func Write(homeDir string, s InstallState) error {
-	dir := filepath.Join(homeDir, stateDir)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(s, "", "  ")
+	release, err := acquireStateLock(homeDir)
 	if err != nil {
 		return err
 	}
-	_, err = filemerge.WriteFileAtomic(Path(homeDir), append(data, '\n'), 0o644)
-	return err
+	defer release()
+	return writeLocked(homeDir, s)
 }

--- a/internal/state/state_lock_test.go
+++ b/internal/state/state_lock_test.go
@@ -1,0 +1,246 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestUpdatePreservesConcurrentRDDModeChange is the regression for issue #1809:
+// actor A reads, actor B writes rdd_mode=off, then actor A persists its own
+// field from the snapshot it captured before B ran. The old Read/mutate/Write
+// pattern sent the whole stale document back and restored rdd_mode=on.
+func TestUpdatePreservesConcurrentRDDModeChange(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{RDDMode: "on", Persona: "gentleman"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	stale, err := Read(homeDir) // actor A, held across a long operation
+	if err != nil {
+		t.Fatalf("actor A read: %v", err)
+	}
+
+	// Actor B turns the kill switch off while A is still working.
+	if err := Update(homeDir, func(s *InstallState) error {
+		s.RDDMode = "off"
+		return nil
+	}); err != nil {
+		t.Fatalf("actor B update: %v", err)
+	}
+
+	// Actor A now persists the persona it derived from its stale snapshot.
+	if err := Update(homeDir, func(s *InstallState) error {
+		if s.RDDMode != "off" {
+			t.Errorf("closure saw RDDMode = %q, want off; the re-read must happen inside the lock", s.RDDMode)
+		}
+		s.Persona = stale.Persona + "-updated"
+		return nil
+	}); err != nil {
+		t.Fatalf("actor A update: %v", err)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.RDDMode != "off" {
+		t.Errorf("RDDMode = %q, want off; actor B's kill-switch decision was clobbered", final.RDDMode)
+	}
+	if final.Persona != "gentleman-updated" {
+		t.Errorf("Persona = %q, want gentleman-updated; actor A's change was lost", final.Persona)
+	}
+}
+
+// TestConcurrentUpdatesDoNotLoseWrites proves the lock serialises writers.
+// Without it, concurrent appends overwrite each other and entries disappear.
+func TestConcurrentUpdatesDoNotLoseWrites(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	const writers = 10
+	done := make(chan error, writers)
+	for i := range writers {
+		go func() {
+			done <- Update(homeDir, func(s *InstallState) error {
+				s.InstalledAgents = append(s.InstalledAgents, fmt.Sprintf("agent-%d", i))
+				return nil
+			})
+		}()
+	}
+	for range writers {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent update: %v", err)
+		}
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	seen := make(map[string]bool, writers)
+	for _, agent := range final.InstalledAgents {
+		seen[agent] = true
+	}
+	for i := range writers {
+		if want := fmt.Sprintf("agent-%d", i); !seen[want] {
+			t.Errorf("missing %s: %d of %d writers survived", want, len(seen), writers)
+		}
+	}
+}
+
+func TestUpdateMutationErrorLeavesFileUnchanged(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{Persona: "gentleman"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	sentinel := errors.New("mutation rejected")
+	err := Update(homeDir, func(s *InstallState) error {
+		s.Persona = "neutral"
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Update error = %v, want %v", err, sentinel)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.Persona != "gentleman" {
+		t.Errorf("Persona = %q, want gentleman; a failed mutation must not be persisted", final.Persona)
+	}
+}
+
+func TestUpdateCreatesStateFromZeroValue(t *testing.T) {
+	homeDir := t.TempDir()
+
+	if err := Update(homeDir, func(s *InstallState) error {
+		if !reflect.DeepEqual(*s, InstallState{}) {
+			t.Errorf("closure received %+v, want the zero value when no state file exists", *s)
+		}
+		s.Persona = "neutral"
+		return nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	final, err := Read(homeDir)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if final.Persona != "neutral" {
+		t.Errorf("Persona = %q, want neutral", final.Persona)
+	}
+}
+
+// TestUpdateRefusesToOverwriteCorruptState mirrors the no-clobber guards the
+// call sites already relied on.
+func TestUpdateRefusesToOverwriteCorruptState(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, stateDir), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	const corrupt = "{not json"
+	if err := os.WriteFile(Path(homeDir), []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("seed corrupt state: %v", err)
+	}
+
+	called := false
+	if err := Update(homeDir, func(*InstallState) error {
+		called = true
+		return nil
+	}); err == nil {
+		t.Fatal("Update returned nil, want a decode error for a corrupt state file")
+	}
+	if called {
+		t.Error("mutation ran against a corrupt state file")
+	}
+
+	data, err := os.ReadFile(Path(homeDir))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	if string(data) != corrupt {
+		t.Errorf("state file = %q, want it left untouched", string(data))
+	}
+}
+
+func TestUpdateReleasesLockOnPanic(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := Write(homeDir, InstallState{}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	func() {
+		defer func() { _ = recover() }()
+		_ = Update(homeDir, func(*InstallState) error { panic("mutation panic") })
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Update(homeDir, func(s *InstallState) error {
+			s.Persona = "neutral"
+			return nil
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Update after panic: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Update after panic blocked; the lock was not released")
+	}
+}
+
+// TestTryLockFileReportsBusyForSecondHandle covers the platform primitive
+// directly: a second open handle on an already-locked file reports busy rather
+// than returning an error or blocking.
+func TestTryLockFileReportsBusyForSecondHandle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+
+	first, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open first handle: %v", err)
+	}
+	defer first.Close()
+	locked, err := tryLockFile(first)
+	if err != nil {
+		t.Fatalf("lock first handle: %v", err)
+	}
+	if !locked {
+		t.Fatal("first handle could not take a free lock")
+	}
+
+	second, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open second handle: %v", err)
+	}
+	defer second.Close()
+	locked, err = tryLockFile(second)
+	if err != nil {
+		t.Fatalf("lock second handle: %v", err)
+	}
+	if locked {
+		t.Error("second handle took a held lock; the lock does not exclude")
+	}
+
+	if err := unlockFile(first); err != nil {
+		t.Fatalf("unlock first handle: %v", err)
+	}
+	locked, err = tryLockFile(second)
+	if err != nil {
+		t.Fatalf("relock second handle: %v", err)
+	}
+	if !locked {
+		t.Error("second handle could not take the lock after release")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -3049,13 +3048,12 @@ func (m Model) startUpgradeSync() tea.Cmd {
 			// present — skip writing to avoid dropping installed_agents, model
 			// assignments, and other persisted fields.
 			if h := homeDir(); h != "" {
-				s, readErr := state.Read(h)
-				if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-					// File exists but unreadable/corrupt — skip to avoid clobber.
-				} else {
+				// Update owns PendingSync field only. Re-read inside lock ensures fresh state.
+				// Ignore errors; non-fatal.
+				_ = state.Update(h, func(s *state.InstallState) error {
 					s.PendingSync = true
-					_ = state.Write(h, s)
-				}
+					return nil
+				})
 			}
 			return SyncDoneMsg{}
 		}

--- a/internal/update/cooldown.go
+++ b/internal/update/cooldown.go
@@ -2,8 +2,6 @@ package update
 
 import (
 	"context"
-	"errors"
-	"os"
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
@@ -68,19 +66,12 @@ func CheckAllWithCooldown(
 	// Also skip write when homeDir is empty.
 	if homeDir != "" && checkSucceeded(results) {
 		// Re-read state to avoid clobbering unrelated fields written concurrently.
-		current, readErr := state.Read(homeDir)
-		if readErr != nil {
-			if !errors.Is(readErr, os.ErrNotExist) {
-				// File exists but is unreadable/corrupt — do not overwrite; skip
-				// persisting the timestamp this round to avoid data loss.
-				return results
-			}
-			// File genuinely missing (first run) — start fresh.
-			current = state.InstallState{}
-		}
-		current.LastUpdateCheck = &now
+		// Update owns LastUpdateCheck field only. Re-read inside lock ensures fresh state.
 		// Ignore write errors — non-fatal; next launch will retry.
-		_ = state.Write(homeDir, current)
+		_ = state.Update(homeDir, func(s *state.InstallState) error {
+			s.LastUpdateCheck = &now
+			return nil
+		})
 	}
 
 	return results


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1809

---

## 🏷️ PR Type

- [x] `type:refactor` — Code refactoring (no functional changes)

---

## 📝 Summary

Slice B of the two-PR chain for #1809. Stacked on the slice that adds `state.Update`.

Migrates the eight remaining read-modify-write call sites off the read-then-`Write` pattern and onto `state.Update`, so each mutation re-reads the persisted state inside the lock instead of writing back a snapshot captured earlier. This is the slice that actually closes the race described in the issue: `sync` read `persistedState` before building its pipeline and could write that same in-memory snapshot afterwards.

No behaviour changes beyond the serialization itself.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/app.go` | State mutations moved onto `Update` |
| `internal/app/selfupdate.go` | Same |
| `internal/cli/review_mode.go` | Same |
| `internal/cli/sync.go` | Closes the read-then-write window described in the issue |
| `internal/components/uninstall/service.go` | Same |
| `internal/tui/model.go` | Same |
| `internal/update/cooldown.go` | Same |

---

## 🧪 Test Plan

```bash
go test ./internal/app/... ./internal/components/uninstall/... ./internal/tui/... ./internal/update/... ./internal/state/...
go run ./internal/gofmtcheck
go build ./...
go vet ./...
```

- [x] Unit tests pass for every touched package
- [x] Go format passes
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Full `go test ./...` — deferring to CI. Locally `internal/cli` needs `-timeout 30m` and fails one unrelated `uv` test that reproduces identically on the base tree.
- [ ] E2E tests — deferring to CI
- [x] Manually reviewed each converted call site for mutation equivalence

Benchmark validation: N/A. This touches install-state persistence call sites only.

- [x] Commits follow Conventional Commits
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**Stacked PR — size will drop when the base lands.** GitHub measures this branch against `main`, which does not yet contain the slice-A commit, so the diff reads 528 changed lines. This slice itself is **137 insertions / 130 deletions = 267 lines**, verifiable with `git diff --stat pablontiv/sdd-1809-state-lock..pablontiv/sdd-1809-state-lock-callsites`. No `size:exception` is requested.

Base: `pablontiv/sdd-1809-state-lock`.

I have no triage rights on this repository. Maintainer-owed label: `type:refactor`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when saving installation, sync, review-mode, and update-check settings.
  - Prevented concurrent operations from overwriting unrelated state changes.
  - Protected existing state from being replaced when it cannot be read or is corrupted.
  - Improved uninstall and pending-sync state handling, including safer recovery from missing state files.

- **Platform Support**
  - Added reliable state-file locking for Unix and Windows environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->