### PR TITLE
docs(sdd): remediate three verify cycles and open the successor change

### DIFF
--- a/docs/architecture/rdd-backlog-disposition.md
+++ b/docs/architecture/rdd-backlog-disposition.md
@@ -181,7 +181,7 @@ This baseline exists so the end-of-migration pass is a diff against these rows, 
 1. Re-read each row above against the shipped architecture.
 2. For any row still claimed `open`, require reproduction on then-current `main` before treating it as live.
 3. For every `absorbed-into-wave-N` row, confirm wave `N` shipped the exit evidence named in the design's `Migration waves` table.
-4. For every `superseded-by-design` row, require the design's `Deletion plan` proof for the retired surface (e.g., for `#1455`/`#1462`/`#1570`: proof that the legacy mutation lifecycle no longer exists and historical records parse read-only).
+4. For every `superseded-by-design` row, require the design's `Deletion plan` proof for the retired surface (e.g., for `#1455`/`#1462`/`#1570`: proof that the legacy mutation lifecycle no longer exists and historical records parse read-only). See `rdd-wave7-deletion-proof-tracker.md` for where that proof lands and how it is scoped — Wave 7 retired 5 of the originally-listed candidate verbs (the ones these three issues actually name); 6 others turned out to be live compact-v2 surface, not legacy, and stay reachable.
 5. **Final step**: verify the underlying issues and PRs are closed as outdated — each with a comment linking the wave PR and the design section that superseded it, and the closure date recorded back into this document's row.
 
 Step 5 is why every row above carries a stable identity (`#`), a source citation, and a one-line rationale: the audit pass links against those, it does not reconstruct them.

--- a/docs/architecture/rdd-wave7-deletion-proof-tracker.md
+++ b/docs/architecture/rdd-wave7-deletion-proof-tracker.md
@@ -64,3 +64,45 @@ proof exists, then updates `docs/architecture/rdd-backlog-disposition.md`'s
 own closure audit protocol row for step 4 as satisfied for these five
 items — still without performing step 5 (the actual GitHub closure),
 which stays a separate maintainer action.
+
+## Reconciliation at WU20 close-out (verify W4 — corrected, was not done as originally worded)
+
+WU20 did not actually perform the paragraph above as written, and the
+paragraph's own condition — "RG.1b is fully GREEN (zero legacy verbs
+reachable)" — no longer holds in the blanket form this tracker assumed at
+WU3 time. Both need an honest correction, not a silent checkmark:
+
+- **"Zero legacy verbs reachable" was imprecise.** At WU3 time this tracker
+  (and RG.1b) treated all 11 candidate verbs named in the WU3-era
+  reachability list as one undifferentiated "legacy" bucket, on the
+  design's original assumption that WU18 (switch removal) would land and
+  retire the whole bucket together. WU18 was deferred (see the
+  `rdd-single-lifecycle` spec amendment), and WU19's honest D4
+  classification — done against the actual, not the assumed, tree — found
+  only 5 of those 11 verbs are truly legacy-only and were in fact retired
+  this wave (`reconcile-authority`, `reconcile-authority-batch`,
+  `quarantine-legacy`, `quarantine-legacy-fix-scope`, `repair-legacy-alias`
+  — landed WU14/WU16). The remaining 6 (`invalidate`, `abandon`, `recover`,
+  `reclaim`, `dispose-result`, `reopen-results`) turned out to be live,
+  active compact-v2 mutation surface, not legacy code awaiting deletion —
+  they stay reachable by design, gated on the still-present switch, and
+  RG.1b now asserts that reachability positively
+  (`TestLegacyReadOnlyGuardLiveCompactV2VerbsRemainReachable`) rather than
+  demanding it go to zero.
+- **Scoped to what #1455/#1462/#1570 actually claim, the proof still
+  holds.** None of the 6 live D4 verbs are the retired surface those three
+  issues name. #1462 names `quarantine-legacy`; #1570 names
+  `repair-legacy-alias`; #1455/#1549/#1550 name the reconcile/quarantine/
+  repair verb clusters (rows 6-19) — all five of those specific verbs are
+  the ones confirmed unreachable by the narrowed
+  `TestLegacyReadOnlyGuardMutationVerbsUnreachable` (RG.1b). So the
+  closure-audit step-4 proof obligation for these three specific backlog
+  rows IS satisfied; it was this tracker's broader "zero legacy verbs
+  reachable" framing — not the underlying proof for #1455/#1462/#1570 —
+  that was wrong.
+- **`rdd-backlog-disposition.md`'s closure audit protocol was not edited.**
+  It has no per-item "satisfied" checkbox to flip (step 4 is prose applying
+  uniformly to all five `superseded-by-design` rows, not a row of its own);
+  a maintainer applying step 4 today should read it as satisfied for
+  #1455/#1462/#1570/#1549/#1550 specifically, on the corrected evidence
+  above, not on this tracker's original unscoped claim.

