### PR TITLE
fix(filemerge): confirm writes by reading them back, from one durability sequence

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -1809,19 +1809,19 @@ func sddJourneys() []Journey {
 				{Name: "review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
 				{Name: "review finalize", Requires: finalizeCapability, Args: productArgs("review", "finalize"), After: rememberLineage},
 				{Name: "walk into the recovery guard rails", Requires: recoverCapability, Composite: sddWalkIntoRecoveryGuardRails},
-				// The third rail is the one whose honest exit is not a command.
-				// The approval covers exactly the candidate in the working tree,
-				// so nothing the operator can run makes it stale; the bytes have
-				// to change first. The product cannot print a complete command
-				// either, because the successor's name is the operator's to
-				// choose. The declaration is what says that out loud, and it is
-				// verified against the words the product actually printed.
+				// This step used to carry a by-design world-action declaration:
+				// the approval covers exactly the candidate in the working tree,
+				// so nothing the operator runs makes it stale, and the product
+				// was said to be unable to print a complete command because the
+				// successor's name is the operator's to choose.
+				//
+				// The product now prints one, so the declaration was failing as
+				// a stale claim. It is removed rather than restated, because the
+				// runner already counts this in_band from mechanical evidence and
+				// a declaration that disagrees with what the product printed is
+				// worth less than the printed words themselves.
 				{Name: "invalidate the healthy approved authority", Requires: invalidateCapability,
-					Args: sddInvalidateHealthyApproved,
-					ByDesign: &ByDesignDeclaration{
-						Shape:      ByDesignWorldAction,
-						NextAction: "change the candidate first",
-					}},
+					Args: sddInvalidateHealthyApproved},
 				{Name: "the refused invalidation changed nothing", Composite: sddProveApprovalSurvived},
 				{Name: "fixture: change the candidate, which is what all three asked for", Fixture: stageProse("", "changed")},
 				{Name: "recover, following exactly what the gate then names",

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -5,8 +5,6 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
@@ -494,8 +493,13 @@ func engramChecksumURL(baseURL, version string) string {
 		baseURL, engramOwner, engramRepo, version)
 }
 
-// engramDownloadToFile downloads the resource at url to outPath and returns
-// the SHA256 hex digest of the downloaded content.
+// engramDownloadToFile downloads the resource at url to outPath and returns the
+// SHA256 hex digest of the bytes that landed there.
+//
+// The digest is read back from outPath, not accumulated from the response body.
+// A digest taken from the stream certifies its own copy: it matched the release
+// manifest even when a write-back failure left the archive incomplete on disk,
+// so verification confirmed corruption instead of catching it (#1998).
 func engramDownloadToFile(ctx context.Context, url string, outPath string) (hexDigest string, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -511,21 +515,16 @@ func engramDownloadToFile(ctx context.Context, url string, outPath string) (hexD
 		return "", fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
 	}
 
+	// Create the parent at 0755 explicitly: the writer's own parent creation is
+	// tuned for private config files, and a download directory on PATH is not one.
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return "", fmt.Errorf("create dir: %w", err)
 	}
-	f, err := os.Create(outPath)
+	result, err := filemerge.WriteStreamAtomic(outPath, resp.Body, 0o644)
 	if err != nil {
-		return "", fmt.Errorf("create %s: %w", outPath, err)
-	}
-	defer f.Close()
-
-	h := sha256.New()
-	if _, err := io.Copy(io.MultiWriter(f, h), resp.Body); err != nil {
 		return "", fmt.Errorf("write %s: %w", outPath, err)
 	}
-
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return result.Digest, nil
 }
 
 // engramFetchChecksums downloads checksums.txt from url and returns its content.
@@ -839,51 +838,21 @@ func engramGoInstallFromMain(pkg string) (string, error) {
 	return filepath.Join(gobin, binaryName), nil
 }
 
-// writeExecutable writes the content from r to outPath with executable permissions.
 // writeExecutable writes a binary to outPath using an atomic rename to avoid
 // ETXTBSY ("text file busy") errors on Linux when the target binary is
 // currently running (e.g. engram as an MCP server). The rename trick works
 // because os.Rename replaces the directory entry — the running process keeps
 // its open file descriptor to the old inode, while new executions pick up
 // the new binary.
+//
+// The staged file is synchronized before publication, so if recovery preserves
+// the new name it also preserves complete content (#2216).
 func writeExecutable(r io.Reader, outPath string) error {
-	dir := filepath.Dir(outPath)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return fmt.Errorf("create parent dir: %w", err)
 	}
-
-	// Write to a temp file in the same directory so Rename is always
-	// same-filesystem (atomic on POSIX).
-	tmp, err := os.CreateTemp(dir, ".engram-upgrade-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
+	if _, err := filemerge.WriteStreamAtomic(outPath, r, 0o755); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
 	}
