### PR TITLE
fix(mcp): write Claude workspace servers to mcp json

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1827,6 +1827,11 @@ func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection m
 		for _, path := range componentPathsWithWorkspaceScoped(homeDir, workspaceDir, scope, selection, adapters, component) {
 			paths[path] = struct{}{}
 		}
+		if component == model.ComponentContext7 {
+			for _, path := range claudeMCPSettingsCleanupPaths(homeDir, workspaceDir, scope, adapters) {
+				paths[path] = struct{}{}
+			}
+		}
 		if component == model.ComponentEngram && scope == ScopeGlobal {
 			for _, adapter := range adapters {
 				if adapter.Agent() == model.AgentClaudeCode {
@@ -1925,6 +1930,24 @@ func adapterSkillBackupTargets(homeDir, workspaceDir string, scope InstallScope,
 		}
 	}
 	return paths, nil
+}
+
+// claudeMCPSettingsCleanupPaths returns legacy Claude settings files that MCP
+// injection may rewrite while removing an inert mcpServers block. These paths
+// belong in the rollback snapshot, but not in post-apply verification because
+// cleanup is best-effort and the file may not exist.
+func claudeMCPSettingsCleanupPaths(homeDir, workspaceDir string, scope InstallScope, adapters []agents.Adapter) []string {
+	paths := []string{}
+	for _, adapter := range adapters {
+		if adapter.Agent() != model.AgentClaudeCode || adapter.MCPStrategy() != model.StrategySeparateMCPFiles {
+			continue
+		}
+		targetDir := componentPathDirScoped(homeDir, workspaceDir, scope, adapter, model.ComponentContext7)
+		if path := adapter.SettingsPath(targetDir); path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths
 }
 
 // routingGuidancePaths declares the files agentRoutingGuidanceStep rewrites for

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2076,9 +2076,14 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 					if targetDir == homeDir {
 						// Context7 injection writes ~/.claude.json (issue #1868).
 						paths = append(paths, claude.UserConfigPath(homeDir))
-					} else if p := adapter.SettingsPath(targetDir); p != "" {
-						// Workspace scope keeps the scoped settings merge.
-						paths = append(paths, p)
+					} else {
+						// Workspace scope writes <project-root>/.mcp.json, the file
+						// Claude Code loads project-scoped MCP servers from (issue #2213).
+						// The legacy .claude/settings.json block is a best-effort
+						// cleanup, not a guaranteed write, so it is not declared as a
+						// verification target (declaring it would force a false-negative
+						// when the file never existed).
+						paths = append(paths, filepath.Join(targetDir, ".mcp.json"))
 					}
 					break
 				}

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -387,9 +387,20 @@ func TestComponentPathsContext7ClaudeRespectsWorkspaceScope(t *testing.T) {
 
 	paths := componentPathsWithWorkspaceScoped(home, workspace, ScopeWorkspace, model.Selection{}, adapters, model.ComponentContext7)
 
-	want := filepath.Join(workspace, ".claude", "settings.json")
+	// Workspace scope writes <project-root>/.mcp.json, the file Claude Code
+	// loads project-scoped MCP servers from (issue #2213). The legacy
+	// .claude/settings.json key is inert for MCP discovery and is not declared.
+	want := filepath.Join(workspace, ".mcp.json")
 	if !containsPath(paths, want) {
 		t.Fatalf("componentPathsWithWorkspaceScoped(context7,claude) with ScopeWorkspace missing %q\npaths=%v", want, paths)
+	}
+	for _, absent := range []string{
+		filepath.Join(workspace, ".claude", "settings.json"),
+		filepath.Join(home, ".claude.json"),
+	} {
+		if containsPath(paths, absent) {
+			t.Fatalf("componentPathsWithWorkspaceScoped(context7,claude) with ScopeWorkspace must not require %q\npaths=%v", absent, paths)
+		}
 	}
 }
 

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -958,7 +958,10 @@ func TestBackupTargetsClaudeContext7IncludeCleanupWithoutVerificationRequirement
 			resolved := planner.ResolvedPlan{Agents: selection.Agents, OrderedComponents: selection.Components}
 			adapters := resolveAdapters(selection.Agents)
 
-			targets := backupTargets(home, workspace, tc.scope, selection, resolved)
+			targets, err := backupTargets(home, workspace, tc.scope, selection, resolved)
+			if err != nil {
+				t.Fatalf("backupTargets() error = %v", err)
+			}
 			root := home
 			if tc.wantRoot == "workspace" {
 				root = workspace

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -934,6 +934,56 @@ func TestBackupTargetsEngramClaudeIncludeRegistryAndLegacyMigrationSource(t *tes
 	}
 }
 
+func TestBackupTargetsClaudeContext7IncludeCleanupWithoutVerificationRequirement(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		scope         InstallScope
+		sameWorkspace bool
+		wantRoot      string
+	}{
+		{name: "user scope", scope: ScopeGlobal, wantRoot: "home"},
+		{name: "workspace scope", scope: ScopeWorkspace, wantRoot: "workspace"},
+		{name: "workspace is home", scope: ScopeWorkspace, sameWorkspace: true, wantRoot: "home"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			if tc.sameWorkspace {
+				workspace = home
+			}
+			selection := model.Selection{
+				Agents:     []model.AgentID{model.AgentClaudeCode},
+				Components: []model.ComponentID{model.ComponentContext7},
+			}
+			resolved := planner.ResolvedPlan{Agents: selection.Agents, OrderedComponents: selection.Components}
+			adapters := resolveAdapters(selection.Agents)
+
+			targets := backupTargets(home, workspace, tc.scope, selection, resolved)
+			root := home
+			if tc.wantRoot == "workspace" {
+				root = workspace
+			}
+			wantSettings := adapters[0].SettingsPath(root)
+			if !containsPath(targets, wantSettings) {
+				t.Fatalf("backupTargets missing cleanup path %q; targets=%v", wantSettings, targets)
+			}
+
+			verificationPaths := componentPathsWithWorkspaceScoped(home, workspace, tc.scope, selection, adapters, model.ComponentContext7)
+			if containsPath(verificationPaths, wantSettings) {
+				t.Fatalf("component verification must not require best-effort cleanup path %q; paths=%v", wantSettings, verificationPaths)
+			}
+
+			otherRoot := workspace
+			if root == workspace {
+				otherRoot = home
+			}
+			if !tc.sameWorkspace && containsPath(targets, adapters[0].SettingsPath(otherRoot)) {
+				t.Fatalf("backupTargets selected the wrong scope's cleanup path; targets=%v", targets)
+			}
+		})
+	}
+}
+
 func TestBackupTargetsContainNoDuplicatePaths(t *testing.T) {
 	home := t.TempDir()
 	agentIDs := []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKimi}

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -2555,9 +2555,10 @@ func TestRunInstallWorkspaceScopeVerification(t *testing.T) {
 
 // TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace verifies that executing
 // a real workspace operation with --scope workspace and Context7 component:
-// 1. Returns a successful result with verification ready.
-// 2. Persists Context7 MCP configuration directly into the workspace-managed settings file.
-// 3. Leaves the user's home directory settings untouched.
+//  1. Returns a successful result with verification ready.
+//  2. Persists Context7 MCP configuration into <project-root>/.mcp.json, the file
+//     Claude Code loads project-scoped MCP servers from (issue #2213).
+//  3. Leaves the user's home directory settings untouched.
 func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
@@ -2605,9 +2606,18 @@ func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
 		t.Fatalf("post-apply verification failed for Context7 workspace scope: %#v", result.Verify)
 	}
 