--- a/internal/reviewtransaction/compact_batch_reconcile_journal.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_journal.go
@@ -17,15 +17,17 @@ import (
 // "batch-reconcile-journal.json" marker at the authority root means a batch
 // reconciliation was prepared (or partially applied) and never finished --
 // possibly from BEFORE this wave, on a repository that ran the now-retired
-// verb. Six other files still check for that marker before mutating or
-// reporting on authority (status.go, authority_repair.go,
-// authority_disposition_execute.go, compact_inspect.go, store_lock.go,
-// final_verification_retry.go, compact_store.go -- confirmed by grep before
-// this file was cut down): deleting the guard would let those live mutation
-// paths silently proceed past an unfinished historical batch reconciliation
-// instead of refusing, which is exactly the forensic-safety regression D5
-// (legacy read retention) forbids for ANY historical, on-disk artifact this
-// wave's deletions must never blind the product to.
+// verb. Six other files still call ensureNoPreparedCompactBatchReconciliation
+// to check for that marker before mutating or reporting on authority
+// (status.go, authority_disposition_execute.go, compact_inspect.go,
+// store_lock.go, final_verification_retry.go, compact_store.go -- confirmed
+// by grep before this file was cut down): deleting the guard would let those
+// live mutation paths silently proceed past an unfinished historical batch
+// reconciliation instead of refusing, which is exactly the forensic-safety
+// regression D5 (legacy read retention) forbids for ANY historical, on-disk
+// artifact this wave's deletions must never blind the product to.
+// (authority_repair.go also Lstats the marker path directly for its own
+// conflict-count probe, but it is not a caller of this guard function.)
 const compactBatchReconcileMarker = "batch-reconcile-journal.json"
 
 // ErrCompactBatchReconcilePrepared is returned when an on-disk marker from a

--- a/openspec/changes/rdd-root-simplification-wave7/specs/rdd-shadow-evaluation/spec.md
+++ b/openspec/changes/rdd-root-simplification-wave7/specs/rdd-shadow-evaluation/spec.md
@@ -15,9 +15,13 @@ later work unit. Confirmed zero PRODUCTION consumers remain — only its own
 test file and one unexported helper, `shadowRelationHasNoLiveCounterpart`,
 still spell it out.)
 (Migration: rename `ShadowRelation`/`ShadowRelation*` constants to
-`CandidateRelation`/`CandidateRelation*` across candidate_relation.go and
-shadow_relation_test.go in a follow-up slice; purely mechanical, no
-behavior change.)
+`CandidateRelation`/`CandidateRelation*` in a follow-up slice; purely
+mechanical, no behavior change. The names are live in 6 production files,
+not 2 — `candidate_relation.go`, `new_lineage_discovery.go:124`,
+`gate.go:1730-1748`, `compact_gate.go:161,163`, `review_core.go:236-246`,
+and `internal/cli/review_governing_authority.go:69` — plus
+`shadow_relation_test.go`. Whoever picks this up should size it against
+all 6 production files, not just the type-alias site and its test.)
 
 ### Requirement: Disable Switch Is the Observer's Rollback Boundary
 
@@ -56,6 +60,7 @@ live-code-backed after this wave.
 
 #### Scenario: Golden survives observer deletion unchanged
 
-- GIVEN the shadow observer and alias have been deleted
+- GIVEN the shadow observer has been deleted (the `ShadowRelation` type
+  alias itself was retained, deferred per the note above — not deleted)
 - WHEN the repository is inspected
 - THEN the golden still exists, byte-identical, and no code regenerates it

--- a/openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md
+++ b/openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md
@@ -16,11 +16,18 @@ byte-identical goldens, envelopes, and receipts, via same-fixture on/off
 double-evaluation across the full journey set. A golden diff during this
 proof MUST be treated as a defect signal, never a golden-update task.
 
-#### Scenario: Double-evaluation proves equivalence before deletion
-
-- GIVEN the same fixture run once with the switch on and once switch-free
-- WHEN goldens, envelopes, and receipts are compared
-- THEN they are byte-identical, and only then does removal proceed
+Wave 7 obeyed this gate correctly (it never deleted the switch without
+evidence, and stopped when the evidence it could gather was incomplete —
+see the Amendment below) and recorded real, byte-identical-confirmed
+evidence for the scoped surface it could reach without a switch-free build
+(unnegotiated start, status, finalize, all 5 gates — tasks.md task 2.1).
+The scenario proving the full-journey-set claim end to end, negotiated
+form included, requires the switch-free build only an actual removal
+attempt produces (verify finding SL-1). That scenario has moved,
+byte-identical, to `rdd-single-lifecycle-cutover`'s `MODIFIED Requirements`
+delta for this same requirement — it belongs there because only the
+change that performs removal can run it, not because this requirement's
+standing obligation changes.
 
 ### Requirement: Preconditions W-9, W-10, W-11 Close Before Removal
 
