### PR TITLE
fix(review): flow captured findings into candidate-causal admission

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -908,10 +908,14 @@ func reviewArtifactModeSafeForOS(mode os.FileMode, directory bool, goos string) 
 
 // ReviewFacadeCaptureResultNewLineageResult is v3's own capture-result
 // response shape (C-A, Wave 5 fix cycle 2). Deliberately narrow: no
-// findings/evidence/admission-decision richness -- that is v2's
-// ArtifactSubject/admission pipeline, not rebuilt for v3 per the
+// evidence/admission-DECISION richness -- that is v2's ArtifactSubject/
+// FrozenCandidateContext/reopen machinery, not rebuilt for v3 per the
 // coordinator's minimal-capture-primitive decision -- just enough to
-// confirm which lens/order was captured and under what subject hash.
+// confirm which lens/order was captured and under what subject hash. The
+// reviewer's own findings ARE captured and persisted (C-E, fix cycle 3,
+// newLineageCapturedFindings below) even though this response does not echo
+// them back; the response shape reports the CAPTURE binding, not the
+// admission consequence, which is decided at finalize.
 type ReviewFacadeCaptureResultNewLineageResult struct {
 	Operation     string `json:"operation"`
 	LineageID     string `json:"lineage_id"`
@@ -921,6 +925,26 @@ type ReviewFacadeCaptureResultNewLineageResult struct {
 	Preflight     bool   `json:"preflight,omitempty"`
 }
 
+// newLineageCapturedFindings converts the reviewer-contract wire shape
+// (facadeFinding, the SAME shape v2's own reviewer results use) into the
+// reviewtransaction admission shape (FindingEvidence, the SAME shape
+// --admission-findings already reads from a caller-supplied file) -- C-E,
+// Wave 5 fix cycle 3: capture-result validates and persists findings, and
+// finalize feeds them into the EXISTING AdmitCandidateCausalFindings, reused
+// rather than duplicated. ProofRefs (a list) joins into Proof (a single
+// string) with "; ", matching the single free-text Proof field
+// FindingEvidence has always carried for the --admission-findings channel.
+func newLineageCapturedFindings(findings []facadeFinding) []reviewtransaction.FindingEvidence {
+	converted := make([]reviewtransaction.FindingEvidence, len(findings))
+	for index, finding := range findings {
+		converted[index] = reviewtransaction.FindingEvidence{
+			FindingID: finding.ID, Class: finding.EvidenceClass, Causality: finding.CausalDisposition,
+			Proof: strings.Join(finding.ProofRefs, "; "),
+		}
+	}
+	return converted
+}
+
 // runReviewFacadeCaptureResultNewLineage is C-A's CLI wiring for the minimal
 // v3 capture primitive (reviewtransaction.AuthorityStore.CaptureLensResult).
 // --preflight derives and returns the exact provider-owned subject hash
@@ -928,8 +952,9 @@ type ReviewFacadeCaptureResultNewLineageResult struct {
 // discovery path an operator or reviewing agent uses to learn what to echo
 // back in a real capture. A real capture reads --input, decodes it as the
 // SAME strict reviewer-result JSON shape v2 uses (facadeReviewerResult --
-// one wire contract for both lineage kinds), and refuses unless its own
-// subject_hash field matches that same provider-owned derivation.
+// one wire contract for both lineage kinds), refuses unless its own
+// subject_hash field matches that same provider-owned derivation, and
+// persists its findings (C-E) alongside the binding.
 func runReviewFacadeCaptureResultNewLineage(
 	ctx context.Context, stdout io.Writer, root, lineage string, record reviewtransaction.NewLineageRecord,
 	lens string, order int, subjectHashFlag, input string, preflight bool,
@@ -976,7 +1001,7 @@ func runReviewFacadeCaptureResultNewLineage(
 	if err != nil {
 		return err
 	}
-	if _, err := store.CaptureLensResult(ctx, record.Revision, lens, order, result.SubjectHash); err != nil {
+	if _, err := store.CaptureLensResult(ctx, record.Revision, lens, order, result.SubjectHash, newLineageCapturedFindings(result.Findings)); err != nil {
 		return reviewPreflightError(err)
 	}
 	return encodeReviewJSON(stdout, ReviewFacadeCaptureResultNewLineageResult{

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2183,11 +2183,21 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 					return reviewPreflightError(fmt.Errorf("new-lineage finalize does not yet support --%s; retry with `gentle-ai review finalize --lineage %s` and, if needed, --failed or --admission-findings", unsupported, *lineage))
 				}
 			}
+			// C-E (Wave 5 fix cycle 3, verify-report #10186 cycle 2): the reviewer
+			// channel's own captured findings feed the identical
+			// AdmitCandidateCausalFindings admission decision --admission-findings
+			// already drives, reused rather than duplicated. --admission-findings
+			// stays an explicit override/compat surface (coordinator decision):
+			// when the caller supplies it, it is used verbatim exactly as before,
+			// UNCONDITIONALLY -- captured findings are consulted only when the
+			// caller did not override.
 			var findings []reviewtransaction.FindingEvidence
 			if trimmed := strings.TrimSpace(*admissionFindingsPath); trimmed != "" {
 				if err := readFacadeJSON(trimmed, &findings); err != nil {
 					return reviewPreflightError(fmt.Errorf("read new-lineage admission findings: %w", err))
 				}
+			} else if *capturedResults {
+				findings = newRecord.Authority.CapturedFindingEvidence()
 			}
 			newTerminalAtEntry := newRecord.Authority.State == reviewtransaction.NewLineageStateApproved || newRecord.Authority.State == reviewtransaction.NewLineageStateEscalated
 			if !newTerminalAtEntry {

--- a/internal/cli/review_facade_finalize_new_lineage.go
+++ b/internal/cli/review_facade_finalize_new_lineage.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
@@ -91,6 +93,21 @@ func runReviewFacadeFinalizeNewLineage(
 		},
 	})
 	if err != nil {
+		// W-8 (Wave 5 fix cycle 3, verify-report #10186 cycle 2): a partial
+		// capture (some, not all, frozen selected lenses captured) is an
+		// ORDINARY incomplete state, not a tool-internal fault -- an
+		// unclassified fmt.Errorf wrap left it falling through to the outer
+		// dispatcher's unexpected-fault/defect-report path. Classified here as
+		// an ordinary preflight refusal (matching every other operator-
+		// actionable refusal in this package) that names exactly which
+		// lens(es) are still missing and the runnable continuation.
+		if errors.Is(err, reviewtransaction.ErrFinalizeRequiresLensResults) {
+			missing := authority.MissingCapturedLensNames()
+			return reviewPreflightError(fmt.Errorf(
+				"new-lineage finalize requires captured results for every frozen selected lens before approving: missing %s; capture each with `gentle-ai review capture-result --cwd <repo> --lineage %s --target <target> --lens <lens> --order <order> --input <result.json>` (run with --preflight first to discover the exact subject hash to echo back), then retry `gentle-ai review finalize --cwd <repo> --lineage %s --captured-results=true`",
+				strings.Join(missing, ", "), lineage, lineage,
+			))
+		}
 		return fmt.Errorf("review core finalize: %w", err)
 	}
 	if transition.Authority != nil {

--- a/internal/cli/review_new_lineage_capture_test.go
+++ b/internal/cli/review_new_lineage_capture_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -293,6 +295,53 @@ func TestReviewFacadeCaptureResultNewLineage_NonCausalFindingDoesNotBlock(t *tes
 	}
 	if len(finalized.AdmittedFindingIDs) != 0 {
 		t.Fatalf("admitted_finding_ids = %v, want empty", finalized.AdmittedFindingIDs)
+	}
+}
+
+// TestReviewFacadeFinalizeNewLineage_PartialCaptureIsOrdinaryNotAFault is
+// W-8 (Wave 5 fix cycle 3, verify-report #10186 cycle 2): a partial capture
+// (some, not all, frozen selected lenses captured) at finalize used to
+// surface as an UNEXPECTED FAULT -- `review core finalize: %w` wrapping
+// ErrFinalizeRequiresLensResults, unclassified, which the outer dispatcher
+// treated as a tool-internal fault and wrote a defect report for. This is an
+// ORDINARY, entirely expected incomplete state (the same category
+// reviewIntegrationPreflightError names throughout this package), and the
+// message must name exactly which lens is still missing plus the runnable
+// capture-result continuation -- never a bare "capture more" or a fault
+// report.
+func TestReviewFacadeFinalizeNewLineage_PartialCaptureIsOrdinaryNotAFault(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "partial-capture-lineage"
+	started := startMediumTierNewLineage(t, repo, lineage)
+	if len(started.SelectedLenses) == 0 {
+		t.Fatal("fixture sanity check failed: need at least one selected lens to leave uncaptured")
+	}
+	// Deliberately capture NOTHING, leaving every selected lens missing --
+	// the simplest genuine partial-capture shape (0 of N captured is still
+	// "some lenses missing", the same code path a partial N-1-of-N capture
+	// reaches).
+	var out bytes.Buffer
+	err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--captured-results=true"}, &out)
+	if err == nil {
+		t.Fatal("finalize with zero captured lenses against a medium-tier lineage unexpectedly succeeded")
+	}
+
+	var progress *reviewFacadeOperationProgressError
+	if errors.As(err, &progress) {
+		err = progress.Cause
+	}
+	var preflight *reviewIntegrationPreflightError
+	if !errors.As(err, &preflight) {
+		t.Fatalf("finalize with an incomplete capture must classify as an ordinary preflight refusal, not fall through to the unclassified/fault path: %v (%T)", err, err)
+	}
+	for _, lens := range started.SelectedLenses {
+		if !strings.Contains(err.Error(), lens) {
+			t.Fatalf("refusal = %q, must name the missing lens %q", err.Error(), lens)
+		}
+	}
+	if !strings.Contains(err.Error(), "gentle-ai review capture-result") {
+		t.Fatalf("refusal = %q, must name the runnable capture-result continuation", err.Error())
 	}
 }
 

--- a/internal/cli/review_new_lineage_capture_test.go
+++ b/internal/cli/review_new_lineage_capture_test.go
@@ -162,6 +162,140 @@ func TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGate
 	}
 }
 
+// TestReviewFacadeCaptureResultNewLineage_CandidateCausalBlockerEscalates is
+// CRITICAL-E's exact A/B repro, inverted (Wave 5 fix cycle 3, verify-report
+// #10186 cycle 2): `review capture-result` on a v3 lineage validated a
+// reviewer result's findings/evidence and then discarded the findings --
+// CaptureLensResult persisted only {Lens, Order, SubjectHash}, so a
+// reviewer-reported, deterministic, candidate-introduced BLOCKER never
+// reached AdmitCandidateCausalFindings, and finalize --captured-results
+// issued `approved` where the identical input escalates on the
+// --admission-findings channel. This test submits the identical BLOCKER
+// shape the verify report used (severity BLOCKER, evidence_class
+// deterministic, causal_disposition introduced) through the real capture
+// CLI and asserts finalize now escalates with the finding admitted -- the
+// SAME outcome (blocks) the v2/compact path reaches as correction_required
+// and the v3 --admission-findings channel already reached as escalated.
+func TestReviewFacadeCaptureResultNewLineage_CandidateCausalBlockerEscalates(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "candidate-causal-blocker-lineage"
+	started := startMediumTierNewLineage(t, repo, lineage)
+	lens := started.SelectedLenses[0]
+
+	var preflightOut bytes.Buffer
+	if err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+		"--lens", lens, "--order", "0", "--preflight",
+	}, &preflightOut); err != nil {
+		t.Fatalf("capture-result preflight: %v\n%s", err, preflightOut.String())
+	}
+	var preflight ReviewFacadeCaptureResultNewLineageResult
+	decodeStrictReviewJSON(t, preflightOut.Bytes(), &preflight)
+
+	inputPath := filepath.Join(t.TempDir(), "blocker.json")
+	payload := `{
+		"subject_hash": "` + preflight.SubjectHash + `",
+		"findings": [{
+			"id": "R3-boom-div-zero",
+			"lens": "` + lens + `",
+			"location": "lib/boom.go:1",
+			"severity": "BLOCKER",
+			"claim": "candidate introduces a division by zero",
+			"proof_refs": ["lib/boom.go:1"],
+			"evidence_class": "deterministic",
+			"causal_disposition": "introduced"
+		}],
+		"evidence": ["reviewed lib/boom.go and confirmed the divide-by-zero"]
+	}`
+	if err := os.WriteFile(inputPath, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var captureOut bytes.Buffer
+	if err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+		"--lens", lens, "--order", "0", "--input", inputPath,
+	}, &captureOut); err != nil {
+		t.Fatalf("capture-result with a candidate-causal BLOCKER: %v\n%s", err, captureOut.String())
+	}
+
+	var finalizeOut bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--captured-results=true"}, &finalizeOut); err != nil {
+		t.Fatalf("finalize after capturing a candidate-causal BLOCKER: %v\n%s", err, finalizeOut.String())
+	}
+	var finalized ReviewFacadeFinalizeNewLineageResult
+	decodeStrictReviewJSON(t, finalizeOut.Bytes(), &finalized)
+	if finalized.State != reviewtransaction.NewLineageStateEscalated {
+		t.Fatalf("finalize after a captured candidate-causal BLOCKER = %q, want escalated (CRITICAL-E: a captured BLOCKER must not silently approve)", finalized.State)
+	}
+	if len(finalized.AdmittedFindingIDs) != 1 || finalized.AdmittedFindingIDs[0] != "R3-boom-div-zero" {
+		t.Fatalf("admitted_finding_ids = %v, want exactly [R3-boom-div-zero]", finalized.AdmittedFindingIDs)
+	}
+}
+
+// TestReviewFacadeCaptureResultNewLineage_NonCausalFindingDoesNotBlock is the
+// companion scenario: a captured finding whose causal_disposition is NOT
+// introduced/behavior-activated/worsened (matching --admission-findings'
+// own AdmitCandidateCausalFindings rules exactly, reused rather than
+// duplicated) is a follow-up, never a blocker -- captured findings must not
+// become MORE aggressive than the existing admission machinery already is.
+func TestReviewFacadeCaptureResultNewLineage_NonCausalFindingDoesNotBlock(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "non-causal-finding-lineage"
+	started := startMediumTierNewLineage(t, repo, lineage)
+	lens := started.SelectedLenses[0]
+
+	var preflightOut bytes.Buffer
+	if err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+		"--lens", lens, "--order", "0", "--preflight",
+	}, &preflightOut); err != nil {
+		t.Fatalf("capture-result preflight: %v\n%s", err, preflightOut.String())
+	}
+	var preflight ReviewFacadeCaptureResultNewLineageResult
+	decodeStrictReviewJSON(t, preflightOut.Bytes(), &preflight)
+
+	inputPath := filepath.Join(t.TempDir(), "pre-existing.json")
+	payload := `{
+		"subject_hash": "` + preflight.SubjectHash + `",
+		"findings": [{
+			"id": "pre-existing-finding",
+			"lens": "` + lens + `",
+			"location": "lib/legacy.go:1",
+			"severity": "WARNING",
+			"claim": "pre-existing issue, not introduced by this candidate",
+			"proof_refs": ["lib/legacy.go:1"],
+			"evidence_class": "deterministic",
+			"causal_disposition": "pre_existing"
+		}],
+		"evidence": ["reviewed lib/legacy.go"]
+	}`
+	if err := os.WriteFile(inputPath, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var captureOut bytes.Buffer
+	if err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+		"--lens", lens, "--order", "0", "--input", inputPath,
+	}, &captureOut); err != nil {
+		t.Fatalf("capture-result with a pre-existing finding: %v\n%s", err, captureOut.String())
+	}
+
+	var finalizeOut bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--captured-results=true"}, &finalizeOut); err != nil {
+		t.Fatalf("finalize after capturing a pre-existing finding: %v\n%s", err, finalizeOut.String())
+	}
+	var finalized ReviewFacadeFinalizeNewLineageResult
+	decodeStrictReviewJSON(t, finalizeOut.Bytes(), &finalized)
+	if finalized.State != reviewtransaction.NewLineageStateApproved {
+		t.Fatalf("finalize after a captured pre-existing (non-causal) finding = %q, want approved (a follow-up must never block)", finalized.State)
+	}
+	if len(finalized.AdmittedFindingIDs) != 0 {
+		t.Fatalf("admitted_finding_ids = %v, want empty", finalized.AdmittedFindingIDs)
+	}
+}
+
 // TestReviewFacadeCaptureResultNewLineage_TierLowZeroResultsStillWorks pins
 // the non-regression: a tier-low v3 lineage (SelectedLenses is empty) still
 // finalizes with zero captured results -- the C-A fix must not require a