-	// Assert that Context7 MCP configuration was persisted to workspace-scoped Claude settings.
-	workspaceSettingsFile := filepath.Join(workspace, ".claude", "settings.json")
-	assertFileContains(t, workspaceSettingsFile, "context7")
+	// Context7 MCP configuration must persist to <project-root>/.mcp.json, the
+	// file Claude Code loads project-scoped MCP servers from (issue #2213).
+	workspaceMCPFile := filepath.Join(workspace, ".mcp.json")
+	assertFileContains(t, workspaceMCPFile, "context7")
+
+	// The legacy .claude/settings.json key is inert for MCP discovery and must
+	// not carry the managed context7 entry after install.
+	if settingsRaw, err := os.ReadFile(filepath.Join(workspace, ".claude", "settings.json")); err == nil {
+		if strings.Contains(string(settingsRaw), `"mcpServers"`) {
+			t.Errorf("workspace .claude/settings.json must not carry mcpServers; got %s", settingsRaw)
+		}
+	}
 
 	// Assert that no Context7 configuration was written to home directory settings.
 	homeSettingsFile := filepath.Join(home, ".claude", "settings.json")
@@ -2653,10 +2663,12 @@ func TestRunInstall_Context7WorkspaceScope_FailurePath(t *testing.T) {
 		t.Fatalf("failed to change working directory to temp workspace: %v", err)
 	}
 
