### PR TITLE
feat(review): add the minimal v3 lens-result capture primitive

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -256,6 +256,25 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 			return fmt.Errorf("resolve review repository root: %w", err)
 		}
 	}
+	// C-A (Wave 5 fix cycle 2, verify-report #10186): capture-result routes
+	// by discovered lineage kind, exactly mirroring finalize's own routing
+	// (task C1, review_facade.go) and start's discovery rule -- lineage kind
+	// is established SOLELY by v3/ record presence. A v3 lineage hits the new
+	// minimal capture primitive (reviewtransaction.AuthorityStore.CaptureLensResult);
+	// v2 falls through to its existing pipeline below, untouched.
+	if strings.TrimSpace(*lineage) != "" {
+		newRecord, newFound, newDiscErr := reviewtransaction.DiscoverNewLineage(ctx, root, *lineage)
+		if newDiscErr != nil {
+			var corrupted *reviewtransaction.NewLineageMarkerCorruptedError
+			if errors.As(newDiscErr, &corrupted) {
+				return reviewPreflightError(fmt.Errorf("new-lineage authority marker is present but its record could not be read; capture-result refused: %w", corrupted))
+			}
+			return newDiscErr
+		}
+		if newFound {
+			return runReviewFacadeCaptureResultNewLineage(ctx, stdout, root, *lineage, newRecord, *lens, *order, *subjectHash, *input, *preflight)
+		}
+	}
 	// --preflight verifies the capture binding without reading or persisting
 	// any result, so it stays reachable under a frozen switch. Everything else
 	// here publishes a reviewer result into the store.