-	tmpPath := tmp.Name()
-
-	// Clean up on any failure path.
-	defer func() {
-		if tmpPath != "" {
-			os.Remove(tmpPath)
-		}
-	}()
-
-	if _, err := io.Copy(tmp, r); err != nil {
-		tmp.Close()
-		return fmt.Errorf("write %s: %w", tmpPath, err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp file: %w", err)
-	}
-
-	if err := os.Chmod(tmpPath, 0o755); err != nil {
-		return fmt.Errorf("chmod temp file: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, outPath); err != nil {
-		return fmt.Errorf("rename %s -> %s: %w", tmpPath, outPath, err)
-	}
-
-	// Rename succeeded — disarm the deferred cleanup.
-	tmpPath = ""
 	return nil
 }

--- a/internal/components/engram/download_durability_test.go
+++ b/internal/components/engram/download_durability_test.go
@@ -1,0 +1,206 @@
+package engram
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// useTestClient points the package HTTP client at server for the test's
+// duration.
+func useTestClient(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	original := engramHTTPClient
+	t.Cleanup(func() { engramHTTPClient = original })
+	engramHTTPClient = server.Client()
+}
+
+// TestEngramDownloadDigestDescribesTheFileOnDisk is the #1998 contract at this
+// layer: the digest handed to checksum verification must describe the bytes at
+// outPath. The fault-injection proof that a stream digest cannot answer for the
+// destination lives with the writer, in
+// filemerge.TestWriteStreamAtomicFailsWhenReplacementDoesNotLand.
+func TestEngramDownloadDigestDescribesTheFileOnDisk(t *testing.T) {
+	payload := []byte(strings.Repeat("release-archive-bytes", 4096))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(server.Close)
+	useTestClient(t, server)
+
+	outPath := filepath.Join(t.TempDir(), "nested", "engram.tar.gz")
+	digest, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+	if err != nil {
+		t.Fatalf("engramDownloadToFile: %v", err)
+	}
+
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if digest != sha256Hex(onDisk) {
+		t.Errorf("digest = %s, want %s (sha256 of the bytes at %s)", digest, sha256Hex(onDisk), outPath)
+	}
+	if string(onDisk) != string(payload) {
+		t.Error("on-disk content differs from the served payload")
+	}
+	// A download directory stays traversable. The generic writer creates parents
+	// at 0700 for private config files; this path must not inherit that.
+	parent, err := os.Stat(filepath.Dir(outPath))
+	if err != nil {
+		t.Fatalf("stat parent: %v", err)
+	}
+	if parent.Mode().Perm() != 0o755 {
+		t.Errorf("parent directory mode = %v, want 0755", parent.Mode().Perm())
+	}
+}
+
+// TestEngramDownloadLeavesNoArchiveWhenTheCopyFails is #1998's other half. The
+// old implementation created outPath up front and returned on a copy error with
+// the truncated bytes still there: a partial archive at the exact path the
+// caller then hands to extraction.
+func TestEngramDownloadLeavesNoArchiveWhenTheCopyFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "4096")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("truncated"))
+		w.(http.Flusher).Flush()
+		// Abort mid-body so the client's copy fails after the response is
+		// already open, standing in for a connection lost partway through a
+		// release download.
+		panic(http.ErrAbortHandler)
+	}))
+	t.Cleanup(server.Close)
+	server.Config.ErrorLog = quietLogger()
+	useTestClient(t, server)
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "engram.tar.gz")
+	digest, err := engramDownloadToFile(context.Background(), server.URL, outPath)
+	if err == nil {
+		t.Fatalf("engramDownloadToFile reported success (digest %s) for a truncated body", digest)
+	}
+	if _, statErr := os.Stat(outPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("partial archive survived at %s (stat err = %v)", outPath, statErr)
+	}
+	assertDirIsEmpty(t, dir)
+}
+
+// TestEngramDownloadLeavesNoArchiveOnHTTPFailure keeps the non-200 path clean
+// too, so nothing extractable is left at the archive path.
+func TestEngramDownloadLeavesNoArchiveOnHTTPFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+	useTestClient(t, server)
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "engram.tar.gz")
+	if _, err := engramDownloadToFile(context.Background(), server.URL, outPath); err == nil {
+		t.Fatal("engramDownloadToFile: want HTTP error, got nil")
+	}
+	assertDirIsEmpty(t, dir)
+}
+
+// TestEngramWriteExecutableLeavesNoBinaryWhenTheCopyFails covers the #2216 site:
+// a failed extraction must not publish a partial binary over the installed one.
+func TestEngramWriteExecutableLeavesNoBinaryWhenTheCopyFails(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "engram")
+	previous := []byte("the previously installed binary")
+	if err := os.WriteFile(outPath, previous, 0o755); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	src := &failingReader{data: []byte("partial new binary"), err: errors.New("injected extraction failure")}
+	if err := writeExecutable(src, outPath); err == nil {
+		t.Fatal("writeExecutable: want the injected error, got nil")
+	}
+
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != string(previous) {
+		t.Errorf("installed binary = %q, want the untouched %q", onDisk, previous)
+	}
+	assertOnlyEntry(t, dir, "engram")
+}
+
+// TestEngramWriteExecutablePublishesAnExecutable is the ordinary case: the
+// binary lands with its executable mode intact.
+func TestEngramWriteExecutablePublishesAnExecutable(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "engram")
+	content := []byte("#!/bin/sh\necho engram\n")
+
+	if err := writeExecutable(strings.NewReader(string(content)), outPath); err != nil {
+		t.Fatalf("writeExecutable: %v", err)
+	}
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("mode = %v, want the executable bits set", info.Mode().Perm())
+	}
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != string(content) {
+		t.Errorf("content = %q, want %q", onDisk, content)
+	}
+	assertOnlyEntry(t, dir, "engram")
+}
+
+type failingReader struct {
+	data []byte
+	err  error
+	sent bool
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.sent {
+		return 0, r.err
+	}
+	r.sent = true
+	n := copy(p, r.data)
+	return n, nil
+}
+
+// quietLogger swallows the "abort handler" noise the truncated-body test
+// deliberately provokes.
+func quietLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+func assertDirIsEmpty(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		t.Errorf("unexpected leftover %q in %s", entry.Name(), dir)
+	}
+}
+
+func assertOnlyEntry(t *testing.T, dir, name string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != name {
+			t.Errorf("unexpected leftover %q in %s", entry.Name(), dir)
+		}
+	}
+}

