### PR TITLE
feat(doctor): detect mixed binary and managed-asset versions

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -110,6 +110,7 @@ func RunDoctor(ctx context.Context, w io.Writer) error {
 		doctor.Check{ID: doctor.CheckStateJSON, Run: func(context.Context) doctor.Result { return checkStateJSON(homeDir) }},
 		doctor.Check{ID: doctor.CheckEngramReachable, Run: func(context.Context) doctor.Result { return checkEngramReachable() }},
 		doctor.Check{ID: doctor.CheckDiskSpace, Run: func(context.Context) doctor.Result { return checkDiskSpace(homeDir) }},
+		doctor.Check{ID: doctor.CheckManagedAssets, Run: func(context.Context) doctor.Result { return checkManagedAssets(homeDir) }},
 	)
 	report := (doctor.Runner{Checks: checks}).Run(ctx)
 
@@ -515,6 +516,45 @@ func checkDiskSpace(homeDir string) CheckResult {
 			Status: CheckStatusPass,
 			Detail: fmt.Sprintf("%d MB free on %s filesystem", freeMB, dir),
 		}
+	}
+}
+
+// checkManagedAssets verifies whether installed managed assets align with the running executable version.
+func checkManagedAssets(homeDir string) CheckResult {
+	const id = doctor.CheckManagedAssets
+	s, err := state.Read(homeDir)
+	if err != nil {
+		return CheckResult{
+			Name:   id,
+			Status: CheckStatusWarn,
+			Detail: "managed assets manifest unknown (state file unreadable)",
+			Remedy: doctor.NewRemedy(doctor.RemedySync, "Run 'gentle-ai sync' to align managed skills with executable"),
+		}
+	}
+
+	if s.ManagedAssetsProducerVersion == "" && s.ManagedAssetsProducerCommit == "" {
+		return CheckResult{
+			Name:   id,
+			Status: CheckStatusWarn,
+			Detail: "no managed assets version recorded in state.json (run 'gentle-ai sync' to generate manifest)",
+			Remedy: doctor.NewRemedy(doctor.RemedySync, "Run 'gentle-ai sync' to record managed assets version"),
+		}
+	}
+
+	exeVersion, exeCommit := reviewGentleAIVersionAndCommit()
+	if s.ManagedAssetsProducerVersion == exeVersion || (exeCommit != "unknown" && s.ManagedAssetsProducerCommit == exeCommit) {
+		return CheckResult{
+			Name:   id,
+			Status: CheckStatusPass,
+			Detail: fmt.Sprintf("managed assets aligned with binary (producer version %s)", s.ManagedAssetsProducerVersion),
+		}
+	}
+
+	return CheckResult{
+		Name:   id,
+		Status: CheckStatusWarn,
+		Detail: fmt.Sprintf("managed assets producer version (%s) differs from executable version (%s) — mixed-version control plane", s.ManagedAssetsProducerVersion, exeVersion),
+		Remedy: doctor.NewRemedy(doctor.RemedySync, "Run 'gentle-ai sync' to align managed skills and configs with current binary"),
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/doctor"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 )
 
 // --- checkOneTool ---
@@ -821,5 +822,39 @@ func TestRenderDoctorReportDoesNotRenderRemedyMetadata(t *testing.T) {
 	want := "gentle-ai doctor — system health check\n=======================================\n\n  [xx]  disk:space                     cleanup needed\n       Remedy: Free disk space\n\nSummary: 0 passed, 1 failed, 0 warnings\nStatus:  unhealthy\n"
 	if got := buf.String(); got != want {
 		t.Fatalf("rendered report mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestCheckManagedAssets(t *testing.T) {
+	homeDir := t.TempDir()
+
+	// 1. Unrecorded state
+	_ = state.Write(homeDir, state.InstallState{InstalledAgents: []string{"codex"}})
+	resUnrecorded := checkManagedAssets(homeDir)
+	if resUnrecorded.Status != CheckStatusWarn || !strings.Contains(resUnrecorded.Detail, "no managed assets version recorded") {
+		t.Fatalf("expected warn for unrecorded managed assets, got status=%v detail=%q", resUnrecorded.Status, resUnrecorded.Detail)
+	}
+
+	// 2. Aligned state
+	exeVersion, exeCommit := reviewGentleAIVersionAndCommit()
+	_ = state.Write(homeDir, state.InstallState{
+		InstalledAgents:              []string{"codex"},
+		ManagedAssetsProducerVersion: exeVersion,
+		ManagedAssetsProducerCommit:  exeCommit,
+	})
+	resAligned := checkManagedAssets(homeDir)
+	if resAligned.Status != CheckStatusPass || !strings.Contains(resAligned.Detail, "aligned") {
+		t.Fatalf("expected pass for aligned managed assets, got status=%v detail=%q", resAligned.Status, resAligned.Detail)
+	}
+
+	// 3. Mismatched / mixed state
+	_ = state.Write(homeDir, state.InstallState{
+		InstalledAgents:              []string{"codex"},
+		ManagedAssetsProducerVersion: "2.1.10",
+		ManagedAssetsProducerCommit:  "oldcommit123",
+	})
+	resMismatched := checkManagedAssets(homeDir)
+	if resMismatched.Status != CheckStatusWarn || !strings.Contains(resMismatched.Detail, "differs") {
+		t.Fatalf("expected warn for mismatched managed assets, got status=%v detail=%q", resMismatched.Status, resMismatched.Detail)
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1382,11 +1382,16 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	if !result.Verify.Ready {
 		return result, fmt.Errorf("post-sync verification failed:\n%s", verify.RenderReport(result.Verify))
 	}
-	if persistedStateErr == nil && !persistedState.CommunityToolsConfigured && selection.CommunityTools != nil {
-		persistedState.CommunityTools = communityToolIDsToStrings(selection.CommunityTools)
-		persistedState.CommunityToolsConfigured = true
+	if persistedStateErr == nil {
+		exeVersion, exeCommit := reviewGentleAIVersionAndCommit()
+		persistedState.ManagedAssetsProducerVersion = exeVersion
+		persistedState.ManagedAssetsProducerCommit = exeCommit
+		if !persistedState.CommunityToolsConfigured && selection.CommunityTools != nil {
+			persistedState.CommunityTools = communityToolIDsToStrings(selection.CommunityTools)
+			persistedState.CommunityToolsConfigured = true
+		}
 		if err := state.Write(homeDir, persistedState); err != nil {
-			return result, fmt.Errorf("persist migrated community tool selection: %w", err)
+			return result, fmt.Errorf("persist sync state: %w", err)
 		}
 	}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -10,6 +10,7 @@ const (
 	CheckStateJSON       CheckID = "state:json"
 	CheckEngramReachable CheckID = "engram:reachable"
 	CheckDiskSpace       CheckID = "disk:space"
+	CheckManagedAssets   CheckID = "managed:assets"
 )
 
 // ToolCheckID returns the stable check identifier for a tool binary.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -129,6 +129,13 @@ type InstallState struct {
 	// recorded is authority, not a cosmetic audit field. Nil for state files
 	// written before the switch existed.
 	RDDModeRecordedAt *time.Time `json:"rdd_mode_recorded_at,omitempty"`
+
+	// ManagedAssetsProducerVersion records the version string of the binary that
+	// last generated/synced managed skills and configs.
+	ManagedAssetsProducerVersion string `json:"managed_assets_producer_version,omitempty"`
+	// ManagedAssetsProducerCommit records the commit hash of the binary that
+	// last generated/synced managed skills and configs.
+	ManagedAssetsProducerCommit string `json:"managed_assets_producer_commit,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.
@@ -215,6 +222,8 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		PendingSync:                 existing.PendingSync,
 		RDDMode:                     existing.RDDMode,
 		RDDModeRecordedAt:           existing.RDDModeRecordedAt,
+		ManagedAssetsProducerVersion: existing.ManagedAssetsProducerVersion,
+		ManagedAssetsProducerCommit:  existing.ManagedAssetsProducerCommit,
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1884

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes

---

## 📝 Summary

- Added managed assets version drift detection to `gentle-ai doctor` (`managed:assets` check ID).
- Persists `ManagedAssetsProducerVersion` and `ManagedAssetsProducerCommit` in `state.InstallState` during `gentle-ai sync` execution.
- Checks whether the running binary version matches the producer version of installed managed assets in `~/.gentle-ai/state.json`.
- Reports `pass` when aligned, or `warn` when unrecorded or mixed-version control plane detected with confirmation remedy `gentle-ai sync`.
- Added unit test `TestCheckManagedAssets` in `internal/cli/doctor_test.go`.

---

## 🧪 Test Plan

```bash
go test ./internal/cli/... -v -run TestCheckManagedAssets
```

- [x] All unit tests pass cleanly
- [x] Deadcode baseline updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic check that verifies whether managed assets match the currently running application version.
  * Doctor now provides warnings and recommends synchronization when managed assets are outdated or their tracking information is unavailable.

* **Bug Fixes**
  * Synchronization now records the application version and commit associated with managed assets, improving consistency checks during future diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->