### PR TITLE
fix(sdd): normalize evidence_revision SHA-256 formats and prevent active attempt deadlocks

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -1798,5 +1798,20 @@ func sddJourneys() []Journey {
 					Requires: recoverCapability, Composite: recoverScopeChangeRoundTrip("review-guardrail-successor")},
 			},
 		},
+
+		// ------------------------------------------------ sdd attempt settle normalization
+		{
+			ID:     "j53-sdd-attempt-settle-normalization",
+			Title:  "sdd-attempt settle accepts uppercase and raw hex evidence_revision formats without deadlock",
+			Source: "Issue #2294",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "sdd-attempt begin", Requires: Capability{Operation: "sdd-attempt"},
+					Args: productArgs("sdd-attempt", "begin", "--cwd", "{dir}", "--change", sddChange, "--expected-revision", "", "--request-id", "req-j53-1", "--work-unit", "wu-j53", "--evidence-goal", "goal-j53")},
+				{Name: "sdd-attempt settle with raw uppercase hex", Requires: Capability{Operation: "sdd-attempt"},
+					Args: productArgs("sdd-attempt", "settle", "--cwd", "{dir}", "--change", sddChange, "--token", "", "--request-id", "req-j53-2", "--outcome", "passed", "--evidence-revision", "A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1", "--diagnosis", "passed normalization test", "--harness-disposition", "reused", "--cleanup-evidence", "clean", "--process-evidence", "proc")},
+			},
+		},
 	}
 }
+

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -495,7 +495,7 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 }
 
 func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptRequest) (RuntimeStatus, error) {
-	request, err := normalizeFinishAttemptRequest(request)
+	request, err := validateFinishAttemptRequest(request)
 	if err != nil {
 		return RuntimeStatus{}, err
 	}
@@ -1542,7 +1542,41 @@ func normalizeBeginAttemptRequest(request BeginAttemptRequest) (BeginAttemptRequ
 	return request, nil
 }
 
-func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptRequest, error) {
+var hex64Pattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+
+func normalizeRuntimeRevision(revision string) string {
+	trimmed := strings.TrimSpace(revision)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), "sha256:") {
+		raw := trimmed[7:]
+		if hex64Pattern.MatchString(raw) {
+			return "sha256:" + strings.ToLower(raw)
+		}
+	}
+	if hex64Pattern.MatchString(trimmed) {
+		return "sha256:" + strings.ToLower(trimmed)
+	}
+	return trimmed
+}
+
+func normalizeFinishAttemptRequest(request FinishAttemptRequest) FinishAttemptRequest {
+	request.RequestID = strings.TrimSpace(strings.ToLower(request.RequestID))
+	request.Outcome = AttemptOutcome(strings.TrimSpace(strings.ToLower(string(request.Outcome))))
+	request.EvidenceRevision = normalizeRuntimeRevision(request.EvidenceRevision)
+	request.Diagnosis = strings.TrimSpace(request.Diagnosis)
+	request.HarnessDisposition = HarnessDisposition(strings.TrimSpace(strings.ToLower(string(request.HarnessDisposition))))
+	request.CleanupEvidence = strings.TrimSpace(request.CleanupEvidence)
+	request.ProcessEvidence = strings.TrimSpace(request.ProcessEvidence)
+	request.ExpectedBindingRevision = normalizeRuntimeRevision(request.ExpectedBindingRevision)
+	request.SuccessorLineageID = strings.TrimSpace(strings.ToLower(request.SuccessorLineageID))
+	request.RemediatesEvidenceRevision = normalizeRuntimeRevision(request.RemediatesEvidenceRevision)
+	return request
+}
+
+func validateFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptRequest, error) {
+	request = normalizeFinishAttemptRequest(request)
 	if request.ExpectedRevision == "" || !runtimeRevisionPattern.MatchString(request.ExpectedRevision) {
 		return FinishAttemptRequest{}, errors.New("finish requires an exact expected runtime revision")
 	}
@@ -1553,7 +1587,7 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 		return FinishAttemptRequest{}, errors.New("outcome must be failed, interrupted, or passed")
 	}
 	if !runtimeRevisionPattern.MatchString(request.EvidenceRevision) {
-		return FinishAttemptRequest{}, errors.New("evidence_revision must be sha256")
+		return FinishAttemptRequest{}, errors.New("evidence_revision must be sha256; rerun `gentle-ai sdd-attempt finish` or `settle` with --evidence-revision sha256:<64-lowercase-hex>")
 	}
 	if err := validateRuntimeText(request.Diagnosis, 500); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid diagnosis: %w", err)

--- a/internal/sddstatus/runtime_ledger_test.go
+++ b/internal/sddstatus/runtime_ledger_test.go
@@ -604,6 +604,38 @@ func countRuntimeRecords(t *testing.T, dir string) int {
 	return count
 }
 
+func TestRuntimeLedgerNormalizesEvidenceRevisionFormats(t *testing.T) {
+	ctx := context.Background()
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(ctx, repo, "ch-test-normalization")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	begin, err := store.Begin(ctx, BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "req-1", WorkUnit: "wu-1", EvidenceGoal: "goal-1",
+		MaxAttempts: 3, MaxChangedLines: 50,
+	})
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+
+	rawHex := strings.Repeat("A1", 32)
+	finish, err := store.Finish(ctx, FinishAttemptRequest{
+		ExpectedRevision: begin.Revision, RequestID: "req-2", Outcome: AttemptPassed,
+		EvidenceRevision: rawHex, Diagnosis: "passed with uppercase hex",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "clean", ProcessEvidence: "proc",
+	})
+	if err != nil {
+		t.Fatalf("Finish() with raw uppercase hex evidence_revision error = %v", err)
+	}
+	wantRevision := "sha256:" + strings.ToLower(rawHex)
+	if finish.EvidenceRevision != wantRevision {
+		t.Fatalf("Finish() EvidenceRevision = %q, want %q", finish.EvidenceRevision, wantRevision)
+	}
+}
+
+
 func runtimeTestHash(char byte) string {
 	return "sha256:" + strings.Repeat(string(char), 64)
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2294

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes

---

## 📝 Summary

- Fixed `sdd-attempt settle` evidence_revision validation by introducing `normalizeRuntimeRevision`.
- `normalizeRuntimeRevision` handles uppercase hex string inputs (e.g. `sha256:ABCDEF...`) and bare 64-hex strings without the `sha256:` prefix, auto-normalizing them to canonical `sha256:<64-lowercase-hex>`.
- Prevents malformed or non-canonical revision strings from rejecting the settle call while leaving the attempt stranded in state `running` (which previously blocked all subsequent `acquire` calls for the change).
- Improved the refusal error message to explicitly guide operators on the canonical SHA-256 format.
- Added unit tests in `internal/sddstatus/runtime_ledger_test.go` covering uppercase hex normalization.
- Added deterministic benchmark journey `j53-sdd-attempt-settle-normalization` in `bench/journeys_sdd.go`.

---

## 🧪 Test Plan

```bash
go test ./internal/sddstatus/... -v -run TestRuntimeLedgerNormalizesEvidenceRevisionFormats
go test ./internal/sddstatus/... ./internal/cli/... -count=1
```

- [x] All unit tests pass cleanly
- [x] Deadcode baseline updated via `./scripts/deadcode-ratchet.sh --update`
- [x] Added benchmark journey `j53-sdd-attempt-settle-normalization`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Evidence revisions now accept uppercase or unprefixed 64-character hexadecimal values.
  * Accepted revisions are automatically normalized to lowercase `sha256:` format.
  * Improved validation messages explain the required revision format and recovery command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->