### PR TITLE
fix(review): real legacy preconditions and wire gateVerdict into the v3 path

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -3031,7 +3031,7 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 		return compactErr
 	}
 	evaluation := reviewtransaction.EvaluateLegacyGate(
-		ctx, root, chain, artifacts.receipt, live, strings.TrimSpace(gateInput.PolicyArtifact) != "", evidence, gateInput.Gate,
+		ctx, root, chain, artifacts.receipt, live, strings.TrimSpace(gateInput.PolicyArtifact) != "", evidence, gateInput,
 	)
 	return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated, *contract)
 }

--- a/internal/cli/review_governing_authority.go
+++ b/internal/cli/review_governing_authority.go
@@ -143,7 +143,7 @@ func resolveGoverningAuthority(ctx context.Context, root, lineage string, gateIn
 		if err != nil {
 			return true, reviewtransaction.NativeGateEvaluation{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted, Detail: err.Error()}
 		}
-		return true, newLineageGateEvaluation(gateInput.Gate, record, transition), nil
+		return true, reviewtransaction.EvaluateNewLineageGate(ctx, root, record, transition, live, gateInput), nil
 	}
 }
 
@@ -211,53 +211,13 @@ func governingAuthorityLiveEvidence(ctx context.Context, repo string, gateInput 
 	return live, reviewtransaction.CoreValidateEvidence{LiveSnapshot: snapshot, ApplicableAuthorities: 1}, nil
 }
 
-// newLineageGateEvaluation translates a ReviewCore validate CoreTransition
-// into gate JSON (design decision 7, task 6.2 — folds in and replaces S4's
-// generic default branch). Every one of CoreTransitionKind's six values has
-// its own explicit case below — the trailing default exists only as a
-// fail-closed guard against a hypothetical future seventh value, never to
-// silently absorb one of the six that already exist:
-//
-//   - continue (exact/compatible_base_advance/provable_contraction) allows —
-//     the legacy analogue of a receipt that still governs exactly.
-//   - collect (changed) reports scope-changed, not invalidated: this is the
-//     new-lineage equivalent of legacy's receipt_scope_changed, which
-//     resolveGoverningAuthorityLiveEvidence-driven relateCandidates reaches
-//     the same way legacy's own scope-changed detection does. A bounded
-//     correction is what a scope-changed candidate asks for, not a bare
-//     denial.
-//   - escalate (ambiguous/unknown/unrelated) escalates. This is a
-//     deliberate STRENGTHENING over legacy: legacy's receipt_ambiguous and
-//     receipt_unrelated both collapse into a generic invalidated denial,
-//     while the new model's relation algebra can tell an operator the
-//     specific reason an escalation-worthy relation was reached. Both are
-//     still non-allow refusals; nothing here is silently permissive.
-//   - approve/repair/stop are UNREACHABLE from ReviewCore's validate() (only
-//     its finalize() ever returns approve, and repair/stop are not returned
-//     by any Next() path this gate reaches) — they get their own explicit
-//     denial cases rather than sharing a default, so a future change to
-//     validate()'s own switch that starts returning one of them fails loud
-//     here instead of silently reusing a catch-all.
-func newLineageGateEvaluation(gate reviewtransaction.GateKind, record reviewtransaction.NewLineageRecord, transition reviewtransaction.CoreTransition) reviewtransaction.NativeGateEvaluation {
-	context := reviewtransaction.GateContext{
-		Gate: gate, LineageID: record.Authority.LineageID, StoreRevision: record.Revision,
-		BaseTree: record.Authority.CandidateIdentity.BaseTree, CandidateTree: record.Authority.CandidateIdentity.CandidateTree,
-		PolicyHash: record.Authority.CandidateIdentity.PolicyHash,
-	}
-	switch transition.Kind {
-	case reviewtransaction.CoreTransitionContinue:
-		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateAllow, Reason: transition.ReasonCode, Context: context}
-	case reviewtransaction.CoreTransitionCollect:
-		context.Denial = &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: transition.ReasonCode}
-		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateScopeChanged, Reason: transition.ReasonCode, Context: context}
-	case reviewtransaction.CoreTransitionEscalate:
-		context.Denial = &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: transition.ReasonCode}
-		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateEscalated, Reason: transition.ReasonCode, Context: context}
-	case reviewtransaction.CoreTransitionApprove, reviewtransaction.CoreTransitionRepair, reviewtransaction.CoreTransitionStop:
-		context.Denial = &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: string(transition.Kind)}
-		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateInvalidated, Reason: transition.ReasonCode, Context: context}
-	default:
-		context.Denial = &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: string(transition.Kind)}
-		return reviewtransaction.NativeGateEvaluation{Result: reviewtransaction.GateInvalidated, Reason: transition.ReasonCode, Context: context}
-	}
-}
+// newLineageGateEvaluation (design decision 7, task 6.2) translated a
+// ReviewCore validate CoreTransition into gate JSON, but mapped Continue
+// straight to GateAllow uniformly for every gate, discarding gateVerdict's
+// per-gate preconditions entirely. Wave 5 fix cycle 1 CRITICAL-C
+// (verify-report #10186, absorbed N2's actual closure) replaces it with
+// reviewtransaction.EvaluateNewLineageGate, which builds the identical gate
+// JSON shape but routes the Continue branch through gateVerdict with real
+// BaseRelationshipValid/Release preconditions -- see that function's own doc
+// comment (internal/reviewtransaction/new_lineage_gate.go) for the full
+// per-transition-kind mapping this function used to own.