-	// Create .claude as a read-only file (not directory) so writing settings.json fails.
-	claudePath := filepath.Join(workspace, ".claude")
-	if err := os.WriteFile(claudePath, []byte("blocking directory creation"), 0o444); err != nil {
-		t.Fatalf("failed to block workspace .claude path: %v", err)
+	// Block the <project-root>/.mcp.json write by making it a directory, so the
+	// atomic file write fails. The primary workspace-scope target is .mcp.json
+	// (issue #2213), not .claude/settings.json.
+	blockingPath := filepath.Join(workspace, ".mcp.json")
+	if err := os.Mkdir(blockingPath, 0o755); err != nil {
+		t.Fatalf("failed to create blocking .mcp.json directory: %v", err)
 	}
 
 	args := []string{

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -579,6 +579,11 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 		for _, path := range syncComponentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
 			paths[path] = struct{}{}
 		}
+		if component == model.ComponentContext7 {
+			for _, path := range claudeMCPSettingsCleanupPaths(homeDir, workspaceDir, ScopeGlobal, adapters) {
+				paths[path] = struct{}{}
+			}
+		}
 		if component == model.ComponentEngram {
 			for _, adapter := range adapters {
 				if adapter.Agent() == model.AgentClaudeCode {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1051,6 +1051,20 @@ func TestSyncBackupTargetsIncludeClaudeEngramLegacyMigrationSource(t *testing.T)
 	}
 }
 
+func TestSyncBackupTargetsIncludeClaudeContext7CleanupPath(t *testing.T) {
+	home := t.TempDir()
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentContext7},
+	}
+
+	targets := syncBackupTargets(home, "", selection, resolveAdapters(selection.Agents))
+	want := filepath.Join(home, ".claude", "settings.json")
+	if !containsPath(targets, want) {
+		t.Fatalf("sync backup targets missing Claude Context7 cleanup path %q: %v", want, targets)
+	}
+}
+
 type failingSyncStep struct{}
 
 func (failingSyncStep) ID() string { return "sync:test:fail-after-engram" }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1058,7 +1058,10 @@ func TestSyncBackupTargetsIncludeClaudeContext7CleanupPath(t *testing.T) {
 		Components: []model.ComponentID{model.ComponentContext7},
 	}
 
