### PR TITLE
fix(review): give every execute transition a command, and make the corpus require one

### DIFF
--- a/bench/classify.go
+++ b/bench/classify.go
@@ -339,6 +339,51 @@ func walkContinuation(node any) bool {
 	return false
 }
 
+// DeadExecuteTransitions returns one description per `execute` transition in a
+// JSON envelope that names an operation and hands the reader no runnable
+// command.
+//
+// The classifier alone cannot see this. Classify only ever runs on a BLOCK,
+// and the invocation that first shipped this defect exited 0 and denied
+// nothing: a `review status --next-transition` answering with a dead
+// review.recover transition. Nothing in the corpus looked at it. So this is
+// checked for EVERY observation, blocking or not, and a hit fails the journey
+// rather than moving it between buckets.
+//
+// That difference is the point. A bucket can be argued about; a failed journey
+// and a non-zero exit cannot be satisfied by teaching one call site to expect
+// the broken shape. It also does not depend on any journey remembering to run
+// the command it was handed, which is exactly the assumption that failed here.
+func DeadExecuteTransitions(stdout string) []string {
+	var envelope any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &envelope); err != nil {
+		return nil
+	}
+	var dead []string
+	collectDeadExecuteTransitions(envelope, &dead)
+	return dead
+}
+
+func collectDeadExecuteTransitions(node any, dead *[]string) {
+	switch typed := node.(type) {
+	case map[string]any:
+		for key, value := range typed {
+			if execute, isObject := value.(map[string]any); isObject && key == "execute" {
+				operation, named := execute["operation"].(string)
+				if named && !nonContinuationValues[strings.ToLower(strings.TrimSpace(operation))] && !executeIsRunnable(execute) {
+					command, _ := execute["command"].(string)
+					*dead = append(*dead, fmt.Sprintf("execute transition %q carries no runnable command (command: %q)", operation, command))
+				}
+			}
+			collectDeadExecuteTransitions(value, dead)
+		}
+	case []any:
+		for _, item := range typed {
+			collectDeadExecuteTransitions(item, dead)
+		}
+	}
+}
+
 // executeIsRunnable reports whether one `execute` transition object is a real
 // continuation: it names an operation AND carries a command the reader can run
 // as printed. The command is held to the same standard as prose that suggests

--- a/bench/classify.go
+++ b/bench/classify.go
@@ -286,37 +286,72 @@ func commandTailIsRunnable(tail string) bool {
 
 // HasEnvelopeContinuation reports whether a JSON envelope on stdout carries a
 // next_action / recovery_operation / collect.capture_operation naming a real
-// operation. next_transition.execute.operation is treated the same way: it is
-// the execute-shaped sibling of collect.capture_operation.
+// operation.
+//
+// An `execute` transition is held to a strictly higher bar than those keys,
+// and the difference is not a detail. next_action and capture_operation name
+// an operation the reader still has to assemble a command for, and the corpus
+// admits them on that basis. An execute transition claims to have already done
+// that assembly: it says "here is the thing to run". So it counts only when it
+// carries a command that really is runnable. An execute transition naming an
+// operation with an empty command tells the reader to run something and then
+// hands them nothing, which is the exact shape this benchmark exists to count
+// as out_of_band -- and it is worse than the keys above, not equal to them,
+// because it looks like the answer.
 func HasEnvelopeContinuation(stdout string) bool {
 	var envelope any
 	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &envelope); err != nil {
 		return false
 	}
-	return walkContinuation(envelope, "")
+	return walkContinuation(envelope)
 }
 
