### PR TITLE
feat(review): close the v3 admission preconditions before any retirement

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -938,7 +938,7 @@ func newLineageCapturedFindings(findings []facadeFinding) []reviewtransaction.Fi
 	converted := make([]reviewtransaction.FindingEvidence, len(findings))
 	for index, finding := range findings {
 		converted[index] = reviewtransaction.FindingEvidence{
-			FindingID: finding.ID, Class: finding.EvidenceClass, Causality: finding.CausalDisposition,
+			FindingID: finding.ID, Severity: finding.Severity, Class: finding.EvidenceClass, Causality: finding.CausalDisposition,
 			Proof: strings.Join(finding.ProofRefs, "; "),
 		}
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2212,7 +2212,15 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 					return reviewPreflightError(fmt.Errorf("read new-lineage admission findings: %w", err))
 				}
 			} else if *capturedResults {
-				findings = newRecord.Authority.CapturedFindingEvidence()
+				// W-11 (Wave 7 S1, design decision 3b): only SEVERE
+				// (BLOCKER/CRITICAL) captured findings are ever candidates for
+				// candidate-causal admission -- a WARNING finding must stay
+				// non-blocking even if its causal_disposition would otherwise
+				// admit it. Filtering here, before AdmitCandidateCausalFindings,
+				// keeps that function itself byte-identical and never touches
+				// the --admission-findings branch above, whose FindingEvidence
+				// carries no Severity at all.
+				findings = reviewtransaction.SevereFindingEvidence(newRecord.Authority.CapturedFindingEvidence())
 			}
 			newTerminalAtEntry := newRecord.Authority.State == reviewtransaction.NewLineageStateApproved || newRecord.Authority.State == reviewtransaction.NewLineageStateEscalated
 			if !newTerminalAtEntry {

--- a/internal/cli/review_facade_finalize_new_lineage.go
+++ b/internal/cli/review_facade_finalize_new_lineage.go
@@ -85,11 +85,19 @@ func runReviewFacadeFinalizeNewLineage(
 	if capturedResults {
 		capturedLensResults = authority.CapturedLensNames()
 	}
-	admitted, _ := reviewtransaction.AdmitCandidateCausalFindings(findings)
+	// W-9 (Wave 7 S1, design decision 3c): an unresolved (unknown or unset)
+	// causal_disposition on a severe finding has no confirmed candidate
+	// cause AND no known non-candidate cause either -- it must terminally
+	// escalate, matching v2's own transaction.go validate logic, rather than
+	// silently approve because it happened not to land in admittedIDs.
+	// unresolvedIDs is never merged into AdmittedFindingIDs itself: that
+	// field's contract is "candidate-caused blocker admitted for
+	// correction", and an unresolved cause is not confirmed candidate-caused.
+	admitted, _, unresolved := reviewtransaction.AdmitCandidateCausalFindings(findings)
 	transition, err := (reviewtransaction.ReviewCore{}).Next(ctx, authority, reviewtransaction.CoreRequest{
 		Kind: reviewtransaction.CoreRequestFinalize,
 		AdvanceRequest: &reviewtransaction.FinalizeAdvanceRequest{
-			Failed: failed, AdmittedFindingIDs: admitted, CapturedLensResults: capturedLensResults,
+			Failed: failed || len(unresolved) > 0, AdmittedFindingIDs: admitted, CapturedLensResults: capturedLensResults,
 		},
 	})
 	if err != nil {

--- a/internal/reviewtransaction/candidate_causal_admission.go
+++ b/internal/reviewtransaction/candidate_causal_admission.go
@@ -17,25 +17,62 @@ package reviewtransaction
 //   - CausalIntroduced, CausalBehaviorActivated, CausalWorsened trace to
 //     paths changed by the frozen candidate — admitted, and only these ever
 //     populate admittedIDs.
-//   - CausalPreExisting, CausalBaseOnly trace to the base tree before the
-//     candidate existed — a follow-up, never a blocker.
+//   - CausalPreExisting, CausalBaseOnly trace to a KNOWN cause outside the
+//     frozen candidate (the base tree, before the candidate existed) — a
+//     follow-up, never a blocker.
 //   - CausalUnknown (and the zero value, an unset disposition) has no
-//     confirmed candidate cause to admit on; it defaults to the same
-//     follow-up routing as pre-existing/base-only rather than silently
-//     admitting an unproven cause.
+//     confirmed candidate cause at all — unlike pre-existing/base-only,
+//     which are a KNOWN non-candidate cause, "unknown" means the cause was
+//     never determined. W-9 (Wave 7 S1, design decision 3c): this is its own
+//     unresolvedIDs bucket, not silently folded into followUpIDs — only v3
+//     finalize (review_facade_finalize_new_lineage.go) consumes it, and
+//     escalates rather than approves, matching v2's own transaction.go
+//     validate logic ("unknown-causality severe finding must terminally
+//     escalate as inconclusive").
 //
-// followUpIDs is returned for caller visibility only — AuthorityStore's
-// NewLineageAuthority schema persists no follow-up field, so a finding's
-// mere absence from admittedIDs IS its "cannot authorize a correction"
-// property: nothing downstream ever reads followUpIDs as authority.
-func AdmitCandidateCausalFindings(findings []FindingEvidence) (admittedIDs []string, followUpIDs []string) {
+// followUpIDs and unresolvedIDs are returned for caller visibility only —
+// AuthorityStore's NewLineageAuthority schema persists no follow-up or
+// unresolved field, so a finding's mere absence from admittedIDs IS its
+// "cannot authorize a correction" property: nothing downstream reads either
+// as authority except v3 finalize's own escalation decision on unresolvedIDs.
+// This third return is purely additive: every existing 2-bucket caller that
+// only read admittedIDs/followUpIDs is otherwise byte-identical, including
+// the shared --admission-findings channel (artifact_admission.go), which
+// this function never gates on severity (decision 3b) or calls at all.
+func AdmitCandidateCausalFindings(findings []FindingEvidence) (admittedIDs []string, followUpIDs []string, unresolvedIDs []string) {
 	for _, finding := range findings {
 		switch finding.Causality {
 		case CausalIntroduced, CausalBehaviorActivated, CausalWorsened:
 			admittedIDs = append(admittedIDs, finding.FindingID)
-		default: // CausalPreExisting, CausalBaseOnly, CausalUnknown, ""
+		case CausalPreExisting, CausalBaseOnly:
 			followUpIDs = append(followUpIDs, finding.FindingID)
+		default: // CausalUnknown, ""
+			unresolvedIDs = append(unresolvedIDs, finding.FindingID)
 		}
 	}
-	return admittedIDs, followUpIDs
+	return admittedIDs, followUpIDs, unresolvedIDs
+}
+
+// SevereFindingEvidence filters findings to only those the shared
+// isSevereSeverity vocabulary (BLOCKER/CRITICAL) treats as severe — W-11's
+// filter (Wave 7 S1, design decision 3b): v3 finalize applies this to the
+// captured-results channel's CapturedFindingEvidence() BEFORE calling
+// AdmitCandidateCausalFindings, so a WARNING-severity candidate-causal
+// finding stays non-blocking (matching v2's artifact_admission.go, which
+// only requires evidence_class/causal_disposition — and therefore only ever
+// considers admitting — severe findings in the first place). This filter is
+// applied by the CALLER, never inside AdmitCandidateCausalFindings itself:
+// that function is also the shared --admission-findings channel's admission
+// decision, whose FindingEvidence carries no Severity at all (zero value,
+// i.e. never severe) — gating inside AdmitCandidateCausalFindings would
+// therefore fail that channel open completely (decision 3b's rejected
+// alternative).
+func SevereFindingEvidence(findings []FindingEvidence) []FindingEvidence {
+	var severe []FindingEvidence
+	for _, finding := range findings {
+		if isSevereSeverity(finding.Severity) {
+			severe = append(severe, finding)
+		}
+	}
+	return severe
 }

--- a/internal/reviewtransaction/candidate_causal_admission_test.go
+++ b/internal/reviewtransaction/candidate_causal_admission_test.go
@@ -22,16 +22,18 @@ func TestAdmitCandidateCausalFindingsBlocksOnlyCandidateCaused(t *testing.T) {
 		{FindingID: "worsened-finding", Causality: CausalWorsened},
 		{FindingID: "pre-existing-finding", Causality: CausalPreExisting},
 		{FindingID: "base-only-finding", Causality: CausalBaseOnly},
-		{FindingID: "unknown-cause-finding", Causality: CausalUnknown},
 	}
-	admitted, followUps := AdmitCandidateCausalFindings(findings)
+	admitted, followUps, unresolved := AdmitCandidateCausalFindings(findings)
 	wantAdmitted := []string{"introduced-finding", "behavior-activated-finding", "worsened-finding"}
-	wantFollowUps := []string{"pre-existing-finding", "base-only-finding", "unknown-cause-finding"}
+	wantFollowUps := []string{"pre-existing-finding", "base-only-finding"}
 	if !equalStrings(admitted, wantAdmitted) {
 		t.Fatalf("admitted = %v, want %v", admitted, wantAdmitted)
 	}
 	if !equalStrings(followUps, wantFollowUps) {
 		t.Fatalf("followUps = %v, want %v", followUps, wantFollowUps)
+	}
+	if len(unresolved) != 0 {
+		t.Fatalf("unresolved = %v, want none (no unknown/unset-disposition finding in this table)", unresolved)
 	}
 	for _, id := range wantFollowUps {
 		if stringIndex(admitted, id) >= 0 {
@@ -44,8 +46,74 @@ func TestAdmitCandidateCausalFindingsBlocksOnlyCandidateCaused(t *testing.T) {
 // no-findings case (the tier-0 minimal finalize path, task C1) never
 // fabricates a blocker.
 func TestAdmitCandidateCausalFindingsEmptyInputAdmitsNothing(t *testing.T) {
-	admitted, followUps := AdmitCandidateCausalFindings(nil)
-	if len(admitted) != 0 || len(followUps) != 0 {
-		t.Fatalf("AdmitCandidateCausalFindings(nil) = (%v, %v), want (nil, nil)", admitted, followUps)
+	admitted, followUps, unresolved := AdmitCandidateCausalFindings(nil)
+	if len(admitted) != 0 || len(followUps) != 0 || len(unresolved) != 0 {
+		t.Fatalf("AdmitCandidateCausalFindings(nil) = (%v, %v, %v), want (nil, nil, nil)", admitted, followUps, unresolved)
+	}
+}
+
+// TestAdmitCandidateCausalFindingsUnknownDispositionIsUnresolvedNotFollowUp
+// is W-9's direct unit proof (Wave 7 S1, design decision 3c): a finding
+// whose causal_disposition is CausalUnknown, or unset entirely (the zero
+// value), traces to no confirmed candidate cause -- unlike pre-existing/
+// base-only, which trace to a KNOWN non-candidate cause -- so it belongs in
+// its own unresolvedIDs bucket, not silently folded into followUpIDs where
+// v3's finalize (review_facade_finalize_new_lineage.go) previously had no
+// way to distinguish "known non-candidate" from "never determined" and so
+// treated both as equally safe to let approve. Only v3 finalize consumes
+// this bucket (to escalate); every existing 2-bucket caller stays additive.
+func TestAdmitCandidateCausalFindingsUnknownDispositionIsUnresolvedNotFollowUp(t *testing.T) {
+	findings := []FindingEvidence{
+		{FindingID: "explicit-unknown", Causality: CausalUnknown},
+		{FindingID: "unset-disposition"},
+	}
+	admitted, followUps, unresolved := AdmitCandidateCausalFindings(findings)
+	if len(admitted) != 0 {
+		t.Fatalf("admitted = %v, want none: an unresolved cause must never authorize a correction", admitted)
+	}
+	if len(followUps) != 0 {
+		t.Fatalf("followUps = %v, want none: unknown/unset disposition is unresolved, not a known non-candidate follow-up", followUps)
+	}
+	wantUnresolved := []string{"explicit-unknown", "unset-disposition"}
+	if !equalStrings(unresolved, wantUnresolved) {
+		t.Fatalf("unresolved = %v, want %v", unresolved, wantUnresolved)
+	}
+}
+
+// TestSevereFindingEvidenceFiltersOutNonSevereFindings is W-11's direct unit
+// proof (design decision 3b): SevereFindingEvidence -- the filter v3
+// finalize applies to the captured-results channel BEFORE
+// AdmitCandidateCausalFindings -- keeps only BLOCKER/CRITICAL findings,
+// dropping WARNING even when it carries a candidate-causal disposition that
+// would otherwise admit it. AdmitCandidateCausalFindings itself stays
+// untouched (byte-identical) -- the filter runs strictly before it, never
+// inside it, so the shared --admission-findings channel (whose
+// FindingEvidence carries no severity at all) is never affected.
+func TestSevereFindingEvidenceFiltersOutNonSevereFindings(t *testing.T) {
+	findings := []FindingEvidence{
+		{FindingID: "blocker-introduced", Severity: "BLOCKER", Causality: CausalIntroduced},
+		{FindingID: "critical-worsened", Severity: "CRITICAL", Causality: CausalWorsened},
+		{FindingID: "warning-introduced", Severity: "WARNING", Causality: CausalIntroduced},
+		{FindingID: "suggestion-introduced", Severity: "SUGGESTION", Causality: CausalIntroduced},
+		{FindingID: "unset-severity-introduced", Causality: CausalIntroduced},
+	}
+	severe := SevereFindingEvidence(findings)
+	wantIDs := []string{"blocker-introduced", "critical-worsened"}
+	var gotIDs []string
+	for _, finding := range severe {
+		gotIDs = append(gotIDs, finding.FindingID)
+	}
+	if !equalStrings(gotIDs, wantIDs) {
+		t.Fatalf("SevereFindingEvidence(findings) ids = %v, want %v", gotIDs, wantIDs)
+	}
+
+	admitted, _, _ := AdmitCandidateCausalFindings(severe)
+	if !equalStrings(admitted, wantIDs) {
+		t.Fatalf("AdmitCandidateCausalFindings(SevereFindingEvidence(findings)) admitted = %v, want %v -- a WARNING candidate-causal finding must never block", admitted, wantIDs)
+	}
+
+	admittedUnfiltered, _, _ := AdmitCandidateCausalFindings(findings)
+	if len(admittedUnfiltered) != len(findings) {
+		t.Fatalf("sanity check failed: AdmitCandidateCausalFindings ignores severity by design (that gate would fail-open the --admission-findings channel, decision 3b); unfiltered admitted = %v", admittedUnfiltered)
 	}
 }

--- a/internal/reviewtransaction/legacy_readonly_guard_test.go
+++ b/internal/reviewtransaction/legacy_readonly_guard_test.go
@@ -9,17 +9,22 @@ package reviewtransaction
 //     its home file -- a sanity fence so a later deletion slice cannot
 //     accidentally sweep the forensic read path away along with the
 //     mutation it sits beside.
-//   - RG.1b (mutation-reachability half, INTENTIONALLY RED until WU19): no
-//     legacy-mutation CLI verb literal is reachable from
+//   - RG.1b (mutation-reachability half, INTENTIONALLY RED until WU19, SKIPPED
+//     WU1-WU18 so the wave's PR chain can ship green CI at every intermediate
+//     head): no legacy-mutation CLI verb literal is reachable from
 //     internal/cli/review_facade.go's own dispatch switches
 //     (runReviewCommand, runReviewCommandContext). At WU1 time every one of
 //     these verbs is still dispatched (rows 6, 10, 14-16, 24 of the
-//     deletion inventory) -- this half fails on purpose, naming exactly
-//     which verbs are still reachable, and shrinks to zero only as WU4-WU19
-//     land, going fully GREEN at WU19 once the last D4 verb is classified
-//     and deleted.
+//     deletion inventory) -- this half's assertion fails on purpose, naming
+//     exactly which verbs are still reachable, and shrinks to zero only as
+//     WU4-WU19 land, going fully GREEN at WU19 once the last D4 verb is
+//     classified and deleted. Rather than let each WU1-WU18 PR head ship a
+//     knowingly-failing test (CI evaluates exact PR heads, not the eventual
+//     merged state), the test body below carries a t.Skip naming this same
+//     reason; the assertion itself is untouched and unskipped again the
+//     moment WU19 lands.
 //
-// `go test ./...` for this package will show ONE failing test
+// `go test ./...` for this package will show ONE skipped test
 // (TestLegacyReadOnlyGuardMutationVerbsUnreachable) from WU1 through WU18 --
 // this is the documented, designed state (tasks.md: "Intentionally RED
 // until WU19"), not a broken build.
@@ -95,6 +100,7 @@ func TestLegacyReadOnlyGuardRetainedSymbolsDeclared(t *testing.T) {
 // dispatch switches. Intentionally RED until WU19 (tasks.md 1.9) -- see the
 // package-level doc comment above.
 func TestLegacyReadOnlyGuardMutationVerbsUnreachable(t *testing.T) {
+	t.Skip("RG.1b intentionally RED WU1-WU18 (tasks.md 1.9): legacyRetiredMutationVerbs' six D4 verbs (invalidate, abandon, recover, reclaim, dispose-result, reopen-results) are retired progressively across WU4-WU19 and stay reachable from review_facade.go's dispatch switches until WU19 classifies and deletes the last one -- skipped rather than failed so every WU1-WU18 PR head ships green CI; unskip lands in the same slice as WU19's own fix.")
 	reachable := map[string]bool{}
 	for _, fn := range legacyDispatchFunctions {
 		verbs, err := dispatchCaseLiterals("../cli/review_facade.go", fn)

--- a/internal/reviewtransaction/legacy_readonly_guard_test.go
+++ b/internal/reviewtransaction/legacy_readonly_guard_test.go
@@ -1,0 +1,178 @@
+package reviewtransaction
+
+// RG.1 (Wave 7 S1, design decision 5 / tasks.md 1.9). D5 defines "one
+// lifecycle" as: delete legacy MUTATION, retain legacy READ. This guard has
+// two halves:
+//
+//   - RG.1a (retained-read half, GREEN from the moment this file lands):
+//     every D5 retained-symbol name still parses as a declared identifier in
+//     its home file -- a sanity fence so a later deletion slice cannot
+//     accidentally sweep the forensic read path away along with the
+//     mutation it sits beside.
+//   - RG.1b (mutation-reachability half, INTENTIONALLY RED until WU19): no
+//     legacy-mutation CLI verb literal is reachable from
+//     internal/cli/review_facade.go's own dispatch switches
+//     (runReviewCommand, runReviewCommandContext). At WU1 time every one of
+//     these verbs is still dispatched (rows 6, 10, 14-16, 24 of the
+//     deletion inventory) -- this half fails on purpose, naming exactly
+//     which verbs are still reachable, and shrinks to zero only as WU4-WU19
+//     land, going fully GREEN at WU19 once the last D4 verb is classified
+//     and deleted.
+//
+// `go test ./...` for this package will show ONE failing test
+// (TestLegacyReadOnlyGuardMutationVerbsUnreachable) from WU1 through WU18 --
+// this is the documented, designed state (tasks.md: "Intentionally RED
+// until WU19"), not a broken build.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// legacyRetainedReadSymbols is D5's closed retained-read list: file path
+// (relative to this package directory) -> identifier names that file must
+// still declare. sddstatus/legacy_binding_read.go, sddstatus/review_binding.go
+// and candidate_decline.go live outside this package's own directory, so
+// their paths are relative to this package's own directory.
+// AuthoritativeStore/LoadChain/NewLegacyReadOnlyError are declared inside
+// THIS package (store.go, compact_store.go) — review_facade.go:1632-1635
+// (design.md) is only their call site, not their declaration.
+var legacyRetainedReadSymbols = map[string][]string{
+	"../sddstatus/legacy_binding_read.go": {"parseLegacyBinding"},
+	"../sddstatus/review_binding.go":      {"parseBinding", "bindingBytes", "bindingDigest", "bindingPath"},
+	"candidate_decline.go":                {"parseCandidateDeclineAuthorization"},
+	"store.go":                            {"AuthoritativeStore", "LoadChain"},
+	"compact_store.go":                    {"NewLegacyReadOnlyError"},
+}
+
+// legacyRetiredMutationVerbs is the exact case-clause literal set the
+// deletion inventory's public-verb rows retire (rows 6, 10, 14-16, 24):
+// reconcile-authority/-batch (S3/S4), the three quarantine/repair verbs
+// (S5), and the six D4 verbs of ambiguous vintage (S8, classified at WU19).
+// invalidate/abandon/recover/reclaim/dispose-result/reopen-results may
+// individually turn out to have a residual legacy-READ role (S8 open
+// question) -- if WU19 retains one under D5, this list (and this test) must
+// be updated in that same slice with the written reason, not silently left
+// red forever.
+var legacyRetiredMutationVerbs = []string{
+	"reconcile-authority", "reconcile-authority-batch",
+	"quarantine-legacy", "quarantine-legacy-fix-scope", "repair-legacy-alias",
+	"invalidate", "abandon", "recover", "reclaim", "dispose-result", "reopen-results",
+}
+
+// legacyDispatchFunctions is the closed set of functions in
+// internal/cli/review_facade.go whose case-clause literals this guard scans
+// -- runReviewCommand (default review command dispatch) and
+// runReviewCommandContext (the context-aware dispatch, which falls through
+// to runReviewCommand by default but has its own reconcile-authority-batch
+// case).
+var legacyDispatchFunctions = []string{"runReviewCommand", "runReviewCommandContext"}
+
+// TestLegacyReadOnlyGuardRetainedSymbolsDeclared is RG.1a: proves every D5
+// retained-read symbol is still a declared identifier in its home file.
+func TestLegacyReadOnlyGuardRetainedSymbolsDeclared(t *testing.T) {
+	for file, symbols := range legacyRetainedReadSymbols {
+		t.Run(file, func(t *testing.T) {
+			declared, err := declaredIdentifiers(file)
+			if err != nil {
+				t.Fatalf("parse %s: %v", file, err)
+			}
+			for _, symbol := range symbols {
+				if !declared[symbol] {
+					t.Fatalf("%s no longer declares retained read symbol %q (D5 requires it to survive every legacy-mutation deletion slice)", file, symbol)
+				}
+			}
+		})
+	}
+}
+
+// TestLegacyReadOnlyGuardMutationVerbsUnreachable is RG.1b: proves no
+// legacy-mutation verb literal remains a case clause in review_facade.go's
+// dispatch switches. Intentionally RED until WU19 (tasks.md 1.9) -- see the
+// package-level doc comment above.
+func TestLegacyReadOnlyGuardMutationVerbsUnreachable(t *testing.T) {
+	reachable := map[string]bool{}
+	for _, fn := range legacyDispatchFunctions {
+		verbs, err := dispatchCaseLiterals("../cli/review_facade.go", fn)
+		if err != nil {
+			t.Fatalf("scan dispatch function %s: %v", fn, err)
+		}
+		for _, verb := range verbs {
+			reachable[verb] = true
+		}
+	}
+	var stillReachable []string
+	for _, verb := range legacyRetiredMutationVerbs {
+		if reachable[verb] {
+			stillReachable = append(stillReachable, verb)
+		}
+	}
+	if len(stillReachable) > 0 {
+		t.Fatalf("legacy-mutation verbs still reachable from review_facade.go dispatch: %v (expected until WU19; this guard goes GREEN once the last one is classified and deleted)", stillReachable)
+	}
+}
+
+// declaredIdentifiers returns every top-level func/type/const/var name
+// declared in path, plus every field/method name on those declarations that
+// carries an *ast.Ident (a coarse but sufficient net for RG.1a's "still
+// declared" check).
+func declaredIdentifiers(path string) (map[string]bool, error) {
+	fileSet := token.NewFileSet()
+	tree, err := parser.ParseFile(fileSet, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	names := map[string]bool{}
+	ast.Inspect(tree, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.FuncDecl:
+			names[n.Name.Name] = true
+		case *ast.TypeSpec:
+			names[n.Name.Name] = true
+		case *ast.ValueSpec:
+			for _, name := range n.Names {
+				names[name.Name] = true
+			}
+		}
+		return true
+	})
+	return names, nil
+}
+
+// dispatchCaseLiterals returns every string literal case-clause value in
+// funcName's top-level switch statement(s) within path.
+func dispatchCaseLiterals(path, funcName string) ([]string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+	fileSet := token.NewFileSet()
+	tree, err := parser.ParseFile(fileSet, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	var literals []string
+	ast.Inspect(tree, func(node ast.Node) bool {
+		fn, ok := node.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != funcName || fn.Body == nil {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			clause, ok := inner.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List {
+				if literal, ok := expr.(*ast.BasicLit); ok && literal.Kind == token.STRING {
+					literals = append(literals, strings.Trim(literal.Value, `"`))
+				}
+			}
+			return true
+		})
+		return false
+	})
+	return literals, nil
+}

--- a/internal/reviewtransaction/new_lineage_capture.go
+++ b/internal/reviewtransaction/new_lineage_capture.go
@@ -82,6 +82,14 @@ var (
 	// captured result under a DIFFERENT subject hash -- one-shot per lens, no
 	// reopen machinery (C-A's explicit scope boundary).
 	ErrNewLineageCaptureConflict = errors.New("lens already captured with a different binding; capture is one-shot per lens") // refusal:by-design world-action: v3 has no reviewer-artifact reopen concept (that is v2-only, Wave 7 deletion scope); the fix is a fresh review start for a corrected candidate, not an operator command that reopens this capture
+	// ErrNewLineageCaptureIncompleteSeverity is refused when a severe
+	// (BLOCKER/CRITICAL) finding is captured without a supported
+	// evidence_class and causal_disposition -- W-10 (Wave 7 S1, design
+	// decision 3a). The message is verbatim identical to
+	// artifact_admission.go's own --admission-findings-channel refusal for
+	// the same shape, so v3 fails the same way v2 already does for the same
+	// operator mistake.
+	ErrNewLineageCaptureIncompleteSeverity = errors.New("severe reviewer finding requires supported evidence_class and causal_disposition") // refusal:by-design operator-knowledge: the reviewer must submit a supported evidence_class and causal_disposition for every BLOCKER/CRITICAL finding; there is no operator command that fabricates that classification on the reviewer's behalf
 )
 
 // CaptureLensResult persists one captured reviewer result onto a v3
@@ -109,6 +117,19 @@ func (store AuthorityStore) CaptureLensResult(ctx context.Context, expectedRevis
 			return fmt.Errorf("%w: lineage %q lens %q", ErrNewLineageCaptureSubjectMismatch, next.LineageID, lens)
 		}
 		normalizedFindings := append([]FindingEvidence(nil), findings...)
+		// W-10 (Wave 7 S1, design decision 3a): refuse a severe finding at
+		// capture time if it lacks a supported evidence_class or
+		// causal_disposition -- previously this was silently accepted
+		// because Severity itself was dropped before reaching this store
+		// (review_artifact.go's newLineageCapturedFindings), so nothing
+		// downstream could even detect the gap. Reuses the identical
+		// in-package vocabulary artifact_admission.go's --admission-findings
+		// channel already enforces for the same shape.
+		for _, finding := range normalizedFindings {
+			if isSevereSeverity(finding.Severity) && (!isSupportedEvidenceClass(finding.Class) || !isSupportedCausalDisposition(finding.Causality)) {
+				return fmt.Errorf("%w: lineage %q lens %q finding %q", ErrNewLineageCaptureIncompleteSeverity, next.LineageID, lens, finding.FindingID)
+			}
+		}
 		for _, existing := range next.CapturedResults {
 			if existing.Lens != lens {
 				continue

--- a/internal/reviewtransaction/new_lineage_capture_test.go
+++ b/internal/reviewtransaction/new_lineage_capture_test.go
@@ -7,6 +7,7 @@ package reviewtransaction
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -174,7 +175,7 @@ func TestCaptureLensResult_PersistsFindingsForAdmission(t *testing.T) {
 		updated.Authority.CapturedResults[0].Findings[0].FindingID != "R3-boom-div-zero" {
 		t.Fatalf("captured findings = %#v, want the submitted finding persisted verbatim", updated.Authority.CapturedResults)
 	}
-	admitted, followUp := AdmitCandidateCausalFindings(updated.Authority.CapturedFindingEvidence())
+	admitted, followUp, _ := AdmitCandidateCausalFindings(updated.Authority.CapturedFindingEvidence())
 	if len(admitted) != 1 || admitted[0] != "R3-boom-div-zero" || len(followUp) != 0 {
 		t.Fatalf("AdmitCandidateCausalFindings(CapturedFindingEvidence()) = admitted=%v followUp=%v, want admitted=[R3-boom-div-zero] followUp=[]", admitted, followUp)
 	}
@@ -197,4 +198,94 @@ func TestCaptureLensResult_DifferentFindingsForSameLensIsConflictNotReopen(t *te
 	if _, err := store.CaptureLensResult(context.Background(), first.Revision, "review-reliability", 0, subject, differentFindings); err == nil {
 		t.Fatal("recaptured the same lens/subject-hash with different findings; capture must be one-shot for the whole result, not just the subject hash")
 	}
+}
+
+// TestFindingEvidenceSeverityFieldRoundTrips is W-10's structural
+// precondition (Wave 7 S1, design decision 3a): FindingEvidence today drops
+// severity entirely (newLineageCapturedFindings, review_artifact.go:940-942
+// pre-fix), which is the reason a severe finding with no evidence_class/
+// causal_disposition can be captured with nothing to refuse it on. This
+// proves the field exists, round-trips through JSON, and is omitted (never
+// "severity":"") when unset -- matching every other omitempty field on this
+// struct.
+func TestFindingEvidenceSeverityFieldRoundTrips(t *testing.T) {
+	severe := FindingEvidence{FindingID: "R3-boom", Severity: "BLOCKER", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "lib/boom.go:1"}
+	payload, err := json.Marshal(severe)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(payload), `"severity":"BLOCKER"`) {
+		t.Fatalf("marshaled FindingEvidence = %s, want a \"severity\":\"BLOCKER\" field", payload)
+	}
+	var decoded FindingEvidence
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Severity != "BLOCKER" {
+		t.Fatalf("decoded Severity = %q, want %q", decoded.Severity, "BLOCKER")
+	}
+
+	unset := FindingEvidence{FindingID: "R3-quiet", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "lib/quiet.go:1"}
+	unsetPayload, err := json.Marshal(unset)
+	if err != nil {
+		t.Fatalf("marshal unset: %v", err)
+	}
+	if strings.Contains(string(unsetPayload), "severity") {
+		t.Fatalf("marshaled unset-severity FindingEvidence = %s, want no \"severity\" key (omitempty)", unsetPayload)
+	}
+}
+
+// TestCaptureLensResult_RefusesSevereFindingMissingEvidenceOrCausality is
+// W-10's behavioral proof (design decision 3a): a BLOCKER/CRITICAL finding
+// captured without a supported evidence_class or causal_disposition must be
+// refused at capture time -- mirroring artifact_admission.go's identical
+// --admission-findings-channel refusal ("severe reviewer finding requires
+// supported evidence_class and causal_disposition") verbatim, so v3 fails
+// the same way v2 already does for the same operator mistake. A WARNING
+// finding with the identical gaps is NOT refused -- only BLOCKER/CRITICAL
+// (isSevereSeverity) triggers the requirement.
+func TestCaptureLensResult_RefusesSevereFindingMissingEvidenceOrCausality(t *testing.T) {
+	t.Run("severe finding missing evidence_class and causal_disposition is refused", func(t *testing.T) {
+		store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+		subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+		findings := []FindingEvidence{{FindingID: "R3-incomplete", Severity: "BLOCKER", Proof: "lib/boom.go:1"}}
+
+		_, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, findings)
+		if err == nil {
+			t.Fatal("captured a BLOCKER finding with no evidence_class/causal_disposition, want refused")
+		}
+		if !strings.Contains(err.Error(), "severe reviewer finding requires supported evidence_class and causal_disposition") {
+			t.Fatalf("error = %q, want the v2-verbatim severe-finding refusal message", err.Error())
+		}
+	})
+
+	t.Run("severe finding with only evidence_class missing causal_disposition is refused", func(t *testing.T) {
+		store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+		subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+		findings := []FindingEvidence{{FindingID: "R3-half", Severity: "CRITICAL", Class: EvidenceDeterministic, Proof: "lib/boom.go:1"}}
+
+		if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, findings); err == nil {
+			t.Fatal("captured a CRITICAL finding with no causal_disposition, want refused")
+		}
+	})
+
+	t.Run("WARNING finding with the identical gaps is not refused", func(t *testing.T) {
+		store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+		subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+		findings := []FindingEvidence{{FindingID: "R3-warning", Severity: "WARNING", Proof: "lib/boom.go:1"}}
+
+		if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, findings); err != nil {
+			t.Fatalf("WARNING finding with no evidence_class/causal_disposition was refused: %v, want accepted (only severe findings require these)", err)
+		}
+	})
+
+	t.Run("severe finding with supported evidence_class and causal_disposition is accepted", func(t *testing.T) {
+		store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+		subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+		findings := []FindingEvidence{{FindingID: "R3-complete", Severity: "BLOCKER", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "lib/boom.go:1"}}
+
+		if _, err := store.CaptureLensResult(context.Background(), record.Revision, "review-reliability", 0, subject, findings); err != nil {
+			t.Fatalf("complete severe finding was refused: %v, want accepted", err)
+		}
+	})
 }

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -145,6 +145,7 @@ type FollowUp struct {
 
 type FindingEvidence struct {
 	FindingID string            `json:"finding_id"`
+	Severity  string            `json:"severity,omitempty"`
 	Class     EvidenceClass     `json:"class"`
 	Causality CausalDisposition `json:"causal_disposition,omitempty"`
 	Proof     string            `json:"proof"`


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2423

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

WU1: severity carried through the finding projection (the shared root of two warnings), capture-time refusal mirroring v2 for schema-forbidden shapes, unknown causal disposition escalating via an additive return consumed only by v3 finalize, and the retention guard written RED to go green when the last legacy mutation dies.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench + e2e) green at chain tip e303d9a9
- [x] Bench corpus and damaged-store axis vs fresh binaries, zero status or structural deltas against the true base
- [x] 3 verify cycles; final envelope pass, 14/14 requirements, 8/8 scenarios, 0 criticals