-	targets := syncBackupTargets(home, "", selection, resolveAdapters(selection.Agents))
+	targets, err := syncBackupTargets(home, "", selection, resolveAdapters(selection.Agents))
+	if err != nil {
+		t.Fatalf("syncBackupTargets() error = %v", err)
+	}
 	want := filepath.Join(home, ".claude", "settings.json")
 	if !containsPath(targets, want) {
 		t.Fatalf("sync backup targets missing Claude Context7 cleanup path %q: %v", want, targets)

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -338,13 +338,12 @@ func removeInertSettingsMCPServers(settingsPath string) (bool, error) {
 		return false, nil
 	}
 	servers, ok := root["mcpServers"].(map[string]any)
-	if !ok {
+	if !ok || len(servers) != 1 {
 		return false, nil
 	}
-	for name, entry := range servers {
-		if name != "context7" || !isManagedSettingsContext7Entry(entry) {
-			return false, nil
-		}
+	entry, ok := servers["context7"]
+	if !ok || !isManagedSettingsContext7Entry(entry) {
+		return false, nil
 	}
 	delete(root, "mcpServers")
 

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
@@ -22,7 +23,10 @@ type InjectionResult struct {
 // scoped injection root (the home directory for user scope, the workspace for
 // workspace scope). Claude Code user-scope registration goes to ~/.claude.json,
 // the only user-scope file Claude Code reads MCP servers from (issue #1868);
-// workspace scope keeps the scoped settings merge.
+// workspace scope writes project-scoped servers to <project-root>/.mcp.json,
+// the file Claude Code loads project MCP servers from, then removes the inert
+// mcpServers block the legacy workspace path wrote into .claude/settings.json
+// (issue #2213).
 func Inject(homeDir, targetDir string, adapter agents.Adapter) (InjectionResult, error) {
 	if !adapter.SupportsMCP() {
 		return InjectionResult{}, nil
@@ -34,7 +38,7 @@ func Inject(homeDir, targetDir string, adapter agents.Adapter) (InjectionResult,
 			if targetDir == homeDir {
 				return injectClaudeUserConfig(homeDir, adapter)
 			}
-			return injectMergeIntoSettings(targetDir, adapter)
+			return injectClaudeWorkspaceMCPJSON(homeDir, targetDir, adapter)
 		}
 		return injectSeparateFile(targetDir, adapter)
 	case model.StrategyMergeIntoSettings:
@@ -279,7 +283,35 @@ func injectClaudeUserConfig(homeDir string, adapter agents.Adapter) (InjectionRe
 	return InjectionResult{Changed: changed, Files: files}, nil
 }
 
-// removeInertSettingsMCPServers deletes the inert top-level mcpServers key
+// injectClaudeWorkspaceMCPJSON registers Context7 in <project-root>/.mcp.json,
+// the file Claude Code loads project-scoped MCP servers from. The merge
+// preserves unrelated servers and any other top-level config the user authored,
+// and a backup is already snapshotted by the installer before this step runs.
+// It also removes the inert mcpServers block the legacy workspace path wrote
+// into <project-root>/.claude/settings.json, which Claude Code ignores for MCP
+// discovery (issue #2213).
+func injectClaudeWorkspaceMCPJSON(homeDir, workspaceDir string, adapter agents.Adapter) (InjectionResult, error) {
+	mcpPath := filepath.Join(workspaceDir, ".mcp.json")
+	mcpWrite, err := mergeJSONFile(mcpPath, DefaultContext7OverlayJSON())
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("merge context7 into %q: %w", mcpPath, err)
+	}
+
+	changed := mcpWrite.Changed
+	files := []string{mcpPath}
+	// Best-effort cleanup of the inert settings.json block the legacy path wrote.
+	// homeDir is passed so a workspace that coincides with the user's home still
+	// cleans the same settings file the user-scope path would have cleaned.
+	settingsPath := adapter.SettingsPath(workspaceDir)
+	if settingsChanged, cleanupErr := removeInertSettingsMCPServers(settingsPath); cleanupErr == nil && settingsChanged {
+		changed = true
+		files = append(files, settingsPath)
+	}
+	_ = homeDir // homeDir kept in the signature for symmetry with injectClaudeUserConfig.
+
+	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
 // from settings.json once the real registration lives in ~/.claude.json —
 // but only when the block holds nothing beyond the managed context7 entry.
 // An unparsable settings file is left untouched.

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -38,7 +38,7 @@ func Inject(homeDir, targetDir string, adapter agents.Adapter) (InjectionResult,
 			if targetDir == homeDir {
 				return injectClaudeUserConfig(homeDir, adapter)
 			}
-			return injectClaudeWorkspaceMCPJSON(homeDir, targetDir, adapter)
+			return injectClaudeWorkspaceMCPJSON(targetDir, adapter)
 		}
 		return injectSeparateFile(targetDir, adapter)
 	case model.StrategyMergeIntoSettings:
@@ -290,7 +290,7 @@ func injectClaudeUserConfig(homeDir string, adapter agents.Adapter) (InjectionRe
 // It also removes the inert mcpServers block the legacy workspace path wrote
 // into <project-root>/.claude/settings.json, which Claude Code ignores for MCP
 // discovery (issue #2213).
-func injectClaudeWorkspaceMCPJSON(homeDir, workspaceDir string, adapter agents.Adapter) (InjectionResult, error) {
+func injectClaudeWorkspaceMCPJSON(workspaceDir string, adapter agents.Adapter) (InjectionResult, error) {
 	mcpPath := filepath.Join(workspaceDir, ".mcp.json")
 	mcpWrite, err := mergeJSONFile(mcpPath, DefaultContext7OverlayJSON())
 	if err != nil {
@@ -300,15 +300,11 @@ func injectClaudeWorkspaceMCPJSON(homeDir, workspaceDir string, adapter agents.A
 	changed := mcpWrite.Changed
 	files := []string{mcpPath}
 	// Best-effort cleanup of the inert settings.json block the legacy path wrote.
-	// homeDir is passed so a workspace that coincides with the user's home still
-	// cleans the same settings file the user-scope path would have cleaned.
 	settingsPath := adapter.SettingsPath(workspaceDir)
 	if settingsChanged, cleanupErr := removeInertSettingsMCPServers(settingsPath); cleanupErr == nil && settingsChanged {
 		changed = true
 		files = append(files, settingsPath)
 	}
-	_ = homeDir // homeDir kept in the signature for symmetry with injectClaudeUserConfig.
-
 	return InjectionResult{Changed: changed, Files: files}, nil
 }
 

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -605,6 +605,174 @@ func TestInjectClaudeSettingsInertBlockCleanup(t *testing.T) {
 	}
 }
 
+// TestInjectClaudeWorkspaceWritesMCPJSONAndIsIdempotent verifies that workspace
+// scope (home != workspace) writes Context7 into <project-root>/.mcp.json — the
+// file Claude Code loads project-scoped MCP servers from — rather than the
+// inert .claude/settings.json key Claude ignores (issue #2213).
+func TestInjectClaudeWorkspaceWritesMCPJSONAndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	mcpPath := filepath.Join(workspace, ".mcp.json")
+
+	first, err := Inject(home, workspace, claudeAdapter())
+	if err != nil {
+		t.Fatalf("Inject() first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject() first changed = false")
+	}
+
+	context7 := readMCPServersContext7Entry(t, mcpPath)
+	if context7["command"] != "npx" {
+		t.Fatalf(".mcp.json mcpServers.context7.command = %#v; want npx", context7["command"])
+	}
+	if args := fmt.Sprintf("%v", context7["args"]); !strings.Contains(args, versions.Context7MCP) {
+		t.Fatalf(".mcp.json context7.args = %s; want pinned version %s", args, versions.Context7MCP)
+	}
+
+	second, err := Inject(home, workspace, claudeAdapter())
+	if err != nil {
+		t.Fatalf("Inject() second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject() second changed = true; want idempotent")
+	}
+
+	// The inert settings.json key must never be (re)written for workspace scope.
+	if _, err := os.Stat(filepath.Join(workspace, ".claude", "settings.json")); err == nil {
+		raw, readErr := os.ReadFile(filepath.Join(workspace, ".claude", "settings.json"))
+		if readErr != nil {
+			t.Fatalf("ReadFile(settings.json) error = %v", readErr)
+		}
+		if strings.Contains(string(raw), `"mcpServers"`) {
+			t.Fatalf("workspace .claude/settings.json must not carry mcpServers; got %s", raw)
+		}
+	}
+}
+
+// TestInjectClaudeWorkspacePreservesUnrelatedServersAndConfig verifies that
+// merging context7 into <project-root>/.mcp.json preserves user-authored
+// servers and top-level config outside the managed entry (issue #2213).
+func TestInjectClaudeWorkspacePreservesUnrelatedServersAndConfig(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	mcpPath := filepath.Join(workspace, ".mcp.json")
+	if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	existing := `{
+  "mcpServers": {
+    "codegraph": {
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  },
+  "enableAllProjectMcpServers": true
+}`
+	if err := os.WriteFile(mcpPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile(.mcp.json) error = %v", err)
+	}
+
+	if _, err := Inject(home, workspace, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("ReadFile(.mcp.json) error = %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("Unmarshal(.mcp.json) error = %v", err)
+	}
+	servers, _ := parsed["mcpServers"].(map[string]any)
+	if codegraph, _ := servers["codegraph"].(map[string]any); codegraph["command"] != "codegraph" {
+		t.Fatalf("unrelated codegraph server must be preserved; got %#v", servers["codegraph"])
+	}
+	if context7, _ := servers["context7"].(map[string]any); context7["command"] != "npx" {
+		t.Fatalf("context7 must be merged; got %#v", servers["context7"])
+	}
+	if parsed["enableAllProjectMcpServers"] != true {
+		t.Fatalf("unrelated top-level config must be preserved; got %#v", parsed["enableAllProjectMcpServers"])
+	}
+}
+
+// TestInjectClaudeWorkspaceCleansInertSettingsBlock verifies that the legacy
+// inert mcpServers block in <project-root>/.claude/settings.json is removed
+// when it only holds the managed context7 entry, but left untouched when it
+// carries foreign servers (issue #2213).
+func TestInjectClaudeWorkspaceCleansInertSettingsBlock(t *testing.T) {
+	cases := []struct {
+		name           string
+		settings       string
+		wantKeyRemoved bool
+	}{
+		{"managed-only block is removed", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]}}}`, true},
+		{"foreign block is left alone", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]},"stranded":{"command":"stranded-server"}}}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			settingsPath := filepath.Join(workspace, ".claude", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll error = %v", err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(tc.settings), 0o644); err != nil {
+				t.Fatalf("WriteFile(settings) error = %v", err)
+			}
+
+			if _, err := Inject(home, workspace, claudeAdapter()); err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+
+			// .mcp.json must always be the real registration target.
+			readMCPServersContext7Entry(t, filepath.Join(workspace, ".mcp.json"))
+
+			raw, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("ReadFile(settings) error = %v", err)
+			}
+			settings := map[string]any{}
+			if err := json.Unmarshal(raw, &settings); err != nil {
+				t.Fatalf("Unmarshal(settings) error = %v", err)
+			}
+			_, hasKey := settings["mcpServers"]
+			if tc.wantKeyRemoved && hasKey {
+				t.Fatalf("inert mcpServers key must be removed; got %s", raw)
+			}
+			if !tc.wantKeyRemoved && !hasKey {
+				t.Fatalf("foreign mcpServers block must be left untouched; got %s", raw)
+			}
+			if settings["theme"] != "dark" {
+				t.Fatalf("settings.theme = %#v; want dark preserved", settings["theme"])
+			}
+		})
+	}
+}
+
+// TestInjectClaudeUserScopeUnaffectedByWorkspaceFix is a regression guard: the
+// workspace-scope fix must not change user-scope behavior, which still writes
+// ~/.claude.json and never creates <home>/.mcp.json.
+func TestInjectClaudeUserScopeUnaffectedByWorkspaceFix(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, home, claudeAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject() changed = false")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude.json")); err != nil {
+		t.Fatalf("~/.claude.json must be written for user scope; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("user scope must not create <home>/.mcp.json; stat err = %v", err)
+	}
+}
+
 func TestInjectClaudeRefusesCorruptUserConfig(t *testing.T) {
 	home := t.TempDir()
 	userConfigPath := filepath.Join(home, ".claude.json")

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -565,6 +565,7 @@ func TestInjectClaudeSettingsInertBlockCleanup(t *testing.T) {
 		{"managed-only block is removed", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]}}}`, true},
 		{"foreign block is left alone", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]},"stranded":{"command":"stranded-server"}}}`, false},
 		{"user-authored context7 is left alone", `{"theme":"dark","mcpServers":{"context7":{"command":"my-own-proxy"}}}`, false},
+		{"empty block is left alone", `{"theme":"dark","mcpServers":{}}`, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -650,6 +651,23 @@ func TestInjectClaudeWorkspaceWritesMCPJSONAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestInjectClaudeWorkspacePreservesMCPReadErrors(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	mcpPath := filepath.Join(workspace, ".mcp.json")
+	if err := os.Mkdir(mcpPath, 0o755); err != nil {
+		t.Fatalf("Mkdir(.mcp.json) error = %v", err)
+	}
+
+	_, err := Inject(home, workspace, claudeAdapter())
+	if err == nil {
+		t.Fatal("Inject() error = nil; want non-not-exist read error")
+	}
+	if !strings.Contains(err.Error(), mcpPath) {
+		t.Fatalf("Inject() error = %v; want path %q", err, mcpPath)
+	}
+}
+
 // TestInjectClaudeWorkspacePreservesUnrelatedServersAndConfig verifies that
 // merging context7 into <project-root>/.mcp.json preserves user-authored
 // servers and top-level config outside the managed entry (issue #2213).
@@ -710,6 +728,7 @@ func TestInjectClaudeWorkspaceCleansInertSettingsBlock(t *testing.T) {
 	}{
 		{"managed-only block is removed", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]}}}`, true},
 		{"foreign block is left alone", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]},"stranded":{"command":"stranded-server"}}}`, false},
+		{"empty block is left alone", `{"theme":"dark","mcpServers":{}}`, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -648,6 +650,58 @@ func TestInjectClaudeWorkspaceWritesMCPJSONAndIsIdempotent(t *testing.T) {
 		if strings.Contains(string(raw), `"mcpServers"`) {
 			t.Fatalf("workspace .claude/settings.json must not carry mcpServers; got %s", raw)
 		}
+	}
+}
+
+// TestInjectClaudeWorkspaceIsDiscoveredByNativeClaudeMCPList proves the
+// project-scope contract through Claude Code itself, without approving the
+// pending project server.
+func TestInjectClaudeWorkspaceIsDiscoveredByNativeClaudeMCPList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires the native Claude Code CLI")
+	}
+
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			t.Skip("native Claude Code CLI is not installed")
+		}
+		t.Fatalf("LookPath(claude) error = %v", err)
+	}
+
+	home := t.TempDir()
+	workspace := t.TempDir()
+	if _, err := Inject(home, workspace, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	cmd := exec.Command(claudePath, "mcp", "list")
+	cmd.Dir = workspace
+	env := os.Environ()
+	homeReplaced := false
+	for index, value := range env {
+		if strings.HasPrefix(value, "HOME=") {
+			env[index] = "HOME=" + home
+			homeReplaced = true
+			break
+		}
+	}
+	if !homeReplaced {
+		env = append(env, "HOME="+home)
+	}
+	cmd.Env = env
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("claude mcp list error = %v\noutput:\n%s", err, output)
+	}
+	t.Logf("native Claude project-scope discovery:\n%s", output)
+	lowerOutput := strings.ToLower(string(output))
+	if !strings.Contains(lowerOutput, "context7") {
+		t.Fatalf("claude mcp list did not discover context7 from %q\noutput:\n%s", filepath.Join(workspace, ".mcp.json"), output)
+	}
+	if !strings.Contains(lowerOutput, "pending") && !strings.Contains(lowerOutput, "approval") {
+		t.Fatalf("claude mcp list did not report the unapproved project server\noutput:\n%s", output)
 	}
 }
 

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -553,6 +553,9 @@ func TestInjectClaudeWritesUserConfigAndIsIdempotent(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, ".claude", "mcp", "context7.json")); !os.IsNotExist(err) {
 		t.Fatalf("Claude Context7 must not be written to ~/.claude/mcp/context7.json; stat err = %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(home, ".mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("user scope must not create <home>/.mcp.json; stat err = %v", err)
+	}
 }
 
 // TestInjectClaudeSettingsInertBlockCleanup: the inert settings.json block is
@@ -770,79 +773,38 @@ func TestInjectClaudeWorkspacePreservesUnrelatedServersAndConfig(t *testing.T) {
 	}
 }
 
-// TestInjectClaudeWorkspaceCleansInertSettingsBlock verifies that the legacy
-// inert mcpServers block in <project-root>/.claude/settings.json is removed
-// when it only holds the managed context7 entry, but left untouched when it
-// carries foreign servers (issue #2213).
+// TestInjectClaudeWorkspaceCleansInertSettingsBlock verifies workspace cleanup.
 func TestInjectClaudeWorkspaceCleansInertSettingsBlock(t *testing.T) {
-	cases := []struct {
-		name           string
-		settings       string
-		wantKeyRemoved bool
-	}{
-		{"managed-only block is removed", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]}}}`, true},
-		{"foreign block is left alone", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]},"stranded":{"command":"stranded-server"}}}`, false},
-		{"empty block is left alone", `{"theme":"dark","mcpServers":{}}`, false},
+	home := t.TempDir()
+	workspace := t.TempDir()
+	settingsPath := filepath.Join(workspace, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
 	}
-	for _, tc := range cases {
+	for _, tc := range []struct {
+		name, settings string
+		wantKey        bool
+	}{
+		{"managed-only", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]}}}`, false},
+		{"foreign", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]},"stranded":{"command":"stranded-server"}}}`, true},
+		{"empty", `{"theme":"dark","mcpServers":{}}`, true},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			home := t.TempDir()
-			workspace := t.TempDir()
-			settingsPath := filepath.Join(workspace, ".claude", "settings.json")
-			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-				t.Fatalf("MkdirAll error = %v", err)
-			}
 			if err := os.WriteFile(settingsPath, []byte(tc.settings), 0o644); err != nil {
 				t.Fatalf("WriteFile(settings) error = %v", err)
 			}
-
 			if _, err := Inject(home, workspace, claudeAdapter()); err != nil {
 				t.Fatalf("Inject() error = %v", err)
 			}
-
-			// .mcp.json must always be the real registration target.
 			readMCPServersContext7Entry(t, filepath.Join(workspace, ".mcp.json"))
-
 			raw, err := os.ReadFile(settingsPath)
 			if err != nil {
 				t.Fatalf("ReadFile(settings) error = %v", err)
 			}
-			settings := map[string]any{}
-			if err := json.Unmarshal(raw, &settings); err != nil {
-				t.Fatalf("Unmarshal(settings) error = %v", err)
-			}
-			_, hasKey := settings["mcpServers"]
-			if tc.wantKeyRemoved && hasKey {
-				t.Fatalf("inert mcpServers key must be removed; got %s", raw)
-			}
-			if !tc.wantKeyRemoved && !hasKey {
-				t.Fatalf("foreign mcpServers block must be left untouched; got %s", raw)
-			}
-			if settings["theme"] != "dark" {
-				t.Fatalf("settings.theme = %#v; want dark preserved", settings["theme"])
+			if got := strings.Contains(string(raw), `"mcpServers"`); got != tc.wantKey {
+				t.Fatalf("mcpServers presence = %t, want %t; got %s", got, tc.wantKey, raw)
 			}
 		})
-	}
-}
-
-// TestInjectClaudeUserScopeUnaffectedByWorkspaceFix is a regression guard: the
-// workspace-scope fix must not change user-scope behavior, which still writes
-// ~/.claude.json and never creates <home>/.mcp.json.
-func TestInjectClaudeUserScopeUnaffectedByWorkspaceFix(t *testing.T) {
-	home := t.TempDir()
-
-	result, err := Inject(home, home, claudeAdapter())
-	if err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-	if !result.Changed {
-		t.Fatalf("Inject() changed = false")
-	}
-	if _, err := os.Stat(filepath.Join(home, ".claude.json")); err != nil {
-		t.Fatalf("~/.claude.json must be written for user scope; stat err = %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".mcp.json")); !os.IsNotExist(err) {
-		t.Fatalf("user scope must not create <home>/.mcp.json; stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2213

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Write Claude Code workspace-scoped Context7 MCP registration to `<project-root>/.mcp.json`.
- Preserve unrelated MCP servers and top-level project configuration.
- Clean the legacy inert workspace settings block when it only contains the managed server.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/mcp` | Added workspace `.mcp.json` merge and cleanup behavior with regression coverage |
| `internal/cli` | Declared and verified the correct workspace MCP target |

