### PR TITLE
fix(tui): preserve cursor position when navigating back (Esc and Back options)

### DIFF
--- a/internal/tui/cursor_memory_test.go
+++ b/internal/tui/cursor_memory_test.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/tui/screens"
 )
@@ -148,6 +149,80 @@ func TestBackOptionRestoresCursorAcrossScreens(t *testing.T) {
 				t.Errorf("cursor not restored: got %d, want %d", m.Cursor, tt.saved)
 			}
 		})
+	}
+}
+
+func TestPickerAdvanceRemembersSourceCursor(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentClaudeCode, model.AgentKiroIDE}
+	m.Selection.Components = []model.ComponentID{model.ComponentSDD}
+	m.Screen = ScreenClaudeModelPicker
+	m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+	m.Cursor = 1 // "Performance" preset row
+
+	// Enter on a named preset advances to the next picker in the chain,
+	// bypassing confirmSelection.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if m.Screen != ScreenKiroModelPicker {
+		t.Fatalf("expected ScreenKiroModelPicker, got %v", m.Screen)
+	}
+
+	// Esc walks back to the Claude picker and must restore the source row.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.Screen != ScreenClaudeModelPicker {
+		t.Fatalf("expected ScreenClaudeModelPicker, got %v", m.Screen)
+	}
+	if m.Cursor != 1 {
+		t.Errorf("cursor not restored after picker advance: got %d, want 1", m.Cursor)
+	}
+}
+
+func TestNoProviderBackRestoresSDDModeCursor(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenModelPicker // zero AvailableIDs → "Continue with defaults" / "Back"
+	m.Cursor = 1                 // "Back"
+	m.CursorMemory[ScreenSDDMode] = 1
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.Screen != ScreenSDDMode {
+		t.Fatalf("expected ScreenSDDMode, got %v", m.Screen)
+	}
+	if m.Cursor != 1 {
+		t.Errorf("cursor not restored on no-provider Back: got %d, want 1", m.Cursor)
+	}
+}
+
+func TestDeleteBackupCancelKeepsRestoredRowVisible(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenBackups
+	count := screens.BackupMaxVisible + 5
+	m.Backups = make([]backup.Manifest, count)
+	for i := range m.Backups {
+		m.Backups[i] = backup.Manifest{ID: string(rune('a' + i))}
+	}
+	m.Cursor = count - 3 // row beyond the first visible window
+	m.BackupScroll = m.Cursor - screens.BackupMaxVisible + 1
+
+	// "d" opens the delete confirmation; Cancel returns to the list.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(Model)
+	m.Cursor = 1 // Cancel
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.Screen != ScreenBackups {
+		t.Fatalf("expected ScreenBackups, got %v", m.Screen)
+	}
+	if m.Cursor != count-3 {
+		t.Fatalf("cursor not restored: got %d, want %d", m.Cursor, count-3)
+	}
+	if m.Cursor < m.BackupScroll || m.Cursor >= m.BackupScroll+screens.BackupMaxVisible {
+		t.Errorf("restored row %d is outside the visible window [%d, %d)",
+			m.Cursor, m.BackupScroll, m.BackupScroll+screens.BackupMaxVisible)
 	}
 }
 

--- a/internal/tui/cursor_memory_test.go
+++ b/internal/tui/cursor_memory_test.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+func TestEscRestoreCursorPosition(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   Screen
+		cursor int
+	}{
+		{name: "welcome remembers selection after esc", from: ScreenWelcome, cursor: 2},
+		{name: "model config remembers selection after esc", from: ScreenModelConfig, cursor: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen = tt.from
+			m.Cursor = tt.cursor
+
+			// forward: Enter opens the child screen
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			m = updated.(Model)
+			if m.Screen == tt.from {
+				t.Fatalf("expected Enter to leave %v", tt.from)
+			}
+
+			// back: Esc returns to the parent screen
+			updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = updated.(Model)
+
+			if m.Screen != tt.from {
+				t.Fatalf("expected to return to %v, got %v", tt.from, m.Screen)
+			}
+			if m.Cursor != tt.cursor {
+				t.Errorf("cursor not restored: got %d, want %d", m.Cursor, tt.cursor)
+			}
+		})
+	}
+}

--- a/internal/tui/cursor_memory_test.go
+++ b/internal/tui/cursor_memory_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/tui/screens"
 )
 
 func TestEscRestoreCursorPosition(t *testing.T) {
@@ -40,5 +42,137 @@ func TestEscRestoreCursorPosition(t *testing.T) {
 				t.Errorf("cursor not restored: got %d, want %d", m.Cursor, tt.cursor)
 			}
 		})