-func walkContinuation(node any, parentKey string) bool {
+func walkContinuation(node any) bool {
 	switch typed := node.(type) {
 	case map[string]any:
 		for key, value := range typed {
-			if continuationKeys[key] || (parentKey == "execute" && key == "operation") {
+			// An execute transition is judged whole, and descending into it
+			// is deliberately skipped: a transition that handed the reader
+			// nothing to run must not be rescued by a continuation key
+			// nested inside its own binding or preconditions.
+			if execute, isObject := value.(map[string]any); isObject && key == "execute" {
+				if executeIsRunnable(execute) {
+					return true
+				}
+				continue
+			}
+			if continuationKeys[key] {
 				if text, ok := value.(string); ok && !nonContinuationValues[strings.ToLower(strings.TrimSpace(text))] {
 					return true
 				}
 			}
-			if walkContinuation(value, key) {
+			if walkContinuation(value) {
 				return true
 			}
 		}
 	case []any:
 		for _, item := range typed {
-			if walkContinuation(item, parentKey) {
+			if walkContinuation(item) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+// executeIsRunnable reports whether one `execute` transition object is a real
+// continuation: it names an operation AND carries a command the reader can run
+// as printed. The command is held to the same standard as prose that suggests
+// one, through the same HasRunnableCommand, so an envelope cannot be in-band on
+// a template like `gentle-ai review validate --gate <gate>` that the identical
+// text in a message would be refused for.
+func executeIsRunnable(execute map[string]any) bool {
+	operation, named := execute["operation"].(string)
+	if !named || nonContinuationValues[strings.ToLower(strings.TrimSpace(operation))] {
+		return false
+	}
+	command, printed := execute["command"].(string)
+	return printed && HasRunnableCommand(command)
 }
 
 // denialResults are gate results that deny delivery. A denial is a block even

--- a/bench/classify_test.go
+++ b/bench/classify_test.go
@@ -168,7 +168,20 @@ func TestHasEnvelopeContinuation(t *testing.T) {
 		want   bool
 	}{
 		{"collect capture operation", `{"next_transition":{"kind":"collect","collect":{"inputs":[{"capture_operation":"review.capture-result"}]}}}`, true},
-		{"execute operation", `{"next_transition":{"kind":"execute","execute":{"operation":"review.finalize"}}}`, true},
+		{"execute operation with a runnable command", `{"next_transition":{"kind":"execute","execute":{"operation":"review.finalize","command":"gentle-ai review finalize --lineage=review-1"}}}`, true},
+		// The defect this benchmark missed: an execute transition names an
+		// operation, carries an empty command, and the reader is told to run
+		// something with nothing to run. An operation alone is a label, not a
+		// continuation.
+		{"execute operation with no command at all", `{"next_transition":{"kind":"execute","execute":{"operation":"review.recover"}}}`, false},
+		{"execute operation with an empty command", `{"next_transition":{"kind":"execute","execute":{"operation":"review.recover","command":""}}}`, false},
+		{"execute command that is still a template", `{"next_transition":{"kind":"execute","execute":{"operation":"review.validate","command":"gentle-ai review validate --gate <gate>"}}}`, false},
+		{"execute command naming no arguments", `{"next_transition":{"kind":"execute","execute":{"operation":"review.status","command":"gentle-ai"}}}`, false},
+		{"execute with a command but no operation", `{"next_transition":{"kind":"execute","execute":{"operation":"","command":"gentle-ai review status --cwd=."}}}`, false},
+		// A dead execute transition must not be rescued by a continuation key
+		// nested inside it: the transition the reader was handed is the thing
+		// under test, not the vocabulary it happens to mention.
+		{"nested key does not rescue a commandless execute", `{"next_transition":{"kind":"execute","execute":{"operation":"review.recover","binding":{"recovery_operation":"review.recover"}}}}`, false},
 		{"next_action", `{"next_action":"review.repair"}`, true},
 		{"recovery_operation", `{"context":{"recovery_operation":"review.recover"}}`, true},
 		{"stop is not a continuation", `{"next_action":"stop"}`, false},

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -266,21 +266,103 @@ func runNextTransitionVerbatim(r *journeyRun) (Observation, error) {
 	if err != nil {
 		return Observation{}, err
 	}
+	return runPrintedTransition(r, envelope)
+}
+
+// runPrintedTransition runs the command the product PRINTED, exactly as
+// printed.
+//
+// It deliberately does not re-derive the verb from the operation name, which
+// is what this corpus used to do. That re-derivation was the reason a journey
+// named "the printed transition executes exactly as printed" kept passing over
+// an execute transition whose `command` was empty: the benchmark quietly
+// assembled the command the product owed the reader, ran its own, and reported
+// the flow as continuing. "Runs verbatim" has to mean the printed bytes, or it
+// measures the benchmark instead of the product.
+//
+// It is also more correct than the split it replaces. An operation name is not
+// a verb -- "review.retry_final_verification" and "review.bind_sdd" spell
+// their verbs with hyphens -- so splitting on "." only ever produced a runnable
+// verb by coincidence.
+func runPrintedTransition(r *journeyRun, envelope statusEnvelope) (Observation, error) {
 	if envelope.NextTransition.Kind != "execute" {
 		return Observation{}, fmt.Errorf("expected an execute transition, got %q", envelope.NextTransition.Kind)
 	}
-	verb := strings.SplitN(envelope.NextTransition.Execute.Operation, ".", 2)
-	if len(verb) != 2 {
-		return Observation{}, fmt.Errorf("execute operation %q is not <verb>.<subcommand>", envelope.NextTransition.Execute.Operation)
-	}
-	args := []string{verb[0], verb[1], "--cwd", r.sandbox.Repo}
-	for _, argument := range envelope.NextTransition.Execute.Arguments {
-		if argument.Token == "" {
-			return Observation{}, fmt.Errorf("argument %q carried no runnable token", argument.Name)
-		}
-		args = append(args, argument.Token)
+	args, err := printedCommandArguments(envelope.NextTransition.Execute.Command)
+	if err != nil {
+		return Observation{}, fmt.Errorf("execute transition for %q %w", envelope.NextTransition.Execute.Operation, err)
 	}
 	return r.run(args, false), nil
+}
+
+// printedCommandArguments turns one printed command line into the argv a POSIX
+// shell would hand the product, and refuses anything that is not a complete,
+// immediately runnable `gentle-ai ...` invocation.
+func printedCommandArguments(command string) ([]string, error) {
+	words, err := splitPrintedCommandWords(command)
+	if err != nil {
+		return nil, err
+	}
+	if len(words) == 0 {
+		return nil, errors.New("carried no command to run")
+	}
+	if words[0] != productName {
+		return nil, fmt.Errorf("printed a command that starts with %q, not %q", words[0], productName)
+	}
+	if len(words) == 1 {
+		return nil, fmt.Errorf("printed a command that names no arguments: %q", command)
+	}
+	if !HasRunnableCommand(command) {
+		return nil, fmt.Errorf("printed a command that is not runnable as printed: %q", command)
+	}
+	return words[1:], nil
+}
+
+// splitPrintedCommandWords splits a printed command line into shell words.
+//
+// It understands exactly the quoting the product emits and nothing more:
+// POSIX single quotes, and a backslash escape for the one character single
+// quotes cannot contain (reviewTransitionShellWord renders an embedded quote
+// as '\”). Anything else -- an unterminated quote, a trailing escape -- is a
+// line that would not run as printed, and saying so is the point.
+func splitPrintedCommandWords(line string) ([]string, error) {
+	words := []string{}
+	var word strings.Builder
+	quoted, escaped, started := false, false, false
+	for _, char := range line {
+		switch {
+		case quoted && char == '\'':
+			quoted = false
+		case quoted:
+			word.WriteRune(char)
+		case escaped:
+			word.WriteRune(char)
+			escaped = false
+		case char == '\\':
+			escaped, started = true, true
+		case char == '\'':
+			quoted, started = true, true
+		case char == ' ' || char == '\t' || char == '\n' || char == '\r':
+			if started {
+				words = append(words, word.String())
+				word.Reset()
+				started = false
+			}
+		default:
+			word.WriteRune(char)
+			started = true
+		}
+	}
+	if quoted {
+		return nil, fmt.Errorf("printed a command with an unterminated quote: %q", line)
+	}
+	if escaped {
+		return nil, fmt.Errorf("printed a command with a trailing escape: %q", line)
+	}
+	if started {
+		words = append(words, word.String())
+	}
+	return words, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/bench/journeys_printed_command_test.go
+++ b/bench/journeys_printed_command_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestPrintedCommandArguments covers the split that lets a journey run the
+// command the product printed instead of one the benchmark assembled for it.
+// The product quotes with POSIX single quotes and escapes an embedded quote as
+// '\” (review_next_transition.go's reviewTransitionShellWord), so a value
+// carrying spaces or newlines -- a recovery authorization is six LF-joined
+// lines -- has to survive the round trip byte for byte.
+func TestPrintedCommandArguments(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "plain flags",
+			command: "gentle-ai review finalize --lineage=review-1 --captured-results=true",
+			want:    []string{"review", "finalize", "--lineage=review-1", "--captured-results=true"},
+		},
+		{
+			name:    "single quoted value keeps its spaces",
+			command: "gentle-ai review repair --reason='the store lost a leaf'",
+			want:    []string{"review", "repair", "--reason=the store lost a leaf"},
+		},
+		{
+			name:    "single quoted value keeps its newlines",
+			command: "gentle-ai review recover '--maintainer-authorization=schema/v1\nactor=maintainer'",
+			want:    []string{"review", "recover", "--maintainer-authorization=schema/v1\nactor=maintainer"},
+		},
+		{
+			name:    "escaped quote survives",
+			command: `gentle-ai review repair --reason='it'\''s broken'`,
+			want:    []string{"review", "repair", "--reason=it's broken"},
+		},
+		{
+			name:    "surrounding whitespace is not an argument",
+			command: "  gentle-ai   review status  ",
+			want:    []string{"review", "status"},
+		},
+		{
+			name:    "an empty command names nothing to run",
+			command: "",
+			wantErr: "carried no command to run",
+		},
+		{
+			name:    "whitespace only names nothing to run",
+			command: "   ",
+			wantErr: "carried no command to run",
+		},
+		{
+			name:    "the product name alone is not runnable",
+			command: "gentle-ai",
+			wantErr: "names no arguments",
+		},
+		{
+			name:    "another program is not the product",
+			command: "git status",
+			wantErr: `starts with "git"`,
+		},
+		{
+			name:    "an unterminated quote is not runnable as printed",
+			command: "gentle-ai review repair --reason='never closed",
+			wantErr: "unterminated quote",
+		},
+		{
+			name:    "a trailing escape is not runnable as printed",
+			command: `gentle-ai review repair --reason=x\`,
+			wantErr: "trailing escape",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := printedCommandArguments(testCase.command)
+			if testCase.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+					t.Fatalf("printedCommandArguments(%q) error = %v, want one containing %q", testCase.command, err, testCase.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("printedCommandArguments(%q) = %v", testCase.command, err)
+			}
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Fatalf("printedCommandArguments(%q) = %#v, want %#v", testCase.command, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestRunPrintedTransitionRefusesATransitionWithNothingToRun is the corpus-side
+// half of the same defect. A journey that re-derives the verb from the
+// operation name assembles the command the product owed the reader, and then
+// reports success for a transition that handed the reader nothing. The refusal
+// happens before the product is ever invoked, so a nil run is never touched.
+func TestRunPrintedTransitionRefusesATransitionWithNothingToRun(t *testing.T) {
+	cases := []struct {
+		name      string
+		kind      string
+		operation string
+		command   string
+		wantErr   string
+	}{
+		{
+			name: "collect is not an execute transition", kind: "collect",
+			wantErr: `expected an execute transition, got "collect"`,
+		},
+		{
+			name: "execute with no command", kind: "execute", operation: "review.recover",
+			wantErr: "carried no command to run",
+		},
+		{
+			name: "execute with a templated command", kind: "execute", operation: "review.validate",
+			command: "gentle-ai review validate --gate <gate>",
+			wantErr: "is not runnable as printed",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var envelope statusEnvelope
+			envelope.NextTransition.Kind = testCase.kind
+			envelope.NextTransition.Execute.Operation = testCase.operation
+			envelope.NextTransition.Execute.Command = testCase.command
+			_, err := runPrintedTransition(nil, envelope)
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("runPrintedTransition error = %v, want one containing %q", err, testCase.wantErr)
+			}
+		})
+	}
+}

--- a/bench/journeys_printed_command_test.go
+++ b/bench/journeys_printed_command_test.go
@@ -134,3 +134,55 @@ func TestRunPrintedTransitionRefusesATransitionWithNothingToRun(t *testing.T) {
 		})
 	}
 }
+
+// TestDeadExecuteTransitionsSeesWhatTheClassifierCannot is the structural half
+// of issue #1865.
+//
+// The invocation that shipped the defect exited 0 and denied nothing, so it was
+// not a block, so Classify never ran on it and no bucket could ever have been
+// wrong. A rule that only grades blocks is blind to a broken continuation
+// handed out on a successful call. This one grades every observation.
+func TestDeadExecuteTransitionsSeesWhatTheClassifierCannot(t *testing.T) {
+	// The real shape, reduced: a successful `review status --next-transition`
+	// answering with an execute transition that has nothing to run.
+	const dead = `{"schema":"gentle-ai.review-status/v1","action":"recover",` +
+		`"next_transition":{"kind":"execute","reason_code":"recovery_authorized",` +
+		`"execute":{"operation":"review.recover","arguments":[{"name":"successor-lineage","value":"s"}]}}}`
+
+	observation := Observation{ExitCode: 0, Stdout: dead, StdoutCaptured: true, StderrCaptured: true}
+	if IsBlock(observation) {
+		t.Fatal("fixture must not be a block; the whole point is that the classifier never sees it")
+	}
+	if got := Classify(observation); got != NotABlock {
+		t.Fatalf("Classify = %q, want %q: this defect is invisible to classification by construction", got, NotABlock)
+	}
+	found := DeadExecuteTransitions(dead)
+	if len(found) != 1 || !strings.Contains(found[0], "review.recover") {
+		t.Fatalf("DeadExecuteTransitions = %#v, want one report naming review.recover", found)
+	}
+
+	// And it must fail the journey rather than adjust a number.
+	accumulator := newAccumulator()
+	accumulator.observe("read status", observation, nil, false)
+	if len(accumulator.deadTransitions) != 1 {
+		t.Fatalf("accumulator.deadTransitions = %#v, want the dead transition recorded", accumulator.deadTransitions)
+	}
+}
+
+// TestDeadExecuteTransitionsAcceptsWhatIsGenuinelyRunnable is the other
+// direction: the invariant must not fire on a healthy corpus, or it would be
+// removed as noise rather than trusted as a gate. A collect transition
+// deliberately carries no command and must never be reported.
+func TestDeadExecuteTransitionsAcceptsWhatIsGenuinelyRunnable(t *testing.T) {
+	for _, stdout := range []string{
+		`{"next_transition":{"kind":"execute","execute":{"operation":"review.finalize","command":"gentle-ai review finalize --lineage=review-1"}}}`,
+		`{"next_transition":{"kind":"collect","collect":{"inputs":[{"capture_operation":"review.capture-result"}]}}}`,
+		`{"result":"allow","allowed":true}`,
+		"Error: not JSON at all",
+		"",
+	} {
+		if found := DeadExecuteTransitions(stdout); len(found) != 0 {
+			t.Fatalf("DeadExecuteTransitions(%q) = %#v, want none", stdout, found)
+		}
+	}
+}

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -195,12 +195,20 @@ func decodeWaveObservation(observation Observation, target any, label string) er
 	return nil
 }
 
+// waveReviewInvocationArgs is printedCommandArguments narrowed to the `review`
+// family. It delegates rather than re-splitting on whitespace: an emitted
+// invocation can carry a single-quoted value holding spaces or newlines (a
+// recovery authorization is six LF-joined lines), and strings.Fields shatters
+// exactly those into stray positional arguments the product then refuses.
 func waveReviewInvocationArgs(invocation string) ([]string, error) {
-	fields := strings.Fields(strings.TrimSpace(invocation))
-	if len(fields) < 3 || fields[0] != "gentle-ai" || fields[1] != "review" {
+	args, err := printedCommandArguments(invocation)
+	if err != nil {
+		return nil, fmt.Errorf("invalid emitted review invocation: %w", err)
+	}
+	if len(args) < 2 || args[0] != "review" {
 		return nil, fmt.Errorf("invalid emitted review invocation %q", invocation)
 	}
-	return fields[1:], nil
+	return args, nil
 }
 
 // requireCandidateDeclineGateDeniesGenerically is Wave 5 Slice 6's
@@ -384,11 +392,11 @@ func recoverStagedCorrection(r *journeyRun) error {
 	if err != nil || envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
 		return fmt.Errorf("authorized staged recovery is not executable: %+v, %v", envelope.NextTransition, err)
 	}
-	args := []string{"review", "recover", "--cwd", r.sandbox.Repo}
-	for _, argument := range envelope.NextTransition.Execute.Arguments {
-		args = append(args, argument.Token)
+	recovered, err := runPrintedTransition(r, envelope)
+	if err != nil {
+		return err
 	}
-	result, err := decodeWaveOperation(r.run(args, false), "staged correction recovery")
+	result, err := decodeWaveOperation(recovered, "staged correction recovery")
 	if err != nil || result.LineageID != stagedSuccessorLineage || result.State != "reviewing" {
 		return fmt.Errorf("staged correction successor = %+v, %v", result, err)
 	}
@@ -1217,14 +1225,10 @@ func waveOneJourneys() []Journey {
 					if envelope.NextTransition.Kind != "execute" {
 						return fmt.Errorf("expected an execute review.start transition for the staged recovery base-diff candidate, got %q", envelope.NextTransition.Kind)
 					}
-					args := []string{"review", "start", "--cwd", r.sandbox.Repo}
-					for _, argument := range envelope.NextTransition.Execute.Arguments {
-						if argument.Token == "" {
-							return fmt.Errorf("execute argument %q carried no runnable token", argument.Name)
-						}
-						args = append(args, argument.Token)
+					started, err := runPrintedTransition(r, envelope)
+					if err != nil {
+						return err
 					}
-					started := r.run(args, false)
 					if started.ExitCode != 0 {
 						return fmt.Errorf("negotiated staged base-diff start failed: exit=%d stderr=%s", started.ExitCode, started.Stderr)
 					}

--- a/bench/metrics.go
+++ b/bench/metrics.go
@@ -194,6 +194,11 @@ type accumulator struct {
 	pendingBlock  int
 	pendingActive bool
 	records       []CommandRecord
+
+	// deadTransitions collects every execute transition the product emitted
+	// with nothing runnable in it, across every observation of the journey.
+	// It is a corpus error, not a metric: see DeadExecuteTransitions.
+	deadTransitions []string
 }
 
 func newAccumulator() *accumulator {
@@ -237,6 +242,14 @@ func (a *accumulator) observe(step string, o Observation, gitCalls *int, modelRu
 	if gitCalls != nil {
 		a.gitCalls += *gitCalls
 		a.gitObserved = true
+	}
+
+	// Checked before the unsupported and block branches on purpose: a dead
+	// execute transition is not a class of block, it is the product breaking
+	// its own promise, and it has to be seen no matter how the invocation
+	// would otherwise be counted.
+	for _, dead := range DeadExecuteTransitions(o.Stdout) {
+		a.deadTransitions = append(a.deadTransitions, step+": "+dead)
 	}
 
 	if IsUnsupported(o) {

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -552,6 +552,15 @@ func runJourney(binary string, journey Journey) JourneyResult {
 		}
 	}
 
+	// A product that emitted an execute transition with nothing to run fails
+	// the journey outright, whatever else the journey managed to do. It is not
+	// a friction number: no honest metric can be reported about a flow whose
+	// stated continuation the reader cannot follow.
+	if len(accumulator.deadTransitions) > 0 && result.Status != StatusFailed {
+		result.Status = StatusFailed
+		result.FailureReason = strings.Join(accumulator.deadTransitions, "; ")
+	}
+
 	result.Metrics = accumulator.metrics("")
 	result.Commands = accumulator.records
 	return result

--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -238,10 +238,34 @@ func TestReviewIntegrationOperationRegistryOwnsPublishedAndFailurePolicy(t *test
 			t.Fatalf("duplicate operation name %q", metadata.Operation)
 		}
 		commands[metadata.Command], operations[metadata.Operation] = struct{}{}, struct{}{}
-		byCommand, commandOK := reviewIntegrationOperationByCommand(metadata.Command)
 		byName, nameOK := reviewIntegrationOperationByName(metadata.Operation)
-		if !commandOK || !nameOK || byCommand.Operation != metadata.Operation || byName.Command != metadata.Command ||
-			!validReviewIntegrationFailureOperation(metadata.Operation) || reviewLockOperationLabel(metadata.Operation) != metadata.Label {
+		if !nameOK || byName.Command != metadata.Command || reviewLockOperationLabel(metadata.Operation) != metadata.Label {
+			t.Fatalf("operation metadata does not drive every policy lookup: %#v", metadata)
+		}
+		byCommand, commandOK := reviewIntegrationOperationByCommand(metadata.Command)
+		if !metadata.Negotiated {
+			// A non-negotiated row exists for exactly one reason: to own the
+			// runnable CLI verb for an operation the status schemas publish as
+			// an execute transition. It must stay out of every negotiated
+			// surface -- the capabilities `operations` array and the failure
+			// envelope's `operation` enum are both published contracts with a
+			// closed vocabulary and a pinned length -- and it must not carry
+			// negotiated flag metadata nothing consumes and nothing verifies,
+			// because unverified metadata rots into a confident lie.
+			if commandOK {
+				t.Fatalf("non-negotiated operation %q is routed as a negotiated command", metadata.Operation)
+			}
+			if validReviewIntegrationFailureOperation(metadata.Operation) {
+				t.Fatalf("non-negotiated operation %q widened the published failure operation enum", metadata.Operation)
+			}
+			if len(metadata.ValueFlags) != 0 || len(metadata.BoolFlags) != 0 || len(metadata.IntFlags) != 0 ||
+				metadata.MutatesAuthority || metadata.JoinOnTimeout || metadata.TimeoutRetryable || metadata.ReadOnlyFlag != "" {
+				t.Fatalf("non-negotiated operation %q carries negotiated policy metadata nothing consumes: %#v", metadata.Operation, metadata)
+			}
+			continue
+		}
+		if !commandOK || byCommand.Operation != metadata.Operation ||
+			!validReviewIntegrationFailureOperation(metadata.Operation) {
 			t.Fatalf("operation metadata does not drive every policy lookup: %#v", metadata)
 		}
 		shape := reviewIntegrationOperationFlagShape(metadata.Operation)

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -33,9 +33,24 @@ const (
 )
 
 type reviewIntegrationOperationMetadata struct {
-	Command          string
-	Operation        string
-	Label            string
+	Command   string
+	Operation string
+	Label     string
+	// Negotiated reports whether this operation is part of the PUBLISHED
+	// negotiated integration surface: the capabilities `operations` array and
+	// the failure envelope's `operation` enum, both of which are versioned
+	// contracts with a closed vocabulary and a pinned length, and the
+	// `--contract` route that reaches runReviewCommandContext.
+	//
+	// It is false for a row that exists only to own the runnable CLI verb of
+	// an operation the status schemas publish as an execute transition. Issue
+	// #1864 is what that distinction is for: "review.recover" is emitted as an
+	// execute transition and dispatched by review_facade.go, but it is not a
+	// negotiated operation, so before this field the only way to give it a
+	// verb was to also publish it -- and publishing it would have broken every
+	// shipped capabilities schema and fixture. Conflating the two left the
+	// caller with `kind: execute`, an operation name, and an empty command.
+	Negotiated       bool
 	ValueFlags       []string
 	BoolFlags        []string
 	IntFlags         []string
@@ -47,27 +62,45 @@ type reviewIntegrationOperationMetadata struct {
 
 // reviewIntegrationOperationRegistry is the single policy source for
 // negotiated routing, safe flag extraction, aggregate-timeout mutation truth,
-// capability publication, and operation-specific diagnostics.
+// capability publication, and operation-specific diagnostics -- and, for every
+// row, the runnable CLI verb an emitted transition command is built from.
+//
+// Those two jobs are not the same set. A row with Negotiated false owns only
+// the verb; see the field's own comment for why the difference is load-bearing.
 var reviewIntegrationOperationRegistry = []reviewIntegrationOperationMetadata{
-	{Command: "bind-sdd", Operation: ReviewIntegrationOperationBindSDD, Label: "Review BIND-SDD", ValueFlags: []string{"cwd", "change", "lineage", "expected-binding-revision"}, MutatesAuthority: true, JoinOnTimeout: true, TimeoutRetryable: true},
-	{Command: "capabilities", Operation: "review.capabilities", Label: "Review CAPABILITIES"},
+	{Command: "bind-sdd", Operation: ReviewIntegrationOperationBindSDD, Label: "Review BIND-SDD", Negotiated: true, ValueFlags: []string{"cwd", "change", "lineage", "expected-binding-revision"}, MutatesAuthority: true, JoinOnTimeout: true, TimeoutRetryable: true},
+	{Command: "capabilities", Operation: "review.capabilities", Label: "Review CAPABILITIES", Negotiated: true},
 	// The reviewer-result and evidence routes are all declared here, including
 	// the retired "result": an undeclared flag makes safeReviewIntegrationArguments
 	// treat the whole invocation as unparseable, which silently drops lineage_id
 	// from the failure envelope. Only "result" was ever listed, so every
 	// negotiated finalize failure on the admitted routes reported less than the
 	// unsafe one did.
-	{Command: "finalize", Operation: ReviewIntegrationOperationFinalize, Label: "Review FINALIZE", ValueFlags: []string{"cwd", "lineage", "expected-revision", "target", "request-hash", "repository-context", "validation", "refuter", "evidence", "trace", "result", "result-artifact", "result-artifact-file"}, BoolFlags: []string{"failed", "captured-results", "captured-evidence"}, IntFlags: []string{"correction-lines"}, MutatesAuthority: true},
-	{Command: "repair", Operation: "review.repair", Label: "Review REPAIR", ValueFlags: []string{"cwd", "class", "lineage", "expected-revision", "cause", "disposition", "repository-binding", "actor", "reason", "maintainer-authorization"}, BoolFlags: []string{"preflight"}, MutatesAuthority: true, JoinOnTimeout: true, ReadOnlyFlag: "preflight"},
-	{Command: "retry-final-verification", Operation: ReviewIntegrationOperationRetryFinalVerification, Label: "Review RETRY-FINAL-VERIFICATION", ValueFlags: []string{"cwd", "predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "incident", "actor", "reason", "maintainer-authorization"}, MutatesAuthority: true, JoinOnTimeout: true},
-	{Command: "start", Operation: "review.start", Label: "Review START", ValueFlags: []string{"cwd", "agent", "target", "lineage", "policy", "focus", "base-ref", "projection", "trace", "consent", "locale"}, BoolFlags: []string{"committed-only", "workspace-overlay"}, MutatesAuthority: true},
-	{Command: "status", Operation: "review.status", Label: "Review STATUS", ValueFlags: []string{"cwd", "agent", "lineage", "projection", "base-ref", "base-tree", "gate", "recovery-successor-lineage", "recovery-reason", "recovery-actor", "recovery-authorization", "repair-actor", "repair-reason", "repair-authorization"}, BoolFlags: []string{"workspace-overlay", "action-eligibility", "next-transition"}},
-	{Command: "validate", Operation: ReviewIntegrationOperationValidate, Label: "Review VALIDATE", ValueFlags: []string{"cwd", "lineage", "gate", "base-ref", "pre-pr-ci-attestation", "policy", "release-configuration", "release-generated", "release-provenance", "release-publication-boundary", "release-evidence-freshness"}},
+	{Command: "finalize", Operation: ReviewIntegrationOperationFinalize, Label: "Review FINALIZE", Negotiated: true, ValueFlags: []string{"cwd", "lineage", "expected-revision", "target", "request-hash", "repository-context", "validation", "refuter", "evidence", "trace", "result", "result-artifact", "result-artifact-file"}, BoolFlags: []string{"failed", "captured-results", "captured-evidence"}, IntFlags: []string{"correction-lines"}, MutatesAuthority: true},
+	// review.recover owns a verb without joining the published negotiated
+	// surface (see Negotiated above). It is emitted as an execute transition by
+	// reviewRecoveryCollection, both shipped status schemas publish it in their
+	// transition_execution operation enum, and `case "recover":` is a real
+	// dispatch in review_facade.go -- so the command line it renders is one a
+	// caller can run. It deliberately declares no flag or timeout metadata:
+	// those fields are consumed only on the negotiated route this row does not
+	// take, and metadata nothing exercises is metadata nothing keeps honest.
+	{Command: "recover", Operation: "review.recover", Label: "Review RECOVER"},
+	{Command: "repair", Operation: "review.repair", Label: "Review REPAIR", Negotiated: true, ValueFlags: []string{"cwd", "class", "lineage", "expected-revision", "cause", "disposition", "repository-binding", "actor", "reason", "maintainer-authorization"}, BoolFlags: []string{"preflight"}, MutatesAuthority: true, JoinOnTimeout: true, ReadOnlyFlag: "preflight"},
+	{Command: "retry-final-verification", Operation: ReviewIntegrationOperationRetryFinalVerification, Label: "Review RETRY-FINAL-VERIFICATION", Negotiated: true, ValueFlags: []string{"cwd", "predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "incident", "actor", "reason", "maintainer-authorization"}, MutatesAuthority: true, JoinOnTimeout: true},
+	{Command: "start", Operation: "review.start", Label: "Review START", Negotiated: true, ValueFlags: []string{"cwd", "agent", "target", "lineage", "policy", "focus", "base-ref", "projection", "trace", "consent", "locale"}, BoolFlags: []string{"committed-only", "workspace-overlay"}, MutatesAuthority: true},
+	{Command: "status", Operation: "review.status", Label: "Review STATUS", Negotiated: true, ValueFlags: []string{"cwd", "agent", "lineage", "projection", "base-ref", "base-tree", "gate", "recovery-successor-lineage", "recovery-reason", "recovery-actor", "recovery-authorization", "repair-actor", "repair-reason", "repair-authorization"}, BoolFlags: []string{"workspace-overlay", "action-eligibility", "next-transition"}},
+	{Command: "validate", Operation: ReviewIntegrationOperationValidate, Label: "Review VALIDATE", Negotiated: true, ValueFlags: []string{"cwd", "lineage", "gate", "base-ref", "pre-pr-ci-attestation", "policy", "release-configuration", "release-generated", "release-provenance", "release-publication-boundary", "release-evidence-freshness"}},
 }
 
+// reviewIntegrationOperationByCommand resolves the negotiated route for one
+// CLI verb. It answers only for published negotiated operations: a verb-owning
+// row is dispatched by runReviewCommand and has no negotiated handler, so
+// routing it here would wrap it in the negotiated facade and then feed it a
+// --contract flag its own flag set does not define.
 func reviewIntegrationOperationByCommand(command string) (reviewIntegrationOperationMetadata, bool) {
 	for _, metadata := range reviewIntegrationOperationRegistry {
-		if metadata.Command == command {
+		if metadata.Negotiated && metadata.Command == command {
 			return metadata, true
 		}
 	}
@@ -83,9 +116,16 @@ func reviewIntegrationOperationByName(operation string) (reviewIntegrationOperat
 	return reviewIntegrationOperationMetadata{}, false
 }
 
+// reviewIntegrationOperationNames is the published capabilities `operations`
+// array, so it carries only the negotiated surface. Every shipped
+// capabilities schema pins both an exact length and a closed enum, and an
+// external consumer reads them.
 func reviewIntegrationOperationNames() []string {
 	operations := make([]string, 0, len(reviewIntegrationOperationRegistry))
 	for _, metadata := range reviewIntegrationOperationRegistry {
+		if !metadata.Negotiated {
+			continue
+		}
 		operations = append(operations, metadata.Operation)
 	}
 	return operations
@@ -1246,9 +1286,14 @@ func supportedReviewIntegrationFailureInput(input string) bool {
 	}
 }
 
+// validReviewIntegrationFailureOperation guards the failure envelope's
+// `operation` field, whose published enum is exactly the negotiated surface. A
+// verb-owning row never reaches the negotiated facade, so it never produces one
+// of these envelopes; admitting it here would only let Validate() pass an
+// envelope the shipped schema rejects.
 func validReviewIntegrationFailureOperation(operation string) bool {
-	_, valid := reviewIntegrationOperationByName(operation)
-	return valid
+	metadata, known := reviewIntegrationOperationByName(operation)
+	return known && metadata.Negotiated
 }
 
 func validReviewIntegrationFailureCode(code string) bool {

--- a/internal/cli/review_transition_command_test.go
+++ b/internal/cli/review_transition_command_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -179,28 +180,24 @@ func reviewTransitionExecutionOperationEnum(t *testing.T, schemaFile string) []s
 // exhaustive set of published transition operations that resolve to NO
 // runnable command, and why.
 //
-// "review.recover" is emitted as an execute transition by
-// reviewRecoveryCollection, is published in both status schemas' operation
-// enums, and `case "recover":` is a real dispatch in review_facade.go -- but
-// reviewIntegrationOperationRegistry has no entry for it, so no registry-owned
-// verb exists to derive. Adding one is NOT a local fix: the registry also
-// drives reviewIntegrationOperationNames(), which publishes the negotiated
-// capabilities `operations` array. Adding "review.recover" there was measured
-// to break five existing tests that pin that published surface
-// (TestReviewCapabilitiesMatchesConformanceFixtureOutsideRepository,
-// TestReviewCapabilitiesAdvertisesOnlyNativeSurface,
-// TestReviewCapabilitiesSchemaAndFixtureAreStrict,
-// TestReviewCapabilitiesVersionsKeepV1ReadableAndFailClosedAcrossSchemas and
-// TestReviewIntegrationOperationRegistryOwnsPublishedAndFailurePolicy), plus
-// the v1.1-v1.5 capability fixtures external consumers read. That is a
-// published-contract change and a maintainer decision, not a derivation.
+// It is EMPTY, and that is the point: every operation either status schema
+// publishes as an execute transition resolves to a verb review_facade.go
+// really dispatches.
+//
+// It held "review.recover" until issue #1864. The reasoning recorded there was
+// that adding a registry row was not a local fix, because the registry also
+// drives reviewIntegrationOperationNames() and therefore the published
+// capabilities `operations` array, whose schemas pin an exact maxItems and a
+// closed enum. That reasoning was right about the constraint and wrong about
+// the conclusion: the fix was to stop conflating "this row owns a runnable CLI
+// verb" with "this operation is part of the published negotiated surface".
+// reviewIntegrationOperationMetadata.Negotiated now separates them, so
+// review.recover owns its verb without appearing in any published contract.
 //
 // This map fails closed in BOTH directions below, so it can never rot: a new
 // unresolved operation fails, and an operation named here that later DOES
 // resolve fails too, forcing the entry to be removed.
-var reviewTransitionOperationsWithoutRegistryEntry = map[string]string{
-	"review.recover": "absent from reviewIntegrationOperationRegistry; adding it changes the published negotiated capabilities surface",
-}
+var reviewTransitionOperationsWithoutRegistryEntry = map[string]string{}
 
 // TestEveryPublishedTransitionOperationProducesARunnableCommand is the test
 // that makes this defect impossible to reintroduce for a FUTURE operation: it
@@ -460,4 +457,127 @@ func TestPublishedStatusSchemasRequireTokenOnExecutableArguments(t *testing.T) {
 			t.Errorf("%s transition_execution declares no command property: %#v", schemaFile, properties["command"])
 		}
 	}
+}
+
+// TestReviewRecoverTransitionEmitsACommandThatRuns is issue #1864 in one test.
+//
+// A negotiated recovery emitted `kind: execute`, named `review.recover`, and
+// carried an empty `command`: the caller was told to run something and handed
+// nothing to run. Asserting the string is only half a proof, so this builds a
+// real authorized recovery, reads the command the product prints, splits it the
+// way a POSIX shell would, and runs exactly those bytes. The recovery has to
+// actually land, because a command that parses but does not work is the dead
+// end this defect class is about.
+func TestReviewRecoverTransitionEmitsACommandThatRuns(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "recover-command"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	result := filepath.Join(t.TempDir(), "blocking.json")
+	writeReviewCLIJSON(t, result, facadeReviewerResult{Lens: started.SelectedLenses[0], Findings: []facadeFinding{{
+		Location: "candidate.go:3", Severity: "CRITICAL", Claim: "candidate requires a helper",
+		ProofRefs: []string{"candidate.go:3 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+		CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, Evidence: []string{"reviewed exact current changes"}})
+	if err := finalizeReviewCLIArgs(t, repo, []string{"--cwd", repo, "--lineage", started.LineageID, "--result", result}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change the candidate so the live target really differs from the frozen
+	// one; recovery onto an unchanged target is refused by design.
+	writeReviewStartCandidate(t, repo, "helper.go", "package candidate\n", 0o644)
+	probe := selectorTransitionStatus(t, repo, "--lineage", started.LineageID)
+	if probe.Authority == nil || probe.Action != reviewtransaction.TargetStatusActionRecover {
+		t.Fatalf("recovery probe = action %q authority %#v", probe.Action, probe.Authority)
+	}
+	const successor, actor, reason = "recover-command-successor", "maintainer", "authorized recovery"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + started.LineageID +
+		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
+		"\nsuccessor_lineage=" + successor + "\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo,
+		"--lineage", started.LineageID,
+		"--recovery-successor-lineage", successor,
+		"--recovery-reason", reason,
+		"--recovery-actor", actor,
+		"--recovery-authorization", authorization,
+	)
+	if status.NextTransition == nil || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.recover" {
+		t.Fatalf("recovery transition = %#v", status.NextTransition)
+	}
+
+	// The exact bytes a caller is handed. The authorization is six LF-joined
+	// lines, so it is the one argument the product must quote for the printed
+	// line to survive a shell.
+	want := "gentle-ai review recover" +
+		" --predecessor-lineage=" + started.LineageID +
+		" --expected-predecessor-revision=" + probe.Authority.Revision +
+		" --successor-lineage=" + successor +
+		" --disposition=" + string(probe.ActionDisposition) +
+		" '--reason=" + reason + "'" +
+		" --actor=" + actor +
+		" '--maintainer-authorization=" + authorization + "'"
+	if status.NextTransition.Execute.Command != want {
+		t.Fatalf("recover command = %q\nwant %q", status.NextTransition.Execute.Command, want)
+	}
+
+	// Run the printed bytes, not a reassembly of them.
+	words := reviewShellWords(t, status.NextTransition.Execute.Command)
+	if len(words) < 3 || words[0] != "gentle-ai" || words[1] != "review" {
+		t.Fatalf("printed command is not a gentle-ai review invocation: %#v", words)
+	}
+	t.Chdir(repo)
+	var recovered bytes.Buffer
+	if err := RunReview(words[2:], &recovered); err != nil {
+		t.Fatalf("the printed command did not run: %v\n%s", err, recovered.String())
+	}
+	var operation ReviewRecoverResult
+	decodeStrictReviewJSON(t, recovered.Bytes(), &operation)
+	if operation.LineageID != successor || operation.State != reviewtransaction.StateReviewing {
+		t.Fatalf("printed recovery command produced %#v, want a reviewing successor %q", operation, successor)
+	}
+}
+
+// reviewShellWords splits a printed command line the way a POSIX shell would,
+// understanding exactly the single quoting reviewTransitionShellWord emits.
+func reviewShellWords(t *testing.T, line string) []string {
+	t.Helper()
+	words := []string{}
+	var word strings.Builder
+	quoted, escaped, started := false, false, false
+	for _, char := range line {
+		switch {
+		case quoted && char == '\'':
+			quoted = false
+		case quoted:
+			word.WriteRune(char)
+		case escaped:
+			word.WriteRune(char)
+			escaped = false
+		case char == '\\':
+			escaped, started = true, true
+		case char == '\'':
+			quoted, started = true, true
+		case char == ' ' || char == '\t' || char == '\n':
+			if started {
+				words = append(words, word.String())
+				word.Reset()
+				started = false
+			}
+		default:
+			word.WriteRune(char)
+			started = true
+		}
+	}
+	if quoted || escaped {
+		t.Fatalf("printed command does not close its quoting: %q", line)
+	}
+	if started {
+		words = append(words, word.String())
+	}
+	return words
 }


### PR DESCRIPTION
A negotiated transition could say `kind: execute`, name an operation, and carry no command. The user was told to run something and given nothing to run. The benchmark that exists to catch exactly that scored it as passing.

## What actually hid it, which is not what the issue said

The stated diagnosis was that `bench/classify.go` accepted any non-empty `execute.operation` without requiring a command. That is true and it is fixed here. **But fixing only that would have left the corpus exactly as blind.**

Instrumenting the runner showed the corpus emits exactly one broken transition, in j46, and it is `is_block=false`. `Classify` only ever runs on blocks, so the defective envelope was never classified at all.

The real leak was `runNextTransitionVerbatim`, inside a journey titled *"the printed transition executes exactly as printed"*. It never read `Execute.Command`. It **rebuilt** one by splitting the operation name on `.` and re-joining the tokens.

The benchmark was assembling the command the product owed the reader. A journey whose entire purpose was to prove the printed command runs was printing its own. That split is also wrong in general: `review.retry_final_verification` and `review.bind_sdd` spell their verbs with hyphens. All three re-derivation sites now run the printed bytes through one POSIX splitter.

That is what produced the corpus red:

```
j46-correction-required-staged-recovery   failed
  failed: step "negotiate and execute staged recovery":
          execute transition for "review.recover" carried no command to run
```

## The structural guard

Rather than only report the blindness, this closes the class. Every observation is scanned for a dead execute transition, blocking or not, and a hit **fails the journey and the run** rather than moving a number.

Two properties do the work. It does not depend on any journey remembering to run the command it was handed, and it produces a failure rather than a classification, so it cannot be satisfied by teaching one call site to expect the broken shape. Proved failable by disabling the branch, watching it go red, and restoring.

This matters because the same disease has now appeared three times in one day: the bench corpus and a unit-test helper were both taught to satisfy a new gate in the very commit that introduced it, and a test row asserted a defect as intended behavior. A guard that only a cooperating journey can trip is not a guard.

## Operations registered, and deliberately not

Verb existence was checked against the built binary, not read from source.

| Operation | Verb | Registered |
|---|---|---|
| `review.recover` | `Usage: gentle-ai review recover [flags]` | yes |
| `review.abandon`, `.invalidate`, `.reclaim` | exist | no |
| `review.quarantine-legacy`, `.reconcile-authority`, `.reconcile-authority-batch` | `unknown review command` | no |

Three verbs were retired in Wave 7, and registering them would name dead commands, which this project has already decided is worse than naming none. The other three exist but are never owed a command: the published `transition_execution.operation` enum is start, finalize, recover, validate, plus repair in v2, and those are the only five `reviewExecuteTransition` call sites. A row for them would be metadata with no consumer. A new guard formalizes that: a non-negotiated row carrying flag or timeout metadata fails.

The registry could not simply gain a row. `reviewIntegrationOperationNames()` drives the published capabilities `operations` array, whose schema pins `maxItems: 8` and a closed enum, and `failure.schema.json` pins the same eight. So the conflated concept is split: a new `Negotiated` field separates published negotiated surface from owning a runnable verb. `review.recover` renders its command and appears in no published contract. The gap map is now empty and still fails closed in both directions.

## Executed evidence

Real shell, real repository, `eval` of the exact emitted string.

Before:
```
{ "kind": "execute", "operation": "review.recover", "command": null }
repro-recover.sh: line 46: null: command not found
```

After, the emitted command runs and returns `{"operation":"review/recover","state":"reviewing"}`. The six-line LF maintainer authorization survives the shell because the whole word is quoted.

## Scorelines

```
BEFORE  bench@main  + product@9b2cf201 : 59 completed, 0 failed
RED     bench fixed + product@9b2cf201 : 58 completed, 1 FAILED
AFTER   bench fixed + product fixed    : 59 completed, 0 failed
```

Every dimension identical before and after except `human_surface_bytes`, 21249 to 21248. That was checked rather than assumed: two identical runs of the same binary give 21249 and 21248, so the dimension carries a couple of bytes of jitter.

## Verification

gofmt and vet clean, root `go test ./... -count=1` exit 0, bench module ok, deadcode ratchet reports no new unreachable functions, refusal ratchet green including the vocabulary test that pairs it with the bench classifier.

## Known, not fixed

`selectorTransitionCommandArguments` in `internal/cli/review_selector_transition_test.go` re-derives the verb with `strings.TrimPrefix(operation, "review.")`. Same blindness, in the unit-test surface. Test-only and outside this scope, but it will keep passing over a transition whose printed command is empty.

Closes #1864
Closes #1865

Part of #2471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Commands emitted for transitions now execute exactly as displayed, including quoted arguments, spaces, and newlines.
  - Invalid, missing, empty, or templated commands are rejected instead of being reconstructed or incorrectly executed.
  - Journeys now fail clearly when an `execute` transition has no runnable continuation.
  - Recovery commands are routed and executed correctly while remaining separate from published review operations.
- **Tests**
  - Added coverage for command parsing, validation, recovery execution, and dead transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->