### PR TITLE
fix(review): validate authorization and CAS on every resume path

### DIFF
--- a/bench/axis_damaged_store_closure.go
+++ b/bench/axis_damaged_store_closure.go
@@ -487,6 +487,45 @@ func requireClosureMemberAlreadyQuarantined(sandbox *Sandbox, lineage string) er
 	return nil
 }
 
+// requireForgedResumeMovedNothingFurther is fix cycle 1's CRITICAL-1
+// (security) journey-level mutation proof: a forged-authorization resume
+// attempt against an in-progress closure must refuse through the real
+// `review repair` binary before touching anything beyond the crash
+// fixture's own pre-authored member — the grandchild's single quarantine
+// directory must be unchanged, and child/seed must have none. This is the
+// black-box, N=3, real-binary twin of
+// TestAuthorityDispositionResumeRefusesForgedAuthorization.
+func requireForgedResumeMovedNothingFurther(r *journeyRun) error {
+	base, err := reviewTransactionsBase(r.sandbox)
+	if err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(filepath.Join(base, "quarantine"))
+	if err != nil {
+		return err
+	}
+	counts := map[string]int{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		for _, lineage := range closureMemberLineages {
+			if strings.HasPrefix(entry.Name(), lineage+"-") {
+				counts[lineage]++
+			}
+		}
+	}
+	if counts[closureGrandchildLineage] != 1 {
+		return fmt.Errorf("grandchild quarantine directories after a refused forged-authorization resume = %d, want exactly 1 (unchanged from before the attempt)", counts[closureGrandchildLineage])
+	}
+	for _, lineage := range []string{closureChildLineage, closureSeedLineage} {
+		if counts[lineage] != 0 {
+			return fmt.Errorf("%q has %d quarantine directories after a refused forged-authorization resume, want 0 — the forged authorization moved something it should have refused", lineage, counts[lineage])
+		}
+	}
+	return nil
+}
+
 // requireNoDoubleMoveAcrossClosure is ds11's resume-convergence proof:
 // after the resumed `review repair` run, every closure member has exactly
 // one quarantine directory — the crash-position fixture's pre-authored one
@@ -610,6 +649,21 @@ func closureDispositionJourneys() []Journey {
 						}
 						return requireClosureMemberAlreadyQuarantined(r.sandbox, closureGrandchildLineage)
 					}},