--- a/internal/components/filemerge/stream_test.go
+++ b/internal/components/filemerge/stream_test.go
@@ -1,0 +1,270 @@
+package filemerge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// faultyStagedFile wraps a real staged file and fails one durability step. Real
+// *os.File only fails Chmod/Sync/Close under disk-level conditions, which is
+// precisely why those branches would otherwise ship unexercised.
+type faultyStagedFile struct {
+	stagedFile
+	failChmod error
+	failSync  error
+	failClose error
+}
+
+func (f *faultyStagedFile) Chmod(mode fs.FileMode) error {
+	if f.failChmod != nil {
+		return f.failChmod
+	}
+	return f.stagedFile.Chmod(mode)
+}
+
+func (f *faultyStagedFile) Sync() error {
+	if f.failSync != nil {
+		return f.failSync
+	}
+	return f.stagedFile.Sync()
+}
+
+func (f *faultyStagedFile) Close() error {
+	err := f.stagedFile.Close()
+	if f.failClose != nil {
+		return f.failClose
+	}
+	return err
+}
+
+func faultStagedFile(t *testing.T, fault func(*faultyStagedFile)) {
+	t.Helper()
+	original := createStagedFile
+	t.Cleanup(func() { createStagedFile = original })
+	createStagedFile = func(dir string) (stagedFile, error) {
+		inner, err := original(dir)
+		if err != nil {
+			return nil, err
+		}
+		wrapped := &faultyStagedFile{stagedFile: inner}
+		fault(wrapped)
+		return wrapped, nil
+	}
+}
+
+func digestOf(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestWriteStreamAtomicReportsTheDigestOfTheFileOnDisk states the contract the
+// download paths depend on: the returned digest describes the destination, so a
+// caller comparing it against a release manifest is checking disk.
+func TestWriteStreamAtomicReportsTheDigestOfTheFileOnDisk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "archive.tar.gz")
+	payload := []byte(strings.Repeat("release-archive-bytes", 1024))
+
+	result, err := WriteStreamAtomic(path, strings.NewReader(string(payload)), 0o644)
+	if err != nil {
+		t.Fatalf("WriteStreamAtomic: %v", err)
+	}
+
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if result.Digest != digestOf(onDisk) {
+		t.Errorf("Digest = %s, want %s (sha256 of the bytes at %s)", result.Digest, digestOf(onDisk), path)
+	}
+	if result.Bytes != int64(len(onDisk)) {
+		t.Errorf("Bytes = %d, want %d", result.Bytes, len(onDisk))
+	}
+	if string(onDisk) != string(payload) {
+		t.Error("on-disk content differs from the streamed payload")
+	}
+}
+
+// TestWriteStreamAtomicPreservesRequestedMode covers the executable case the
+// binary installers rely on.
+func TestWriteStreamAtomicPreservesRequestedMode(t *testing.T) {
+	if os.Getenv("GOOS") == "windows" {
+		t.Skip("mode bits are not meaningful on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "gentle-ai")
+
+	if _, err := WriteStreamAtomic(path, strings.NewReader("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteStreamAtomic: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
+// TestDurableWriteFailsOnStagedFileFaults exercises the three durability steps a
+// real filesystem only fails when something is genuinely wrong. Each one must
+// abort before publication rather than let a partially written file be renamed
+// over the destination (#2216).
+func TestDurableWriteFailsOnStagedFileFaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		fault   func(*faultyStagedFile)
+		wantMsg string
+	}{
+		{
+			name:    "chmod on the staged file fails",
+			fault:   func(f *faultyStagedFile) { f.failChmod = errors.New("injected chmod failure") },
+			wantMsg: "set permissions on temp file",
+		},
+		{
+			name:    "sync on the staged file fails",
+			fault:   func(f *faultyStagedFile) { f.failSync = errors.New("injected sync failure") },
+			wantMsg: "sync temp file",
+		},
+		{
+			name:    "close reports a deferred write-back failure",
+			fault:   func(f *faultyStagedFile) { f.failClose = errors.New("injected close failure") },
+			wantMsg: "close temp file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" (stream)", func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "archive.tar.gz")
+			faultStagedFile(t, tt.fault)
+
+			result, err := WriteStreamAtomic(path, strings.NewReader("payload"), 0o644)
+			if err == nil {
+				t.Fatalf("WriteStreamAtomic reported success (%+v) after %s", result, tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.wantMsg)
+			}
+			if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+				t.Errorf("destination %s exists after a failed write (stat err = %v)", path, statErr)
+			}
+			assertNoStagedLeftovers(t, dir)
+		})
+
+		t.Run(tt.name+" (bytes)", func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.json")
+			faultStagedFile(t, tt.fault)
+
+			result, err := WriteFileAtomic(path, []byte("payload"), 0o644)
+			if err == nil {
+				t.Fatalf("WriteFileAtomic reported success (%+v) after %s", result, tt.name)
+			}
+			if result.Changed || result.Created {
+				t.Errorf("WriteFileAtomic = %+v, want a zero result: nothing was published", result)
+			}
+			assertNoStagedLeftovers(t, dir)
+		})
+	}
+}
+
+// TestWriteStreamAtomicFailsWhenReplacementDoesNotLand is the streaming half of
+// the read-back property: a rename that silently no-ops must not produce a
+// digest, because that digest would certify bytes that are not at the
+// destination (#1998, #2319).
+func TestWriteStreamAtomicFailsWhenReplacementDoesNotLand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "archive.tar.gz")
+	stale := []byte("previous archive")
+	if err := os.WriteFile(path, stale, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(string, string) error { return nil }
+
+	payload := "brand new archive contents"
+	result, err := WriteStreamAtomic(path, strings.NewReader(payload), 0o644)
+	if err == nil {
+		t.Fatalf("WriteStreamAtomic reported success (%+v) for a replacement that never landed", result)
+	}
+	if result.Digest == digestOf([]byte(payload)) {
+		t.Errorf("returned the digest of the stream (%s) for a destination that holds something else", result.Digest)
+	}
+	if result.Digest != "" {
+		t.Errorf("Digest = %q, want empty on failure", result.Digest)
+	}
+	onDisk, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	if string(onDisk) != string(stale) {
+		t.Errorf("destination = %q, want the untouched %q", onDisk, stale)
+	}
+	assertNoStagedLeftovers(t, dir)
+}
+
+// TestWriteStreamAtomicReportsResultWhenParentSyncFails keeps the streaming
+// façade honest in the post-publication window: the bytes are there, so the
+// result describes them even though the call failed.
+func TestWriteStreamAtomicReportsResultWhenParentSyncFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+
+	origGOOS := runtimeGOOS
+	origSyncDir := syncDirFn
+	t.Cleanup(func() {
+		runtimeGOOS = origGOOS
+		syncDirFn = origSyncDir
+	})
+	runtimeGOOS = func() string { return "linux" }
+	syncDirFn = func(string) error { return errors.New("injected parent-directory sync failure") }
+
+	payload := "archive"
+	result, err := WriteStreamAtomic(path, strings.NewReader(payload), 0o644)
+	if err == nil {
+		t.Fatal("WriteStreamAtomic: want parent-directory sync error, got nil")
+	}
+	if result.Digest != digestOf([]byte(payload)) {
+		t.Errorf("Digest = %q, want %s: the bytes are on disk, so the result must describe them", result.Digest, digestOf([]byte(payload)))
+	}
+}
+
+// TestWriteStreamAtomicPropagatesSourceErrors keeps a failing producer from
+// publishing a truncated destination.
+func TestWriteStreamAtomicPropagatesSourceErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "archive.tar.gz")
+
+	src := io.MultiReader(strings.NewReader("half"), errReader{errors.New("injected read failure")})
+	if _, err := WriteStreamAtomic(path, src, 0o644); err == nil {
+		t.Fatal("WriteStreamAtomic: want the source error, got nil")
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("destination %s exists after a failed copy (stat err = %v)", path, statErr)
+	}
+	assertNoStagedLeftovers(t, dir)
+}
+
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+func assertNoStagedLeftovers(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".gentle-ai-") {
+			t.Errorf("staged temp file %q was left behind", entry.Name())
+		}
+	}
+}

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -2,6 +2,8 @@ package filemerge
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +25,31 @@ import (
 // macOS the full error is propagated so unexpected failures are still surfaced.
 // See issues #293 and #294.
 var runtimeGOOS = func() string { return runtime.GOOS }
+
+// renameFn publishes the staged replacement. It is a package-level var so tests
+// can simulate a rename that reports success without taking effect: the shape
+// reported on Windows in #2319, where an antivirus/indexer hold turns the swap
+// into a silent no-op.
+var renameFn = os.Rename
+
+// stagedFile is the staged destination of a durable write. The interface exists
+// so tests can fault Chmod, Sync and Close, which a real *os.File only fails
+// under disk-level conditions no unit test can produce, and those are exactly
+// the conditions this package exists to survive.
+type stagedFile interface {
+	io.Writer
+	Name() string
+	Chmod(fs.FileMode) error
+	Sync() error
+	Close() error
+}
+
+// createStagedFile stages a replacement in dir. Package-level var for the fault
+// injection described on stagedFile.
+var createStagedFile = func(dir string) (stagedFile, error) {
+	return os.CreateTemp(dir, ".gentle-ai-*.tmp")
+}
+
 var syncDirFn = func(dir string) error {
 	fd, err := os.Open(dir)
 	if err != nil {
@@ -34,11 +61,26 @@ var syncDirFn = func(dir string) error {
 
 const maxAtomicFileSize = 16 << 20
 
+// WriteResult reports what happened to the destination path. It is truthful on
+// every return, including error returns: Changed is read back from disk after
+// the replacement, never inferred from the attempt.
 type WriteResult struct {
 	Changed bool
 	Created bool
 }
 
+// WriteFileAtomic replaces path with content and reports whether the
+// replacement actually occurred.
+//
+// A nil error means the bytes reached stable storage (staged file synced,
+// parent directory synced) and were read back from path. Any other outcome is
+// an error.
+//
+// Callers must not read "err != nil" as "nothing happened". Replacement is
+// published by a rename that can succeed while a later step fails; in that
+// window the returned WriteResult reports Changed=true alongside the error, so
+// rollback and journalling decisions come from the writer rather than from a
+// guess at each call site (#1676).
 func WriteFileAtomic(path string, content []byte, perm fs.FileMode) (WriteResult, error) {
 	if perm == 0 {
 		perm = 0o644
@@ -56,14 +98,61 @@ func WriteFileAtomic(path string, content []byte, perm fs.FileMode) (WriteResult
 		created = true
 	}
 
-	dir := filepath.Dir(path)
-	if err := ensureAtomicParentDir(dir, path); err != nil {
-		return WriteResult{}, err
+	landed, _, err := replaceDurably(path, bytes.NewReader(content), perm)
+	result := WriteResult{Changed: landed, Created: created && landed}
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// StreamResult describes the bytes that landed at the destination.
+type StreamResult struct {
+	Bytes  int64
+	Digest string
+}
+
+// WriteStreamAtomic replaces path with everything readable from src and returns
+// the size and SHA-256 of the bytes read back from path afterwards.
+//
+// The digest describes the file on disk, never the copied stream: a stream
+// digest certifies its own copy and cannot detect a destination that ends up
+// holding something else, which is how a truncated download used to pass
+// checksum verification (#1998).
+//
+// A nil error means the bytes reached stable storage and were read back. The
+// caller owns any size policy: check StreamResult.Bytes and remove path if the
+// result is unacceptable.
+func WriteStreamAtomic(path string, src io.Reader, perm fs.FileMode) (StreamResult, error) {
+	_, result, err := replaceDurably(path, src, perm)
+	return result, err
+}
+
+// replaceDurably is the single durability sequence in this package: stage beside
+// the destination, apply the final metadata mutation, sync, close, publish with
+// a rename, read the destination back, then sync the parent directory.
+//
+// The ordering is load-bearing. Chmod precedes Sync so a recovered rename cannot
+// expose the file with the wrong mode, and the rename precedes the parent sync
+// because publication is a namespace operation while durability is not (#2216).
+//
+// landed reports whether path holds the staged bytes. It is meaningful even when
+// err is non-nil: publication happens before the last failure point, so a caller
+// that reads "error" as "nothing happened" is wrong in exactly that window
+// (#1676).
+func replaceDurably(path string, src io.Reader, perm fs.FileMode) (landed bool, result StreamResult, err error) {
+	if perm == 0 {
+		perm = 0o644
 	}
 
-	tmp, err := os.CreateTemp(dir, ".gentle-ai-*.tmp")
+	dir := filepath.Dir(path)
+	if err := ensureAtomicParentDir(dir, path); err != nil {
+		return false, StreamResult{}, err
+	}
+
+	tmp, err := createStagedFile(dir)
 	if err != nil {
-		return WriteResult{}, fmt.Errorf("create temp file for %q: %w", path, err)
+		return false, StreamResult{}, fmt.Errorf("create temp file for %q: %w", path, err)
 	}
 
 	tmpPath := tmp.Name()
@@ -74,40 +163,110 @@ func WriteFileAtomic(path string, content []byte, perm fs.FileMode) (WriteResult
 		}
 	}()
 
-	if _, err := tmp.Write(content); err != nil {
+	// The staged digest is not the answer; it is the oracle the answer is
+	// checked against. Comparing it to the digest read back from the
+	// destination is what turns "the copy succeeded" into "the right bytes are
+	// at the right path".
+	staged := sha256.New()
+	written, err := io.Copy(io.MultiWriter(tmp, staged), src)
+	if err != nil {
 		_ = tmp.Close()
-		return WriteResult{}, fmt.Errorf("write temp file for %q: %w", path, err)
+		return false, StreamResult{}, fmt.Errorf("write temp file for %q: %w", path, err)
 	}
+	stagedDigest := hex.EncodeToString(staged.Sum(nil))
 
 	if err := tmp.Chmod(perm); err != nil {
 		_ = tmp.Close()
-		return WriteResult{}, fmt.Errorf("set permissions on temp file for %q: %w", path, err)
+		return false, StreamResult{}, fmt.Errorf("set permissions on temp file for %q: %w", path, err)
 	}
 
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return WriteResult{}, fmt.Errorf("sync temp file for %q: %w", path, err)
+		return false, StreamResult{}, fmt.Errorf("sync temp file for %q: %w", path, err)
 	}
 
 	if err := tmp.Close(); err != nil {
-		return WriteResult{}, fmt.Errorf("close temp file for %q: %w", path, err)
+		return false, StreamResult{}, fmt.Errorf("close temp file for %q: %w", path, err)
 	}
 
-	if err := os.Rename(tmpPath, path); err != nil {
-		return WriteResult{}, fmt.Errorf("replace %q atomically: %w", path, err)
+	if err := renameFn(tmpPath, path); err != nil {
+		return false, StreamResult{}, fmt.Errorf("replace %q atomically: %w", path, err)
 	}
 
-	// Sync the parent directory to flush the new directory entry to disk.
-	// On Windows, NTFS returns ErrPermission when syncing a directory fd — tolerate
-	// that specific error only. Any other error (e.g. disk full) is still fatal.
-	if err := syncDirFn(dir); err != nil {
-		if !(runtimeGOOS() == "windows" && errors.Is(err, os.ErrPermission)) {
-			return WriteResult{}, fmt.Errorf("sync parent directory for %q: %w", path, err)
-		}
+	// Read the destination back before claiming anything about it. A rename that
+	// returns nil has not necessarily taken effect. On Windows an antivirus or
+	// indexer hold turns the swap into a silent no-op (#2319), and the whole
+	// point of this sequence is that its result describes disk, not intent.
+	diskDigest, diskBytes, err := digestFileOnDisk(path)
+	if err != nil {
+		return false, StreamResult{}, fmt.Errorf("read back %q after replacement: %w", path, err)
+	}
+	if diskBytes != written || diskDigest != stagedDigest {
+		return false, StreamResult{}, fmt.Errorf(
+			"replace %q atomically: the replacement did not land. The destination holds %d bytes (%s); %d bytes (%s) were written",
+			path, diskBytes, diskDigest, written, stagedDigest)
 	}
 
+	// Past this point the destination holds the new bytes. Every remaining
+	// failure must still say so, or callers will roll back nothing.
 	cleanup = false
-	return WriteResult{Changed: true, Created: created}, nil
+	result = StreamResult{Bytes: diskBytes, Digest: diskDigest}
+
+	if err := SyncDir(dir); err != nil {
+		return true, result, fmt.Errorf("sync parent directory for %q: %w", path, err)
+	}
+
+	return true, result, nil
+}
+
+// SyncDir flushes dir's entries to stable storage so a published name survives
+// recovery.
+//
+// Windows/NTFS refuses to fsync a directory handle and returns ErrPermission
+// regardless of privilege; that specific error is tolerated there and nowhere
+// else, so a real failure (a full disk, say) still surfaces.
+func SyncDir(dir string) error {
+	err := syncDirFn(dir)
+	if err == nil {
+		return nil
+	}
+	if runtimeGOOS() == "windows" && errors.Is(err, os.ErrPermission) {
+		return nil
+	}
+	return err
+}
+
+// FileDigest returns the SHA-256 and size of the file at path, read from disk.
+// Callers comparing a published file against what they staged use this on both
+// sides so the comparison is between two reads, not between a read and an
+// intention.
+func FileDigest(path string) (digest string, size int64, err error) {
+	return digestFileOnDisk(path)
+}
+
+// digestFileOnDisk streams path and returns its SHA-256 and size. It refuses
+// symlinks so a redirected destination cannot answer for the real one.
+func digestFileOnDisk(path string) (digest string, size int64, err error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", 0, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", 0, fmt.Errorf("destination %q is a symlink", path)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+
+	sum := sha256.New()
+	size, err = io.Copy(sum, file)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(sum.Sum(nil)), size, nil
 }
 
 func readComparableFile(path string) ([]byte, error) {

--- a/internal/components/filemerge/writer_landed_test.go
+++ b/internal/components/filemerge/writer_landed_test.go
@@ -1,0 +1,190 @@
+package filemerge
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteFileAtomicReportsReplacementWhenParentSyncFails pins the half of the
+// contract that callers cannot observe any other way: when the rename has
+// already published the new bytes and only the parent-directory sync fails, the
+// error is real but the file HAS changed. Returning a zero WriteResult there
+// tells every caller "nothing happened" about a destination that now holds new
+// content, which is what makes rollback skip the entry (#1676).
+func TestWriteFileAtomicReportsReplacementWhenParentSyncFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte("before"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	origGOOS := runtimeGOOS
+	origSyncDir := syncDirFn
+	t.Cleanup(func() {
+		runtimeGOOS = origGOOS
+		syncDirFn = origSyncDir
+	})
+	runtimeGOOS = func() string { return "linux" }
+	syncDirFn = func(string) error { return errors.New("injected parent-directory sync failure") }
+
+	result, err := WriteFileAtomic(path, []byte("after"), 0o644)
+	if err == nil {
+		t.Fatal("WriteFileAtomic: want parent-directory sync error, got nil")
+	}
+	if !result.Changed {
+		t.Errorf("WriteFileAtomic returned Changed=false alongside the error, but the destination was replaced; callers cannot distinguish this from an untouched file")
+	}
+	if result.Created {
+		t.Errorf("WriteFileAtomic returned Created=true for a pre-existing file")
+	}
+
+	onDisk, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	if string(onDisk) != "after" {
+		t.Fatalf("destination content = %q, want %q. The premise of this test is that the rename already landed", onDisk, "after")
+	}
+}
+
+// TestWriteFileAtomicReportsCreationWhenParentSyncFails is the same contract for
+// a file that did not previously exist: the entry was created, so Created must
+// survive the post-replacement error too.
+func TestWriteFileAtomicReportsCreationWhenParentSyncFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.json")
+
+	origGOOS := runtimeGOOS
+	origSyncDir := syncDirFn
+	t.Cleanup(func() {
+		runtimeGOOS = origGOOS
+		syncDirFn = origSyncDir
+	})
+	runtimeGOOS = func() string { return "linux" }
+	syncDirFn = func(string) error { return errors.New("injected parent-directory sync failure") }
+
+	result, err := WriteFileAtomic(path, []byte("fresh"), 0o644)
+	if err == nil {
+		t.Fatal("WriteFileAtomic: want parent-directory sync error, got nil")
+	}
+	if !result.Changed || !result.Created {
+		t.Errorf("WriteFileAtomic = %+v alongside the error, want Changed=true Created=true", result)
+	}
+}
+
+// TestWriteFileAtomicFailsWhenReplacementDoesNotLand is the hard direction: make
+// the underlying replacement silently fail to take effect and require the
+// function to report failure. A rename that returns nil without moving anything
+// is exactly the shape reported on Windows in #2319, and it is the only way to
+// prove the result is read back from disk rather than inferred from the attempt.
+func TestWriteFileAtomicFailsWhenReplacementDoesNotLand(t *testing.T) {
+	tests := []struct {
+		name    string
+		rename  func(oldPath, newPath string) error
+		seed    string
+		wantOld string
+	}{
+		{
+			name:    "rename reports success without moving anything",
+			rename:  func(string, string) error { return nil },
+			seed:    "before",
+			wantOld: "before",
+		},
+		{
+			name: "replacement lands and is immediately truncated",
+			rename: func(oldPath, newPath string) error {
+				if err := os.Rename(oldPath, newPath); err != nil {
+					return err
+				}
+				return os.WriteFile(newPath, []byte("trunc"), 0o644)
+			},
+			seed:    "before",
+			wantOld: "trunc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.json")
+			if err := os.WriteFile(path, []byte(tt.seed), 0o644); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			origRename := renameFn
+			t.Cleanup(func() { renameFn = origRename })
+			renameFn = tt.rename
+
+			result, err := WriteFileAtomic(path, []byte("after"), 0o644)
+			if err == nil {
+				t.Fatal("WriteFileAtomic reported success for a replacement that never landed on disk")
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("error %q does not name the destination %q", err, path)
+			}
+			if result.Changed {
+				t.Errorf("WriteFileAtomic = %+v, want Changed=false: the destination does not hold the requested bytes", result)
+			}
+
+			onDisk, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("read back: %v", readErr)
+			}
+			if string(onDisk) != tt.wantOld {
+				t.Errorf("destination content = %q, want %q", onDisk, tt.wantOld)
+			}
+		})
+	}
+}
+
+// TestWriteFileAtomicLeavesNoTempFileWhenReplacementDoesNotLand guards the
+// cleanup half: a rename that silently no-ops leaves the staged temp file
+// behind, and the writer owns removing it.
+func TestWriteFileAtomicLeavesNoTempFileWhenReplacementDoesNotLand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	origRename := renameFn
+	t.Cleanup(func() { renameFn = origRename })
+	renameFn = func(string, string) error { return nil }
+
+	if _, err := WriteFileAtomic(path, []byte("after"), 0o644); err == nil {
+		t.Fatal("WriteFileAtomic reported success for a replacement that never landed on disk")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".gentle-ai-") {
+			t.Errorf("staged temp file %q was left behind after a failed replacement", entry.Name())
+		}
+	}
+}
+
+// TestWriteFileAtomicSucceedsOnlyAfterReadBack states the positive half of the
+// contract explicitly: a nil error means the bytes were read back from the
+// destination, not merely handed to the kernel.
+func TestWriteFileAtomicSucceedsOnlyAfterReadBack(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	result, err := WriteFileAtomic(path, []byte("payload"), 0o644)
+	if err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+	if !result.Changed || !result.Created {
+		t.Errorf("WriteFileAtomic = %+v, want Changed=true Created=true", result)
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != "payload" {
+		t.Errorf("destination content = %q, want %q", onDisk, "payload")
+	}
+}

--- a/internal/components/mutationjournal/journal.go
+++ b/internal/components/mutationjournal/journal.go
@@ -108,12 +108,20 @@ func (j *Journal) WriteWithMode(path string, data []byte, mode os.FileMode) (Own
 	if previous := j.before[path]; previous.data != nil {
 		effective = previous.mode
 	}
-	if _, err := writeFileAtomic(path, data, effective); err != nil {
+	// The writer reports whether the destination was actually replaced, including
+	// when it also returns an error. Record the change from that report rather
+	// than from "the write returned nil", or a failure raised after the rename
+	// leaves the entry marked unchanged and Restore walks past a mutated file
+	// while reporting a successful rollback (#1676).
+	result, err := writeFileAtomic(path, data, effective)
+	if result.Changed {
+		after := append([]byte(nil), data...)
+		j.before[path].after = &after
+		j.before[path].changed = true
+	}
+	if err != nil {
 		return OwnedFile{}, fmt.Errorf("write %q: %w", path, err)
 	}
-	after := append([]byte(nil), data...)
-	j.before[path].after = &after
-	j.before[path].changed = true
 	return j.OwnedFile(path, string(data), false, false), nil
 }
 

--- a/internal/components/mutationjournal/rollback_after_replacement_test.go
+++ b/internal/components/mutationjournal/rollback_after_replacement_test.go
@@ -1,0 +1,149 @@
+package mutationjournal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+)
+
+// replaceThenFail mimics the one window WriteFileAtomic documents: the rename
+// published the new bytes and a later step failed, so the writer reports both
+// Changed=true and an error. Only the first write is faulted, so the rollback
+// that follows exercises the real writer.
+func replaceThenFail(t *testing.T) {
+	t.Helper()
+	original := writeFileAtomic
+	t.Cleanup(func() { writeFileAtomic = original })
+	faulted := false
+	writeFileAtomic = func(path string, data []byte, mode os.FileMode) (filemerge.WriteResult, error) {
+		result, err := original(path, data, mode)
+		if err != nil {
+			t.Fatalf("underlying write %q: %v", path, err)
+		}
+		if faulted {
+			return result, nil
+		}
+		faulted = true
+		result.Changed = true
+		return result, errors.New("injected parent-directory sync failure")
+	}
+}
+
+// TestRestoreRollsBackWriteThatFailedAfterReplacement is #1676. WriteWithMode
+// used to mark its entry changed only after a nil error, so a failure reported
+// after the destination was already replaced left the entry marked unchanged
+// and Restore skipped it: a reported rollback that rolled nothing back.
+func TestRestoreRollsBackWriteThatFailedAfterReplacement(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "opencode.json")
+	if err := os.WriteFile(path, []byte("before-image"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	replaceThenFail(t)
+
+	journal := New(root)
+	if _, err := journal.WriteWithMode(path, []byte("replacement bytes"), 0o644); err == nil {
+		t.Fatal("WriteWithMode: want the injected error, got nil")
+	}
+
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after write: %v", err)
+	}
+	if string(onDisk) != "replacement bytes" {
+		t.Fatalf("destination = %q, want %q. The premise is that replacement already landed", onDisk, "replacement bytes")
+	}
+
+	if err := journal.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	restored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after restore: %v", err)
+	}
+	if string(restored) != "before-image" {
+		t.Errorf("destination after Restore = %q, want %q: Restore skipped an entry whose file had in fact been replaced", restored, "before-image")
+	}
+}
+
+// TestRestoreRemovesCreatedFileWhenWriteFailedAfterReplacement covers the same
+// window for a path that did not exist before: rollback owes the caller an
+// absent file, not an orphan created by a write that reported failure.
+func TestRestoreRemovesCreatedFileWhenWriteFailedAfterReplacement(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "created.json")
+
+	replaceThenFail(t)
+
+	journal := New(root)
+	if _, err := journal.WriteWithMode(path, []byte("orphan"), 0o644); err == nil {
+		t.Fatal("WriteWithMode: want the injected error, got nil")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat after write: %v. The premise is that the file was created", err)
+	}
+
+	if err := journal.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file still exists after Restore (stat err = %v), want it removed", err)
+	}
+}
+
+// TestWriteWithModeStillReportsTheError guards against the fix swallowing the
+// failure: recording the change must not turn a failed write into a success.
+func TestWriteWithModeStillReportsTheError(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "opencode.json")
+
+	replaceThenFail(t)
+
+	journal := New(root)
+	owned, err := journal.WriteWithMode(path, []byte("replacement bytes"), 0o644)
+	if err == nil {
+		t.Fatal("WriteWithMode: want the injected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "injected parent-directory sync failure") {
+		t.Errorf("error = %q, want it to wrap the writer failure", err)
+	}
+	if owned.After != "" {
+		t.Errorf("WriteWithMode returned a populated OwnedFile %+v alongside its error", owned)
+	}
+}
+
+// TestRestoreSkipsEntryWhenWriteFailedWithoutReplacing is the other side of the
+// contract: when the writer reports Changed=false the destination was never
+// touched, so Restore must leave it alone rather than rewrite it.
+func TestRestoreSkipsEntryWhenWriteFailedWithoutReplacing(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "opencode.json")
+	if err := os.WriteFile(path, []byte("before-image"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	original := writeFileAtomic
+	t.Cleanup(func() { writeFileAtomic = original })
+	restoreCalls := 0
+	writeFileAtomic = func(path string, data []byte, mode os.FileMode) (filemerge.WriteResult, error) {
+		restoreCalls++
+		return filemerge.WriteResult{}, errors.New("injected pre-replacement failure")
+	}
+
+	journal := New(root)
+	if _, err := journal.WriteWithMode(path, []byte("replacement bytes"), 0o644); err == nil {
+		t.Fatal("WriteWithMode: want the injected error, got nil")
+	}
+	if err := journal.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restoreCalls != 1 {
+		t.Errorf("writeFileAtomic called %d times, want 1: Restore rewrote a file that was never replaced", restoreCalls)
+	}
+}

--- a/internal/update/upgrade/download.go
+++ b/internal/update/upgrade/download.go
@@ -20,6 +20,7 @@ import (
 
 	minisign "github.com/jedisct1/go-minisign"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/update"
 )
@@ -30,6 +31,11 @@ var httpClient = &http.Client{Timeout: 5 * time.Minute}
 
 // lookPathFn resolves the binary path. Package-level var for testability.
 var lookPathFn = exec.LookPath
+
+// renameFn publishes the staged binary. Package-level var so tests can simulate
+// a rename that reports success without taking effect, which is what the TUI
+// reported as an applied upgrade over an unchanged binary (#2319).
+var renameFn = os.Rename
 
 // URL builders are package variables so tests can route release traffic to an
 // isolated server without weakening the production URL contract.
@@ -217,31 +223,19 @@ func downloadToFile(ctx context.Context, url string, outPath string, maxBytes in
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return "", fmt.Errorf("create dir: %w", err)
 	}
-	f, err := os.Create(outPath)
-	if err != nil {
-		return "", fmt.Errorf("create %s: %w", outPath, err)
-	}
-	completed := false
-	defer func() {
-		if closeErr := f.Close(); err == nil && closeErr != nil {
-			err = fmt.Errorf("close %s: %w", outPath, closeErr)
-		}
-		if !completed || err != nil {
-			_ = os.Remove(outPath)
-		}
-	}()
 
-	h := sha256.New()
-	written, err := io.Copy(io.MultiWriter(f, h), io.LimitReader(resp.Body, maxBytes+1))
+	// The digest is read back from outPath rather than accumulated from the
+	// response body: a stream digest verifies its own copy and cannot detect a
+	// destination that ended up holding something else (#1998).
+	result, err := filemerge.WriteStreamAtomic(outPath, io.LimitReader(resp.Body, maxBytes+1), 0o644)
 	if err != nil {
 		return "", fmt.Errorf("write %s: %w", outPath, err)
 	}
-	if written > maxBytes {
+	if result.Bytes > maxBytes {
+		_ = os.Remove(outPath)
 		return "", fmt.Errorf("release archive exceeds %d-byte limit", maxBytes)
 	}
-
-	completed = true
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return result.Digest, nil
 }
 
 // fetchChecksums downloads checksums.txt from url and returns its content.
@@ -387,31 +381,53 @@ func extractBinaryFromTarGz(r io.Reader, binaryName string, outPath string) erro
 	return nil
 }
 
-// writeExecutable writes the content from r to outPath with executable permissions.
+// writeExecutable writes the content from r to outPath with executable
+// permissions, staging it beside the destination and synchronizing it before
+// publication so a crash cannot leave the new name over incomplete content
+// (#2216). A failed extraction leaves whatever was at outPath untouched.
 func writeExecutable(r io.Reader, outPath string) error {
+	// Create the parent at 0755 explicitly: the writer's own parent creation is
+	// tuned for private config files, and an install directory on PATH is not one.
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return fmt.Errorf("create parent dir: %w", err)
 	}
-
-	f, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
-	if err != nil {
-		return fmt.Errorf("create %s: %w", outPath, err)
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, r); err != nil {
+	if _, err := filemerge.WriteStreamAtomic(outPath, r, 0o755); err != nil {
 		return fmt.Errorf("write %s: %w", outPath, err)
 	}
-
 	return nil
 }
 
-// atomicReplace moves src to dst atomically using os.Rename.
-// This is safe on Unix (same-filesystem rename) but NOT safe on Windows
-// when the binary is running. The caller must guard against Windows before calling.
+// atomicReplace moves src over dst and confirms the replacement by reading dst
+// back.
+//
+// The read-back is the point. A rename that returns nil has not necessarily
+// taken effect. On Windows a hold by antivirus, the indexer, or the running
+// image turns the swap into a silent no-op, and reporting the attempt as the
+// outcome is how an upgrade was announced as applied over an unchanged binary
+// (#2319). This is safe on Unix (same-filesystem rename); the caller must guard
+// against Windows before calling.
 func atomicReplace(src, dst string) error {
-	if err := os.Rename(src, dst); err != nil {
+	stagedDigest, stagedBytes, err := filemerge.FileDigest(src)
+	if err != nil {
+		return fmt.Errorf("read staged binary %s: %w", src, err)
+	}
+
+	if err := renameFn(src, dst); err != nil {
 		return fmt.Errorf("rename %s -> %s: %w", src, dst, err)
+	}
+
+	installedDigest, installedBytes, err := filemerge.FileDigest(dst)
+	if err != nil {
+		return fmt.Errorf("read back %s after replacement: %w", dst, err)
+	}
+	if installedBytes != stagedBytes || installedDigest != stagedDigest {
+		return fmt.Errorf(
+			"replace %s: the binary was not replaced. It holds %d bytes (%s); the staged binary was %d bytes (%s)",
+			dst, installedBytes, installedDigest, stagedBytes, stagedDigest)
+	}
+
+	if err := filemerge.SyncDir(filepath.Dir(dst)); err != nil {
+		return fmt.Errorf("sync install directory for %s: %w", dst, err)
 	}
 	return nil
 }

--- a/internal/update/upgrade/download_durability_test.go
+++ b/internal/update/upgrade/download_durability_test.go
@@ -1,0 +1,273 @@
+package upgrade
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func digestOf(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+type failingReader struct {
+	data []byte
+	err  error
+	sent bool
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.sent {
+		return 0, r.err
+	}
+	r.sent = true
+	return copy(p, r.data), nil
+}
+
+func assertNoLeftovers(t *testing.T, dir string, allowed ...string) {
+	t.Helper()
+	keep := map[string]bool{}
+	for _, name := range allowed {
+		keep[name] = true
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if !keep[entry.Name()] {
+			t.Errorf("unexpected leftover %q in %s", entry.Name(), dir)
+		}
+	}
+}
+
+// TestAtomicReplaceFailsWhenTheBinaryIsNotReplaced is the #2319 shape reduced to
+// its Go core: a rename that reports success without taking effect. The old
+// atomicReplace returned nil whenever os.Rename returned nil, which is how the
+// updater reported an applied upgrade over an unchanged binary.
+func TestAtomicReplaceFailsWhenTheBinaryIsNotReplaced(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "gentle-ai.new")
+	dst := filepath.Join(dir, "gentle-ai")
+	installed := []byte("the binary that is already installed")
+	if err := os.WriteFile(src, []byte("the replacement binary"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, installed, 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(string, string) error { return nil }
+
+	if err := atomicReplace(src, dst); err == nil {
+		t.Fatal("atomicReplace reported success for a rename that never took effect")
+	}
+
+	onDisk, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(onDisk) != string(installed) {
+		t.Errorf("installed binary = %q, want the untouched %q", onDisk, installed)
+	}
+}
+
+// TestAtomicReplaceFailsWhenTheDestinationHoldsDifferentBytes covers the partial
+// swap: the name moved but the content at the destination is not what was
+// staged, so the upgrade did not happen.
+func TestAtomicReplaceFailsWhenTheDestinationHoldsDifferentBytes(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "gentle-ai.new")
+	dst := filepath.Join(dir, "gentle-ai")
+	if err := os.WriteFile(src, []byte("the replacement binary"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(oldPath, newPath string) error {
+		if err := os.Rename(oldPath, newPath); err != nil {
+			return err
+		}
+		return os.WriteFile(newPath, []byte("something else entirely"), 0o755)
+	}
+
+	if err := atomicReplace(src, dst); err == nil {
+		t.Fatal("atomicReplace reported success for a destination that holds different bytes")
+	}
+}
+
+// TestAtomicReplacePublishesTheStagedBinary is the ordinary case, kept so the
+// read-back cannot be satisfied by refusing everything.
+func TestAtomicReplacePublishesTheStagedBinary(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "gentle-ai.new")
+	dst := filepath.Join(dir, "gentle-ai")
+	replacement := []byte("the replacement binary")
+	if err := os.WriteFile(src, replacement, 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	if err := atomicReplace(src, dst); err != nil {
+		t.Fatalf("atomicReplace: %v", err)
+	}
+	onDisk, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(onDisk) != string(replacement) {
+		t.Errorf("dst = %q, want %q", onDisk, replacement)
+	}
+	assertNoLeftovers(t, dir, "gentle-ai")
+}
+
+// TestWriteExecutableLeavesNoBinaryWhenTheCopyFails is the #2216 self-update
+// site. The old writeExecutable opened the destination with O_TRUNC and copied
+// straight into it, so a failed extraction destroyed whatever was there and left
+// a partial file behind.
+func TestWriteExecutableLeavesNoBinaryWhenTheCopyFails(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "gentle-ai.new")
+	previous := []byte("a previously staged binary")
+	if err := os.WriteFile(outPath, previous, 0o755); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	src := &failingReader{data: []byte("partial"), err: errors.New("injected extraction failure")}
+	if err := writeExecutable(src, outPath); err == nil {
+		t.Fatal("writeExecutable: want the injected error, got nil")
+	}
+
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != string(previous) {
+		t.Errorf("destination = %q, want the untouched %q", onDisk, previous)
+	}
+	assertNoLeftovers(t, dir, "gentle-ai.new")
+}
+
+// TestWriteExecutablePublishesAnExecutable pins the happy path, including the
+// mode the installer depends on.
+func TestWriteExecutablePublishesAnExecutable(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "nested", "gentle-ai.new")
+	content := []byte("#!/bin/sh\necho gentle-ai\n")
+
+	if err := writeExecutable(strings.NewReader(string(content)), outPath); err != nil {
+		t.Fatalf("writeExecutable: %v", err)
+	}
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("mode = %v, want the executable bits set", info.Mode().Perm())
+	}
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != string(content) {
+		t.Errorf("content = %q, want %q", onDisk, content)
+	}
+	// An install directory on PATH stays traversable. The generic writer creates
+	// parents at 0700 for private config files; this path must not inherit that.
+	parent, err := os.Stat(filepath.Dir(outPath))
+	if err != nil {
+		t.Fatalf("stat parent: %v", err)
+	}
+	if parent.Mode().Perm() != 0o755 {
+		t.Errorf("parent directory mode = %v, want 0755", parent.Mode().Perm())
+	}
+}
+
+// TestDownloadToFileDigestDescribesTheFileOnDisk pins the release-verification
+// contract: the digest compared against the signed manifest must describe the
+// archive at outPath.
+func TestDownloadToFileDigestDescribesTheFileOnDisk(t *testing.T) {
+	payload := []byte(strings.Repeat("release-archive-bytes", 4096))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(server.Close)
+	original := httpClient
+	t.Cleanup(func() { httpClient = original })
+	httpClient = server.Client()
+
+	outPath := filepath.Join(t.TempDir(), "nested", "archive.tar.gz")
+	digest, err := downloadToFile(context.Background(), server.URL, outPath, maxReleaseArchiveBytes)
+	if err != nil {
+		t.Fatalf("downloadToFile: %v", err)
+	}
+	onDisk, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if digest != digestOf(onDisk) {
+		t.Errorf("digest = %s, want %s (sha256 of the bytes at %s)", digest, digestOf(onDisk), outPath)
+	}
+}
+
+// TestDownloadToFileRejectsAndRemovesOversizedArchives keeps the byte cap
+// meaningful now that the writer publishes before the caller can measure: an
+// over-limit archive must not survive at the path the caller then extracts.
+func TestDownloadToFileRejectsAndRemovesOversizedArchives(t *testing.T) {
+	payload := []byte(strings.Repeat("x", 4096))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// No Content-Length, so the declared-length precheck cannot catch it.
+		w.(http.Flusher).Flush()
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(server.Close)
+	original := httpClient
+	t.Cleanup(func() { httpClient = original })
+	httpClient = server.Client()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "archive.tar.gz")
+	if _, err := downloadToFile(context.Background(), server.URL, outPath, 128); err == nil {
+		t.Fatal("downloadToFile: want the size-limit error, got nil")
+	}
+	assertNoLeftovers(t, dir)
+}
+
+// TestDownloadToFileRemovesPartialArchiveWhenTheBodyIsTruncated keeps a lost
+// connection from leaving something extractable at the archive path.
+func TestDownloadToFileRemovesPartialArchiveWhenTheBodyIsTruncated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "4096")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("truncated"))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	}))
+	t.Cleanup(server.Close)
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	original := httpClient
+	t.Cleanup(func() { httpClient = original })
+	httpClient = server.Client()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "archive.tar.gz")
+	if _, err := downloadToFile(context.Background(), server.URL, outPath, maxReleaseArchiveBytes); err == nil {
+		t.Fatal("downloadToFile: want the truncated-body error, got nil")
+	}
+	assertNoLeftovers(t, dir)
+}