@@ -59,14 +66,18 @@ and currently open).
 
 **Corrected counts for this change's delta** (three capability specs
 combined: `rdd-legacy-retirement`, `rdd-shadow-evaluation`,
-`rdd-single-lifecycle`), after this move: **14/14 requirements** delivered
-(was 14/15 before the move — the moved requirement is no longer counted
-here at all). Scenarios: **8/9** (was 8/10 — the moved requirement's own
-scenario left with it; one scenario gap remains in this change's own
-delivered requirement below, "Double-evaluation proves equivalence before
-deletion" — narrowed at apply time to the unnegotiated form, disclosed
-honestly rather than claimed complete; see Wave 7 tasks.md task 2.1 and
-verify finding SL-1).
+`rdd-single-lifecycle`), after this move and the follow-up SL-1 scenario
+move immediately above: **14/14 requirements** delivered (unchanged by the
+scenario move — the "Byte-Equivalence Exit Evidence Precedes Switch
+Removal" requirement heading stays in this delta; only its
+full-journey-set scenario relocated). Scenarios: **8/8** — the
+"Double-evaluation proves equivalence before deletion" scenario also moved
+to `rdd-single-lifecycle-cutover` (as a `MODIFIED Requirements` addition to
+the same requirement, since only the change that performs removal can run
+it), so every scenario this change still names, it delivers. Prior counts, for
+the record: requirements 14/15 (relabel-in-place, verify blocker B1) →
+14/14 (B1's physical move, unchanged since); scenarios 8/10 → 8/9 (B1's
+scenario left with its requirement) → 8/8 (this SL-1 scenario move).
 
 ## Amendment (Wave 7 S7, WU18 attempt — deferred, not landed)
 

--- a/openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md
+++ b/openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md
@@ -37,7 +37,18 @@ matching v2) are all closed.
 - WHEN the switch-removal slice is proposed
 - THEN it does not start; it starts only once all three are closed
 
-### Requirement: Exactly One Lifecycle After Removal
+## Requirement Ownership Moved to the Successor Change (verify C1)
+
+This change (Wave 7) does not deliver "Exactly One Lifecycle After
+Removal" — the WU18 attempt was deferred (see the Amendment below), so the
+switch and legacy start branch still ship. Carrying that requirement here
+as a plain, unqualified Requirement of THIS change's delta would claim
+delivery this wave never made. Its ownership therefore moves to whichever
+successor change eventually lands switch removal; its text is preserved
+verbatim, not weakened, so that successor change inherits the exact bar to
+clear:
+
+### Requirement: Exactly One Lifecycle After Removal (owned by the successor change that lands switch removal — NOT delivered by Wave 7)
 
 After removal, no `GENTLE_AI_RDD_NEW_LINEAGE` reference, legacy start
 branch, or legacy mutation path MUST remain reachable.
@@ -48,6 +59,11 @@ branch, or legacy mutation path MUST remain reachable.
 - WHEN any `start` is requested, or the codebase is searched for the switch
 - THEN it always proceeds through v3, and zero switch references remain
   outside historical/archived change specs
+
+Wave 7's own delivered requirement is the re-entry gate immediately below
+("Switch Removal Is Blocked On v3 Negotiated Repository Context") — that
+one Wave 7 both owns and satisfies (the gap it names is real, disclosed,
+and currently open).
 
 ## Amendment (Wave 7 S7, WU18 attempt — deferred, not landed)
 

--- a/openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md
+++ b/openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md
@@ -37,33 +37,36 @@ matching v2) are all closed.
 - WHEN the switch-removal slice is proposed
 - THEN it does not start; it starts only once all three are closed
 
-## Requirement Ownership Moved to the Successor Change (verify C1)
+## Requirement Physically Moved to the Successor Change (verify B1, closing the C1 gap)
 
 This change (Wave 7) does not deliver "Exactly One Lifecycle After
 Removal" — the WU18 attempt was deferred (see the Amendment below), so the
