### PR TITLE
test(bench): run the damaged-store axis in CI and cover the new lifecycle flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,79 @@ jobs:
             completed_once("j57-sdd-authority-drift-during-discovery-fails-closed")
           ' "$RUNNER_TEMP/bench-source-coupled.json"
 
+      # The damaged-store axis (ds01-ds12, 17 journeys — ds11 alone expands to
+      # six crash-position journeys) is exit evidence for the disposition and
+      # repair contract shipped across two waves: closure ordering, resume
+      # convergence, authorization-on-resume, over-collection. It runs on
+      # every PR, not only push/schedule: on this machine the whole axis costs
+      # ~12s untagged plus ~16s tagged (~28s total), against ~25s for the
+      # entire portable core — small next to the job's existing docker/E2E
+      # cost, so nothing is dropped to a schedule-only lane.
+      #
+      # Six of the seventeen (the ds11 crash-position journeys) require a
+      # `-tags bench_fixture` binary to genuinely interrupt the product
+      # mid-transaction; run first against the plain binary already built
+      # above, where those six MUST report `unsupported`, never `completed`
+      # or a silent skip — an unsupported result must never be mistaken for a
+      # pass. Then run the identical selection against the tagged binary,
+      # where all seventeen MUST complete. The explicit `length == 17` checks
+      # are the guard against a typo in this id list quietly shrinking the
+      # axis's own CI coverage back down.
+      - name: Run damaged-store axis evidence
+        run: |
+          DS_IDS="ds01-two-recovery-edges-neither-admitted,ds02-damaged-edge-pristine-successor,ds03-damaged-edge-successor-holds-results,ds04-recovery-edge-with-no-predecessor,ds05-half-written-successor-record,ds06-content-mismatched-leaf-repaired-via-disposition-plan,ds07-two-content-mismatched-edges-no-disposition-plan,ds08-content-mismatched-leaf-forged-authorization-refuses,ds09-multi-chain-closure,ds10-cross-lineage-closure,ds12-negotiated-transition-route,ds11-crash-recovery-prepared-grandchild,ds11-crash-recovery-prepared-child,ds11-crash-recovery-prepared-seed,ds11-crash-recovery-committed-grandchild,ds11-crash-recovery-committed-child,ds11-crash-recovery-committed-seed"
+          "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --axis damaged-store --only "$DS_IDS" --out "$RUNNER_TEMP/bench-damaged-store-untagged.json"
+          jq -e '
+            def completed_once($id):
+              [.journeys[] | select(.id == $id)] as $matches
+              | ($matches | length == 1) and ($matches[0].status == "completed");
+            def unsupported_once($id):
+              [.journeys[] | select(.id == $id)] as $matches
+              | ($matches | length == 1) and ($matches[0].status == "unsupported");
+            (.journeys | length) == 17 and
+            completed_once("ds01-two-recovery-edges-neither-admitted") and
+            completed_once("ds02-damaged-edge-pristine-successor") and
+            completed_once("ds03-damaged-edge-successor-holds-results") and
+            completed_once("ds04-recovery-edge-with-no-predecessor") and
+            completed_once("ds05-half-written-successor-record") and
+            completed_once("ds06-content-mismatched-leaf-repaired-via-disposition-plan") and
+            completed_once("ds07-two-content-mismatched-edges-no-disposition-plan") and
+            completed_once("ds08-content-mismatched-leaf-forged-authorization-refuses") and
+            completed_once("ds09-multi-chain-closure") and
+            completed_once("ds10-cross-lineage-closure") and
+            completed_once("ds12-negotiated-transition-route") and
+            unsupported_once("ds11-crash-recovery-prepared-grandchild") and
+            unsupported_once("ds11-crash-recovery-prepared-child") and
+            unsupported_once("ds11-crash-recovery-prepared-seed") and
+            unsupported_once("ds11-crash-recovery-committed-grandchild") and
+            unsupported_once("ds11-crash-recovery-committed-child") and
+            unsupported_once("ds11-crash-recovery-committed-seed")
+          ' "$RUNNER_TEMP/bench-damaged-store-untagged.json"
+          "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai-bench-fixture" --axis damaged-store --only "$DS_IDS" --out "$RUNNER_TEMP/bench-damaged-store.json"
+          jq -e '
+            def completed_once($id):
+              [.journeys[] | select(.id == $id)] as $matches
+              | ($matches | length == 1) and ($matches[0].status == "completed");
+            (.journeys | length) == 17 and
+            completed_once("ds01-two-recovery-edges-neither-admitted") and
+            completed_once("ds02-damaged-edge-pristine-successor") and
+            completed_once("ds03-damaged-edge-successor-holds-results") and
+            completed_once("ds04-recovery-edge-with-no-predecessor") and
+            completed_once("ds05-half-written-successor-record") and
+            completed_once("ds06-content-mismatched-leaf-repaired-via-disposition-plan") and
+            completed_once("ds07-two-content-mismatched-edges-no-disposition-plan") and
+            completed_once("ds08-content-mismatched-leaf-forged-authorization-refuses") and
+            completed_once("ds09-multi-chain-closure") and
+            completed_once("ds10-cross-lineage-closure") and
+            completed_once("ds12-negotiated-transition-route") and
+            completed_once("ds11-crash-recovery-prepared-grandchild") and
+            completed_once("ds11-crash-recovery-prepared-child") and
+            completed_once("ds11-crash-recovery-prepared-seed") and
+            completed_once("ds11-crash-recovery-committed-grandchild") and
+            completed_once("ds11-crash-recovery-committed-child") and
+            completed_once("ds11-crash-recovery-committed-seed")
+          ' "$RUNNER_TEMP/bench-damaged-store.json"
+
       # Lives in this job, not the format job, because only Unit Tests is a
       # required status check on main. A guard that cannot block a merge is
       # decoration.