@@ -886,6 +905,85 @@ func reviewArtifactModeSafe(mode os.FileMode, directory bool) bool {
 func reviewArtifactModeSafeForOS(mode os.FileMode, directory bool, goos string) bool {
 	return goos == "windows" || mode.Perm()&0o077 == 0 && (!directory || mode.Perm()&0o700 == 0o700)
 }
+
+// ReviewFacadeCaptureResultNewLineageResult is v3's own capture-result
+// response shape (C-A, Wave 5 fix cycle 2). Deliberately narrow: no
+// findings/evidence/admission-decision richness -- that is v2's
+// ArtifactSubject/admission pipeline, not rebuilt for v3 per the
+// coordinator's minimal-capture-primitive decision -- just enough to
+// confirm which lens/order was captured and under what subject hash.
+type ReviewFacadeCaptureResultNewLineageResult struct {
+	Operation     string `json:"operation"`
+	LineageID     string `json:"lineage_id"`
+	Lens          string `json:"lens"`
+	SelectedOrder int    `json:"selected_order"`
+	SubjectHash   string `json:"subject_hash"`
+	Preflight     bool   `json:"preflight,omitempty"`
+}
+
+// runReviewFacadeCaptureResultNewLineage is C-A's CLI wiring for the minimal
+// v3 capture primitive (reviewtransaction.AuthorityStore.CaptureLensResult).
+// --preflight derives and returns the exact provider-owned subject hash
+// without persisting anything, mirroring v2's own preflight shape -- the
+// discovery path an operator or reviewing agent uses to learn what to echo
+// back in a real capture. A real capture reads --input, decodes it as the
+// SAME strict reviewer-result JSON shape v2 uses (facadeReviewerResult --
+// one wire contract for both lineage kinds), and refuses unless its own
+// subject_hash field matches that same provider-owned derivation.
+func runReviewFacadeCaptureResultNewLineage(
+	ctx context.Context, stdout io.Writer, root, lineage string, record reviewtransaction.NewLineageRecord,
+	lens string, order int, subjectHashFlag, input string, preflight bool,
+) error {
+	authority := record.Authority
+	if order < 0 || order >= len(authority.SelectedLenses) || authority.SelectedLenses[order] != lens {
+		return reviewPreflightError(fmt.Errorf("capture binding does not match the frozen selected-lens order for lineage %q; discover the exact lens/order pairs with `gentle-ai review capture-result --cwd <repo> --lineage %s --target <target> --lens <lens> --order <order> --preflight`", lineage, lineage))
+	}
+	wantSubject := reviewtransaction.NewLineageArtifactSubjectHash(authority, lens, order)
+	if preflight {
+		if subjectHashFlag != "" && subjectHashFlag != wantSubject {
+			return reviewPreflightError(fmt.Errorf("capture preflight subject hash does not match the provider-owned authority; refresh the binding with `gentle-ai review capture-result --cwd <repo> --lineage %s --target <target> --lens %s --order %d --preflight`", lineage, lens, order))
+		}
+		return encodeReviewJSON(stdout, ReviewFacadeCaptureResultNewLineageResult{
+			Operation: "review/capture-result", LineageID: lineage, Lens: lens, SelectedOrder: order,
+			SubjectHash: wantSubject, Preflight: true,
+		})
+	}
+	if err := authorizeReviewAuthorityMutation(ctx, root); err != nil {
+		return err
+	}
+	rawPayload, err := readFacadeBytes(input)
+	if err != nil {
+		return reviewPreflightError(fmt.Errorf("read reviewer result: %w", err))
+	}
+	if err := validateReviewerResultPayload(rawPayload); err != nil {
+		return reviewPreflightError(err)
+	}
+	payload, decision, err := reviewtransaction.ExtractBoundedSingleJSONObject(rawPayload, reviewResultArtifactLimit)
+	if err != nil {
+		return reviewPreflightError(fmt.Errorf("reviewer artifact admission %s: %w", decision, err))
+	}
+	var result facadeReviewerResult
+	if err := decodeFacadeJSONBytes(payload, &result); err != nil {
+		return reviewPreflightError(fmt.Errorf("decode reviewer result: %w", err))
+	}
+	if result.Findings == nil || result.Evidence == nil {
+		return reviewPreflightError(errors.New("reviewer result requires explicit findings and evidence arrays"))
+	}
+	if result.SubjectHash != wantSubject {
+		return reviewPreflightError(fmt.Errorf("captured reviewer result does not bind the provider-owned subject hash; refresh the binding with `gentle-ai review capture-result --cwd <repo> --lineage %s --target <target> --lens %s --order %d --preflight`", lineage, lens, order))
+	}
+	store, err := reviewtransaction.NewLineageAuthorityStore(ctx, root, lineage)
+	if err != nil {
+		return err
+	}
+	if _, err := store.CaptureLensResult(ctx, record.Revision, lens, order, result.SubjectHash); err != nil {
+		return reviewPreflightError(err)
+	}
+	return encodeReviewJSON(stdout, ReviewFacadeCaptureResultNewLineageResult{
+		Operation: "review/capture-result", LineageID: lineage, Lens: lens, SelectedOrder: order, SubjectHash: result.SubjectHash,
+	})
+}
+
 func removeOwnedArtifact(path string, owned os.FileInfo) {
 	if owned == nil {
 		return

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -64,6 +64,26 @@ func reviewFacadeReceiptNotAvailableReason(lineageID string) string {
 	return fmt.Sprintf("facade review receipt is not available; run gentle-ai review finalize --lineage %s to produce one", lineageID)
 }
 
+// reviewFacadeApprovedReceiptCorruptReason (W-7, Wave 5 fix cycle 2,
+// verify-report #10186) is the honest continuation for an approved v3
+// authority whose receipt file EXISTS but fails to parse/validate or does
+// not match the authority's own frozen state (tampered, corrupted, or
+// otherwise diverged). Deliberately distinct from
+// reviewFacadeReceiptNotAvailableReason: naming `review finalize` here would
+// name a continuation that itself refuses -- WriteReceipt's own
+// publishImmutable never overwrites existing bytes that differ from what it
+// would republish (ImmutablePublicationConflictError), and v3 has no
+// reopen/repair machinery for a corrupted receipt. A fresh lineage is the
+// only continuation that actually clears this denial.
+func reviewFacadeApprovedReceiptCorruptReason(lineageID string) string {
+	return fmt.Sprintf(
+		"approved new-lineage authority %s has a receipt that cannot be trusted (missing valid content, or its recorded identity does not match the frozen authority); "+
+			"a corrupted receipt cannot be repaired -- v3 has no reopen path for it, and re-running finalize would itself refuse (its own immutable-publication check never overwrites differing existing bytes) -- "+
+			"start a fresh review instead: gentle-ai review start --cwd <repo> --lineage <new-lineage-id>",
+		lineageID,
+	)
+}
+
 // reviewCompactFacadeLineageNotDiscoverableReason is the single wording
 // source for the refusal when selector-free compact lineage discovery finds
 // no candidate. This is reached only after every otherwise-loadable leaf has

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2150,11 +2150,15 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 			return newDiscErr
 		}
 		if newFound {
-			// The legacy reviewer-result ingestion pipeline (readFacadeReviewerArtifacts,
-			// readCapturedReviewerResults) is bound to CompactState/CompactStore and has
-			// no v3 equivalent yet (Wave 4+ territory) — refuse explicitly rather than
-			// silently ignore a caller's reviewer-result flags for a new-lineage authority.
-			for _, unsupported := range []string{"result", "result-artifact", "result-artifact-file", "captured-results", "captured-evidence", "validation", "refuter", "evidence"} {
+			// The legacy reviewer-result ARTIFACT ingestion pipeline
+			// (readFacadeReviewerArtifacts, readCapturedReviewerResults) is bound to
+			// CompactState/CompactStore and has no v3 equivalent — refuse explicitly
+			// rather than silently ignore a caller's reviewer-result flags for a
+			// new-lineage authority. --captured-results is excluded from this list
+			// (C-A, Wave 5 fix cycle 2): it now names the minimal v3 capture
+			// primitive's own persisted CapturedResults, not the legacy artifact
+			// pipeline these other flags name.
+			for _, unsupported := range []string{"result", "result-artifact", "result-artifact-file", "captured-evidence", "validation", "refuter", "evidence"} {
 				if reviewFinalizeFlagProvided(args, unsupported) {
 					return reviewPreflightError(fmt.Errorf("new-lineage finalize does not yet support --%s; retry with `gentle-ai review finalize --lineage %s` and, if needed, --failed or --admission-findings", unsupported, *lineage))
 				}
@@ -2171,7 +2175,7 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 					return err
 				}
 			}
-			return runReviewFacadeFinalizeNewLineage(ctx, stdout, root, *lineage, newRecord, findings, *failed)
+			return runReviewFacadeFinalizeNewLineage(ctx, stdout, root, *lineage, newRecord, findings, *failed, *capturedResults)
 		}
 	}
 	store, record, err := discoverCompactFacadeFinalize(ctx, root, *lineage)

--- a/internal/cli/review_facade_finalize_new_lineage.go
+++ b/internal/cli/review_facade_finalize_new_lineage.go
@@ -64,7 +64,7 @@ type ReviewFacadeFinalizeNewLineageResult struct {
 // own precedent (review_facade_new_lineage.go:73-78) exactly.
 func runReviewFacadeFinalizeNewLineage(
 	ctx context.Context, stdout io.Writer, root, lineage string, record reviewtransaction.NewLineageRecord,
-	findings []reviewtransaction.FindingEvidence, failed bool,
+	findings []reviewtransaction.FindingEvidence, failed, capturedResults bool,
 ) error {
 	store, err := reviewtransaction.NewLineageAuthorityStore(ctx, root, lineage)
 	if err != nil {
@@ -73,10 +73,22 @@ func runReviewFacadeFinalizeNewLineage(
 	authority := record.Authority
 	revision := record.Revision
 
+	// C-A (Wave 5 fix cycle 2): --captured-results names the lens results the
+	// minimal v3 capture primitive already persisted onto this authority
+	// (AuthorityStore.CaptureLensResult) -- never a caller-supplied list, the
+	// same "only the caller's own already-admitted results, never new input"
+	// shape v2's --captured-results has. A tier-low authority (SelectedLenses
+	// empty) passes hasCapturedAllSelectedLenses trivially either way.
+	var capturedLensResults []string
+	if capturedResults {
+		capturedLensResults = authority.CapturedLensNames()
+	}
 	admitted, _ := reviewtransaction.AdmitCandidateCausalFindings(findings)
 	transition, err := (reviewtransaction.ReviewCore{}).Next(ctx, authority, reviewtransaction.CoreRequest{
-		Kind:           reviewtransaction.CoreRequestFinalize,
-		AdvanceRequest: &reviewtransaction.FinalizeAdvanceRequest{Failed: failed, AdmittedFindingIDs: admitted},
+		Kind: reviewtransaction.CoreRequestFinalize,
+		AdvanceRequest: &reviewtransaction.FinalizeAdvanceRequest{
+			Failed: failed, AdmittedFindingIDs: admitted, CapturedLensResults: capturedLensResults,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("review core finalize: %w", err)

--- a/internal/cli/review_governing_authority.go
+++ b/internal/cli/review_governing_authority.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -101,16 +102,38 @@ func resolveGoverningAuthority(ctx context.Context, root, lineage string, gateIn
 				return true, reviewtransaction.NativeGateEvaluation{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted, Detail: storeErr.Error()}
 			}
 			receipt, receiptErr := authorityStore.LoadReceipt()
-			if receiptErr != nil || receipt.LineageID != record.Authority.LineageID ||
+			// W-7 (Wave 5 fix cycle 2, verify-report #10186): a genuinely ABSENT
+			// receipt (never published, e.g. a crash between Mutate and
+			// WriteReceipt) is repaired by a plain finalize replay --
+			// WriteReceipt's own publishImmutable (authority_store.go) writes
+			// fresh content when none exists yet. A PRESENT receipt that fails to
+			// parse/validate, or does not match the authority's own frozen state,
+			// can NEVER be repaired the same way: publishImmutable refuses to
+			// overwrite differing existing bytes (ImmutablePublicationConflictError,
+			// store.go's publishNoReplace path) rather than repairing them, and v3
+			// has no reopen/repair machinery for that case (the same "no reopen"
+			// boundary AuthorityStore.CaptureLensResult enforces, C-A). Naming
+			// `review finalize` for THIS case named a continuation that would
+			// itself refuse -- the honest continuation is a fresh lineage.
+			receiptAbsent := receiptErr != nil && os.IsNotExist(receiptErr)
+			receiptInvalid := receiptErr == nil && (receipt.LineageID != record.Authority.LineageID ||
 				receipt.AuthorityRevision != record.Revision || receipt.TerminalState != record.Authority.State ||
-				receipt.CandidateIdentity != record.Authority.CandidateIdentity {
+				receipt.CandidateIdentity != record.Authority.CandidateIdentity)
+			receiptUnreadable := receiptErr != nil && !receiptAbsent
+			if receiptAbsent || receiptInvalid || receiptUnreadable {
+				reason := reviewFacadeReceiptNotAvailableReason(record.Authority.LineageID)
+				code := "approved_without_receipt"
+				if !receiptAbsent {
+					reason = reviewFacadeApprovedReceiptCorruptReason(record.Authority.LineageID)
+					code = "approved_receipt_corrupt"
+				}
 				return true, reviewtransaction.NativeGateEvaluation{
-					Result: reviewtransaction.GateInvalidated, Reason: reviewFacadeReceiptNotAvailableReason(record.Authority.LineageID),
+					Result: reviewtransaction.GateInvalidated, Reason: reason,
 					Context: reviewtransaction.GateContext{
 						Gate: gateInput.Gate, LineageID: record.Authority.LineageID, StoreRevision: record.Revision,
 						BaseTree: record.Authority.CandidateIdentity.BaseTree, CandidateTree: record.Authority.CandidateIdentity.CandidateTree,
 						PolicyHash: record.Authority.CandidateIdentity.PolicyHash,
-						Denial:     &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: "approved_without_receipt"},
+						Denial:     &reviewtransaction.GateDenial{Stage: "new-lineage-validate", Code: code},
 					},
 				}, nil
 			}

--- a/internal/cli/review_governing_authority_test.go
+++ b/internal/cli/review_governing_authority_test.go
@@ -305,6 +305,90 @@ func TestResolveGoverningAuthorityCandidateIdentityMismatchDenies(t *testing.T) 
 	}
 }
 
+// TestResolveGoverningAuthorityCorruptReceiptNamesFreshLineageNotFinalize is
+// W-7 (Wave 5 fix cycle 2, verify-report #10186): a PRESENT but tampered/
+// mismatched receipt used to name the exact same continuation as a genuinely
+// ABSENT one (reviewFacadeReceiptNotAvailableReason, "run gentle-ai review
+// finalize --lineage %s"). Investigated: WriteReceipt's own publishImmutable
+// (authority_store.go, store.go's publishNoReplace path) refuses to
+// overwrite EXISTING content that differs from what it would (re)publish --
+// it returns ImmutablePublicationConflictError rather than repairing the
+// tamper. So for an approved lineage whose receipt exists but does not match
+// the frozen authority, `review finalize --lineage <id>` would itself
+// refuse: the named continuation was a dead end, not a repair. This pins the
+// honest replacement: a distinct denial code (approved_receipt_corrupt, not
+// approved_without_receipt) and a message naming the only continuation that
+// actually clears it -- a fresh lineage; v3 has no reopen/repair machinery
+// for a corrupted receipt (the same "no reopen" boundary
+// AuthorityStore.CaptureLensResult enforces).
+func TestResolveGoverningAuthorityCorruptReceiptNamesFreshLineageNotFinalize(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "corrupt-receipt-names-fresh-lineage"
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("corrupt-receipt fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+
+	live, _, err := governingAuthorityLiveEvidence(context.Background(), repo, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.NewLineageAuthorityStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Mutate(context.Background(), "", func(next *reviewtransaction.NewLineageAuthority) error {
+		next.State = reviewtransaction.NewLineageStateApproved
+		next.CandidateIdentity = live
+		next.Tier = reviewtransaction.RiskLow
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteReceipt(context.Background(), reviewtransaction.NewLineageReceipt{
+		Schema: reviewtransaction.NewLineageReceiptSchema, LineageID: lineage,
+		TerminalState: reviewtransaction.NewLineageStateApproved, AuthorityRevision: revision,
+		CandidateIdentity: live,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tampered := live
+	tampered.BaseTree = strings.Repeat("f", len(live.BaseTree))
+	tamperedPayload, err := json.MarshalIndent(reviewtransaction.NewLineageReceipt{
+		Schema: reviewtransaction.NewLineageReceiptSchema, LineageID: lineage,
+		TerminalState: reviewtransaction.NewLineageStateApproved, AuthorityRevision: revision,
+		CandidateIdentity: tampered,
+	}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.ReceiptPath(), append(tamperedPayload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	governs, evaluation, discoveryErr := resolveGoverningAuthority(context.Background(), repo, lineage, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
+	if !governs {
+		t.Fatal("a corrupted receipt must still govern (deny), got governs=false")
+	}
+	if discoveryErr != nil {
+		t.Fatalf("unexpected discovery error: %v", discoveryErr)
+	}
+	if evaluation.Result == reviewtransaction.GateAllow {
+		t.Fatalf("a tampered receipt must never allow, got %#v", evaluation)
+	}
+	if evaluation.Context.Denial == nil || evaluation.Context.Denial.Code != "approved_receipt_corrupt" {
+		t.Fatalf("denial code = %#v, want approved_receipt_corrupt (distinct from the genuinely-absent approved_without_receipt case)", evaluation.Context.Denial)
+	}
+	if strings.Contains(evaluation.Reason, "review finalize --lineage") {
+		t.Fatalf("reason = %q, must not name finalize -- WriteReceipt refuses to overwrite the differing on-disk bytes, so finalize would itself refuse", evaluation.Reason)
+	}
+	if !strings.Contains(evaluation.Reason, "gentle-ai review start") {
+		t.Fatalf("reason = %q, must name the only continuation that actually clears a corrupted receipt: a fresh lineage via review start", evaluation.Reason)
+	}
+}
+
 // TestRunReviewFacadeValidateNewLineageGovernsOverAnAllowingLegacyReceipt is
 // Wave 5 Slice 4's receipt-precedence proof: a v3 record AND a legacy v1
 // chain both exist under the IDENTICAL lineage id and the SAME exact

--- a/internal/cli/review_new_lineage_capture_test.go
+++ b/internal/cli/review_new_lineage_capture_test.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// Wave 5 fix cycle 2, CRITICAL-A (verify-report #10186, coordinator's
+// "minimal capture primitive" decision, NOT a rebuilt v2-shaped admission
+// pipeline): the exact verify repro is the RED shape below --
+// `GENTLE_AI_RDD_NEW_LINEAGE=1 gentle-ai review start --lineage med1`
+// (medium tier, consent granted) then `gentle-ai review finalize --lineage
+// med1` fails with "new-lineage finalize requires captured results for
+// every frozen selected lens before approving" because no production code
+// ever set FinalizeAdvanceRequest.CapturedLensResults and `review
+// capture-result` bound only the v2 compact store.
+
+// startMediumTierNewLineage starts a v3 lineage whose content classifies as
+// RiskMedium: an executable (non-documentation) file change is enough
+// (risk_test.go's own "remaining executable change is medium" fixture:
+// Stats{Additions: 1} on a .go path). Consent is granted through the plain
+// (non-negotiated) one-time console path: authorizeReviewStart's own
+// non-interactive branch (review_mode.go, "!console.Interactive") shows the
+// "reviewed without asking" notice and proceeds without blocking -- the
+// exact shape a non-interactive test process reaches with no --consent flag
+// at all (--consent itself requires the negotiated --contract form, a
+// separate surface this fixture deliberately does not use, matching the
+// verify repro's own plain `review start` shape).
+func startMediumTierNewLineage(t *testing.T, repo, lineage string) ReviewFacadeStartNewLineageResult {
+	t.Helper()
+	t.Setenv("GENTLE_AI_RDD_NEW_LINEAGE", "1")
+	path := filepath.Join(repo, "lib", lineage+".go")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("package lib\n\nfunc Example() int { return 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, &out); err != nil {
+		t.Fatalf("medium-tier new-lineage start: %v\n%s", err, out.String())
+	}
+	var started ReviewFacadeStartNewLineageResult
+	decodeStrictReviewJSON(t, out.Bytes(), &started)
+	if started.LineageID != lineage || started.State != reviewtransaction.NewLineageStateReviewing {
+		t.Fatalf("medium-tier new-lineage start = %#v", started)
+	}
+	if started.RiskLevel != reviewtransaction.RiskMedium {
+		t.Fatalf("fixture sanity check failed: tier = %q, want medium (the exact verify repro tier)", started.RiskLevel)
+	}
+	if len(started.SelectedLenses) == 0 {
+		t.Fatalf("fixture sanity check failed: medium tier selected zero lenses, nothing to capture")
+	}
+	t.Setenv("GENTLE_AI_RDD_NEW_LINEAGE", "")
+	return started
+}
+
+// captureNewLineageLensResults submits one strict reviewer result for every
+// one of the lineage's frozen selected lenses through the real CLI
+// `review capture-result`, deriving each lens's provider-owned subject hash
+// via --preflight first (the exact discovery path an operator or reviewing
+// agent uses) rather than reimplementing the derivation in the test.
+func captureNewLineageLensResults(t *testing.T, repo, lineage string, lenses []string) {
+	t.Helper()
+	for order, lens := range lenses {
+		var preflightOut bytes.Buffer
+		if err := RunReviewCaptureResult([]string{
+			"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+			"--lens", lens, "--order", strconv.Itoa(order), "--preflight",
+		}, &preflightOut); err != nil {
+			t.Fatalf("capture-result preflight for lens %q: %v\n%s", lens, err, preflightOut.String())
+		}
+		var preflight ReviewFacadeCaptureResultNewLineageResult
+		decodeStrictReviewJSON(t, preflightOut.Bytes(), &preflight)
+		if preflight.SubjectHash == "" {
+			t.Fatalf("capture-result preflight for lens %q returned no subject hash: %#v", lens, preflight)
+		}
+
+		inputPath := filepath.Join(t.TempDir(), lens+".json")
+		payload := `{"subject_hash":"` + preflight.SubjectHash + `","findings":[],"evidence":["reviewed"]}`
+		if err := os.WriteFile(inputPath, []byte(payload), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var out bytes.Buffer
+		if err := RunReviewCaptureResult([]string{
+			"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+			"--lens", lens, "--order", strconv.Itoa(order), "--input", inputPath,
+		}, &out); err != nil {
+			t.Fatalf("capture-result for lens %q: %v\n%s", lens, err, out.String())
+		}
+		var result ReviewFacadeCaptureResultNewLineageResult
+		decodeStrictReviewJSON(t, out.Bytes(), &result)
+		if result.SubjectHash != preflight.SubjectHash {
+			t.Fatalf("capture-result for lens %q did not echo the preflight subject hash: got %q want %q", lens, result.SubjectHash, preflight.SubjectHash)
+		}
+	}
+}
+
+// TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGates
+// is C-A's END STATE: the coordinator's exact repro (medium-tier v3, consent
+// granted, capture via the real CLI, finalize -> approved) then all five
+// gates allow. Before this fix, finalize refused with
+// ErrFinalizeRequiresLensResults and there was no way to satisfy it.
+func TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGates(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "medium-tier-capture-lineage"
+	started := startMediumTierNewLineage(t, repo, lineage)
+
+	captureNewLineageLensResults(t, repo, lineage, started.SelectedLenses)
+
+	var finalizeOut bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--captured-results=true"}, &finalizeOut); err != nil {
+		t.Fatalf("finalize after capturing every selected lens: %v\n%s", err, finalizeOut.String())
+	}
+	var finalized ReviewFacadeFinalizeNewLineageResult
+	decodeStrictReviewJSON(t, finalizeOut.Bytes(), &finalized)
+	if finalized.State != reviewtransaction.NewLineageStateApproved {
+		t.Fatalf("finalize(captured) state = %q, want approved", finalized.State)
+	}
+
+	dir := t.TempDir()
+	releaseArtifact := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	releaseArgs := []string{
+		"--release-configuration", releaseArtifact("configuration.txt", "configuration\n"),
+		"--release-generated", releaseArtifact("generated.txt", "generated\n"),
+		"--release-provenance", releaseArtifact("provenance.txt", "provenance\n"),
+		"--release-publication-boundary", releaseArtifact("publication-boundary.txt", "publication boundary\n"),
+		"--release-evidence-freshness", releaseArtifact("evidence-freshness.txt", "evidence freshness\n"),
+	}
+	runReviewCLIGit(t, repo, "add", "-A")
+
+	for _, gate := range []struct {
+		kind  reviewtransaction.GateKind
+		extra []string
+	}{
+		{kind: reviewtransaction.GatePostApply},
+		{kind: reviewtransaction.GatePreCommit},
+		{kind: reviewtransaction.GatePrePush},
+		{kind: reviewtransaction.GatePrePR},
+		{kind: reviewtransaction.GateRelease, extra: releaseArgs},
+	} {
+		t.Run(string(gate.kind), func(t *testing.T) {
+			args := append([]string{"--cwd", repo, "--lineage", lineage, "--gate", string(gate.kind)}, gate.extra...)
+			var out bytes.Buffer
+			if err := RunReviewFacadeValidate(args, &out); err != nil {
+				t.Fatalf("gate %q must allow the approved medium-tier v3 candidate: %v\n%s", gate.kind, err, out.String())
+			}
+			assertReviewGateResult(t, out.Bytes(), reviewtransaction.GateAllow)
+		})
+	}
+}
+
+// TestReviewFacadeCaptureResultNewLineage_TierLowZeroResultsStillWorks pins
+// the non-regression: a tier-low v3 lineage (SelectedLenses is empty) still
+// finalizes with zero captured results -- the C-A fix must not require a
+// capture that a tier-low lineage never asked for.
+func TestReviewFacadeCaptureResultNewLineage_TierLowZeroResultsStillWorks(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "tier-low-zero-results-lineage"
+	startNewLineageForFinalizeTest(t, repo, lineage)
+
+	var out bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--captured-results=true"}, &out); err != nil {
+		t.Fatalf("tier-low finalize with --captured-results=true and zero results: %v\n%s", err, out.String())
+	}
+	var result ReviewFacadeFinalizeNewLineageResult
+	decodeStrictReviewJSON(t, out.Bytes(), &result)
+	if result.State != reviewtransaction.NewLineageStateApproved {
+		t.Fatalf("tier-low finalize(captured-results, zero lenses) state = %q, want approved", result.State)
+	}
+}

--- a/internal/reviewtransaction/authority_store.go
+++ b/internal/reviewtransaction/authority_store.go
@@ -96,6 +96,36 @@ type NewLineageAuthority struct {
 	AdmittedFindingIDs    []string          `json:"admitted_finding_ids,omitempty"`
 	ReplayIdentity        string            `json:"replay_identity,omitempty"`
 	LastTransition        json.RawMessage   `json:"last_transition,omitempty"`
+	// CapturedResults is C-A's minimal capture primitive (Wave 5 fix cycle 2,
+	// coordinator decision: not a rebuilt v2-shaped admission pipeline --
+	// ArtifactSubject/FrozenCandidateContext/reopen machinery is Wave 7
+	// deletion scope). Written only through AuthorityStore.CaptureLensResult
+	// (new_lineage_capture.go), never directly: one entry per captured lens,
+	// one-shot (no reopen), each bound to its own provider-owned subject hash.
+	CapturedResults []NewLineageCapturedResult `json:"captured_results,omitempty"`
+}
+
+// NewLineageCapturedResult is one captured reviewer result's minimal
+// persisted binding: which lens, at which frozen selected-lens order, under
+// which provider-owned subject hash (NewLineageArtifactSubjectHash). It
+// deliberately carries no findings/evidence/admission-decision richness --
+// those stay v2's ArtifactSubject-admission concern, not rebuilt for v3.
+type NewLineageCapturedResult struct {
+	Lens        string `json:"lens"`
+	Order       int    `json:"order"`
+	SubjectHash string `json:"subject_hash"`
+}
+
+// CapturedLensNames returns the plain lens-name list
+// FinalizeAdvanceRequest.CapturedLensResults (and hasCapturedAllSelectedLenses)
+// need, derived from the richer CapturedResults slice rather than storing
+// the same names twice.
+func (authority NewLineageAuthority) CapturedLensNames() []string {
+	names := make([]string, len(authority.CapturedResults))
+	for index, captured := range authority.CapturedResults {
+		names[index] = captured.Lens
+	}
+	return names
 }
 
 // Validate enforces the structural half of the two-artifact contract this
@@ -136,6 +166,16 @@ func (authority NewLineageAuthority) Validate() error {
 		if strings.TrimSpace(id) != id || id == "" {
 			return errors.New("new-lineage authority admitted finding ids must be canonical non-empty strings") // refusal:by-design world-action: AdmittedFindingIDs is set by ReviewCore's causal-admission logic; malformed entries are a caller bug, not an operator-fixable state
 		}
+	}
+	seenCapturedLenses := make(map[string]bool, len(authority.CapturedResults))
+	for _, captured := range authority.CapturedResults {
+		if strings.TrimSpace(captured.Lens) == "" || captured.Order < 0 || !validSHA256(captured.SubjectHash) {
+			return errors.New("new-lineage authority captured results must carry a non-empty lens, a non-negative order, and a canonical subject hash") // refusal:by-design world-action: captured results are only ever written by AuthorityStore.CaptureLensResult after validating them; malformed entries here mean in-process corruption, not something an operator command repairs
+		}
+		if seenCapturedLenses[captured.Lens] {
+			return errors.New("new-lineage authority captured results must name each lens at most once") // refusal:by-design world-action: CaptureLensResult enforces one-shot-per-lens before ever appending; a duplicate here means in-process corruption, not something an operator command repairs
+		}
+		seenCapturedLenses[captured.Lens] = true
 	}
 	if authority.ReplayIdentity != "" && !validSHA256(authority.ReplayIdentity) {
 		return errors.New("new-lineage authority replay identity must be a canonical digest") // refusal:by-design world-action: the replay identity is only ever set by RecordTransition's own digest computation; a malformed value means in-process corruption, not something an operator command repairs

--- a/internal/reviewtransaction/gate_boundary_matrix_test.go
+++ b/internal/reviewtransaction/gate_boundary_matrix_test.go
@@ -461,6 +461,82 @@ func TestGateBoundaryMatrix_35Cells(t *testing.T) {
 		}
 	}
 
+	// W-2 (Wave 5 fix cycle 2, verify-report #10186): release had zero driven
+	// cells (W-2's own finding). release/exact and release/changed are wired
+	// here, mirroring the identical exact/changed recipes above, extended
+	// with the five release-boundary artifact flags gateVerdict's
+	// gate==GateRelease precondition requires (C-B/C-C wired the receiving
+	// end of that precondition for legacy and v3; this cell exercises it
+	// through the compact/v2 path, the one lineage kind a plain binary-driven
+	// `review start` can freshly create -- confirmed empirically: a v1 legacy
+	// lineage has no CLI-reachable creation path at all, and a v3 lineage
+	// needs GENTLE_AI_RDD_NEW_LINEAGE threaded into the subprocess, both
+	// deferred rather than rushed into this budget).
+	releaseArtifactArgs := func(t *testing.T) []string {
+		t.Helper()
+		dir := t.TempDir()
+		artifact := func(name, content string) string {
+			path := filepath.Join(dir, name)
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		}
+		return []string{
+			"--release-configuration", artifact("configuration.txt", "configuration\n"),
+			"--release-generated", artifact("generated.txt", "generated\n"),
+			"--release-provenance", artifact("provenance.txt", "provenance\n"),
+			"--release-publication-boundary", artifact("publication-boundary.txt", "publication boundary\n"),
+			"--release-evidence-freshness", artifact("evidence-freshness.txt", "evidence freshness\n"),
+		}
+	}
+
+	// release / exact: release's own target resolution is TargetExactRevision
+	// at the current committed HEAD (lifecycleTargetForGate's GateRelease
+	// case), not TargetCurrentChanges -- so, unlike post-apply/pre-commit,
+	// the reviewed candidate must actually be committed before release can
+	// see it at all (confirmed empirically: an uncommitted candidate denies
+	// scope-changed, HEAD's tree never contained the reviewed path).
+	{
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "docs/notes.md", "release notes\n")
+		lineage := "matrix-release-exact"
+		if out, err := runGateBoundaryMatrixReview(binary, repo, "start", "--lineage", lineage); err != nil {
+			t.Fatalf("release/exact review start: %v\n%s", err, out)
+		}
+		if out, err := runGateBoundaryMatrixReview(binary, repo, "finalize", "--lineage", lineage); err != nil {
+			t.Fatalf("release/exact review finalize: %v\n%s", err, out)
+		}
+		gitSnapshot(t, repo, "add", "docs/notes.md")
+		gitSnapshot(t, repo, "commit", "-m", "deliver reviewed candidate")
+		args := append([]string{"validate", "--lineage", lineage, "--gate", string(GateRelease)}, releaseArtifactArgs(t)...)
+		out, err := runGateBoundaryMatrixReview(binary, repo, args...)
+		if err != nil {
+			t.Fatalf("release/exact review validate: %v\n%s", err, out)
+		}
+		result := decodeGateBoundaryMatrixResult(t, out)
+		if result.Result != string(GateAllow) {
+			t.Fatalf("release/exact result = %#v", result)
+		}
+		wired[[2]string{string(GateRelease), "exact"}] = gateBoundaryMatrixRow{
+			Gate: string(GateRelease), Relation: "exact", Verdict: string(GateAllow), Explained: false,
+			Reason: "driven via the real gentle-ai binary: review start -> finalize -> validate --gate release with the five release-boundary artifacts on the identical, unchanged candidate",
+		}
+	}
+
+	// release / changed: investigated, not pursued this budget. Unlike the
+	// other four gates, release's own target resolves TargetExactRevision at
+	// the current committed HEAD (lifecycleTargetForGate/buildCompactGateRequestWithPushBase's
+	// GateRelease case), not TargetCurrentChanges -- an uncommitted workspace
+	// drift (the recipe the other four "changed" cells use) never reaches
+	// release's own candidate comparison at all, and the fixture instead
+	// needs a genuinely delivered (committed) drift, mirroring pre-push's own
+	// "amend the delivery commit" recipe rather than the plain post-apply/
+	// pre-commit/pre-pr shape. Confirmed empirically: the plain-drift recipe
+	// produces an unrelated scope-change diagnostic, not a clean "changed"
+	// denial. Deferred rather than rushed; release/exact above is this
+	// budget's genuine, verified increment.
+
 	rows := make([]gateBoundaryMatrixRow, 0, len(gateBoundaryMatrixGates)*len(gateBoundaryMatrixRelations))
 	for _, gate := range gateBoundaryMatrixGates {
 		for _, relation := range gateBoundaryMatrixRelations {
@@ -480,8 +556,8 @@ func TestGateBoundaryMatrix_35Cells(t *testing.T) {
 	if len(rows) != 35 {
 		t.Fatalf("gate boundary matrix has %d rows, want 35 (5 gates x 7 relations)", len(rows))
 	}
-	if len(wired) != 8 {
-		t.Fatalf("gate boundary matrix wired %d cells, want exactly 8 this slice (4 from S1: post-apply/pre-commit/pre-push/pre-pr exact; 3 from S3: post-apply/pre-commit/pre-push changed; 1 new from S5: pre-pr changed)", len(wired))
+	if len(wired) != 9 {
+		t.Fatalf("gate boundary matrix wired %d cells, want exactly 9 (4 from S1: post-apply/pre-commit/pre-push/pre-pr exact; 3 from S3: post-apply/pre-commit/pre-push changed; 1 from S5: pre-pr changed; 1 new from Wave 5 fix cycle 2 W-2: release exact)", len(wired))
 	}
 
 	actual, err := json.MarshalIndent(rows, "", "  ")

--- a/internal/reviewtransaction/new_lineage_capture.go
+++ b/internal/reviewtransaction/new_lineage_capture.go
@@ -1,0 +1,111 @@
+package reviewtransaction
+
+// Wave 5 fix cycle 2, CRITICAL-A closure (verify-report #10186). Coordinator
+// decision, recorded here and in design.md: a MINIMAL capture primitive, not
+// a parallel v2-shaped admission pipeline. v2's ArtifactSubject/
+// FrozenCandidateContext/reopen/journal machinery is legacy-era complexity
+// already scheduled for Wave 7 deletion; rebuilding it for v3 would violate
+// the wave's own simplification mandate. v3 needs exactly the minimum that
+// makes ReviewCore.finalize's ErrFinalizeRequiresLensResults refusal
+// satisfiable: persist captured lens results onto the v3 authority, bound
+// to a provider-owned subject hash, through the existing Mutate/CAS path --
+// no reopen, no separate artifact store, no findings/evidence admission
+// pipeline (that stays a v2-only concept).
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// NewLineageArtifactSubjectHash is C-A's minimal provider-owned binding: it
+// proves a reviewer result was computed against THIS exact frozen authority
+// (lineage, candidate identity), lens, and order -- the same "the reviewer
+// inspected the exact frozen candidate" guarantee v2's ArtifactSubject.
+// SubjectHash gives, derived only from data already persisted on
+// NewLineageAuthority, with no additional Git diff/manifest work (that
+// richer FrozenCandidateContext derivation is v2-only).
+//
+// Deliberately excludes the authority's own revision (the CAS token): the
+// revision changes on every Mutate, including the very capture this hash
+// authorizes, so binding to it would relabel the "correct" subject hash on
+// every resubmission -- the exact frozen-anchor lesson Phase 9 already
+// applied to the archive re-verify gate (see review_reverify.go). LineageID
+// and CandidateIdentity are frozen once at start and never mutate again for
+// the authority's whole lifetime, so binding to them instead keeps this hash
+// stable across every capture, including the idempotent-resubmission case.
+func NewLineageArtifactSubjectHash(authority NewLineageAuthority, lens string, order int) string {
+	hash := sha256.New()
+	hash.Write([]byte("gentle-ai.new-lineage-artifact-subject/v1\x00"))
+	for _, value := range []string{
+		authority.LineageID, authority.CandidateIdentity.RepositoryID,
+		authority.CandidateIdentity.BaseTree, authority.CandidateIdentity.CandidateTree,
+		authority.CandidateIdentity.ChangedPathsModesDigest, authority.CandidateIdentity.PolicyHash,
+		lens,
+	} {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	writeLengthPrefixed(hash, []byte(strconv.Itoa(order)))
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+var (
+	// ErrNewLineageCaptureNotReviewable is refused when capture-result is
+	// attempted against an authority that is not reviewing or validating
+	// (approved/escalated are terminal; correcting has no lens-capture
+	// concept at all -- captures happen before a correction, not during one).
+	ErrNewLineageCaptureNotReviewable = errors.New("new-lineage capture-result requires a reviewing or validating authority") // refusal:by-design operator-knowledge: the caller must capture against the exact reviewing/validating window a fresh review status reports; there is no operator command that reopens a terminal or correcting authority for capture
+	// ErrNewLineageCaptureLensNotSelected is refused when the named lens/order
+	// does not match the frozen SelectedLenses set at that exact index --
+	// C-A's "reject unknown/missing lenses against the frozen selection".
+	ErrNewLineageCaptureLensNotSelected = errors.New("capture binding does not match the frozen selected-lens order") // refusal:by-design operator-knowledge: SelectedLenses is frozen at start and never renegotiated; the caller must capture only a lens genuinely selected, at its genuine order
+	// ErrNewLineageCaptureSubjectMismatch is refused when the submitted
+	// subject hash does not match NewLineageArtifactSubjectHash's own
+	// derivation for this exact authority/revision/lens/order.
+	ErrNewLineageCaptureSubjectMismatch = errors.New("captured reviewer result does not bind the provider-owned subject hash") // refusal:by-design operator-knowledge: the reviewer must echo the exact subject hash a fresh capture-result --preflight derives; there is no operator command that fabricates a matching binding
+	// ErrNewLineageCaptureConflict is refused when a lens already has a
+	// captured result under a DIFFERENT subject hash -- one-shot per lens, no
+	// reopen machinery (C-A's explicit scope boundary).
+	ErrNewLineageCaptureConflict = errors.New("lens already captured with a different binding; capture is one-shot per lens") // refusal:by-design world-action: v3 has no reviewer-artifact reopen concept (that is v2-only, Wave 7 deletion scope); the fix is a fresh review start for a corrected candidate, not an operator command that reopens this capture
+)
+
+// CaptureLensResult persists one captured reviewer result onto a v3
+// authority through the existing Mutate/CAS path. Semantics (C-A):
+//   - only a reviewing or validating authority may capture;
+//   - lens/order must match the frozen SelectedLenses set exactly;
+//   - subjectHash must match NewLineageArtifactSubjectHash's own derivation;
+//   - one-shot per lens: capturing the SAME lens again with the IDENTICAL
+//     subject hash is an idempotent replace (Mutate's own byte-identical
+//     no-op path); a DIFFERENT subject hash for an already-captured lens is
+//     refused (ErrNewLineageCaptureConflict) -- there is no reopen.
+func (store AuthorityStore) CaptureLensResult(ctx context.Context, expectedRevision, lens string, order int, subjectHash string) (NewLineageRecord, error) {
+	if _, err := store.Mutate(ctx, expectedRevision, func(next *NewLineageAuthority) error {
+		if next.State != NewLineageStateReviewing && next.State != NewLineageStateValidating {
+			return fmt.Errorf("%w: lineage %q is %q", ErrNewLineageCaptureNotReviewable, next.LineageID, next.State)
+		}
+		if order < 0 || order >= len(next.SelectedLenses) || next.SelectedLenses[order] != lens {
+			return fmt.Errorf("%w: lineage %q lens %q order %d", ErrNewLineageCaptureLensNotSelected, next.LineageID, lens, order)
+		}
+		want := NewLineageArtifactSubjectHash(*next, lens, order)
+		if subjectHash != want {
+			return fmt.Errorf("%w: lineage %q lens %q", ErrNewLineageCaptureSubjectMismatch, next.LineageID, lens)
+		}
+		for _, existing := range next.CapturedResults {
+			if existing.Lens != lens {
+				continue
+			}
+			if existing.SubjectHash == subjectHash {
+				return nil // identical binding already captured: idempotent no-op
+			}
+			return fmt.Errorf("%w: lineage %q lens %q", ErrNewLineageCaptureConflict, next.LineageID, lens)
+		}
+		next.CapturedResults = append(append([]NewLineageCapturedResult(nil), next.CapturedResults...), NewLineageCapturedResult{Lens: lens, Order: order, SubjectHash: subjectHash})
+		return nil
+	}); err != nil {
+		return NewLineageRecord{}, err
+	}
+	return store.Load()
+}

--- a/internal/reviewtransaction/new_lineage_capture_test.go
+++ b/internal/reviewtransaction/new_lineage_capture_test.go
@@ -1,0 +1,155 @@
+package reviewtransaction
+
+// Wave 5 fix cycle 2, CRITICAL-A (verify-report #10186). Unit-level RED/
+// GREEN coverage for the minimal capture primitive, independent of the CLI
+// routing (internal/cli's own end-to-end test drives the real verify repro
+// through the compiled binary path).
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func newLineageCaptureFixtureStore(t *testing.T, lenses []string) (AuthorityStore, NewLineageRecord) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	treeOutput, err := runGit(context.Background(), repo, nil, nil, "rev-parse", "HEAD^{tree}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := strings.TrimSpace(string(treeOutput))
+	store, err := NewLineageAuthorityStore(context.Background(), repo, "capture-fixture")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Mutate(context.Background(), "", func(next *NewLineageAuthority) error {
+		next.State = NewLineageStateReviewing
+		next.CandidateIdentity = CandidateIdentity{
+			RepositoryID: "repo-id", BaseTree: tree, CandidateTree: tree, PolicyHash: "sha256:" + hash("policy"),
+		}
+		next.Tier = RiskMedium
+		next.SelectedLenses = lenses
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, record
+}
+
+// TestCaptureLensResult_HappyPathThenFinalizeSatisfiesLensResults is C-A's
+// core proof: a captured result for every selected lens, fed into
+// hasCapturedAllSelectedLenses via CapturedLensNames, satisfies the exact
+// check ReviewCore.finalize enforces (review_core.go:159) -- the check that
+// was permanently unsatisfiable before this fix.
+func TestCaptureLensResult_HappyPathThenFinalizeSatisfiesLensResults(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+
+	updated, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject)
+	if err != nil {
+		t.Fatalf("CaptureLensResult happy path: %v", err)
+	}
+	if len(updated.Authority.CapturedResults) != 1 || updated.Authority.CapturedResults[0].Lens != "review-reliability" {
+		t.Fatalf("captured results = %#v", updated.Authority.CapturedResults)
+	}
+	if !hasCapturedAllSelectedLenses(updated.Authority.SelectedLenses, updated.Authority.CapturedLensNames()) {
+		t.Fatalf("hasCapturedAllSelectedLenses = false after capturing every selected lens: captured=%v selected=%v",
+			updated.Authority.CapturedLensNames(), updated.Authority.SelectedLenses)
+	}
+}
+
+// TestCaptureLensResult_RejectsLensNotInFrozenSelection proves C-A's
+// explicit reject-unknown-lens requirement.
+func TestCaptureLensResult_RejectsLensNotInFrozenSelection(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-risk", 0)
+
+	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-risk", 0, subject); err == nil {
+		t.Fatal("captured a lens that was never in the frozen SelectedLenses set")
+	}
+}
+
+// TestCaptureLensResult_RejectsWrongOrder proves the order binding: a real
+// selected lens at the WRONG order index must still be refused.
+func TestCaptureLensResult_RejectsWrongOrder(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability", "review-risk"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 1)
+
+	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 1, subject); err == nil {
+		t.Fatal("captured a real lens at the wrong frozen order index")
+	}
+}
+
+// TestCaptureLensResult_RejectsSubjectHashMismatch proves the "echo
+// subject_hash binding per the reviewer contract" requirement: an
+// arbitrary/fabricated subject hash must be refused, not silently accepted.
+func TestCaptureLensResult_RejectsSubjectHashMismatch(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+
+	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, "sha256:fabricated"); err == nil {
+		t.Fatal("captured a result whose subject hash does not match the provider-owned derivation")
+	}
+}
+
+// TestCaptureLensResult_OneShotNoReopen proves C-A's explicit scope
+// boundary: recapturing the SAME lens with the IDENTICAL subject hash is an
+// idempotent no-op (Mutate's own byte-identical replay path), but a
+// DIFFERENT subject hash for an already-captured lens is refused -- there is
+// no reopen machinery.
+func TestCaptureLensResult_OneShotNoReopen(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+
+	first, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject)
+	if err != nil {
+		t.Fatalf("first capture: %v", err)
+	}
+
+	t.Run("identical resubmission is an idempotent no-op", func(t *testing.T) {
+		again, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, subject)
+		if err != nil {
+			t.Fatalf("identical resubmission: %v", err)
+		}
+		if again.Revision != first.Revision {
+			t.Fatalf("identical resubmission changed the revision: %q -> %q, want an idempotent no-op", first.Revision, again.Revision)
+		}
+	})
+
+	t.Run("different subject hash for an already-captured lens is refused, not reopened", func(t *testing.T) {
+		differentSubject := NewLineageArtifactSubjectHash(first.Authority, "review-reliability-different-domain", 0)
+		if _, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, differentSubject); err == nil {
+			t.Fatal("recaptured an already-captured lens under a different subject hash; capture must be one-shot, no reopen")
+		}
+	})
+}
+
+// TestCaptureLensResult_RejectsNonReviewableStates proves the state gate:
+// only reviewing/validating may capture -- approved, escalated, and
+// correcting must all be refused.
+func TestCaptureLensResult_RejectsNonReviewableStates(t *testing.T) {
+	for _, state := range []NewLineageState{NewLineageStateApproved, NewLineageStateEscalated, NewLineageStateCorrecting} {
+		t.Run(string(state), func(t *testing.T) {
+			store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+			revision, err := store.Mutate(context.Background(), record.Revision, func(next *NewLineageAuthority) error {
+				next.State = state
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			authority, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			subject := NewLineageArtifactSubjectHash(authority.Authority, "review-reliability", 0)
+			if _, err := store.CaptureLensResult(context.Background(), revision, "review-reliability", 0, subject); err == nil {
+				t.Fatalf("captured against a %q authority, want refused", state)
+			}
+		})
+	}
+}

--- a/internal/reviewtransaction/testdata/gate-boundary-matrix.golden
+++ b/internal/reviewtransaction/testdata/gate-boundary-matrix.golden
@@ -201,9 +201,9 @@
   {
     "gate": "release",
     "relation": "exact",
-    "verdict": "",
-    "explained": true,
-    "reason": "gateVerdict, NativeGateEvaluation.Relation, EvaluateLegacyGate, and EvaluateNewLineageGate all exist and are wired production code as of Wave 5 fix cycle 1 (verify-report #10186's C-B/C-C) -- this cell's own binary-driven fixture (start/finalize/validate through the compiled gentle-ai binary) has not been built yet, not because the underlying mechanism is missing. This harness must drive real code, not reimplement the algebra by hand, so an unbuilt fixture is an explicit SKIP, not a fabricated pass."
+    "verdict": "allow",
+    "explained": false,
+    "reason": "driven via the real gentle-ai binary: review start -\u003e finalize -\u003e validate --gate release with the five release-boundary artifacts on the identical, unchanged candidate"
   },
   {
     "gate": "release",

--- a/openspec/changes/rdd-root-simplification-wave5/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave5/tasks.md
@@ -395,3 +395,67 @@ all 63 packages green; bench module green; bench journey corpus vs a freshly bui
 0 failed, exit 0; `bench/results.json` reverted; gofmt/vet clean; deadcode ratchet clean; rebase-contract
 clean (root `7598eda4` still an ancestor of `origin/main`). Not archivable yet: C-A and its dependents
 (W-2's v3 half) remain open. Return to sdd-apply fix cycle 2.
+
+## Fix Cycle 2 (closes the cycle-1 findings: C-A, W-2, W-7)
+
+Branch `feat/rdd-wave5-f2-v3-capture`, chained from fix cycle 1 @ `e0a51de3`. Coordinator design decision
+recorded here (design.md amendment): C-A is a MINIMAL capture primitive, not a rebuilt v2-shaped admission
+pipeline — that machinery (`ArtifactSubject`/`FrozenCandidateContext`/reopen/journal) is Wave 7 deletion
+scope; rebuilding it for v3 would violate the wave's own simplification mandate.
+
+- [x] **C-A** (v3 lens-result capture, the wave's last CRITICAL): new `reviewtransaction`
+      `NewLineageAuthority.CapturedResults` field + `AuthorityStore.CaptureLensResult` (existing Mutate/CAS
+      path; reviewing/validating only; lens/order must match the frozen `SelectedLenses` set; submitted
+      subject hash must match `NewLineageArtifactSubjectHash`'s own derivation; one-shot per lens, no reopen
+      — an identical resubmission is `Mutate`'s own idempotent no-op, a different subject hash for an
+      already-captured lens is refused). `review capture-result` routes by discovered lineage kind exactly
+      like finalize (wave-3 "ln" precedent); `review finalize`'s v3 branch now accepts `--captured-results`.
+      **Genuine mid-implementation bug caught and fixed before it shipped**: the first subject-hash design
+      bound to the authority's own revision, which changes on every `Mutate` including the capture write
+      itself — a self-relabeling bug shaped exactly like Phase 9's own frozen-anchor lesson (an idempotent
+      resubmission would have failed to match its own freshly-recomputed subject hash). Caught by
+      `TestCaptureLensResult_OneShotNoReopen`'s idempotent-resubmission subtest before any CLI code was
+      written against it; fixed by dropping revision from the hash's domain (binds only to the immutable
+      `LineageID`/`CandidateIdentity`/lens/order tuple instead). END STATE (coordinator's exact repro):
+      medium-tier v3, capture via the real CLI, finalize → approved, all five gates allow
+      (`TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGates`); tier-low zero-results
+      unaffected (`TestReviewFacadeCaptureResultNewLineage_TierLowZeroResultsStillWorks`). Mutation-proven:
+      the finalize `capturedLensResults` derivation and the CLI routing wiring were each independently
+      disconnected and confirmed to reproduce the ORIGINAL verify-report failure shapes exactly (the same
+      `ErrFinalizeRequiresLensResults` refusal and the same "v2 store not found" error), then restored. 3 new
+      refusal sites named their runnable `capture-result --preflight` continuation (refusal-resolution
+      ratchet). Commit `d43870ef`.
+- [x] **W-2** (partial, disclosed): unskipped `release/exact` in the 35-cell matrix (8/35 → 9/35 wired),
+      driven through the real binary via the compact/v2 path — the one lineage kind a plain binary-driven
+      `review start` can freshly create (confirmed empirically: v1 legacy has no CLI-reachable creation path
+      at all — a probe build showed ordinary `review start` always creates a `v2/` compact record, never
+      `v1/`; v3 needs `GENTLE_AI_RDD_NEW_LINEAGE` threaded into the matrix harness's subprocess, not pursued
+      this budget). Discovered and documented: release's own target resolution is `TargetExactRevision` at
+      the current COMMITTED HEAD, not `TargetCurrentChanges` like post-apply/pre-commit — the reviewed
+      candidate must be committed before release can see it at all, confirmed by an initial failing attempt
+      and fixed by adding the commit step (mutation-proven: removing it reproduces the exact scope-changed
+      denial). Deferred, disclosed: `release/changed` needs a genuinely delivered (committed) drift recipe
+      mirroring pre-push's amend-based shape, not the plain workspace-drift recipe the other four gates'
+      "changed" cells use; the remaining 5 release relations and any legacy(v1)/v3-specific cells stay
+      explicit skips. Matrix: **8/35 → 9/35 wired** (before/after, as requested). Commit `f4b47266`.
+- [x] **W-7**: investigated `AuthorityStore.WriteReceipt`'s conflict semantics
+      (`WriteReceipt` → `publishImmutable` → `publishNoReplace`, `store.go`): a genuinely ABSENT receipt
+      (never published) is repaired by a plain finalize replay, but a PRESENT receipt that fails to
+      parse/validate or does not match the frozen authority can never be repaired the same way —
+      `publishImmutable` refuses to overwrite differing existing bytes
+      (`ImmutablePublicationConflictError`) rather than repairing them, so the old shared denial (naming
+      `review finalize --lineage <id>`) named a continuation that would itself refuse. Split the single
+      `approved_without_receipt` denial into two: the genuinely-absent case keeps naming finalize (still
+      honest), and a new `approved_receipt_corrupt` case for a present-but-invalid receipt names the only
+      continuation that actually clears it — a fresh lineage via `review start`, since v3 has no
+      reopen/repair machinery for a corrupted receipt (the same "no reopen" boundary C-A's
+      `CaptureLensResult` enforces). Mutation-proven: collapsing the two cases back into one is caught by
+      the new test naming the exact wrong denial code. Commit `59df5f92`.
+
+Fix cycle 2 verification (covers C-A/W-2/W-7, the 3 commits above): `go test ./... -count=1` all 63 packages
+green; bench module green; bench journey corpus vs a freshly built binary: 59/59 completed, 0 failed, exit 0;
+`bench/results.json` reverted; gofmt/vet clean; deadcode ratchet clean; refusal-resolution ratchet clean;
+rebase-contract clean (root `7598eda4` still an ancestor of `origin/main`). **This closes every CRITICAL and
+every fold-in warning the cycle-1 verify named** (C-A, C-B, C-C, C-D-core, W-1, W-3, W-7 all closed; W-2
+partial and disclosed — the v3/legacy halves of release-cell unskipping remain a genuine, scoped follow-up,
+not a blocking gap in any of the four CRITICALs). Return to sdd-verify for re-verification.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2369

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

Fix cycle 2: AuthorityStore.CaptureLensResult (CAS path, frozen-selection validation, immutable subject-hash binding), capture-result routes by lineage kind; medium/high v3 candidates reach approved receipts end-to-end; split tamper denial codes with runnable continuations.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench + e2e) green at chain tip 63c0583a
- [x] Bench corpus 59/59 + --axis all 79/1-declared/0-failed vs fresh binaries
- [x] 3 verify cycles; final envelope pass_with_warnings 17/17 requirements, 26/26 scenarios