### PR TITLE
fix(backup): validate rollback paths against caller-known scope roots

### DIFF
--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -154,7 +154,7 @@ var BackupRootFn = backupRoot
 // Symlink note: if the path already exists on disk, EvalSymlinks is used to
 // resolve the real path and re-check against the backup root, preventing symlink escapes.
 // If the path does not exist yet, only filepath.Clean is used — this limitation is accepted
-// and documented here, consistent with isPathUnderHome.
+// and documented here, consistent with isPathUnderRoot.
 func isRootDirUnderBackupRoot(dir string) (bool, error) {
 	root, err := BackupRootFn()
 	if err != nil {

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -13,38 +13,90 @@ import (
 // Package-level var for testability — swapped in tests to use a temp directory.
 var UserHomeDirFn = os.UserHomeDir
 
-// isPathUnderHome reports whether path is an absolute path that resides under
-// the current user's home directory. This is used to prevent arbitrary file
-// writes via tampered manifest OriginalPath fields.
+// isPathUnderRoot reports whether path is an absolute path that resides under
+// root. This is used to prevent arbitrary file writes via tampered manifest
+// OriginalPath fields: root must come from the caller (something it knows out
+// of band, e.g. the home or workspace directory it actually installed into),
+// never from the manifest itself — a tampered manifest would otherwise simply
+// declare a wider root and walk straight through the guard.
 //
 // Symlink note: if the path already exists on disk, EvalSymlinks is used to
-// resolve the real path and re-check against home, preventing symlink escapes.
+// resolve the real path and re-check against root, preventing symlink escapes.
 // If the path does not exist yet (typical during restore), only filepath.Clean
 // is used — symlinks cannot be resolved for non-existent paths, so this
 // limitation is accepted and documented here.
-func isPathUnderHome(path string) bool {
-	home, err := UserHomeDirFn()
-	if err != nil {
+func isPathUnderRoot(path, root string) bool {
+	rootClean := filepath.Clean(root)
+	if rootClean == "" || rootClean == "." {
 		return false
 	}
 	clean := filepath.Clean(path)
-	homeClean := filepath.Clean(home)
-	if !strings.HasPrefix(clean, homeClean+string(filepath.Separator)) {
+	if !strings.HasPrefix(clean, rootClean+string(filepath.Separator)) {
 		return false
 	}
 	// If the path exists, resolve symlinks and re-check to prevent symlink escapes.
 	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
-		resolvedHome, err := filepath.EvalSymlinks(homeClean)
+		resolvedRoot, err := filepath.EvalSymlinks(rootClean)
 		if err != nil {
-			resolvedHome = homeClean
+			resolvedRoot = rootClean
 		}
-		return strings.HasPrefix(resolved, resolvedHome+string(filepath.Separator))
+		return strings.HasPrefix(resolved, resolvedRoot+string(filepath.Separator))
 	}
 	// Path does not exist yet (file will be created by restore) — accept Clean-only check.
 	return true
 }
 
-type RestoreService struct{}
+// isPathUnderRoots reports whether path resides under at least one of roots.
+func isPathUnderRoots(path string, roots []string) bool {
+	for _, root := range roots {
+		if isPathUnderRoot(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// invalidOriginalPathErr builds the refusal returned when a manifest entry's
+// OriginalPath does not resolve under any allowed root. It names the roots
+// actually validated against so a user who hits it can tell which boundary
+// was crossed.
+func invalidOriginalPathErr(originalPath string, roots []string) error {
+	return fmt.Errorf("manifest entry has invalid OriginalPath %q: must be an absolute path under an allowed root (%s)", originalPath, strings.Join(roots, ", "))
+}
+
+// RestoreService restores a backup manifest, writing back or removing files
+// at their OriginalPath.
+//
+// Roots restricts which directories a restore is allowed to write to or
+// remove from. Every non-pre-existing manifest entry's OriginalPath must
+// resolve under at least one Roots entry, or the restore refuses it.
+//
+// When Roots is empty, Restore falls back to the single directory returned by
+// UserHomeDirFn — the historical, backward-compatible behavior. This is the
+// correct default for standalone restores (`gentle-ai restore <id>` and the
+// TUI "restore from list" screen): the backup being restored may be
+// arbitrarily old, and the workspace root that was in effect when it was
+// created is not something the current process can safely rediscover on its
+// own, so it falls back to the one directory it explicitly owns.
+//
+// Callers that are still inside the same install/sync run that produced the
+// manifest (e.g. pipeline rollback) know their own scope roots out of band
+// and should set Roots explicitly — see rollbackRoots in internal/cli.
+type RestoreService struct {
+	Roots []string
+}
+
+// allowedRoots resolves the roots this restore may write under.
+func (s RestoreService) allowedRoots() ([]string, error) {
+	if len(s.Roots) > 0 {
+		return s.Roots, nil
+	}
+	home, err := UserHomeDirFn()
+	if err != nil {
+		return nil, err
+	}
+	return []string{home}, nil
+}
 
 func (s RestoreService) Restore(manifest Manifest) error {
 	if manifest.Compressed {
@@ -57,6 +109,11 @@ func (s RestoreService) Restore(manifest Manifest) error {
 // It extracts the tar.gz archive into a temp directory, then restores each
 // entry by resolving the relative SnapshotPath inside that temp directory.
 func (s RestoreService) restoreCompressed(manifest Manifest) error {
+	roots, err := s.allowedRoots()
+	if err != nil {
+		return fmt.Errorf("resolve restore roots: %w", err)
+	}
+
 	tempDir, err := os.MkdirTemp("", "gentle-ai-restore-*")
 	if err != nil {
 		return fmt.Errorf("create temp restore dir: %w", err)
@@ -82,14 +139,14 @@ func (s RestoreService) restoreCompressed(manifest Manifest) error {
 				Existed:      true,
 				Mode:         entry.Mode,
 			}
-			if err := restoreEntry(resolvedEntry, true); err != nil {
+			if err := restoreEntry(resolvedEntry, true, roots); err != nil {
 				return err
 			}
 			continue
 		}
 
-		if !filepath.IsAbs(entry.OriginalPath) || !isPathUnderHome(entry.OriginalPath) {
-			return fmt.Errorf("manifest entry has invalid OriginalPath %q: must be an absolute path under the user home directory", entry.OriginalPath)
+		if !filepath.IsAbs(entry.OriginalPath) || !isPathUnderRoots(entry.OriginalPath, roots) {
+			return invalidOriginalPathErr(entry.OriginalPath, roots)
 		}
 		if err := os.Remove(entry.OriginalPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove path %q: %w", entry.OriginalPath, err)
@@ -102,16 +159,21 @@ func (s RestoreService) restoreCompressed(manifest Manifest) error {
 // restorePlain handles old-style backups where Compressed==false.
 // SnapshotPath is an absolute path to a plain file on disk.
 func (s RestoreService) restorePlain(manifest Manifest) error {
+	roots, err := s.allowedRoots()
+	if err != nil {
+		return fmt.Errorf("resolve restore roots: %w", err)
+	}
+
 	for _, entry := range manifest.Entries {
 		if entry.Existed {
-			if err := restoreEntry(entry, false); err != nil {
+			if err := restoreEntry(entry, false, roots); err != nil {
 				return err
 			}
 			continue
 		}
 
-		if !filepath.IsAbs(entry.OriginalPath) || !isPathUnderHome(entry.OriginalPath) {
-			return fmt.Errorf("manifest entry has invalid OriginalPath %q: must be an absolute path under the user home directory", entry.OriginalPath)
+		if !filepath.IsAbs(entry.OriginalPath) || !isPathUnderRoots(entry.OriginalPath, roots) {
+			return invalidOriginalPathErr(entry.OriginalPath, roots)
 		}
 		if err := os.Remove(entry.OriginalPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove path %q: %w", entry.OriginalPath, err)
@@ -126,9 +188,9 @@ func (s RestoreService) restorePlain(manifest Manifest) error {
 // temp directory (compressed restores), skipping the isRootDirUnderBackupRoot check.
 // It must be false for plain restores where SnapshotPath comes directly from the manifest
 // and must be validated against the backup root to prevent arbitrary file reads.
-func restoreEntry(entry ManifestEntry, trustedSnapshot bool) error {
-	if !filepath.IsAbs(entry.OriginalPath) || !isPathUnderHome(entry.OriginalPath) {
-		return fmt.Errorf("manifest entry has invalid OriginalPath %q: must be an absolute path under the user home directory", entry.OriginalPath)
+func restoreEntry(entry ManifestEntry, trustedSnapshot bool, roots []string) error {
+	if !filepath.IsAbs(entry.OriginalPath) || !isPathUnderRoots(entry.OriginalPath, roots) {
+		return invalidOriginalPathErr(entry.OriginalPath, roots)
 	}
 
 	// Validate SnapshotPath is under the backup root to prevent reading arbitrary

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -3,6 +3,8 @@ package backup
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -326,4 +328,253 @@ func TestRestoreCompressedRemovesCreatedFiles(t *testing.T) {
 	if _, statErr := os.Stat(createdFile); !os.IsNotExist(statErr) {
 		t.Fatalf("expected %q to be removed after restore, got stat err = %v", createdFile, statErr)
 	}
+}
+
+// ─── Scope containment (issue #2451) ───────────────────────────────────────
+//
+// These tests pin the RestoreService.Roots contract: a workspace-scoped
+// rollback must be able to restore/remove files under its workspace root
+// (which is frequently not under the user home directory) without tripping
+// the "must be an absolute path under the user home directory" refusal,
+// while a path that escapes every allowed root — via traversal or a symlink
+// — must still be refused, and the refusal must name the roots it checked.
+
+// TestRestoreScope_WorkspaceRootRestoresAndRemovesWithoutError pins property 1:
+// a workspace-scoped rollback restores a file under the workspace root (and
+// removes a workspace-scoped file that did not exist at snapshot time)
+// without error, when the workspace root is supplied via Roots the way
+// rollbackRoots (internal/cli) supplies it.
+func TestRestoreScope_WorkspaceRootRestoresAndRemovesWithoutError(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	origBackupRootFn := BackupRootFn
+	t.Cleanup(func() { BackupRootFn = origBackupRootFn })
+	BackupRootFn = func() (string, error) { return home, nil }
+
+	// entry A: existed at snapshot time, under the workspace root — restore
+	// must write the snapshotted content back.
+	originalPath := filepath.Join(workspace, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("modified\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	snapshotPath := filepath.Join(home, "backup", "files", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() snapshot error = %v", err)
+	}
+	if err := os.WriteFile(snapshotPath, []byte("original\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() snapshot error = %v", err)
+	}
+
+	// entry B: did not exist at snapshot time, under the workspace root —
+	// restore must remove it (mirrors the engram MCP config scenario from #2451).
+	createdPath := filepath.Join(workspace, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(createdPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(createdPath, []byte("written by the failed install\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	manifest := Manifest{
+		RootDir: filepath.Join(home, "backup"),
+		Entries: []ManifestEntry{
+			{OriginalPath: originalPath, SnapshotPath: snapshotPath, Existed: true, Mode: 0o600},
+			{OriginalPath: createdPath, Existed: false},
+		},
+	}
+
+	// Roots mirrors internal/cli's rollbackRoots(homeDir, workspaceDir): the
+	// scope root comes from the caller, never from manifest.RootDir.
+	service := RestoreService{Roots: []string{home, workspace}}
+	if err := service.Restore(manifest); err != nil {
+		t.Fatalf("Restore() error = %v, want no error for a workspace-scoped rollback", err)
+	}
+
+	restored, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("ReadFile() restored path error = %v", err)
+	}
+	if string(restored) != "original\n" {
+		t.Fatalf("restored content = %q, want %q", string(restored), "original\n")
+	}
+
+	if _, statErr := os.Stat(createdPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected workspace-scoped created path %q to be removed, stat err = %v", createdPath, statErr)
+	}
+}
+
+// TestRestoreScope_HomeRootUnchanged pins property 2: a home-scoped rollback
+// (Roots containing only the home directory, exactly what rollbackRoots
+// produces for a ScopeGlobal install) keeps restoring and removing exactly
+// as it did before Roots existed.
+func TestRestoreScope_HomeRootUnchanged(t *testing.T) {
+	home := t.TempDir()
+
+	origBackupRootFn := BackupRootFn
+	t.Cleanup(func() { BackupRootFn = origBackupRootFn })
+	BackupRootFn = func() (string, error) { return home, nil }
+
+	originalPath := filepath.Join(home, "config", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("modified\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	snapshotPath := filepath.Join(home, "backup", "files", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() snapshot error = %v", err)
+	}
+	if err := os.WriteFile(snapshotPath, []byte("original\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() snapshot error = %v", err)
+	}
+
+	manifest := Manifest{
+		Entries: []ManifestEntry{
+			{OriginalPath: originalPath, SnapshotPath: snapshotPath, Existed: true, Mode: 0o600},
+		},
+	}
+
+	service := RestoreService{Roots: []string{home}}
+	if err := service.Restore(manifest); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+
+	restored, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("ReadFile() restored path error = %v", err)
+	}
+	if string(restored) != "original\n" {
+		t.Fatalf("restored content = %q, want %q", string(restored), "original\n")
+	}
+}
+
+// TestRestoreScope_TraversalEscapingRootStillRefuses pins half of property 3:
+// an OriginalPath containing ".." segments that clean outside every allowed
+// root is refused, even though the raw string is textually prefixed by the
+// workspace root.
+func TestRestoreScope_TraversalEscapingRootStillRefuses(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	secret := filepath.Join(parent, "secret")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatalf("MkdirAll(secret) error = %v", err)
+	}
+
+	// Textually prefixed by workspace, but Clean resolves it into the sibling
+	// "secret" directory — outside every allowed root.
+	escapingPath := filepath.Join(workspace, "..", "secret", "payload.json")
+
+	manifest := Manifest{
+		Entries: []ManifestEntry{
+			{OriginalPath: escapingPath, Existed: false},
+		},
+	}
+
+	service := RestoreService{Roots: []string{workspace}}
+	err := service.Restore(manifest)
+	if err == nil {
+		t.Fatalf("Restore() expected error for a path traversing outside the allowed root")
+	}
+	if !strings.Contains(err.Error(), "invalid OriginalPath") {
+		t.Fatalf("Restore() error = %v, want an invalid OriginalPath refusal", err)
+	}
+}
+
+// TestRestoreScope_SymlinkEscapingRootStillRefuses pins the other half of
+// property 3: an OriginalPath that is textually under the allowed root but
+// resolves through a symlink to somewhere outside every allowed root is
+// refused — mirroring the existing symlink handling documented at the top
+// of restore.go for the single-root case.
+func TestRestoreScope_SymlinkEscapingRootStillRefuses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	workspace := t.TempDir()
+	outside := t.TempDir()
+
+	outsideFile := filepath.Join(outside, "secret.json")
+	if err := os.WriteFile(outsideFile, []byte("outside\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// workspace/link -> outside (escapes the allowed root via a symlink).
+	linkPath := filepath.Join(workspace, "link")
+	if err := os.Symlink(outside, linkPath); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	// Textually under workspace; resolves through the symlink to "outside".
+	escapingPath := filepath.Join(linkPath, "secret.json")
+
+	manifest := Manifest{
+		Entries: []ManifestEntry{
+			{OriginalPath: escapingPath, Existed: false},
+		},
+	}
+
+	service := RestoreService{Roots: []string{workspace}}
+	err := service.Restore(manifest)
+	if err == nil {
+		t.Fatalf("Restore() expected error for a path symlink-escaping the allowed root")
+	}
+	if !strings.Contains(err.Error(), "invalid OriginalPath") {
+		t.Fatalf("Restore() error = %v, want an invalid OriginalPath refusal", err)
+	}
+
+	// The real file outside the allowed root must be untouched.
+	content, readErr := os.ReadFile(outsideFile)
+	if readErr != nil {
+		t.Fatalf("ReadFile() outside file error = %v", readErr)
+	}
+	if string(content) != "outside\n" {
+		t.Fatalf("outside file was modified: %q", string(content))
+	}
+}
+
+// TestRestoreScope_RefusalNamesTheValidatedRoots pins property 4: the refusal
+// message names the root(s) actually validated against, so a user who hits
+// it can tell which boundary they crossed — both for a single implicit-home
+// root and for an explicit multi-root (home + workspace) rollback.
+func TestRestoreScope_RefusalNamesTheValidatedRoots(t *testing.T) {
+	t.Run("implicit home root", func(t *testing.T) {
+		home := t.TempDir()
+		origUserHomeDirFn := UserHomeDirFn
+		t.Cleanup(func() { UserHomeDirFn = origUserHomeDirFn })
+		UserHomeDirFn = func() (string, error) { return home, nil }
+
+		outsidePath := filepath.Join(t.TempDir(), "outside.json")
+		manifest := Manifest{Entries: []ManifestEntry{{OriginalPath: outsidePath, Existed: false}}}
+
+		err := RestoreService{}.Restore(manifest)
+		if err == nil {
+			t.Fatalf("Restore() expected error")
+		}
+		if !strings.Contains(err.Error(), home) {
+			t.Fatalf("Restore() error = %v, want it to name the validated home root %q", err, home)
+		}
+	})
+
+	t.Run("explicit home and workspace roots", func(t *testing.T) {
+		home := t.TempDir()
+		workspace := t.TempDir()
+		outsidePath := filepath.Join(t.TempDir(), "outside.json")
+		manifest := Manifest{Entries: []ManifestEntry{{OriginalPath: outsidePath, Existed: false}}}
+
+		err := RestoreService{Roots: []string{home, workspace}}.Restore(manifest)
+		if err == nil {
+			t.Fatalf("Restore() expected error")
+		}
+		if !strings.Contains(err.Error(), home) || !strings.Contains(err.Error(), workspace) {
+			t.Fatalf("Restore() error = %v, want it to name both validated roots %q and %q", err, home, workspace)
+		}
+	})
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -616,7 +616,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	apply := make([]pipeline.Step, 0, len(r.resolved.Agents)+len(r.selection.CommunityTools)+len(r.resolved.OrderedComponents)+1)
-	apply = append(apply, rollbackRestoreStep{id: "apply:rollback-restore", state: r.state})
+	apply = append(apply, rollbackRestoreStep{id: "apply:rollback-restore", state: r.state, homeDir: r.homeDir, workspaceDir: r.workspaceDir})
 
 	// Before installing components, ensure modular agents have their system prompt hub.
 	// This ensures that SDD or Engram can inject their modules even if Persona is skipped.
@@ -977,8 +977,10 @@ func (s prepareBackupStep) Run() error {
 }
 
 type rollbackRestoreStep struct {
-	id    string
-	state *runtimeState
+	id           string
+	state        *runtimeState
+	homeDir      string
+	workspaceDir string
 }
 
 func (s rollbackRestoreStep) ID() string {
@@ -995,7 +997,27 @@ func (s rollbackRestoreStep) Rollback() error {
 		return nil
 	}
 
-	return backup.RestoreService{}.Restore(s.state.manifest)
+	return backup.RestoreService{Roots: rollbackRoots(s.homeDir, s.workspaceDir)}.Restore(s.state.manifest)
+}
+
+// rollbackRoots returns the directories this install/sync run could
+// legitimately have written under, for validating rollback's manifest
+// entries against a caller-known root instead of anything the manifest
+// itself declares.
+//
+// homeDir is always included. workspaceDir is included too when set and
+// distinct from homeDir: componentInjectionDirScoped resolves most
+// component targets there under ScopeWorkspace, and OpenClaw resolves its
+// workspace independent of --scope entirely (resolveOpenClawWorkspaceDir).
+// Both values are exactly what backupTargets/syncBackupTargets used to
+// compute what this run actually snapshotted, so allowing rollback to
+// write within them is not wider than what this run could already do.
+func rollbackRoots(homeDir, workspaceDir string) []string {
+	roots := []string{homeDir}
+	if workspaceDir != "" && workspaceDir != homeDir {
+		roots = append(roots, workspaceDir)
+	}
+	return roots
 }
 
 type agentInstallStep struct {

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -634,6 +634,67 @@ func TestRunInstallLinuxRollsBackOnComponentFailure(t *testing.T) {
 	}
 }
 
+// TestRunInstallWorkspaceScopeRollback_SurfacesRealError reproduces issue #2451:
+// a workspace-scoped install (--scope workspace) legitimately writes files whose
+// OriginalPath resolves outside the user home directory. When the backup snapshot
+// captures such a path (Existed:false, since it does not exist yet) and a LATER
+// apply step fails, rollback fires and must restore/remove that workspace-scoped
+// entry — not refuse it and mask the real download failure with a validation
+// error claiming the path must be "under the user home directory".
+func TestRunInstallWorkspaceScopeRollback_SurfacesRealError(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Errorf("failed to restore working directory: %v", err)
+		}
+	})
+	cmdLookPath = missingBinaryLookPath
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(name string, args ...string) error { return nil }
+
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("failed to change working directory to temp workspace: %v", err)
+	}
+
+	// Fail the engram download AFTER the backup snapshot has already captured
+	// the not-yet-existing workspace-scoped engram MCP config path (Existed:false),
+	// so the pipeline's apply stage fails and rollback fires against that entry.
+	origDownloadFn := engramDownloadFn
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		return "", os.ErrPermission
+	}
+	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
+
+	detection := linuxDetectionResult(system.LinuxDistroUbuntu, "apt")
+	_, err = RunInstall(
+		[]string{"--scope", "workspace", "--agent", "opencode", "--component", "engram"},
+		detection,
+	)
+	if err == nil {
+		t.Fatalf("RunInstall() expected error")
+	}
+
+	if strings.Contains(err.Error(), "user home directory") {
+		t.Fatalf("rollback masked the real download error with a home-directory validation refusal: %v", err)
+	}
+	if !strings.Contains(err.Error(), "permission") {
+		t.Fatalf("RunInstall() error = %v, want it to surface the real download failure (os.ErrPermission)", err)
+	}
+}
+
 func TestRunInstallFedoraQwenEngramSkipsUnsupportedSetupAndWritesSettings(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -491,7 +491,7 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	apply := []pipeline.Step{
-		rollbackRestoreStep{id: "apply:rollback-restore", state: r.state},
+		rollbackRestoreStep{id: "apply:rollback-restore", state: r.state, homeDir: r.homeDir, workspaceDir: r.workspaceDir},
 	}
 
 	for _, component := range r.selection.Components {


### PR DESCRIPTION
Rollback refused workspace-scoped paths and its refusal replaced the real error, so the user lost both the diagnosis and the recovery. Full analysis in #2451.

## Why the obvious fix would have been wrong

The guard exists to stop a tampered manifest from writing arbitrary paths; its own comment says so. `Manifest` already carries a `RootDir`, which makes validating against it look like the natural fix. It is not. `RootDir` is the backup storage root rather than the install scope, and more importantly, letting the manifest declare the root it will be validated against is the vulnerability restated. A tampered manifest would simply declare a wider root and walk through.

So the root arrives from the caller, out of band from the data being checked.

## The change

`RestoreService` gains `Roots []string`. `isPathUnderHome` becomes `isPathUnderRoot` / `isPathUnderRoots`, keeping the identical Clean-prefix plus EvalSymlinks-if-exists logic, evaluated across roots. An empty or `.` root is rejected outright, so a caller that threads an empty string does not silently open everything.

**Empty `Roots` falls back to `UserHomeDirFn()`, exactly today's behavior.** Home-scoped installs are unchanged, and so is every caller that does not opt in.

`rollbackRestoreStep` threads `homeDir` and `workspaceDir` from the runtime. These are the same values `backupTargets` and `syncBackupTargets` already used to decide what got snapshotted, so permitting rollback within them is not wider than what the run itself already did.

## Two things found while fixing it

**A second construction site.** #2451 named three `.Restore()` call sites, but `sync.go:494` constructs the same shared step type as `run.go:619`. Missing it would have left sync passing empty-string roots. The issue's inventory undercounted, which is normal, and worth stating so the next reader does not trust it as complete.

**`resolveOpenClawWorkspaceDir` ignores `--scope` entirely.** A home-scoped install, the default, can therefore legitimately write outside home when OpenClaw is configured with a custom workspace. That means this defect was never limited to `--scope workspace`. `rollbackRoots()` includes `workspaceDir` whenever it is set and distinct, rather than gating on the scope value.

## What deliberately did not change

`app.go:579` (`tuiRestore`) and `cli/restore.go:232` (`defaultRestorer`) are the standalone "restore an old backup" flow. They stay on the home-only default because they have no live scope to consult: the workspace root in effect when an arbitrary old backup was made cannot be safely rediscovered, and persisting it in the manifest for later trust would reopen the hole this fix exists to keep closed. Stated rather than defaulted.

## Reachability

**Reachable on the current released binary.** The reproduction runs on a base containing none of #2450's changes and fails through a generic apply-stage failure unrelated to agent-runtime install. #2450 is how it was noticed, not what caused it.

## RED evidence

Compile-fail RED in the backup package, and behavioral RED in the CLI integration test carrying the exact masking message:

```
rollback masked the real download error with a home-directory validation refusal:
execute install pipeline: rollback step "apply:rollback-restore": manifest entry has
invalid OriginalPath "/tmp/.../001/.config/opencode/opencode.json": must be an
absolute path under the user home directory
```

## Properties pinned

A workspace-scoped rollback restores under the workspace root without erroring. A home-scoped rollback is unchanged. A path escaping its scope root still refuses, covering both `..` traversal and symlink escape. The refusal names the roots it actually validated against:

```
manifest entry has invalid OriginalPath %q: must be an absolute path under an allowed root (<root1>, <root2>...)
```

## Verification

Root `go test ./... -count=1` exit 0 across 63 packages, bench module ok, gofmt clean, vet clean, deadcode ratchet reports no new unreachable functions, refusal ratchet passes. Independently re-run uncached before this PR.

## Known limitation, unchanged

The non-existent-path branch still accepts a Clean-only check, because symlinks cannot be resolved for a path that does not exist. That limitation is structurally identical to before, but it now covers the union of two roots when a workspace root is in play. Not widened beyond what `backupTargets` already computed, and flagged because the same accepted weakness now spans more ground.

Closes #2451
