### PR TITLE
test(e2e): provision agent runtimes in the E2E images

### DIFF
--- a/e2e/Dockerfile.arch
+++ b/e2e/Dockerfile.arch
@@ -26,6 +26,24 @@ RUN echo 'DisableSandbox' >> /etc/pacman.conf && \
     && pacman -Scc --noconfirm
 
 # ---------------------------------------------------------------------------
+# Agent runtimes the E2E suite drives through the real install pipeline
+# ---------------------------------------------------------------------------
+# Gentle-AI itself no longer installs agent runtimes (agentInstallStep in
+# internal/cli/run.go refuses instead — see PR #2450/#2458). This suite
+# exercises the install pipeline end to end for these agents, so the test
+# image provisions what it needs to test, same as any other test dependency
+# — the same reasoning already applied to the organic-runtime-e2e job in
+# .github/workflows/ci.yml. OpenCode is pinned to match that job and
+# internal/versions.OpenCode, the one runtime with a real version owner.
+# The rest advise "latest" in gentle-ai's own display-only refusal text (see
+# each adapter's InstallCommand), so there is no pin to reuse here either.
+RUN npm install --global opencode-ai@1.18.10 && \
+    npm install --global @anthropic-ai/claude-code@latest && \
+    npm install --global @openai/codex@latest && \
+    npm install --global @google/gemini-cli@latest && \
+    npm install --global @qwen-code/qwen-code@latest
+
+# ---------------------------------------------------------------------------
 # Create non-root test user with passwordless sudo
 # ---------------------------------------------------------------------------
 RUN useradd -m -s /bin/bash testuser && \

--- a/e2e/Dockerfile.fedora
+++ b/e2e/Dockerfile.fedora
@@ -21,6 +21,24 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash - && \
     dnf install -y nodejs
 
 # ---------------------------------------------------------------------------
+# Agent runtimes the E2E suite drives through the real install pipeline
+# ---------------------------------------------------------------------------
+# Gentle-AI itself no longer installs agent runtimes (agentInstallStep in
+# internal/cli/run.go refuses instead — see PR #2450/#2458). This suite
+# exercises the install pipeline end to end for these agents, so the test
+# image provisions what it needs to test, same as any other test dependency
+# — the same reasoning already applied to the organic-runtime-e2e job in
+# .github/workflows/ci.yml. OpenCode is pinned to match that job and
+# internal/versions.OpenCode, the one runtime with a real version owner.
+# The rest advise "latest" in gentle-ai's own display-only refusal text (see
+# each adapter's InstallCommand), so there is no pin to reuse here either.
+RUN npm install --global opencode-ai@1.18.10 && \
+    npm install --global @anthropic-ai/claude-code@latest && \
+    npm install --global @openai/codex@latest && \
+    npm install --global @google/gemini-cli@latest && \
+    npm install --global @qwen-code/qwen-code@latest
+
+# ---------------------------------------------------------------------------
 # Install Go (match go.mod version)
 # ---------------------------------------------------------------------------
 ARG GO_VERSION=1.25.10

--- a/e2e/Dockerfile.ubuntu
+++ b/e2e/Dockerfile.ubuntu
@@ -29,6 +29,24 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y nodejs
 
 # ---------------------------------------------------------------------------
+# Agent runtimes the E2E suite drives through the real install pipeline
+# ---------------------------------------------------------------------------
+# Gentle-AI itself no longer installs agent runtimes (agentInstallStep in
+# internal/cli/run.go refuses instead — see PR #2450/#2458). This suite
+# exercises the install pipeline end to end for these agents, so the test
+# image provisions what it needs to test, same as any other test dependency
+# — the same reasoning already applied to the organic-runtime-e2e job in
+# .github/workflows/ci.yml. OpenCode is pinned to match that job and
+# internal/versions.OpenCode, the one runtime with a real version owner.
+# The rest advise "latest" in gentle-ai's own display-only refusal text (see
+# each adapter's InstallCommand), so there is no pin to reuse here either.
+RUN npm install --global opencode-ai@1.18.10 && \
+    npm install --global @anthropic-ai/claude-code@latest && \
+    npm install --global @openai/codex@latest && \
+    npm install --global @google/gemini-cli@latest && \
+    npm install --global @qwen-code/qwen-code@latest
+
+# ---------------------------------------------------------------------------
 # Install Go (match go.mod version)
 # ---------------------------------------------------------------------------
 ARG GO_VERSION=1.25.10

