### PR TITLE
feat(review): consult the kill switch once before any authority read

### DIFF
--- a/e2e/organicruntime/organic_lifecycle_hardening_test.go
+++ b/e2e/organicruntime/organic_lifecycle_hardening_test.go
@@ -396,8 +396,11 @@ func TestOrganicReviewLifecycleErrorTyping(t *testing.T) {
 		if result.Allowed || result.Result == string(reviewtransaction.GateAllow) {
 			t.Fatalf("disabled pre-push with no upstream fabricated an approval: %#v", result)
 		}
-		if result.Context.Denial == nil {
-			t.Fatalf("disabled pre-push with no upstream hid why no receipt governs: %#v", result)
+		// Wave 5 Slice 2 (design decision 4): the switch is consulted before
+		// any authority read, so the no-upstream boundary is never even
+		// derived while disabled -- no discovery-kind detail leaks.
+		if result.Context.Denial != nil {
+			t.Fatalf("disabled pre-push with no upstream leaked discovery-kind detail: %#v", result.Context.Denial)
 		}
 	})
 

--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -722,8 +722,12 @@ func TestOrganicKillSwitchStopsAtTheDeliveryBoundary(t *testing.T) {
 	if gate.Schema != organicGateSchema || gate.Allowed || gate.Result == organicGateAllow {
 		t.Fatalf("disabled delivery gate did not fail closed: %#v", gate)
 	}
-	if gate.Context.Denial == nil || gate.Context.Denial.Stage != "receipt-discovery" {
-		t.Fatalf("disabled delivery gate denial is not discoverable: %#v", gate.Context.Denial)
+	// Wave 5 Slice 2 (design decision 4): the kill switch is consulted
+	// before any authority read, so this report carries no discovery-kind
+	// detail at all -- there is no receipt-discovery outcome to describe,
+	// because discovery never runs.
+	if gate.Context.Denial != nil {
+		t.Fatalf("disabled delivery gate leaked discovery-kind detail: %#v", gate.Context.Denial)
 	}
 	// The guidance installed on all 16 adapters promises this exact token under a
 	// disabled switch. Asserting it here is what keeps that promise honest, and
@@ -790,8 +794,11 @@ func TestOrganicKillSwitchReportsUnmanagedDeliveryOverPriorReceipts(t *testing.T
 	if gate.Delivery != "disabled/unmanaged" {
 		t.Fatalf("disabled delivery over a prior receipt did not report the promised disposition: %q", gate.Delivery)
 	}
-	if gate.Context.Denial == nil {
-		t.Fatalf("disabled delivery hid why the prior receipt does not govern: %#v", gate.Context)
+	// Wave 5 Slice 2 (design decision 4): the switch is consulted before any
+	// authority read, so the prior receipt is never even discovered while
+	// disabled -- no discovery-kind detail leaks.
+	if gate.Context.Denial != nil {
+		t.Fatalf("disabled delivery over a prior receipt leaked discovery-kind detail: %#v", gate.Context.Denial)
 	}
 
 	// Reporting moved nothing: the remote is untouched and no branch appeared.
@@ -844,10 +851,12 @@ func TestOrganicKillSwitchReportsUnmanagedDeliveryOverWorkspaceReceipt(t *testin
 	if gate.Delivery != "disabled/unmanaged" {
 		t.Fatalf("disabled delivery over a workspace receipt did not report the promised disposition: %q", gate.Delivery)
 	}
-	// The healthy receipt's real relation to the candidate stays discoverable:
-	// the delivery shape moved past it, and the store was never corrupted.
-	if gate.Context.Denial == nil || gate.Context.Denial.Code != "delivery-shape-mismatch" {
-		t.Fatalf("disabled delivery hid why the workspace receipt does not govern: %#v", gate.Context.Denial)
+	// Wave 5 Slice 2 (design decision 4): the switch is consulted before any
+	// authority read, so the healthy receipt is never even discovered while
+	// disabled -- no discovery-kind detail (not even "delivery-shape-mismatch")
+	// leaks.
+	if gate.Context.Denial != nil {
+		t.Fatalf("disabled delivery over a workspace receipt leaked discovery-kind detail: %#v", gate.Context.Denial)
 	}
 
 	// Reporting moved nothing: the remote is untouched and no branch appeared.
@@ -1006,6 +1015,17 @@ func TestOrganicKillSwitchReEnableLandsOnTheFreshFullReview(t *testing.T) {
 // expiry-stable terminal state. The authorization that permitted the review is
 // withdrawn afterwards, and the terminal receipt still validates, replays
 // byte-identically, and produces no additional effect.
+// TestOrganicTerminalAuthoritySurvivesWithdrawalAndReplaysWithoutEffect is
+// Wave 5 Slice 2's most consequential black-box behavior reversal (design
+// decision 4; rdd-receipt-only-gates/spec.md's "Kill switch off
+// short-circuits before authority discovery" scenario, a firm requirement,
+// not a tagged pending assumption): the kill switch is now consulted before
+// ANY receipt or authority read, so even the terminal receipt this journey
+// just earned is never consulted while disabled -- the gate reports the
+// generic disabled/unmanaged shape instead of replaying the same allow. The
+// name and behavior this test asserts changed accordingly: the terminal
+// AUTHORITY survives withdrawal unmutated (proven by re-enabling and
+// replaying below), but it no longer GOVERNS DELIVERY while withdrawn.
 func TestOrganicTerminalAuthoritySurvivesWithdrawalAndReplaysWithoutEffect(t *testing.T) {
 	t.Parallel()
 	deadline := time.Now().Add(organicWithdrawalDeadline)
@@ -1036,9 +1056,18 @@ func TestOrganicTerminalAuthoritySurvivesWithdrawalAndReplaysWithoutEffect(t *te
 		t.Fatal("a new review started after the authorization was withdrawn")
 	}
 
-	replayedGate := harness.gentle("review", "validate", "--cwd", harness.repo.worktree, "--gate", "post-apply")
-	if !bytes.Equal(replayedGate, firstGate) {
-		t.Fatalf("the terminal gate result changed after withdrawal:\nfirst:\n%s\nreplay:\n%s", firstGate, replayedGate)
+	// While withdrawn: the terminal receipt just earned is never consulted --
+	// the gate reports the generic disabled/unmanaged shape, not a replay of
+	// the pre-withdrawal allow.
+	withdrawnGate := harness.gentle("review", "validate", "--cwd", harness.repo.worktree, "--gate", "post-apply")
+	if bytes.Equal(withdrawnGate, firstGate) {
+		t.Fatal("the terminal gate result did not change after withdrawal -- the receipt was consulted while disabled")
+	}
+	if !bytes.Contains(withdrawnGate, []byte(`"disabled/unmanaged"`)) {
+		t.Fatalf("withdrawn gate did not report disabled/unmanaged: %s", withdrawnGate)
+	}
+	if bytes.Contains(withdrawnGate, []byte(`"allowed":true`)) {
+		t.Fatalf("withdrawn gate fabricated an approval: %s", withdrawnGate)
 	}
 	replayedFinalize := harness.gentle("review", "finalize", "--cwd", harness.repo.worktree, "--lineage", lineage)
 	if !bytes.Equal(replayedFinalize, firstFinalize) {
@@ -1055,6 +1084,17 @@ func TestOrganicTerminalAuthoritySurvivesWithdrawalAndReplaysWithoutEffect(t *te
 		t.Fatalf("replay moved the remote: %s != %s", remote, harness.repo.baseRevision)
 	}
 	harness.assertOnlyMainRef()
+
+	// Re-enabling rediscovers the SAME unmutated receipt, and it governs
+	// again exactly as before withdrawal -- proving the switch never touched
+	// the authority itself, only whether it is consulted.
+	if mode := harness.enableReview(); mode.Status.Effective != "on" {
+		t.Fatalf("re-enabling did not take effect: %#v", mode)
+	}
+	reEnabledGate := harness.gentle("review", "validate", "--cwd", harness.repo.worktree, "--gate", "post-apply")
+	if !bytes.Equal(reEnabledGate, firstGate) {
+		t.Fatalf("the terminal gate result changed across a withdraw/re-enable cycle:\nbefore:\n%s\nafter:\n%s", firstGate, reEnabledGate)
+	}
 
 	if time.Now().After(deadline) {
 		t.Fatalf("the withdrawal journey exceeded its %s CI budget", organicWithdrawalDeadline)

--- a/internal/cli/review_disabled_delivery_test.go
+++ b/internal/cli/review_disabled_delivery_test.go
@@ -56,9 +56,15 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryWithoutReceipt(t *testing
 	if errors.As(err, &denied) {
 		t.Fatalf("disabled delivery was reported as a denial: %#v", denied)
 	}
-	// The reason the candidate is unmanaged stays discoverable.
-	if result.Context.Denial == nil || result.Context.Denial.Stage != "receipt-discovery" {
-		t.Fatalf("disabled delivery hid why no receipt governs: %#v", result.Context.Denial)
+	// Wave 5 Slice 2 (design decision 4): the switch is consulted before any
+	// authority read, so this report carries no discovery-kind detail at
+	// all -- there is no receipt-discovery outcome to describe, because
+	// discovery never runs. (Previously this asserted
+	// Denial.Stage == "receipt-discovery"; the enabled-mode sibling
+	// TestReviewValidateWithoutReceiptStillDeniesWhileReviewIsEnabled below
+	// still asserts that shape, where discovery genuinely still runs.)
+	if result.Context.Denial != nil {
+		t.Fatalf("disabled delivery leaked discovery-kind detail: %#v", result.Context.Denial)
 	}
 
 	// The report is an observation, so replaying the same request must return
@@ -77,11 +83,25 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryWithoutReceipt(t *testing
 	}
 }
 
-// TestReviewValidateKeepsGoverningReceiptAuthoritativeWhileDisabled proves the
-// asymmetry the disposition already encodes: disabling freezes authority
-// read-only, it never unmakes an approval that was content-bound to exactly
-// these bytes.
-func TestReviewValidateKeepsGoverningReceiptAuthoritativeWhileDisabled(t *testing.T) {
+// TestReviewValidateReportsDisabledUnmanagedDeliveryEvenOverAGoverningReceipt
+// is Wave 5 Slice 2's most consequential behavior reversal (design decision
+// 4; rdd-receipt-only-gates/spec.md's "Kill switch off short-circuits before
+// authority discovery" scenario, stated as a firm requirement, not a tagged
+// pending assumption): the kill switch is now consulted before ANY receipt
+// or authority read, so even an EXACTLY governing receipt is never
+// consulted while disabled -- not read, not silently kept authoritative, not
+// distinguished from "no receipt at all". This replaces the former
+// TestReviewValidateKeepsGoverningReceiptAuthoritativeWhileDisabled, which
+// asserted the opposite: that disabling froze a governing receipt read-only
+// and it kept authorizing delivery. Under the new ordered contract
+// (capability -> kill switch -> governing authority -> relation -> verdict)
+// that asymmetry no longer holds: while disabled, receipt-driven development
+// does not exist at all, so nothing -- not even an approval earned moments
+// earlier over the exact same bytes -- governs. Re-enabling rediscovers the
+// SAME receipt and it governs again unchanged (proven below): the receipt
+// itself is never mutated or invalidated, it is simply not consulted while
+// the switch is off.
+func TestReviewValidateReportsDisabledUnmanagedDeliveryEvenOverAGoverningReceipt(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("reviewed candidate behavior\n"), 0o644); err != nil {
@@ -98,6 +118,7 @@ func TestReviewValidateKeepsGoverningReceiptAuthoritativeWhileDisabled(t *testin
 	}
 	runReviewCLIGit(t, repo, "add", "tracked.txt")
 
+	// Before disabling: the receipt genuinely governs and allows.
 	var enabled bytes.Buffer
 	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &enabled); err != nil {
 		t.Fatalf("receipt-governed gate before disabling: %v\n%s", err, enabled.String())
@@ -106,18 +127,26 @@ func TestReviewValidateKeepsGoverningReceiptAuthoritativeWhileDisabled(t *testin
 
 	disableReviewForClone(t, repo)
 
+	// While disabled: the same governing receipt is never consulted. The
+	// report is the identical generic disabled/unmanaged shape every other
+	// disabled scenario produces, not the allow the receipt would have
+	// earned.
 	var disabled bytes.Buffer
-	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &disabled); err != nil {
-		t.Fatalf("disabling revoked a receipt that governs these exact bytes: %v\n%s", err, disabled.String())
+	disabledErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &disabled)
+	if disabledErr != nil {
+		t.Fatalf("disabled gate vetoed delivery instead of reporting it: %v\n%s", disabledErr, disabled.String())
 	}
-	assertReviewGateResult(t, disabled.Bytes(), reviewtransaction.GateAllow)
-	var result ReviewValidateResult
-	decodeStrictReviewJSON(t, disabled.Bytes(), &result)
-	if result.Delivery == reviewtransaction.RDDDeliveryDisabledUnmanaged {
-		t.Fatalf("a governing receipt was reported as unmanaged: %#v", result)
+	assertDisabledUnmanagedGate(t, disabledErr, disabled.Bytes())
+
+	// Re-enabling rediscovers the SAME receipt, unmutated, and it governs
+	// again exactly as before -- proving the switch never touched it.
+	enableReviewForClone(t, repo)
+	var reEnabled bytes.Buffer
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &reEnabled); err != nil {
+		t.Fatalf("receipt-governed gate after re-enabling: %v\n%s", err, reEnabled.String())
 	}
-	if !bytes.Equal(disabled.Bytes(), enabled.Bytes()) {
-		t.Fatalf("the receipt-governed projection changed after disabling:\nenabled:\n%s\ndisabled:\n%s", enabled.String(), disabled.String())
+	if !bytes.Equal(reEnabled.Bytes(), enabled.Bytes()) {
+		t.Fatalf("the receipt-governed projection changed across a disable/re-enable cycle:\nbefore:\n%s\nafter:\n%s", enabled.String(), reEnabled.String())
 	}
 }
 
@@ -158,6 +187,11 @@ func TestReviewValidateWithoutReceiptStillDeniesWhileReviewIsEnabled(t *testing.
 // govern the current candidate is the expected state of a disabled clone — no
 // new receipt could have been created while disabled — so it must not turn
 // "unmanaged by choice" into a mismatch denial.
+//
+// Wave 5 Slice 2 (design decision 4): each shape also asserts the SAME drift
+// still denies with its named code while reviews are ON, checked BEFORE
+// disabling -- the discovery-kind visibility this test's disabled half used
+// to assert moved here, since discovery genuinely still runs while enabled.
 func TestReviewValidateReportsDisabledUnmanagedDeliveryWithPriorReceipt(t *testing.T) {
 	shapes := []struct {
 		name string
@@ -213,16 +247,32 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryWithPriorReceipt(t *testi
 			shape.review(t, repo)
 			configureCLIReviewPublicationRemote(t, repo, branch)
 
-			disableReviewForClone(t, repo)
-
-			// New work authored and committed while disabled: no receipt can
-			// exist for it, so the stale receipt must not turn "unmanaged by
-			// choice" into a fault.
-			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("work authored while disabled\n"), 0o644); err != nil {
+			// New work authored and committed: no receipt can exist for it, so
+			// the stale receipt must not turn "unmanaged by choice" into a
+			// fault while disabled -- but while ENABLED it must still fail
+			// closed and name this exact discovery kind.
+			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("work authored after the reviewed candidate\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			runReviewCLIGit(t, repo, "add", "tracked.txt")
-			runReviewCLIGit(t, repo, "commit", "-qm", "authored while disabled")
+			runReviewCLIGit(t, repo, "commit", "-qm", "work authored after the reviewed candidate")
+
+			var enabledOutput bytes.Buffer
+			enabledErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(shape.gate)}, &enabledOutput)
+			var enabledDenied ReviewGateDeniedError
+			if !errors.As(enabledErr, &enabledDenied) {
+				t.Fatalf("enabled drift over a prior receipt did not fail closed: %T %v\n%s", enabledErr, enabledErr, enabledOutput.String())
+			}
+			var enabledResult ReviewValidateResult
+			decodeStrictReviewJSON(t, enabledOutput.Bytes(), &enabledResult)
+			if enabledResult.Delivery != "" {
+				t.Fatalf("an enabled switch reported a delivery disposition: %#v", enabledResult)
+			}
+			if enabledResult.Allowed || enabledResult.Context.Denial == nil || enabledResult.Context.Denial.Code != shape.wantDenialCode {
+				t.Fatalf("enabled drift denial = %#v, want code %q", enabledResult.Context.Denial, shape.wantDenialCode)
+			}
+
+			disableReviewForClone(t, repo)
 
 			var output bytes.Buffer
 			err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(shape.gate)}, &output)
@@ -232,26 +282,7 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryWithPriorReceipt(t *testi
 			if err != nil {
 				t.Fatalf("disabled delivery with a prior receipt was denied instead of reported: %v\n%s", err, output.String())
 			}
-			var result ReviewValidateResult
-			decodeStrictReviewJSON(t, output.Bytes(), &result)
-			if result.Schema != ReviewValidateSchema {
-				t.Fatalf("disabled delivery left the typed gate schema = %q", result.Schema)
-			}
-			if result.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
-				t.Fatalf("disabled delivery with a prior receipt = %q, want %q", result.Delivery, reviewtransaction.RDDDeliveryDisabledUnmanaged)
-			}
-			// Unmanaged by choice is neither an approval nor a fault.
-			if result.Allowed || result.Result == reviewtransaction.GateAllow {
-				t.Fatalf("disabled delivery fabricated an approval: %#v", result)
-			}
-			var denied ReviewGateDeniedError
-			if errors.As(err, &denied) {
-				t.Fatalf("disabled delivery was reported as a denial: %#v", denied)
-			}
-			// The reason the prior receipt does not govern stays discoverable.
-			if result.Context.Denial == nil || result.Context.Denial.Code != shape.wantDenialCode {
-				t.Fatalf("disabled delivery hid why no receipt governs: %#v, want code %q", result.Context.Denial, shape.wantDenialCode)
-			}
+			assertDisabledUnmanagedGate(t, err, output.Bytes())
 
 			// The report is an observation: replaying returns the same bytes.
 			var replay bytes.Buffer
@@ -274,6 +305,11 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryWithPriorReceipt(t *testi
 // versus the reviewed receipt, made over a provably healthy authority store.
 // It must classify as a receipt/scope mismatch that the disabled switch
 // reports as `disabled/unmanaged` with exit 0, never as `authority_corrupted`.
+//
+// Wave 5 Slice 2 supersession (design decision 4): the "delivery-shape-mismatch"
+// detail this disabled report used to carry moved to the enabled-mode
+// sibling TestReviewValidateDeniesDeliveredWorkspaceReceiptPrePushAsScopeMismatchWhileEnabled
+// below, where discovery genuinely still runs.
 func TestReviewValidateReportsDisabledUnmanagedDeliveryOverDeliveredWorkspaceReceiptAtPrePush(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -308,27 +344,7 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverDeliveredWorkspaceRec
 	if err != nil {
 		t.Fatalf("disabled delivery over a delivered workspace receipt was denied instead of reported: %v\n%s", err, output.String())
 	}
-	var result ReviewValidateResult
-	decodeStrictReviewJSON(t, output.Bytes(), &result)
-	if result.Schema != ReviewValidateSchema {
-		t.Fatalf("disabled delivery left the typed gate schema = %q", result.Schema)
-	}
-	if result.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
-		t.Fatalf("disabled delivery over a delivered workspace receipt = %q, want %q", result.Delivery, reviewtransaction.RDDDeliveryDisabledUnmanaged)
-	}
-	// Unmanaged by choice is neither an approval nor a fault.
-	if result.Allowed || result.Result == reviewtransaction.GateAllow {
-		t.Fatalf("disabled delivery fabricated an approval: %#v", result)
-	}
-	var denied ReviewGateDeniedError
-	if errors.As(err, &denied) {
-		t.Fatalf("disabled delivery was reported as a denial: %#v", denied)
-	}
-	// The real reason the receipt does not govern stays discoverable, and it is
-	// the delivery shape — never corruption of a provably healthy store.
-	if result.Context.Denial == nil || result.Context.Denial.Code != "delivery-shape-mismatch" {
-		t.Fatalf("disabled delivery hid why no receipt governs: %#v, want code %q", result.Context.Denial, "delivery-shape-mismatch")
-	}
+	assertDisabledUnmanagedGate(t, err, output.Bytes())
 
 	// The report is an observation: replaying returns the same bytes.
 	var replay bytes.Buffer
@@ -403,6 +419,14 @@ func TestReviewValidateDeniesDeliveredWorkspaceReceiptPrePushAsScopeMismatchWhil
 // and the reason names it — and it is deferred, not forgiven, because
 // re-enabling rediscovers it and blocks again (see
 // TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled).
+//
+// Wave 5 Slice 2 supersession (design decision 4): the switch is consulted
+// BEFORE any authority read regardless of gate, so this pre-push disabled
+// report no longer discovers the corruption either -- the "unavailable or
+// corrupted" visibility property is gate-independent (corruption is about
+// the authority inventory, not the boundary) and is already the sole
+// responsibility of TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled
+// (pre-commit gate, identical inventory-corruption mechanism).
 func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthorityAtPrePush(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -436,10 +460,7 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthorityAtP
 
 	var output bytes.Buffer
 	runErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePush)}, &output)
-	result := assertDisabledUnmanagedGate(t, runErr, output.Bytes(), string(ReviewAuthorityCorrupted))
-	if !strings.Contains(result.Reason, "unavailable or corrupted") {
-		t.Fatalf("disabled corrupted-authority reason hid the damage at pre-push: %q", result.Reason)
-	}
+	assertDisabledUnmanagedGate(t, runErr, output.Bytes())
 }
 
 // TestReviewValidateReportsDisabledUnmanagedDeliveryWhenNoUpstreamConfigured
@@ -477,24 +498,7 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryWhenNoUpstreamConfigured(
 	if err != nil {
 		t.Fatalf("disabled delivery with no configured upstream was denied instead of reported: %v\n%s", err, output.String())
 	}
-	var result ReviewValidateResult
-	decodeStrictReviewJSON(t, output.Bytes(), &result)
-	if result.Schema != ReviewValidateSchema {
-		t.Fatalf("disabled delivery left the typed gate schema = %q", result.Schema)
-	}
-	if result.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
-		t.Fatalf("disabled delivery with no upstream = %q, want %q", result.Delivery, reviewtransaction.RDDDeliveryDisabledUnmanaged)
-	}
-	if result.Allowed || result.Result == reviewtransaction.GateAllow {
-		t.Fatalf("disabled delivery with no upstream fabricated an approval: %#v", result)
-	}
-	var denied ReviewGateDeniedError
-	if errors.As(err, &denied) {
-		t.Fatalf("disabled delivery with no upstream was reported as a denial: %#v", denied)
-	}
-	if result.Context.Denial == nil {
-		t.Fatalf("disabled delivery with no upstream hid why no receipt governs: %#v", result)
-	}
+	assertDisabledUnmanagedGate(t, err, output.Bytes())
 
 	// The report is an observation, so replaying the same request must return
 	// the same bytes.
@@ -552,9 +556,13 @@ func TestReviewValidateDeniesNoUpstreamTargetResolutionWhileEnabled(t *testing.T
 // TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthorityNoUpstream
 // covers issue-1832's own fix site under the maintainer's rule. It previously
 // asserted the opposite (`...KeepsFailingClosedOnCorruptedAuthorityWhileDisabledNoUpstream`).
-// A damaged store with no upstream and the switch off still names
-// `authority_corrupted` — the damage is never hidden — but it no longer stops a
-// push, because a switched-off system has no implications.
+// A damaged store with no upstream and the switch off no longer stops a push,
+// because a switched-off system has no implications.
+//
+// Wave 5 Slice 2 supersession (design decision 4): same as the pre-push
+// corrupted-authority case above -- corruption visibility is gate-independent
+// and already the sole responsibility of
+// TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled.
 func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthorityNoUpstream(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -586,10 +594,7 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthorityNoU
 
 	var output bytes.Buffer
 	runErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePush)}, &output)
-	result := assertDisabledUnmanagedGate(t, runErr, output.Bytes(), string(ReviewAuthorityCorrupted))
-	if !strings.Contains(result.Reason, "unavailable or corrupted") {
-		t.Fatalf("disabled corrupted-authority reason with no upstream hid the damage: %q", result.Reason)
-	}
+	assertDisabledUnmanagedGate(t, runErr, output.Bytes())
 }
 
 // TestReviewValidatePluralStaleReceiptsReportDisabledUnmanagedDelivery closes
@@ -603,6 +608,13 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthorityNoU
 // receipt_ambiguous, which was never in the unmanaged-while-disabled set, so
 // the gate failed closed (exit 1) and blocked an ordinary commit with reviews
 // OFF -- exactly the pre-commit-hook shape decode2 reported.
+//
+// Wave 5 Slice 2 supersession (design decision 4): the specific
+// "candidate-or-paths-mismatch" (alone) and "receipt_ambiguous"
+// (deterministically-stale, plural) codes this disabled report used to carry
+// moved to TestReviewValidateStaleAndPluralStaleReceiptsFailClosedWhileEnabled
+// below, which builds the identical alone-then-plural fixture progression
+// with reviews ON throughout.
 func TestReviewValidatePluralStaleReceiptsReportDisabledUnmanagedDelivery(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -623,14 +635,7 @@ func TestReviewValidatePluralStaleReceiptsReportDisabledUnmanagedDelivery(t *tes
 	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &alone); err != nil {
 		t.Fatalf("one stale receipt while disabled was denied instead of reported: %v\n%s", err, alone.String())
 	}
-	var aloneResult ReviewValidateResult
-	decodeStrictReviewJSON(t, alone.Bytes(), &aloneResult)
-	if aloneResult.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged || aloneResult.Allowed {
-		t.Fatalf("one stale receipt while disabled = %#v, want disabled/unmanaged", aloneResult)
-	}
-	if aloneResult.Context.Denial == nil || aloneResult.Context.Denial.Code != "candidate-or-paths-mismatch" {
-		t.Fatalf("one stale receipt while disabled denial = %#v", aloneResult.Context.Denial)
-	}
+	assertDisabledUnmanagedGate(t, nil, alone.Bytes())
 
 	// cloneApprovedDiscoveryAuthority operates directly on the compact store,
 	// bypassing the CLI's own disabled-mode gate on review/start -- exactly
@@ -651,21 +656,7 @@ func TestReviewValidatePluralStaleReceiptsReportDisabledUnmanagedDelivery(t *tes
 	if err != nil {
 		t.Fatalf("plural stale receipts while disabled were denied instead of reported: %v\n%s", err, plural.String())
 	}
-	var pluralResult ReviewValidateResult
-	decodeStrictReviewJSON(t, plural.Bytes(), &pluralResult)
-	if pluralResult.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
-		t.Fatalf("plural stale receipts while disabled = %q, want %q", pluralResult.Delivery, reviewtransaction.RDDDeliveryDisabledUnmanaged)
-	}
-	if pluralResult.Allowed || pluralResult.Result == reviewtransaction.GateAllow {
-		t.Fatalf("plural stale receipts while disabled fabricated an approval: %#v", pluralResult)
-	}
-	var denied ReviewGateDeniedError
-	if errors.As(err, &denied) {
-		t.Fatalf("plural stale receipts while disabled were reported as a denial: %#v", denied)
-	}
-	if pluralResult.Context.Denial == nil || pluralResult.Context.Denial.Code != string(ReviewReceiptAmbiguous) {
-		t.Fatalf("plural stale receipts while disabled hid why no receipt governs: %#v", pluralResult.Context.Denial)
-	}
+	assertDisabledUnmanagedGate(t, nil, plural.Bytes())
 
 	// The report is an observation, so replaying the same request must return
 	// the same bytes.
@@ -678,52 +669,49 @@ func TestReviewValidatePluralStaleReceiptsReportDisabledUnmanagedDelivery(t *tes
 	}
 }
 
-// TestReviewDiscoveryLeftTheGateUndecidedNamesTheUndecidableCompositions
-// replaces the former
-// `TestReviewReceiptDiscoveryIsUnmanagedWhileDisabledRejectsUndecidableAmbiguousCompositions`,
-// which asserted that these compositions keep BLOCKING while disabled. Under
-// the maintainer's rule nothing blocks while the switch is off, so the same
-// distinction now decides something else: whether the reported result must
-// additionally SAY the gate could not decide which authority applies. It is
-// still load-bearing — it is what keeps "not blocking" from collapsing into
-// "pretending nothing was ambiguous".
-//
-// The two live producers of an undecidable composition (assessmentUnknown and
-// scopeWithoutContext) require forcing an untyped AssessCompactGateTarget error
-// or a CompactScopeChangeDiagnostics failure, both unit-tested at their own
-// layer in internal/reviewtransaction, so this proves the classifier directly
-// against the exact composition boundary discoverCompactFacadeGateReview
-// computes: DeterministicallyStaleOnly is set only when both scopeWithoutContext
-// and assessmentUnknown are empty.
-func TestReviewDiscoveryLeftTheGateUndecidedNamesTheUndecidableCompositions(t *testing.T) {
-	// An undecidable mixture, or two receipts each exactly governing: the gate
-	// could not decide, so the disabled report must say so.
-	undecidable := &ReviewReceiptDiscoveryError{Kind: ReviewReceiptAmbiguous, Candidates: []string{"a", "b"}}
-	if !reviewDiscoveryLeftTheGateUndecided(undecidable) {
-		t.Fatalf("undecidable ambiguous composition was not reported as undecided: %#v", undecidable)
+// TestReviewValidateStaleAndPluralStaleReceiptsFailClosedWhileEnabled is the
+// enabled half of TestReviewValidatePluralStaleReceiptsReportDisabledUnmanagedDelivery
+// above: the identical alone-then-plural fixture progression, reviews ON
+// throughout, pinning the discovery-kind visibility the disabled half no
+// longer carries (Wave 5 Slice 2, design decision 4).
+func TestReviewValidateStaleAndPluralStaleReceiptsFailClosedWhileEnabled(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	logicalPath := "docs/plural-stale-enabled.md"
+	lineageA := "review-enabled-plural-stale-a"
+	lineageB := "review-enabled-plural-stale-b"
+
+	_, storeA := approveDiscoveryMarkdownProjection(t, repo, lineageA, logicalPath, "reviewed\n", reviewtransaction.ProjectionWorkspace)
+	if err := os.WriteFile(filepath.Join(repo, filepath.FromSlash(logicalPath)), []byte("drifted\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	// Proven stale-only: discovery DID decide — nothing governs — so the
-	// disposition sentence stands alone, byte-identical to what already shipped.
-	staleOnly := &ReviewReceiptDiscoveryError{Kind: ReviewReceiptAmbiguous, Candidates: []string{"a", "b"}, DeterministicallyStaleOnly: true}
-	if reviewDiscoveryLeftTheGateUndecided(staleOnly) {
-		t.Fatalf("deterministically-stale-only composition was reported as undecided: %#v", staleOnly)
+
+	// One stale receipt: candidate-or-paths-mismatch, still fails closed.
+	var alone bytes.Buffer
+	aloneErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &alone)
+	var aloneDenied ReviewGateDeniedError
+	if !errors.As(aloneErr, &aloneDenied) {
+		t.Fatalf("one stale receipt while enabled did not fail closed: %T %v\n%s", aloneErr, aloneErr, alone.String())
 	}
-	// Damaged authority is always undecided, whatever the field says.
-	corrupted := &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
-	if !reviewDiscoveryLeftTheGateUndecided(corrupted) {
-		t.Fatalf("corrupted authority was not reported as undecided: %#v", corrupted)
+	var aloneResult ReviewValidateResult
+	decodeStrictReviewJSON(t, alone.Bytes(), &aloneResult)
+	if aloneResult.Allowed || aloneResult.Context.Denial == nil || aloneResult.Context.Denial.Code != "candidate-or-paths-mismatch" {
+		t.Fatalf("one stale receipt while enabled denial = %#v", aloneResult.Context.Denial)
 	}
-	// Outcomes that prove non-governance keep the plain disposition sentence.
-	for _, kind := range []ReviewReceiptDiscoveryKind{
-		ReviewReceiptMissing, ReviewReceiptUnrelated, ReviewReceiptScopeChanged, ReviewReceiptTargetUnresolvable,
-	} {
-		decided := &ReviewReceiptDiscoveryError{Kind: kind}
-		if reviewDiscoveryLeftTheGateUndecided(decided) {
-			t.Fatalf("%q was reported as undecided", kind)
-		}
-		if got := reviewDisabledUnmanagedDeliveryReason(decided); got != reviewDisabledUnmanagedReason {
-			t.Fatalf("%q disabled reason = %q, want the shipped sentence unchanged", kind, got)
-		}
+
+	// A second, independently-reviewed stale receipt: the pair classifies
+	// deterministically-stale-only ambiguous, and still fails closed.
+	cloneApprovedDiscoveryAuthority(t, repo, storeA, lineageB)
+	var plural bytes.Buffer
+	pluralErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &plural)
+	var pluralDenied ReviewGateDeniedError
+	if !errors.As(pluralErr, &pluralDenied) {
+		t.Fatalf("plural stale receipts while enabled did not fail closed: %T %v\n%s", pluralErr, pluralErr, plural.String())
+	}
+	var pluralResult ReviewValidateResult
+	decodeStrictReviewJSON(t, plural.Bytes(), &pluralResult)
+	if pluralResult.Allowed || pluralResult.Context.Denial == nil || pluralResult.Context.Denial.Code != string(ReviewReceiptAmbiguous) {
+		t.Fatalf("plural stale receipts while enabled denial = %#v", pluralResult.Context.Denial)
 	}
 }
 

--- a/internal/cli/review_disabled_reach_test.go
+++ b/internal/cli/review_disabled_reach_test.go
@@ -64,10 +64,17 @@ func corruptReviewAuthorityInventory(t *testing.T, repo string) {
 	}
 }
 
-// assertDisabledUnmanagedGate is the single shape every reclassified discovery
-// outcome must produce while disabled: exit 0, no denial error, no approval, no
-// invented receipt, and the reason the gate could not govern still discoverable.
-func assertDisabledUnmanagedGate(t *testing.T, runErr error, payload []byte, wantCode string) ReviewValidateResult {
+// assertDisabledUnmanagedGate is the single shape EVERY reclassified discovery
+// outcome must produce while disabled (Wave 5 Slice 2, design decision 4):
+// exit 0, no denial error, no approval, no invented receipt, the fixed
+// generic disabled reason (reviewDisabledUnmanagedReason, byte-identical
+// regardless of what authority-store damage or ambiguity exists — discovery
+// never runs while disabled, so there is nothing scenario-specific to carry),
+// and no Denial/discovery-kind detail at all. The discovery-kind-specific
+// visibility this helper used to assert (a `wantCode` parameter) moved to
+// each scenario's "...WhileEnabled" sibling test, where discovery genuinely
+// still runs and the property is still true.
+func assertDisabledUnmanagedGate(t *testing.T, runErr error, payload []byte) ReviewValidateResult {
 	t.Helper()
 	if runErr != nil {
 		t.Fatalf("disabled gate vetoed delivery instead of reporting it: %v\n%s", runErr, string(payload))
@@ -84,8 +91,11 @@ func assertDisabledUnmanagedGate(t *testing.T, runErr error, payload []byte, wan
 	if result.Allowed || result.Result == reviewtransaction.GateAllow {
 		t.Fatalf("disabled gate fabricated an approval: %#v", result)
 	}
-	if result.Context.Denial == nil || result.Context.Denial.Code != wantCode {
-		t.Fatalf("disabled gate denial = %#v, want code %q", result.Context.Denial, wantCode)
+	if result.Context.Denial != nil {
+		t.Fatalf("disabled gate leaked discovery-kind detail: %#v (design decision 4: no discovery kind while disabled)", result.Context.Denial)
+	}
+	if result.Reason != reviewDisabledUnmanagedReason {
+		t.Fatalf("disabled gate reason = %q, want the fixed generic sentence %q", result.Reason, reviewDisabledUnmanagedReason)
 	}
 	return result
 }
@@ -99,7 +109,7 @@ func assertDisabledUnmanagedGate(t *testing.T, runErr error, payload []byte, wan
 func TestReviewValidateReportsDisabledUnmanagedDeliveryOverMultipleExactReceipts(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
-	lineages := approveTwoExactlyGoverningReceipts(t, repo)
+	_ = approveTwoExactlyGoverningReceipts(t, repo)
 
 	disableReviewForClone(t, repo)
 
@@ -112,15 +122,12 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverMultipleExactReceipts
 
 	var output bytes.Buffer
 	runErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output)
-	result := assertDisabledUnmanagedGate(t, runErr, output.Bytes(), string(ReviewReceiptAmbiguous))
-
-	// Information must not be destroyed: not blocking is not the same as
-	// pretending nothing was ambiguous, so the competing lineages stay named.
-	for _, lineage := range lineages {
-		if !strings.Contains(result.Reason, lineage) {
-			t.Fatalf("disabled gate dropped the competing lineage %q from its reason: %q", lineage, result.Reason)
-		}
-	}
+	// Wave 5 Slice 2 (design decision 4): the competing-lineage detail this
+	// disabled report used to carry moved to the enabled-mode sibling
+	// TestReviewValidateKeepsFailingClosedOnMultipleExactReceiptsWhileEnabled
+	// below, where discovery genuinely still runs. While disabled, discovery
+	// never runs at all, so there is nothing scenario-specific left to name.
+	assertDisabledUnmanagedGate(t, runErr, output.Bytes())
 
 	var replay bytes.Buffer
 	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &replay); err != nil {
@@ -135,6 +142,14 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverMultipleExactReceipts
 // the regression that matters most: with reviews ON, two exactly-governing
 // receipts still block, byte-for-byte as before, and the gate still refuses to
 // pick for the caller.
+//
+// Wave 5 Slice 2 supersession: this is also now the sole home of the
+// competing-lineage-names-visible property that
+// TestReviewValidateReportsDisabledUnmanagedDeliveryOverMultipleExactReceipts
+// above used to assert on the DISABLED half too (removed there — design
+// decision 4's "no discovery kind while disabled" means that half no longer
+// runs discovery at all, so it has nothing to name). The property survives
+// here because discovery genuinely still runs while reviews are ON.
 func TestReviewValidateKeepsFailingClosedOnMultipleExactReceiptsWhileEnabled(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -170,11 +185,15 @@ func TestReviewValidateKeepsFailingClosedOnMultipleExactReceiptsWhileEnabled(t *
 // TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthority is
 // the deliberate decision on damaged authority. Corrupted review authority is
 // damage to a system the operator switched off; blocking an ordinary commit on
-// it is exactly the implication the rule removes. So the gate defers — and says
-// so loudly rather than silently: the denial code stays `authority_corrupted`
-// and the reason names the damage, so the user is told without being stopped.
-// Re-enabling rediscovers the same damage and blocks again, so nothing is
-// forgiven, only deferred.
+// it is exactly the implication the rule removes. So the gate defers.
+//
+// Wave 5 Slice 2 supersession (design decision 4): the switch is now
+// consulted BEFORE any authority read, so this disabled report no longer even
+// discovers the corruption — "visible, not silent: the damage is named" moved
+// to TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled
+// below, where discovery genuinely still runs. Re-enabling still rediscovers
+// the same damage and blocks, so nothing is forgiven, only deferred; while
+// disabled, the damage simply never gets read in the first place.
 func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthority(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -196,16 +215,14 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverCorruptedAuthority(t 
 
 	var output bytes.Buffer
 	runErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &output)
-	result := assertDisabledUnmanagedGate(t, runErr, output.Bytes(), string(ReviewAuthorityCorrupted))
-	// Visible, not silent: the damage is named in the reported reason.
-	if !strings.Contains(result.Reason, "unavailable or corrupted") {
-		t.Fatalf("disabled corrupted-authority reason hid the damage: %q", result.Reason)
-	}
+	assertDisabledUnmanagedGate(t, runErr, output.Bytes())
 }
 
 // TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled is the
 // enabled half: with reviews on, damaged authority still fails closed exactly
-// as before.
+// as before, and still names the damage in the reason -- visible, not silent
+// (Wave 5 Slice 2: this is now the sole home of that visibility property; the
+// disabled half above no longer discovers the corruption at all).
 func TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -235,6 +252,10 @@ func TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled(t *tes
 	}
 	if result.Allowed || result.Context.Denial == nil || result.Context.Denial.Code != string(ReviewAuthorityCorrupted) {
 		t.Fatalf("enabled corrupted-authority denial = %#v", result)
+	}
+	// Visible, not silent: the damage is named in the reported reason.
+	if !strings.Contains(result.Reason, "unavailable or corrupted") {
+		t.Fatalf("enabled corrupted-authority reason hid the damage: %q", result.Reason)
 	}
 }
 
@@ -312,6 +333,14 @@ func TestReviewValidateNegotiatedContractKeepsFailingClosedWhileEnabled(t *testi
 // outside the disposition machinery on the argument that reclassifying would
 // mean "silently picking one authority system over the other". While disabled
 // neither is picked — the gate reports that it is not governing at all.
+//
+// Wave 5 Slice 2 supersession (design decision 4): the switch is consulted
+// BEFORE any authority read, so this disabled report no longer discovers the
+// contest at all, and the "compact v2 and legacy v1" detail it used to name
+// moved to review_receipt_discovery_test.go's
+// TestUnqualifiedGateDiscoveryOnMixedCompactAndLegacyAuthorityHonorsTheKillSwitch,
+// whose enabled half asserts the same message (errReviewMixedCompactLegacyAuthority
+// is returned directly while enabled, since discovery genuinely still runs).
 func TestReviewValidateReportsDisabledUnmanagedDeliveryOverMixedCompactAndLegacyAuthority(t *testing.T) {
 	fixture := newLegacyCLIFixture(t, "review-disabled-reach-mixed-legacy")
 	finalizeFacadeReviewForRepo(t, fixture.repo)
@@ -322,10 +351,7 @@ func TestReviewValidateReportsDisabledUnmanagedDeliveryOverMixedCompactAndLegacy
 	runErr := RunReviewFacadeValidate([]string{
 		"--cwd", fixture.repo, "--gate", string(reviewtransaction.GatePostApply),
 	}, &output)
-	result := assertDisabledUnmanagedGate(t, runErr, output.Bytes(), string(ReviewReceiptAmbiguous))
-	if !strings.Contains(result.Reason, "compact v2 and legacy v1") {
-		t.Fatalf("disabled mixed-authority reason hid the competing stores: %q", result.Reason)
-	}
+	assertDisabledUnmanagedGate(t, runErr, output.Bytes())
 }
 
 // TestReviewValidateReValidatesFromScratchAfterReEnabling proves the second
@@ -502,16 +528,26 @@ func finalizeApprovedFacadeReview(t *testing.T, repo, lineage string) {
 // TestDisabledGateNeverEmitsAllowOrCreatesReceipt sweeps every reclassified
 // discovery outcome and holds the non-negotiable boundary: `disabled/unmanaged`
 // exits 0 because it defers, never because it approved.
+//
+// Wave 5 Slice 2 (design decision 4): also the decoy-store zero-reads proof.
+// These three cases stage wildly different, even damaged, authority-store
+// content -- an ambiguous multi-receipt composition, a genuinely corrupted
+// (truncated) compact record, and no receipt at all -- behind the SAME gate.
+// Under the pre-Slice-2 contract these produced three DIFFERENT disabled
+// reasons (each naming its own discovery kind). Under the new contract the
+// switch is consulted before any of that content is ever read, so all three
+// must produce BYTE-IDENTICAL disabled output: the store's content
+// contributes nothing to what is reported, which is the portable,
+// CI-safe equivalent of Wave 4's own strace-based "zero authority-store
+// opens while disabled" verifier proof.
 func TestDisabledGateNeverEmitsAllowOrCreatesReceipt(t *testing.T) {
 	cases := []struct {
 		name  string
 		stage func(t *testing.T, repo string)
-		code  string
 	}{
 		{
 			name:  "multiple exactly governing receipts",
 			stage: func(t *testing.T, repo string) { approveTwoExactlyGoverningReceipts(t, repo) },
-			code:  string(ReviewReceiptAmbiguous),
 		},
 		{
 			name: "corrupted authority",
@@ -519,14 +555,13 @@ func TestDisabledGateNeverEmitsAllowOrCreatesReceipt(t *testing.T) {
 				approveDiscoveryMarkdownProjection(t, repo, "review-disabled-sweep-corrupt", "docs/sweep.md", "reviewed\n", reviewtransaction.ProjectionWorkspace)
 				corruptReviewAuthorityInventory(t, repo)
 			},
-			code: string(ReviewAuthorityCorrupted),
 		},
 		{
 			name:  "no receipt at all",
 			stage: func(t *testing.T, repo string) {},
-			code:  string(ReviewReceiptMissing),
 		},
 	}
+	outputs := make(map[string][]byte, len(cases))
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			reviewModeHome(t)
@@ -537,14 +572,22 @@ func TestDisabledGateNeverEmitsAllowOrCreatesReceipt(t *testing.T) {
 
 			var output bytes.Buffer
 			runErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output)
-			assertDisabledUnmanagedGate(t, runErr, output.Bytes(), testCase.code)
+			assertDisabledUnmanagedGate(t, runErr, output.Bytes())
 			if bytes.Contains(output.Bytes(), []byte(`"allow"`)) {
 				t.Fatalf("disabled gate emitted an allow: %s", output.String())
 			}
 			if after := reviewAuthorityFingerprint(t, repo); after != before {
 				t.Fatalf("disabled gate mutated review authority:\nbefore: %s\nafter:  %s", before, after)
 			}
+			outputs[testCase.name] = append([]byte(nil), output.Bytes()...)
 		})
+	}
+	first := outputs[cases[0].name]
+	for _, testCase := range cases[1:] {
+		if !bytes.Equal(outputs[testCase.name], first) {
+			t.Fatalf("decoy-store zero-reads proof failed: disabled output differs by store content\n%s:\n%s\n%s:\n%s",
+				cases[0].name, first, testCase.name, outputs[testCase.name])
+		}
 	}
 }
 

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2946,15 +2946,34 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 			}, negotiated, *contract)
 		}
 	}
+	// Wave 5 (Gate Cutover) Slice 2, design decision 4: the kill switch is
+	// consulted EXACTLY ONCE, here, before any review-authority read at all —
+	// before Amendment C's resolveGoverningAuthority, before compact
+	// discovery, before candidate-decline resolution, before legacy
+	// discovery. This collapses three prior consultation points
+	// (Amendment C's own discoveryErr branch, the contested compact+legacy
+	// branch, and the disabledDiscovery branch below — all removed) into
+	// one. Disabled ⇒ ordinary unmanaged delivery with a fixed, generic
+	// reason and no discovery-kind detail: while the switch is off,
+	// receipt-driven development does not exist, so nothing an authority
+	// read could have discovered — missing, stale, ambiguous, corrupted, or
+	// mixed compact/legacy — ever governs, or is even read, in the first
+	// place. This is an intentional loss of discovery detail versus the
+	// pre-Slice-2 shape (see review_disabled_reach_test.go /
+	// review_disabled_delivery_test.go for the enabled-mode homes the
+	// removed detail-visibility assertions moved to). Fencing this behind
+	// `!negotiated` used to mean the identical repository exited 0 for a
+	// human and 1 for any agent driving the negotiated contract (#2222).
+	if reviewDeliveryDisposition(ctx, root, false) == reviewtransaction.RDDDeliveryDisabledUnmanaged {
+		return emitDisabledUnmanagedDelivery(stdout, gateInput.Gate, negotiated, *contract)
+	}
 	// Amendment C's single shared branch (design decision 4, Wave 3 Slice
 	// 4): resolved BEFORE discoverCompactFacadeGateReview so every gate call
 	// that supplies no explicit --lineage marker for a v3 lineage stays
 	// byte-identical to legacy discovery below. A non-nil discoveryErr here
 	// is always a deny that must never fall through to legacy authorization.
+	// Reviews are ON here — a disabled switch already returned above.
 	if governs, evaluation, discoveryErr := resolveGoverningAuthority(ctx, root, *lineage, gateInput); discoveryErr != nil {
-		if reviewDeliveryDisposition(ctx, root, false) == reviewtransaction.RDDDeliveryDisabledUnmanaged {
-			return emitDisabledUnmanagedDelivery(stdout, gateInput.Gate, discoveryErr, negotiated, *contract)
-		}
 		return emitFacadeGateEvaluationNegotiated(stdout, reviewtransaction.NativeGateEvaluation{
 			Result: reviewtransaction.GateInvalidated, Reason: discoveryErr.Error(),
 			Context: reviewtransaction.GateContext{
@@ -2977,16 +2996,9 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 		}
 		if contested {
 			// Two independent authority systems both claim to govern this exact
-			// candidate. With reviews ON that refusal is correct: answering would
-			// mean silently picking one store over the other. With reviews OFF
-			// nothing is picked — the gate names neither store as governing,
-			// emits no lineage and no receipt, and defers to ordinary repository
-			// policy, so the contest has no delivery consequence until the
-			// operator turns reviews back on and resolves it.
-			mixed := &ReviewReceiptDiscoveryError{Kind: ReviewReceiptAmbiguous, Detail: errReviewMixedCompactLegacyAuthority.Error()}
-			if reviewDeliveryDisposition(ctx, root, false) == reviewtransaction.RDDDeliveryDisabledUnmanaged {
-				return emitDisabledUnmanagedDelivery(stdout, gateInput.Gate, mixed, negotiated, *contract)
-			}
+			// candidate. Reviews are ON here (a disabled switch already
+			// returned above before this discovery ever ran), so answering
+			// would mean silently picking one store over the other.
 			return errReviewMixedCompactLegacyAuthority
 		}
 		payload, err := os.ReadFile(compactStore.ReceiptPath())
@@ -3025,30 +3037,15 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 	} else if found {
 		return emitCandidateDeclinedUnmanagedDelivery(stdout, gateInput.Gate, decline, negotiated, *contract)
 	}
-	// The kill switch is consulted BEFORE the negotiation branch and for every
-	// discovery outcome. While reviews are off, receipt-driven development does
-	// not exist, so nothing it discovered — a missing receipt, a stale one, an
-	// unresolvable target, competing authority, or a damaged inventory — governs
-	// this candidate, and the gate reports rather than vetoes. It never
-	// approves: `allowed` stays false, no receipt or authority is invented, and
-	// the command exits successfully only because ordinary repository policy —
-	// hooks, tests, CI — decides instead. Fencing this behind `!negotiated` used
-	// to mean the identical repository exited 0 for a human and 1 for any agent
-	// driving the negotiated contract.
+	// Reviews are ON for everything below — the single early kill-switch
+	// consultation above already returned before any authority read when
+	// disabled, so every remaining branch is a genuine denial, never a
+	// disabled/unmanaged report (design decision 4; issue-1832's no-upstream
+	// case and every other compactErr shape here reach the SAME early
+	// disabled exit as everything else, before target resolution is even
+	// attempted).
 	var targetResolution *reviewtransaction.GateTargetResolutionError
-	var disabledDiscovery *ReviewReceiptDiscoveryError
-	if errors.As(compactErr, &targetResolution) {
-		// issue-1832: a repository with no upstream has no publication boundary
-		// to derive at all. It has no receipt to lose here, only a target it
-		// cannot compute while off.
-		disabledDiscovery = &ReviewReceiptDiscoveryError{Kind: ReviewReceiptTargetUnresolvable, Detail: targetResolution.Error()}
-	} else {
-		_ = errors.As(compactErr, &disabledDiscovery)
-	}
-	if disabledDiscovery != nil &&
-		reviewDeliveryDisposition(ctx, root, false) == reviewtransaction.RDDDeliveryDisabledUnmanaged {
-		return emitDisabledUnmanagedDelivery(stdout, gateInput.Gate, disabledDiscovery, negotiated, *contract)
-	}
+	_ = errors.As(compactErr, &targetResolution)
 	if !negotiated {
 		if targetResolution != nil {
 			return emitFacadeGateEvaluationNegotiated(stdout, reviewtransaction.NativeGateEvaluation{
@@ -4001,67 +3998,6 @@ const reviewDisabledUnmanagedReason = "receipt-driven development is disabled an
 // because anything was reviewed, so it says so in the same sentence.
 const reviewEmptyPublicationRangeReason = "the publication range is empty: every commit reachable from HEAD is already published on the push destination, so this push delivers nothing and no review receipt governs it"
 
-// reviewDiscoveryLeftTheGateUndecided reports whether discovery ended without
-// being able to say which authority applies, as opposed to proving that none
-// does.
-//
-// This no longer decides whether the gate blocks — while the kill switch is off
-// nothing does — it decides whether the emitted result must additionally SAY
-// that the gate could not decide. Not blocking is not the same as pretending
-// nothing was ambiguous, so these outcomes carry their full typed cause into
-// the reported reason instead of being flattened into the plain disposition
-// sentence.
-//
-// Two outcomes qualify. Ambiguous authority that is not provably stale-only:
-// either several receipts each EXACTLY govern (len(exact) > 1), or the mixture
-// contains a lineage whose assessment could not even be completed
-// (assessmentUnknown or scopeWithoutContext). And corrupted authority: the
-// inventory itself is unreadable.
-func reviewDiscoveryLeftTheGateUndecided(discovery *ReviewReceiptDiscoveryError) bool {
-	switch discovery.Kind {
-	case ReviewAuthorityCorrupted:
-		return true
-	case ReviewReceiptAmbiguous:
-		return !discovery.DeterministicallyStaleOnly
-	default:
-		return false
-	}
-}
-
-// reviewDisabledUnmanagedDeliveryReason states what governs delivery and, when
-// the gate could not decide which authority applies, exactly what it could not
-// decide. The damage or the contest is named rather than dropped, so a user who
-// wants to know still learns about it — they simply are not stopped by it.
-func reviewDisabledUnmanagedDeliveryReason(discovery *ReviewReceiptDiscoveryError) string {
-	if !reviewDiscoveryLeftTheGateUndecided(discovery) {
-		return reviewDisabledUnmanagedReason
-	}
-	detail := discovery.Error()
-	if discovery.Kind == ReviewAuthorityCorrupted && strings.TrimSpace(discovery.Category) != "" {
-		detail += " (" + discovery.Category + ")"
-	}
-	return reviewDisabledUnmanagedReason + "; the gate could not decide which review authority applies: " + detail
-}
-
-// emitDisabledUnmanagedDelivery reports a candidate no receipt governs under a
-// user-disabled kill switch.
-//
-// It never approves: `allowed` stays false, the result is not an allow, and no
-// receipt, PASS, or authority is invented. It also never vetoes, because a
-// disabled switch defers delivery to ordinary repository policy — hooks, tests,
-// and CI stay active and decide — so the command exits successfully and the
-// typed result names `disabled/unmanaged` as what governs. The discovery
-// context is preserved so the reason no receipt governs stays discoverable —
-// including the full scope-change diagnostics when a stale receipt stopped
-// matching the candidate, and the typed cause when the gate could not decide at
-// all — and the whole result is derived from the same frozen authority so
-// replaying the same request returns the same bytes.
-//
-// Damage is deferred, never forgiven: a corrupted inventory reported here is
-// rediscovered and blocks again the moment reviews are switched back on. What
-// still fails closed is an unreadable KILL SWITCH — reviewDeliveryDisposition
-// treats an unresolvable mode as managed — so a tampered or broken mode record
-// can never manufacture this disposition.
 // emitCandidateDeclinedUnmanagedDelivery reports that RDD remains enabled but
 // the operator declined review for this exact candidate. It exits successfully
 // so ordinary repository policy can decide delivery, while explicitly refusing to
@@ -4089,20 +4025,39 @@ func emitCandidateDeclinedUnmanagedDelivery(stdout io.Writer, gate reviewtransac
 	return encodeReviewIntegrationOperation(stdout, negotiated, ReviewIntegrationOperationValidate, result, result, contract)
 }
 
-func emitDisabledUnmanagedDelivery(stdout io.Writer, gate reviewtransaction.GateKind, discovery *ReviewReceiptDiscoveryError, negotiated bool, contract string) error {
-	context := reviewtransaction.GateContext{
-		Gate:   gate,
-		Denial: &reviewtransaction.GateDenial{Stage: "receipt-discovery", Code: string(discovery.Kind)},
-	}
-	if discovery.Kind == ReviewReceiptScopeChanged && discovery.Context != nil {
-		context = *discovery.Context
-	}
+// emitDisabledUnmanagedDelivery reports a candidate no receipt governs under a
+// user-disabled kill switch.
+//
+// It never approves: `allowed` stays false, the result is not an allow, and no
+// receipt, PASS, or authority is invented. It also never vetoes, because a
+// disabled switch defers delivery to ordinary repository policy — hooks, tests,
+// and CI stay active and decide — so the command exits successfully and the
+// typed result names `disabled/unmanaged` as what governs.
+//
+// Wave 5 (Gate Cutover) Slice 2, design decision 4: the caller consults the
+// kill switch BEFORE any authority read, so this always reports the same
+// fixed, generic reason and carries no discovery-kind detail (no Denial, no
+// Context beyond the gate) — there is no discovery outcome to describe,
+// because discovery never runs. This is an intentional behavior change from
+// the pre-Slice-2 shape, which read authority first and then decorated the
+// disabled report with what it found (a missing receipt, a stale one, an
+// unresolvable target, competing authority, or a damaged inventory). That
+// detail-visibility property is still true and still tested — while reviews
+// are ON — in review_disabled_reach_test.go / review_disabled_delivery_test.go's
+// "...WhileEnabled" siblings; it never applied while disabled, because while
+// disabled receipt-driven development does not exist at all.
+//
+// The whole result is a fixed constant for a given gate, so replaying the
+// same request always returns the same bytes, and a decoy/corrupted store
+// contributes nothing to it — proven by
+// TestDisabledOutputIsByteIdenticalRegardlessOfAuthorityStoreContent.
+func emitDisabledUnmanagedDelivery(stdout io.Writer, gate reviewtransaction.GateKind, negotiated bool, contract string) error {
 	result := ReviewValidateResult{
 		Schema: ReviewValidateSchema, Result: reviewtransaction.GateInvalidated, Allowed: false,
 		Action:   reviewDeliveryPolicyAction,
-		Reason:   reviewDisabledUnmanagedDeliveryReason(discovery),
+		Reason:   reviewDisabledUnmanagedReason,
 		Delivery: reviewtransaction.RDDDeliveryDisabledUnmanaged,
-		Context:  context,
+		Context:  reviewtransaction.GateContext{Gate: gate},
 	}
 	return encodeReviewIntegrationOperation(stdout, negotiated, ReviewIntegrationOperationValidate, result, result, contract)
 }

--- a/internal/cli/review_kill_switch_single_call_test.go
+++ b/internal/cli/review_kill_switch_single_call_test.go
@@ -1,0 +1,93 @@
+package cli
+
+// TestKillSwitchOrdering_SingleCallBeforeAuthorityRead is Wave 5 Slice 2's
+// task 3.1: a static AST guard proving runReviewFacadeValidate calls
+// reviewDeliveryDisposition EXACTLY ONCE. Before Slice 2 the funnel had
+// THREE such call sites (Amendment C's own discoveryErr branch, the
+// contested compact+legacy branch, and the disabledDiscovery branch --
+// design.md's stale "two late reads" prose undercounted this; see the
+// design.md amendment landed alongside this test). A behavioral (fixture)
+// proof cannot distinguish "one call" from "N calls that all happen to
+// agree" without an unwieldy toggle-mid-evaluation rig; a call-count guard
+// proves it directly and durably, in the pattern review_offer_absence_guard_test.go
+// and review_named_continuation_test.go already use for call-absence proofs
+// in this package.
+//
+// This is also the FIRST call any authority read must follow: the guard
+// additionally asserts the reviewDeliveryDisposition call is lexically
+// positioned before the function's first call to any of the authority-read
+// entry points (resolveGoverningAuthority, discoverCompactFacadeGateReview,
+// ResolveCandidateDeclineForGate, discoverFacadeReview), proving "before any
+// authority read" by source position, not just by call count.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+var killSwitchAuthorityReadSelectors = map[string]bool{
+	"resolveGoverningAuthority":       true,
+	"discoverCompactFacadeGateReview": true,
+	"ResolveCandidateDeclineForGate":  true,
+	"discoverFacadeReview":            true,
+}
+
+func TestKillSwitchOrdering_SingleCallBeforeAuthorityRead(t *testing.T) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, filepath.Join(".", "review_facade.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse review_facade.go: %v", err)
+	}
+
+	var target *ast.FuncDecl
+	ast.Inspect(file, func(node ast.Node) bool {
+		if fn, ok := node.(*ast.FuncDecl); ok && fn.Name.Name == "runReviewFacadeValidate" {
+			target = fn
+			return false
+		}
+		return true
+	})
+	if target == nil || target.Body == nil {
+		t.Fatal("runReviewFacadeValidate not found in review_facade.go")
+	}
+
+	killSwitchCalls := 0
+	var killSwitchPos, firstAuthorityReadPos token.Pos
+	ast.Inspect(target.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "reviewDeliveryDisposition" {
+			killSwitchCalls++
+			if killSwitchPos == token.NoPos {
+				killSwitchPos = call.Pos()
+			}
+		}
+		if killSwitchAuthorityReadSelectors[ident.Name] && firstAuthorityReadPos == token.NoPos {
+			firstAuthorityReadPos = call.Pos()
+		}
+		return true
+	})
+
+	if killSwitchCalls != 1 {
+		t.Fatalf("runReviewFacadeValidate calls reviewDeliveryDisposition %d times, want exactly 1 (three pre-Slice-2 call sites collapsed into one)", killSwitchCalls)
+	}
+	if killSwitchPos == token.NoPos {
+		t.Fatal("reviewDeliveryDisposition call not found")
+	}
+	if firstAuthorityReadPos == token.NoPos {
+		t.Fatal("no authority-read call found to order against -- update killSwitchAuthorityReadSelectors if the funnel's read entry points were renamed")
+	}
+	if killSwitchPos >= firstAuthorityReadPos {
+		t.Fatalf("kill switch consulted at %v is not lexically before the first authority read at %v",
+			fileSet.Position(killSwitchPos), fileSet.Position(firstAuthorityReadPos))
+	}
+}

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -631,6 +631,21 @@ func TestUnqualifiedGateDiscoveryOnMixedCompactAndLegacyAuthorityHonorsTheKillSw
 	if err == nil {
 		t.Fatal("mixed compact/legacy authority was silently resolved while enabled")
 	}
+	// Wave 5 Slice 2 supersession: this is now the sole home of the
+	// competing-stores-named-in-the-message property that
+	// review_disabled_reach_test.go's
+	// TestReviewValidateReportsDisabledUnmanagedDeliveryOverMixedCompactAndLegacyAuthority
+	// used to assert on its DISABLED half too (removed there -- design
+	// decision 4 means that half no longer discovers the contest at all).
+	// The negotiated envelope wraps the raw error behind a fixed catch-all
+	// message with no Cause populated for this unclassified error type, so
+	// the raw (non-negotiated) call is what still carries
+	// errReviewMixedCompactLegacyAuthority's own text verbatim.
+	var rawEnabled bytes.Buffer
+	rawErr := RunReviewFacadeValidate([]string{"--cwd", fixture.repo, "--gate", string(reviewtransaction.GatePostApply)}, &rawEnabled)
+	if rawErr == nil || !strings.Contains(rawErr.Error(), "compact v2 and legacy v1") {
+		t.Fatalf("enabled mixed-authority error hid the competing stores: %v", rawErr)
+	}
 
 	disableReviewForClone(t, fixture.repo)
 

--- a/internal/cli/review_wave5_kill_switch_ordering_test.go
+++ b/internal/cli/review_wave5_kill_switch_ordering_test.go
@@ -1,0 +1,135 @@
+package cli
+
+// Wave 5 (Gate Cutover), Slice 2: named per-gate regression tests (#2222/#2239
+// supersession evidence, tasks.md Gate Regression Test Index). Each of the 5
+// gates gets its own disabled-before-authority-read test and its own
+// switch-off double-eval byte-equivalence test, using the exact names
+// tasks.md specifies.
+//
+// Fixture: a corrupted (truncated) compact authority record present on disk,
+// per corruptReviewAuthorityInventory -- if the kill-switch check were not
+// genuinely first, this damage would surface (as it did before Slice 2; see
+// the removed reviewDisabledUnmanagedDeliveryReason-based visibility this
+// batch's other reconciled tests moved to their enabled-mode siblings). No
+// governing receipt is needed: the property under test is ORDERING (the
+// switch is consulted before any authority read happens at all), which a
+// no-receipt-plus-decoy-corruption fixture proves for every gate uniformly.
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// killSwitchOrderingFixture builds a repo with a corrupted authority decoy
+// and returns it disabled, ready for a validate call at any gate.
+func killSwitchOrderingFixture(t *testing.T) string {
+	t.Helper()
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	corruptReviewAuthorityInventory(t, repo)
+	disableReviewForClone(t, repo)
+	return repo
+}
+
+func assertGateDisabledBeforeAuthorityRead(t *testing.T, gate reviewtransaction.GateKind) {
+	t.Helper()
+	repo := killSwitchOrderingFixture(t)
+	var output bytes.Buffer
+	err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(gate)}, &output)
+	if err != nil {
+		t.Fatalf("%s disabled gate vetoed delivery instead of reporting it: %v\n%s", gate, err, output.String())
+	}
+	// assertDisabledUnmanagedGate itself proves no discovery-kind detail
+	// leaked -- the decoy corruption present on disk never surfaces, which
+	// is only possible if the switch was consulted before it was ever read.
+	assertDisabledUnmanagedGate(t, err, output.Bytes())
+}
+
+func assertDisabledDoubleEvalByteEquivalent(t *testing.T, gate reviewtransaction.GateKind) {
+	t.Helper()
+	repo := killSwitchOrderingFixture(t)
+	args := []string{"--cwd", repo, "--gate", string(gate)}
+	var first bytes.Buffer
+	if err := RunReviewFacadeValidate(args, &first); err != nil {
+		t.Fatalf("%s first disabled evaluation vetoed delivery: %v\n%s", gate, err, first.String())
+	}
+	var second bytes.Buffer
+	if err := RunReviewFacadeValidate(args, &second); err != nil {
+		t.Fatalf("%s second disabled evaluation vetoed delivery: %v\n%s", gate, err, second.String())
+	}
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatalf("%s disabled output is not byte-equivalent across two evaluations of the identical fixture (only the toggle stayed off -- idempotence proof, zero mutation on repeat):\nfirst:\n%s\nsecond:\n%s",
+			gate, first.String(), second.String())
+	}
+}
+
+func TestPostApplyGate_Disabled_ReportsUnmanagedBeforeAuthorityRead(t *testing.T) {
+	assertGateDisabledBeforeAuthorityRead(t, reviewtransaction.GatePostApply)
+}
+func TestPreCommitGate_Disabled_ReportsUnmanagedBeforeAuthorityRead(t *testing.T) {
+	assertGateDisabledBeforeAuthorityRead(t, reviewtransaction.GatePreCommit)
+}
+func TestPrePushGate_Disabled_ReportsUnmanagedBeforeAuthorityRead(t *testing.T) {
+	assertGateDisabledBeforeAuthorityRead(t, reviewtransaction.GatePrePush)
+}
+func TestPrePRGate_Disabled_ReportsUnmanagedBeforeAuthorityRead(t *testing.T) {
+	assertGateDisabledBeforeAuthorityRead(t, reviewtransaction.GatePrePR)
+}
+func TestReleaseGate_Disabled_ReportsUnmanagedBeforeAuthorityRead(t *testing.T) {
+	assertGateDisabledBeforeAuthorityRead(t, reviewtransaction.GateRelease)
+}
+
+func TestDisabledGateOutput_DoubleEval_ByteEquivalent_PostApply(t *testing.T) {
+	assertDisabledDoubleEvalByteEquivalent(t, reviewtransaction.GatePostApply)
+}
+func TestDisabledGateOutput_DoubleEval_ByteEquivalent_PreCommit(t *testing.T) {
+	assertDisabledDoubleEvalByteEquivalent(t, reviewtransaction.GatePreCommit)
+}
+func TestDisabledGateOutput_DoubleEval_ByteEquivalent_PrePush(t *testing.T) {
+	assertDisabledDoubleEvalByteEquivalent(t, reviewtransaction.GatePrePush)
+}
+func TestDisabledGateOutput_DoubleEval_ByteEquivalent_PrePR(t *testing.T) {
+	assertDisabledDoubleEvalByteEquivalent(t, reviewtransaction.GatePrePR)
+}
+func TestDisabledGateOutput_DoubleEval_ByteEquivalent_Release(t *testing.T) {
+	assertDisabledDoubleEvalByteEquivalent(t, reviewtransaction.GateRelease)
+}
+
+// TestDisabledOutputIsByteIdenticalRegardlessOfAuthorityStoreContent is the
+// decoy-store zero-reads proof referenced by emitDisabledUnmanagedDelivery's
+// doc comment: the SAME gate call, across a clean repo and a repo carrying a
+// corrupted authority decoy, must produce byte-identical disabled output.
+// The store's content contributes nothing to what is reported, which is the
+// portable, CI-safe equivalent of Wave 4's own strace-based "zero authority-
+// store opens while disabled" verifier proof (TestDisabledGateNeverEmitsAllowOrCreatesReceipt
+// in review_disabled_reach_test.go proves the same property across a wider
+// fixture sweep at post-apply specifically; this proves it across all 5
+// gates using the minimal clean-vs-decoy pair).
+func TestDisabledOutputIsByteIdenticalRegardlessOfAuthorityStoreContent(t *testing.T) {
+	for _, gate := range []reviewtransaction.GateKind{
+		reviewtransaction.GatePostApply, reviewtransaction.GatePreCommit, reviewtransaction.GatePrePush,
+		reviewtransaction.GatePrePR, reviewtransaction.GateRelease,
+	} {
+		t.Run(string(gate), func(t *testing.T) {
+			reviewModeHome(t)
+			clean := initReviewCLIRepo(t)
+			disableReviewForClone(t, clean)
+			var cleanOutput bytes.Buffer
+			if err := RunReviewFacadeValidate([]string{"--cwd", clean, "--gate", string(gate)}, &cleanOutput); err != nil {
+				t.Fatalf("%s clean disabled evaluation vetoed delivery: %v\n%s", gate, err, cleanOutput.String())
+			}
+
+			decoy := killSwitchOrderingFixture(t)
+			var decoyOutput bytes.Buffer
+			if err := RunReviewFacadeValidate([]string{"--cwd", decoy, "--gate", string(gate)}, &decoyOutput); err != nil {
+				t.Fatalf("%s decoy disabled evaluation vetoed delivery: %v\n%s", gate, err, decoyOutput.String())
+			}
+			if !bytes.Equal(cleanOutput.Bytes(), decoyOutput.Bytes()) {
+				t.Fatalf("%s disabled output differs between a clean repo and a corrupted-decoy repo:\nclean:\n%s\ndecoy:\n%s",
+					gate, cleanOutput.String(), decoyOutput.String())
+			}
+		})
+	}
+}

--- a/openspec/changes/rdd-root-simplification-wave5/design.md
+++ b/openspec/changes/rdd-root-simplification-wave5/design.md
@@ -6,6 +6,8 @@ The proposal claims "a gate mutates authority". Verified against `d591f4cf`, tha
 
 **Routing gate (hard block).** `resolveGoverningAuthority`, `CandidateIdentity` promotion, `ReceiptRef`, and capability admission do not exist at `d591f4cf` — they are Wave 3/4 deliverables. Wave 5 is HARD-GATED on Waves 3 and 4 landing; no Wave 5 slice may start before both merge.
 
+**Amendment (Slice 2 implementation, documented per the PR0 precedent):** the "two late kill-switch reads (`:2905`, `:2967`)" and "Removes `:2905` and `:2967`" references below describe the funnel's shape at `d591f4cf`, before Wave 3's Amendment C landed. By Slice 2's implementation the funnel actually had **three** `reviewDeliveryDisposition` call sites, not two: Amendment C's own `resolveGoverningAuthority` discoveryErr branch (a new site Wave 3 introduced), the contested compact+legacy branch, and the `disabledDiscovery` branch. Decision 4's own rationale column already anticipated this ("Three reads of one switch is the #2222/#2239 bug"); only the exit-count prose and line numbers were stale. All three collapsed into the single early consultation Decision 4 specifies; substance unchanged.
+
 ## Technical Approach
 
 Invert the gate from actor to reporter and collapse the funnel. `runReviewFacadeValidate` (`review_facade.go:2822`) today has four exits — compact receipt (`:2921`), pre-PR chain composition (`:2924`, `:2933`), decline authorization (`:2941`), legacy subprocess re-entry (`:3000-3023`) — plus two late kill-switch reads (`:2905`, `:2967`). Wave 5 replaces all of it with one ordered contract:

--- a/openspec/changes/rdd-root-simplification-wave5/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave5/tasks.md
@@ -157,14 +157,28 @@ added at that phase so the debt is not silently lost.
 
 **Phase 2 (S1) is COMPLETE.**
 
-## Phase 3 (S2): Kill Switch Consulted Once + Per-Gate Disabled Goldens
+## Phase 3 (S2): Kill Switch Consulted Once + Per-Gate Disabled Goldens — COMPLETE
 
-- [ ] 3.1 RED: `TestKillSwitchOrdering_SingleCallBeforeAuthorityRead` — one `reviewDeliveryDisposition(ctx, root, false)` call immediately after flag/contract resolution, before `discoverCompactFacadeGateReview` or any authority read; fails against current two-late-reads shape (`review_facade.go:2905`, `:2967`).
-- [ ] 3.2 RED per-gate disabled branch (5 named tests, #2222 evidence — see index above): kill switch off + ambiguous/corrupted authority-store fixture ⇒ ordinary unmanaged delivery, `reason_code: reviews_disabled`, no discovery kind, underlying authority error never surfaces.
-- [ ] 3.3 RED switch-off byte-equivalence via same-fixture double-eval (5 named tests, see index above): evaluate the same fixture twice while switch is OFF, assert byte-identical serialized `NativeGateEvaluation` output across both evaluations (idempotence proof, zero mutation on repeat).
-- [ ] 3.4 Implement single-call kill-switch ordering; remove the two late reads (`review_facade.go:2905`, `:2967`); wire `emitDisabledUnmanagedDelivery`.
-- [ ] 3.5 GREEN: 3.1–3.3 pass (11 named tests this slice).
-- [ ] 3.6 Full verification: `go test ./... -count=1`; bench module; `scripts/deadcode-ratchet.sh --update` for removed late-read call sites; refusal-resolution notes (none pending).
+Branch `feat/rdd-wave5-s2-kill-switch-first` (chained off S1). Real scope
+exceeded the ~350-line forecast (funnel actually had THREE kill-switch
+consultation points at implementation time, not the two the design doc's
+stale `d591f4cf`-era line references named — see the design.md amendment
+landed alongside this slice — and reconciling ~20 existing assertions across
+`review_disabled_reach_test.go`/`review_disabled_delivery_test.go`/e2e
+`organic_runtime_test.go` that pinned the OLD "discovery detail visible while
+disabled" contract was inseparable from the funnel reorder itself). Landed as
+one slice per the coordinator's explicit decision to accept the real ~850-line
+scope rather than split.
+
+- [x] 3.1 RED/GREEN: `TestKillSwitchOrdering_SingleCallBeforeAuthorityRead` — AST guard (not a behavioral fixture) proving `runReviewFacadeValidate` calls `reviewDeliveryDisposition` exactly once, lexically before its first authority-read call (`resolveGoverningAuthority`/`discoverCompactFacadeGateReview`/`ResolveCandidateDeclineForGate`/`discoverFacadeReview`). Genuine-wiring proven by reintroducing a second call site — guard failed ("calls reviewDeliveryDisposition 2 times, want exactly 1"); reverted byte-identically.
+- [x] 3.2 RED/GREEN per-gate disabled branch (5 named tests, exact names from the index above, `internal/cli/review_wave5_kill_switch_ordering_test.go`): corrupted-decoy-store fixture ⇒ ordinary unmanaged delivery, fixed generic reason, no discovery kind, underlying corruption never surfaces (proven directly by `assertDisabledUnmanagedGate`'s `Denial == nil` check).
+- [x] 3.3 RED/GREEN switch-off double-eval byte-equivalence (5 named tests, same file): identical fixture evaluated twice while off, byte-identical output.
+- [x] Additional (not in the original 11, added for rigor): `TestDisabledOutputIsByteIdenticalRegardlessOfAuthorityStoreContent` — the decoy-store zero-reads proof across all 5 gates (clean repo vs corrupted-decoy repo produce byte-identical disabled output — the portable, CI-safe equivalent of Wave 4's strace-based verifier proof).
+- [x] 3.4 Implemented: single-call kill-switch ordering placed immediately before `resolveGoverningAuthority` (after the pre-existing `GatePrePush`/`PrePushDeliversNothing` git-fact shortcut, a deliberate scoping choice — that shortcut reads repository state, not review authority, so it is unaffected); removed all three prior consultation points; `emitDisabledUnmanagedDelivery` simplified to a fixed-shape emitter (dropped its `discovery` parameter; deleted now-dead `reviewDiscoveryLeftTheGateUndecided` and `reviewDisabledUnmanagedDeliveryReason`). Mutation-proven by disabling the single check entirely — all 5 per-gate tests + the byte-identity test failed; reverted byte-identically.
+- [x] **Behavior reversal absorbed (found during reconciliation, not pre-planned)**: a governing receipt is no longer authoritative while disabled — `TestReviewValidateKeepsGoverningReceiptAuthoritativeWhileDisabled` (asserted the opposite) replaced with `TestReviewValidateReportsDisabledUnmanagedDeliveryEvenOverAGoverningReceipt`, and e2e's `TestOrganicTerminalAuthoritySurvivesWithdrawalAndReplaysWithoutEffect` updated to match — both now prove the receipt is unmutated and regoverns identically after re-enabling, but is never consulted while off. This is the literal reading of the spec-ratified (untagged, not a pending assumption) "before ANY receipt or authority read" scenario.
+- [x] **~20 discovery-visibility assertions reconciled** (guidance point 1): `assertDisabledUnmanagedGate` updated to the new contract first (reconciled ~10 sites in one move); remaining direct sites handled scenario-by-scenario — where the "damage/ambiguity is named" property still holds ENABLED, it moved to (or was added to) the enabled-mode sibling with a documented supersession comment; the `TestReviewDiscoveryLeftTheGateUndecided...` unit test (whose entire subject — how much detail to add — no longer applies) was deleted, not just edited.
+- [x] 3.5 GREEN: all named tests pass (16 in the dedicated kill-switch files + the AST guard), plus the full existing `internal/cli` and `e2e/organicruntime` suites green after reconciliation.
+- [x] 3.6 Full verification: `go test ./... -count=1` root module all green (including `e2e/organicruntime`, 6 tests reconciled to the new contract); bench module green; `scripts/deadcode-ratchet.sh` reports "no new unreachable functions" (2 functions deleted were reachable, not baseline entries, so no `--update` needed); bench journey corpus run against a fresh `go build ./cmd/gentle-ai` binary: 59/59 completed, 0 unsupported, 0 failed, exit 0; `gofmt -l .` / `go vet ./...` clean repo-wide. Rebase contract re-checked before this run: `feat/rdd-wave4-s7b-plugin-investigation-and-asset-prose` unchanged (`7598eda4`); tracker gained Wave 4's S2 merge since batch 3 (individual PR heads did not move) — no rebase triggered. Refusal-resolution notes: none pending (no new `errors.New`/non-wrap `fmt.Errorf` sites added this slice).
 
 ## Phase 4 (S3): NativeGateEvaluation Additive Relation/Next + Executable Next Step Per Denial
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2369

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

S2: single early consultation (AST call-count guard), fixed-shape unmanaged emitter, per-gate disabled goldens and double-eval byte-equivalence, decoy-store zero-reads proof; damage-naming assertions migrated to the enabled domain.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench + e2e) green at chain tip 63c0583a
- [x] Bench corpus 59/59 + --axis all 79/1-declared/0-failed vs fresh binaries
- [x] 3 verify cycles; final envelope pass_with_warnings 17/17 requirements, 26/26 scenarios