--- a/internal/reviewtransaction/authority_store.go
+++ b/internal/reviewtransaction/authority_store.go
@@ -101,19 +101,28 @@ type NewLineageAuthority struct {
 	// ArtifactSubject/FrozenCandidateContext/reopen machinery is Wave 7
 	// deletion scope). Written only through AuthorityStore.CaptureLensResult
 	// (new_lineage_capture.go), never directly: one entry per captured lens,
-	// one-shot (no reopen), each bound to its own provider-owned subject hash.
+	// one-shot (no reopen), each bound to its own provider-owned subject hash
+	// and (C-E, fix cycle 3) its own validated findings.
 	CapturedResults []NewLineageCapturedResult `json:"captured_results,omitempty"`
 }
 
-// NewLineageCapturedResult is one captured reviewer result's minimal
-// persisted binding: which lens, at which frozen selected-lens order, under
-// which provider-owned subject hash (NewLineageArtifactSubjectHash). It
-// deliberately carries no findings/evidence/admission-decision richness --
-// those stay v2's ArtifactSubject-admission concern, not rebuilt for v3.
+// NewLineageCapturedResult is one captured reviewer result's persisted
+// binding: which lens, at which frozen selected-lens order, under which
+// provider-owned subject hash (NewLineageArtifactSubjectHash), carrying the
+// reviewer's OWN validated findings (C-E, Wave 5 fix cycle 3). Cycle 2
+// deliberately omitted Findings ("no findings/evidence/admission-decision
+// richness"); cycle 3's verify (CRITICAL-E) found that omission was a
+// fail-open, not a scope boundary -- capture-result already required and
+// validated findings/evidence were present, so silently discarding them let
+// a candidate-causal BLOCKER approve unadmitted. It still carries no
+// evidence/admission-DECISION richness (no re-derivable ArtifactSubject,
+// no reopen) -- only the findings themselves, fed into the existing
+// AdmitCandidateCausalFindings at finalize time.
 type NewLineageCapturedResult struct {
-	Lens        string `json:"lens"`
-	Order       int    `json:"order"`
-	SubjectHash string `json:"subject_hash"`
+	Lens        string            `json:"lens"`
+	Order       int               `json:"order"`
+	SubjectHash string            `json:"subject_hash"`
+	Findings    []FindingEvidence `json:"findings,omitempty"`
 }
 
 // CapturedLensNames returns the plain lens-name list