+	}
+}
+
+func TestBackMenuOptionRestoresCursorPosition(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenModelConfig
+	m.Cursor = 2 // "Configure Kiro models"
+	// Position the user had on Welcome before entering Model Config.
+	m.CursorMemory[ScreenWelcome] = 3
+
+	// Enter into Kiro picker, saving the position on Model Config.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	// Return to Model Config via Esc, then select its "Back" option.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	m.Cursor = 4 // "Back"
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.Screen != ScreenWelcome {
+		t.Fatalf("expected ScreenWelcome, got %v", m.Screen)
+	}
+	if m.Cursor != 3 {
+		t.Errorf("cursor not restored on Back option: got %d, want 3", m.Cursor)
+	}
+}
+
+func TestBackOptionRestoresCursorAcrossScreens(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(m *Model)
+		want  Screen
+		saved int
+	}{
+		{
+			name:  "detection back returns to welcome position",
+			setup: func(m *Model) { m.Screen = ScreenDetection; m.Cursor = 1 },
+			want:  ScreenWelcome,
+			saved: 1,
+		},
+		{
+			name: "agent builder engine back returns to welcome position",
+			setup: func(m *Model) {
+				m.Screen = ScreenAgentBuilderEngine
+				m.AgentBuilder.AvailableEngines = nil
+				m.Cursor = 0
+			},
+			want:  ScreenWelcome,
+			saved: 1,
+		},
+		{
+			name: "backups back returns to welcome position",
+			setup: func(m *Model) {
+				m.Screen = ScreenBackups
+				m.Backups = nil
+				m.Cursor = 0 // with no backups, the only row is "Back"
+			},
+			want:  ScreenWelcome,
+			saved: 1,
+		},
+		{
+			name: "agent builder sdd phase back returns to sdd menu position",
+			setup: func(m *Model) {
+				m.Screen = ScreenAgentBuilderSDDPhase
+				m.Cursor = len(screens.ABSDDPhases())
+			},
+			want:  ScreenAgentBuilderSDD,
+			saved: 1,
+		},
+		{
+			name: "uninstall agents back returns to uninstall mode position",
+			setup: func(m *Model) {
+				m.Screen = ScreenUninstall
+				m.Cursor = len(screens.UninstallAgentOptions()) + 1
+			},
+			want:  ScreenUninstallMode,
+			saved: 1,
+		},
+		{
+			name: "persona back returns to agents position",
+			setup: func(m *Model) {
+				m.Screen = ScreenPersona
+				m.Cursor = len(screens.PersonaOptions())
+			},
+			want:  ScreenAgents,
+			saved: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			tt.setup(&m)
+			m.CursorMemory[tt.want] = tt.saved
+
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			m = updated.(Model)
+
+			if m.Screen != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, m.Screen)
+			}
+			if m.Cursor != tt.saved {
+				t.Errorf("cursor not restored: got %d, want %d", m.Cursor, tt.saved)
+			}
+		})
+	}
+}
+
+func TestDeleteBackupCancelRestoresCursorPosition(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenBackups
+	m.Backups = []backup.Manifest{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+	m.Cursor = 2 // third backup row
+
+	// "d" opens the delete confirmation, remembering the row.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(Model)
+	if m.Screen != ScreenDeleteConfirm {
+		t.Fatalf("expected ScreenDeleteConfirm, got %v", m.Screen)
+	}
+
+	// "Cancel" returns to the backup list on the same row.
+	m.Cursor = 1 // Cancel
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.Screen != ScreenBackups {
+		t.Fatalf("expected ScreenBackups, got %v", m.Screen)
+	}
+	if m.Cursor != 2 {
+		t.Errorf("cursor not restored after cancel: got %d, want 2", m.Cursor)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1303,6 +1303,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m = m.withResetSyncState()
 					m.setScreen(ScreenSync)
 				} else if next, ok := m.pickerNextScreen(); ok {
+					m.rememberCursor()
 					return m, m.advanceToNextPickerScreen(next)
 				}
 			}
@@ -1328,6 +1329,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m = m.withResetSyncState()
 					m.setScreen(ScreenSync)
 				} else if next, ok := m.pickerNextScreen(); ok {
+					m.rememberCursor()
 					return m, m.advanceToNextPickerScreen(next)
 				}
 			}