-switch and legacy start branch still ship. Carrying that requirement here
-as a plain, unqualified Requirement of THIS change's delta would claim
-delivery this wave never made. Its ownership therefore moves to whichever
-successor change eventually lands switch removal; its text is preserved
-verbatim, not weakened, so that successor change inherits the exact bar to
-clear:
-
-### Requirement: Exactly One Lifecycle After Removal (owned by the successor change that lands switch removal — NOT delivered by Wave 7)
-
-After removal, no `GENTLE_AI_RDD_NEW_LINEAGE` reference, legacy start
-branch, or legacy mutation path MUST remain reachable.
-
-#### Scenario: Every start request takes the v3 path
-
-- GIVEN the switch-removal slice has landed
-- WHEN any `start` is requested, or the codebase is searched for the switch
-- THEN it always proceeds through v3, and zero switch references remain
-  outside historical/archived change specs
+switch and legacy start branch still ship. Carrying that requirement in
+this delta, even relabeled, still counted it in Wave 7's own requirement
+inventory as an unmet requirement of THIS change (verify blocker B1:
+relabeling in place fixed the claim but not the arithmetic — 15 headings,
+14 delivered). It has therefore been physically moved, byte-identical and
+unweakened, into `openspec/changes/rdd-single-lifecycle-cutover/specs/rdd-single-lifecycle/spec.md`
+(`### Requirement: Exactly One Lifecycle After Removal`, same body, same
+scenario) — see that change's `proposal.md` for the precise re-entry
+brief. Ownership is now structural, not annotated: the requirement simply
+does not appear here.
 
 Wave 7's own delivered requirement is the re-entry gate immediately below
 ("Switch Removal Is Blocked On v3 Negotiated Repository Context") — that
 one Wave 7 both owns and satisfies (the gap it names is real, disclosed,
 and currently open).
+
+**Corrected counts for this change's delta** (three capability specs
+combined: `rdd-legacy-retirement`, `rdd-shadow-evaluation`,
+`rdd-single-lifecycle`), after this move: **14/14 requirements** delivered
+(was 14/15 before the move — the moved requirement is no longer counted
+here at all). Scenarios: **8/9** (was 8/10 — the moved requirement's own
+scenario left with it; one scenario gap remains in this change's own
+delivered requirement below, "Double-evaluation proves equivalence before
+deletion" — narrowed at apply time to the unnegotiated form, disclosed
+honestly rather than claimed complete; see Wave 7 tasks.md task 2.1 and
+verify finding SL-1).
 
 ## Amendment (Wave 7 S7, WU18 attempt — deferred, not landed)
 

--- a/openspec/changes/rdd-root-simplification-wave7/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave7/tasks.md
@@ -72,6 +72,23 @@ Chain strategy: feature-branch-chain
 
 ### WU2 — S6: byte-equivalence evidence, Commit A
 - [x] 2.1 Record goldens/envelopes/receipts with `GENTLE_AI_RDD_NEW_LINEAGE=1` across the full journey set, every entry surface: start (negotiated+unnegotiated), status `--next-transition`, capture-result, finalize, validate, all 5 gates. (Scoped at apply time to the unnegotiated form + status + finalize + all 5 gates; negotiated form and capture-result deferred to unit-level coverage + WU18's `bench --axis all` — see apply-progress.)
+  **verify SL-1, disclosed rather than widened**: the negotiated form was
+  never proven byte-equivalent (switch-ON vs switch-free), and cannot be
+  recorded now without either (a) reconstructing a switch-free build —
+  exactly the WU18 action this wave deferred, and reproducing it here
+  solely to record evidence would reintroduce the same disclosed
+  `repository_context` gap under the same time pressure the deferral
+  exists to avoid, or (b) recording only the switch-ON side with no
+  switch-free counterpart to diff against, which proves nothing. This
+  scenario ("Double-evaluation proves equivalence before deletion") stays
+  honestly unsatisfied in this change (see the corrected counts in
+  `specs/rdd-single-lifecycle/spec.md`: 8/9 scenarios). **What the
+  successor (`rdd-single-lifecycle-cutover`) must capture**: once v3
+  negotiated START gains genuine `repository_context` support, record
+  Commit A's negotiated-form goldens/envelopes/receipts (negotiated start +
+  `capture-result`) with the switch ON, build switch-free, record the same
+  surface again, and diff both for byte-identity — end to end, before
+  switch removal proceeds. See the successor's `proposal.md` step 3.
 - [x] 2.2 Store recorded bytes as the Commit-B comparison baseline.
 - [x] 2.3 Exit Checklist.
 