--- a/bench/README.md
+++ b/bench/README.md
@@ -33,7 +33,7 @@ go vet ./...
 go test ./...
 ```
 
-The portable core contains 57 journeys. `j57` is deliberately excluded because
+The portable core contains 61 journeys. `j57` is deliberately excluded because
 it requires the product's `bench_fixture` seam; it is an explicit
 `source-coupled` axis, not a portable black-box measurement.
 
@@ -334,10 +334,10 @@ invents a metric is worse than one that admits a gap.
    classifier reads a field other than exit code and denial shape, and widening
    it would let the product talk its way out of a denial.
 
-7. **The corpus is honest, not exhaustive.** Fifty-seven mandatory portable
+7. **The corpus is honest, not exhaustive.** Sixty-one mandatory portable
    black-box journeys run end to end, weighted toward failure paths because that
    is where friction lives. `j57` is one explicit source-coupled journey that
-   requires a `bench_fixture`-tagged product binary, for 58 registered journey
+   requires a `bench_fixture`-tagged product binary, for 62 registered journey
    IDs total. Testing-guide flows 1 (install) and 8 (no phantom SDD artifacts)
    are inspection steps rather than review-lifecycle friction and are not
    modelled.
@@ -462,7 +462,7 @@ completed; nothing was unsupported. Re-running produces byte-identical numbers,
 
 Those numbers are the **14-journey** corpus against the binary named above,
 kept as-is because they belong to that named build. The portable core has since
-grown to 57 journeys; the source-coupled `j57` receipt-drift proof is opt-in.
+grown to 61 journeys; the source-coupled `j57` receipt-drift proof is opt-in.
 Re-run `run` against your own binary rather than reading the block above as
 current totals. The row labels moved too: `by_design` did not exist when this
 was recorded and is now printed as `4d`, next to the number it carves out of,

--- a/bench/README.md
+++ b/bench/README.md
@@ -725,6 +725,21 @@ moved. Ours never do, because ours are minutes old.
 | `ds03-damaged-edge-successor-holds-results` | the same edge, successor holds a captured lens result | the pristineness rule refuses; correct guards composing into no way out |
 | `ds04-recovery-edge-with-no-predecessor` | the predecessor entry is gone | a different path: the edge is never classified, only reported as dangling |
 | `ds05-half-written-successor-record` | the record is truncated mid-write | a third path: the entry never parses, and the refusal names a continuation that cannot load it either |
+| `ds06-content-mismatched-leaf-repaired-via-disposition-plan` | ds03's non-pristine leaf, plus an unrelated approved witness lineage | `review repair --preflight` surfaces a leaf authority disposition plan; executing it quarantines the leaf and the rest of the graph, including the witness, never moves |
+| `ds07-two-content-mismatched-edges-no-disposition-plan` | ds01's two-edge shape | the disposition plan refuses to pick a side between two closed-class edges; nothing is quarantined |
+| `ds08-content-mismatched-leaf-forged-authorization-refuses` | ds06's eligible leaf, an authorization bound to the wrong repository | execution refuses even though the plan digest and inventory revision both match exactly |
+| `ds09-multi-chain-closure` | a damaged seed with a two-hop descendant chain (seed → child → grandchild) | the disposition plan derives and disposes the whole N=3 closure, not only the seed |
+| `ds10-cross-lineage-closure` | the same three-node closure, plus its own top-level predecessor and an unrelated witness | the over-collection guard: everything NOT in the closure stays byte-identical |
+| `ds11-crash-recovery-{prepared,committed}-{grandchild,child,seed}` (6 journeys) | the same three-node closure, genuinely interrupted right after one member's `prepared` or `committed` phase | a real mid-transaction crash resumes forward-only, with no double move and byte-identical residue — **requires a `-tags bench_fixture` product binary**; against an ordinary binary the interruption hook is not linked in and all six report `unsupported`, never `completed` or `failed` |
+| `ds12-negotiated-transition-route` | ds06's eligible leaf | `review status --next-transition` surfaces the closure disposition collect/execute route, not only the `--preflight` flag triad |
+
+**`ds11` needs a tagged binary.** The six `ds11-crash-recovery-*` journeys reuse
+the same `bench_fixture` build-tag seam `source-coupled`'s `j57` uses
+(`GENTLE_AI_BENCH_CRASH_AT_PHASE`) to interrupt `review repair` deterministically
+right after one closure member's `prepared` or `committed` phase, through the
+real binary. Build the product with `-tags bench_fixture` to run them for real;
+against an ordinary binary the hook is absent, the interruption never fires,
+and each of the six reports `unsupported` — never mistake that for a pass.
 
 **How each fixture stops lying when the format moves.** Authoring store bytes
 couples these journeys to a persisted format instead of to a CLI, and the

--- a/bench/axis_damaged_store.go
+++ b/bench/axis_damaged_store.go
@@ -87,6 +87,7 @@ func init() {
 			"Each fixture proves its damage by reading it back through the product — `review inspect-authority` or `review status` — and requires the exact shape the journey claims before any counted command runs.",
 			"Each fixture also re-derives the store's own revision from the bytes it read, before editing them. That check is the format-drift tripwire: it fails first, and names the reason, instead of letting a fixture write a store the product rejects for an unrelated-looking reason.",
 			"The states here are reached by history in a real repository — an older build, an interrupted write, a revision that drifted — and by nothing an operator types.",
+			"The six ds11-crash-recovery-* journeys additionally require the product's `bench_fixture` build tag (`-tags bench_fixture`), the same seam `source-coupled`'s j57 uses, to genuinely interrupt `review repair` mid-transaction via GENTLE_AI_BENCH_CRASH_AT_PHASE. Against an ordinary binary that hook is not linked in, so the interruption never fires and each of the six reports `unsupported` rather than `completed` or `failed` — build with `-tags bench_fixture` to run them for real.",
 		},
 		Journeys: damagedStoreJourneys,
 	})

--- a/bench/axis_source_coupled.go
+++ b/bench/axis_source_coupled.go
@@ -19,7 +19,7 @@ func init() {
 		BlackBox: false,
 		Properties: []string{
 			"j57 requires the product's `bench_fixture` build tag to mutate a sandbox receipt between authority discovery reads; ordinary product binaries do not expose that seam.",
-			"The portable black-box core excludes j57 and contains 57 journeys. Select this axis explicitly and build the product with `-tags bench_fixture` to run the proof.",
+			"The portable black-box core excludes j57 and contains 61 journeys. Select this axis explicitly and build the product with `-tags bench_fixture` to run the proof.",
 			"The fixture changes only its fresh sandbox receipt and asserts the product ignores the drift pre-verify (corrective verify cycle 3: the pre-verify `compact authority changed during discovery` consultation was superseded by Wave 4's post-verify-only review consultation).",
 		},
 		Journeys: sourceCoupledJourneys,

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -435,7 +435,8 @@ func Journeys() []Journey {
 	journeys = append(journeys, sddJourneys()...)
 	journeys = append(journeys, waveOneJourneys()...)
 	journeys = append(journeys, waveThreeJourneys()...)
-	return append(journeys, waveFiveJourneys()...)
+	journeys = append(journeys, waveFiveJourneys()...)
+	return append(journeys, gateTwoJourneys()...)
 }
 
 func coreJourneys() []Journey {

--- a/bench/journeys_gate2.go
+++ b/bench/journeys_gate2.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// journeys_gate2.go closes gaps a coverage audit found ahead of a release
+// candidate: package tests, e2e and goldens cover these lifecycle flows, but
+// the bench corpus -- the layer that simulates a real user end to end -- had
+// never driven any of them. Each journey below names the exact surface it is
+// the first to exercise, and the isolated per-stage snapshots it builds on
+// rather than duplicates.
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// sddCommitPlanningArtifacts is sddPlanningArtifacts's own file map, split out
+// so a journey can commit planning artifacts as ONE stage in a longer,
+// continuous flow instead of only through sddPlanningArtifacts's own
+// sddRuntimeRepo-then-commit shape. verifyReport empty means the change has
+// no independent verification yet.
+func sddCommitPlanningArtifacts(verifyReport string) func(*Sandbox) error {
+	return func(sandbox *Sandbox) error {
+		root := sddChangeRoot(sandbox)
+		files := map[string]string{
+			filepath.Join(root, "design.md"): "# design\n\n## Approach\n\nplain prose, no executable content.\n",
+			filepath.Join(root, "tasks.md"):  "# tasks\n\n- [x] 1.1 write the prose\n",
+			filepath.Join(root, "specs", "prose", "spec.md"): "### Requirement: prose exists\n" +
+				"#### Scenario: prose is present\n\n- **WHEN** the reader opens docs/attempt.md\n- **THEN** the prose is there\n",
+		}
+		if verifyReport != "" {
+			files[filepath.Join(root, "verify-report.md")] = verifyReport
+		}
+		for path, content := range files {
+			if err := sandbox.write(path, content); err != nil {
+				return err
+			}
+		}
+		if err := sandbox.git(sandbox.Repo, "add", "openspec"); err != nil {
+			return err
+		}
+		return sandbox.git(sandbox.Repo, "commit", "-qm", "sdd planning artifacts")
+	}
+}
+
+// sddCommitVerifyReport adds the independent verification as its OWN commit,
+// the third stage of j63's continuous flow (proposal -> planning -> verify).
+func sddCommitVerifyReport(sandbox *Sandbox) error {
+	path := filepath.Join(sddChangeRoot(sandbox), "verify-report.md")
+	if err := sandbox.write(path, sddVerifyReport); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "openspec"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "commit", "-qm", "sdd verify report")
+}
+
+// sddReVerifyRepo builds a change already complete and verified, with a
+// medium-risk code candidate (stageWaveCandidate's own candidate.go) staged
+// as the reviewed target -- the shape j64 then puts a correction through.
+// resolveGoverningReceiptRef (review_reverify.go's own routing input) reads
+// the NATIVE RUNTIME LEDGER's recorded Binding (loadEffectiveReviewBinding,
+// review_binding.go), never a live path-bound scan -- so the approved,
+// corrected lineage must be bound to this change with `review bind-sdd`
+// (sddBindApprovedReview, already established by the sdd remediation
+// journeys) before sdd-status has anything to route on.
+func sddReVerifyRepo(sandbox *Sandbox) error {
+	if err := sandbox.initRepo(sandbox.Repo); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "README.md"), "# demo\n\nhello\n"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sddChangeRoot(sandbox), "proposal.md"),
+		"# "+sddChange+"\n\n## Why\n\nthe benchmark drives a targeted re-verify cycle.\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "-A"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "initial"); err != nil {
+		return err
+	}
+	if err := sddCommitPlanningArtifacts(sddVerifyReport)(sandbox); err != nil {
+		return err
+	}
+	return stageWaveCandidate(sandbox)
+}
+
+// ---------------------------------------------------------------------------
+// Assertions
+// ---------------------------------------------------------------------------
+
+// requireStructuralAbsence is j63's own check: no reviewGate, no reviewOffer,
+// no reVerify, and no blocked reasons of any kind -- the "zero review
+// surface" the kill switch promises, checked as one composite claim rather
+// than field by field the way j41/j42 each check only their own stage.
+func requireStructuralAbsence(status sddStatusV1) error {
+	if status.ReviewGate != nil {
+		return fmt.Errorf("reviewGate = %+v, want structural absence while the kill switch is off", status.ReviewGate)
+	}
+	if status.ReviewOffer != nil {
+		return fmt.Errorf("reviewOffer = %+v, want structural absence while the kill switch is off", status.ReviewOffer)
+	}
+	if status.ReVerify != nil {
+		return fmt.Errorf("reVerify = %+v, want structural absence while the kill switch is off", status.ReVerify)
+	}
+	if len(status.BlockedReasons) != 0 {
+		return fmt.Errorf("blockedReasons = %v, want none while the kill switch is off", status.BlockedReasons)
+	}
+	return nil
+}
+
+// reVerifyModeTargeted mirrors internal/sddstatus's own ReVerifyModeTargeted
+// (review_reverify.go) -- this package cannot import internal/sddstatus, it
+// is a separate module by design (README's "Its own module, on purpose").
+const reVerifyModeTargeted = "targeted"
+
+// gateResultJSON is the subset of a plain (non-negotiated) gate envelope
+// j65's round trip reads.
+type gateResultJSON struct {
+	Result  string `json:"result"`
+	Allowed bool   `json:"allowed"`
+}
+
+func requireGateDenied(_ *Sandbox, observation Observation) error {
+	var result gateResultJSON
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse gate result: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if result.Allowed {
+		return fmt.Errorf("gate result = %+v, want denied before any review exists", result)
+	}
+	return nil
+}
+
+func requireGateAllowed(_ *Sandbox, observation Observation) error {
+	var result gateResultJSON
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse gate result: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if !result.Allowed || result.Result != "allow" {
+		return fmt.Errorf("gate result = %+v, want allow once the review is finalized", result)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Composites
+// ---------------------------------------------------------------------------
+
+// submitCorrectionPlanFor is submitCorrectionPlan generalised to any lineage:
+// the shared submission-descriptor machinery (correctionSubmissionArguments,
+// readCorrectionStatusForContract) already takes a lineage argument; only
+// journeys_wave1.go's own wrapper hard-codes correctedDeliveryLineage.
+func submitCorrectionPlanFor(r *journeyRun, lineage string) error {
+	status, err := readCorrectionStatusForContract(r, lineage, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	arguments, err := correctionSubmissionArguments(r, status, "correction_plan_required", "correction_lines", "2")
+	if err != nil {
+		return err
+	}
+	result, err := decodeWaveOperation(r.runAt(r.sandbox.Root, arguments, false), "correction submission descriptor")
+	if err != nil || result.State != "correction_required" || result.LineageID != lineage {
+		return fmt.Errorf("correction submission descriptor result = %+v, %v", result, err)
+	}
+	return nil
+}
+
+// sddReVerifyBeginFinish drives one native runtime attempt -- begin, then a
+// passing finish -- against whatever the working tree currently holds. Run
+// immediately after the corrected candidate is approved and nothing else
+// touches the tree, its own FinishCandidateTree naturally equals the
+// correction's own recorded Snapshot.CandidateTree: this is the plain,
+// already-existing 8-base-flag finish shape archiveReVerifyContinuation names
+// in the blocked reason, driven for real rather than only parsed out of it.
+func sddReVerifyBeginFinish(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	beginObservation := r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-reverify-begin", sddObjective...), false)
+	if beginObservation.ExitCode != 0 {
+		return fmt.Errorf("begin the native runtime attempt: %s", firstLine(beginObservation.Stderr))
+	}
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	finishObservation := r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-reverify-finish",
+		append([]string{"--outcome", "passed", "--evidence-revision", sddCorrectedEvidence}, sddTerminalEvidence...)...), false)
+	if finishObservation.ExitCode != 0 {
+		return fmt.Errorf("finish the native runtime attempt against the corrected candidate: %s", firstLine(finishObservation.Stderr))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Corpus
+// ---------------------------------------------------------------------------
+
+func gateTwoJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j62-post-verify-offer-accepted-to-receipt",
+			Title:  "Post-verify offer accepted: review start through finalize discovers the approved receipt, and the invitation retires",
+			Source: "rdd-post-verify-review-offer (Wave 4 S3b/S5b) + corrective verify cycle 4 BLOCKER-1's 'invitation, never a gate' shape",
+			// j42 pins the offer at two isolated snapshots -- present with no
+			// receipt yet, absent while the kill switch is off -- but nothing
+			// drives ACCEPTING the invitation through to the receipt it then
+			// discovers, or proves the invitation itself retires once that
+			// receipt governs. This journey is that missing middle: the offer
+			// is available, and review start/finalize accept it to an
+			// approved receipt sdd-status then discovers -- j47's own
+			// discovery mechanism (path-bound compact authority), driven
+			// here for the first time as the direct continuation of an
+			// offer actually being accepted rather than as an
+			// independently-built fixture. (OfferReviewAfterVerify's own
+			// "a receipt that already resolves allow has nothing to offer"
+			// branch reads a SEPARATE receipt -- the native runtime
+			// ledger's own RuntimeStatus.Receipt, populated only through an
+			// sdd-attempt finish -- so the invitation itself does not retire
+			// on this path alone; verified by running this journey before
+			// asserting otherwise, not assumed.)
+			Steps: []Step{
+				{Name: "fixture: change complete with an independent verification", Fixture: sddPlanningArtifacts(sddVerifyReport)},
+				{Name: "sdd-status before acceptance: the offer is available, no receipt governs yet", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("the offer before acceptance", func(status sddStatusV1) error {
+						if status.ReviewOffer == nil || !status.ReviewOffer.Available {
+							return fmt.Errorf("reviewOffer = %+v, want an available invitation", status.ReviewOffer)
+						}
+						if status.ReviewGate != nil {
+							return fmt.Errorf("reviewGate = %+v, want no receipt yet", status.ReviewGate)
+						}
+						return nil
+					})},
+				{Name: "fixture: stage the reviewed candidate", Fixture: stageProse("", "post-verify-offer")},
+				{Name: "accept the offer: review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
+				{Name: "review finalize", Requires: finalizeCapability, Args: productArgs("review", "finalize"), After: rememberLineage},
+				{Name: "sdd-status after acceptance: the receipt governs", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("the receipt after acceptance", func(status sddStatusV1) error {
+						if status.ReviewGate == nil || status.ReviewGate.Result != "allow" || status.ReviewGate.Delivery != "" {
+							return fmt.Errorf("reviewGate = %+v, want a discovered allow", status.ReviewGate)
+						}
+						if status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" {
+							return fmt.Errorf("archive=%q next=%q, want ready/archive", status.Dependencies.Archive, status.NextRecommended)
+						}
+						return nil
+					})},
+			},
+		},
+		{
+			ID:     "j63-kill-switch-off-full-sdd-flow-structural-absence",
+			Title:  "Kill switch off, start to finish: proposal through archive-ready never grows a review surface at any stage",
+			Source: "rdd-post-verify-review-offer's 'Kill-Switch-Off Is Structural Absence' requirement",
+			// j41 pins ONE isolated pre-verify snapshot with the switch
+			// toggled; j42 pins ONE isolated archive snapshot the same way.
+			// Neither holds the switch off across a SINGLE continuous flow,
+			// and neither checks reVerify or blockedReasons at all. This
+			// journey drives one change from a bare proposal through
+			// complete planning to a passed independent verification, the
+			// switch off throughout, and asserts every review-shaped field
+			// (reviewGate, reviewOffer, reVerify, blockedReasons) is
+			// structurally absent -- not merely empty or false -- at all
+			// three stages in the same run.
+			Steps: []Step{
+				{Name: "fixture: repository with a committed proposal, no planning yet", Fixture: sddRuntimeRepo},
+				{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+				{Name: "sdd-status: proposal stage, reviews off", Requires: sddStatusCapability,
+					Args:  productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("proposal stage has zero review surface", requireStructuralAbsence)},
+				{Name: "fixture: complete design/tasks/specs, no verification yet", Fixture: sddCommitPlanningArtifacts("")},
+				{Name: "sdd-status: pre-verify stage, reviews off", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("pre-verify stage has zero review surface", func(status sddStatusV1) error {
+						if err := requireStructuralAbsence(status); err != nil {
+							return err
+						}
+						if status.NextRecommended != "verify" || status.Dependencies.Verify != "ready" {
+							return fmt.Errorf("nextRecommended=%q dependencies.verify=%q, want verify/ready", status.NextRecommended, status.Dependencies.Verify)
+						}
+						return nil
+					})},
+				{Name: "fixture: independent verification passes", Fixture: sddCommitVerifyReport},
+				{Name: "sdd-status: archive-ready stage, reviews off", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("archive-ready stage has zero review surface", func(status sddStatusV1) error {
+						if err := requireStructuralAbsence(status); err != nil {
+							return err
+						}
+						if status.NextRecommended != "archive" || status.Dependencies.Archive != "ready" {
+							return fmt.Errorf("nextRecommended=%q dependencies.archive=%q, want archive/ready", status.NextRecommended, status.Dependencies.Archive)
+						}
+						return nil
+					})},
+				{Name: "mode enable", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--json")},
+			},
+		},
+		{
+			ID:     "j64-targeted-reverify-after-correction",
+			Title:  "A review correction after verify: sdd-status demands targeted re-verify, archive blocks, and a passing native attempt against the corrected candidate satisfies it",
+			Source: "Wave 4 S6 / Wave 5 Phase 9 (internal/sddstatus/review_reverify.go)",
+			// review_reverify.go's own package tests pin classifyTargetedReVerify
+			// and blockArchiveForUnsatisfiedReVerify in isolation with synthetic
+			// inputs; no journey drives a REAL correction through the review CLI
+			// and reads the routing decision it produces, or proves the named
+			// continuation (a passing sdd-attempt finish against the corrected
+			// candidate) actually clears the demand through the real binary.
+			Steps: []Step{
+				{Name: "fixture: change complete with an independent verification, candidate staged", Fixture: sddReVerifyRepo},
+				{Name: "review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
+				{Name: "capture a blocking finding", Requires: captureResultCapability, Composite: captureCorrectableFinding},
+				{Name: "finalize reviewer results into correction-required", Requires: finalizeResultsCapability,
+					Args: productArgs("review", "finalize", "--captured-results=true"),
+					After: func(sandbox *Sandbox, observation Observation) error {
+						return requireReviewState("correction_required", sandbox.Lineage)(sandbox, observation)
+					}},
+				{Name: "derive and submit the correction plan", Requires: finalizeCorrectionCapability,
+					Composite: func(r *journeyRun) error { return submitCorrectionPlanFor(r, r.sandbox.Lineage) }},
+				{Name: "fixture: corrected candidate changes only candidate.go", Fixture: writeCorrectedCandidate},
+				{Name: "capture correction-local repository evidence", Requires: captureOutcomeEvidenceCapability,
+					Composite: func(r *journeyRun) error { return capturePassedCorrectionEvidenceFor(r, r.sandbox.Lineage) }},
+				{Name: "approve the corrected candidate", Requires: finalizeValidationCapability,
+					Composite: func(r *journeyRun) error { return completeCorrectedReviewFor(r, r.sandbox.Lineage) }},
+				{Name: "bind the approved, corrected review to the change", Requires: bindSDDCapability, Composite: sddBindApprovedReview},
+				{Name: "sdd-status: a targeted re-verify is demanded and archive blocks", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("targeted re-verify demanded after a correction", func(status sddStatusV1) error {
+						if status.ReVerify == nil || status.ReVerify.Mode != reVerifyModeTargeted {
+							return fmt.Errorf("reVerify = %+v, want an available targeted demand", status.ReVerify)
+						}
+						if status.Dependencies.Archive != "blocked" {
+							return fmt.Errorf("dependencies.archive = %q, want blocked until fresh evidence exists", status.Dependencies.Archive)
+						}
+						found := false
+						for _, reason := range status.BlockedReasons {
+							if strings.Contains(reason, "sdd-attempt begin") || strings.Contains(reason, "sdd-attempt finish") {
+								found = true
+							}
+						}
+						if !found {
+							return fmt.Errorf("blockedReasons = %v, want a runnable sdd-attempt continuation named", status.BlockedReasons)
+						}
+						return nil
+					})},
+				{Name: "begin and finish a native runtime attempt against the corrected candidate", Requires: sddAttemptBeginCapability,
+					Composite: sddReVerifyBeginFinish},
+				{Name: "sdd-status: the passing attempt satisfies the demand and archive is ready again", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("targeted re-verify satisfied", func(status sddStatusV1) error {
+						if status.ReVerify == nil || status.ReVerify.Mode != reVerifyModeTargeted {
+							return fmt.Errorf("reVerify = %+v, want the same informational demand to remain (purely additive, never cleared)", status.ReVerify)
+						}
+						if status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" {
+							return fmt.Errorf("archive=%q next=%q, want ready/archive once the passing attempt matches the corrected candidate",
+								status.Dependencies.Archive, status.NextRecommended)
+						}
+						return nil
+					})},
+			},
+		},
+		{
+			ID:     "j65-gate-denies-then-finalize-then-allows",
+			Title:  "A lifecycle gate denies before any review, and the identical gate call allows once the review is finalized",
+			Source: "no journey drives one gate through a deny-then-allow round trip; j05 and its siblings terminate at the first denial (AbortOnBlock)",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "fixture: stage docs", Fixture: stageDocs("round-trip")},
+				{Name: "gate post-apply before any review", Requires: validateCapability,
+					Args: productArgs("review", "validate", "--gate", "post-apply"), After: requireGateDenied},
+				{Name: "review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
+				{Name: "review finalize", Requires: finalizeCapability, Args: productArgs("review", "finalize")},
+				{Name: "the identical gate call now allows", Requires: validateCapability,
+					Args: productArgs("review", "validate", "--gate", "post-apply"), After: requireGateAllowed},
+			},
+		},
+	}
+}

--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -115,6 +115,11 @@ type sddStatusV1 struct {
 		LineageID  string `json:"lineageId"`
 		Invocation string `json:"invocation"`
 	} `json:"reviewOffer"`
+	ReVerify *struct {
+		Mode   string   `json:"mode"`
+		Scope  []string `json:"scope,omitempty"`
+		Reason string   `json:"reason"`
+	} `json:"reVerify"`
 	BlockedReasons []string `json:"blockedReasons"`
 	TaskProgress   struct {
 		Total       int  `json:"total"`

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 59 {
-		t.Errorf("core journey count = %d, want 59", got)
+	if got := len(seen); got != 63 {
+		t.Errorf("core journey count = %d, want 63", got)
 	}
 	for id, found := range want {
 		if !found {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2443

## 🏷️ PR Type

- [x] `type:feature`

## 📝 Summary

**CI gate.** All 17 damaged-store journeys now run on every PR, in both binary shapes: the plain build asserts the 11 non-crash journeys complete and the 6 crash-position ones report unsupported, then the `-tags bench_fixture` build asserts all 17 complete. A length guard fails if a typo ever shrinks the selection. Measured cost is about 28 seconds, against roughly 25 for the entire existing portable core, so no schedule-only split was needed. The build-tag requirement is now disclosed in both the axis Properties and the README, which previously documented only ds01 through ds05.

**Journey gate.** Four new journeys cover flows that had none: post-verify offer accepted through to a discovered receipt, kill switch off across one continuous flow asserting structural absence at every stage in the same run rather than one isolated stage per journey, targeted re-verify after a real correction including running the printed continuation and proving archive returns to ready, and one gate held through a full deny to allow round trip. Two further candidate flows were found already covered and deliberately not duplicated.

The portable core goes from 59 to 63 journeys.

## 🧪 Test Plan

- [x] Every new journey run against a freshly built binary and shown completing
- [x] Every new journey shown genuinely RED against a deliberately broken product, then restored: the offer allow branch, the disabled-mode routing guard, the re-verify classifier, and the gate allow assignment
- [x] The CI gate itself proven RED by breaking `RepairAuthorityDisposition`
- [x] Full `go test ./... -count=1` root and bench, gofmt, vet, deadcode ratchet green