@@ -1393,6 +1395,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m = m.withResetSyncState()
 					m.setScreen(ScreenSync)
 				} else if next, ok := m.pickerNextScreen(); ok {
+					m.rememberCursor()
 					return m, m.advanceToNextPickerScreen(next)
 				}
 			}
@@ -2176,6 +2179,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			}
 			if m.Cursor == 1 {
 				m.applyPickerEntry(ScreenSDDMode)
+				m.restoreCursorMemory()
 				return m, nil
 			}
 			// Continue with OpenCode defaults when no providers are available yet.
@@ -3488,6 +3492,17 @@ func (m *Model) restoreCursorMemory() {
 		saved = count - 1
 	}
 	m.Cursor = saved
+	// Backups is currently the only m.Cursor screen with a scroll window, so
+	// its scroll sync lives inline here for simplicity. If another scrolled
+	// screen needs this, replace it with a centralized per-screen post-restore
+	// hook instead of adding more cases.
+	if m.Screen == ScreenBackups {
+		if m.Cursor < m.BackupScroll {
+			m.BackupScroll = m.Cursor
+		} else if m.Cursor >= m.BackupScroll+screens.BackupMaxVisible {
+			m.BackupScroll = m.Cursor - screens.BackupMaxVisible + 1
+		}
+	}
 }
 
 func (m *Model) returnToScreen(next Screen) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -420,6 +420,7 @@ type Model struct {
 	Width          int
 	Height         int
 	Cursor         int
+	CursorMemory   map[Screen]int
 	Version        string
 	SpinnerFrame   int
 
@@ -674,6 +675,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		UninstallAgents:      agents,
 		UninstallComponents:  defaultUninstallComponents(),
 		UninstallEngramScope: model.EngramUninstallScopeGlobal,
+		CursorMemory:         make(map[Screen]int),
 		Progress: NewProgressState([]string{
 			"Install dependencies",
 			"Configure selected agents",
@@ -1528,6 +1530,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		var cmd tea.Cmd
 		m = m.goBack(&cmd)
+		m.restoreCursorMemory()
 		return m, cmd
 	case " ":
 		switch m.Screen {
@@ -1637,6 +1640,10 @@ func (m Model) isModelPickerSeparatorCursor() bool {
 }
 
 func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
+	if m.CursorMemory == nil {
+		m.CursorMemory = make(map[Screen]int)
+	}
+	m.CursorMemory[m.Screen] = m.Cursor
 	switch m.Screen {
 	case ScreenWelcome:
 		switch m.Cursor {
@@ -3457,6 +3464,17 @@ func (m *Model) setScreen(next Screen) {
 		m.UninstallProfileSelection = false
 		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
 	}
+}
+
+func (m *Model) restoreCursorMemory() {
+	saved, ok := m.CursorMemory[m.Screen]
+	if !ok {
+		return
+	}
+	if count := m.optionCount(); count > 0 && saved >= count {
+		saved = count - 1
+	}
+	m.Cursor = saved
 }
 
 // handleRenameInput processes key events when the rename backup screen is active.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1561,6 +1561,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		// Rename: only when on ScreenBackups and cursor is on a backup item (not "Back").
 		if m.Screen == ScreenBackups && m.Cursor < len(m.Backups) {
+			m.rememberCursor()
 			m.SelectedBackup = m.Backups[m.Cursor]
 			m.BackupRenameText = m.SelectedBackup.Description
 			m.BackupRenamePos = len([]rune(m.SelectedBackup.Description))
@@ -1570,6 +1571,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "n":
 		// "n" on ScreenProfiles: shortcut for "Create new profile".
 		if m.Screen == ScreenProfiles {
+			m.rememberCursor()
 			m.ProfileEditMode = false
 			m.ProfileDraft = model.Profile{}
 			m.ProfileCreateStep = 0
@@ -1583,12 +1585,14 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		// Delete: only when on ScreenBackups and cursor is on a backup item (not "Back").
 		if m.Screen == ScreenBackups && m.Cursor < len(m.Backups) {
+			m.rememberCursor()
 			m.SelectedBackup = m.Backups[m.Cursor]
 			m.setScreen(ScreenDeleteConfirm)
 			return m, nil
 		}
 		// Delete on ScreenProfiles: only non-default profiles (those in ProfileList).
 		if m.Screen == ScreenProfiles && m.Cursor < len(m.ProfileList) {
+			m.rememberCursor()
 			m.ProfileDeleteErr = nil
 			m.ProfileDeleteTarget = m.ProfileList[m.Cursor].Name
 			m.setScreen(ScreenProfileDelete)
@@ -1640,10 +1644,7 @@ func (m Model) isModelPickerSeparatorCursor() bool {
 }
 
 func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
-	if m.CursorMemory == nil {
-		m.CursorMemory = make(map[Screen]int)
-	}
-	m.CursorMemory[m.Screen] = m.Cursor
+	m.rememberCursor()
 	switch m.Screen {
 	case ScreenWelcome:
 		switch m.Cursor {
@@ -1785,7 +1786,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				}
 			}
 		case m.Cursor == len(options):
-			m.setScreen(ScreenWelcome)
+			m.returnToScreen(ScreenWelcome)
 		}
 		return m, nil
 	case ScreenUninstall:
@@ -1796,7 +1797,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		case m.Cursor == agentCount && len(m.UninstallAgents) > 0:
 			m.setScreen(ScreenUninstallComponents)
 		case m.Cursor == agentCount+1:
-			m.setScreen(ScreenUninstallMode)
+			m.returnToScreen(ScreenUninstallMode)
 		}
 		return m, nil
 	case ScreenUninstallComponents:
@@ -1815,7 +1816,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				m.setScreen(ScreenUninstallConfirm)
 			}
 		case m.Cursor == componentCount+1:
-			m.setScreen(ScreenUninstall)
+			m.returnToScreen(ScreenUninstall)
 		}
 		return m, nil
 	case ScreenUninstallProfiles:
@@ -1835,9 +1836,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenUninstallConfirm)
 		case m.Cursor == continueIdx+1:
 			if m.UninstallMode == model.UninstallModePartial {
-				m.setScreen(ScreenUninstallComponents)
+				m.returnToScreen(ScreenUninstallComponents)
 			} else {
-				m.setScreen(ScreenUninstallMode)
+				m.returnToScreen(ScreenUninstallMode)
 			}
 		}
 		return m, nil
@@ -1854,13 +1855,13 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// - partial: go back to components selection
 		// - full/full-remove: go back to uninstall mode selection
 		if m.UninstallProfileSelection {
-			m.setScreen(ScreenUninstallProfiles)
+			m.returnToScreen(ScreenUninstallProfiles)
 		} else {
 			switch m.UninstallMode {
 			case model.UninstallModePartial:
-				m.setScreen(ScreenUninstallComponents)
+				m.returnToScreen(ScreenUninstallComponents)
 			default:
-				m.setScreen(ScreenUninstallMode)
+				m.returnToScreen(ScreenUninstallMode)
 			}
 		}
 		return m, nil
@@ -1972,7 +1973,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenProfileCreate)
 		default:
 			// "Back"
-			m.setScreen(ScreenWelcome)
+			m.returnToScreen(ScreenWelcome)
 		}
 		return m, nil
 	case ScreenProfileCreate:
