### PR TITLE
fix(review): answer negotiated status without a declared runtime identity

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -772,9 +772,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			return err
 		}
 		var runtime model.AgentID
-		if *contract == ReviewIntegrationContractV2 {
+		// A declared runtime identity is validated exactly as before, so an
+		// unsupported transport still stops here. An undeclared one is the
+		// manual/non-agent compatibility path runReviewFacadeStart already
+		// names: a read-only STATUS creates no authority, tier, budget, or
+		// collection state, so it has no state to fail closed over, and the
+		// documented route never declares an identity.
+		if *contract == ReviewIntegrationContractV2 && reviewRuntimeAgentCount(args) != 0 {
 			if reviewRuntimeAgentCount(args) != 1 {
-				// refusal:by-design world-action: a lifecycle route without one generated runtime identity cannot safely select a review transport
+				// refusal:by-design world-action: an ambiguous runtime identity cannot safely select a review transport
 				return reviewPreflightRefusal(reviewImmutableTransportUnsupportedReason, errors.New("negotiated lifecycle STATUS requires exactly one generated runtime identity"))
 			}
 			var runtimeErr error
@@ -1466,9 +1472,13 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			return reviewPreflightRefusal(reviewTransportCapabilityUnsupportedReason, err)
 		}
 	}
-	if negotiated && (*contract == ReviewIntegrationContractV2 || runtimeRequested) {
+	// The same admission as the capability gate above: an absent agent
+	// identity is the manual/non-agent compatibility path and is not gated,
+	// so the provider-returned START of an undeclared route stays runnable.
+	// Every declared identity is still proven before authority is created.
+	if negotiated && runtimeRequested {
 		if reviewRuntimeAgentCount(args) != 1 {
-			// refusal:by-design world-action: a START without one generated runtime identity cannot safely create review authority
+			// refusal:by-design world-action: an ambiguous runtime identity cannot safely create review authority
 			return reviewPreflightRefusal(reviewImmutableTransportUnsupportedReason, errors.New("negotiated START requires exactly one generated runtime identity"))
 		}
 		if _, err := reviewRuntimeWithImmutableTransport(*runtimeAgent); err != nil {

--- a/internal/cli/review_missing_runtime_identity_test.go
+++ b/internal/cli/review_missing_runtime_identity_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// The documented negotiated lifecycle route in
+// internal/assets/claude/commands/sdd-apply.md and
+// internal/assets/opencode/commands/sdd-apply.md declares no runtime
+// identity. A read-only STATUS creates no authority, tier, budget, or
+// collection state, so it has nothing to fail closed over: an undeclared
+// identity is the manual/non-agent compatibility path that
+// runReviewFacadeStart already documents, not an unsupported transport.
+func TestNegotiatedStatusWithoutRuntimeIdentityIsAnswered(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "documented route", args: []string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition"}},
+		{name: "without transition", args: []string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := RunReview(test.args, &output)
+			if err == nil {
+				return
+			}
+			failure := decodeReviewIntegrationFailure(t, output.Bytes())
+			if failure.Code == reviewImmutableTransportUnsupportedCode {
+				t.Fatalf("undeclared runtime identity refused a read-only STATUS: %#v", failure)
+			}
+			t.Fatalf("negotiated STATUS failed: %v %#v", err, failure)
+		})
+	}
+}
+
+// A candidate-bearing repository must complete the documented route: STATUS
+// answers, and the exact provider-returned START it names must execute
+// rather than refuse the same undeclared identity one step later.
+func TestNegotiatedRouteWithoutRuntimeIdentityReachesStart(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n", 0o644)
+
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition",
+	}, &statusOutput); err != nil {
+		t.Fatalf("negotiated STATUS failed: %v %s", err, statusOutput.String())
+	}
+
+	var status struct {
+		NextTransition *struct {
+			Execute *struct {
+				Operation string `json:"operation"`
+				Arguments []struct {
+					Name  string `json:"name"`
+					Token string `json:"token"`
+				} `json:"arguments"`
+			} `json:"execute"`
+		} `json:"next_transition"`
+	}
+	if err := json.Unmarshal(statusOutput.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.NextTransition == nil || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.start" {
+		t.Fatalf("STATUS named no executable START: %s", statusOutput.String())
+	}
+
+	startArgs := []string{"start", "--cwd", repo}
+	for _, argument := range status.NextTransition.Execute.Arguments {
+		if argument.Name == "agent" {
+			t.Fatalf("STATUS invented a runtime identity the caller never declared: %s", argument.Token)
+		}
+		startArgs = append(startArgs, argument.Token)
+	}
+
+	var startOutput bytes.Buffer
+	if err := RunReview(startArgs, &startOutput); err != nil {
+		failure := decodeReviewIntegrationFailure(t, startOutput.Bytes())
+		if failure.Code == reviewImmutableTransportUnsupportedCode {
+			t.Fatalf("undeclared runtime identity refused the provider-returned START: %#v", failure)
+		}
+		t.Fatalf("provider-returned START failed: %v %#v", err, failure)
+	}
+	if !strings.Contains(startOutput.String(), "consent") {
+		t.Fatalf("negotiated START answered without the consent envelope: %s", startOutput.String())
+	}
+}
+
+// The refusal for a genuinely unsupported declared runtime is untouched.
+func TestDeclaredUnsupportedRuntimeStillRefusesNegotiatedStatus(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	for _, runtime := range []string{string(model.AgentOpenCode), string(model.AgentCodex), "unknown-runtime"} {
+		t.Run(runtime, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunReview([]string{
+				"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--agent", runtime, "--next-transition",
+			}, &output); err == nil {
+				t.Fatalf("declared unsupported runtime %q was accepted", runtime)
+			}
+			failure := decodeReviewIntegrationFailure(t, output.Bytes())
+			if failure.Code != reviewImmutableTransportUnsupportedCode || failure.NextAction != "stop" {
+				t.Fatalf("declared unsupported runtime %q failure = %#v", runtime, failure)
+			}
+		})
+	}
+}

