### PR TITLE
fix(system): resolve virtualenv executable symlinks during dependency verification

### DIFF
--- a/internal/system/deps.go
+++ b/internal/system/deps.go
@@ -3,8 +3,11 @@ package system
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -127,15 +130,37 @@ func detectDeps(ctx context.Context, deps []Dependency) DependencyReport {
 	return report
 }
 
+// isExecutablePath checks whether a binary exists and is executable, resolving symlinks for virtualenvs.
+func isExecutablePath(binary string) bool {
+	if _, err := exec.LookPath(binary); err == nil {
+		return true
+	}
+	resolved, err := filepath.EvalSymlinks(binary)
+	if err != nil {
+		resolved = binary
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return false
+	}
+	if runtime.GOOS != "windows" {
+		return info.Mode()&0111 != 0 || info.Mode().IsRegular()
+	}
+	return true
+}
+
 // detectSingleDep probes a single dependency using exec.LookPath + version command.
 func detectSingleDep(ctx context.Context, dep Dependency) Dependency {
 	if len(dep.DetectCmd) == 0 {
 		return dep
 	}
 
-	// First check if binary exists on PATH.
+	// First check if binary exists on PATH or filesystem (resolving virtualenv symlinks).
 	binary := dep.DetectCmd[0]
-	if _, err := exec.LookPath(binary); err != nil {
+	if !isExecutablePath(binary) {
 		return dep
 	}
 

--- a/internal/system/deps_test.go
+++ b/internal/system/deps_test.go
@@ -2,6 +2,8 @@ package system
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -311,6 +313,23 @@ func TestDetectSingleDepEmptyDetectCmd(t *testing.T) {
 	result := detectSingleDep(context.Background(), dep)
 	if result.Installed {
 		t.Fatalf("expected dep with empty DetectCmd to not be installed")
+	}
+}
+
+func TestIsExecutablePathResolvesVirtualenvSymlinks(t *testing.T) {
+	tempDir := t.TempDir()
+	realExe := filepath.Join(tempDir, "real_python")
+	if err := os.WriteFile(realExe, []byte("#!/bin/sh\necho Python 3.11.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkExe := filepath.Join(tempDir, "python")
+	if err := os.Symlink(realExe, symlinkExe); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	if !isExecutablePath(symlinkExe) {
+		t.Fatalf("isExecutablePath(%q) = false, want true for valid virtualenv symlink", symlinkExe)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2275

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes

---

## 📝 Summary

- Fixed false missing-path findings when dependency verification checks Python virtualenv interpreters that exist as symlinks or relative executable paths.
- Added `isExecutablePath` in `internal/system/deps.go` which evaluates symlinks via `filepath.EvalSymlinks` and inspects file mode/regular status.
- Prevents false-negative dependency failures during SDD plan and environment validation.
- Added unit test `TestIsExecutablePathResolvesVirtualenvSymlinks` in `internal/system/deps_test.go`.

---

## 🧪 Test Plan

```bash
go test ./internal/system/... -v -run TestIsExecutablePathResolvesVirtualenvSymlinks
go test ./internal/system/... -v
```

- [x] Unit test passes cleanly
- [x] Deadcode baseline updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of installed command-line tools supplied through direct filesystem paths.
  * Added support for executable symlinks, including virtual-environment-style paths.
  * Excludes directories and non-executable files from dependency detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->