@@ -1983,7 +1984,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			if err := removeProfileAgentsFn(opencode.DefaultSettingsPath(), m.ProfileDeleteTarget); err != nil {
 				// Store the error so it can be displayed on ScreenProfiles.
 				m.ProfileDeleteErr = err
-				m.setScreen(ScreenProfiles)
+				m.returnToScreen(ScreenProfiles)
 			} else {
 				m.ProfileDeleteErr = nil
 				m.PendingSyncOverrides = nil
@@ -1994,7 +1995,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				return m, tea.Batch(tickCmd(), m.startSync(nil))
 			}
 		default: // "Cancel"
-			m.setScreen(ScreenProfiles)
+			m.returnToScreen(ScreenProfiles)
 		}
 		return m, nil
 	case ScreenModelConfig:
@@ -2031,7 +2032,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
 			m.setScreen(ScreenCodexModelPicker)
 		case 4: // Back
-			m.setScreen(ScreenWelcome)
+			m.returnToScreen(ScreenWelcome)
 		}
 		return m, nil
 	case ScreenDetection:
@@ -2039,7 +2040,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenAgents)
 			return m, nil
 		}
-		m.setScreen(ScreenWelcome)
+		m.returnToScreen(ScreenWelcome)
 	case ScreenAgents:
 		agentCount := len(screens.AgentOptions())
 		switch {
@@ -2054,7 +2055,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			}
 			m.setScreen(ScreenPersona)
 		case m.Cursor == agentCount+1:
-			m.setScreen(ScreenDetection)
+			m.returnToScreen(ScreenDetection)
 		}
 	case ScreenPersona:
 		options := screens.PersonaOptions()
@@ -2067,7 +2068,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenPreset)
 			return m, nil
 		}
