### PR TITLE
fix(sdd): make attempt-ledger refusals self-diagnosing with classified exits

### DIFF
--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -59,6 +59,17 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected sdd-attempt argument %q", flags.Arg(0))
 	}
+	// Identity/revision-shaped values are trimmed at this CLI boundary so
+	// incidental leading/trailing whitespace from a shell or PowerShell
+	// copy-paste (e.g. `Get-FileHash`/`shasum` output) does not itself cause
+	// the sha256:<64-lowercase-hex> shape rejection this exists to prevent
+	// (#2294). sddstatus stays a pure validator with no normalization of its
+	// own.
+	*expected = strings.TrimSpace(*expected)
+	*token = strings.TrimSpace(*token)
+	*evidenceRevision = strings.TrimSpace(*evidenceRevision)
+	*expectedBindingRevision = strings.TrimSpace(*expectedBindingRevision)
+	*remediatesEvidenceRevision = strings.TrimSpace(*remediatesEvidenceRevision)
 	if strings.TrimSpace(*cwd) == "" {
 		return errors.New("sdd-attempt requires --cwd")
 	}

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -293,3 +293,33 @@ func TestRunSDDAttemptStatusPathUsesRepositoryCommonDir(t *testing.T) {
 		t.Fatalf("linked status = %#v, want revision %s", fromLinked, started.Revision)
 	}
 }
+
+// TestRunSDDAttemptTrimsWhitespaceFromRevisionShapedFlags is the RED
+// reproduction of the CLI-boundary half of #2294: a reporter pasting
+// --evidence-revision from PowerShell `Get-FileHash` or `shasum` output often
+// carries incidental leading/trailing whitespace, which the sha256:<64-hex>
+// pattern then rejects for a reason that has nothing to do with the actual
+// evidence-revision defect being reported. The CLI boundary must trim
+// identity/revision-shaped flag values before they ever reach sddstatus,
+// which stays a pure validator with no normalization of its own.
+func TestRunSDDAttemptTrimsWhitespaceFromRevisionShapedFlags(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	hash := cliAttemptHash('a')
+	padded := "  " + hash + "\n"
+
+	started := runSDDAttemptStatus(t, []string{
+		"begin", "--cwd", repo, "--change", "cli-trim", "--expected-revision=", "--request-id", "trim-begin",
+		"--work-unit", "trim-unit", "--evidence-goal", "prove trimmed CLI revisions", "--max-attempts", "1", "--max-changed-lines", "10",
+	})
+
+	finished := runSDDAttemptStatus(t, []string{
+		"finish", "--cwd", repo, "--change", "cli-trim", "--expected-revision", started.Revision, "--request-id", "trim-finish",
+		"--outcome", "failed", "--evidence-revision", padded,
+		"--diagnosis", "diagnosis", "--harness-disposition", "reused",
+		"--cleanup-evidence", "cleanup", "--process-evidence", "process",
+	})
+	last := finished.Attempts[len(finished.Attempts)-1]
+	if last.EvidenceRevision != hash {
+		t.Fatalf("finish with a whitespace-padded --evidence-revision = %#v, want trimmed evidence_revision %q", last, hash)
+	}
+}

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -20,15 +20,25 @@ const (
 	CompactBlockMaintainerDecision  CompactBlockReason = "maintainer_decision"
 	CompactBlockCorruptAuthority    CompactBlockReason = "corrupt_authority"
 	CompactBlockInvalidContinuation CompactBlockReason = "invalid_continuation"
+	CompactBlockRemediationRequired CompactBlockReason = "remediation_required"
 	CompactBlockAuthorityFailure    CompactBlockReason = "authority_failure"
 )
 
 // CompactAttemptResult is the bounded orchestration projection. RuntimeStatus
 // remains available through the legacy diagnostic operations only.