---

## 🧪 Test Plan

- [x] `go test ./internal/components/mcp/...`
- [x] Focused Context7 workspace CLI tests
- [x] `go test ./internal/components/uninstall/...`
- [x] `go vet ./internal/components/mcp/ ./internal/cli/`
- [x] Go formatting and `git diff --check`
- [ ] E2E Docker suite — N/A for this focused filesystem-registration fix; repository CI remains authoritative
- [x] Benchmark validation — N/A; this does not alter review lifecycle, gates, recovery, delivery, or benchmark code

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Appropriate `type:*` label added
- [x] Focused unit and integration tests pass
- [x] Go format passes
- [x] Documentation impact is covered by code comments and tests
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Please focus on preservation of existing `.mcp.json` content and the best-effort cleanup boundary for legacy `.claude/settings.json` data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace-scoped Claude Code Context7 configuration is now stored in the project’s `.mcp.json` file.
  * Existing project MCP settings and unrelated configuration are preserved.
  * Legacy workspace settings are cleaned up safely without affecting user-scoped configuration.
  * Repeated configuration updates no longer create duplicate entries.
  * Configuration backups now include relevant Claude Code cleanup settings.
  * Improved handling of configuration read and write errors.
  * Workspace configuration is now correctly discoverable through Claude Code’s native MCP listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->