+				// Fix cycle 1 (CRITICAL-1, security): before Wave 6's fix,
+				// validateAuthorityDispositionAuthorization was gated inside
+				// a fresh-execution-only branch, so this exact resume shape —
+				// a real `review repair` call against an in-progress
+				// closure — executed unauthorized regardless of what
+				// --authorization it was given. This step submits the CORRECT
+				// --plan-digest/--inventory-revision (so CAS and plan-match
+				// both pass) but an authorization bound to a repository
+				// identity that can never be the real one, mirroring
+				// ds08's N=1 forged-authorization journey — the N=3,
+				// mid-closure-resume twin.
+				{Name: "attempt to resume with an authorization bound to the wrong repository — refused, nothing moves further", Requires: repairDispositionExecuteCapability,
+					Args: forgedDispositionRepairArgs("quarantine the multi-hop closure")},
+				{Name: "the forged-authorization resume attempt moved nothing beyond the pre-authored member",
+					Composite: requireForgedResumeMovedNothingFurther},
 				{Name: "resume the interrupted closure with the identical plan", Requires: repairDispositionExecuteCapability,
 					Args: dispositionRepairArgs("quarantine the multi-hop closure"), After: requireDispositionQuarantineCommitted},
 				{Name: "the authority graph after resume", Requires: inspectAuthorityCapability,

--- a/internal/cli/review_repair.go
+++ b/internal/cli/review_repair.go
@@ -162,7 +162,21 @@ type reviewRepairOperationError struct {
 	cause   error
 }
 
-func (err *reviewRepairOperationError) Error() string { return err.message }
+// Error includes cause, not only message. Fix cycle 1 (CRITICAL-2): dropping
+// the cause here made every leaf authority disposition execution refusal —
+// by-design or not — read identically ("...did not complete"), with the
+// actual reason ("plan_digest does not match", "authorization does not
+// bind", ...) discarded. A caller that provably mutated nothing (see the
+// call site below) is never wrapped in this type at all, so its cause is not
+// merely appended here — it IS the visible error. This wrapping still
+// matters for the rarer partial-mutation case that call site keeps in this
+// type.
+func (err *reviewRepairOperationError) Error() string {
+	if err.cause == nil {
+		return err.message
+	}
+	return err.message + ": " + err.cause.Error()
+}
 func (err *reviewRepairOperationError) Unwrap() error { return err.cause }
 
 func RunReviewRepair(args []string, stdout io.Writer) error {
@@ -273,6 +287,32 @@ func runReviewRepair(ctx context.Context, args []string, stdout io.Writer) error
 		// preflight value.
 		record, err := reviewtransaction.RepairAuthorityDisposition(ctx, root, *planDigest, *inventoryRevision, *actor, *reason, *dispositionAuthorization)
 		if err != nil {
+			// Fix cycle 1 (CRITICAL-2): a returned zero-value record proves
+			// this call provably mutated nothing — lockedAuthorityDispositionMutation
+			// only ever returns a non-empty record once it committed at least
+			// one closure member (a NEW quarantine, or a discovered
+			// already-committed one from a prior interrupted attempt), and
+			// every refusal that runs before its per-node loop starts (plan
+			// re-derivation mismatch, admission, digest drift, authorization,
+			// CAS-all-N) — fresh or resumed alike — returns before that ever
+			// happens. Base bb3c22a9 classified this exact "nothing mutated"
+			// shape as a preflight-style refusal (its own CLI-level
+			// plan_digest/inventory_revision pre-check, removed when this
+			// call replaced it): the classification cascade recognizes
+			// reviewPreflightError, propagates the real cause verbatim, and
+			// never appends a saved-defect-report clause for it. Wrapping
+			// every RepairAuthorityDisposition error in the generic,
+			// unrecognized reviewRepairOperationError below regressed that —
+			// a by-design refusal like a stale/forged --plan-digest started
+			// reading as "tool-internal fault state that should never
+			// happen", complete with a saved defect report and an issue URL.
+			// The rarer case — a refusal reached only after at least one
+			// closure member already committed in this call, i.e. a
+			// genuinely unanticipated mid-loop fault — keeps the existing,
+			// now cause-preserving reviewRepairOperationError classification.
+			if record.LineageID == "" {
+				return reviewPreflightError(err)
+			}
 			return &reviewRepairOperationError{message: "review repair leaf authority disposition execution did not complete", cause: err}
 		}
 		result, err := newReviewRepairDispositionExecutionResult(assessment, record, *contract)

--- a/internal/cli/review_repair_test.go
+++ b/internal/cli/review_repair_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -637,6 +638,54 @@ func TestReviewRepairDispositionExecutionQuarantinesEligibleLeaf(t *testing.T) {
 	}
 	if preflight.DispositionProviderInputs != nil {
 		t.Fatalf("follow-on preflight still surfaced a plan for an already-quarantined leaf: %#v", preflight)
+	}
+}
+
+// TestReviewRepairDispositionExecutionDigestMismatchRefusesWithoutDefectReport
+// is fix cycle 1's CRITICAL-2 mutation proof: a by-design digest-mismatch
+// refusal on a `review repair` leaf authority disposition execution must
+// propagate its real cause and MUST NOT be surfaced as an unexpected
+// tool-internal fault with a saved defect report. Before Wave 6 Slice S3
+// removed the CLI's own plan_digest/inventory_revision pre-check (base
+// bb3c22a9), this exact N=1 scenario refused with its real cause text and no
+// defect report; Slice S3's replacement wraps every
+// RepairAuthorityDisposition error in reviewRepairOperationError, whose
+// Error() dropped the cause entirely and which the classification cascade
+// does not recognize, so it fell through to operation_outcome_unknown and
+// appended a saved-defect-report clause even though nothing mutated and
+// nothing is actually wrong with the tool.
+func TestReviewRepairDispositionExecutionDigestMismatchRefusesWithoutDefectReport(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeInspectCLIRecoveryPair(t, repo, "leaf-digest-mismatch", false, dispositionForgedAuthorization)
+
+	actor, reason := "maintainer@example.com", "quarantine content-mismatched leaf"
+	plan, err := reviewtransaction.DeriveAuthorityDispositionPlanAtRepo(context.Background(), repo, actor, reason)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := authorityDispositionAuthorization(plan)
+
+	staleDigest := "sha256:" + strings.Repeat("a", 64)
+	executeArgs := []string{
+		"repair", "--cwd", repo,
+		"--plan-digest", staleDigest, "--inventory-revision", plan.AuthorityInventoryRevision,
+		"--actor", actor, "--reason", reason, "--authorization", authorization,
+	}
+	var executed bytes.Buffer
+	err = RunReview(executeArgs, &executed)
+	if err == nil {
+		t.Fatal("digest-mismatched disposition execution was admitted")
+	}
+	if !errors.Is(err, reviewtransaction.ErrConcurrentUpdate) {
+		t.Fatalf("digest-mismatch execution error = %v, want it to wrap ErrConcurrentUpdate", err)
+	}
+	if !strings.Contains(err.Error(), "does not match the current provider-derived plan") {
+		t.Fatalf("digest-mismatch execution error dropped its real cause: %v", err)
+	}
+	for _, unwanted := range []string{"defect report", "tool-internal fault", "operation_outcome_unknown"} {
+		if strings.Contains(err.Error(), unwanted) {
+			t.Fatalf("by-design digest-mismatch refusal was misclassified as an unexpected tool fault (%q present): %v", unwanted, err)
+		}
 	}
 }
 

--- a/internal/reviewtransaction/authority_disposition_execute.go
+++ b/internal/reviewtransaction/authority_disposition_execute.go
@@ -171,11 +171,28 @@ func lockedAuthorityDispositionMutation(ctx context.Context, maintenance *Mainte
 		return CompactReclaimRecord{}, err
 	}
 
+	// Fix cycle 1 (CRITICAL-1, security): Authorization and CAS-all-N
+	// validate on EVERY execution path, fresh or resume — only the plan
+	// RE-DERIVATION comparison below is fresh-only, because that is the one
+	// part that legitimately cannot work mid-closure (re-deriving against a
+	// store that has already shrunk as prior members were quarantined away
+	// is a narrowing re-derivation the spec forbids, not a real staleness
+	// signal). Gating validateAuthorityDispositionAuthorization inside the
+	// fresh-only branch (as this function previously did) meant every
+	// RESUME executed unauthorized: RepairAuthorityDisposition's resume path
+	// (reconstructAuthorityDispositionPlanForResume, authority_repair.go)
+	// sets Authorization from the CURRENT caller's argument, unverified, so
+	// any caller who merely knew an in-progress plan_digest could resume
+	// with a forged Authorization and it would commit every remaining
+	// closure member.
+	var records map[string]CompactRecord
+	validationInventoryRevision := plan.AuthorityInventoryRevision
 	if freshExecution {
-		report, records, err := loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
+		report, freshRecords, err := loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
 		if err != nil {
 			return CompactReclaimRecord{}, err
 		}
+		records = freshRecords
 		currentPlan, err := deriveAuthorityDispositionPlan(report, records, binding, plan.Actor, plan.Reason)
 		if err != nil {
 			return CompactReclaimRecord{}, fmt.Errorf("authority disposition execution refused: re-derivation under lock did not reproduce a closed classification: %w", err)
@@ -190,28 +207,55 @@ func lockedAuthorityDispositionMutation(ctx context.Context, maintenance *Mainte
 		if err != nil {
 			return CompactReclaimRecord{}, err
 		}
-		if err := validateAuthorityDispositionAuthorization(plan, currentInventoryRevision); err != nil {
+		validationInventoryRevision = currentInventoryRevision
+	}
+	// A non-fresh closure (freshExecution == false) skips re-derivation
+	// entirely: this exact plan_digest already passed re-derivation and CAS
+	// the one time its per-node loop first began (when plan.Closure[0] still
+	// had a live, untouched v2/ entry). Authorization, though, binds
+	// plan_digest and plan.AuthorityInventoryRevision to each other
+	// cryptographically (authorityDispositionAuthorizationBinding);
+	// comparing plan's own frozen inventory revision to itself below makes
+	// the drift half of validateAuthorityDispositionAuthorization a no-op on
+	// resume (as it must be — the store has legitimately shrunk), while the
+	// binding half still catches a forged or mismatched Authorization on
+	// every single call, fresh or resumed.
+	if err := validateAuthorityDispositionAuthorization(plan, validationInventoryRevision); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+
+	// CAS-all-N: every closure member's expected revision is checked before
+	// the first move — drift on ANY member, not only the seed, refuses
+	// pre-move and names exactly which member drifted. On resume, records
+	// were not already loaded above (freshExecution == false skipped
+	// re-derivation), so load them once here, for CAS-all-N only.
+	if records == nil {
+		_, freshRecords, err := loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
+		if err != nil {
 			return CompactReclaimRecord{}, err
 		}
-
-		// CAS-all-N: every closure member's expected revision is checked
-		// before the first move — drift on ANY member, not only the seed,
-		// refuses pre-move and names exactly which member drifted.
-		for _, lineage := range plan.Closure {
-			targetRecord, found := records[lineage]
-			expectedRevision, expectedFound := plan.ExpectedRevisions[lineage]
-			if !found || !expectedFound || targetRecord.Revision != expectedRevision {
+		records = freshRecords
+	}
+	for _, lineage := range plan.Closure {
+		targetRecord, found := records[lineage]
+		if !found {
+			// On a fresh execution a missing member is drift — nothing has
+			// legitimately removed it yet. On resume it is very likely
+			// already quarantined by the interrupted attempt this call
+			// resumes; the per-node loop below discovers and either skips
+			// it cleanly or refuses it by name (a genuine digest mismatch),
+			// so CAS-all-N does not refuse pre-emptively for a member that
+			// simply is not live anymore.
+			if freshExecution {
 				return CompactReclaimRecord{}, fmt.Errorf("%w: expected revision for closure member %q drifted", ErrConcurrentUpdate, lineage)
 			}
+			continue
+		}
+		expectedRevision, expectedFound := plan.ExpectedRevisions[lineage]
+		if !expectedFound || targetRecord.Revision != expectedRevision {
+			return CompactReclaimRecord{}, fmt.Errorf("%w: expected revision for closure member %q drifted", ErrConcurrentUpdate, lineage)
 		}
 	}
-	// A non-fresh closure (freshExecution == false) skips re-derivation, CAS,
-	// and authorization entirely: this exact plan_digest already passed all
-	// three the one time its per-node loop first began (when plan.Closure[0]
-	// still had a live, untouched v2/ entry). Re-running them now would
-	// compare against a store that has legitimately shrunk as prior members
-	// were quarantined away — a narrowing re-derivation the spec forbids,
-	// not a real staleness signal.
 
 	recordedAuthorization := sha256.Sum256([]byte(plan.Authorization))
 	var lastCommitted CompactReclaimRecord
@@ -322,6 +366,14 @@ func authorityDispositionClosureIsFresh(ctx context.Context, base string, plan A
 // falling back to memberLineage's own quarantine directory under any digest
 // (a still-incomplete run), or a generic escalation with neither path when
 // even that cannot be found. It never attempts a narrowing re-derivation.
+//
+// SUGGESTION (fix cycle 1): both loops select a candidate quarantine
+// directory by name-prefix alone, mirroring the directory-naming scheme
+// (`<lineage>-<random-suffix>`) but not verifying it — a lineage ID that is
+// itself a prefix of another (e.g. "foo" and "foo-bar") could otherwise
+// match the wrong directory. quarantineDirectoryLineageMatches decodes the
+// candidate's own reclaim-record.json and checks its LineageID field
+// explicitly, exactly like discoverAuthorityDispositionRecord already does.
 func authorityDispositionResumeDigestMismatchRefusal(base, seedLineage, memberLineage, planDigest string) error {
 	quarantineRoot := filepath.Join(base, "quarantine")
 	entries, err := os.ReadDir(quarantineRoot)
@@ -330,7 +382,8 @@ func authorityDispositionResumeDigestMismatchRefusal(base, seedLineage, memberLi
 		return fmt.Errorf("authority disposition execution refused: closure member %q is missing from the authority store with no matching quarantine record for plan_digest %q; escalate — resume never attempts a narrowing re-derivation", memberLineage, planDigest)
 	}
 	for _, entry := range entries {
-		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), seedLineage+"-") {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), seedLineage+"-") ||
+			!quarantineDirectoryLineageMatches(quarantineRoot, entry.Name(), seedLineage) {
 			continue
 		}
 		manifestPath := filepath.Join(quarantineRoot, entry.Name(), "closure-manifest.json")
@@ -340,13 +393,31 @@ func authorityDispositionResumeDigestMismatchRefusal(base, seedLineage, memberLi
 		}
 	}
 	for _, entry := range entries {
-		if entry.IsDir() && strings.HasPrefix(entry.Name(), memberLineage+"-") {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), memberLineage+"-") &&
+			quarantineDirectoryLineageMatches(quarantineRoot, entry.Name(), memberLineage) {
 			// refusal:by-design human-authority: a digest-mismatched or otherwise ambiguous partial closure needs a maintainer's diagnosis before any resume continues; forward-only resume never attempts a narrowing re-derivation, so there is no command this refusal can name
 			return fmt.Errorf("authority disposition execution refused: closure member %q was already quarantined under a different plan_digest than %q; inspect %s and escalate — resume never attempts a narrowing re-derivation", memberLineage, planDigest, filepath.Join(quarantineRoot, entry.Name()))
 		}
 	}
 	// refusal:by-design human-authority: a closure member missing from the authority store with no matching quarantine record under any digest needs a maintainer's diagnosis; forward-only resume never attempts a narrowing re-derivation, so there is no command this refusal can name
 	return fmt.Errorf("authority disposition execution refused: closure member %q is missing from the authority store with no matching quarantine record for plan_digest %q; escalate — resume never attempts a narrowing re-derivation", memberLineage, planDigest)
+}
+
+// quarantineDirectoryLineageMatches reports whether the quarantine directory
+// entryName (a child of quarantineRoot) holds a decodable reclaim-record.json
+// whose own LineageID field equals expectedLineage. It never returns true on
+// any read or decode failure — an unreadable or malformed record is not
+// evidence of a match, only a name-prefix coincidence would be.
+func quarantineDirectoryLineageMatches(quarantineRoot, entryName, expectedLineage string) bool {
+	payload, err := os.ReadFile(filepath.Join(quarantineRoot, entryName, "reclaim-record.json"))
+	if err != nil {
+		return false
+	}
+	var record CompactReclaimRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return false
+	}
+	return record.LineageID == expectedLineage
 }
 
 // loadCompactRecoveryRecordsUnderMaintenanceHold mirrors

--- a/internal/reviewtransaction/authority_disposition_resume_test.go
+++ b/internal/reviewtransaction/authority_disposition_resume_test.go
@@ -343,6 +343,67 @@ func TestRepairAuthorityDispositionResumesThroughPublicEntrypoint(t *testing.T) 
 	}
 }
 