-		m.setScreen(ScreenAgents)
+		m.returnToScreen(ScreenAgents)
 	case ScreenPreset:
 		options := screens.PresetOptions()
 		if m.Cursor < len(options) {
@@ -2098,18 +2099,19 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenDependencyTree)
 			return m, nil
 		}
-		m.setScreen(ScreenPersona)
+		m.returnToScreen(ScreenPersona)
 	case ScreenClaudeModelPicker:
 		if !m.ClaudeModelPicker.InCustomMode && m.Cursor == screens.ClaudeModelPickerOptionCount(m.ClaudeModelPicker)-1 {
 			// "Back" option: in ModelConfigMode return to the config menu,
 			// otherwise use pickerPreviousScreen for unified reverse navigation.
 			if m.ModelConfigMode {
 				m.ModelConfigMode = false
-				m.setScreen(ScreenModelConfig)
+				m.returnToScreen(ScreenModelConfig)
 				return m, nil
 			}
 			if prev, ok := m.pickerPreviousScreen(); ok {
 				m.applyPickerEntry(prev)
+				m.restoreCursorMemory()
 			}
 			return m, nil
 		}
@@ -2117,11 +2119,12 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		if !m.KiroModelPicker.InCustomMode && m.Cursor == screens.KiroModelPickerOptionCount(m.KiroModelPicker)-1 {
 			if m.ModelConfigMode {
 				m.ModelConfigMode = false
-				m.setScreen(ScreenModelConfig)
+				m.returnToScreen(ScreenModelConfig)
 				return m, nil
 			}
 			if prev, ok := m.pickerPreviousScreen(); ok {
 				m.applyPickerEntry(prev)
+				m.restoreCursorMemory()
 			}
 			return m, nil
 		}
@@ -2129,11 +2132,12 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		if m.CodexModelPicker.CustomMode == screens.CodexCustomModeNone && m.Cursor == screens.CodexModelPickerOptionCount(m.CodexModelPicker)-1 {
 			if m.ModelConfigMode {
 				m.ModelConfigMode = false
-				m.setScreen(ScreenModelConfig)
+				m.returnToScreen(ScreenModelConfig)
 				return m, nil
 			}
 			if prev, ok := m.pickerPreviousScreen(); ok {
 				m.applyPickerEntry(prev)
+				m.restoreCursorMemory()
 			}
 			return m, nil
 		}
@@ -2159,6 +2163,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Back — use pickerPreviousScreen for unified reverse navigation.
 		if prev, ok := m.pickerPreviousScreen(); ok {
 			m.applyPickerEntry(prev)
+			m.restoreCursorMemory()
 		}
 	case ScreenModelPicker:
 		// When no providers are detected the screen offers Continue with defaults
@@ -2166,7 +2171,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		if len(m.ModelPicker.AvailableIDs) == 0 {
 			if m.ModelConfigMode {
 				m.ModelConfigMode = false
-				m.setScreen(ScreenModelConfig)
+				m.returnToScreen(ScreenModelConfig)
 				return m, nil
 			}
 			if m.Cursor == 1 {
@@ -2235,11 +2240,12 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Back → ModelConfigMode early-return, then pickerPreviousScreen (SDDMode).
 		if m.ModelConfigMode {
 			m.ModelConfigMode = false
-			m.setScreen(ScreenModelConfig)
+			m.returnToScreen(ScreenModelConfig)
 			return m, nil
 		}
 		if prev, ok := m.pickerPreviousScreen(); ok {
 			m.applyPickerEntry(prev)
+			m.restoreCursorMemory()
 		}
 	case ScreenStrictTDD:
 		options := screens.StrictTDDOptions()
@@ -2274,7 +2280,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		}
 		// Back — use pickerPreviousScreen for unified reverse navigation.
 		if prev, ok := m.pickerPreviousScreen(); ok {
-			return m, m.applyPickerEntry(prev)
+			cmd := m.applyPickerEntry(prev)
+			m.restoreCursorMemory()
+			return m, cmd
 		}
 	case ScreenOpenCodePlugins:
 		return m.confirmOpenCodePlugins()
@@ -2343,7 +2351,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				m.Review = planner.BuildReviewPayload(m.Selection, m.DependencyPlan)
 				m.setScreen(ScreenReview)
 			default:
-				m.setScreen(ScreenPreset)
+				m.returnToScreen(ScreenPreset)
 			}
 			return m, nil
 		}