@@ -126,6 +135,21 @@ func (authority NewLineageAuthority) CapturedLensNames() []string {
 		names[index] = captured.Lens
 	}
 	return names
+}
+
+// CapturedFindingEvidence flattens every captured lens's own Findings into
+// the single []FindingEvidence AdmitCandidateCausalFindings consumes (C-E) --
+// the exact shape --admission-findings already reads from a caller-supplied
+// file, sourced here from the reviewer channel's own persisted captures
+// instead. Order matches CapturedResults' own append order (capture order),
+// which AdmitCandidateCausalFindings does not depend on (it partitions by
+// Causality alone).
+func (authority NewLineageAuthority) CapturedFindingEvidence() []FindingEvidence {
+	var findings []FindingEvidence
+	for _, captured := range authority.CapturedResults {
+		findings = append(findings, captured.Findings...)
+	}
+	return findings
 }
 
 // Validate enforces the structural half of the two-artifact contract this
@@ -176,6 +200,11 @@ func (authority NewLineageAuthority) Validate() error {
 			return errors.New("new-lineage authority captured results must name each lens at most once") // refusal:by-design world-action: CaptureLensResult enforces one-shot-per-lens before ever appending; a duplicate here means in-process corruption, not something an operator command repairs
 		}
 		seenCapturedLenses[captured.Lens] = true