+//
+// Exit and Detail carry a wrapped mutation refusal's message text through to
+// this compact boundary (#2249): compactMutationFailure populates both
+// whenever it classifies a real error, so a well-constructed refusal that
+// names a runnable continuation — like runtimeRemediationExitRefusal's — is
+// never silently reduced to a bare Reason. Both stay empty on every happy
+// path (proceed, complete-with-no-error).
 type CompactAttemptResult struct {
 	State  CompactAttemptState `json:"state"`
 	Reason CompactBlockReason  `json:"reason,omitempty"`
 	Token  string              `json:"token,omitempty"`
+	Exit   string              `json:"exit,omitempty"`
+	Detail string              `json:"detail,omitempty"`
 }
 
 // CompactAcquireRequest is the bounded orchestration projection of
@@ -293,19 +303,34 @@ func (store RuntimeStore) compactMutationFailure(err error, settle bool, begin B
 		}
 		return compactAcquireResult(replay, begin, publication.Revision)
 	}
+	// Every branch below wraps a real error, so `detail` always has message
+	// text to carry through to the compact JSON boundary instead of being
+	// thrown away behind a bare classification (#2249). `exit` reuses the
+	// same text: these refusals are constructed specifically to name a
+	// runnable continuation inline (see runtimeRemediationExitRefusal), and
+	// there is no reliable field-agnostic way to shorten that further.
+	detail := err.Error()
+	reason := CompactBlockAuthorityFailure
 	switch {
 	case errors.Is(err, ErrRuntimeObjectiveDone):
-		return CompactAttemptResult{State: CompactStateComplete}
+		return CompactAttemptResult{State: CompactStateComplete, Exit: detail, Detail: detail}
 	case errors.Is(err, ErrRuntimeBudgetExhausted), errors.Is(err, ErrRuntimeObjectiveChange):
-		return compactBlocked(CompactBlockMaintainerDecision, "")
+		reason = CompactBlockMaintainerDecision
 	case errors.Is(err, ErrRuntimeAttemptActive):
-		return compactBlocked(CompactBlockActiveAttempt, "")
+		reason = CompactBlockActiveAttempt
 	case errors.Is(err, ErrRuntimeRevisionConflict), errors.Is(err, ErrRuntimeConcurrentUpdate),
-		errors.Is(err, ErrRuntimeRequestConflict), errors.Is(err, ErrRuntimeNoActiveAttempt):
-		return compactBlocked(CompactBlockInvalidContinuation, "")
-	default:
-		return compactBlocked(CompactBlockAuthorityFailure, "")
+		errors.Is(err, ErrRuntimeRequestConflict), errors.Is(err, ErrRuntimeNoActiveAttempt),
+		errors.Is(err, ErrBindingRevisionConflict):
+		reason = CompactBlockInvalidContinuation
+	// ErrRuntimeRemediationSuccessorRequired is the sentinel behind
+	// runtimeRemediationExitRefusal (runtime_ledger.go:628-646): the candidate
+	// moved after Begin, so a passing finish demands the remediation trio
+	// naming its own runnable exit. It previously fell through to the
+	// default authority_failure and lost that exit entirely (#2249).
+	case errors.Is(err, ErrRuntimeRemediationSuccessorRequired):
+		reason = CompactBlockRemediationRequired
 	}