--- a/internal/cli/review_reason_taxonomy_test.go
+++ b/internal/cli/review_reason_taxonomy_test.go
@@ -181,7 +181,7 @@ func TestNewLineageReasonTaxonomyCoversLegacyRefusals(t *testing.T) {
 		// receipt_scope_changed reaches. Calling the real production
 		// function, not a duplicated table.
 		transition := reviewtransaction.CoreTransition{Kind: reviewtransaction.CoreTransitionCollect, ReasonCode: string(reviewtransaction.ShadowRelationChanged)}
-		got := newLineageGateEvaluation(reviewtransaction.GatePreCommit, fixtureRecord, transition).Result
+		got := reviewtransaction.EvaluateNewLineageGate(context.Background(), "", fixtureRecord, transition, reviewtransaction.CandidateIdentity{}, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit}).Result
 		want := legacyReasonTaxonomyGateResult(ReviewReceiptScopeChanged)
 		if got != want {
 			t.Fatalf("new-lineage collect(changed) reaches %q, want the legacy-reachable %q", got, want)
@@ -196,7 +196,7 @@ func TestNewLineageReasonTaxonomyCoversLegacyRefusals(t *testing.T) {
 		// the assertion below is exactly that: never allow, and reachable
 		// through the real production function.
 		transition := reviewtransaction.CoreTransition{Kind: reviewtransaction.CoreTransitionEscalate, ReasonCode: string(reviewtransaction.ShadowRelationAmbiguous)}
-		got := newLineageGateEvaluation(reviewtransaction.GatePreCommit, fixtureRecord, transition).Result
+		got := reviewtransaction.EvaluateNewLineageGate(context.Background(), "", fixtureRecord, transition, reviewtransaction.CandidateIdentity{}, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit}).Result
 		if got == reviewtransaction.GateAllow {
 			t.Fatalf("new-lineage ambiguous relation must never allow, got %q", got)
 		}
@@ -218,7 +218,7 @@ func TestNewLineageGateEvaluationClosedSwitchNeverAllowsUnreachableKinds(t *test
 		reviewtransaction.CoreTransitionApprove, reviewtransaction.CoreTransitionRepair, reviewtransaction.CoreTransitionStop,
 	} {
 		t.Run(string(kind), func(t *testing.T) {
-			evaluation := newLineageGateEvaluation(reviewtransaction.GatePreCommit, fixtureRecord, reviewtransaction.CoreTransition{Kind: kind})
+			evaluation := reviewtransaction.EvaluateNewLineageGate(context.Background(), "", fixtureRecord, reviewtransaction.CoreTransition{Kind: kind}, reviewtransaction.CandidateIdentity{}, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
 			if evaluation.Result == reviewtransaction.GateAllow {
 				t.Fatalf("unreachable transition kind %q must never allow, got %#v", kind, evaluation)
 			}

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -1742,7 +1742,15 @@ func nativeGateReason(result GateResult) string {
 // with the identical compatible_base_advance exemption; release evidence is
 // gated to release only (receipt.go:307-314).
 func gateVerdict(gate GateKind, relation CandidateRelation, context GateContext) (GateResult, GateNextStep) {
-	if (gate == GatePrePR || gate == GateRelease) && !context.BaseRelationshipValid && relation != ShadowRelationCompatibleBaseAdvance {
+	// W-3 (Wave 5 fix cycle 1, verify-report #10186): the compatible_base_advance
+	// exemption is scoped to pre-PR only, matching validateDerivedGate's own
+	// `context.Gate == GatePrePR && ...` scoping (receipt.go:289) exactly --
+	// release is never exempted. Testing `gate == GatePrePR` inside the
+	// exemption clause itself (rather than broadening the OR above) keeps the
+	// precondition's own gate scope (pre-pr AND release) unchanged; only the
+	// exemption narrows.
+	compatibleBaseAdvanceAtPrePR := gate == GatePrePR && relation == ShadowRelationCompatibleBaseAdvance
+	if (gate == GatePrePR || gate == GateRelease) && !context.BaseRelationshipValid && !compatibleBaseAdvanceAtPrePR {
 		return GateInvalidated, GateNextStep{ReasonCode: "base_relationship_invalid"}
 	}
 	if gate == GateRelease && context.Release == nil {

--- a/internal/reviewtransaction/gate_boundary_matrix_test.go
+++ b/internal/reviewtransaction/gate_boundary_matrix_test.go
@@ -48,10 +48,27 @@ var gateBoundaryMatrixRelations = []string{
 	"exact", "compatible_base_advance", "provable_contraction", "changed", "ambiguous", "unknown", "unrelated",
 }
 
-const gateBoundaryMatrixNotWiredReason = "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); " +
-	"NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in " +
-	"Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real " +
-	"code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+// gateBoundaryMatrixNotWiredReason (W-1, Wave 5 fix cycle 1, verify-report
+// #10186): the ORIGINAL text below claimed gateVerdict, NativeGateEvaluation's
+// Relation field, and legacy-through-algebra projection did not exist yet --
+// all three landed in S3/S4 and every one of gateVerdict/EvaluateLegacyGate/
+// EvaluateNewLineageGate is now real, wired production code (this fix
+// cycle's C-B/C-C). The honest remaining reason for every cell still marked
+// here is narrower and true today: this harness only counts a cell as
+// wired once it drives that real code end-to-end through the compiled
+// binary with a genuinely constructed fixture (this file's own top-level
+// doc comment, "a REAL, ALREADY-SHIPPED production code path can be
+// driven"), and building that fixture -- particularly for release, whose
+// boundary needs five additional artifact files and (for a v3 lineage)
+// GENTLE_AI_RDD_NEW_LINEAGE plus a tier that can actually reach approved
+// (C-A) -- has not been done for every remaining cell yet. This is a
+// disclosed scope/time gap, not a missing mechanism.
+const gateBoundaryMatrixNotWiredReason = "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and " +
+	"EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report " +
+	"#10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled " +
+	"gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must " +
+	"drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a " +
+	"fabricated pass."
 
 // gateBoundaryMatrixPrePRCompatibleBaseAdvanceReason is task 6.3's named,
 // specific explained-divergence reason for pre-pr's compatible_base_advance

--- a/internal/reviewtransaction/gate_verdict_test.go
+++ b/internal/reviewtransaction/gate_verdict_test.go
@@ -18,11 +18,41 @@ var gateVerdictAllRelations = []CandidateRelation{
 	ShadowRelationChanged, ShadowRelationAmbiguous, ShadowRelationUnknown, ShadowRelationUnrelated,
 }
 
+// gateVerdictWantResultByRelation and gateVerdictWantReasonCodeByRelation are
+// the EXACT expected (GateResult, ReasonCode) per relation under a healthy
+// precondition context (CRITICAL-D, Wave 5 fix cycle 1, verify-report
+// #10186): before this fix, TestGateVerdict_TotalFunction_35Cells asserted
+// only that the result was one of the four known GateResult values and that
+// a non-allow carried SOME next step -- flipping provable_contraction,
+// unrelated, ambiguous, or unknown to GateAllow left this test (and every
+// other suite) green. These two tables pin gateVerdict's relation switch
+// (gate.go:1751-1774) by VALUE, not merely by shape, so a regression to
+// fail-open on any of the seven relations fails this test by name.
+var gateVerdictWantResultByRelation = map[CandidateRelation]GateResult{
+	ShadowRelationExact:                 GateAllow,
+	ShadowRelationCompatibleBaseAdvance: GateAllow,
+	ShadowRelationProvableContraction:   GateInvalidated,
+	ShadowRelationChanged:               GateInvalidated,
+	ShadowRelationUnrelated:             GateInvalidated,
+	ShadowRelationAmbiguous:             GateInvalidated,
+	ShadowRelationUnknown:               GateInvalidated,
+}
+
+var gateVerdictWantReasonCodeByRelation = map[CandidateRelation]string{
+	ShadowRelationExact:                 "allow",
+	ShadowRelationCompatibleBaseAdvance: "allow",
+	ShadowRelationProvableContraction:   "scope_contracted",
+	ShadowRelationChanged:               "candidate_changed",
+	ShadowRelationUnrelated:             "no_receipt",
+	ShadowRelationAmbiguous:             "authority_ambiguous",
+	ShadowRelationUnknown:               "target_unresolvable",
+}
+
 // TestGateVerdict_TotalFunction_35Cells is task 4.1: every one of the
-// 5 gates x 7 relations = 35 pairings must resolve to a defined
-// (GateResult, GateNextStep), and every denial (non-allow) must name either
-// an executable Transition or a ReasonCode -- never a bare denial with
-// neither.
+// 5 gates x 7 relations = 35 pairings must resolve to the EXACT expected
+// (GateResult, ReasonCode) pinned above -- not merely a defined shape -- and
+// every denial (non-allow) must name either an executable Transition or a
+// ReasonCode -- never a bare denial with neither.
 func TestGateVerdict_TotalFunction_35Cells(t *testing.T) {
 	// A "healthy" context: BaseRelationshipValid true and Release populated,
 	// so the totality sweep exercises the relation table itself, not the
@@ -39,10 +69,16 @@ func TestGateVerdict_TotalFunction_35Cells(t *testing.T) {
 			context := healthy
 			context.Gate = gate
 			result, next := gateVerdict(gate, relation, context)
-			switch result {
-			case GateAllow, GateScopeChanged, GateInvalidated, GateEscalated:
-			default:
-				t.Fatalf("gate %q relation %q resolved to unrecognized GateResult %q", gate, relation, result)
+			wantResult, ok := gateVerdictWantResultByRelation[relation]
+			if !ok {
+				t.Fatalf("relation %q has no pinned expected result; the 7-value CandidateRelation vocabulary and this table have drifted apart", relation)
+			}
+			if result != wantResult {
+				t.Fatalf("gate %q relation %q = %q, want the pinned %q (CRITICAL-D: this is the exact regression a fail-open flip must be caught by)", gate, relation, result, wantResult)
+			}
+			wantReasonCode := gateVerdictWantReasonCodeByRelation[relation]
+			if next.ReasonCode != wantReasonCode {
+				t.Fatalf("gate %q relation %q reason_code = %q, want the pinned %q", gate, relation, next.ReasonCode, wantReasonCode)
 			}
 			if result != GateAllow && next.Transition == "" && next.ReasonCode == "" {
 				t.Fatalf("gate %q relation %q denial carries neither a Transition nor a ReasonCode (bare denial)", gate, relation)

--- a/internal/reviewtransaction/gate_verdict_test.go
+++ b/internal/reviewtransaction/gate_verdict_test.go
@@ -82,17 +82,26 @@ func TestGateVerdict_PerGatePreconditions_MatchLegacyValidateDerivedGate(t *test
 		}
 	})
 
-	t.Run("compatible_base_advance relation exempts the BaseRelationshipValid precondition", func(t *testing.T) {
+	t.Run("compatible_base_advance relation exempts the BaseRelationshipValid precondition at pre-PR only", func(t *testing.T) {
 		// Mirrors validateDerivedGate's own !compatibleAdvance exemption
-		// (receipt.go:304): a proven compatible base advance is exactly the
-		// case BaseRelationshipValid=false is EXPECTED to report, so the
-		// relation itself must still allow.
-		for _, gate := range []GateKind{GatePrePR, GateRelease} {
-			context := GateContext{Gate: gate, BaseRelationshipValid: false, Release: completeRelease}
-			result, _ := gateVerdict(gate, ShadowRelationCompatibleBaseAdvance, context)
-			if result != GateAllow {
-				t.Fatalf("gate %q denied a compatible_base_advance relation despite the exemption: %q", gate, result)
-			}
+		// (receipt.go:289, receipt.go:304): compatibleAdvance there is
+		// literally scoped `context.Gate == GatePrePR && ...` -- release is
+		// NOT exempted. W-3 (Wave 5 fix cycle 1, verify-report #10186):
+		// gateVerdict's own exemption previously fired for BOTH GatePrePR and
+		// GateRelease (the exemption's condition tested only the relation,
+		// never the gate), a latent fail-open that becomes real the moment
+		// release is evaluated through this function -- exactly what
+		// EvaluateLegacyGate's CRITICAL-B fix now does. A compatible base
+		// advance still allows at pre-PR (where the relation is derived and
+		// the exemption is scoped) and must DENY at release, matching
+		// validateDerivedGate exactly.
+		prePR := GateContext{Gate: GatePrePR, BaseRelationshipValid: false, Release: completeRelease}
+		if result, _ := gateVerdict(GatePrePR, ShadowRelationCompatibleBaseAdvance, prePR); result != GateAllow {
+			t.Fatalf("pre-pr denied a compatible_base_advance relation despite the exemption: %q", result)
+		}
+		release := GateContext{Gate: GateRelease, BaseRelationshipValid: false, Release: completeRelease}
+		if result, _ := gateVerdict(GateRelease, ShadowRelationCompatibleBaseAdvance, release); result == GateAllow {
+			t.Fatal("release allowed a compatible_base_advance relation with BaseRelationshipValid=false; validateDerivedGate scopes this exemption to pre-PR only (receipt.go:289)")
 		}
 	})
 

--- a/internal/reviewtransaction/legacy_projection.go
+++ b/internal/reviewtransaction/legacy_projection.go
@@ -127,7 +127,7 @@ func EvaluateLegacyGate(ctx context.Context, root string, chain ValidatedChain, 
 		BaseRelationshipValid: live.BaseTree == identity.BaseTree,
 	}
 	if gate == GateRelease {
-		release, releaseErr := deriveLegacyReleaseEvidence(ctx, root, gateInput)
+		release, releaseErr := deriveGateReleaseEvidenceFromInput(ctx, root, gateInput)
 		if releaseErr != nil {
 			return NativeGateEvaluation{
 				Result: GateInvalidated, Reason: "release boundary cannot be derived: " + releaseErr.Error(),
@@ -146,13 +146,15 @@ func EvaluateLegacyGate(ctx context.Context, root string, chain ValidatedChain, 
 	}
 }
 
-// deriveLegacyReleaseEvidence derives release evidence for a legacy gate
-// evaluation from the same caller-supplied artifact locations
-// BuildNativeGateRequest already uses to build a ReleaseRequest for the
-// native v1 path (native_request.go:94-107) -- reused verbatim rather than
-// re-derived, so a legacy release boundary is held to the identical
-// PublicationStateSealed/EvidenceFreshnessCurrent contract.
-func deriveLegacyReleaseEvidence(ctx context.Context, root string, gateInput NativeGateRequestInput) (ReleaseEvidence, error) {
+// deriveGateReleaseEvidenceFromInput derives release evidence from the same
+// caller-supplied artifact locations BuildNativeGateRequest already uses to
+// build a ReleaseRequest for the native v1 path (native_request.go:94-107)
+// -- reused verbatim rather than re-derived, and shared by both
+// EvaluateLegacyGate (CRITICAL-B) and EvaluateNewLineageGate (CRITICAL-C, in
+// new_lineage_gate.go): a release boundary is held to the identical
+// PublicationStateSealed/EvidenceFreshnessCurrent contract regardless of
+// which lineage kind it governs.
+func deriveGateReleaseEvidenceFromInput(ctx context.Context, root string, gateInput NativeGateRequestInput) (ReleaseEvidence, error) {
 	head, err := resolveCommit(ctx, root, "HEAD")
 	if err != nil {
 		return ReleaseEvidence{}, err

--- a/internal/reviewtransaction/legacy_projection.go
+++ b/internal/reviewtransaction/legacy_projection.go
@@ -95,7 +95,16 @@ func ProjectLegacyAuthority(ctx context.Context, root string, chain ValidatedCha
 // the projected identity's own PolicyHash before relating -- policy content
 // legacy never asked to be live-compared can never manufacture a false
 // "changed" relation.
-func EvaluateLegacyGate(ctx context.Context, root string, chain ValidatedChain, receiptPath string, live CandidateIdentity, livePolicyOverridden bool, evidence CoreValidateEvidence, gate GateKind) NativeGateEvaluation {
+// EvaluateLegacyGate's gate parameter was a bare GateKind before CRITICAL-B
+// (Wave 5 fix cycle 1, verify-report #10186): a bare GateKind carries no
+// release-boundary artifact locations, so the pre-pr/release preconditions
+// gateVerdict enforces (BaseRelationshipValid, Release) could never be
+// populated -- a byte-identical legacy candidate denied FOREVER at those two
+// gates. NativeGateRequestInput is the same caller-supplied artifact-location
+// carrier EvaluateNativeGate/evaluateCompactGate already take (native_request.go);
+// its Gate field replaces the old bare parameter one-for-one.
+func EvaluateLegacyGate(ctx context.Context, root string, chain ValidatedChain, receiptPath string, live CandidateIdentity, livePolicyOverridden bool, evidence CoreValidateEvidence, gateInput NativeGateRequestInput) NativeGateEvaluation {
+	gate := gateInput.Gate
 	identity, receiptRef, err := ProjectLegacyAuthority(ctx, root, chain, receiptPath)
 	if err != nil {
 		return NativeGateEvaluation{
@@ -110,6 +119,22 @@ func EvaluateLegacyGate(ctx context.Context, root string, chain ValidatedChain, 
 	context := GateContext{
 		Gate: gate, LineageID: receiptRef.LineageID, StoreRevision: receiptRef.AuthorityRevision,
 		BaseTree: identity.BaseTree, CandidateTree: identity.CandidateTree, PolicyHash: identity.PolicyHash,
+		// CRITICAL-B fix: derived faithfully from the legacy chain's real live
+		// state, mirroring EvaluateNativeGate's own derivation
+		// (gate.go:289 -- BaseRelationshipValid: snapshot.BaseTree == receipt.BaseTree)
+		// instead of leaving the zero value (false) that denied every legacy
+		// candidate, even an unchanged one, at pre-pr/release.
+		BaseRelationshipValid: live.BaseTree == identity.BaseTree,
+	}
+	if gate == GateRelease {
+		release, releaseErr := deriveLegacyReleaseEvidence(ctx, root, gateInput)
+		if releaseErr != nil {
+			return NativeGateEvaluation{
+				Result: GateInvalidated, Reason: "release boundary cannot be derived: " + releaseErr.Error(),
+				Context: context, Cause: releaseErr,
+			}
+		}
+		context.Release = &release
 	}
 	result, next := gateVerdict(gate, observation.Relation, context)
 	if result != GateAllow {
@@ -119,4 +144,29 @@ func EvaluateLegacyGate(ctx context.Context, root string, chain ValidatedChain, 
 		Result: result, Reason: string(observation.Relation), Context: context,
 		Relation: observation.Relation, Next: &next,
 	}
+}
+
+// deriveLegacyReleaseEvidence derives release evidence for a legacy gate
+// evaluation from the same caller-supplied artifact locations
+// BuildNativeGateRequest already uses to build a ReleaseRequest for the
+// native v1 path (native_request.go:94-107) -- reused verbatim rather than
+// re-derived, so a legacy release boundary is held to the identical
+// PublicationStateSealed/EvidenceFreshnessCurrent contract.
+func deriveLegacyReleaseEvidence(ctx context.Context, root string, gateInput NativeGateRequestInput) (ReleaseEvidence, error) {
+	head, err := resolveCommit(ctx, root, "HEAD")
+	if err != nil {
+		return ReleaseEvidence{}, err
+	}
+	request := &ReleaseRequest{
+		Revision: head, ConfigurationArtifact: gateInput.ReleaseConfiguration,
+		GeneratedArtifact: gateInput.ReleaseGenerated, ProvenanceArtifact: gateInput.ReleaseProvenance,
+		PublicationBoundaryArtifact: gateInput.ReleasePublicationBoundary,
+		EvidenceFreshnessArtifact:   gateInput.ReleaseEvidenceFreshness,
+		PublicationState:            PublicationStateSealed, EvidenceFreshnessState: EvidenceFreshnessCurrent,
+	}
+	preimages, err := readGateArtifactPreimages(GateRequest{Release: request})
+	if err != nil {
+		return ReleaseEvidence{}, err
+	}
+	return deriveReleaseEvidence(ctx, root, request, preimages)
 }

--- a/internal/reviewtransaction/legacy_projection_test.go
+++ b/internal/reviewtransaction/legacy_projection_test.go
@@ -208,7 +208,7 @@ func TestEvaluateLegacyGateAllowsExactAndDeniesChanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	evidence := CoreValidateEvidence{LiveSnapshot: tx.Snapshot, ApplicableAuthorities: 1}
-	exact := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, live, true, evidence, GatePreCommit)
+	exact := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, live, true, evidence, NativeGateRequestInput{Gate: GatePreCommit})
 	if exact.Result != GateAllow {
 		t.Fatalf("exact live candidate = %#v, want allow", exact)
 	}
@@ -228,9 +228,56 @@ func TestEvaluateLegacyGateAllowsExactAndDeniesChanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	changedEvidence := CoreValidateEvidence{LiveSnapshot: changedSnapshot, ApplicableAuthorities: 1}
-	changed := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, changedLive, true, changedEvidence, GatePreCommit)
+	changed := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, changedLive, true, changedEvidence, NativeGateRequestInput{Gate: GatePreCommit})
 	if changed.Result == GateAllow {
 		t.Fatalf("out-of-scope candidate = %#v, want deny", changed)
+	}
+}
+
+// TestEvaluateLegacyGateAllowsExactAtAllFiveGates reproduces the verify
+// report's CRITICAL-B probe directly: an unchanged, byte-identical legacy
+// candidate must allow at every one of the five gates, not just the three
+// EvaluateLegacyGateAllowsExactAndDeniesChanged already covered. Before the
+// fix, pre-pr and release denied permanently with reason_code
+// base_relationship_invalid / release_evidence_missing because
+// EvaluateLegacyGate never populated GateContext.BaseRelationshipValid or
+// Release at all (base-relationship precondition regression, W3
+// EvaluateNativeGate's own gate.go:326/301-310 precedent).
+func TestEvaluateLegacyGateAllowsExactAtAllFiveGates(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, chain, receiptPath := legacyApprovedChainFixture(t, repo, "legacy-gate-all-five-exact")
+	tx := chain.Records[len(chain.Records)-1].Transaction
+
+	live, err := FreezeCandidateIdentity(context.Background(), repo, tx.Snapshot, tx.PolicyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := CoreValidateEvidence{LiveSnapshot: tx.Snapshot, ApplicableAuthorities: 1}
+
+	dir := t.TempDir()
+	releaseArtifact := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	releaseInput := NativeGateRequestInput{
+		Gate:                       GateRelease,
+		ReleaseConfiguration:       releaseArtifact("configuration.txt", "release configuration\n"),
+		ReleaseGenerated:           releaseArtifact("generated.txt", "release generated artifact\n"),
+		ReleaseProvenance:          releaseArtifact("provenance.txt", "release provenance\n"),
+		ReleasePublicationBoundary: releaseArtifact("publication-boundary.txt", "release publication boundary\n"),
+		ReleaseEvidenceFreshness:   releaseArtifact("evidence-freshness.txt", "release evidence freshness\n"),
+	}
+
+	for _, gateInput := range []NativeGateRequestInput{
+		{Gate: GatePostApply}, {Gate: GatePreCommit}, {Gate: GatePrePush}, {Gate: GatePrePR}, releaseInput,
+	} {
+		evaluation := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, live, true, evidence, gateInput)
+		if evaluation.Result != GateAllow {
+			t.Fatalf("gate %q on an unchanged legacy candidate = %#v, want allow", gateInput.Gate, evaluation)
+		}
 	}
 }
 
@@ -398,7 +445,7 @@ func TestEvaluateLegacyGateValidatesReceiptFromAnInFlightCorrection(t *testing.T
 		t.Fatal(err)
 	}
 	evidence := CoreValidateEvidence{LiveSnapshot: liveSnapshot, ApplicableAuthorities: 1}
-	evaluation := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, live, true, evidence, GatePreCommit)
+	evaluation := EvaluateLegacyGate(context.Background(), repo, chain, receiptPath, live, true, evidence, NativeGateRequestInput{Gate: GatePreCommit})
 	if evaluation.Result != GateAllow {
 		t.Fatalf("in-flight-correction receipt validation = %#v, want allow", evaluation)
 	}

--- a/internal/reviewtransaction/new_lineage_gate.go
+++ b/internal/reviewtransaction/new_lineage_gate.go
@@ -1,0 +1,74 @@
+package reviewtransaction
+
+// Wave 5 fix cycle 1, CRITICAL-C closure (verify-report #10186, absorbed N2):
+// EvaluateNewLineageGate is the real gateVerdict-consulting replacement for
+// what internal/cli/review_governing_authority.go's newLineageGateEvaluation
+// used to do on its own -- map CoreTransitionContinue straight to GateAllow,
+// uniformly, for every gate, discarding gateVerdict's per-gate preconditions
+// entirely (the exact gap task 4.7's "ABSORBED N2" claimed was closed but
+// never wired). This mirrors EvaluateLegacyGate's own shape exactly: build a
+// GateContext, populate BaseRelationshipValid/Release for pre-pr/release,
+// then let gateVerdict decide -- "ALL five gates evaluate through
+// gateVerdict, one meaning, no re-derived gate semantics" now genuinely
+// covers all three lineage kinds (legacy, compact/v2, new-lineage/v3), not
+// two of three.
+//
+// gateVerdict's preconditions apply ONLY inside the Continue branch
+// (exact/compatible_base_advance/provable_contraction): Collect (changed)
+// and Escalate (ambiguous/unknown/unrelated) are already non-allow outcomes
+// unaffected by base-relationship or release evidence, and Approve/Repair/
+// Stop are unreachable from ReviewCore.validate() and stay explicit denials
+// -- deriving release evidence for those paths would be unnecessary work for
+// an outcome gateVerdict cannot change.
+
+import "context"
+
+// EvaluateNewLineageGate translates a ReviewCore validate CoreTransition into
+// gate JSON. live is the caller's already-resolved live CandidateIdentity
+// (package cli's governingAuthorityLiveEvidence, reused verbatim -- the same
+// value ReviewCore.Next(validate) itself consulted to produce transition, so
+// this function re-derives no relation, only the gate preconditions
+// gateVerdict needs that the relation alone does not carry).
+func EvaluateNewLineageGate(ctx context.Context, root string, record NewLineageRecord, transition CoreTransition, live CandidateIdentity, gateInput NativeGateRequestInput) NativeGateEvaluation {
+	gate := gateInput.Gate
+	context := GateContext{
+		Gate: gate, LineageID: record.Authority.LineageID, StoreRevision: record.Revision,
+		BaseTree: record.Authority.CandidateIdentity.BaseTree, CandidateTree: record.Authority.CandidateIdentity.CandidateTree,
+		PolicyHash: record.Authority.CandidateIdentity.PolicyHash,
+	}
+	switch transition.Kind {
+	case CoreTransitionContinue:
+		// Mirrors EvaluateLegacyGate's own derivation (legacy_projection.go):
+		// live.BaseTree == the frozen authority's own BaseTree, the same
+		// comparison EvaluateNativeGate makes at gate.go:289.
+		context.BaseRelationshipValid = live.BaseTree == record.Authority.CandidateIdentity.BaseTree
+		if gate == GateRelease {
+			release, releaseErr := deriveGateReleaseEvidenceFromInput(ctx, root, gateInput)
+			if releaseErr != nil {
+				return NativeGateEvaluation{
+					Result: GateInvalidated, Reason: "release boundary cannot be derived: " + releaseErr.Error(),
+					Context: context, Cause: releaseErr,
+				}
+			}
+			context.Release = &release
+		}
+		relation := CandidateRelation(transition.ReasonCode)
+		result, next := gateVerdict(gate, relation, context)
+		if result != GateAllow {
+			context.Denial = &GateDenial{Stage: "new-lineage-validate", Code: transition.ReasonCode}
+		}
+		return NativeGateEvaluation{Result: result, Reason: transition.ReasonCode, Context: context, Relation: relation, Next: &next}
+	case CoreTransitionCollect:
+		context.Denial = &GateDenial{Stage: "new-lineage-validate", Code: transition.ReasonCode}
+		return NativeGateEvaluation{Result: GateScopeChanged, Reason: transition.ReasonCode, Context: context}
+	case CoreTransitionEscalate:
+		context.Denial = &GateDenial{Stage: "new-lineage-validate", Code: transition.ReasonCode}
+		return NativeGateEvaluation{Result: GateEscalated, Reason: transition.ReasonCode, Context: context}
+	case CoreTransitionApprove, CoreTransitionRepair, CoreTransitionStop:
+		context.Denial = &GateDenial{Stage: "new-lineage-validate", Code: string(transition.Kind)}
+		return NativeGateEvaluation{Result: GateInvalidated, Reason: transition.ReasonCode, Context: context}
+	default:
+		context.Denial = &GateDenial{Stage: "new-lineage-validate", Code: string(transition.Kind)}
+		return NativeGateEvaluation{Result: GateInvalidated, Reason: transition.ReasonCode, Context: context}
+	}
+}

--- a/internal/reviewtransaction/new_lineage_gate_test.go
+++ b/internal/reviewtransaction/new_lineage_gate_test.go
@@ -1,0 +1,117 @@
+package reviewtransaction
+
+// Wave 5 fix cycle 1, CRITICAL-C (verify-report #10186): absorbed N2 was
+// marked closed (task 4.7) but the v3 gate path never called gateVerdict at
+// all -- newLineageGateEvaluation (internal/cli/review_governing_authority.go)
+// mapped CoreTransitionContinue -> GateAllow uniformly for every gate,
+// discarding gateVerdict's per-gate preconditions entirely. This file's
+// tests drive the shared reviewtransaction-side replacement,
+// EvaluateNewLineageGate, directly -- the real production entry point, not a
+// duplicated table.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newLineageGateFixtureRecord(baseTree, candidateTree string) NewLineageRecord {
+	return NewLineageRecord{
+		Revision: "sha256:" + hash("new-lineage-gate-fixture-revision"),
+		Authority: NewLineageAuthority{
+			LineageID: "new-lineage-gate-fixture", State: NewLineageStateApproved,
+			CandidateIdentity: CandidateIdentity{BaseTree: baseTree, CandidateTree: candidateTree, PolicyHash: "sha256:" + hash("policy")},
+		},
+	}
+}
+
+// TestEvaluateNewLineageGate_ContinueConsultsGateVerdictPreconditions is
+// CRITICAL-C's exact reproduction: an approved v3 authority whose live base
+// tree diverges from the frozen one (BaseRelationshipValid=false, exactly the
+// verify report's "approved v3 receipt allows at --gate release with
+// base_relationship_valid: false") must now DENY at pre-pr and release, and
+// still ALLOW at the three gates the precondition never gates.
+func TestEvaluateNewLineageGate_ContinueConsultsGateVerdictPreconditions(t *testing.T) {
+	record := newLineageGateFixtureRecord("base-tree", "candidate-tree")
+	transition := CoreTransition{Kind: CoreTransitionContinue, ReasonCode: string(ShadowRelationExact)}
+	// live.BaseTree diverges from record.Authority.CandidateIdentity.BaseTree
+	// ("base-tree"), reproducing BaseRelationshipValid=false without needing
+	// a real repository.
+	live := CandidateIdentity{BaseTree: "a-different-base-tree", CandidateTree: "candidate-tree"}
+
+	for _, gate := range []GateKind{GatePostApply, GatePreCommit, GatePrePush} {
+		evaluation := EvaluateNewLineageGate(context.Background(), "", record, transition, live, NativeGateRequestInput{Gate: gate})
+		if evaluation.Result != GateAllow {
+			t.Fatalf("gate %q with a diverged base must still allow (precondition is pre-pr/release only): %#v", gate, evaluation)
+		}
+	}
+	for _, gate := range []GateKind{GatePrePR, GateRelease} {
+		evaluation := EvaluateNewLineageGate(context.Background(), "", record, transition, live, NativeGateRequestInput{Gate: gate})
+		if evaluation.Result == GateAllow {
+			t.Fatalf("gate %q allowed an approved v3 receipt with a diverged base and no release evidence; want deny (CRITICAL-C, absorbed N2 must actually be enforced)", gate)
+		}
+	}
+}
+
+// TestEvaluateNewLineageGate_ReleaseRequiresDerivedEvidence proves the other
+// half of the release precondition: an exact relation with a MATCHING base
+// still denies at release until real release evidence is derived from the
+// caller-supplied artifact locations, then allows once it is.
+func TestEvaluateNewLineageGate_ReleaseRequiresDerivedEvidence(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	record := newLineageGateFixtureRecord("matching-base", "matching-candidate")
+	transition := CoreTransition{Kind: CoreTransitionContinue, ReasonCode: string(ShadowRelationExact)}
+	live := CandidateIdentity{BaseTree: "matching-base", CandidateTree: "matching-candidate"}
+
+	withoutRelease := EvaluateNewLineageGate(context.Background(), repo, record, transition, live, NativeGateRequestInput{Gate: GateRelease})
+	if withoutRelease.Result == GateAllow {
+		t.Fatalf("release allowed with no release artifacts supplied at all: %#v", withoutRelease)
+	}
+
+	dir := t.TempDir()
+	artifact := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	gateInput := NativeGateRequestInput{
+		Gate:                       GateRelease,
+		ReleaseConfiguration:       artifact("configuration.txt", "configuration\n"),
+		ReleaseGenerated:           artifact("generated.txt", "generated\n"),
+		ReleaseProvenance:          artifact("provenance.txt", "provenance\n"),
+		ReleasePublicationBoundary: artifact("publication-boundary.txt", "publication boundary\n"),
+		ReleaseEvidenceFreshness:   artifact("evidence-freshness.txt", "evidence freshness\n"),
+	}
+	withRelease := EvaluateNewLineageGate(context.Background(), repo, record, transition, live, gateInput)
+	if withRelease.Result != GateAllow {
+		t.Fatalf("release denied with real release evidence supplied and a matching base: %#v", withRelease)
+	}
+}
+
+// TestEvaluateNewLineageGate_NonContinueTransitionsUnaffected pins the scope
+// boundary: gateVerdict's preconditions apply ONLY to the Continue branch --
+// Collect/Escalate/Approve/Repair/Stop are already non-allow outcomes,
+// unaffected by base-relationship or release evidence, exactly as before
+// this fix.
+func TestEvaluateNewLineageGate_NonContinueTransitionsUnaffected(t *testing.T) {
+	record := newLineageGateFixtureRecord("base-tree", "candidate-tree")
+	live := CandidateIdentity{BaseTree: "base-tree", CandidateTree: "candidate-tree"}
+
+	collect := EvaluateNewLineageGate(context.Background(), "", record, CoreTransition{Kind: CoreTransitionCollect, ReasonCode: string(ShadowRelationChanged)}, live, NativeGateRequestInput{Gate: GateRelease})
+	if collect.Result != GateScopeChanged {
+		t.Fatalf("collect transition = %#v, want scope-changed regardless of release evidence", collect)
+	}
+	escalate := EvaluateNewLineageGate(context.Background(), "", record, CoreTransition{Kind: CoreTransitionEscalate, ReasonCode: string(ShadowRelationAmbiguous)}, live, NativeGateRequestInput{Gate: GateRelease})
+	if escalate.Result != GateEscalated {
+		t.Fatalf("escalate transition = %#v, want escalated regardless of release evidence", escalate)
+	}
+	for _, kind := range []CoreTransitionKind{CoreTransitionApprove, CoreTransitionRepair, CoreTransitionStop} {
+		evaluation := EvaluateNewLineageGate(context.Background(), "", record, CoreTransition{Kind: kind}, live, NativeGateRequestInput{Gate: GatePreCommit})
+		if evaluation.Result == GateAllow {
+			t.Fatalf("unreachable transition kind %q must never allow, got %#v", kind, evaluation)
+		}
+	}
+}

--- a/internal/reviewtransaction/testdata/gate-boundary-matrix.golden
+++ b/internal/reviewtransaction/testdata/gate-boundary-matrix.golden
@@ -11,14 +11,14 @@
     "relation": "compatible_base_advance",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "post-apply",
     "relation": "provable_contraction",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "post-apply",
@@ -33,21 +33,21 @@
     "relation": "ambiguous",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "post-apply",
     "relation": "unknown",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "post-apply",
     "relation": "unrelated",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-commit",
@@ -61,14 +61,14 @@
     "relation": "compatible_base_advance",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-commit",
     "relation": "provable_contraction",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-commit",
@@ -83,21 +83,21 @@
     "relation": "ambiguous",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-commit",
     "relation": "unknown",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-commit",
     "relation": "unrelated",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-push",
@@ -111,14 +111,14 @@
     "relation": "compatible_base_advance",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-push",
     "relation": "provable_contraction",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-push",
@@ -133,21 +133,21 @@
     "relation": "ambiguous",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-push",
     "relation": "unknown",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-push",
     "relation": "unrelated",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-pr",
@@ -168,7 +168,7 @@
     "relation": "provable_contraction",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-pr",
@@ -182,69 +182,69 @@
     "relation": "ambiguous",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-pr",
     "relation": "unknown",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "pre-pr",
     "relation": "unrelated",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "exact",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "compatible_base_advance",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "provable_contraction",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "changed",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "ambiguous",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "unknown",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   },
   {
     "gate": "release",
     "relation": "unrelated",
     "verdict": "",
     "explained": true,
-    "reason": "gateVerdict(gate, relation) does not exist yet (Wave 5 Slice 3 deliverable); NativeGateEvaluation carries no Relation field until Slice 3, and legacy-through-algebra projection lands in Slice 4, so no real production code path can be driven to prove this cell yet. This harness must drive real code, not reimplement the algebra by hand, so the cell is an explicit SKIP, not a fabricated pass."
+    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
   }
 ]

--- a/openspec/changes/rdd-root-simplification-wave5/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave5/tasks.md
@@ -333,3 +333,65 @@ the full W4 CRITICAL-A citation.
       still an ancestor of `origin/main`, confirmed via `git merge-base --is-ancestor`). This closes Wave 5's
       apply: Phases 1-9 (S1-S7 plus this phase) are all complete. Commit `31799ec2` (code) plus this docs
       commit.
+
+## Fix Cycle 1 (SDD-Verify FAIL, Engram #10186 — 4 CRITICAL, 7 WARNING)
+
+Branch `feat/rdd-wave5-f1-legacy-preconditions`, chained from Phase 9 @ `1f875015`. sdd-verify found
+the gate-cutover's own headline promises broken at the product surface: a medium/high v3 candidate could
+never obtain an approved receipt, every legacy candidate denied forever at 2 of 5 gates, absorbed N2's
+closure claim was untrue on the shipped v3 path, and default-deny was mutation-unpinned for 4 of 7
+relations. Full detail: Engram `#10187`.
+
+- [x] **C-B** (legacy real preconditions): `EvaluateLegacyGate` never populated `GateContext.BaseRelationshipValid`
+      or `Release`, so legacy denied FOREVER at pre-pr/release even for `exact`. Fixed by deriving
+      `BaseRelationshipValid` from the live-vs-projected base-tree comparison (mirroring `EvaluateNativeGate`'s
+      own `gate.go:289`) and `Release` from the same caller-supplied artifact locations
+      `BuildNativeGateRequest` already uses. `EvaluateLegacyGate`'s signature changes from a bare `GateKind`
+      to `NativeGateRequestInput` to carry the release-artifact locations a bare `GateKind` cannot express.
+      Mutation-proven (both derivations independently reverted, caught, restored). Commit `e2423787`.
+- [x] **W-3** (fold-in, adjacent to C-B): `gateVerdict`'s `compatible_base_advance` exemption from the
+      `BaseRelationshipValid` precondition fired at both pre-PR and release; `validateDerivedGate` (the
+      function it reproduces) scopes it to pre-PR only. Narrowed to match — a latent fail-open that becomes
+      reachable now that C-B routes legacy release evaluations through `gateVerdict` with real precondition
+      data. Genuine RED (existing test encoded the bug as intended behavior, corrected), mutation-proven.
+      Commit `e2423787`.
+- [x] **C-C** (wire `gateVerdict` into the v3 path, the real N2 closure): the v3 gate path
+      (`newLineageGateEvaluation`) never called `gateVerdict` at all — it mapped `CoreTransitionContinue`
+      straight to `GateAllow` uniformly for every gate. Replaced with `reviewtransaction.EvaluateNewLineageGate`
+      (new file `new_lineage_gate.go`), mirroring `EvaluateLegacyGate`'s shape: preconditions populate only
+      inside the Continue branch (Collect/Escalate/Approve/Repair/Stop are already non-allow, unaffected).
+      `newLineageGateEvaluation` removed from `internal/cli`; its 4 test call sites migrated to the new
+      function. Mutation-proven (reverting the `gateVerdict` call to a hardcoded allow is caught by name).
+      Full reviewtransaction/cli/sddstatus/e2e suites green. Commit `92682ed1`.
+- [x] **C-D** (partial — pin deny verdicts by value) + **W-1** (fold-in): `TestGateVerdict_TotalFunction_35Cells`
+      asserted shape only (any of 4 known `GateResult` values, some next step) — flipping
+      `provable_contraction`/`unrelated`/`ambiguous`/`unknown` to allow stayed green. Pinned to the exact
+      expected `(GateResult, ReasonCode)` per relation via two lookup tables; each of the 4 previously-unpinned
+      deny relations independently flipped to `GateAllow` and confirmed caught by name, then reverted. W-1:
+      `gateBoundaryMatrixNotWiredReason` still claimed `gateVerdict`/`NativeGateEvaluation.Relation`/legacy
+      projection didn't exist — all landed in S3/S4 and are now real (C-B/C-C). Rewritten to the honest
+      current reason (fixture not yet built, not mechanism missing); golden regenerated, diff confined to
+      reason text only (still 8/35 wired, no verdict/relation changed). Commit `e0a51de3`.
+- [ ] **C-D remainder / W-2** (deferred, disclosed): un-skip the release-gate matrix cells. Investigated:
+      the existing "exact" cells all drive the COMPACT/v2 lineage path (`approveDiscoveryMarkdown`-style
+      helpers), not legacy v1 or new-lineage v3, so reusing that recipe for "release/exact" would not
+      actually exercise either C-B's or C-C's fix. A genuinely new fixture is needed — a legacy-specific
+      recipe (tractable now) or a v3 recipe (blocked on C-A, since only tier-low can currently finalize).
+      Follow-up slice.
+- [ ] **C-A** (v3 lens-result ingestion — NOT STARTED, largest remaining item): no production code sets
+      `FinalizeAdvanceRequest.CapturedLensResults`; `review capture-result` binds only the v2 compact store,
+      and v3's `NewLineageAuthority`/`AuthorityStore` has no persistence primitive for captured reviewer
+      results at all — `NewArtifactSubject`/the admission pipeline is tightly coupled to `CompactState`.
+      Needs a dedicated design/implementation slice: either a full parallel v3 artifact-capture pipeline, or
+      a minimal v3-specific persistence primitive plus CLI routing (mirroring wave-3's "ln" precedent: route
+      `capture-result` by lineage kind exactly like `finalize` now does). Follow-up slice.
+- [ ] **W-7** (deferred, disclosed): the v3 tamper denial names `review finalize --lineage <id>`, which
+      re-issues rather than repairs an already-approved lineage's receipt. `AuthorityStore.WriteReceipt`'s
+      exact conflict semantics (no-op / refusal / silent overwrite) need investigating before an accurate
+      replacement message can be written. Follow-up slice.
+
+Fix cycle 1 verification (covers C-B/W-3/C-C/C-D-partial/W-1, the 3 commits above): `go test ./... -count=1`
+all 63 packages green; bench module green; bench journey corpus vs a freshly built binary: 59/59 completed,
+0 failed, exit 0; `bench/results.json` reverted; gofmt/vet clean; deadcode ratchet clean; rebase-contract
+clean (root `7598eda4` still an ancestor of `origin/main`). Not archivable yet: C-A and its dependents
+(W-2's v3 half) remain open. Return to sdd-apply fix cycle 2.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2369

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

Fix cycle 1: legacy projects real BaseRelationshipValid/release evidence (was zero-valued, denying forever); EvaluateNewLineageGate routes v3 through gateVerdict (real N2 closure); 35-cell verdicts pinned by exact value with per-relation flip proofs.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench + e2e) green at chain tip 63c0583a
- [x] Bench corpus 59/59 + --axis all 79/1-declared/0-failed vs fresh binaries
- [x] 3 verify cycles; final envelope pass_with_warnings 17/17 requirements, 26/26 scenarios