### PR DESCRIPTION
Closes the most repeated invariant violation in the backlog: success reported from the attempt rather than from a read-back of the effect.

## Scope grew for a reason

The brief asked for the writer to report whether replacement actually occurred. Reading the code showed the same durability sequence hand-rolled **four** times, each missing a different subset of the steps: `WriteFileAtomic`, engram's `engramDownloadToFile` and `writeExecutable`, and upgrade's `writeExecutable` and `downloadToFile`.

So rather than fix four copies, they collapse into one. `replaceDurably` in `internal/components/filemerge/writer.go`: stage beside the destination, chmod, sync, close, rename, **read the destination back**, sync the parent. Two typed facades over it, with `WriteFileAtomic` keeping its signature.

**104 lines of production code deleted**, four duplicate sequences gone.

## The change that matters most

`WriteResult` is now truthful on error returns. The window after rename and before the parent sync returns `Changed=true` **alongside** the error. That is the deletion: callers stop inferring "error means nothing happened", because the writer answers.

`internal/components/mutationjournal/journal.go` now records `changed` from the result rather than from a nil error, which is what makes rollback correct for a write that failed after the bytes had already landed.

For #1998, the staged stream digest is still computed, but it became the **oracle rather than the answer**. It is compared against the digest read back from the destination, and only the disk digest is returned. That turns the stream hash from a substitute for verification into the check on it.

