### PR TITLE
fix(review): refuse direct start when it cannot produce a completable review

### DIFF
--- a/bench/axis_compatibility.go
+++ b/bench/axis_compatibility.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// This axis exists because of a NAMED blind spot (issue #2447): the core
+// corpus, and every axis added before this one, drive the NEGOTIATED review
+// lifecycle exclusively (`review status --next-transition` -> execute /
+// collect). The direct, manual, non-negotiated surfaces the project
+// explicitly KEPT for "explicit/manual non-negotiated callers" --
+// internal/assets/skills/_shared/review-ledger-contract.md: "Direct
+// `gentle-ai review start` remains compatibility-supported for
+// explicit/manual non-negotiated callers" -- were never in the corpus at
+// all. A direct `review start --base-ref ... --committed-only` could create a
+// lineage no reviewer lens could ever complete, and NOTHING in ~57 journeys
+// and 4 prior axes would have noticed, because none of them ever drove that
+// surface. This axis is the standing fix for that blind spot, not a one-off
+// regression test for #2447 alone: it is where the next compatibility-surface
+// gap belongs.
+//
+// Unlike damaged-store, this axis IS black-box: every journey drives the
+// product's own CLI only, exactly like the core corpus. It is opt-in anyway,
+// for the same reason real-world is: these are a different population
+// (direct/manual invocations) from the negotiated-only core, and "N core
+// journeys" must never silently grow to include them.
+func init() {
+	RegisterAxis(Axis{
+		Name:     compatibilityAxis,
+		Title:    "Non-negotiated, legacy-facing surfaces a real user (or a script, or an old integration) can still reach directly",
+		BlackBox: true,
+		Properties: []string{
+			"Black-box: every journey drives the product's own CLI only, exactly like the core corpus; nothing product-owned is read or written.",
+			"Opt-in anyway: the core and every prior axis measure the NEGOTIATED lifecycle exclusively. This axis measures the DIRECT/manual compatibility surfaces the execution contract explicitly keeps alongside it. \"N core journeys\" and \"N plus compatibility\" must never look alike, because the whole point of #2447 is that the two populations are not interchangeable.",
+			"cw01 pins the issue #2447 fix: a direct `review start --base-ref ... --committed-only` over a candidate large enough to select a reviewer lens now refuses before creating any lineage, naming the negotiated form. Before the fix (verified by running this exact journey against a pre-fix binary) it exited 0, created a lineage, and no reviewer lens could ever complete it -- the trap the issue reports. The journey also proves the refusal is idempotent (repeating the identical call produces byte-identical output), which is this benchmark's only black-box way to show nothing was persisted on the first attempt.",
+			"cw02 pins a sibling surface of the same shape: the hyphenated `review-start` (note: no space) v1-compatibility verb, registered in internal/app/app.go alongside `review start`. It has refused unconditionally since before this axis existed. It belongs here because an axis about direct/legacy start surfaces that omitted the one already-closed door would be an incomplete map of exactly the territory #2447 is about.",
+			"cw03 proves the surface #2447's fix deliberately leaves open still completes a review end to end: `review capture-result --cwd` (review-ledger-contract.md: \"Capture follows the native transition; opaque handles are cwd-independent and legacy bindings need --cwd\") drives a negotiated-started review through capture, finalize and a gate WITHOUT ever supplying --repository-context. This is the direct/manual capture path the execution contract still names as supported, and #2447's maintainer decision explicitly kept it: closing direct START does not close direct capture/finalize.",
+			"Surveyed from internal/app/app.go and excluded from this slice, with reasons: `review-resume`, `review-bundle-export`, `review-bundle-import`, and `review-validate` operate over authority the core corpus's ordinary lifecycle journeys already create and exercise through their own verbs -- they are not START-shaped, so they carry none of #2447's specific gap (a route that CREATES a lineage nothing can complete). `review-step` is structurally identical to cw02's already-closed shape (a permanent read-only refusal naming the compact verb) and would duplicate it rather than add coverage. The retired `--result` finalize flag no longer exists in the flag set at all (internal/cli/review_facade.go), so it is not a surface a caller can reach and is not a corpus member.",
+		},
+		Journeys: compatibilityJourneys,
+	})
+}
+
+const compatibilityAxis = "compatibility"
+
+// ---------------------------------------------------------------------------
+// cw01 -- direct base-diff start refuses instead of trapping (issue #2447)
+// ---------------------------------------------------------------------------
+
+// compatBaseDiffCandidate reproduces the issue #2447 repro shape: a base
+// commit, a feature branch, and a committed candidate on top -- exactly the
+// sequence `gentle-ai review start --base-ref <base-sha> --committed-only`
+// was reported against.
+func compatBaseDiffCandidate(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	base, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["compat-base"] = base
+	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "-b", "feature/change"); err != nil {
+		return err
+	}
+	content := "package feature\n\nfunc Compute(x int) int {\n\tif x > 10 {\n\t\treturn x * 2\n\t}\n\treturn x + 1\n}\n"
+	if err := sandbox.write(sandbox.Repo+"/feature.go", content); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "-A"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "commit", "-qm", "add a method")
+}
+
+func compatDirectBaseDiffStartArgs(sandbox *Sandbox) []string {
+	return []string{"review", "start", "--cwd", sandbox.Repo,
+		"--base-ref", sandbox.Scratch["compat-base"], "--committed-only=true"}
+}
+
+// compatDirectBaseDiffRefusesTwice is the counted step: it drives the direct
+// route once, asserts the refusal names a runnable `gentle-ai` continuation,
+// then drives the IDENTICAL call again and asserts byte-identical output.
+// A trap that had created a lineage on the first call would behave
+// differently on the second (resume, collision, or a different error), so
+// identical output across both calls is this black-box corpus's evidence
+// that nothing was persisted -- it cannot read the authority store directly
+// without giving up black-box status, which this axis declares it keeps.
+func compatDirectBaseDiffRefusesTwice(r *journeyRun) error {
+	args := compatDirectBaseDiffStartArgs(r.sandbox)
+	first := r.run(args, false)
+	if err := compatAssertNamedRefusal(first, "direct base-diff start with a real candidate"); err != nil {
+		return err
+	}
+	second := r.run(args, false)
+	if second.ExitCode != first.ExitCode || second.Stdout != first.Stdout || second.Stderr != first.Stderr {
+		return fmt.Errorf(
+			"repeating the identical refused start changed the result, which means the first attempt left something behind:\n"+
+				"first:  exit=%d stdout=%q stderr=%q\nsecond: exit=%d stdout=%q stderr=%q",
+			first.ExitCode, first.Stdout, first.Stderr, second.ExitCode, second.Stdout, second.Stderr)
+	}
+	return nil
+}
+
+// compatAssertNamedRefusal is the shared detector for cw01 and cw02: the
+// observation must be a genuine block (nonzero exit) whose emitted bytes
+// name a runnable `gentle-ai <verb> ...` continuation. It reuses the same
+// HasRunnableCommand detector the corpus's own Classify function uses, so a
+// journey's private assertion and the corpus's own in_band/out_of_band
+// bookkeeping can never silently disagree about the same bytes.
+func compatAssertNamedRefusal(observation Observation, what string) error {
+	if observation.ExitCode == 0 {
+		return fmt.Errorf("%s succeeded, want an up-front refusal: %s", what, observation.Stdout)
+	}
+	if !HasRunnableCommand(observation.Stdout + "\n" + observation.Stderr) {
+		return fmt.Errorf("%s refused but named no runnable `gentle-ai` continuation: stdout=%q stderr=%q",
+			what, observation.Stdout, observation.Stderr)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// cw02 -- the hyphenated `review-start` v1-compatibility verb always refuses
+// ---------------------------------------------------------------------------
+
+var compatHyphenatedStartCapability = &Capability{Verb: []string{"review-start"}, Flags: []string{"--cwd"}}
+
+func compatHyphenatedStartArgs(sandbox *Sandbox) ([]string, error) {
+	return []string{"review-start", "--cwd", sandbox.Repo,
+		"--lineage", "compat-legacy-v1", "--policy-file", "unused-compatibility-probe.md"}, nil
+}
+
+// compatAssertHyphenatedStartRefuses checks the one property that makes cw02
+// worth pinning: the refusal explicitly redirects to the real verb, `review
+// start` (with a space), not just to "gentle-ai" generically -- a caller who
+// typed the retired hyphenated form needs to land on the live one.
+func compatAssertHyphenatedStartRefuses(_ *Sandbox, observation Observation) error {
+	if err := compatAssertNamedRefusal(observation, "hyphenated `review-start` v1-compatibility verb"); err != nil {
+		return err
+	}
+	combined := observation.Stdout + "\n" + observation.Stderr
+	if !strings.Contains(combined, "gentle-ai review start") {
+		return fmt.Errorf("review-start refusal did not name `gentle-ai review start` (with a space): %q", combined)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// cw03 -- negotiated start, then the direct --cwd capture/finalize/gate path
+// ---------------------------------------------------------------------------
+
+// compatCaptureAllLensesDirectCwd is captureAllLenses's sibling: it drives
+// the same collect loop STATUS dictates, but captures with --cwd on every
+// round instead of the collect step's own --repository-context argument,
+// proving the "legacy bindings need --cwd" compatibility path the execution
+// contract names still completes a negotiated-started review end to end.
+func compatCaptureAllLensesDirectCwd(r *journeyRun) error {
+	for round := 0; round < 8; round++ {
+		envelope, err := readStatus(r)
+		if err != nil {
+			return err
+		}
+		if envelope.NextTransition.Kind != "collect" || len(envelope.NextTransition.Collect.Inputs) == 0 ||
+			envelope.NextTransition.Collect.Inputs[0].Name != "reviewer_result" {
+			return nil
+		}
+		result, err := synthesizeReviewerResult(
+			envelope.NextTransition.Collect.Inputs[0].ArtifactSubject.SubjectHash, envelope.paths())
+		if err != nil {
+			return err
+		}
+		path, err := writeScratch(r.sandbox, fmt.Sprintf("compat-reviewer-%d.json", round), result)
+		if err != nil {
+			return err
+		}
+		captured := r.run([]string{
+			"review", "capture-result", "--cwd", r.sandbox.Repo,
+			"--lineage", envelope.argument("lineage"),
+			"--target", envelope.argument("target"),
+			"--expected-revision", envelope.argument("expected-revision"),
+			"--lens", envelope.argument("lens"),
+			"--order", envelope.argument("order"),
+			"--input", path,
+		}, true)
+		if captured.ExitCode != 0 {
+			return fmt.Errorf("direct --cwd capture-result failed: %s", captured.Stderr)
+		}
+		if err := compatAssertNoRepositoryContext(r.sandbox, captured); err != nil {
+			return err
+		}
+	}
+	return errors.New("direct --cwd capture loop did not converge")
+}
+
+// compatAssertNoRepositoryContext fails the journey the moment a counted
+// invocation carries --repository-context: this journey exists specifically
+// to prove the --cwd form alone completes the review, and a fixture that
+// silently used the opaque-handle form instead would pass while proving
+// nothing about the surface it claims to measure.
+func compatAssertNoRepositoryContext(_ *Sandbox, observation Observation) error {
+	for _, arg := range observation.Args {
+		if arg == "--repository-context" || strings.HasPrefix(arg, "--repository-context=") {
+			return fmt.Errorf("capture used --repository-context (args %v); this journey must complete on --cwd alone", observation.Args)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Corpus
+// ---------------------------------------------------------------------------
+
+func compatibilityJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "cw01-direct-start-refuses-uncompletable-base-diff",
+			Title:  "Direct `review start --base-ref ... --committed-only` over a real candidate refuses up front and names the negotiated exit",
+			Source: "issue #2447: the direct route created a lineage no reviewer lens could ever capture a result against, because its own response type never carries repository_context and the negotiated facade never rediscovers a lineage it did not create",
+			Steps: []Step{
+				{Name: "fixture: base commit, feature branch, committed candidate", Fixture: compatBaseDiffCandidate},
+				{Name: "direct base-diff start refuses twice, identically, naming the negotiated form", Requires: startCapability,
+					Composite: compatDirectBaseDiffRefusesTwice},
+			},
+		},
+		{
+			ID:     "cw02-hyphenated-review-start-always-refuses",
+			Title:  "The hyphenated `review-start` v1-compatibility verb refuses unconditionally and names `gentle-ai review start`",
+			Source: "internal/cli/review.go RunReviewStart: \"Read-only legacy v1 compatibility command. New authority is created with gentle-ai review start.\"",
+			Steps: []Step{
+				{Name: "fixture: base repo", Fixture: baseRepo},
+				{Name: "hyphenated review-start always refuses", Requires: compatHyphenatedStartCapability,
+					Args: compatHyphenatedStartArgs, After: compatAssertHyphenatedStartRefuses, AbortOnBlock: true},
+			},
+		},
+		{
+			ID:     "cw03-negotiated-start-then-direct-cwd-capture-completes",
+			Title:  "A negotiated-started review completes end to end through the direct --cwd capture/finalize path, never touching a repository-context handle",
+			Source: "review-ledger-contract.md: \"Capture follows the native transition; opaque handles are cwd-independent and legacy bindings need --cwd\" -- the surface issue #2447's fix deliberately leaves open for direct/manual callers",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "fixture: stage auth code", Fixture: stageAuthCode},
+				{Name: "negotiated review start, run verbatim from next-transition", Requires: statusCapability,
+					Composite: executeNextTransitionVerbatim},
+				{Name: "capture every lens directly via --cwd, never --repository-context", Requires: captureResultCapability,
+					Composite: compatCaptureAllLensesDirectCwd},
+				{Name: "finalize with captured results, direct --cwd", Requires: finalizeResultsCapability,
+					Args: productArgs("review", "finalize", "--captured-results=true"), After: compatAssertNoRepositoryContext},
+				// captureFinalEvidence (journeys.go) already drives `review
+				// capture-evidence --cwd ...` -- no --repository-context --
+				// so it is reused verbatim rather than duplicated here.
+				{Name: "capture final evidence directly via --cwd", Requires: captureEvidenceCapability, Composite: captureFinalEvidence},
+				{Name: "finalize with captured evidence, direct --cwd", Requires: finalizeEvidenceCapability,
+					Args: productArgs("review", "finalize", "--captured-evidence=true"), After: compatAssertNoRepositoryContext},
+				{Name: "gate pre-commit", Requires: validateCapability, Args: productArgs("review", "validate", "--gate", "pre-commit")},
+			},
+		},
+	}
+}

--- a/bench/axis_compatibility_test.go
+++ b/bench/axis_compatibility_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file belongs to the compatibility axis and is deleted with it:
+// `rm bench/axis_compatibility*.go` removes the axis whole, and the core
+// corpus still builds, tests and reports exactly as it did.
+//
+// A driven run proves most of this axis for itself against a real binary
+// (see the commit that added this axis for the before/after evidence: cw01
+// fails against a pre-#2447-fix binary and passes against a fixed one). What
+// a `go test` run can pin, cheaply and on every change, is the axis's own
+// declarations and the half of each detector that never fires on a healthy
+// build -- exactly the axis_real_world_test.go idiom.
+
+func TestCompatibilityAxisDeclaresItselfAndItsJourneys(t *testing.T) {
+	found := false
+	for _, axis := range Axes() {
+		if axis.Name != compatibilityAxis {
+			continue
+		}
+		found = true
+		if !axis.BlackBox {
+			t.Fatal("the compatibility axis drives the product's CLI only; declaring it not black-box would surrender the portability it actually has")
+		}
+		if len(axis.Properties) == 0 {
+			t.Fatal("the compatibility axis declares no properties")
+		}
+		journeys := axis.Journeys()
+		if len(journeys) == 0 {
+			t.Fatal("the compatibility axis contributes no journeys")
+		}
+		for _, journey := range journeys {
+			if !strings.HasPrefix(journey.ID, "cw") {
+				t.Fatalf("axis journey %q does not carry the axis id prefix, so a reader cannot tell it from a core journey at a glance", journey.ID)
+			}
+			if len(journey.Steps) == 0 {
+				t.Fatalf("journey %q has no steps", journey.ID)
+			}
+		}
+		want := map[string]bool{
+			"cw01-direct-start-refuses-uncompletable-base-diff":       true,
+			"cw02-hyphenated-review-start-always-refuses":             true,
+			"cw03-negotiated-start-then-direct-cwd-capture-completes": true,
+		}
+		for _, journey := range journeys {
+			delete(want, journey.ID)
+		}
+		if len(want) != 0 {
+			t.Fatalf("expected compatibility journeys not found: %v", want)
+		}
+	}
+	if !found {
+		t.Fatal("the compatibility axis is not registered")
+	}
+}
+
+// compatAssertNamedRefusal is cw01 and cw02's shared detector. A pass on a
+// genuine refusal (nonzero exit, runnable continuation) means nothing unless
+// the detector demonstrably fires on the two ways a refusal can go wrong:
+// exiting 0 (no refusal at all), and refusing with nothing runnable in the
+// message (a dead end).
+func TestCompatAssertNamedRefusalFiresOnSuccessAndOnDeadEnd(t *testing.T) {
+	if err := compatAssertNamedRefusal(Observation{ExitCode: 1, Stdout: "Error: cannot proceed; rerun with `gentle-ai review start --contract x`"}, "test"); err != nil {
+		t.Fatalf("the detector rejected a genuine named refusal: %v", err)
+	}
+	if err := compatAssertNamedRefusal(Observation{ExitCode: 0, Stdout: `{"action":"created"}`}, "test"); err == nil {
+		t.Fatal("a successful (exit 0) start was accepted as a refusal; cw01/cw02 would pass while measuring nothing")
+	}
+	if err := compatAssertNamedRefusal(Observation{ExitCode: 1, Stderr: "Error: cannot proceed"}, "test"); err == nil {
+		t.Fatal("a refusal naming no runnable command was accepted; cw01/cw02 would pass on a dead end")
+	}
+}
+
+// compatAssertHyphenatedStartRefuses adds one more requirement on top of
+// compatAssertNamedRefusal: the refusal must specifically name `gentle-ai
+// review start` (with a space), not just any command.
+func TestCompatAssertHyphenatedStartRefusesRequiresTheSpacedVerb(t *testing.T) {
+	ok := Observation{ExitCode: 1, Stderr: "legacy v1 review lineage is read-only: use gentle-ai review start"}
+	if err := compatAssertHyphenatedStartRefuses(nil, ok); err != nil {
+		t.Fatalf("rejected a refusal that names gentle-ai review start: %v", err)
+	}
+	wrongVerb := Observation{ExitCode: 1, Stderr: "refused; rerun `gentle-ai review status --next-transition`"}
+	if err := compatAssertHyphenatedStartRefuses(nil, wrongVerb); err == nil {
+		t.Fatal("accepted a refusal that names a DIFFERENT gentle-ai command, not `review start`; cw02 would pass without proving the redirect it claims")
+	}
+}
+
+// compatAssertNoRepositoryContext is cw03's whole point: it must fail the
+// moment --repository-context appears among the counted invocation's
+// arguments, on either spelling (space or =).
+func TestCompatAssertNoRepositoryContextFiresOnEitherSpelling(t *testing.T) {
+	if err := compatAssertNoRepositoryContext(nil, Observation{Args: []string{"review", "capture-result", "--cwd", "/repo"}}); err != nil {
+		t.Fatalf("the detector fired on a clean --cwd invocation: %v", err)
+	}
+	if err := compatAssertNoRepositoryContext(nil, Observation{Args: []string{"review", "capture-result", "--repository-context", "rctx1_x"}}); err == nil {
+		t.Fatal("--repository-context (space form) was used and the detector did not fire; cw03 would pass while measuring the opaque-handle path it claims not to use")
+	}
+	if err := compatAssertNoRepositoryContext(nil, Observation{Args: []string{"review", "capture-result", "--repository-context=rctx1_x"}}); err == nil {
+		t.Fatal("--repository-context= (equals form) was used and the detector did not fire; cw03 would pass while measuring the opaque-handle path it claims not to use")
+	}
+}

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -1202,8 +1202,33 @@ func waveOneJourneys() []Journey {
 			Steps: []Step{
 				{Name: "fixture: linked worktree and remote", Fixture: linkedWorktreeWithRemote},
 				{Name: "fixture: commit base-diff candidate", Fixture: commitStagedRecoveryCandidate},
-				{Name: "start workspace-projected base-diff review", Requires: startNamedCapability, Args: func(s *Sandbox) ([]string, error) {
-					return append([]string{"review", "start", "--lineage", stagedRecoveryLineage, "--base-ref", s.Scratch["staged-recovery-base"], "--committed-only"}, "--cwd", s.Repo), nil
+				// Issue #2447: a direct (non-negotiated) `review start` over a
+				// base-diff candidate that selects a lens now refuses up
+				// front, so this step goes through the negotiated form
+				// instead. `--lineage` on `review status` pins the exact
+				// derived lineage name into the printed execute transition,
+				// so stagedRecoveryLineage still names the review every
+				// later step in this journey references.
+				{Name: "start workspace-projected base-diff review", Requires: statusCapability, Composite: func(r *journeyRun) error {
+					envelope, err := readStatusFor(r, "--lineage", stagedRecoveryLineage, "--base-ref", r.sandbox.Scratch["staged-recovery-base"])
+					if err != nil {
+						return err
+					}
+					if envelope.NextTransition.Kind != "execute" {
+						return fmt.Errorf("expected an execute review.start transition for the staged recovery base-diff candidate, got %q", envelope.NextTransition.Kind)
+					}
+					args := []string{"review", "start", "--cwd", r.sandbox.Repo}
+					for _, argument := range envelope.NextTransition.Execute.Arguments {
+						if argument.Token == "" {
+							return fmt.Errorf("execute argument %q carried no runnable token", argument.Name)
+						}
+						args = append(args, argument.Token)
+					}
+					started := r.run(args, false)
+					if started.ExitCode != 0 {
+						return fmt.Errorf("negotiated staged base-diff start failed: exit=%d stderr=%s", started.ExitCode, started.Stderr)
+					}
+					return nil
 				}},
 				{Name: "capture blocker on predecessor", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
 					return captureCorrectableFindingFor(r, stagedPredecessorSelectors(r.sandbox)...)

--- a/internal/cli/review_disabled_delivery_test.go
+++ b/internal/cli/review_disabled_delivery_test.go
@@ -719,11 +719,16 @@ func TestReviewValidateStaleAndPluralStaleReceiptsFailClosedWhileEnabled(t *test
 // candidate: start with the given extra arguments, submit one clean result per
 // selected lens, and finalize to a terminal receipt.
 //
-// Uses runLegacyFacadeStartForTest (Wave 7 S7/WU18), not RunReviewFacadeStart
+// Uses runLegacyFacadeStartForTest (Wave 7 S7a/WU18a), not RunReviewFacadeStart
 // directly: every caller of this helper needs genuine legacy (compact-v2)
 // authority (proven by pervasive reviewtransaction.CompactAuthoritativeStore/
-// CompactAuthorityLeaves follow-up reads across its 6 call sites), which the
-// CLI's own `review start` can no longer create now that v3 is unconditional.
+// CompactAuthorityLeaves follow-up reads across its call sites). It also
+// sidesteps issue #2447's direct-route refusal for base-diff/workspace-overlay
+// candidates large enough to select a lens: this helper is SETUP for behavior
+// unrelated to that refusal (delivery gates), so bypassing
+// RunReviewFacadeStart's CLI dispatch entirely, the same pattern every other
+// legacy fixture in this codebase now uses, is the right tool rather than
+// routing SETUP through the negotiated contract.
 func finalizeFacadeReviewForRepo(t *testing.T, repo string, startExtra ...string) {
 	t.Helper()
 	var output bytes.Buffer

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -142,9 +142,12 @@ const ReviewStartConsentDeclinedThisCandidate = "declined_this_candidate"
 // and the fix is to name the base to compare against, not to redo the work.
 const reviewStartEmptyCandidateHint = "the candidate has no pending changes; already-committed work can be reviewed by rerunning review start with --base-ref <commit> naming the base to compare against"
 
-// reviewStartNegotiateContractHint makes the negotiated contract path
-// discoverable from the plain START response.
-func reviewStartNegotiateContractHint(snapshot reviewtransaction.Snapshot) string {
+// reviewNegotiatedStartCommand builds the exact negotiated `review start`
+// invocation for a frozen snapshot. It is the single source of the runnable
+// continuation the direct route names when it refuses (issue #2447): every
+// direct-route refusal must name a command that actually runs, so the
+// command shape lives here once instead of being reconstructed per call site.
+func reviewNegotiatedStartCommand(snapshot reviewtransaction.Snapshot) string {
 	command := fmt.Sprintf("gentle-ai review start --contract %s --agent %s --target %s --projection %s",
 		ReviewIntegrationContractV2, model.AgentClaudeCode, snapshot.Identity, facadeProjection(snapshot.Projection))
 	switch snapshot.Kind {
@@ -153,7 +156,7 @@ func reviewStartNegotiateContractHint(snapshot reviewtransaction.Snapshot) strin
 	case reviewtransaction.TargetBaseWorkspaceOverlay:
 		command += " --base-ref " + snapshot.BaseTree + " --workspace-overlay"
 	}
-	return "this response's selected lenses require the frozen Git trees, changed-path manifest, and artifact subjects, which only the negotiated contract form returns; rerun with `" + command + "` to receive them"
+	return command
 }
 
 // ReviewFacadeLensBinding pairs one selected lens with its frozen zero-based
@@ -1552,6 +1555,27 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	if err != nil {
 		return err
 	}
+	// Issue #2447. The direct route's own response type
+	// (ReviewFacadeStartResult) never carries repository_context -- only the
+	// negotiated ReviewIntegrationStartResult does -- so no reviewer lens can
+	// ever capture a result against a lineage this call would create, and
+	// the negotiated facade does not rediscover a lineage the direct route
+	// created. Refusing here, before the candidate is frozen into any
+	// lineage, authority, tier freeze, or budget, leaves nothing behind to
+	// strand. The maintainer decision recorded on #2447 made this the
+	// permanent shape of the direct route, not a stopgap: carrying
+	// repository_context on this path was considered and cancelled.
+	// Lineages the direct route created before this fix landed are a
+	// separate, still-open recovery/visibility gap tracked on #2447 and
+	// rdd-single-lifecycle-cutover; this refusal only stops new ones. The
+	// error below names the exact runnable negotiated continuation, so the
+	// refusal-resolution ratchet resolves it by naming, needing no by-design
+	// annotation.
+	if !negotiated && target.Kind != reviewtransaction.TargetCurrentChanges && len(lenses) > 0 {
+		return reviewPreflightRefusal(reviewPreflightDirectRouteUncompletableReason,
+			fmt.Errorf("review start without --contract cannot produce a completable review because its %d selected lens(es) require repository_context, which only the negotiated contract form publishes; rerun with `gentle-ai review start %s` instead",
+				len(lenses), strings.TrimPrefix(reviewNegotiatedStartCommand(snapshot), "gentle-ai review start ")))
+	}
 	// The candidate is frozen and the tier is classified, so this is the one
 	// point where the kill switch can stop a start and consent can name the real
 	// reason. Nothing has been persisted yet, so refusing here leaves no
@@ -1679,7 +1703,8 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		case legacyResult.ChangedFiles == 0 && target.Kind == reviewtransaction.TargetCurrentChanges:
 			legacyResult.Hint = reviewStartEmptyCandidateHint
 		case legacyResult.LensesRequired:
-			legacyResult.Hint = reviewStartNegotiateContractHint(snapshot)
+			legacyResult.Hint = "this response's selected lenses require the frozen Git trees, changed-path manifest, and artifact subjects, which only the negotiated contract form returns; rerun with `" +
+				reviewNegotiatedStartCommand(snapshot) + "` to receive them"
 		}
 		// Negotiated envelope, new in Wave 7 S7a (WU18a): runReviewFacadeStartNewLineage
 		// never had negotiated-form support before this (it was called
@@ -1833,11 +1858,22 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		// reporting a different frozen authority keeps the previous shape.
 		if authority.InitialSnapshot.Identity == snapshot.Identity {
 			legacyResult.RiskEvidence = reviewConsentRiskEvidence(assessment)
+			// A base-diff direct start that would select lenses now refuses
+			// up front (issue #2447), before this point ever runs, so
+			// LensesRequired only reads true here for a workspace-mode
+			// candidate -- the one shape issue #2447 left untouched, since a
+			// bare `review status --next-transition` rediscovers it from the
+			// live workspace with no extra flags. It still completes through
+			// the direct route, so it keeps the informational hint pointing
+			// at the negotiated form for callers who want the frozen Git
+			// trees, changed-path manifest, and artifact subjects a plain
+			// response cannot carry.
 			switch {
 			case legacyResult.ChangedFiles == 0 && target.Kind == reviewtransaction.TargetCurrentChanges:
 				legacyResult.Hint = reviewStartEmptyCandidateHint
 			case legacyResult.LensesRequired:
-				legacyResult.Hint = reviewStartNegotiateContractHint(authority.InitialSnapshot)
+				legacyResult.Hint = "this response's selected lenses require the frozen Git trees, changed-path manifest, and artifact subjects, which only the negotiated contract form returns; rerun with `" +
+					reviewNegotiatedStartCommand(authority.InitialSnapshot) + "` to receive them"
 			}
 		}
 		return encodeReviewJSON(stdout, legacyResult)

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -373,6 +373,11 @@ func TestReviewFacadeStartSupportsCommittedBaseDiff(t *testing.T) {
 	runReviewCLIGit(t, repo, "add", "tracked.txt")
 	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
 
+	// The committed candidate selects a lens, so a direct base-diff start
+	// through the CLI now hits issue #2447's up-front refusal (see
+	// runReviewFacadeStart). This is SETUP for the pre-PR gate behavior under
+	// test, not the refusal itself, so it constructs legacy authority directly
+	// via runLegacyFacadeStartForTest instead of going through that dispatch.
 	var output bytes.Buffer
 	if err := runLegacyFacadeStartForTest(t, []string{"--cwd", repo, "--base-ref", base}, &output); err != nil {
 		t.Fatal(err)
@@ -443,6 +448,14 @@ func TestReviewFacadeStartRequiresCommittedOnlyAndReusesEquivalentAuthority(t *t
 		t.Fatalf("rejected start persisted authority = %v, %v", stores, err)
 	}
 
+	// The candidate selects a lens (LensesRequired is asserted true below), and
+	// a direct start over --base-ref for a lens-selecting candidate now hits
+	// issue #2447's up-front refusal in production (see runReviewFacadeStart).
+	// This helper is SETUP for the resume/reuse authority behavior under test
+	// (the underlying reviewtransaction.StartCompactAuthority state machine),
+	// not the refusal itself, so it constructs legacy authority directly via
+	// runLegacyFacadeStartForTest, bypassing the CLI dispatch the refusal lives
+	// in entirely.
 	start := func(args ...string) ReviewFacadeStartResult {
 		t.Helper()
 		var output bytes.Buffer
@@ -481,6 +494,9 @@ func TestReviewFacadeStartRequiresCommittedOnlyAndReusesEquivalentAuthority(t *t
 	if err := os.WriteFile(policy, []byte("different policy\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	// The candidate still selects a lens up front (the blocked-scope-action
+	// downgrade to zero lenses is decided downstream of the refusal check);
+	// same bypass rationale as above.
 	var blockedOutput bytes.Buffer
 	if err := runLegacyFacadeStartForTest(t, []string{"--cwd", repo, "--base-ref", base, "--committed-only", "--policy", policy}, &blockedOutput); err != nil {
 		t.Fatal(err)
@@ -1798,6 +1814,9 @@ func TestReviewRecoverRetainsCommittedOnlyBaseDiffAndIgnoresWorkspace(t *testing
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("ignored workspace\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// This is SETUP for the "recover" behavior under test, not the start
+	// refusal itself; the committed candidate selects a lens, so a direct
+	// base-diff start now hits issue #2447's up-front refusal.
 	var output bytes.Buffer
 	if err := runLegacyFacadeStartForTest(t, []string{"--cwd", repo, "--base-ref", baseRef, "--committed-only"}, &output); err != nil {
 		t.Fatal(err)

--- a/internal/cli/review_finalize_preflight_test.go
+++ b/internal/cli/review_finalize_preflight_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -292,14 +293,54 @@ func TestReviewFinalizeBindsCorrectedRetrySuccessorToLiveFixDiff(t *testing.T) {
 
 func startFinalizeLiveTarget(t *testing.T, repo, lineage string, extra ...string) (ReviewFacadeStartResult, reviewtransaction.CompactStore, []string) {
 	t.Helper()
-	args := []string{"--cwd", repo, "--lineage", lineage}
-	args = append(args, extra...)
-	var output bytes.Buffer
-	if err := RunReviewFacadeStart(args, &output); err != nil {
-		t.Fatal(err)
+	isBaseDiff := false
+	for _, item := range extra {
+		if item == "--base-ref" || item == "--workspace-overlay" ||
+			strings.HasPrefix(item, "--base-ref=") || strings.HasPrefix(item, "--workspace-overlay=") {
+			isBaseDiff = true
+			break
+		}
 	}
+	var output bytes.Buffer
 	var started ReviewFacadeStartResult
-	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	if isBaseDiff {
+		// A base-diff/workspace-overlay candidate large enough to select a
+		// lens now refuses a direct start up front (issue #2447); this
+		// helper is SETUP for the finalize behavior under test, so it starts
+		// through the negotiated contract instead. boundNegotiatedStartArgs
+		// derives its own --committed-only from --base-ref, so drop any copy
+		// already present to avoid a duplicate flag.
+		filtered := make([]string, 0, len(extra))
+		for _, item := range extra {
+			if item == "--committed-only" || strings.HasPrefix(item, "--committed-only=") {
+				continue
+			}
+			filtered = append(filtered, item)
+		}
+		startArgs := boundNegotiatedStartArgs(t, append([]string{
+			"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", lineage,
+		}, filtered...))
+		if err := RunReview(startArgs, &output); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		args := []string{"--cwd", repo, "--lineage", lineage}
+		args = append(args, extra...)
+		if err := RunReviewFacadeStart(args, &output); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if isBaseDiff {
+		// The negotiated envelope carries additional fields (schema, contract,
+		// repository_context, ...) that ReviewFacadeStartResult does not
+		// declare, so a strict decode here would fault on plumbing, not on
+		// anything this helper's callers actually assert.
+		if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		decodeStrictReviewJSON(t, output.Bytes(), &started)
+	}
 	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/review_integration_contract_guard_test.go
+++ b/internal/cli/review_integration_contract_guard_test.go
@@ -420,7 +420,15 @@ func TestReviewIntegrationNonVacuousModeClassificationsAreEvidenced(t *testing.T
 		file     string
 		evidence string
 	}{
-		{fn: "runReviewFacadeStart", file: "review_facade.go", evidence: "reviewStartNegotiateContractHint"},
+		// Issue #2447 replaced the named reviewStartNegotiateContractHint
+		// constant with an up-front refusal for base-diff/workspace-overlay
+		// candidates that select lenses (see runReviewFacadeStart's refusal
+		// at reviewPreflightDirectRouteUncompletableReason). The additive
+		// Hint field survives for the one shape #2447 left untouched --
+		// workspace-mode candidates whose selected lenses still need the
+		// negotiated form's repository_context -- so the evidence now points
+		// at that call site instead of the removed constant.
+		{fn: "runReviewFacadeStart", file: "review_facade.go", evidence: "reviewNegotiatedStartCommand(authority.InitialSnapshot)"},
 		{fn: "runReviewFacadeFinalize", file: "review_facade.go", evidence: "reviewContractRequiredForActionEligibilityReason"},
 	}
 	for _, testCase := range cases {

--- a/internal/cli/review_legacy_start_test_helper_test.go
+++ b/internal/cli/review_legacy_start_test_helper_test.go
@@ -148,7 +148,8 @@ func runLegacyFacadeStartForTest(t *testing.T, args []string, stdout io.Writer) 
 		case result.ChangedFiles == 0 && target.Kind == reviewtransaction.TargetCurrentChanges:
 			result.Hint = reviewStartEmptyCandidateHint
 		case result.LensesRequired:
-			result.Hint = reviewStartNegotiateContractHint(started.Record.State.InitialSnapshot)
+			result.Hint = "this response's selected lenses require the frozen Git trees, changed-path manifest, and artifact subjects, which only the negotiated contract form returns; rerun with `" +
+				reviewNegotiatedStartCommand(started.Record.State.InitialSnapshot) + "` to receive them"
 		}
 	}
 	return encodeReviewJSON(stdout, result)

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -227,6 +227,19 @@ var reviewPreflightUntrackedScopeReason = reviewPreflightReason{
 	NextAction: "stop",
 }
 
+// reviewPreflightDirectRouteUncompletableReason classifies a direct
+// (non-negotiated) `review start` that would select at least one lens.
+// Issue #2447: the direct route's own response type cannot carry
+// repository_context, so no reviewer lens can ever capture a result against
+// a lineage it creates, and the negotiated facade does not rediscover a
+// lineage the direct route created. The named next action is the negotiated
+// review.start form; the exact runnable command travels in the cause.
+var reviewPreflightDirectRouteUncompletableReason = reviewPreflightReason{
+	Code:       "direct_start_uncompletable",
+	Message:    "The direct (non-negotiated) review start route cannot host a completable review: no reviewer lens can capture a result against the lineage it would create. Rerun with the negotiated contract form.",
+	NextAction: "review.start",
+}
+
 // reviewPreflightMissingInputsReason names the contract-level inputs a caller
 // must supply. Callers pass only inputs the published required_inputs enum
 // actually defines; a refusal whose missing inputs are not all expressible

--- a/internal/cli/review_recovery_target_kind_test.go
+++ b/internal/cli/review_recovery_target_kind_test.go
@@ -119,8 +119,14 @@ func TestReviewRecoverBaseDiffPredecessorStillBindsFrozenBaseTree(t *testing.T) 
 	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
 	runReviewCLIGit(t, repo, "commit", "-m", "candidate")
 
+	// This is SETUP for the "recover" behavior under test, not the start
+	// refusal itself; the committed candidate selects a lens, so a direct
+	// base-diff start now hits issue #2447's up-front refusal.
 	var output bytes.Buffer
-	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", firstBase, "--committed-only"}, &output); err != nil {
+	startArgs := boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--base-ref", firstBase,
+	})
+	if err := RunReview(startArgs, &output); err != nil {
 		t.Fatal(err)
 	}
 	var started ReviewFacadeStartResult

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -86,12 +86,22 @@ func TestStatusRecoverTransitionExecutesExactBaseDiffSelectors(t *testing.T) {
 	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
 	runReviewCLIGit(t, repo, "add", "candidate.go")
 	runReviewCLIGit(t, repo, "commit", "-qm", "add candidate")
+	// This is SETUP for the RECOVER selector-transition behavior under test,
+	// not the start refusal itself; the committed candidate selects a lens,
+	// so a direct base-diff start now hits issue #2447's up-front refusal.
+	// The negotiated envelope carries extra fields ReviewFacadeStartResult
+	// does not declare, so a plain (non-strict) decode is used here.
 	var output bytes.Buffer
-	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-recover", "--base-ref", base, "--committed-only"}, &output); err != nil {
+	startArgs := boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", "selector-recover", "--base-ref", base,
+	})
+	if err := RunReview(startArgs, &output); err != nil {
 		t.Fatal(err)
 	}
 	var started ReviewFacadeStartResult
-	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
 	result := filepath.Join(t.TempDir(), "blocking.json")
 	writeReviewCLIJSON(t, result, facadeReviewerResult{Lens: started.SelectedLenses[0], Findings: []facadeFinding{{
 		Location: "candidate.go:3", Severity: "CRITICAL", Claim: "candidate requires a helper",
@@ -333,15 +343,23 @@ func TestStatusRecoverTransitionExecutesCorrectionRequiredStagedScopeExpansion(t
 	runReviewCLIGit(t, repo, "add", "candidate.go")
 	runReviewCLIGit(t, repo, "commit", "-qm", "add reviewed candidate")
 
+	// This is SETUP for the RECOVER selector-transition behavior under test,
+	// not the start refusal itself; the committed candidate selects a lens,
+	// so a direct base-diff start now hits issue #2447's up-front refusal.
+	// The negotiated envelope carries extra fields ReviewFacadeStartResult
+	// does not declare, so a plain (non-strict) decode is used here.
 	const predecessorLineage = "correction-staged-root"
 	var startedOut bytes.Buffer
-	if err := RunReviewFacadeStart([]string{
-		"--cwd", repo, "--lineage", predecessorLineage, "--base-ref", base, "--committed-only",
-	}, &startedOut); err != nil {
+	startArgs := boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", predecessorLineage, "--base-ref", base,
+	})
+	if err := RunReview(startArgs, &startedOut); err != nil {
 		t.Fatal(err)
 	}
 	var started ReviewFacadeStartResult
-	decodeStrictReviewJSON(t, startedOut.Bytes(), &started)
+	if err := json.Unmarshal(startedOut.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
 	if len(started.SelectedLenses) == 0 {
 		t.Fatal("base-diff fixture selected no reviewer lenses")
 	}
@@ -578,8 +596,14 @@ func TestStatusStopsUnchangedBaseDiffRecoveryWithoutSuccessor(t *testing.T) {
 	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n", 0o644)
 	runReviewCLIGit(t, repo, "add", "candidate.go")
 	runReviewCLIGit(t, repo, "commit", "-qm", "add candidate")
+	// This is SETUP for the STATUS/recover stop behavior under test, not the
+	// start refusal itself; the committed candidate selects a lens, so a
+	// direct base-diff start now hits issue #2447's up-front refusal.
 	var output bytes.Buffer
-	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-unchanged", "--base-ref", base, "--committed-only"}, &output); err != nil {
+	startArgs := boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", "selector-unchanged", "--base-ref", base,
+	})
+	if err := RunReview(startArgs, &output); err != nil {
 		t.Fatal(err)
 	}
 	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "selector-unchanged")

--- a/internal/cli/review_start_contract_test.go
+++ b/internal/cli/review_start_contract_test.go
@@ -393,6 +393,11 @@ func approvedWorkspaceOverlayRecoveryPredecessor(t *testing.T, lineage string) (
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("overlay\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// A workspace-overlay candidate large enough to select a lens now refuses
+	// a direct start up front through the CLI (issue #2447); this helper is
+	// SETUP for the recover behavior its callers test, so it constructs legacy
+	// authority directly via runLegacyFacadeStartForTest instead of going
+	// through that dispatch.
 	if err := runLegacyFacadeStartForTest(t, []string{"--cwd", repo, "--base-ref", base, "--workspace-overlay", "--lineage", lineage}, io.Discard); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/review_start_direct_route_refusal_test.go
+++ b/internal/cli/review_start_direct_route_refusal_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestReviewFacadeStartDirectRouteRefusesUncompletableReview reproduces the
+// exact sequence from issue #2447 (reported by @danizafa on 2.2.4): a direct
+// (non-negotiated) `review start --base-ref <base> --committed-only=true`
+// used to create a lineage no reviewer lens could ever capture against,
+// because the direct route's own response type (ReviewFacadeStartResult)
+// never carries repository_context and the negotiated facade never
+// rediscovers a lineage it did not create. The maintainer decision recorded
+// on #2447 made refusal the permanent destination for the direct route, not
+// a stopgap: it must refuse before anything is persisted, naming the
+// negotiated form as the exit.
+func TestReviewFacadeStartDirectRouteRefusesUncompletableReview(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	runReviewCLIGit(t, repo, "checkout", "-qb", "feature/change")
+	changeFile := filepath.Join(repo, "change.go")
+	if err := os.WriteFile(changeFile, []byte("package main\n\nfunc doSomething(x int) int {\n\tif x > 10 {\n\t\treturn x * 2\n\t}\n\treturn x + 1\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "change.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add a method")
+
+	var output bytes.Buffer
+	err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base, "--committed-only=true"}, &output)
+	if err == nil {
+		t.Fatalf("direct route start with lenses required succeeded = %s, want an up-front refusal", output.String())
+	}
+	if !strings.Contains(err.Error(), "gentle-ai review start --contract") {
+		t.Fatalf("refusal error = %v, want it to name the exact negotiated review start continuation", err)
+	}
+	if !strings.Contains(err.Error(), "--base-ref") || !strings.Contains(err.Error(), "--committed-only") {
+		t.Fatalf("refusal error = %v, want it to carry the base-diff continuation flags", err)
+	}
+
+	stores, storesErr := reviewtransaction.CompactAuthorityLeaves(context.Background(), repo)
+	if storesErr != nil {
+		t.Fatal(storesErr)
+	}
+	if len(stores) != 0 {
+		t.Fatalf("refused direct start persisted authority = %v, want none created", stores)
+	}
+}

--- a/internal/cli/review_start_evidence_test.go
+++ b/internal/cli/review_start_evidence_test.go
@@ -315,6 +315,20 @@ func TestReviewFacadeStartLensesRequiredHintsNegotiatedContract(t *testing.T) {
 	}
 }
 
+// TestReviewFacadeStartBaseDiffHintReplaysFrozenSelector proves the hint-replay
+// contract for a base-diff START that ALREADY has legacy (compact-v2)
+// authority: replaying the hint's named negotiated command resolves into the
+// SAME frozen lineage rather than creating a second one, and a stale replay
+// (after the candidate moved) is refused with nothing new persisted. This is
+// the "replay this hint verbatim" workflow the Wave 7 v2-collision start
+// guard (runReviewFacadeStart) explicitly carves an exact-content exception
+// for. Since issue #2447 (see the sibling
+// TestReviewFacadeStartBaseDiffRefusalReplaysFrozenSelector below), a direct
+// CLI START can no longer create this authority itself for a lens-selecting
+// base-diff candidate, so this test constructs it directly via
+// runLegacyFacadeStartForTest and starts the replay from an authority that
+// already exists -- the complementary starting condition to the sibling test,
+// which starts with none.
 func TestReviewFacadeStartBaseDiffHintReplaysFrozenSelector(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "dependency.go"), []byte("package dependency\n"), 0o644); err != nil {
@@ -388,5 +402,87 @@ func TestReviewFacadeStartBaseDiffHintReplaysFrozenSelector(t *testing.T) {
 	stores, err = reviewtransaction.DiscoverCompactStores(context.Background(), repo)
 	if err != nil || len(stores) != 1 {
 		t.Fatalf("stale hint created authority: stores=%d error=%v", len(stores), err)
+	}
+}
+
+// TestReviewFacadeStartBaseDiffRefusalReplaysFrozenSelector is the
+// complementary starting condition to
+// TestReviewFacadeStartBaseDiffHintReplaysFrozenSelector above: no legacy
+// authority exists yet, because issue #2447 made a direct (non-negotiated)
+// base-diff START whose candidate selects lenses refuse up front, before
+// anything is persisted (see runReviewFacadeStart), naming the exact
+// negotiated `review start` continuation. This test proves that refusal's
+// named continuation resolves the mutable `feature-base` ref into its
+// immutable tree BEFORE anything is created, that running it verbatim
+// creates exactly one fresh negotiated authority, and that a stale replay
+// (after the candidate moved) is refused with nothing persisted, exactly
+// like any other negotiated START would be.
+func TestReviewFacadeStartBaseDiffRefusalReplaysFrozenSelector(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "dependency.go"), []byte("package dependency\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "dependency.go")
+	runReviewCLIGit(t, repo, "commit", "-m", "feature dependency")
+	runReviewCLIGit(t, repo, "branch", "feature-base")
+	if err := os.WriteFile(filepath.Join(repo, "service-token.ts"), []byte("export const token = 'candidate'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "service-token.ts")
+	runReviewCLIGit(t, repo, "commit", "-m", "feature candidate")
+	baseTree := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "feature-base^{tree}"))
+
+	var refusedFirst bytes.Buffer
+	err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", "feature-base", "--committed-only"}, &refusedFirst)
+	if err == nil {
+		t.Fatalf("direct base-diff start with lenses required succeeded = %s, want an up-front refusal", refusedFirst.String())
+	}
+	if stores, storesErr := reviewtransaction.DiscoverCompactStores(context.Background(), repo); storesErr != nil || len(stores) != 0 {
+		t.Fatalf("refused direct start persisted authority: stores=%d error=%v", len(stores), storesErr)
+	}
+	if !strings.Contains(err.Error(), "--base-ref "+baseTree+" --committed-only") || strings.Contains(err.Error(), "--base-ref feature-base") {
+		t.Fatalf("refusal did not name the immutable resolved selector: %v", err)
+	}
+
+	opening := strings.IndexByte(err.Error(), '`')
+	closing := strings.IndexByte(err.Error()[opening+1:], '`')
+	if opening < 0 || closing < 0 {
+		t.Fatalf("refusal has no executable command: %v", err)
+	}
+	command := strings.Fields(err.Error()[opening+1 : opening+1+closing])
+	if len(command) < 3 || !reflect.DeepEqual(command[:3], []string{"gentle-ai", "review", "start"}) {
+		t.Fatalf("refusal command = %v", command)
+	}
+	args := append([]string{"start", "--cwd", repo}, command[3:]...)
+	var replay bytes.Buffer
+	if err := RunReview(args, &replay); err != nil {
+		t.Fatalf("named negotiated START failed: %v\n%s", err, replay.String())
+	}
+	var negotiated ReviewIntegrationStartResult
+	decodeStrictReviewJSON(t, replay.Bytes(), &negotiated)
+	if negotiated.RepositoryContext == nil {
+		t.Fatalf("named negotiated START carried no repository_context: %#v", negotiated)
+	}
+	stores, err := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if err != nil || len(stores) != 1 {
+		t.Fatalf("named negotiated START authorities = %d, %v; want exactly one", len(stores), err)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "service-token.ts"), []byte("export const token = 'mutated'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "service-token.ts")
+	runReviewCLIGit(t, repo, "commit", "-m", "mutate candidate")
+	var refused bytes.Buffer
+	if err := RunReview(args, &refused); err == nil {
+		t.Fatalf("stale named START succeeded: %s", refused.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, refused.Bytes())
+	if failure.Code != reviewPreflightStaleTargetCode {
+		t.Fatalf("mutated named START code = %q, want %q", failure.Code, reviewPreflightStaleTargetCode)
+	}
+	stores, err = reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if err != nil || len(stores) != 1 {
+		t.Fatalf("stale replay created authority: stores=%d error=%v", len(stores), err)
 	}
 }


### PR DESCRIPTION
`review start` on the direct (non-negotiated) route could create a lineage that no later step could ever complete, because only the negotiated contract form publishes `repository_context`, which the selected lenses require. The user reached a dead end holding state that looked valid.

The refusal is the permanent destination, not a stopgap. Teaching the direct route to carry `repository_context` was considered and cancelled: gentle-ai is an organic tool, and nobody should be typing review commands by hand. Full reasoning in #2447.

## The condition

`!negotiated && target.Kind != TargetCurrentChanges && len(lenses) > 0`

Placed before anything is persisted. Plain workspace-mode direct starts are unaffected.

The trap mechanism is worth stating, because it is what makes the old behavior a dead end rather than an inconvenience: a bare `review status --next-transition`, with no re-supplied `--base-ref`, never rediscovers a base-diff legacy lineage. Once created, it could not be found again from the documented recovery path.

## Executed evidence

Direct call, refused before persisting anything:

```
Error: review start without --contract cannot produce a completable review because its 1 selected
lens(es) require repository_context, which only the negotiated contract form publishes; rerun with
`gentle-ai review start --contract gentle-ai.review-integration/v2 --agent claude-code --target
sha256:ff744756... --projection workspace --base-ref 619289f1... --committed-only` instead
exit=1
```

The named continuation runs clean and returns `action: created` with a `repository_context` handle. Nothing was persisted by the refused call.

## Interaction with Wave 7's collision guards

`02ff50ea` (#2436) added start-time legacy-collision guards to the same surface. Both can fire on the same call, so the relationship was analyzed rather than assumed.

They are orthogonal. Wave 7's guards fire on an existing v1 chain or a v2 record with a different candidate identity for the same lineage id, independent of route, target, or lenses, and only under the activation switch. This guard fires on routing capability. Neither makes the other's production logic unreachable.

This guard sits earlier, so it fires first, and that ordering is correct: a routing problem blocks any resolution attempt regardless of collision state, so surfacing it first sends the caller somewhere they can actually act. If a collision is also real, the negotiated retry then meets Wave 7's guard and is told to recover. Two-step discovery of two independent problems.

One redundancy did surface, at the fixture level. This branch had added a negotiated-form workaround to roughly seven pure-setup call sites; `02ff50ea` established `runLegacyFacadeStartForTest` as the intended bypass for exactly that need across forty-plus sites. The tracker's pattern was adopted and the workaround dropped where it was purely setup, kept where it is genuinely exercised.

The one genuine semantic fork was `review_start_evidence_test.go`. This branch had renamed and rewritten a test to prove refuse-then-create-fresh; the tracker kept the original proving hint-replay into existing authority, which is the exact-content-replay contract Wave 7's own v2 guard depends on. **Both functions are kept**, under distinct names with cross-referencing comments. They assert complementary starting conditions, and choosing either one would have deleted real coverage.

## Compatibility axis

Three journeys covering the non-negotiated surfaces, enumerated from `internal/app/app.go` and the ledger contract rather than guessed:

- **cw01** drives the direct start over a real base-diff candidate, asserts the refusal names a runnable continuation, and repeats the identical call to prove idempotence, which is this black-box corpus's only way to show nothing was persisted.
- **cw02** covers the hyphenated v1 `review-start`, which already refuses permanently. Included so the axis does not map the territory with a hole in it.
- **cw03** completes a negotiated review end to end using `--cwd` only, never `--repository-context`.

Exclusions are recorded in the axis `Properties` with reasons rather than left silent: `review-resume`, bundle export/import and `review-validate` are not START-shaped and are already covered by core lifecycle journeys; `review-step` is structurally identical to cw02; the retired `--result` finalize flag no longer exists in the flag set.

Pre-fix binary: cw01 fails with "direct base-diff start with a real candidate succeeded, want an up-front refusal". Fixed binary: all three complete. Full corpus after the rebase: 62 of 62 journeys completed, zero failed.

## Verification after the rebase

The original evidence was captured before the rebase and does not carry over, so all of it was re-executed against a binary built from the rebased tree. Root `go test ./... -count=1` passes on every package, bench module passes, gofmt and vet clean on both modules, deadcode ratchet reports no new unreachable functions, refusal ratchet passes. Wave 7's own guard tests (`TestReviewFacadeStartRefusesOverExistingV1Authority`, `...V2AuthorityAndNamesRecover`) pass, confirming no Wave 7 behavior regressed.

## Out of scope

Recognizing lineages the direct route created before this landed is a separate gap, deferred in #2447 and noted in the code.

Closes #2447
