### PR TITLE
fix(review): reject unsupported gates before resolution

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2918,6 +2918,9 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 	if strings.TrimSpace(*gate) == "" {
 		return fmt.Errorf("review validate requires --gate: one of %s", strings.Join(reviewIntegrationGateNames(), ", "))
 	}
+	if !validReviewIntegrationGate(reviewtransaction.GateKind(*gate)) {
+		return reviewPreflightError(fmt.Errorf("review validate requires --gate: one of %s", strings.Join(reviewIntegrationGateNames(), ", ")))
+	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)

--- a/internal/cli/review_wave5_kill_switch_ordering_test.go
+++ b/internal/cli/review_wave5_kill_switch_ordering_test.go
@@ -17,10 +17,72 @@ package cli
 
 import (
 	"bytes"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
+
+func TestReviewValidateRejectsUnsupportedGateBeforeRepositoryAndModeResolution(t *testing.T) {
+	fixtures := []struct {
+		name string
+		cwd  func(*testing.T) string
+	}{
+		{
+			name: "repository discovery",
+			cwd: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing")
+			},
+		},
+		{
+			name: "disabled mode bypass with corrupt authority",
+			cwd:  killSwitchOrderingFixture,
+		},
+	}
+	forms := []struct {
+		name       string
+		negotiated bool
+	}{
+		{name: "plain"},
+		{name: "negotiated", negotiated: true},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			for _, form := range forms {
+				t.Run(form.name, func(t *testing.T) {
+					args := []string{"validate", "--cwd", fixture.cwd(t), "--gate", "unsupported"}
+					if form.negotiated {
+						args = append(args, "--contract", ReviewIntegrationContractV1)
+					}
+					var output bytes.Buffer
+					err := RunReview(args, &output)
+					if err == nil {
+						t.Fatalf("unsupported gate succeeded:\n%s", output.String())
+					}
+
+					reason := err.Error()
+					if form.negotiated {
+						failure := decodeReviewIntegrationFailure(t, output.Bytes())
+						if failure.Phase != "preflight" || failure.Code != reviewIntegrationInvalidRequestCode ||
+							failure.MutationOutcome != ReviewMutationNotStarted || failure.AuthorityApplicability != "not_evaluated" {
+							t.Fatalf("unsupported gate failure = %#v", failure)
+						}
+						reason = failure.Cause
+					} else if output.Len() != 0 {
+						t.Fatalf("plain unsupported gate emitted output before refusal: %q", output.String())
+					}
+					for _, gate := range reviewIntegrationGateNames() {
+						if !strings.Contains(reason, gate) {
+							t.Fatalf("unsupported gate refusal = %q, missing supported gate %q", reason, gate)
+						}
+					}
+				})
+			}
+		})
+	}
+}
 
 // killSwitchOrderingFixture builds a repo with a corrupted authority decoy
 // and returns it disabled, ready for a validate call at any gate.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2145

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Maintenance/tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Rejects unsupported lifecycle gate names before repository, mode, or authority resolution.
- Prevents malformed input from being misclassified as repository failure or disabled/unmanaged delivery.
- Preserves the current Wave 5 five-gate kill-switch contract unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Applies the canonical gate-vocabulary validator during preflight. |
| `internal/cli/review_wave5_kill_switch_ordering_test.go` | Adds plain and negotiated ordering coverage for missing repositories and disabled/corrupt authority. |

---

## 🧪 Test Plan

- [x] RED proved unsupported gates leaked repository errors and disabled/unmanaged output.
- [x] Focused regression: `go test ./internal/cli -run "^TestReviewValidateRejectsUnsupportedGateBeforeRepositoryAndModeResolution$" -count=1 -v`
- [x] CLI package: `go test ./internal/cli -count=1 -timeout 30m`
- [x] Go format: `go run ./internal/gofmtcheck`
- [x] Static analysis: `go vet ./...`
- [x] Benchmark module build, vet, and tests.
- [x] Docker E2E: Ubuntu, Arch, and Fedora each passed 79 tests with 2 opt-in skips.
- [x] Manual built-binary probes confirmed plain and negotiated `invalid_request` before repository resolution.
- [ ] Host root `go test ./...` is not green locally because unrelated suites depend on non-`/var` lock paths, host Git defaults, global review-mode state, and Bash associative arrays; relevant packages and Docker E2E are green, and CI remains authoritative.

---

## 🤖 Automated Checks

All repository CI checks are expected to run on this PR.

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #2145.
- [x] PR is 65 changed lines, below the 400-line budget.
- [x] Exactly one `type:*` label will be applied.
- [x] Relevant unit and regression tests pass.
- [x] Go format and vet pass.
- [x] Docker E2E passes on all three platforms.
- [x] Benchmark validation completed.
- [x] Documentation is not required for this input-validation correction.
- [x] Commit follows Conventional Commits.
- [x] Commit has no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

PR #2222 carries a broader early-kill-switch patch from an older architecture. Current main has already landed the Wave 4/5 kill-switch and structural-absence design; this PR isolates the one remaining current-main gap to two files and 65 lines.

The new guard admits exactly the existing five canonical lifecycle gates. Its legitimate population is every `review validate` request; malformed gate names are rejected before repository, mode, or authority state can influence classification. No guard-population baseline changes are needed because this is input vocabulary validation using the existing registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `review validate` now rejects unsupported gate values before attempting repository or mode resolution.
  * Error messages identify the supported gate options.
  * Negotiated validation responses now report consistent failure details for invalid gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->