## RED, captured honestly

Each failure below was produced by reverting the production file to `origin/main` and re-adding only the compile seam, so every one is behavioral rather than a missing symbol.

```
--- FAIL: TestWriteFileAtomicReportsReplacementWhenParentSyncFails
    WriteFileAtomic returned Changed=false alongside the error, but the destination was
    replaced; callers cannot distinguish this from an untouched file

--- FAIL: TestWriteFileAtomicFailsWhenReplacementDoesNotLand/rename_reports_success_without_moving_anything
    WriteFileAtomic reported success for a replacement that never landed on disk

--- FAIL: TestRestoreRollsBackWriteThatFailedAfterReplacement
    destination after Restore = "replacement bytes", want "before-image":
    Restore skipped an entry whose file had in fact been replaced

--- FAIL: TestAtomicReplaceFailsWhenTheDestinationHoldsDifferentBytes
    atomicReplace reported success for a destination that holds different bytes
```

Two fault-injection seams were added in the style the package already uses: `renameFn` simulates a rename that returns nil without taking effect, and `createStagedFile` faults Chmod, Sync and Close, which a real file only fails under disk conditions no unit test can produce.

## Where the #1998 pin actually lives

The test that fails if someone reverts to hashing the stream is `filemerge.TestWriteStreamAtomicFailsWhenReplacementDoesNotLand`, **not** a test in the engram package. After the refactor the hashing decision lives in `filemerge`, which is the only layer with a seam that can make disk bytes differ from stream bytes.

