### PR TITLE
fix(assets): derive the shared skill file set instead of enumerating it three times

### DIFF
--- a/internal/assets/shared_skill_files.go
+++ b/internal/assets/shared_skill_files.go
@@ -1,0 +1,40 @@
+package assets
+
+import (
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+// SharedSkillDir is the embedded directory holding the skill files that are
+// shared across skills rather than owned by any single one.
+const SharedSkillDir = "skills/_shared"
+
+// SharedSkillFileNames returns every file embedded under SharedSkillDir as a
+// slash-separated path relative to that directory, sorted for deterministic
+// ordering. The walk is recursive, so a nested shared file is reported too.
+//
+// The embedded directory listing is the single source of truth for the shared
+// skill inventory. Every deployment path (install, sync, upgrade) derives from
+// this function; none of them may keep a literal list, because a literal that
+// drifts silently strands a shared file on the build machine.
+func SharedSkillFileNames() ([]string, error) {
+	var names []string
+	err := fs.WalkDir(FS, SharedSkillDir, func(assetPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		names = append(names, strings.TrimPrefix(assetPath, SharedSkillDir+"/"))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list embedded %s: %w", SharedSkillDir, err)
+	}
+
+	sort.Strings(names)
+	return names, nil
+}

--- a/internal/assets/shared_skill_files_test.go
+++ b/internal/assets/shared_skill_files_test.go
@@ -1,0 +1,78 @@
+package assets
+
+import (
+	"io/fs"
+	"sort"
+	"testing"
+)
+
+// collectSharedFilesByReadDir independently derives the shared inventory with
+// manual recursion over fs.ReadDir, so the helper is compared against a
+// separately written traversal rather than against itself.
+func collectSharedFilesByReadDir(t *testing.T, dir, prefix string) []string {
+	t.Helper()
+
+	entries, err := fs.ReadDir(FS, dir)
+	if err != nil {
+		t.Fatalf("ReadDir(FS, %q) error = %v", dir, err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, collectSharedFilesByReadDir(t, dir+"/"+entry.Name(), prefix+entry.Name()+"/")...)
+			continue
+		}
+		names = append(names, prefix+entry.Name())
+	}
+	return names
+}
+
+// TestSharedSkillFileNamesMatchesEmbeddedListing pins that the derivation
+// helper reproduces the embedded skills/_shared listing exactly. Deployment
+// call sites read this helper instead of maintaining literal inventories.
+func TestSharedSkillFileNamesMatchesEmbeddedListing(t *testing.T) {
+	want := collectSharedFilesByReadDir(t, SharedSkillDir, "")
+	sort.Strings(want)
+
+	got, err := SharedSkillFileNames()
+	if err != nil {
+		t.Fatalf("SharedSkillFileNames() error = %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("SharedSkillFileNames() = %v (%d files), want %v (%d files)", got, len(got), want, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("SharedSkillFileNames()[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestSharedSkillFileNamesIsSortedAndReadable pins deterministic ordering and
+// that every reported name resolves as an embedded asset, so derived path
+// lists stay stable and every entry is deployable.
+func TestSharedSkillFileNamesIsSortedAndReadable(t *testing.T) {
+	got, err := SharedSkillFileNames()
+	if err != nil {
+		t.Fatalf("SharedSkillFileNames() error = %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("SharedSkillFileNames() returned no files; the shared inventory cannot be empty")
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("SharedSkillFileNames() = %v, want sorted order", got)
+	}
+
+	for _, name := range got {
+		content, readErr := Read(SharedSkillDir + "/" + name)
+		if readErr != nil {
+			t.Errorf("SharedSkillFileNames() reported %q but it is not readable: %v", name, readErr)
+			continue
+		}
+		if len(content) == 0 {
+			t.Errorf("SharedSkillFileNames() reported %q but the embedded asset is empty", name)
+		}
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1903,13 +1903,18 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if adapter.SupportsSkills() {
 				skillDir := adapter.SkillsDir(targetDir)
 				if skillDir != "" {
+					// The embedded skills/_shared listing is the single source of
+					// truth for the shared inventory; deriving it here keeps a
+					// newly added shared file from silently missing a sync.
+					// A listing error can only mean the embedded directory is
+					// gone, which Inject reports as a hard failure. This
+					// function has no error channel, so it contributes no
+					// shared paths rather than inventing them.
+					sharedFiles, _ := assets.SharedSkillFileNames()
+					for _, relPath := range sharedFiles {
+						paths = append(paths, filepath.Join(skillDir, "_shared", filepath.FromSlash(relPath)))
+					}
 					paths = append(paths,
-						filepath.Join(skillDir, "_shared", "persistence-contract.md"),
-						filepath.Join(skillDir, "_shared", "engram-convention.md"),
-						filepath.Join(skillDir, "_shared", "openspec-convention.md"),
-						filepath.Join(skillDir, "_shared", "sdd-phase-common.md"),
-						filepath.Join(skillDir, "_shared", "sdd-status-contract.md"),
-						filepath.Join(skillDir, "_shared", "skill-resolver.md"),
 						filepath.Join(skillDir, "sdd-init", "SKILL.md"),
 						filepath.Join(skillDir, "sdd-explore", "SKILL.md"),
 						filepath.Join(skillDir, "sdd-propose", "SKILL.md"),

--- a/internal/cli/run_shared_asset_deployment_test.go
+++ b/internal/cli/run_shared_asset_deployment_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// embeddedSharedFileNames returns the names of every file embedded under
+// skills/_shared. Sync path coverage is asserted against this listing rather
+// than a literal so a newly added shared file cannot silently miss a path.
+func embeddedSharedFileNames(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := fs.ReadDir(assets.FS, "skills/_shared")
+	if err != nil {
+		t.Fatalf("ReadDir(assets.FS, skills/_shared) error = %v", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		t.Fatal("embedded skills/_shared listing is empty; the source of truth cannot be empty")
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestComponentPathsSDDCoversEveryEmbeddedSharedFile pins the sync property:
+// every embedded shared file is a tracked SDD component path, so a sync backs
+// it up and verifies it instead of leaving it unmanaged.
+func TestComponentPathsSDDCoversEveryEmbeddedSharedFile(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentGeminiCLI})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentSDD)
+	skillDir := adapters[0].SkillsDir(home)
+
+	for _, name := range embeddedSharedFileNames(t) {
+		want := filepath.Join(skillDir, "_shared", name)
+		if !containsPath(paths, want) {
+			t.Errorf("componentPaths(sdd) missing embedded shared file %q (%s)", name, want)
+		}
+	}
+}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -494,14 +494,15 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	if adapter.SupportsSkills() {
 		skillDir := adapter.SkillsDir(homeDir)
 		if skillDir != "" {
-			sharedFiles := []string{
-				"SKILL.md",
-				"persistence-contract.md",
-				"engram-convention.md",
-				"openspec-convention.md",
-				"sdd-phase-common.md",
-				"sdd-status-contract.md",
-				"skill-resolver.md",
+			// The embedded skills/_shared listing is the single source of
+			// truth for the shared inventory; deriving it here keeps a newly
+			// added shared file from silently missing this deployment path.
+			sharedFiles, sharedErr := assets.SharedSkillFileNames()
+			if sharedErr != nil {
+				return InjectionResult{}, fmt.Errorf("resolve SDD shared files: %w", sharedErr)
+			}
+			if len(sharedFiles) == 0 {
+				return InjectionResult{}, fmt.Errorf("resolve SDD shared files: embedded %s listing is empty", assets.SharedSkillDir)
 			}
 			sddSkillIDs := []model.SkillID{
 				"sdd-init", "sdd-explore", "sdd-propose", "sdd-spec",
@@ -513,7 +514,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			// These are written directly, not via skills.Inject, since they are
 			// not part of the skills component's injection scope.
 			for _, fileName := range sharedFiles {
-				assetPath := "skills/_shared/" + fileName
+				assetPath := assets.SharedSkillDir + "/" + fileName
 				content, readErr := assets.Read(assetPath)
 				if readErr != nil {
 					return InjectionResult{}, fmt.Errorf("required SDD shared file %q: embedded asset not found: %w", fileName, readErr)

--- a/internal/components/sdd/shared_asset_deployment_test.go
+++ b/internal/components/sdd/shared_asset_deployment_test.go
@@ -1,0 +1,109 @@
+package sdd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+)
+
+// embeddedSharedFileNames returns the names of every file embedded under
+// skills/_shared. The embedded listing is the single source of truth for the
+// shared skill inventory; tests must derive from it so that adding a file
+// cannot silently skip a deployment path.
+func embeddedSharedFileNames(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := fs.ReadDir(assets.FS, "skills/_shared")
+	if err != nil {
+		t.Fatalf("ReadDir(assets.FS, skills/_shared) error = %v", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		t.Fatal("embedded skills/_shared listing is empty; the source of truth cannot be empty")
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestInjectDeploysEveryEmbeddedSharedFile pins the install property: every file
+// embedded under skills/_shared reaches the user's machine. Asserting against
+// the embedded listing rather than a literal keeps a newly added shared file
+// from silently missing this path.
+func TestInjectDeploysEveryEmbeddedSharedFile(t *testing.T) {
+	mockNoPackageManager(t)
+	home := t.TempDir()
+
+	result, err := Inject(home, opencodeAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	reported := make(map[string]struct{}, len(result.Files))
+	for _, file := range result.Files {
+		reported[file] = struct{}{}
+	}
+
+	sharedDir := filepath.Join(home, ".config", "opencode", "skills", "_shared")
+	for _, name := range embeddedSharedFileNames(t) {
+		path := filepath.Join(sharedDir, name)
+
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Errorf("embedded shared file %q not deployed by Inject(): %v", name, statErr)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("embedded shared file %q deployed empty at %s", name, path)
+		}
+		if _, ok := reported[path]; !ok {
+			t.Errorf("embedded shared file %q deployed but not reported in result.Files", name)
+		}
+	}
+}
+
+var sharedRelativeLinkPattern = regexp.MustCompile(`\]\(\.\./_shared/([^)#]+)`)
+
+// TestSkillRelativeSharedLinksResolveAfterInject pins that a skill shipping a
+// ../_shared/ relative link resolves on disk after install. judgment-day links
+// to review-ledger-contract.md, so a shared file that never deploys turns into
+// a dangling reference on every synced machine.
+func TestSkillRelativeSharedLinksResolveAfterInject(t *testing.T) {
+	mockNoPackageManager(t)
+	home := t.TempDir()
+
+	if _, err := Inject(home, opencodeAdapter(), ""); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	skillsRoot := filepath.Join(home, ".config", "opencode", "skills")
+	skillDoc := filepath.Join(skillsRoot, "judgment-day", "SKILL.md")
+
+	content, err := os.ReadFile(skillDoc)
+	if err != nil {
+		t.Fatalf("read deployed judgment-day SKILL.md: %v", err)
+	}
+
+	matches := sharedRelativeLinkPattern.FindAllStringSubmatch(string(content), -1)
+	if len(matches) == 0 {
+		t.Fatal("judgment-day SKILL.md has no ../_shared/ relative link; the guard would prove nothing")
+	}
+
+	for _, match := range matches {
+		target := filepath.Join(skillsRoot, "_shared", filepath.FromSlash(match[1]))
+		if _, statErr := os.Stat(target); statErr != nil {
+			t.Errorf("judgment-day SKILL.md links to %q but it does not resolve on disk: %v", match[1], statErr)
+		}
+	}
+}

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -277,15 +277,15 @@ func managedSkillBackupPaths(homeDir string, adapter agents.Adapter, diagnostics
 		})
 	}
 
-	for _, relPath := range []string{
-		"_shared/persistence-contract.md",
-		"_shared/engram-convention.md",
-		"_shared/openspec-convention.md",
-		"_shared/sdd-phase-common.md",
-		"_shared/sdd-status-contract.md",
-		"_shared/skill-resolver.md",
-	} {
-		paths = append(paths, filepath.Join(skillDir, relPath))
+	// The embedded skills/_shared listing is the single source of truth for the
+	// shared inventory; deriving it here keeps a newly added shared file from
+	// silently missing the upgrade backup.
+	sharedFiles, sharedErr := assets.SharedSkillFileNames()
+	if sharedErr != nil {
+		writeBackupDiagnostic(diagnostics, "backup: skipping embedded path %s: %v", assets.SharedSkillDir, sharedErr)
+	}
+	for _, relPath := range sharedFiles {
+		paths = append(paths, filepath.Join(skillDir, "_shared", filepath.FromSlash(relPath)))
 	}
 
 	return paths

--- a/internal/update/upgrade/shared_asset_deployment_test.go
+++ b/internal/update/upgrade/shared_asset_deployment_test.go
@@ -1,0 +1,59 @@
+package upgrade
+
+import (
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+)
+
+// embeddedSharedFileNames returns the names of every file embedded under
+// skills/_shared. Upgrade backup coverage is asserted against this listing
+// rather than a literal so a newly added shared file cannot silently miss it.
+func embeddedSharedFileNames(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := fs.ReadDir(assets.FS, "skills/_shared")
+	if err != nil {
+		t.Fatalf("ReadDir(assets.FS, skills/_shared) error = %v", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		t.Fatal("embedded skills/_shared listing is empty; the source of truth cannot be empty")
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestManagedSkillBackupPathsCoverEveryEmbeddedSharedFile pins the upgrade
+// property: every embedded shared file is a managed backup path, so upgrading
+// preserves and restores it instead of dropping it.
+func TestManagedSkillBackupPathsCoverEveryEmbeddedSharedFile(t *testing.T) {
+	home := t.TempDir()
+	adapter := opencode.NewAdapter()
+
+	paths := managedSkillBackupPaths(home, adapter, io.Discard)
+	got := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		got[path] = struct{}{}
+	}
+
+	skillDir := adapter.SkillsDir(home)
+	for _, name := range embeddedSharedFileNames(t) {
+		want := filepath.Join(skillDir, "_shared", name)
+		if _, ok := got[want]; !ok {
+			t.Errorf("managedSkillBackupPaths missing embedded shared file %q (%s)", name, want)
+		}
+	}
+}


### PR DESCRIPTION
`internal/assets/skills/_shared/` ships 8 files. Three independent hardcoded lists enumerated them and none was right, so `review-ledger-contract.md` never reached a user's machine at all, and `skills/judgment-day/SKILL.md:51` linked to it on every synced install.

That matters more than it sounds: PR #2462 rewrote that file's contents, including the table telling an orchestrator how to recover from a stop reason code. The rewrite reached nobody.

## The three lists as found

| Site | Count | Missing |
|---|---|---|
| `internal/components/sdd/inject.go:497-505` | 7 | `review-ledger-contract.md` |
| `internal/cli/run.go:1906-1912` | 6 | `review-ledger-contract.md`, `SKILL.md` |
| `internal/update/upgrade/executor.go:280-287` | 6 | same two |

## The change

All three literals are deleted. A new `assets.SharedSkillFileNames()` walks `assets.FS` rooted at a new `assets.SharedSkillDir` constant and returns the sorted slash-relative paths. It uses `fs.WalkDir` rather than `ReadDir`, matching `walkEmbeddedFiles` semantics, so a future nested shared file is covered rather than silently dropped.

No subset predicate was needed: all three call sites want the whole directory. `inject.go` treats a listing failure or empty listing as a hard error, `executor.go` emits its existing backup diagnostic, and `run.go` has no error channel so it contributes no shared paths rather than inventing them.

No fourth representation was added. #1810 proposes a per-component path spec, which is the additive shape that produced this drift in the first place.

## Evidence at the binary level

The strongest proof here is not a unit test. `origin/main` was built unmodified and a real install run into a sandboxed `HOME`:

```
=== baseline (origin/main) deployed _shared ===
engram-convention.md   openspec-convention.md   persistence-contract.md
sdd-phase-common.md    sdd-status-contract.md   skill-resolver.md   SKILL.md
```

Seven files. After the fix the same install produces all eight, the deployed `review-ledger-contract.md` is byte-identical to the embedded source, and the `judgment-day` link resolves on disk.

## Properties pinned

Every new test derives its expected set from `fs.ReadDir(assets.FS, "skills/_shared")` at runtime. **No test names the eight files by hand**, because a test that lists them recreates the drift one layer up. The link test derives the filename from the shipped `../_shared/` link in the deployed `judgment-day/SKILL.md` rather than hardcoding it, and fails loudly if that skill ever stops carrying such a link, so the guard cannot go vacuous.

## Correction to #1806's premise

#1806 states that `inject.go` already deploys all 8 post-#1805, and its reproduction says "observe `inject.go` lists 8 files". **PR #1805 never landed.** On main the list is 7.

Anyone picking up #1806 on that premise will go looking for a correct 8-entry list to copy, will not find one, and will conclude only two of the three sites are broken. All three were.

## Relationship to PR #2038

#2038 fixes the same symptom by extending the lists. This removes the lists. They cannot both merge; whoever merges should close one against the other. Nothing was closed here.

## Verification

gofmt and vet clean on both modules, root and bench `go test ./... -count=1` clean, deadcode ratchet reports no new unreachable functions with no `--update` needed, refusal ratchet green. No goldens changed, and every test passed without `-update`, so there was nothing to regenerate and no blind-regeneration risk.

Shell E2E Tier 1 and 2: 488 passed, 0 failed, run twice.

## Undetermined

The Docker E2E matrix did not run: the image build failed on docker socket permissions for this account. `e2e/e2e_test.sh`, the same script the container runs, was executed directly with a sandboxed `HOME` and passed 488 of 488, but that covers one distro rather than the ubuntu, arch and fedora matrix. Worth a re-run by someone with docker access before merge.

Three pre-existing tests still name 5 or 6 shared files by hand and are now strict subsets of the derived guards. They were left rather than deleted on one agent's judgment, but they encode the same stale inventory and should be folded in.

`internal/update` carries a pre-existing flake: `TestCheckSingleToolGentleAIStableVersionWithoutChannelComparesLatestRelease` swaps a package-level `httpClient` global and can collide with siblings. Green in isolation, green on rerun, green on a clean tree. Untouched by this change and worth its own issue.

Closes #1485
Closes #1806

Part of #2471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared skill assets are now discovered automatically, ensuring newly added files are included in deployments, backups, and upgrades.
  * Shared assets are consistently listed and processed in a predictable order.

* **Bug Fixes**
  * Improved reliability of shared skill installation and backup handling.
  * Added validation to detect missing, unreadable, or empty shared assets and unresolved links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->