### PR TITLE
feat(review): add Amendment C governing-authority resolution

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2893,6 +2893,25 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 			}, negotiated, *contract)
 		}
 	}
+	// Amendment C's single shared branch (design decision 4, Wave 3 Slice
+	// 4): resolved BEFORE discoverCompactFacadeGateReview so every gate call
+	// that supplies no explicit --lineage marker for a v3 lineage stays
+	// byte-identical to legacy discovery below. A non-nil discoveryErr here
+	// is always a deny that must never fall through to legacy authorization.
+	if governs, evaluation, discoveryErr := resolveGoverningAuthority(ctx, root, *lineage, gateInput); discoveryErr != nil {
+		if reviewDeliveryDisposition(ctx, root, false) == reviewtransaction.RDDDeliveryDisabledUnmanaged {
+			return emitDisabledUnmanagedDelivery(stdout, gateInput.Gate, discoveryErr, negotiated, *contract)
+		}
+		return emitFacadeGateEvaluationNegotiated(stdout, reviewtransaction.NativeGateEvaluation{
+			Result: reviewtransaction.GateInvalidated, Reason: discoveryErr.Error(),
+			Context: reviewtransaction.GateContext{
+				Gate: gateInput.Gate, Denial: &reviewtransaction.GateDenial{Stage: "receipt-discovery", Code: string(discoveryErr.Kind)},
+			},
+		}, negotiated, *contract)
+	} else if governs {
+		return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated, *contract)
+	}
+
 	compactStore, compactRecord, compactErr := discoverCompactFacadeGateReview(ctx, root, *lineage, gateInput)
 	if compactErr == nil {
 		contested := false

--- a/internal/cli/review_governing_authority.go
+++ b/internal/cli/review_governing_authority.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// resolveGoverningAuthority is Amendment C's single shared branch (design
+// decision 4): every one of the five gates traverses it through
+// runReviewFacadeValidate, immediately before discoverCompactFacadeGateReview
+// runs — so legacy discovery stays byte-identical whenever nothing v3
+// governs this candidate, which is every call that supplies no explicit
+// --lineage marker (the ordinary hook-invoked shape) or names a lineage id
+// with no v3/ directory at all.
+//
+// governs=true means the caller MUST NOT fall through to legacy discovery
+// for this candidate, even when a legacy receipt exists (Amendment C: "a
+// new-lineage candidate is never authorized by legacy"). evaluation is only
+// meaningful when governs is true and discoveryErr is nil.
+//
+// discoveryErr is non-nil for exactly two Amendment-C denial shapes, both of
+// which MUST NEVER fall through to legacy authorization: the
+// discovery-integrity corruption path (a v3/<lineage> marker exists but its
+// record could not be read — reviewtransaction.NewLineageMarkerCorruptedError,
+// task 5.2) and the matrix's own "new present but unrelated, legacy present"
+// deny cell. Task 5.3's decision: both reuse existing
+// ReviewReceiptDiscoveryKind constants rather than minting a new one —
+// ReviewAuthorityCorrupted for the corruption path (identical semantics to
+// every other "the inventory could not be trusted" denial this file already
+// emits) and ReviewReceiptUnrelated for the deny cell (identical semantics
+// to the legacy "a receipt exists but does not govern this candidate"
+// denial). No silent default: every reachable *ReviewReceiptDiscoveryError
+// this function returns has an explicit Kind assigned at its construction
+// site below.
+func resolveGoverningAuthority(ctx context.Context, root, lineage string, gateInput reviewtransaction.NativeGateRequestInput) (governs bool, evaluation reviewtransaction.NativeGateEvaluation, discoveryErr *ReviewReceiptDiscoveryError) {
+	if strings.TrimSpace(lineage) == "" {
+		// Discovery rule (design's corrected Amendment C clause): lineage
+		// kind is established SOLELY by v3/ record presence. No explicit
+		// lineage marker means no v3 authority is discoverable for this
+		// candidate at all — "new absent" by construction — so the
+		// ordinary hook-invoked gate call costs no extra Git subprocess
+		// here, matching decision 5's zero-cost-by-default guarantee.
+		return false, reviewtransaction.NativeGateEvaluation{}, nil
+	}
+	record, found, err := reviewtransaction.DiscoverNewLineage(ctx, root, lineage)
+	if err != nil {
+		var corrupted *reviewtransaction.NewLineageMarkerCorruptedError
+		if errors.As(err, &corrupted) {
+			return true, reviewtransaction.NativeGateEvaluation{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted, Detail: corrupted.Error()}
+		}
+		return false, reviewtransaction.NativeGateEvaluation{}, nil
+	}
+	if !found {
+		return false, reviewtransaction.NativeGateEvaluation{}, nil
+	}
+	live, evidence, err := governingAuthorityLiveEvidence(ctx, root, gateInput)
+	if err != nil {
+		// No live candidate could be resolved at all — legacy discovery
+		// below reports its own target-resolution failure; nothing new
+		// governs a candidate identity that could not even be built.
+		return false, reviewtransaction.NativeGateEvaluation{}, nil
+	}
+	observation := reviewtransaction.DeriveObservation(record.Authority, live, evidence)
+	legacyPresent := false
+	if observation.Relation == reviewtransaction.ShadowRelationUnrelated {
+		if _, _, _, legacyErr := discoverFacadeReview(ctx, root, lineage, true); legacyErr == nil {
+			legacyPresent = true
+		}
+	}
+	switch reviewtransaction.ResolveGoverningAuthority(true, observation.Relation, legacyPresent) {
+	case reviewtransaction.GoverningAuthorityKindDeny:
+		return true, reviewtransaction.NativeGateEvaluation{}, &ReviewReceiptDiscoveryError{
+			Kind: ReviewReceiptUnrelated, Detail: "a new-lineage candidate is never authorized by a legacy receipt",
+		}
+	case reviewtransaction.GoverningAuthorityKindLegacy:
+		return false, reviewtransaction.NativeGateEvaluation{}, nil
+	default: // reviewtransaction.GoverningAuthorityKindNew
+		transition, err := (reviewtransaction.ReviewCore{}).Next(ctx, record.Authority, reviewtransaction.CoreRequest{
+			Kind: reviewtransaction.CoreRequestValidate, LiveCandidateIdentity: live, Evidence: evidence,
+		})
+		if err != nil {
+			return true, reviewtransaction.NativeGateEvaluation{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted, Detail: err.Error()}
+		}
+		return true, newLineageGateEvaluation(gateInput.Gate, record, transition), nil
+	}
+}
+
+// governingAuthorityLiveEvidence resolves the live candidate identity and
+// validate evidence ReviewCore.Next(validate) needs, reusing the same
+// workspace-selector resolution ObserveShadowRelation already uses at every
+// one of its five gate call sites (shadow_observer.go) rather than
+// rebuilding a gate-specific target a second time.
+//
+// Scope note (S4/task 5.4): this is a workspace-only resolution, not the
+// gate-target-accurate selector each of the five gates' own legacy discovery
+// already composes (staged for pre-commit, committed-range for pre-push/
+// pre-pr/release). Wave 3 Slice 5's bench journeys (task 6.7) are the
+// declared place to widen this to per-gate accuracy; S4's own task list
+// requires only the governance decision itself (Amendment C) and the
+// continue/escalate shapes the switch-off-equivalence goldens exercise
+// without ever reaching this function (no explicit --lineage marker means
+// resolveGoverningAuthority returns before this is ever called).
+func governingAuthorityLiveEvidence(ctx context.Context, repo string, gateInput reviewtransaction.NativeGateRequestInput) (reviewtransaction.CandidateIdentity, reviewtransaction.CoreValidateEvidence, error) {
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	intendedUntracked := gateInput.IntendedUntracked
+	if intendedUntracked == nil {
+		intendedUntracked = []string{}
+	}
+	snapshot, err := builder.Build(ctx, reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: intendedUntracked,
+	})
+	if err != nil {
+		return reviewtransaction.CandidateIdentity{}, reviewtransaction.CoreValidateEvidence{}, err
+	}
+	live, err := reviewtransaction.FreezeCandidateIdentity(ctx, repo, snapshot, "")
+	if err != nil {
+		return reviewtransaction.CandidateIdentity{}, reviewtransaction.CoreValidateEvidence{}, err
+	}
+	return live, reviewtransaction.CoreValidateEvidence{LiveSnapshot: snapshot, ApplicableAuthorities: 1}, nil
+}
+
+// newLineageGateEvaluation translates a ReviewCore validate CoreTransition
+// into gate JSON. It covers exactly the two shapes reachable from S4's own
+// task list: continue (allow) and escalate. Every other CoreTransitionKind
+// (collect/approve/repair/stop) is denied with its transition kind named as
+// the reason code rather than silently mapped to allow — the full
+// CoreTransition-to-reason-taxonomy mapping for those kinds is Wave 3 Slice
+// 5's task 6.2, reused rather than duplicated here (design decision 7).
+func newLineageGateEvaluation(gate reviewtransaction.GateKind, record reviewtransaction.NewLineageRecord, transition reviewtransaction.CoreTransition) reviewtransaction.NativeGateEvaluation {
+	context := reviewtransaction.GateContext{
+		Gate: gate, LineageID: record.Authority.LineageID, StoreRevision: record.Revision,
+		BaseTree: record.Authority.CandidateIdentity.BaseTree, CandidateTree: record.Authority.CandidateIdentity.CandidateTree,
+		PolicyHash: record.Authority.CandidateIdentity.PolicyHash,
+	}
+	switch transition.Kind {
+	case reviewtransaction.CoreTransitionContinue:
+		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateAllow, Reason: transition.ReasonCode, Context: context}
+	case reviewtransaction.CoreTransitionEscalate:
+		context.Denial = &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: transition.ReasonCode}
+		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateEscalated, Reason: transition.ReasonCode, Context: context}
+	default:
+		context.Denial = &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: string(transition.Kind)}
+		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateInvalidated, Reason: transition.ReasonCode, Context: context}
+	}
+}