+// TestAuthorityDispositionResumeRefusesForgedAuthorization is fix cycle 1's
+// CRITICAL-1 (security) mutation proof: a resumed closure execution must
+// validate Authorization on EVERY execution path, not only a fresh one.
+// lockedAuthorityDispositionMutation previously gated
+// validateAuthorityDispositionAuthorization inside the `if freshExecution`
+// block — its ONLY non-test call site — so every resume executed
+// unauthorized: an attacker who knew nothing but an in-progress plan_digest
+// could resume with a garbage Authorization and a different Actor, and it
+// would commit every remaining closure member. This interrupts a real
+// 3-node closure exactly like
+// TestAuthorityDispositionResumeSkipsCommittedAndFinishesPrepared, then
+// resumes with Authorization replaced by garbage and Actor replaced by
+// "attacker" (mirroring the verifier's exact repro): this must refuse, and
+// nothing beyond the grandchild's already-committed member may move. If
+// authorization validation is ever re-gated inside a fresh-only branch
+// again, this test fails immediately (the forged resume would be admitted).
+func TestAuthorityDispositionResumeRefusesForgedAuthorization(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	plan, child, grandchild := threeNodeClosureFixture(t, repo, "forged-resume")
+	seed := plan.Closure[len(plan.Closure)-1]
+
+	base, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalHook := compactReclaimPhaseHook
+	injected := errors.New("injected interruption after grandchild commits")
+	compactReclaimPhaseHook = func(ctx context.Context, current string, record CompactReclaimRecord) error {
+		if current == compactReclaimPhaseCommitted && record.LineageID == grandchild.State.LineageID {
+			return injected
+		}
+		return originalHook(ctx, current, record)
+	}
+	t.Cleanup(func() { compactReclaimPhaseHook = originalHook })
+
+	if _, err := executeAuthorityDisposition(context.Background(), repo, plan); !errors.Is(err, injected) {
+		t.Fatalf("first (interrupted) execution error = %v, want the injected interruption", err)
+	}
+	compactReclaimPhaseHook = originalHook
+
+	forged := plan
+	forged.Actor = "attacker"
+	forged.Authorization = "garbage authorization forged by an attacker"
+
+	if _, err := executeAuthorityDisposition(context.Background(), repo, forged); err == nil {
+		t.Fatal("resumed execution with a forged authorization and a different actor was admitted")
+	} else if !strings.Contains(err.Error(), "authorization does not bind") {
+		t.Fatalf("forged-authorization resume error = %v, want the authorization binding refusal", err)
+	}
+
+	for _, lineage := range []string{child.State.LineageID, seed} {
+		if got := quarantineEntriesForLineage(t, base, lineage); len(got) != 0 {
+			t.Fatalf("forged-authorization resume moved %q despite refusing: %v", lineage, got)
+		}
+	}
+	if got := quarantineEntriesForLineage(t, base, grandchild.State.LineageID); len(got) != 1 {
+		t.Fatalf("grandchild quarantine entries after refused forged resume = %v, want exactly 1 (unchanged)", got)
+	}
+}
+
 // TestAuthorityDispositionResumeCrashPositionMatrix is the load-bearing
 // proof tasks.md 3.5 and the coordinator's batch require: for a 3-node
 // closure, interrupting at EVERY position — after each node's prepared


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2400

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

Fix cycle 1: maintainer authorization and CAS-all-N had become gated inside the fresh-execution branch, so resumes executed unauthorized (CLI repro: garbage authorization exited 0). Both now validate on every path; only plan re-derivation stays fresh-only. Refusals no longer surface as tool-internal defect reports.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench) green at chain tip e174bc2b
- [x] Damaged-store axis vs fresh binaries (plain and -tags bench_fixture); ds06-ds12 completed
- [x] 3 verify cycles; final envelope pass_with_warnings 10/10 requirements, 13/13 scenarios, 0 criticals