--- a/internal/cli/review_transport_capability_test.go
+++ b/internal/cli/review_transport_capability_test.go
@@ -69,7 +69,10 @@ func TestUnsupportedImmutableReviewTransportStopsBeforeRepositoryOrAuthority(t *
 		{name: "Pi", runtime: string(model.AgentPi), startCode: reviewTransportCapabilityUnsupportedCode},
 		{name: "Kilo", runtime: string(model.AgentKilocode), startCode: reviewImmutableTransportUnsupportedCode},
 		{name: "unknown", runtime: "unknown-runtime", startCode: reviewTransportCapabilityUnsupportedCode},
-		{name: "missing runtime", startCode: reviewImmutableTransportUnsupportedCode},
+		// An undeclared runtime identity is deliberately absent from this
+		// matrix: it makes no transport claim to refuse, so it stays on the
+		// manual/non-agent compatibility path. See
+		// review_missing_runtime_identity_test.go.
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			for _, invocation := range []struct {


### PR DESCRIPTION
Negotiated `review status` and `review start` refused any caller that did not declare a runtime identity, returning `immutable_review_transport_unsupported` with `next_action: stop` and `retry_safe: false`, before any authority was evaluated and on a repository with no review history at all.

Reproduced on the published v2.3.0-rc.1 binary in a fresh `git init`.

## The gate contradicted three things already in the tree

**The spec.** `openspec/specs/rdd-transport-capability/spec.md:31` scopes the declaration to "BEFORE any authority, tier, lens set, budget, or collection state is created", and every scenario reads "WHEN a review start is attempted". A read-only STATUS creates none of that, so it has nothing to fail closed over.

**The code beside it.** `review_facade.go:1459-1463` carries the recorded Wave 4 design decision: "An absent agent identity is the manual/non-agent compatibility path and is not gated." The very next block gated it. The accepted implementation of that same spec, `review_transport_admission.go`, already skips admission on an absent identity and has a matrix test asserting that as intended. Two mechanisms disagreed, and the harsher one was the one without a spec behind it.

**The refusal contract.** `internal/assets/skills/_shared/review-ledger-contract.md:11` requires every stop code to have a row in the continuation table and says "never a bare code with nothing behind it". `immutable_review_transport_unsupported` has no row, so the shipped refusal violated the contract it was enforcing.

## The change

Two conditions, +18/-5, in `internal/cli/review_facade.go`. A declared identity is validated exactly as before. None is required. No flag, no state, no config, no environment sniffing, no inference.

`reviewRuntimeWithImmutableTransport`, `authorizeReviewTransportCapability` and `reviewImmutableRuntimeCapability` are untouched. Every declared-runtime refusal still refuses with the same code and the same `stop`: OpenCode and Codex still report lacking the transport, Pi and unknown runtimes still report ineligibility, and a duplicate `--agent` still refuses on the identity count.

The provider never invents an identity the caller did not declare. A same-fixture diff between the undeclared and `--agent claude-code` runs shows the only delta is `--agent` propagation into the emitted command and its argument list.

## Why the corpus stayed green, which matters more than the fix

`57cafd02`, the commit that introduced this gate, also changed one line of `bench/journeys_wave1.go`: the conditional that appends `--agent` when the contract is v2. In the same commit, the unit-test helper `boundNegotiatedStartArgs` grew a block that silently injects `--agent` into any v2 arguments lacking it.

So the un-flagged shape stopped existing anywhere in the test surface at the exact moment it became broken. Every `reviewContractV2` call site in bench carries `--agent claude-code`; the four sites that omit it are all contract v1, which the gate never touched.

Worse, `TestUnsupportedImmutableReviewTransportStopsBeforeRepositoryOrAuthority` had a `{name: "missing runtime"}` row asserting the stop as correct behavior. The defect was pinned as intended. That row is removed rather than left asserting the bug.

The only remaining caller of the un-flagged form was shipped documentation, which nothing executes.

## Verification

Genuine RED on unmodified `9b2cf201`, with the released envelope reproduced verbatim in the failure output. `TestDeclaredUnsupportedRuntimeStillRefusesNegotiatedStatus` passed in the same RED run, so it is a guard rather than a bugfix test.

Before and after captured from built binaries in `git init` sandboxes. In a repository with a commit, the documented invocation goes from a non-retryable stop to `exit=0` with a full status envelope and a runnable START command. The whole route was executed token for token through to the consent envelope, because relaxing STATUS alone would have dead-ended one step later at START.

Root `go test ./... -count=1` exit 0 across 63 packages, bench module exit 0, gofmt clean, vet clean, deadcode ratchet reports no new unreachable functions, refusal ratchet green with no baseline churn.

The shell E2E was not run and is not applicable: that suite never invokes `gentle-ai review`, and this diff touches only `review_facade.go` and two test files.

## Known, not fixed here

`immutable_review_transport_unsupported` still has no continuation row, so the genuine OpenCode and Codex refusal still names no runnable exit. Fixing that means editing the shared contract asset and regenerating every agent golden, which entangles the hardcoded-identity work in #2440.

`internal/assets/claude/commands/sdd-apply.md:51` and `internal/assets/opencode/commands/sdd-apply.md:40` still document the un-flagged form while the shared contract row 01 says `--agent claude-code`. This change makes both forms work, so the contradiction is now benign, but it should be reconciled.

Closes #2473

Part of #2471



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review status and start flows now work without a declared runtime identity, preserving manual review compatibility.
  * Provider-selected reviews can proceed without creating an unsupported agent identity.
  * Explicitly unsupported runtime declarations continue to be rejected with the appropriate transport error.

* **Tests**
  * Added coverage for identity-free status and review-start flows, including consent responses and rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->