--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -1777,6 +1777,9 @@ test_antigravity_sdd_skills_path() {
     log_test "Antigravity: SDD skills install to ~/.gemini/antigravity-cli/skills/"
     cleanup_test_env
 
+    # Antigravity is a desktop app — create the config dir to signal it's "installed"
+    mkdir -p "$HOME/.gemini/antigravity"
+
     if $BINARY install --agent antigravity --component sdd --persona neutral 2>&1; then
         local skills_dir="$HOME/.gemini/antigravity-cli/skills"
         assert_dir_exists "$skills_dir" "Antigravity skills directory"
@@ -1801,6 +1804,9 @@ test_antigravity_sdd_skills_path() {
 test_windsurf_persona_and_sdd_content() {
     log_test "Windsurf: persona + SDD inject into global_rules.md"
     cleanup_test_env
+
+    # Windsurf is a desktop app — create the config dir to signal it's "installed"
+    mkdir -p "$HOME/.codeium/windsurf"
 
     if $BINARY install --agent windsurf --component persona --component sdd --persona gentleman 2>&1; then
         local rules="$HOME/.codeium/windsurf/memories/global_rules.md"


### PR DESCRIPTION
The E2E Docker images never provisioned any agent runtime. That was invisible while gentle-ai installed whatever was missing. After #2450 a missing runtime is a real refusal, so roughly twenty Tier 2 and Tier 3 tests that drive a real install pipeline started failing on `main`.

CI installing the tools it needs to test is ordinary and violates nothing. The principle #2450 restored is that the *product* does not install runtimes for *users*.

## What to provision

The agent set was determined by reading every `--agent` flag the suite actually uses under Tier 2/3, not from the CI log, which truncates before showing the full picture (see #2466): antigravity, claude-code, codex, cursor, gemini-cli, opencode, qwen-code, windsurf.

Of those, cursor, windsurf and antigravity are desktop apps with no CLI install path at all; their adapters return `AgentNotInstallableError`. No image provisioning can ever satisfy them. Those tests instead pre-create the agent's config directory, which is what `Detect()` reads.

The remaining five are installed in all three images, reusing exactly what the `organic-runtime-e2e` job already does: the same packages and the same OpenCode pin from `internal/versions`. For codex, gemini-cli and qwen-code there was no CI precedent to copy, so each uses the exact package name its own adapter's `InstallCommand()` advises, which is the string a user would now be told to run.

## A second defect, found only by running the suite

`test_antigravity_sdd_skills_path` and `test_windsurf_persona_and_sdd_content` never created their agent's config-directory fixture, unlike their siblings (cursor's test, and the first windsurf test) which already do.

This is a test-code gap rather than a provisioning gap: those agents have no install command at all, so no image change could ever have fixed them. They now use the same one-line fixture their passing siblings already use. No assertion was weakened; detection is simply accurate the way it already was next door.

## Verification

Real Docker builds and runs on all three platforms, before and after, because a host-machine pass has already produced a false green twice in this work.

Before, on every platform: exit 1, aborting roughly 300 lines in with `agent "claude-code" is not installed`.

After, on every platform: `PASSED: 494 / FAILED: 0 / TOTAL: 494`, exit 0.

## Scope

No product code changed. No assertion was weakened, and no test was converted to expect the refusal: the refusal path already has dedicated coverage from #2450, while these tests exist to prove the pipeline works when the runtime is present.

Closes #2467

The reason this reached `main` at all is filed separately as #2466.
Closes #2467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test environments to include OpenCode, Claude Code, Codex, Gemini CLI, and Qwen Code.
  * Improved installation testing for Antigravity and Windsurf by preparing their configuration directories automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->