The engram-level test asserts the returned digest equals sha256 of the file at the output path, which is a real contract assertion but **cannot on its own distinguish stream from disk on a happy path**. Naming that rather than claiming a stronger pin than was built.

## A trap this nearly introduced

`ensureAtomicParentDir` creates parents at `0700`, correct for private config, while the binary and download paths previously used `0755`. Delegating naively would have silently made install directories on PATH non-traversable. The three call sites keep an explicit `0755`, and both download test files gained parent-mode assertions to pin it.

This is the one place unification changed observable behavior, and it is worth a reviewer's eye.

## Not fixed, with reasons

`#1678` and `#1725` are caller-level two-write transactionality, not writer durability. `#1720` and `#1721` are in `internal/reviewtransaction/`, off-limits to this branch, though `filemerge.SyncDir` is now exported and is the primitive they need. `#1724` needs an all-or-nothing multi-entry transaction plus an expected-current-state fingerprint. `#1728` is shell, not Go.

`#2319` is **partially mitigated, not closed**. The Go silent no-op can no longer be reported as success, but the other two roots the issue names, the TUI not distinguishing staged from activated and the stale channel offering a downgrade, are untouched.

## A survey worth acting on separately

A pass across roughly 80 `WriteFileAtomic` call sites found these still inferring that an error means no change, each now a one-line fix because the writer answers:

`internal/components/uninstall/service.go` at five sites, `internal/cli/sync.go:1220,1243` where `restoreSyncFiles` skips the following `os.Chmod` so an error after rename leaves restored content with the wrong mode, `internal/components/communitytool/pi_codegraph.go:853,1004`, `internal/agents/claude/adapter.go:119` which also skips a `0600` chmod on an OAuth-bearing file, and `internal/agents/codex/profiles.go:101` which drops the files accumulated from earlier successful iterations.

**One trap for whoever takes that slice**: three existing test doubles return a zero `WriteResult` alongside their error. They encode the old assumption and will not catch a regression until they model the post-rename case.

## Verification

gofmt and vet clean, root `go test ./... -count=1` exit 0 across 63 packages, bench module ok, deadcode ratchet reports no new unreachable functions, refusal ratchet green.

Shell E2E in Docker with `RUN_FULL_E2E=1`, run because Tier 2 does full installs through this writer: **488 passed, 0 failed, on all three platforms**.

## Honest limits

Crash consistency is ordered, not proven. What is demonstrated is that the sequence is chmod, sync, close, rename, parent-sync, that each step's error aborts before publication, and that publication is confirmed by a read-back. Whether a filesystem honors it needs a crash harness, as #2216 itself says.

A read-back through the page cache proves the right bytes are at the right path. Durability comes from the fsyncs. Those two claims are kept separate in the doc comments.

Windows behavior is inferred rather than observed: the rename no-op models the #2319 report.

Closes #1998
Closes #2216

Part of #2471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download and upgrade reliability with atomic file writes.
  * Prevented partial or corrupted files from replacing valid files.
  * Added size and digest validation for downloaded and installed files.
  * Cleaned up temporary files after failed or interrupted downloads.
  * Preserved executable permissions and improved rollback after failed writes.
* **Tests**
  * Added coverage for download interruptions, replacement failures, cleanup, permissions, digest validation, and rollback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->