+		for _, finding := range captured.Findings {
+			if strings.TrimSpace(finding.FindingID) == "" {
+				return errors.New("new-lineage authority captured findings must carry a non-empty finding id") // refusal:by-design world-action: captured findings are only ever written by AuthorityStore.CaptureLensResult from an already-decoded reviewer result; a malformed entry here means in-process corruption, not something an operator command repairs
+			}
+		}
 	}
 	if authority.ReplayIdentity != "" && !validSHA256(authority.ReplayIdentity) {
 		return errors.New("new-lineage authority replay identity must be a canonical digest") // refusal:by-design world-action: the replay identity is only ever set by RecordTransition's own digest computation; a malformed value means in-process corruption, not something an operator command repairs

--- a/internal/reviewtransaction/authority_store.go
+++ b/internal/reviewtransaction/authority_store.go
@@ -137,6 +137,25 @@ func (authority NewLineageAuthority) CapturedLensNames() []string {
 	return names
 }
 
+// MissingCapturedLensNames returns the frozen SelectedLenses not yet present
+// in CapturedLensNames, in SelectedLenses' own order (W-8, Wave 5 fix cycle
+// 3, verify-report #10186 cycle 2): a partial capture is an ORDINARY
+// incomplete state, not a fault, and naming exactly which lenses remain is
+// what makes the continuation runnable rather than a bare "capture more".
+func (authority NewLineageAuthority) MissingCapturedLensNames() []string {
+	captured := make(map[string]bool, len(authority.CapturedResults))
+	for _, result := range authority.CapturedResults {
+		captured[result.Lens] = true
+	}
+	var missing []string
+	for _, lens := range authority.SelectedLenses {
+		if !captured[lens] {
+			missing = append(missing, lens)
+		}
+	}
+	return missing
+}
+
 // CapturedFindingEvidence flattens every captured lens's own Findings into
 // the single []FindingEvidence AdmitCandidateCausalFindings consumes (C-E) --
 // the exact shape --admission-findings already reads from a caller-supplied

--- a/internal/reviewtransaction/new_lineage_capture.go
+++ b/internal/reviewtransaction/new_lineage_capture.go
@@ -9,8 +9,19 @@ package reviewtransaction
 // makes ReviewCore.finalize's ErrFinalizeRequiresLensResults refusal
 // satisfiable: persist captured lens results onto the v3 authority, bound
 // to a provider-owned subject hash, through the existing Mutate/CAS path --
-// no reopen, no separate artifact store, no findings/evidence admission
-// pipeline (that stays a v2-only concept).
+// no reopen, no separate artifact store, no findings/evidence ADMISSION
+// pipeline (ArtifactSubject/FrozenCandidateContext/reopen stay v2-only).
+//
+// Fix cycle 3, CRITICAL-E closure (verify-report #10186 cycle 2, coordinator
+// decision "option 2, the channel does what it appears to do"): the capture
+// primitive DOES persist the reviewer's validated findings (not just
+// SubjectHash) -- cycle 2's own capture-result already required and
+// validated `findings`/`evidence` were present before this fix, so silently
+// discarding them was a channel that looked like it carried findings and
+// did not, a fail-open in an authorization system. Persisted findings feed
+// the EXISTING AdmitCandidateCausalFindings at finalize (review_facade.go)
+// -- the same admission decision function the --admission-findings channel
+// already uses, reused rather than duplicated.
 
 import (
 	"context"
@@ -18,6 +29,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 )
 
@@ -73,15 +85,18 @@ var (
 )
 
 // CaptureLensResult persists one captured reviewer result onto a v3
-// authority through the existing Mutate/CAS path. Semantics (C-A):
+// authority through the existing Mutate/CAS path. Semantics (C-A, extended
+// by C-E):
 //   - only a reviewing or validating authority may capture;
 //   - lens/order must match the frozen SelectedLenses set exactly;
 //   - subjectHash must match NewLineageArtifactSubjectHash's own derivation;
+//   - findings ARE persisted verbatim (C-E) -- fed into
+//     AdmitCandidateCausalFindings at finalize, never discarded;
 //   - one-shot per lens: capturing the SAME lens again with the IDENTICAL
-//     subject hash is an idempotent replace (Mutate's own byte-identical
-//     no-op path); a DIFFERENT subject hash for an already-captured lens is
-//     refused (ErrNewLineageCaptureConflict) -- there is no reopen.
-func (store AuthorityStore) CaptureLensResult(ctx context.Context, expectedRevision, lens string, order int, subjectHash string) (NewLineageRecord, error) {
+//     subject hash AND identical findings is an idempotent replace (Mutate's
+//     own byte-identical no-op path); anything else for an already-captured
+//     lens is refused (ErrNewLineageCaptureConflict) -- there is no reopen.
+func (store AuthorityStore) CaptureLensResult(ctx context.Context, expectedRevision, lens string, order int, subjectHash string, findings []FindingEvidence) (NewLineageRecord, error) {
 	if _, err := store.Mutate(ctx, expectedRevision, func(next *NewLineageAuthority) error {
 		if next.State != NewLineageStateReviewing && next.State != NewLineageStateValidating {
 			return fmt.Errorf("%w: lineage %q is %q", ErrNewLineageCaptureNotReviewable, next.LineageID, next.State)
@@ -93,16 +108,19 @@ func (store AuthorityStore) CaptureLensResult(ctx context.Context, expectedRevis
 		if subjectHash != want {
 			return fmt.Errorf("%w: lineage %q lens %q", ErrNewLineageCaptureSubjectMismatch, next.LineageID, lens)
 		}
+		normalizedFindings := append([]FindingEvidence(nil), findings...)
 		for _, existing := range next.CapturedResults {
 			if existing.Lens != lens {
 				continue
 			}
-			if existing.SubjectHash == subjectHash {
+			if existing.SubjectHash == subjectHash && reflect.DeepEqual(existing.Findings, normalizedFindings) {
 				return nil // identical binding already captured: idempotent no-op
 			}
 			return fmt.Errorf("%w: lineage %q lens %q", ErrNewLineageCaptureConflict, next.LineageID, lens)
 		}
-		next.CapturedResults = append(append([]NewLineageCapturedResult(nil), next.CapturedResults...), NewLineageCapturedResult{Lens: lens, Order: order, SubjectHash: subjectHash})
+		next.CapturedResults = append(append([]NewLineageCapturedResult(nil), next.CapturedResults...), NewLineageCapturedResult{
+			Lens: lens, Order: order, SubjectHash: subjectHash, Findings: normalizedFindings,
+		})
 		return nil
 	}); err != nil {
 		return NewLineageRecord{}, err

--- a/internal/reviewtransaction/new_lineage_capture_test.go
+++ b/internal/reviewtransaction/new_lineage_capture_test.go
@@ -50,7 +50,7 @@ func TestCaptureLensResult_HappyPathThenFinalizeSatisfiesLensResults(t *testing.
 	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
 	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
 
-	updated, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject)
+	updated, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, nil)
 	if err != nil {
 		t.Fatalf("CaptureLensResult happy path: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestCaptureLensResult_RejectsLensNotInFrozenSelection(t *testing.T) {
 	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
 	subject := NewLineageArtifactSubjectHash(record.Authority, "review-risk", 0)
 
-	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-risk", 0, subject); err == nil {
+	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-risk", 0, subject, nil); err == nil {
 		t.Fatal("captured a lens that was never in the frozen SelectedLenses set")
 	}
 }
@@ -80,7 +80,7 @@ func TestCaptureLensResult_RejectsWrongOrder(t *testing.T) {
 	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability", "review-risk"})
 	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 1)
 
-	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 1, subject); err == nil {
+	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 1, subject, nil); err == nil {
 		t.Fatal("captured a real lens at the wrong frozen order index")
 	}
 }
@@ -91,7 +91,7 @@ func TestCaptureLensResult_RejectsWrongOrder(t *testing.T) {
 func TestCaptureLensResult_RejectsSubjectHashMismatch(t *testing.T) {
 	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
 
-	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, "sha256:fabricated"); err == nil {
+	if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, "sha256:fabricated", nil); err == nil {
 		t.Fatal("captured a result whose subject hash does not match the provider-owned derivation")
 	}
 }
@@ -105,13 +105,13 @@ func TestCaptureLensResult_OneShotNoReopen(t *testing.T) {
 	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
 	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
 
-	first, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject)
+	first, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, nil)
 	if err != nil {
 		t.Fatalf("first capture: %v", err)
 	}
 
 	t.Run("identical resubmission is an idempotent no-op", func(t *testing.T) {
-		again, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, subject)
+		again, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, subject, nil)
 		if err != nil {
 			t.Fatalf("identical resubmission: %v", err)
 		}
@@ -122,7 +122,7 @@ func TestCaptureLensResult_OneShotNoReopen(t *testing.T) {
 
 	t.Run("different subject hash for an already-captured lens is refused, not reopened", func(t *testing.T) {
 		differentSubject := NewLineageArtifactSubjectHash(first.Authority, "review-reliability-different-domain", 0)
-		if _, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, differentSubject); err == nil {
+		if _, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, differentSubject, nil); err == nil {
 			t.Fatal("recaptured an already-captured lens under a different subject hash; capture must be one-shot, no reopen")
 		}
 	})
@@ -147,9 +147,54 @@ func TestCaptureLensResult_RejectsNonReviewableStates(t *testing.T) {
 				t.Fatal(err)
 			}
 			subject := NewLineageArtifactSubjectHash(authority.Authority, "review-reliability", 0)
-			if _, err := store.CaptureLensResult(context.Background(), revision, "review-reliability", 0, subject); err == nil {
+			if _, err := store.CaptureLensResult(context.Background(), revision, "review-reliability", 0, subject, nil); err == nil {
 				t.Fatalf("captured against a %q authority, want refused", state)
 			}
 		})
+	}
+}
+
+// TestCaptureLensResult_PersistsFindingsForAdmission is C-E's unit-level
+// proof (Wave 5 fix cycle 3, verify-report #10186 cycle 2): findings
+// submitted with a capture are PERSISTED, not discarded, and
+// CapturedFindingEvidence flattens them into the exact shape
+// AdmitCandidateCausalFindings consumes -- reused, not duplicated.
+func TestCaptureLensResult_PersistsFindingsForAdmission(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+	findings := []FindingEvidence{
+		{FindingID: "R3-boom-div-zero", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "lib/boom.go:1"},
+	}
+
+	updated, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, findings)
+	if err != nil {
+		t.Fatalf("CaptureLensResult with findings: %v", err)
+	}
+	if len(updated.Authority.CapturedResults) != 1 || len(updated.Authority.CapturedResults[0].Findings) != 1 ||
+		updated.Authority.CapturedResults[0].Findings[0].FindingID != "R3-boom-div-zero" {
+		t.Fatalf("captured findings = %#v, want the submitted finding persisted verbatim", updated.Authority.CapturedResults)
+	}
+	admitted, followUp := AdmitCandidateCausalFindings(updated.Authority.CapturedFindingEvidence())
+	if len(admitted) != 1 || admitted[0] != "R3-boom-div-zero" || len(followUp) != 0 {
+		t.Fatalf("AdmitCandidateCausalFindings(CapturedFindingEvidence()) = admitted=%v followUp=%v, want admitted=[R3-boom-div-zero] followUp=[]", admitted, followUp)
+	}
+}
+
+// TestCaptureLensResult_DifferentFindingsForSameLensIsConflictNotReopen
+// extends the one-shot guard (C-A) to findings (C-E): an already-captured
+// lens resubmitted with the SAME subject hash but DIFFERENT findings must
+// still refuse -- one-shot means the whole captured result is immutable,
+// not just the subject hash.
+func TestCaptureLensResult_DifferentFindingsForSameLensIsConflictNotReopen(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+
+	first, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, nil)
+	if err != nil {
+		t.Fatalf("first capture (zero findings): %v", err)
+	}
+	differentFindings := []FindingEvidence{{FindingID: "late-finding", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "proof"}}
+	if _, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, subject, differentFindings); err == nil {
+		t.Fatal("recaptured the same lens/subject-hash with different findings; capture must be one-shot for the whole result, not just the subject hash")
 	}
 }