@@ -2356,18 +2364,19 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// then optional setup guards (outside the slice), then pickerPreviousScreen.
 		// INV-2: Enter-on-Back and Esc must produce identical results.
 		if isPiOnlyAgents(m.Selection.Agents) {
-			m.setScreen(ScreenAgents)
+			m.returnToScreen(ScreenAgents)
 		} else if m.shouldShowOpenCodePluginsScreen() {
 			// OpenCodePlugins sits between CommunityTools and DependencyTree.
-			m.setScreen(ScreenOpenCodePlugins)
+			m.returnToScreen(ScreenOpenCodePlugins)
 		} else if m.shouldShowCommunityToolsScreen() {
 			// CommunityTools sits between the picker chain and DependencyTree in
 			// the actual flow but is NOT in pickerFlowSlice. Check it so
 			// Enter-on-Back matches Esc behavior (INV-2).
-			m.setScreen(ScreenCommunityTools)
+			m.returnToScreen(ScreenCommunityTools)
 		} else if prev, ok := m.pickerPreviousScreen(); ok {
 			// No OpenCode; step back through the picker slice.
 			m.applyPickerEntry(prev)
+			m.restoreCursorMemory()
 		}
 	case ScreenSkillPicker:
 		allSkills := screens.AllSkillsOrdered()
@@ -2384,20 +2393,22 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			// "Back" — in custom preset, return to the screen that preceded SkillPicker.
 			if m.Selection.Preset == model.PresetCustom {
 				if m.shouldShowStrictTDDScreen() {
-					m.setScreen(ScreenStrictTDD)
+					m.returnToScreen(ScreenStrictTDD)
 				} else if m.shouldShowSDDModeScreen() {
 					if m.Selection.SDDMode == model.SDDModeMulti {
-						return m, m.applyPickerEntry(ScreenModelPicker)
+						cmd := m.applyPickerEntry(ScreenModelPicker)
+						m.restoreCursorMemory()
+						return m, cmd
 					} else {
-						m.setScreen(ScreenSDDMode)
+						m.returnToScreen(ScreenSDDMode)
 					}
 				} else if m.shouldShowClaudeModelPickerScreen() {
-					m.setScreen(ScreenClaudeModelPicker)
+					m.returnToScreen(ScreenClaudeModelPicker)
 				} else {
-					m.setScreen(ScreenDependencyTree)
+					m.returnToScreen(ScreenDependencyTree)
 				}
 			} else {
-				m.setScreen(ScreenDependencyTree)
+				m.returnToScreen(ScreenDependencyTree)
 			}
 		}
 	case ScreenReview:
@@ -2410,22 +2421,24 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				if len(m.SkillPicker) == 0 {
 					m.initSkillPicker()
 				}
-				m.setScreen(ScreenSkillPicker)
+				m.returnToScreen(ScreenSkillPicker)
 			} else if m.shouldShowStrictTDDScreen() {
-				m.setScreen(ScreenStrictTDD)
+				m.returnToScreen(ScreenStrictTDD)
 			} else if m.shouldShowSDDModeScreen() {
 				if m.Selection.SDDMode == model.SDDModeMulti {
-					return m, m.applyPickerEntry(ScreenModelPicker)
+					cmd := m.applyPickerEntry(ScreenModelPicker)
+					m.restoreCursorMemory()
+					return m, cmd
 				} else {
-					m.setScreen(ScreenSDDMode)
+					m.returnToScreen(ScreenSDDMode)
 				}
 			} else if m.shouldShowClaudeModelPickerScreen() {
-				m.setScreen(ScreenClaudeModelPicker)
+				m.returnToScreen(ScreenClaudeModelPicker)
 			} else {
-				m.setScreen(ScreenDependencyTree)
+				m.returnToScreen(ScreenDependencyTree)
 			}
 		} else {
-			m.setScreen(ScreenDependencyTree)
+			m.returnToScreen(ScreenDependencyTree)
 		}
 	case ScreenInstalling:
 		if m.Progress.Done() {
@@ -2448,14 +2461,14 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenRestoreConfirm)
 			return m, nil
 		}
-		m.setScreen(ScreenWelcome)
+		m.returnToScreen(ScreenWelcome)
 	case ScreenRestoreConfirm:
 		// Cursor 0 = "Restore", Cursor 1 = "Cancel".
 		if m.Cursor == 0 {
 			m.OperationRunning = true
 			return m.restoreBackup(m.SelectedBackup)
 		}
-		m.setScreen(ScreenBackups)
+		m.returnToScreen(ScreenBackups)
 	case ScreenRestoreResult:
 		// Enter on the result screen returns to backup selection.
 		// Refresh the backup list to reflect any changes from the restore.