+	return CompactAttemptResult{State: CompactStateBlocked, Reason: reason, Exit: detail, Detail: detail}
 }
 
 func compactBlocked(reason CompactBlockReason, token string) CompactAttemptResult {

--- a/internal/sddstatus/runtime_compact_sentinel_test.go
+++ b/internal/sddstatus/runtime_compact_sentinel_test.go
@@ -1,0 +1,127 @@
+package sddstatus
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCompactSettleRemediationRefusalIsClassifiedNotAuthorityFailure is the RED
+// reproduction for #2249: a compact `sdd-attempt settle --outcome passed` with
+// otherwise valid inputs, issued against an attempt whose candidate drifted
+// after Begin while a review binding is in place, used to collapse into
+// {"state":"blocked","reason":"authority_failure"} while status kept
+// reporting outcome: running, next_action: finish — a dead end. Root cause:
+// compactMutationFailure's switch had no case for
+// ErrRuntimeRemediationSuccessorRequired, so it fell through to the default
+// branch and threw away runtimeRemediationExitRefusal's actionable message.
+func TestCompactSettleRemediationRefusalIsClassifiedNotAuthorityFailure(t *testing.T) {
+	change := "compact-remediation-legibility"
+	fixture := newRuntimeUnchangedBindingFixture(t, change)
+
+	// Drift the candidate after Begin: the ordinary continuation for a
+	// passing finish bound to a review is now the remediation trio, not a
+	// bare pass.
+	write(t, filepath.Join(fixture.store.Repo, "openspec", "changes", change, "tasks.md"), "- [x] 1.1 Done\n# post-begin drift\n")
+
+	result, err := fixture.store.Settle(context.Background(), CompactSettleRequest{
+		Token: fixture.active.Revision, RequestID: change + "-settle", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('e'), Diagnosis: "drifted candidate settle reproduces #2249",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "settle cleanup completed",
+		ProcessEvidence: "settle process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != CompactStateBlocked {
+		t.Fatalf("drifted compact settle result = %#v, want state=blocked", result)
+	}
+	if result.Reason == CompactBlockAuthorityFailure {
+		t.Fatalf("drifted compact settle reason = %q, want a specific classification, not the opaque default authority_failure dead end", result.Reason)
+	}
+	if result.Reason != CompactBlockRemediationRequired {
+		t.Fatalf("drifted compact settle reason = %q, want %q", result.Reason, CompactBlockRemediationRequired)
+	}
+	if result.Detail == "" || result.Exit == "" {
+		t.Fatalf("drifted compact settle result = %#v, want non-empty Detail/Exit carrying the wrapped refusal instead of throwing it away", result)
+	}
+	for _, want := range []string{"--expected-binding-revision", "--successor-lineage", "--remediates-evidence-revision"} {
+		if !strings.Contains(result.Detail, want) {
+			t.Fatalf("drifted compact settle detail = %q, want it to name the remediation trio exit including %s", result.Detail, want)
+		}
+	}
+}
+
+// TestCompactMutationFailureClassifiesEveryReachableLedgerSentinel is the
+// table-driven sentinel enumeration test required alongside the #2249 fix. It
+// audits every ErrRuntime*/ErrBindingRevisionConflict sentinel declared in the
+// var block at runtime_ledger.go:61-92 against whether Begin or Finish (the
+// only two mutations Acquire/Settle drive through compactMutationFailure) can
+// actually produce it, and fails if a sentinel marked reachable still lands on
+// the opaque CompactBlockAuthorityFailure default. This is a genuine
+// regression guard: deleting the ErrRuntimeRemediationSuccessorRequired or
+// ErrBindingRevisionConflict case from compactMutationFailure's switch makes
+// this test fail, not just the #2249 repro above.
+func TestCompactMutationFailureClassifiesEveryReachableLedgerSentinel(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		reachable  bool // producible by Begin or Finish, and therefore by Acquire/Settle
+		wantState  CompactAttemptState
+		wantReason CompactBlockReason
+	}{
+		{name: "ErrRuntimeObjectiveDone", err: ErrRuntimeObjectiveDone, reachable: true, wantState: CompactStateComplete},
+		{name: "ErrRuntimeBudgetExhausted", err: ErrRuntimeBudgetExhausted, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockMaintainerDecision},
+		{name: "ErrRuntimeObjectiveChange", err: ErrRuntimeObjectiveChange, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockMaintainerDecision},
+		{name: "ErrRuntimeAttemptActive", err: ErrRuntimeAttemptActive, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockActiveAttempt},
+		{name: "ErrRuntimeRevisionConflict", err: ErrRuntimeRevisionConflict, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockInvalidContinuation},
+		{name: "ErrRuntimeConcurrentUpdate", err: ErrRuntimeConcurrentUpdate, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockInvalidContinuation},
+		{name: "ErrRuntimeRequestConflict", err: ErrRuntimeRequestConflict, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockInvalidContinuation},
+		{name: "ErrRuntimeNoActiveAttempt", err: ErrRuntimeNoActiveAttempt, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockInvalidContinuation},
+		{name: "ErrRuntimeRemediationSuccessorRequired", err: ErrRuntimeRemediationSuccessorRequired, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockRemediationRequired},
+		{name: "ErrBindingRevisionConflict", err: ErrBindingRevisionConflict, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockInvalidContinuation},
+		// Reset is the only mutation that can produce these two; Begin/Finish
+		// never do, so Acquire/Settle never route them into
+		// compactMutationFailure. They stay intentionally unclassified.
+		{name: "ErrRuntimeNoObjective", err: ErrRuntimeNoObjective, reachable: false},
+		{name: "ErrRuntimeResetNotAllowed", err: ErrRuntimeResetNotAllowed, reachable: false},
+	}
+
+	store := RuntimeStore{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := store.compactMutationFailure(tt.err, false, BeginAttemptRequest{})
+			if !tt.reachable {
+				return
+			}
+			if result.Reason == CompactBlockAuthorityFailure {
+				t.Fatalf("compactMutationFailure(%v) = %#v, a Begin/Finish-reachable sentinel must not fall through to authority_failure", tt.err, result)
+			}
+			if result.State != tt.wantState || result.Reason != tt.wantReason {
+				t.Fatalf("compactMutationFailure(%v) = %#v, want state=%q reason=%q", tt.err, result, tt.wantState, tt.wantReason)
+			}
+			if result.Detail == "" || result.Exit == "" {
+				t.Fatalf("compactMutationFailure(%v) = %#v, want non-empty Detail/Exit", tt.err, result)
+			}
+		})
+	}
+}
+
+// TestCompactMutationFailureLeavesUnexpectedErrorsAtAuthorityFailure proves
+// the classification is not a blanket bypass: a genuinely unclassified error
+// (unrelated to any declared ledger sentinel, e.g. a raw I/O failure) still
+// lands on CompactBlockAuthorityFailure, and still carries Detail/Exit so it
+// is visible instead of silently swallowed.
+func TestCompactMutationFailureLeavesUnexpectedErrorsAtAuthorityFailure(t *testing.T) {
+	store := RuntimeStore{}
+	err := errors.New("simulated unexpected I/O failure")
+	result := store.compactMutationFailure(err, false, BeginAttemptRequest{})
+	if result.State != CompactStateBlocked || result.Reason != CompactBlockAuthorityFailure {
+		t.Fatalf("compactMutationFailure(%v) = %#v, want state=blocked reason=authority_failure", err, result)
+	}
+	if result.Detail != err.Error() || result.Exit != err.Error() {
+		t.Fatalf("compactMutationFailure(%v) = %#v, want Detail/Exit = %q", err, result, err.Error())
+	}
+}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -1579,6 +1579,27 @@ func normalizeBeginAttemptRequest(request BeginAttemptRequest) (BeginAttemptRequ
 	return request, nil
 }
 