--- a/internal/cli/review_governing_authority_test.go
+++ b/internal/cli/review_governing_authority_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestResolveGoverningAuthorityAbsentWithoutMarkerCostsNoGitCall proves the
+// cheap common case at the CLI wiring layer: with no explicit --lineage
+// marker, resolveGoverningAuthority returns "legacy governs unchanged"
+// without resolving a repository root or issuing any Git command — the
+// switch-off-equivalence goldens (tasks 5.6-5.10) depend on this being true
+// for the ordinary hook-invoked gate call shape.
+func TestResolveGoverningAuthorityAbsentWithoutMarkerCostsNoGitCall(t *testing.T) {
+	governs, evaluation, discoveryErr := resolveGoverningAuthority(context.Background(), "/does/not/exist", "", reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
+	if governs || discoveryErr != nil || evaluation != (reviewtransaction.NativeGateEvaluation{}) {
+		t.Fatalf("resolveGoverningAuthority(no marker) = governs=%v evaluation=%#v discoveryErr=%v, want a pure no-op", governs, evaluation, discoveryErr)
+	}
+}
+
+// TestReviewValidateDiscoveryIntegrityMarkerCorruptedDeniesNeverLegacy is
+// task 5.2's MANDATORY RED test at the CLI integration layer (design
+// decision 4's non-matrix discovery-integrity clause): a new-lineage marker
+// (the v3/<lineage> directory) is present for the exact lineage id an
+// otherwise-valid, otherwise-governing legacy receipt ALSO claims — but the
+// v3 record itself was removed. The gate MUST deny and MUST NEVER fall
+// through to the legacy receipt, even though that legacy receipt alone would
+// have allowed this exact candidate.
+func TestReviewValidateDiscoveryIntegrityMarkerCorruptedDeniesNeverLegacy(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineageID = "shared-legacy-and-new-lineage"
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate reviewed under legacy and named by a corrupted v3 marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a real, terminal, GOVERNING legacy receipt at this exact
+	// lineage id: without the v3 marker below, this candidate would allow.
+	finalizeApprovedFacadeReview(t, repo, lineageID)
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+
+	var legacyOnly bytes.Buffer
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", lineageID, "--gate", string(reviewtransaction.GatePreCommit)}, &legacyOnly); err != nil {
+		t.Fatalf("legacy-only baseline before adding the v3 marker must allow: %v\n%s", err, legacyOnly.String())
+	}
+	assertReviewGateResult(t, legacyOnly.Bytes(), reviewtransaction.GateAllow)
+
+	// Now plant the new-lineage marker under the IDENTICAL lineage id and
+	// corrupt it: the directory (the marker) exists, but its record does
+	// not — task 5.2's exact shape ("new-lineage marker present, v3 record
+	// removed, legacy receipt present").
+	store, err := reviewtransaction.NewLineageAuthorityStore(context.Background(), repo, lineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^{tree}"))
+	if _, err := store.Mutate(context.Background(), "", func(next *reviewtransaction.NewLineageAuthority) error {
+		next.State = reviewtransaction.NewLineageStateReviewing
+		next.CandidateIdentity = reviewtransaction.CandidateIdentity{
+			RepositoryID: "corrupted-marker-repo", BaseTree: head, CandidateTree: head,
+			ChangedPathsModesDigest: "sha256:" + head, PolicyHash: "unknown",
+		}
+		next.Tier = reviewtransaction.RiskLow
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(store.StatePath()); err != nil {
+		t.Fatal(err)
+	}
+	if info, statErr := os.Stat(store.Dir); statErr != nil || !info.IsDir() {
+		t.Fatalf("v3 marker directory must survive removing only its record: stat=%v err=%v", info, statErr)
+	}
+
+	var output bytes.Buffer
+	err = RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", lineageID, "--gate", string(reviewtransaction.GatePreCommit)}, &output)
+	if err == nil {
+		t.Fatalf("discovery-integrity corruption must deny, got allow:\n%s", output.String())
+	}
+	var denied ReviewGateDeniedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("discovery-integrity corruption error = %T %v, want ReviewGateDeniedError", err, err)
+	}
+	if denied.Result == reviewtransaction.GateAllow {
+		t.Fatalf("discovery-integrity corruption fell through to the legacy allow: %#v", denied)
+	}
+	// Task 5.3's decision: the discovery-integrity denial reuses the
+	// existing ReviewAuthorityCorrupted constant — this assertion is that
+	// decision's regression guard, not a silent default.
+	if denied.Context.Denial == nil || denied.Context.Denial.Code != string(ReviewAuthorityCorrupted) {
+		t.Fatalf("discovery-integrity corruption denial code = %#v, want %q", denied.Context.Denial, ReviewAuthorityCorrupted)
+	}
+
+	// Replay stability: the same denial, byte-identical, and no mutation of
+	// either authority system.
+	var replay bytes.Buffer
+	replayErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", lineageID, "--gate", string(reviewtransaction.GatePreCommit)}, &replay)
+	if replayErr == nil || !bytes.Equal(replay.Bytes(), output.Bytes()) {
+		t.Fatalf("discovery-integrity corruption denial is not replay-stable:\nfirst:\n%s\nreplay:\n%s", output.String(), replay.String())
+	}
+}

--- a/internal/cli/review_new_lineage_rollback_safety_test.go
+++ b/internal/cli/review_new_lineage_rollback_safety_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestNewLineageRollbackSafetyStaysReadableAndFinalizableWhileSwitchIsOff is
+// task 5.11: an in-flight new-lineage authority created while the activation
+// switch was ON must remain fully readable, still govern its candidate at
+// validate, and remain finalizable to a terminal receipt after the switch is
+// turned back off (design decision 5, "Rollback Disables New Starts Only";
+// spec rdd-new-lineage-activation, "Rollback Disables New Starts Only").
+//
+// resolveGoverningAuthority and ReviewCore never read the activation switch
+// at all — only the CLI's start branch (review_facade_new_lineage.go) does —
+// so this proves that invariant end-to-end rather than by code inspection
+// alone.
+func TestNewLineageRollbackSafetyStaysReadableAndFinalizableWhileSwitchIsOff(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineageID = "rollback-safety-lineage"
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("rollback-safety candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GENTLE_AI_RDD_NEW_LINEAGE", "1")
+	live, _, err := governingAuthorityLiveEvidence(context.Background(), repo, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.NewLineageAuthorityStore(context.Background(), repo, lineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Mutate(context.Background(), "", func(next *reviewtransaction.NewLineageAuthority) error {
+		next.State = reviewtransaction.NewLineageStateReviewing
+		next.CandidateIdentity = live
+		next.Tier = reviewtransaction.RiskLow
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rollback: the activation switch goes back off. No new start would use
+	// v3, but this lineage already exists.
+	t.Setenv("GENTLE_AI_RDD_NEW_LINEAGE", "")
+
+	if _, err := store.Load(); err != nil {
+		t.Fatalf("in-flight new lineage unreadable after rollback: %v", err)
+	}
+
+	// Still readable AND still the governing authority at validate time —
+	// resolveGoverningAuthority/runReviewFacadeValidate never consult the
+	// activation switch.
+	var output bytes.Buffer
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", lineageID, "--gate", "pre-commit"}, &output); err != nil {
+		t.Fatalf("in-flight new lineage stopped governing validate after rollback: %v\n%s", err, output.String())
+	}
+	assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
+	if _, statErr := os.Stat(filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "v2")); !os.IsNotExist(statErr) {
+		t.Fatalf("rollback validate fabricated a legacy authority instead of using the in-flight v3 one: %v", statErr)
+	}
+
+	// Still finalizable: drive it to a terminal state and issue the
+	// terminal receipt, with the switch still off.
+	if _, err = store.Mutate(context.Background(), revision, func(next *reviewtransaction.NewLineageAuthority) error {
+		next.State = reviewtransaction.NewLineageStateApproved
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	transition, err := (reviewtransaction.ReviewCore{}).Next(context.Background(), record.Authority, reviewtransaction.CoreRequest{Kind: reviewtransaction.CoreRequestFinalize})
+	if err != nil {
+		t.Fatalf("in-flight new lineage refused to finalize after rollback: %v", err)
+	}
+	if transition.Kind != reviewtransaction.CoreTransitionApprove || transition.Receipt == nil {
+		t.Fatalf("finalize(approved) after rollback = %#v", transition)
+	}
+	if err := store.WriteReceipt(context.Background(), reviewtransaction.NewLineageReceipt{
+		Schema: reviewtransaction.NewLineageReceiptSchema, LineageID: record.Authority.LineageID,
+		TerminalState: record.Authority.State, AuthorityRevision: transition.Receipt.AuthorityRevision,
+		CandidateIdentity: record.Authority.CandidateIdentity,
+	}); err != nil {
+		t.Fatalf("terminal receipt refused after rollback: %v", err)
+	}
+	if _, err := os.Stat(store.ReceiptPath()); err != nil {
+		t.Fatalf("terminal receipt not published after rollback: %v", err)
+	}
+}

--- a/internal/cli/review_new_lineage_switch_off_golden_test.go
+++ b/internal/cli/review_new_lineage_switch_off_golden_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// updateReviewNewLineageSwitchOffGolden regenerates the byte-equivalence
+// golden fixtures below (design's Testing Strategy: "Golden JSON per gate,
+// regenerated only via -update"), matching the same convention
+// internal/components/golden_test.go and shadow_matrix_test.go already use.
+var updateReviewNewLineageSwitchOffGolden = flag.Bool("update", false, "update review new-lineage switch-off byte-equivalence golden files")
+
+// TestReviewNewLineageSwitchOffByteEquivalence* (tasks 5.6-5.10) prove
+// Amendment C's additive resolveGoverningAuthority branch (design decision
+// 4) changes NOTHING at any of the five gates when the new-lineage
+// activation switch has never created a v3 authority: the ordinary
+// hook-invoked shape — no explicit --lineage marker — costs no extra Git
+// call and produces byte-identical output to the pre-Wave-3-Slice-4
+// baseline, captured here as a golden fixture per gate. This is
+// switch-off byte-EQUIVALENCE, never a cutover (spec
+// rdd-new-lineage-activation, "Additive Gate Branch, Switch-Off
+// Byte-Equivalence, Not a Cutover").
+func TestReviewNewLineageSwitchOffByteEquivalencePostApply(t *testing.T) {
+	assertReviewNewLineageSwitchOffByteEquivalence(t, reviewtransaction.GatePostApply)
+}
+
+func TestReviewNewLineageSwitchOffByteEquivalencePreCommit(t *testing.T) {
+	assertReviewNewLineageSwitchOffByteEquivalence(t, reviewtransaction.GatePreCommit)
+}
+
+func TestReviewNewLineageSwitchOffByteEquivalencePrePush(t *testing.T) {
+	assertReviewNewLineageSwitchOffByteEquivalence(t, reviewtransaction.GatePrePush)
+}
+
+func TestReviewNewLineageSwitchOffByteEquivalencePrePR(t *testing.T) {
+	assertReviewNewLineageSwitchOffByteEquivalence(t, reviewtransaction.GatePrePR)
+}
+
+func TestReviewNewLineageSwitchOffByteEquivalenceRelease(t *testing.T) {
+	assertReviewNewLineageSwitchOffByteEquivalence(t, reviewtransaction.GateRelease)
+}
+
+func assertReviewNewLineageSwitchOffByteEquivalence(t *testing.T, gate reviewtransaction.GateKind) {
+	t.Helper()
+	// GENTLE_AI_RDD_NEW_LINEAGE is deliberately never set in this fixture:
+	// the activation switch is start-only (design decision 5), so a v3
+	// authority never exists here regardless. What this test actually
+	// proves is decision 4's own zero-cost construction: no explicit
+	// --lineage marker means resolveGoverningAuthority returns before any
+	// v3 lookup, switch state notwithstanding.
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate with the new-lineage switch off\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(gate)}, &output)
+	if err == nil {
+		t.Fatalf("switch-off %s gate over a receiptless candidate allowed instead of denying:\n%s", gate, output.String())
+	}
+	assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateInvalidated)
+	if fields := strictReviewJSONFields(t, output.Bytes()); !reflect.DeepEqual(fields, wantEnabledReviewGateFields) {
+		t.Fatalf("switch-off %s gate field set = %v, want %v", gate, fields, wantEnabledReviewGateFields)
+	}
+
+	goldenPath := filepath.Join("testdata", "review_new_lineage_switch_off", string(gate)+".golden.json")
+	golden := reviewNewLineageSwitchOffGolden(t, goldenPath, output.Bytes())
+	if !bytes.Equal(bytes.TrimRight(output.Bytes(), "\n"), bytes.TrimRight(golden, "\n")) {
+		t.Fatalf("switch-off %s gate output diverged from the byte-equivalence golden (rerun `go test ./internal/cli/... -run TestReviewNewLineageSwitchOffByteEquivalence -update` only if this is an intended legacy-shape change):\ngot:\n%s\nwant:\n%s",
+			gate, output.String(), string(golden))
+	}
+
+	// The additive branch is a true no-op for this candidate: no v3/ root
+	// is ever created.
+	if _, statErr := os.Stat(filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "v3")); !os.IsNotExist(statErr) {
+		t.Fatalf("switch-off %s gate created a v3 authority root: %v", gate, statErr)
+	}
+}
+
+func reviewNewLineageSwitchOffGolden(t *testing.T, path string, got []byte) []byte {
+	t.Helper()
+	if *updateReviewNewLineageSwitchOffGolden {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		normalized := append(bytes.TrimRight(got, "\n"), '\n')
+		if err := os.WriteFile(path, normalized, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return normalized
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read byte-equivalence golden %s: %v (regenerate with -update)", path, err)
+	}
+	return payload
+}

--- a/internal/cli/testdata/review_new_lineage_switch_off/post-apply.golden.json
+++ b/internal/cli/testdata/review_new_lineage_switch_off/post-apply.golden.json
@@ -1,0 +1,24 @@
+{
+  "schema": "gentle-ai.review-gate-result/v1",
+  "result": "invalidated",
+  "allowed": false,
+  "action": "explicit-maintainer-action",
+  "reason": "no terminal review receipt exists for gate validation",
+  "context": {
+    "gate": "post-apply",
+    "lineage_id": "",
+    "generation": 0,
+    "base_tree": "",
+    "candidate_tree": "",
+    "paths_digest": "",
+    "fix_delta_hash": "",
+    "policy_hash": "",
+    "ledger_hash": "",
+    "evidence_hash": "",
+    "base_relationship_valid": false,
+    "denial": {
+      "stage": "receipt-discovery",
+      "code": "receipt_missing"
+    }
+  }
+}

--- a/internal/cli/testdata/review_new_lineage_switch_off/pre-commit.golden.json
+++ b/internal/cli/testdata/review_new_lineage_switch_off/pre-commit.golden.json
@@ -1,0 +1,24 @@
+{
+  "schema": "gentle-ai.review-gate-result/v1",
+  "result": "invalidated",
+  "allowed": false,
+  "action": "explicit-maintainer-action",
+  "reason": "no terminal review receipt exists for gate validation",
+  "context": {
+    "gate": "pre-commit",
+    "lineage_id": "",
+    "generation": 0,
+    "base_tree": "",
+    "candidate_tree": "",
+    "paths_digest": "",
+    "fix_delta_hash": "",
+    "policy_hash": "",
+    "ledger_hash": "",
+    "evidence_hash": "",
+    "base_relationship_valid": false,
+    "denial": {
+      "stage": "receipt-discovery",
+      "code": "receipt_missing"
+    }
+  }
+}

--- a/internal/cli/testdata/review_new_lineage_switch_off/pre-pr.golden.json
+++ b/internal/cli/testdata/review_new_lineage_switch_off/pre-pr.golden.json
@@ -1,0 +1,24 @@
+{
+  "schema": "gentle-ai.review-gate-result/v1",
+  "result": "invalidated",
+  "allowed": false,
+  "action": "explicit-maintainer-action",
+  "reason": "no terminal review receipt exists for gate validation",
+  "context": {
+    "gate": "pre-pr",
+    "lineage_id": "",
+    "generation": 0,
+    "base_tree": "",
+    "candidate_tree": "",
+    "paths_digest": "",
+    "fix_delta_hash": "",
+    "policy_hash": "",
+    "ledger_hash": "",
+    "evidence_hash": "",
+    "base_relationship_valid": false,
+    "denial": {
+      "stage": "receipt-discovery",
+      "code": "receipt_missing"
+    }
+  }
+}

--- a/internal/cli/testdata/review_new_lineage_switch_off/pre-push.golden.json
+++ b/internal/cli/testdata/review_new_lineage_switch_off/pre-push.golden.json
@@ -1,0 +1,24 @@
+{
+  "schema": "gentle-ai.review-gate-result/v1",
+  "result": "invalidated",
+  "allowed": false,
+  "action": "explicit-maintainer-action",
+  "reason": "no terminal review receipt exists for gate validation",
+  "context": {
+    "gate": "pre-push",
+    "lineage_id": "",
+    "generation": 0,
+    "base_tree": "",
+    "candidate_tree": "",
+    "paths_digest": "",
+    "fix_delta_hash": "",
+    "policy_hash": "",
+    "ledger_hash": "",
+    "evidence_hash": "",
+    "base_relationship_valid": false,
+    "denial": {
+      "stage": "receipt-discovery",
+      "code": "receipt_missing"
+    }
+  }
+}

--- a/internal/cli/testdata/review_new_lineage_switch_off/release.golden.json
+++ b/internal/cli/testdata/review_new_lineage_switch_off/release.golden.json
@@ -1,0 +1,24 @@
+{
+  "schema": "gentle-ai.review-gate-result/v1",
+  "result": "invalidated",
+  "allowed": false,
+  "action": "explicit-maintainer-action",
+  "reason": "no terminal review receipt exists for gate validation",
+  "context": {
+    "gate": "release",
+    "lineage_id": "",
+    "generation": 0,
+    "base_tree": "",
+    "candidate_tree": "",
+    "paths_digest": "",
+    "fix_delta_hash": "",
+    "policy_hash": "",
+    "ledger_hash": "",
+    "evidence_hash": "",
+    "base_relationship_valid": false,
+    "denial": {
+      "stage": "receipt-discovery",
+      "code": "receipt_missing"
+    }
+  }
+}

--- a/internal/reviewtransaction/new_lineage_discovery.go
+++ b/internal/reviewtransaction/new_lineage_discovery.go
@@ -1,0 +1,138 @@
+// Package reviewtransaction — new-lineage governing-authority discovery
+// (Wave 3 Slice 4, design decision 4). This file owns exactly two things:
+// DiscoverNewLineage, which answers "does a v3 authority record exist for
+// this exact lineage marker, and is it readable", and
+// ResolveGoverningAuthority, the pure Amendment C decision matrix that turns
+// that answer (plus an independently-resolved legacy presence bit) into one
+// of three outcomes — new governs, legacy governs unchanged, or deny.
+//
+// Both are deliberately I/O-light: DiscoverNewLineage costs one os.Stat and
+// (at most) one store Load when an explicit --lineage marker is supplied,
+// and nothing at all otherwise (design's corrected discovery rule: lineage
+// kind is established SOLELY by v3/ record presence, so no marker means
+// "new absent" by construction, not a name to go look up). The CLI-level
+// caller (internal/cli/review_governing_authority.go) is the only place
+// that resolves live Git evidence, and only after DiscoverNewLineage has
+// already proven a record exists to compare against.
+package reviewtransaction
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// NewLineageMarkerCorruptedError proves a candidate carries a new-lineage
+// MARKER — an explicit --lineage reference whose v3/<lineage> directory
+// exists on disk, asserting that this lineage was (or is being) reviewed
+// under the new-lineage model — but the record itself could not be read:
+// deleted, quarantined, corrupted, or (a foreign common dir) simply never
+// written where this repository expects it.
+//
+// This is NOT one of Amendment C's six matrix cells (design decision 4's
+// literal text: "not a matrix cell — a corruption path"). A caller that
+// receives this error MUST deny and MUST NEVER fall through to legacy
+// authorization, even when an otherwise-valid legacy receipt exists for the
+// identical lineage id.
+type NewLineageMarkerCorruptedError struct {
+	LineageID string
+	Cause     error
+}
+
+func (err *NewLineageMarkerCorruptedError) Error() string {
+	return fmt.Sprintf("new-lineage authority marker %q is present but its record could not be read: %v", err.LineageID, err.Cause)
+}
+
+func (err *NewLineageMarkerCorruptedError) Unwrap() error { return err.Cause }
+
+// DiscoverNewLineage resolves the v3 authority record for one candidate,
+// scoped by an explicit lineage marker (the caller's --lineage flag; the
+// only way a v3 record is ever named without a full-inventory scan this
+// slice does not add, matching the discovery rule's own construction).
+//
+// found=false, err=nil means truly absent: either no marker was supplied at
+// all, or the v3/<lineage> directory does not exist — the {new absent}
+// matrix cell, unreachable except by this exact construction. A non-nil err
+// is always *NewLineageMarkerCorruptedError: the directory (the marker)
+// exists, but review-state.json could not be parsed into a valid record.
+func DiscoverNewLineage(ctx context.Context, repo, lineage string) (NewLineageRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return NewLineageRecord{}, false, err
+	}
+	if strings.TrimSpace(lineage) == "" {
+		return NewLineageRecord{}, false, nil
+	}
+	store, err := NewLineageAuthorityStore(ctx, repo, lineage)
+	if err != nil {
+		// An unresolvable store root (a malformed lineage id, an
+		// unreadable Git common dir) names no marker at all — the
+		// caller's own root/lineage validation reports the real cause;
+		// this is not new-lineage discovery-integrity damage.
+		return NewLineageRecord{}, false, nil
+	}
+	marker := false
+	if info, statErr := os.Stat(store.Dir); statErr == nil && info.IsDir() {
+		marker = true
+	}
+	record, loadErr := store.Load()
+	if loadErr != nil {
+		if os.IsNotExist(loadErr) && !marker {
+			return NewLineageRecord{}, false, nil
+		}
+		return NewLineageRecord{}, false, &NewLineageMarkerCorruptedError{LineageID: lineage, Cause: loadErr}
+	}
+	return record, true, nil
+}
+
+// GoverningAuthorityKind is ResolveGoverningAuthority's exact three-value
+// outcome vocabulary (design decision 4).
+type GoverningAuthorityKind string
+
+const (
+	// GoverningAuthorityKindNew: the v3 authority governs; legacy is
+	// ignored regardless of its own presence.
+	GoverningAuthorityKindNew GoverningAuthorityKind = "new"
+	// GoverningAuthorityKindLegacy: defer unchanged to legacy discovery —
+	// byte-identical to today's behavior.
+	GoverningAuthorityKindLegacy GoverningAuthorityKind = "legacy"
+	// GoverningAuthorityKindDeny: a new-lineage candidate is never
+	// authorized by a legacy receipt.
+	GoverningAuthorityKindDeny GoverningAuthorityKind = "deny"
+)
+
+// ResolveGoverningAuthority is Amendment C's pure decision matrix (design
+// decision 4): the full 2×2 over {new: related | unrelated | absent} ×
+// {legacy: present | absent}. found and relation together encode the "new"
+// axis — found=false is `absent`; found=true with relation ==
+// ShadowRelationUnrelated is `unrelated`; found=true with any other
+// relation (including ambiguous/unknown, which ReviewCore.validate itself
+// escalates) is `related`. legacyPresent encodes the "legacy" axis and is
+// only ever consulted for the `unrelated` case — it is not needed to reach
+// `new` (new always governs regardless of legacy) or `legacy` (nothing new
+// exists to prefer over it).
+//
+// This function performs no I/O and mutates nothing: every input is already
+// resolved by the caller. The discovery-integrity corruption path is
+// explicitly NOT one of this matrix's cells — DiscoverNewLineage's
+// *NewLineageMarkerCorruptedError is handled entirely by the caller before
+// this function is ever reached.
+func ResolveGoverningAuthority(found bool, relation CandidateRelation, legacyPresent bool) GoverningAuthorityKind {
+	if !found {
+		return GoverningAuthorityKindLegacy
+	}
+	if relation == ShadowRelationUnrelated {
+		if legacyPresent {
+			// Amendment C: "a new-lineage candidate is never authorized
+			// by legacy" — a v3 record exists for this exact lineage id
+			// but does not relate to the live candidate, and a legacy
+			// receipt independently claims the same id. Naming that
+			// legacy receipt as governing would silently let a stale
+			// v3 marker fall back to an authority system it was never
+			// reviewed under.
+			return GoverningAuthorityKindDeny
+		}
+		return GoverningAuthorityKindLegacy
+	}
+	return GoverningAuthorityKindNew
+}

--- a/internal/reviewtransaction/new_lineage_discovery_test.go
+++ b/internal/reviewtransaction/new_lineage_discovery_test.go
@@ -1,0 +1,134 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestResolveGoverningAuthorityFullMatrix is task 5.1's RED test: the full
+// 2×2 over {new: related | unrelated | absent} × {legacy: present | absent}
+// (design decision 4, Amendment C). ResolveGoverningAuthority performs no
+// I/O, so every one of the six cells is exercised as a pure table-driven
+// case.
+func TestResolveGoverningAuthorityFullMatrix(t *testing.T) {
+	cases := []struct {
+		name          string
+		found         bool
+		relation      CandidateRelation
+		legacyPresent bool
+		want          GoverningAuthorityKind
+	}{
+		{"related, legacy present: new governs regardless", true, ShadowRelationExact, true, GoverningAuthorityKindNew},
+		{"related, legacy absent: new governs", true, ShadowRelationExact, false, GoverningAuthorityKindNew},
+		{"related (changed), legacy present: new still governs", true, ShadowRelationChanged, true, GoverningAuthorityKindNew},
+		{"related (ambiguous has no live counterpart but is still 'related'): new governs", true, ShadowRelationAmbiguous, false, GoverningAuthorityKindNew},
+		{"unrelated, legacy present: deny — never authorized by legacy", true, ShadowRelationUnrelated, true, GoverningAuthorityKindDeny},
+		{"unrelated, legacy absent: defer to legacy, byte-identical", true, ShadowRelationUnrelated, false, GoverningAuthorityKindLegacy},
+		{"absent, legacy present: legacy path, byte-identical (today's behavior)", false, "", true, GoverningAuthorityKindLegacy},
+		{"absent, legacy absent: legacy's receipt_missing path, byte-identical", false, "", false, GoverningAuthorityKindLegacy},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveGoverningAuthority(tc.found, tc.relation, tc.legacyPresent)
+			if got != tc.want {
+				t.Fatalf("ResolveGoverningAuthority(found=%v, relation=%q, legacyPresent=%v) = %q, want %q",
+					tc.found, tc.relation, tc.legacyPresent, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiscoverNewLineageAbsentWithoutMarker proves the discovery rule's
+// corrected construction: no explicit --lineage marker means "new absent"
+// without ever resolving a store root or touching the filesystem.
+func TestDiscoverNewLineageAbsentWithoutMarker(t *testing.T) {
+	record, found, err := DiscoverNewLineage(context.Background(), "/does/not/exist", "")
+	if err != nil || found || record.Authority.LineageID != "" {
+		t.Fatalf("DiscoverNewLineage(no marker) = record=%#v found=%v err=%v, want absent", record, found, err)
+	}
+}
+
+// TestDiscoverNewLineageAbsentWithMarkerButNoDirectory proves a marker that
+// simply never wrote anything (the ordinary "new absent" case reachable
+// through an explicit --lineage flag naming a lineage id that has no v3
+// directory at all) is absent, not corrupted.
+func TestDiscoverNewLineageAbsentWithMarkerButNoDirectory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	record, found, err := DiscoverNewLineage(context.Background(), repo, "never-started-lineage")
+	if err != nil || found || record.Authority.LineageID != "" {
+		t.Fatalf("DiscoverNewLineage(no directory) = record=%#v found=%v err=%v, want absent", record, found, err)
+	}
+}
+
+// TestDiscoverNewLineageRelatedFindsTheRecord proves the ordinary present
+// case: a real Mutate-written record is found and returned intact.
+func TestDiscoverNewLineageRelatedFindsTheRecord(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	store, err := NewLineageAuthorityStore(context.Background(), repo, "discoverable-lineage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority := fixtureNewLineageAuthority("discoverable-lineage", NewLineageStateReviewing)
+	if _, err := store.Mutate(context.Background(), "", func(next *NewLineageAuthority) error {
+		*next = authority
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, found, err := DiscoverNewLineage(context.Background(), repo, "discoverable-lineage")
+	if err != nil || !found {
+		t.Fatalf("DiscoverNewLineage(present) = found=%v err=%v, want found", found, err)
+	}
+	if record.Authority.LineageID != "discoverable-lineage" {
+		t.Fatalf("DiscoverNewLineage(present) authority = %#v", record.Authority)
+	}
+}
+
+// TestDiscoverNewLineageMarkerPresentRecordRemovedDenies is task 5.2's
+// MANDATORY RED test (design decision 4's non-matrix discovery-integrity
+// clause): a new-lineage marker (the v3/<lineage> directory) is present —
+// asserting this lineage was reviewed under the new-lineage model — but its
+// record (review-state.json) was removed. This MUST report
+// *NewLineageMarkerCorruptedError, distinct from — and never collapsing
+// into — the ordinary "absent" case a caller could silently fall through to
+// legacy from.
+func TestDiscoverNewLineageMarkerPresentRecordRemovedDenies(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	store, err := NewLineageAuthorityStore(context.Background(), repo, "corrupted-marker-lineage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority := fixtureNewLineageAuthority("corrupted-marker-lineage", NewLineageStateReviewing)
+	if _, err := store.Mutate(context.Background(), "", func(next *NewLineageAuthority) error {
+		*next = authority
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The marker (the directory) survives; only the record inside it is
+	// removed — the exact shape task 5.2 names: "v3 record removed".
+	if err := os.Remove(store.StatePath()); err != nil {
+		t.Fatal(err)
+	}
+	if info, statErr := os.Stat(store.Dir); statErr != nil || !info.IsDir() {
+		t.Fatalf("marker directory must still exist after removing only the record: stat=%v err=%v", info, statErr)
+	}
+
+	record, found, err := DiscoverNewLineage(context.Background(), repo, "corrupted-marker-lineage")
+	if found || record.Authority.LineageID != "" {
+		t.Fatalf("DiscoverNewLineage(marker present, record removed) reported found=%v record=%#v, want not-found", found, record)
+	}
+	var corrupted *NewLineageMarkerCorruptedError
+	if !errors.As(err, &corrupted) {
+		t.Fatalf("DiscoverNewLineage(marker present, record removed) error = %T %v, want *NewLineageMarkerCorruptedError", err, err)
+	}
+	if corrupted.LineageID != "corrupted-marker-lineage" {
+		t.Fatalf("corrupted marker error lineage = %q", corrupted.LineageID)
+	}
+	if !strings.Contains(corrupted.Error(), "corrupted-marker-lineage") {
+		t.Fatalf("corrupted marker error message = %q, must name the lineage", corrupted.Error())
+	}
+}

--- a/openspec/changes/rdd-root-simplification-wave3/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave3/tasks.md
@@ -65,18 +65,18 @@ Chain strategy: feature-branch-chain
 
 ## Phase 5 (S4): Amendment C + Switch-Off Equivalence
 
-- [ ] 5.1 RED: full 2×2 matrix table test — new{related|unrelated|absent} × legacy{present|absent}.
-- [ ] 5.2 RED (mandatory): new-lineage marker present, v3 record removed, legacy receipt present ⇒ **deny** (discovery-integrity corruption path, never falls through to legacy).
-- [ ] 5.3 Decision task: confirm discovery-integrity denial routes to existing `authority_corrupted` constant, or document why a new reason constant is required — no silent default.
-- [ ] 5.4 Implement `resolveGoverningAuthority(new, legacy)` in `runReviewFacadeValidate`, single shared path for all five gates.
-- [ ] 5.5 GREEN: 5.1, 5.2 pass.
-- [ ] 5.6 Switch-off byte-equivalence golden — post-apply: capture, diff against pre-change golden, byte-identical.
-- [ ] 5.7 Switch-off byte-equivalence golden — pre-commit: same.
-- [ ] 5.8 Switch-off byte-equivalence golden — pre-push: same.
-- [ ] 5.9 Switch-off byte-equivalence golden — pre-pr: same.
-- [ ] 5.10 Switch-off byte-equivalence golden — release: same.
-- [ ] 5.11 Rollback-safety test: switch OFF after in-flight new lineage exists — lineage stays readable and finalizable.
-- [ ] 5.12 `scripts/deadcode-ratchet.sh --update` for `resolveGoverningAuthority` and golden fixtures.
+- [x] 5.1 RED: full 2×2 matrix table test — new{related|unrelated|absent} × legacy{present|absent}.
+- [x] 5.2 RED (mandatory): new-lineage marker present, v3 record removed, legacy receipt present ⇒ **deny** (discovery-integrity corruption path, never falls through to legacy).
+- [x] 5.3 Decision task: confirm discovery-integrity denial routes to existing `authority_corrupted` constant, or document why a new reason constant is required — no silent default.
+- [x] 5.4 Implement `resolveGoverningAuthority(new, legacy)` in `runReviewFacadeValidate`, single shared path for all five gates.
+- [x] 5.5 GREEN: 5.1, 5.2 pass.
+- [x] 5.6 Switch-off byte-equivalence golden — post-apply: capture, diff against pre-change golden, byte-identical.
+- [x] 5.7 Switch-off byte-equivalence golden — pre-commit: same.
+- [x] 5.8 Switch-off byte-equivalence golden — pre-push: same.
+- [x] 5.9 Switch-off byte-equivalence golden — pre-pr: same.
+- [x] 5.10 Switch-off byte-equivalence golden — release: same.
+- [x] 5.11 Rollback-safety test: switch OFF after in-flight new lineage exists — lineage stays readable and finalizable.
+- [x] 5.12 `scripts/deadcode-ratchet.sh --update` for `resolveGoverningAuthority` and golden fixtures.
 
 ## Phase 6 (S5): Reason Taxonomy, Offer API, Bench
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2292

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

S4: governing-authority discovery and the 2x2 governing matrix deciding which lineage owns each gate evaluation, with switch-off goldens proving byte-equivalence when GENTLE_AI_RDD_NEW_LINEAGE is unset.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` green (root + bench module) at the chain tip 67be4867
- [x] Deadcode + refusal-resolution ratchets clean
- [x] Three verify cycles; final envelope pass 19/19 requirements, 32/32 scenarios