@@ -2468,7 +2481,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			}
 			m.setScreen(ScreenDeleteResult)
 		} else {
-			m.setScreen(ScreenBackups)
+			m.returnToScreen(ScreenBackups)
 		}
 	case ScreenDeleteResult:
 		// Enter on the result screen returns to backup selection.
@@ -2481,7 +2494,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenAgentBuilderPrompt)
 		} else {
 			// "Back" option.
-			m.setScreen(ScreenWelcome)
+			m.returnToScreen(ScreenWelcome)
 		}
 	case ScreenAgentBuilderPrompt:
 		// "Continue" only if textarea is not empty.
@@ -2510,7 +2523,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			return m.startGeneration()
 		}
 		// "Back" option.
-		m.setScreen(ScreenAgentBuilderSDD)
+		m.returnToScreen(ScreenAgentBuilderSDD)
 	case ScreenAgentBuilderGenerating:
 		// Only interactive when an error is shown (retry/back).
 		if m.AgentBuilder.GenerationErr != nil {
@@ -2814,7 +2827,7 @@ func (m Model) confirmOpenCodePluginUninstallSelect() (tea.Model, tea.Cmd) {
 	}
 	// Back row.
 	m.resetOpenCodePluginUninstallState()
-	m.setScreen(ScreenWelcome)
+	m.returnToScreen(ScreenWelcome)
 	return m, nil
 }
 
@@ -3477,6 +3490,20 @@ func (m *Model) restoreCursorMemory() {
 	m.Cursor = saved
 }
 
+func (m *Model) returnToScreen(next Screen) {
+	m.setScreen(next)
+	m.restoreCursorMemory()
+}
+
+// rememberCursor records the current cursor position for the current screen
+// so back navigation can restore it later.
+func (m *Model) rememberCursor() {
+	if m.CursorMemory == nil {
+		m.CursorMemory = make(map[Screen]int)
+	}
+	m.CursorMemory[m.Screen] = m.Cursor
+}
+
 // handleRenameInput processes key events when the rename backup screen is active.
 // It manages text input for the new backup description.
 func (m Model) handleRenameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -3489,10 +3516,10 @@ func (m Model) handleRenameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.ListBackupsFn != nil {
 			m.Backups = m.ListBackupsFn()
 		}
-		m.setScreen(ScreenBackups)
+		m.returnToScreen(ScreenBackups)
 		return m, nil
 	case tea.KeyEsc:
-		m.setScreen(ScreenBackups)
+		m.returnToScreen(ScreenBackups)
 		return m, nil
 	case tea.KeyBackspace:
 		if m.BackupRenamePos > 0 {
@@ -3864,7 +3891,9 @@ func (m Model) confirmCommunityTools() (tea.Model, tea.Cmd) {
 		}
 		return m.continueAfterCommunityTools(), nil
 	default:
-		return m.goBackFromCommunityTools(), nil
+		m = m.goBackFromCommunityTools()
+		m.restoreCursorMemory()
+		return m, nil
 	}
 }
 
@@ -3951,7 +3980,9 @@ func (m Model) confirmOpenCodePlugins() (tea.Model, tea.Cmd) {
 		}
 		return m.continueAfterOpenCodePlugins(), nil
 	default:
-		return m.goBackFromOpenCodePlugins(), nil
+		m = m.goBackFromOpenCodePlugins()
+		m.restoreCursorMemory()
+		return m, nil
 	}
 }
 
@@ -4531,7 +4562,7 @@ func (m Model) handleProfileNameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, discoveryCmd
 	case tea.KeyEsc:
 		m.ProfileNameCollision = false