+// runtimeRevisionShapeObservation describes a rejected sha256:<64-lowercase-hex>
+// candidate without ever echoing it verbatim: the value may be long or, for a
+// caller that pasted the wrong secret, sensitive. It reports only what the
+// exact-match failure cannot otherwise tell an operator — length, whether the
+// sha256: prefix is present, and whether the remainder contains characters
+// outside 0-9a-f (which catches the common case of uppercase hex from
+// PowerShell `Get-FileHash` or `shasum -a 256` output).
+func runtimeRevisionShapeObservation(value string) string {
+	const prefix = "sha256:"
+	hasPrefix := strings.HasPrefix(value, prefix)
+	body := strings.TrimPrefix(value, prefix)
+	nonLowercaseHex := false
+	for _, r := range body {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			nonLowercaseHex = true
+			break
+		}
+	}
+	return fmt.Sprintf("received length=%d, sha256: prefix=%t, non-lowercase-hex characters=%t", len(value), hasPrefix, nonLowercaseHex)
+}
+
 func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptRequest, error) {
 	if request.ExpectedRevision == "" || !runtimeRevisionPattern.MatchString(request.ExpectedRevision) {
 		return FinishAttemptRequest{}, errors.New("finish requires an exact expected runtime revision")
@@ -1590,7 +1611,10 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 		return FinishAttemptRequest{}, errors.New("outcome must be failed, interrupted, or passed")
 	}
 	if !runtimeRevisionPattern.MatchString(request.EvidenceRevision) {
-		return FinishAttemptRequest{}, errors.New("evidence_revision must be sha256")
+		return FinishAttemptRequest{}, fmt.Errorf(
+			"evidence_revision must be sha256:<64-lowercase-hex> (%s); rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --evidence-revision sha256:<64-lowercase-hex>",
+			runtimeRevisionShapeObservation(request.EvidenceRevision),
+		)
 	}
 	if err := validateRuntimeText(request.Diagnosis, 500); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid diagnosis: %w", err)
@@ -1618,13 +1642,19 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 			return FinishAttemptRequest{}, errors.New("an atomic remediation successor is valid only for a passed attempt")
 		}
 		if !runtimeRevisionPattern.MatchString(request.ExpectedBindingRevision) {
-			return FinishAttemptRequest{}, errors.New("expected_binding_revision must be sha256 for atomic remediation")
+			return FinishAttemptRequest{}, fmt.Errorf(
+				"expected_binding_revision must be sha256:<64-lowercase-hex> for atomic remediation (%s); rerun `gentle-ai sdd-attempt finish` with --expected-binding-revision sha256:<64-lowercase-hex> --successor-lineage <lineage> --remediates-evidence-revision sha256:<64-lowercase-hex>",
+				runtimeRevisionShapeObservation(request.ExpectedBindingRevision),
+			)
 		}
 		if !validReviewBindingLineage(request.SuccessorLineageID) {
 			return FinishAttemptRequest{}, errors.New("successor_lineage_id must be a canonical lowercase lineage")
 		}
 		if !runtimeRevisionPattern.MatchString(request.RemediatesEvidenceRevision) {
-			return FinishAttemptRequest{}, errors.New("remediates_evidence_revision must be sha256")
+			return FinishAttemptRequest{}, fmt.Errorf(
+				"remediates_evidence_revision must be sha256:<64-lowercase-hex> (%s); rerun `gentle-ai sdd-attempt finish` with --expected-binding-revision sha256:<64-lowercase-hex> --successor-lineage <lineage> --remediates-evidence-revision sha256:<64-lowercase-hex>",
+				runtimeRevisionShapeObservation(request.RemediatesEvidenceRevision),
+			)
 		}
 	}
 	return request, nil