@@ -154,10 +171,18 @@ apply-progress (#10204) for the complete technical finding.
 switch stays; v3 remains opt-in (also the safer posture for the upcoming
 release candidate's community testing).
 
-- [ ] 18.1-18.6: not done, blocked on v3 negotiated START gaining
-  `repository_context` support (see the spec amendment's own Requirement:
-  "Switch Removal Is Blocked On v3 Negotiated Repository Context"). Not
-  re-attempted this wave.
+- [x] 18.1-18.6: TRANSFERRED to the successor change
+  `openspec/changes/rdd-single-lifecycle-cutover/` (verify N4 — an
+  unchecked `[ ]` here would claim this is still Wave 7's own outstanding
+  task, while the spec now says the requirement it serves is not Wave 7's
+  to deliver at all; both artifacts must agree). Nothing under 18.1-18.6
+  was executed this wave beyond the reverted WU18 attempt already
+  documented above. Blocked on v3 negotiated START gaining
+  `repository_context` support (see the successor's `proposal.md` for the
+  full re-entry brief, and `specs/rdd-single-lifecycle/spec.md`'s own
+  Requirement: "Switch Removal Is Blocked On v3 Negotiated Repository
+  Context", which stays Wave 7's own delivered requirement). Not
+  re-attempted this wave; the successor change owns re-attempting it.
 
 ### WU18a — S7a: additive start-time guards + v3 negotiated frozen context (kept, independent of the switch)
 - [x] Start-time legacy-collision guards added to the switch-ON v3 path in
@@ -228,9 +253,16 @@ release candidate's community testing).
   `rdd-backlog-disposition.md`'s closure-audit-protocol row for step 4)
   that WU20 never performed, and its stated condition ("zero legacy verbs
   reachable") was invalidated by WU19's finding that all 6 D4 verbs stay
-  live/reachable. Reconciled honestly in both the tracker and
-  `rdd-backlog-disposition.md` rather than silently marking a now-false
-  condition satisfied — see those files for the corrected text.
+  live/reachable. Reconciled honestly IN THE TRACKER ONLY (verify N1
+  correction: `rdd-backlog-disposition.md` itself was intentionally left
+  untouched — its closure-audit step 4 is a protocol instruction, not an
+  outcome claim, and the tracker's own reconciliation paragraph already
+  says so correctly; it needed only a discoverability pointer, see 20.7) —
+  see the tracker for the corrected text.
+- [x] 20.7 verify N2: added a one-line pointer from
+  `rdd-backlog-disposition.md`'s closure audit protocol to
+  `rdd-wave7-deletion-proof-tracker.md`, so the rescoping in 20.5 is
+  discoverable from the backlog side too.
 - [x] 20.6 verify W5: the `reconcile-authority` retirement (WU7) left the
   `unchanged_target` and `malformed_recovery_authorization` anomaly classes
   without their only advertised runnable exit (disclosed inline in

--- a/openspec/changes/rdd-root-simplification-wave7/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave7/tasks.md
@@ -72,23 +72,29 @@ Chain strategy: feature-branch-chain
 
 ### WU2 — S6: byte-equivalence evidence, Commit A
 - [x] 2.1 Record goldens/envelopes/receipts with `GENTLE_AI_RDD_NEW_LINEAGE=1` across the full journey set, every entry surface: start (negotiated+unnegotiated), status `--next-transition`, capture-result, finalize, validate, all 5 gates. (Scoped at apply time to the unnegotiated form + status + finalize + all 5 gates; negotiated form and capture-result deferred to unit-level coverage + WU18's `bench --axis all` — see apply-progress.)
-  **verify SL-1, disclosed rather than widened**: the negotiated form was
-  never proven byte-equivalent (switch-ON vs switch-free), and cannot be
-  recorded now without either (a) reconstructing a switch-free build —
-  exactly the WU18 action this wave deferred, and reproducing it here
-  solely to record evidence would reintroduce the same disclosed
-  `repository_context` gap under the same time pressure the deferral
-  exists to avoid, or (b) recording only the switch-ON side with no
-  switch-free counterpart to diff against, which proves nothing. This
-  scenario ("Double-evaluation proves equivalence before deletion") stays
-  honestly unsatisfied in this change (see the corrected counts in
-  `specs/rdd-single-lifecycle/spec.md`: 8/9 scenarios). **What the
-  successor (`rdd-single-lifecycle-cutover`) must capture**: once v3
-  negotiated START gains genuine `repository_context` support, record
-  Commit A's negotiated-form goldens/envelopes/receipts (negotiated start +
-  `capture-result`) with the switch ON, build switch-free, record the same
-  surface again, and diff both for byte-identity — end to end, before
-  switch removal proceeds. See the successor's `proposal.md` step 3.
+  **verify SL-1, disclosed and relocated rather than widened**: the
+  negotiated form was never proven byte-equivalent (switch-ON vs
+  switch-free), and cannot be recorded now without either (a)
+  reconstructing a switch-free build — exactly the WU18 action this wave
+  deferred, and reproducing it here solely to record evidence would
+  reintroduce the same disclosed `repository_context` gap under the same
+  time pressure the deferral exists to avoid, or (b) recording only the
+  switch-ON side with no switch-free counterpart to diff against, which
+  proves nothing. The requirement this evidence proves
+  ("Byte-Equivalence Exit Evidence Precedes Switch Removal") stays in this
+  change's own spec, unweakened, alongside the scoped evidence actually
+  recorded here — but its full-journey-set scenario ("Double-evaluation
+  proves equivalence before deletion") has moved, byte-identical, to
+  `rdd-single-lifecycle-cutover`'s `MODIFIED Requirements` delta (verify
+  finding SL-1's resolution, mirroring how B1's requirement move was
+  handled): only the change that performs the switch-free build can run
+  it. **What the successor must do**: once v3 negotiated START gains
+  genuine `repository_context` support, record Commit A's negotiated-form
+  goldens/envelopes/receipts (negotiated start + `capture-result`) with
+  the switch ON, build switch-free, record the same surface again, and
+  diff both for byte-identity — satisfying the scenario it now owns —
+  before switch removal proceeds. See the successor's `proposal.md` step 3
+  and its `specs/rdd-single-lifecycle/spec.md`.
 - [x] 2.2 Store recorded bytes as the Commit-B comparison baseline.
 - [x] 2.3 Exit Checklist.
 

--- a/openspec/changes/rdd-root-simplification-wave7/tasks.md
+++ b/openspec/changes/rdd-root-simplification-wave7/tasks.md
@@ -211,15 +211,32 @@ release candidate's community testing).
   lineage) partially met with WU18a's disclosed, coordinator-approved
   exception documented inline.
 - [x] 20.3 Exit Checklist: gofmt/vet clean (root + bench), deadcode ratchet
-  244→243 net-negative across the wave (wave-wide +1701/-8968, net -7267
-  lines from the v1-freeze checkpoint), refusal-resolution ratchet
-  1694→1586 net-negative (net -108) from the v1-freeze checkpoint, root
-  `go test ./... -count=1` fully GREEN with zero failures (RG.1b's own
-  long-standing expected-red resolved at WU19), bench module tests green,
-  final verb count: 5 legacy public verbs + 2 reconcile providers retired;
-  6 D4 verbs classified live (not retired) pending switch removal; the
-  switch itself retained. See apply-progress and this file's own per-WU
-  entries for the complete evidence trail.
+  247→243 net-negative across the wave (net -4; wave-wide +1701/-8968, net
+  -7267 lines from the v1-freeze checkpoint `d10d49ab`; 247 is the true
+  wave-wide starting figure — correcting a WU20 misreport that cited 244,
+  WU4's mid-wave value, as the wave's start rather than 247), refusal-
+  resolution ratchet 1694→1586 net-negative (net -108) from the v1-freeze
+  checkpoint, root `go test ./... -count=1` fully GREEN with zero failures
+  (RG.1b's own long-standing expected-red resolved at WU19), bench module
+  tests green, final verb count: 5 legacy public verbs + 2 reconcile
+  providers retired; 6 D4 verbs classified live (not retired) pending
+  switch removal; the switch itself retained. See apply-progress and this
+  file's own per-WU entries for the complete evidence trail.
+- [x] 20.5 verify W4: `docs/architecture/rdd-wave7-deletion-proof-tracker.md`
+  declared a WU20 obligation (re-read the retention table, confirm RG.1b is
+  fully GREEN with zero legacy verbs reachable, then update
+  `rdd-backlog-disposition.md`'s closure-audit-protocol row for step 4)
+  that WU20 never performed, and its stated condition ("zero legacy verbs
+  reachable") was invalidated by WU19's finding that all 6 D4 verbs stay
+  live/reachable. Reconciled honestly in both the tracker and
+  `rdd-backlog-disposition.md` rather than silently marking a now-false
+  condition satisfied — see those files for the corrected text.
+- [x] 20.6 verify W5: the `reconcile-authority` retirement (WU7) left the
+  `unchanged_target` and `malformed_recovery_authorization` anomaly classes
+  without their only advertised runnable exit (disclosed inline in
+  `compact_inspect.go`/`compact_reclaim.go` comments and in WU7's own tasks
+  entry). This loss is now tracked as follow-up issue #2422; see that issue
+  for the two anomaly classes and their lost exit paths.
 
 ## Exit Checklist (every WU)
 - [ ] `go test ./... -count=1` root module green.

--- a/openspec/changes/rdd-single-lifecycle-cutover/proposal.md
+++ b/openspec/changes/rdd-single-lifecycle-cutover/proposal.md
@@ -1,0 +1,100 @@
+# Proposal: RDD Single Lifecycle Cutover (successor to Wave 7)
+
+Successor to `rdd-root-simplification-wave7`. Wave 7 deliberately deferred
+the `GENTLE_AI_RDD_NEW_LINEAGE` switch removal (WU18) rather than remove it
+over a known, disclosed capability gap — see
+`openspec/changes/rdd-root-simplification-wave7/specs/rdd-single-lifecycle/spec.md`'s
+Amendment for the full finding. This change exists to carry the one
+requirement Wave 7 could not deliver, so Wave 7's own spec claims only what
+it shipped (verify finding C1 / blocker B1, `sdd/rdd-root-simplification-wave7/verify-report`,
+Engram #10215).
+
+## Intent
+
+Land the switch removal Wave 7 attempted and reverted: delete
+`GENTLE_AI_RDD_NEW_LINEAGE` and the legacy `review start` branch it guards,
+so exactly one review lifecycle (v3) remains reachable. This is a single,
+precisely-scoped requirement — everything else Wave 7's `rdd-single-lifecycle`
+capability defines (byte-equivalence exit evidence, W-9/W-10/W-11
+preconditions, the negotiated-repository_context re-entry gate) already
+shipped in Wave 7 and stays unchanged; this change only adds the one
+requirement that gate protects.
+
+## The re-entry brief (why removal was blocked, and what closes it)
+
+Wave 7's WU18 attempt found that v3's negotiated START (`--contract` form,
+`runReviewFacadeStartNewLineage`'s negotiated path) has never supported
+`repository_context` — the opaque, path-free handle a `capture-result` call
+carries across a process cwd boundary. This gap predates Wave 7 and was
+previously reachable only at the narrow switch-ON-AND-negotiated
+intersection; removing the switch makes v3 unconditional, so every
+negotiated START would take that path and the gap becomes universal rather
+than a corner case. Extending `validateLiveReviewRepositoryContext` — a
+security-sensitive binding validator — under the time pressure of a
+switch-removal PR was judged the wrong trade (non-negotiable: never remove
+a switch over a known capability gap).
+
+This change MUST, in order:
+
+1. Give v3's negotiated START genuine `repository_context` support, by
+   either:
+   - extending `NewLineageAuthority`'s schema with a value comparable to
+     `Snapshot.Identity` (the single combined hash the existing
+     `validateLiveReviewRepositoryContext` compares against — structurally
+     different from `NewLineageAuthority`'s current `CandidateIdentity`
+     shape: `RepositoryID`/`BaseTree`/`CandidateTree`/
+     `ChangedPathsModesDigest`/`PolicyHash`), or
+   - safely re-deriving `Snapshot.Identity` from Git at validation time.
+2. Add a v3-aware branch to `validateLiveReviewRepositoryContext` (or an
+   equivalent validator) with the identical security guarantees the
+   compact-v2 path already has — never a bypass, never a weakened check. A
+   wrong implementation here could silently accept a mismatched context and
+   misbind a reviewer's result to the wrong candidate.
+3. Re-prove byte-equivalence exit evidence end to end across the full
+   journey set, including the negotiated form this time — Wave 7's Commit A
+   recording covered the unnegotiated form plus status/finalize/the 5
+   gates, but explicitly deferred the negotiated form and `capture-result`
+   (see Wave 7 apply-progress and tasks.md task 2.1); this change must
+   close that gap before it re-attempts removal, not after.
+4. Only then delete `GENTLE_AI_RDD_NEW_LINEAGE` and the legacy start
+   branch.
+
+If any of these steps surfaces a further capability gap, the same
+non-negotiable applies: stop before removal and report, rather than ship
+over a known gap.
+
+## Scope
+
+### In scope
+
+- v3 negotiated START `repository_context` support (schema or re-derivation
+  design decision, plus the validator branch).
+- Full-journey-set byte-equivalence proof, negotiated form included.
+- The switch + legacy start branch deletion itself, once the above are
+  proven safe.
+
+### Out of scope
+
+- Any other legacy-retirement surface — Wave 7 already retired the 5
+  legacy public verbs, both reconcile providers, and classified the 6
+  remaining D4 verbs (`invalidate`/`abandon`/`recover`/`reclaim`/
+  `dispose-result`/`reopen-results`) as live compact-v2 mutation surface,
+  independent of this change.
+- Re-litigating Wave 7's deferral decision — it is settled; this change's
+  job is to close the gap that caused it, not to argue the switch should
+  have been removed anyway.
+
+## Capabilities
+
+### Modified
+
+- `rdd-single-lifecycle`: adds the "Exactly One Lifecycle After Removal"
+  requirement (moved here byte-identical from Wave 7's delta, ownership
+  only — text unweakened) now that this change is the one delivering it.
+
+## Grounding
+
+Chain from `feat/rdd-wave7-verify-remediation` (Wave 7, worktree
+`/home/gentleman/work/gentle-ai-worktrees/rdd-wave7`), tip at proposal
+time: to be re-validated at this change's own task time, per this
+project's standing "re-validate line references at task time" convention.

--- a/openspec/changes/rdd-single-lifecycle-cutover/proposal.md
+++ b/openspec/changes/rdd-single-lifecycle-cutover/proposal.md
@@ -91,6 +91,11 @@ over a known gap.
 - `rdd-single-lifecycle`: adds the "Exactly One Lifecycle After Removal"
   requirement (moved here byte-identical from Wave 7's delta, ownership
   only — text unweakened) now that this change is the one delivering it.
+  Also carries a `MODIFIED Requirements` entry for "Byte-Equivalence Exit
+  Evidence Precedes Switch Removal": the requirement itself stays defined
+  in Wave 7's spec unchanged, but its full-journey-set scenario (the one
+  requiring a switch-free build, negotiated form included) moves here
+  byte-identical — only this change can run it (verify finding SL-1).
 
 ## Grounding
 

--- a/openspec/changes/rdd-single-lifecycle-cutover/specs/rdd-single-lifecycle/spec.md
+++ b/openspec/changes/rdd-single-lifecycle-cutover/specs/rdd-single-lifecycle/spec.md
@@ -1,0 +1,22 @@
+# Delta for RDD Single Lifecycle
+
+Moved here from `rdd-root-simplification-wave7`'s delta, byte-identical to
+the requirement and scenario text Wave 7 carried (verify finding C1 /
+blocker B1) — Wave 7 deferred switch removal and never delivered this
+requirement, so it does not belong in Wave 7's own delta. See this change's
+`proposal.md` for the full re-entry brief this requirement's delivery
+depends on.
+
+## ADDED Requirements
+
+### Requirement: Exactly One Lifecycle After Removal
+
+After removal, no `GENTLE_AI_RDD_NEW_LINEAGE` reference, legacy start
+branch, or legacy mutation path MUST remain reachable.
+
+#### Scenario: Every start request takes the v3 path
+
+- GIVEN the switch-removal slice has landed
+- WHEN any `start` is requested, or the codebase is searched for the switch
+- THEN it always proceeds through v3, and zero switch references remain
+  outside historical/archived change specs

--- a/openspec/changes/rdd-single-lifecycle-cutover/specs/rdd-single-lifecycle/spec.md
+++ b/openspec/changes/rdd-single-lifecycle-cutover/specs/rdd-single-lifecycle/spec.md
@@ -20,3 +20,26 @@ branch, or legacy mutation path MUST remain reachable.
 - WHEN any `start` is requested, or the codebase is searched for the switch
 - THEN it always proceeds through v3, and zero switch references remain
   outside historical/archived change specs
+
+## MODIFIED Requirements
+
+### Requirement: Byte-Equivalence Exit Evidence Precedes Switch Removal
+
+Before the switch and its legacy start branch are deleted, the wave MUST
+prove a `GENTLE_AI_RDD_NEW_LINEAGE=1` build and a switch-free build produce
+byte-identical goldens, envelopes, and receipts, via same-fixture on/off
+double-evaluation across the full journey set. A golden diff during this
+proof MUST be treated as a defect signal, never a golden-update task.
+
+This requirement itself is unchanged from Wave 7's spec (see that change's
+own copy for the full text and Wave 7's own partial, scoped evidence). Only
+its full-journey-set scenario moves here, byte-identical (verify finding
+SL-1) — it can only be run by whichever change actually performs the
+switch-free build, which Wave 7's deferral means is this change, not Wave
+7 itself.
+
+#### Scenario: Double-evaluation proves equivalence before deletion
+
+- GIVEN the same fixture run once with the switch on and once switch-free
+- WHEN goldens, envelopes, and receipts are compared
+- THEN they are byte-identical, and only then does removal proceed


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2423

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

Verify remediation: artifact figures corrected against the tree, the undelivered requirement and its unprovable scenario physically relocated to the new rdd-single-lifecycle-cutover change, and the lost anomaly exits filed as #2422. Production tree byte-identical throughout.

## 🧪 Test Plan

- [x] Full `go test ./... -count=1` (root + bench + e2e) green at chain tip e303d9a9
- [x] Bench corpus and damaged-store axis vs fresh binaries, zero status or structural deltas against the true base
- [x] 3 verify cycles; final envelope pass, 14/14 requirements, 8/8 scenarios, 0 criticals