-		m.setScreen(ScreenProfiles)
+		m.returnToScreen(ScreenProfiles)
 		return m, nil
 	case tea.KeyBackspace:
 		if m.ProfileNamePos > 0 {
@@ -4595,7 +4626,7 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 				m.Cursor = 0
 			case 1:
 				if m.ProfileEditMode {
-					m.setScreen(ScreenProfiles)
+					m.returnToScreen(ScreenProfiles)
 				} else {
 					m.ProfileCreateStep = 0
 					m.Cursor = 0
@@ -4640,7 +4671,7 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 		if m.Cursor == len(rows)+1 {
 			// "Back": return to step 0 (name) or profiles list.
 			if m.ProfileEditMode {
-				m.setScreen(ScreenProfiles)
+				m.returnToScreen(ScreenProfiles)
 			} else {
 				m.ProfileCreateStep = 0
 				m.Cursor = 0
@@ -4662,7 +4693,7 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 			m.OperationMode = "sync"
 			return m, tea.Batch(tickCmd(), m.startSync(m.PendingSyncOverrides))
 		default: // "Cancel"
-			m.setScreen(ScreenProfiles)
+			m.returnToScreen(ScreenProfiles)
 		}
 		return m, nil
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2095

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- The TUI reset the cursor to the first option on every screen transition because `setScreen` unconditionally sets `m.Cursor = 0`, so any back navigation (Esc, "Back" menu rows, "Cancel" options) lost the user's position.
- This PR adds a `CursorMemory map[Screen]int` to the model: the position is saved when the user leaves a screen (`confirmSelection`, plus the `r`/`n`/`d` keyboard shortcuts that leave a screen without pressing Enter), and restored when they navigate back.
- Restoration is applied on every back path: the Esc handler (after `goBack`), all "Back" menu rows, "Cancel" confirmation options, and the picker-chain walk-backs — honoring the existing INV-2 invariant documented in `model.go`: "Enter-on-Back and Esc must produce identical results". Forward navigation into a screen still starts at the first option, as before.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Added `CursorMemory map[Screen]int` field (initialized in `NewModel`) with three primitives: `rememberCursor()` (saves position for the current screen), `restoreCursorMemory()` (restores it, clamped to the destination's current `optionCount()` since lists are dynamic), and `returnToScreen(next)` (`setScreen` + restore, the back-navigation counterpart of `setScreen`). |
| `internal/tui/model.go` | Save points: top of `confirmSelection`, and the `r` (rename backup), `d` (delete backup / delete profile) and `n` (new profile) shortcuts that leave a screen without Enter. |
| `internal/tui/model.go` | Restore points: Esc handler after `goBack`; every "Back" menu row (Welcome wizard, Model Config, model pickers, uninstall flow, backups, profiles, agent builder, community tools, OpenCode plugins, detection, persona, preset, dependency tree, skill picker, review); "Cancel" rows of restore/delete/profile confirmations; rename input (Enter and Esc); picker-chain walk-backs via `applyPickerEntry` + restore. |
| `internal/tui/cursor_memory_test.go` | New tests: Esc restore (table-driven), Back-option restore on Model Config, table-driven Back-row restore across six screens (Detection, Agent Builder engine/SDD phase, Backups, Uninstall, Persona), and the `d`-shortcut → Cancel roundtrip on backups. |

Intentionally **not** changed: "Back" rows that land on the Agent Builder prompt (a textarea, `m.Cursor` is unused there), result/complete screens returning to Welcome (finishing a flow is not back navigation), the picker sub-cursors (`ProviderCursor` etc., intentionally reset per #147), and the internal `setScreen` calls inside `goBack`/`goBackFrom*` (their callers already restore).

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — TUI-only navigation fix; no review-lifecycle, gates, recovery, delivery, or benchmark code is touched.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual testing: reproduced the exact steps from #2095 (Welcome → "Configure models" → Esc, and nested menus), plus the Back menu rows and Cancel options on Model Config, Manage Backups (including `r`/`d` shortcuts), Manage Uninstall (all four levels), and the profiles flow. Cursor is restored at every depth; forward navigation still starts at the first option.

Note: `go test ./internal/tui/` passes cleanly. A local full-suite run on macOS shows pre-existing environment failures in the review subsystem (`/var` symlink temp dirs, system Bash 3.2 lacking `declare -A`) that are unrelated to this change and don't occur on Linux CI.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The fix deliberately saves the cursor at the moment of **leaving** a screen (top of `confirmSelection` / the keyed shortcuts) rather than inside `setScreen`, because some Welcome forward paths zero the cursor via `withReset*State` helpers *before* `setScreen` runs — saving there would record a corrupted position.
- Restoration only happens on back navigation, never on forward transitions, so existing expectations like `TestConditionalPickerNavigationResetsState` and the `ScreenUpdatePrompt` default cursor remain untouched.
- Restored positions are clamped against `optionCount()` because several lists are dynamic (Welcome depends on detected engines, backups/profiles shrink after deletions).
- This PR does not touch `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`, so the guard-population checklist below is not applicable.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [ ] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved navigation across screens by remembering and restoring the previous cursor position.
  * Back and cancel actions now return users to the expected screen and menu item.
  * Enhanced navigation consistency across pickers, profiles, backups, uninstall flows, community tools, and agent-building screens.
  * Preserved picker state when navigating back.
* **Tests**
  * Added coverage for cursor restoration, back navigation, picker chains, and backup cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->