--- a/internal/sddstatus/runtime_ledger_refusal_legibility_test.go
+++ b/internal/sddstatus/runtime_ledger_refusal_legibility_test.go
@@ -1,0 +1,79 @@
+package sddstatus
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNormalizeFinishAttemptRequestRevisionRefusalsAreSelfDiagnosing is the RED
+// reproduction for #2294: `sdd-attempt settle` (and `finish`) rejected every
+// --evidence-revision value — a 40-hex git SHA, a bare 64-hex value, and a
+// sha256:<64-hex>-prefixed value with uppercase hex or incidental whitespace —
+// with the identical opaque "evidence_revision must be sha256" text. The
+// validation RULE (require an exact sha256:<64-lowercase-hex> token) is
+// correct and stays unchanged here; only the message's legibility is under
+// test: it must name the expected shape, describe (without echoing) what was
+// actually received, and name a runnable exit.
+func TestNormalizeFinishAttemptRequestRevisionRefusalsAreSelfDiagnosing(t *testing.T) {
+	uppercaseHex := "sha256:" + strings.Repeat("A", 64)
+	base := func() FinishAttemptRequest {
+		return FinishAttemptRequest{
+			ExpectedRevision: runtimeTestHash('1'), RequestID: "legibility-check", Outcome: AttemptPassed,
+			EvidenceRevision: runtimeTestHash('2'), Diagnosis: "diagnosis", HarnessDisposition: HarnessReused,
+			CleanupEvidence: "cleanup", ProcessEvidence: "process",
+		}
+	}
+
+	t.Run("evidence_revision", func(t *testing.T) {
+		request := base()
+		request.EvidenceRevision = uppercaseHex
+		_, err := normalizeFinishAttemptRequest(request)
+		assertSelfDiagnosingRevisionRefusal(t, err, uppercaseHex, "--evidence-revision")
+	})
+
+	t.Run("expected_binding_revision", func(t *testing.T) {
+		request := base()
+		request.ExpectedBindingRevision = uppercaseHex
+		request.SuccessorLineageID = "lineage"
+		request.RemediatesEvidenceRevision = runtimeTestHash('3')
+		_, err := normalizeFinishAttemptRequest(request)
+		assertSelfDiagnosingRevisionRefusal(t, err, uppercaseHex, "--expected-binding-revision")
+	})
+
+	t.Run("remediates_evidence_revision", func(t *testing.T) {
+		request := base()
+		request.ExpectedBindingRevision = runtimeTestHash('4')
+		request.SuccessorLineageID = "lineage"
+		request.RemediatesEvidenceRevision = uppercaseHex
+		_, err := normalizeFinishAttemptRequest(request)
+		assertSelfDiagnosingRevisionRefusal(t, err, uppercaseHex, "--remediates-evidence-revision")
+	})
+}
+
+// assertSelfDiagnosingRevisionRefusal is the mutation-style proof for the
+// message-shape fix: it asserts the concrete expected-shape literal, a
+// redacted length observation, and a runnable exit naming the actual flag —
+// and that the raw offending value never appears verbatim, since it may be
+// sensitive or long. Reverting the message-quality fix collapses the refusal
+// back to the bare "<field> must be sha256" text and fails every assertion
+// here except the raw-value-absence one (which a bare message also passes
+// vacuously, so the other three are what actually guard the fix).
+func assertSelfDiagnosingRevisionRefusal(t *testing.T, err error, rawValue, wantFlag string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("normalizeFinishAttemptRequest = nil error, want a refusal")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "sha256:<64-lowercase-hex>") {
+		t.Fatalf("refusal %q does not name the expected shape sha256:<64-lowercase-hex>", message)
+	}
+	if !strings.Contains(message, "length=") {
+		t.Fatalf("refusal %q does not include a redacted length observation", message)
+	}
+	if !strings.Contains(message, wantFlag) {
+		t.Fatalf("refusal %q does not name a runnable exit with %s", message, wantFlag)
+	}
+	if strings.Contains(message, rawValue) {
+		t.Fatalf("refusal %q echoes the raw revision value verbatim, which may be sensitive/long", message)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2294
Closes #2249

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

Slice 1: the three opaque sha256 refusals now name the expected shape, a redacted observation, and the exact rerun exit; CompactAttemptResult gains Exit/Detail; remediation_required classification replaces the authority_failure swallow; sentinel-enumeration test covers all 12.

## 🧪 Test Plan

- [x] STRICT TDD with the reported scenarios as REDs; mutation proofs on guards
- [x] Full `go test ./... -count=1` (root + bench) green per slice; bench corpus zero structural deltas
- [x] Cluster plan and maintainer decisions: Engram exploration + ratified narrowing-rescope decision