--- a/openspec/changes/rdd-root-simplification-wave5/specs/rdd-new-lineage-activation/spec.md
+++ b/openspec/changes/rdd-root-simplification-wave5/specs/rdd-new-lineage-activation/spec.md
@@ -22,6 +22,22 @@ Each of the five gates (`post-apply`, `pre-commit`, `pre-push`, `pre-pr`, `relea
 - WHEN the two verdicts are compared
 - THEN equivalence is proven by the 35-cell gate boundary matrix, not by asserting the executed code path is byte-identical
 
+> **Amendment (Wave 5 fix cycle 3, verify-report #10186 cycle 2, W-2): letter-vs-intent divergence closed by
+> amendment, coordinator-accepted.** The matrix is 9/35 wired and every wired cell drives the compact/v2
+> path — zero cells drive legacy v1 or new-lineage v3 — so the scenario's literal letter ("proven by the
+> 35-cell gate boundary matrix") is not yet satisfied by the matrix alone. The scenario's INTENT — proven
+> outcome equivalence for a legacy candidate across all five gates — IS satisfied today, by
+> `TestEvaluateLegacyGateAllowsExactAtAllFiveGates` (Fix Cycle 1's C-B fix, `internal/reviewtransaction/legacy_projection_test.go`)
+> and its siblings (`TestEvaluateLegacyGateAllowsExactAndDeniesChanged`,
+> `TestEvaluateLegacyGateValidatesReceiptFromAnInFlightCorrection`), which drive the real
+> `EvaluateLegacyGate` production path directly and prove `allow` at post-apply/pre-commit/pre-push/pre-pr/
+> release for an exact legacy candidate, and correct denial for a changed one. The coordinator's own fix
+> cycle 3 instruction (item 4, "amend the matrix-equivalence scenario in the delta spec... cite this
+> message") accepts this named-test proof as satisfying the requirement's intent for now. The matrix
+> remains the incremental, long-term vehicle this requirement still points at — its wired-cell count is
+> tracked explicitly in `tasks.md`'s Fix Cycle 2/3 W-2 entries (8/35 → 9/35 as of Fix Cycle 2, release/exact)
+> — but is not, itself, a blocking gap for this requirement while the named-test proof stands.
+
 ### Requirement: Unconditional Receipt Precedence (Amendment C Generalized)
 
 Authority precedence generalizes to unconditional receipt precedence: an immutable, boundary-validated receipt of the correct lineage kind governs; absence of such a receipt denies regardless of legacy authority. A legacy-only authority record MUST NEVER authorize a new-lineage candidate, and — post-cutover — a legacy authority record is evaluated through the same receipt-precedence rule as new-lineage authority; there is no separate per-gate {legacy, new} x {exists, absent} branch table.

--- a/openspec/changes/rdd-root-simplification-wave5/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave5/tasks.md
@@ -49,7 +49,16 @@ composition-specific corroboration (S5):
 - Disabled (S2, #2222): `TestPostApplyGate_Disabled_ReportsUnmanagedBeforeAuthorityRead`, `TestPreCommitGate_Disabled_ReportsUnmanagedBeforeAuthorityRead`, `TestPrePushGate_Disabled_ReportsUnmanagedBeforeAuthorityRead`, `TestPrePRGate_Disabled_ReportsUnmanagedBeforeAuthorityRead`, `TestReleaseGate_Disabled_ReportsUnmanagedBeforeAuthorityRead`
 - Double-eval byte-equivalence (S2): `TestDisabledGateOutput_DoubleEval_ByteEquivalent_PostApply`, `TestDisabledGateOutput_DoubleEval_ByteEquivalent_PreCommit`, `TestDisabledGateOutput_DoubleEval_ByteEquivalent_PrePush`, `TestDisabledGateOutput_DoubleEval_ByteEquivalent_PrePR`, `TestDisabledGateOutput_DoubleEval_ByteEquivalent_Release`
 - Deny (S3): `TestPostApplyGate_Deny_ChangedRelationCarriesNextStep`, `TestPreCommitGate_Deny_ChangedRelationCarriesNextStep`, `TestPrePushGate_Deny_ChangedRelationCarriesNextStep`, `TestPrePRGate_Deny_BaseMismatchDeniesWithoutComposition`, `TestReleaseGate_Deny_ChangedRelationCarriesNextStep`
-- Allow (S4): `TestPostApplyGate_Allow_ExactReceiptGovernsDelivery`, `TestPreCommitGate_Allow_ExactReceiptGovernsDelivery`, `TestPrePushGate_Allow_ExactReceiptGovernsDelivery`, `TestPrePRGate_Allow_ExactReceiptGovernsDelivery`, `TestReleaseGate_Allow_ExactReceiptGovernsDelivery`
+- Allow — **corrected (W-5, Wave 5 fix cycle 3, verify-report #10186 cycle 2, S7 precedent applied)**: the
+  original "Allow (S4)" row named 5 tests (`Test{PostApply,PreCommit,PrePush,PrePR,Release}Gate_Allow_ExactReceiptGovernsDelivery`)
+  that were never implemented under those names — task 8.9 already disclosed and corrected this once (zero
+  `rg` matches, confirmed again here); this index itself was never fixed to match. What genuinely proves
+  "allow" at all five gates today: the 35-cell gate-boundary-matrix golden's own wired "exact" cells
+  (post-apply/pre-commit/pre-push/pre-pr, S1; release/exact, Fix Cycle 2's W-2, `TestGateBoundaryMatrix_35Cells`)
+  plus `TestReceiptFilePersistsAfterDerivedInvalidation_AllFiveGates`'s drifted-denies-cleanly proof for all 5
+  gates (S7), plus two fix-cycle additions that independently drive real allow at all five gates through
+  production code: `TestEvaluateLegacyGateAllowsExactAtAllFiveGates` (legacy, Fix Cycle 1's C-B) and
+  `TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGates` (v3, Fix Cycle 2's C-A).
 - #2239 (S5): `TestPrePRGate_KillSwitchBeforeComposition_TriviallyPreserved`
 
 ## Absorbed from Wave 3/4 Verification (PR0)
@@ -143,7 +152,7 @@ added at that phase so the debt is not silently lost.
 - [x] 1.1 Land `openspec/changes/rdd-root-simplification-wave5/{proposal,specs,design,tasks}.md` (already written).
 - [x] 1.2 Confirm Gate: verify Wave 3 AND Wave 4 have landed on `feature/rdd-root-simplification` before opening any Wave 5 slice PR. **Confirmed with a documented exception**: Wave 3 is fully merged on `origin/feature/rdd-root-simplification` (tip `f188be85`, PRs #2309-#2314). Wave 4 has NOT yet merged onto that tracker branch at apply time — its 12-PR chain is queued/merging (per orchestrator's rebase contract). This worktree's base branch `feat/rdd-wave5-base` @ `7598eda4` sits directly on the verified Wave 4 chain tip (`feat/rdd-wave4-s7b-plugin-investigation-and-asset-prose`, confirmed identical SHA, ancestor check passed), which the orchestrator states already passed its own envelope (16/16, 31/31). Wave 5 slices therefore build on Wave 4's verified content even though the tracker-merge event itself is still in flight; the rebase contract requires re-checking the Wave 4 chain tip before each slice's final full-test run and rebasing if it moved.
 - [x] 1.3 Fix stale SHA token (Wave-4 verify-report W-e): `openspec/changes/rdd-root-simplification-wave4/specs/rdd-transport-capability/spec.md` cited pre-rebase SHA `ead610f6`; corrected to the patch-id-equal delivered commit `acb3c7c1`.
-- [ ] 1.4 Archive Wave 4 (`openspec/changes/rdd-root-simplification-wave4/**` → `openspec/specs/`) when its turn comes, mirroring prior wave pattern (deferred — Wave 4 has not yet landed on the tracker at apply time; do not archive prematurely).
+- [ ] 1.4 Archive Wave 4 (`openspec/changes/rdd-root-simplification-wave4/**` → `openspec/specs/`) when its turn comes, mirroring prior wave pattern. **Still genuinely open FROM THIS BRANCH'S OWN PERSPECTIVE** (W-6, Wave 5 fix cycle 3, verify-report #10186 cycle 2): confirmed via direct directory check that `openspec/changes/archive/2026-08-03-rdd-root-simplification-wave4/` already exists on the `main` checkout — Wave 4 HAS been archived, but by a separate, unrelated commit on `main` this branch's own history does not yet contain (this worktree's `feat/rdd-wave5-*` chain branches from a Wave 4 tip that predates that archival commit). Archiving is therefore not an action this SDD change's own commits perform; the checkbox stays honestly unchecked until this branch is rebased past that point or the archival is otherwise reflected in this branch's own history, rather than being marked done for an action this branch never took.
 
 ## Phase 2 (S1): Characterization Corpus + Gate-Boundary Matrix Harness (zero behavior change)
 
@@ -372,23 +381,25 @@ relations. Full detail: Engram `#10187`.
       projection didn't exist — all landed in S3/S4 and are now real (C-B/C-C). Rewritten to the honest
       current reason (fixture not yet built, not mechanism missing); golden regenerated, diff confined to
       reason text only (still 8/35 wired, no verdict/relation changed). Commit `e0a51de3`.
-- [ ] **C-D remainder / W-2** (deferred, disclosed): un-skip the release-gate matrix cells. Investigated:
-      the existing "exact" cells all drive the COMPACT/v2 lineage path (`approveDiscoveryMarkdown`-style
-      helpers), not legacy v1 or new-lineage v3, so reusing that recipe for "release/exact" would not
-      actually exercise either C-B's or C-C's fix. A genuinely new fixture is needed — a legacy-specific
-      recipe (tractable now) or a v3 recipe (blocked on C-A, since only tier-low can currently finalize).
-      Follow-up slice.
-- [ ] **C-A** (v3 lens-result ingestion — NOT STARTED, largest remaining item): no production code sets
-      `FinalizeAdvanceRequest.CapturedLensResults`; `review capture-result` binds only the v2 compact store,
-      and v3's `NewLineageAuthority`/`AuthorityStore` has no persistence primitive for captured reviewer
-      results at all — `NewArtifactSubject`/the admission pipeline is tightly coupled to `CompactState`.
-      Needs a dedicated design/implementation slice: either a full parallel v3 artifact-capture pipeline, or
-      a minimal v3-specific persistence primitive plus CLI routing (mirroring wave-3's "ln" precedent: route
-      `capture-result` by lineage kind exactly like `finalize` now does). Follow-up slice.
-- [ ] **W-7** (deferred, disclosed): the v3 tamper denial names `review finalize --lineage <id>`, which
-      re-issues rather than repairs an already-approved lineage's receipt. `AuthorityStore.WriteReceipt`'s
-      exact conflict semantics (no-op / refusal / silent overwrite) need investigating before an accurate
-      replacement message can be written. Follow-up slice.
+- [x] **C-D remainder / W-2** (deferred, disclosed, then picked up): un-skip the release-gate matrix cells.
+      Investigated: the existing "exact" cells all drive the COMPACT/v2 lineage path
+      (`approveDiscoveryMarkdown`-style helpers), not legacy v1 or new-lineage v3, so reusing that recipe for
+      "release/exact" would not actually exercise either C-B's or C-C's fix. A genuinely new fixture was
+      needed — a legacy-specific recipe (tractable now) or a v3 recipe (blocked on C-A, since only tier-low
+      could then finalize). Follow-up picked up in Fix Cycle 2's own W-2 entry below (release/exact wired,
+      8→9/35) — **still a disclosed partial overall** (release/changed and the other release relations remain
+      skips), not fully closed; W-2's final disposition is amended by cycle 3, see below.
+- [x] **C-A** (v3 lens-result ingestion — was NOT STARTED, the wave's largest remaining item at this point):
+      no production code set `FinalizeAdvanceRequest.CapturedLensResults`; `review capture-result` bound only
+      the v2 compact store, and v3's `NewLineageAuthority`/`AuthorityStore` had no persistence primitive for
+      captured reviewer results at all — `NewArtifactSubject`/the admission pipeline is tightly coupled to
+      `CompactState`. Closed in Fix Cycle 2 (commit `d43870ef`, minimal capture primitive + CLI routing) and
+      extended in Fix Cycle 3 (commit `ff3b2a72`, C-E: findings admission) — see both sections below.
+- [x] **W-7** (deferred, disclosed, then picked up): the v3 tamper denial named `review finalize --lineage
+      <id>`, which re-issues rather than repairs an already-approved lineage's receipt.
+      `AuthorityStore.WriteReceipt`'s exact conflict semantics (no-op / refusal / silent overwrite) needed
+      investigating before an accurate replacement message could be written. Closed in Fix Cycle 2 (commit
+      `59df5f92`) — see below.
 
 Fix cycle 1 verification (covers C-B/W-3/C-C/C-D-partial/W-1, the 3 commits above): `go test ./... -count=1`
 all 63 packages green; bench module green; bench journey corpus vs a freshly built binary: 59/59 completed,
@@ -459,3 +470,73 @@ rebase-contract clean (root `7598eda4` still an ancestor of `origin/main`). **Th
 every fold-in warning the cycle-1 verify named** (C-A, C-B, C-C, C-D-core, W-1, W-3, W-7 all closed; W-2
 partial and disclosed — the v3/legacy halves of release-cell unskipping remain a genuine, scoped follow-up,
 not a blocking gap in any of the four CRITICALs). Return to sdd-verify for re-verification.
+
+## Fix Cycle 3 (closing pass: C-E, W-8, W-5/W-6, W-2 amendment — the wave's final fix cycle)
+
+Branch `feat/rdd-wave5-f3-findings-admission`, chained from fix cycle 2 @ `8e5f287a`. sdd-verify's cycle-2
+report (Engram `#10186`) found 1 NEW CRITICAL that fix cycle 2's own capture primitive introduced, plus 5
+WARNING (2 new, 3 carried). Full detail: Engram `#10186`/`#10188`.
+
+- [x] **C-E** (the blocker, coordinator decision "option 2, the channel does what it appears to do"): the v3
+      capture channel required and validated a reviewer result's `findings`/`evidence`, then discarded the
+      findings — `CaptureLensResult` persisted only `{Lens, Order, SubjectHash}`. A/B on an identical
+      candidate with an identical BLOCKER (deterministic, candidate-introduced): v2 returned
+      `correction_required`; v3 issued `approved`. `NewLineageCapturedResult` gains a
+      `Findings []FindingEvidence` field, persisted verbatim (one-shot semantics extended: a resubmission is
+      idempotent only when BOTH subject hash AND findings match). New
+      `NewLineageAuthority.CapturedFindingEvidence()` flattens every captured lens's findings into the exact
+      shape the EXISTING `AdmitCandidateCausalFindings` already consumes — reused, not duplicated, the same
+      admission decision `--admission-findings` already drives. `--admission-findings` stays an explicit
+      override: when supplied it is used verbatim exactly as before; captured findings are consulted only
+      when it is absent. Genuine RED = the verify's exact A/B repro, inverted
+      (`TestReviewFacadeCaptureResultNewLineage_CandidateCausalBlockerEscalates`), plus a non-causal-finding
+      companion proving the fix does not over-block
+      (`TestReviewFacadeCaptureResultNewLineage_NonCausalFindingDoesNotBlock`). Mutation-proven: both halves
+      of the fix (findings persistence in `CaptureLensResult`, and the finalize-side
+      `CapturedFindingEvidence()` wiring) were independently reverted and each confirmed to reproduce the
+      ORIGINAL CRITICAL-E fail-open exactly, then restored; a dedicated unit test also proves one-shot now
+      covers findings, not just the subject hash. Commit `ff3b2a72`.
+- [x] **W-8**: a partial capture (some, not all, frozen selected lenses captured) reached finalize's
+      `ReviewCore` error path unclassified (`fmt.Errorf` wrap of `ErrFinalizeRequiresLensResults`), which the
+      outer dispatcher treated as a tool-internal fault and wrote a defect report for — an entirely ordinary,
+      expected incomplete state. New `NewLineageAuthority.MissingCapturedLensNames()` names exactly which
+      frozen selected lenses remain uncaptured; the finalize error path now recognizes
+      `ErrFinalizeRequiresLensResults` specifically and wraps it as an ordinary `reviewPreflightError` (the
+      same classification every other operator-actionable refusal in this package already uses), naming the
+      missing lenses and the runnable `capture-result` continuation. Mutation-proven: disabling the
+      classification branch reproduces the exact unclassified `*fmt.wrapError` shape the verify report found,
+      then restored. Commit `a793e02c`.
+- [x] **W-5**: the Gate Regression Test Index's "Allow (S4)" row named 5 tests
+      (`Test{PostApply,PreCommit,PrePush,PrePR,Release}Gate_Allow_ExactReceiptGovernsDelivery`) that were
+      never implemented under those names. Task 8.9 already disclosed and corrected this once (against the
+      superseded-issue evidence); the index itself was never fixed. Re-verified via direct search (S7
+      precedent: zero `rg` matches across the whole repo) before citing, then replaced the phantom row with
+      what genuinely proves "allow" at all five gates today: the matrix's own wired "exact"/`release/exact`
+      cells, `TestReceiptFilePersistsAfterDerivedInvalidation_AllFiveGates` (S7), and the two fix-cycle
+      additions that independently drive real allow at all five gates through production code —
+      `TestEvaluateLegacyGateAllowsExactAtAllFiveGates` (C-B) and
+      `TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGates` (C-A).
+- [x] **W-6**: stale checkboxes reconciled. Fix Cycle 1's own deferral entries for C-A, C-D-remainder/W-2, and
+      W-7 stayed `[ ]` even though Fix Cycle 2 (and this cycle) closed them — flipped to `[x]` above, each
+      pointing at the commit(s) that closed it, with W-2 explicitly still marked as a disclosed partial
+      overall (not falsely closed). Task 1.4 (archive Wave 4) investigated directly: confirmed via directory
+      check that Wave 4 HAS been archived on `main` (`openspec/changes/archive/2026-08-03-rdd-root-simplification-wave4/`
+      exists there), but by a separate commit this branch's own history does not yet contain — the checkbox
+      stays honestly unchecked (archiving is not an action this branch's own commits perform) with a note
+      explaining why, rather than being marked done for an action never taken on this branch.
+- [x] **W-2** (amendment, not code): per the coordinator's explicit decision (fix cycle 3 instruction, item 4,
+      cited in the spec amendment itself), amended
+      `specs/rdd-new-lineage-activation/spec.md`'s "Outcome equivalence proven by matrix, not byte-diff"
+      scenario — the letter (proof via the 35-cell matrix specifically) is not yet satisfied (9/35 wired, all
+      compact/v2), but the INTENT (proven outcome equivalence for a legacy candidate across all five gates)
+      IS satisfied today by `TestEvaluateLegacyGateAllowsExactAtAllFiveGates` and its siblings, which the
+      amendment now cites as the accepted proof while the matrix remains the incremental long-term vehicle,
+      its wired-cell count tracked here (8/35 at Fix Cycle 1 → 9/35 at Fix Cycle 2's W-2 entry).
+
+Fix cycle 3 verification (covers C-E/W-8, the 2 code commits above, plus the W-5/W-6/W-2 docs-only commit):
+`go test ./... -count=1` all 63 packages green; bench module green; bench journey corpus vs a freshly built
+binary: 59/59 completed, 0 failed, exit 0; `bench/results.json` reverted; gofmt/vet clean; deadcode ratchet
+clean; refusal-resolution ratchet clean; rebase-contract clean (root `7598eda4` still an ancestor of
+`origin/main`). **This is the wave's final fix cycle**: every CRITICAL (C-A through C-E) and every WARNING
+the verify cycles named (W-1 through W-8) is either fully closed or an explicitly-accepted, cited amendment
+(W-2). Return to sdd-verify for final re-verification.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2369

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

Fix cycle 3: captured findings persist and feed the existing admission machinery — a BLOCKER escalates on v3 exactly as it blocks on v2 (A/B parity, both fix halves independently mutation-proven); partial capture names its runnable continuation.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench + e2e) green at chain tip 63c0583a
- [x] Bench corpus 59/59 + --axis all 79/1-declared/0-failed vs fresh binaries
- [x] 3 verify cycles; final envelope pass_with_warnings 17/17 requirements, 26/26 scenarios