### PR TITLE
fix(sdd): build the artifact map from the store instead of relabelling it after

### DIFF
--- a/internal/sddstatus/artifact_states.go
+++ b/internal/sddstatus/artifact_states.go
@@ -1,0 +1,106 @@
+package sddstatus
+
+// artifactStates carries one field per SDD artifact whose readiness a status
+// reports, and statesFor is the only builder of a status artifact map.
+//
+// Issue #2346: before this, three call sites each wrote their own artifact map
+// literal (Resolve, resolveEngramStatus, baseStatus) and baseStatus hardcoded
+// an OpenSpec-shaped map that blockedEngramStatus then relabelled "engram"
+// without rebuilding it. The v1 projection derives its required key set from
+// the store, so it demanded a "reviewPolicy" entry nobody had populated and
+// rejected the whole status with the Go zero value in the message:
+// `unsupported SDD v1 artifact "reviewPolicy" state ""`. Deriving both the map
+// and the projection's key set from artifactStateFields, and taking the store
+// as a build-time input rather than a post-hoc relabel, removes the ability
+// for the two to disagree instead of teaching the projection to tolerate it.
+type artifactStates struct {
+	Proposal      ArtifactState
+	Specs         ArtifactState
+	Design        ArtifactState
+	Tasks         ArtifactState
+	ApplyProgress ArtifactState
+	VerifyReport  ArtifactState
+	ReviewPolicy  ArtifactState
+	ReviewLedger  ArtifactState
+	ReviewReceipt ArtifactState
+	ReviewBundle  ArtifactState
+	ReviewContext ArtifactState
+	ReviewState   ArtifactState
+}
+
+// artifactStateField binds one wire key to its artifactStates field and to the
+// stores that declare it.
+type artifactStateField struct {
+	key   string
+	field func(*artifactStates) *ArtifactState
+	// stores lists the artifact stores that declare this key. An empty list
+	// means every store declares it.
+	stores []ArtifactStore
+}
+
+func (field artifactStateField) declaredBy(store ArtifactStore) bool {
+	if len(field.stores) == 0 {
+		return true
+	}
+	for _, declared := range field.stores {
+		if declared == store {
+			return true
+		}
+	}
+	return false
+}
+
+// artifactStateFields is the single authority for the SDD v1 artifact key set.
+// Both artifactStateKeys (what the projection demands) and statesFor (what the
+// builders supply) read it, so an artifact added here reaches every store's
+// builder and the projection together, and one added anywhere else reaches
+// neither.
+//
+// reviewPolicy is Engram-only by ratified contract: assets/skills/_shared/
+// sdd-status-contract.md states that reviewPolicy is present in artifactPaths
+// and contextFiles, while "its artifact-state entry is present only for Engram
+// status and omitted otherwise".
+var artifactStateFields = []artifactStateField{
+	{key: "proposal", field: func(states *artifactStates) *ArtifactState { return &states.Proposal }},
+	{key: "specs", field: func(states *artifactStates) *ArtifactState { return &states.Specs }},
+	{key: "design", field: func(states *artifactStates) *ArtifactState { return &states.Design }},
+	{key: "tasks", field: func(states *artifactStates) *ArtifactState { return &states.Tasks }},
+	{key: "applyProgress", field: func(states *artifactStates) *ArtifactState { return &states.ApplyProgress }},
+	{key: "verifyReport", field: func(states *artifactStates) *ArtifactState { return &states.VerifyReport }},
+	{key: "reviewPolicy", field: func(states *artifactStates) *ArtifactState { return &states.ReviewPolicy }, stores: []ArtifactStore{ArtifactStoreEngram}},
+	{key: "reviewLedger", field: func(states *artifactStates) *ArtifactState { return &states.ReviewLedger }},
+	{key: "reviewReceipt", field: func(states *artifactStates) *ArtifactState { return &states.ReviewReceipt }},
+	{key: "reviewBundle", field: func(states *artifactStates) *ArtifactState { return &states.ReviewBundle }},
+	{key: "reviewContext", field: func(states *artifactStates) *ArtifactState { return &states.ReviewContext }},
+	{key: "reviewState", field: func(states *artifactStates) *ArtifactState { return &states.ReviewState }},
+}
+
+// artifactStateKeys reports, in wire order, the artifact keys the given store
+// declares.
+func artifactStateKeys(store ArtifactStore) []string {
+	keys := make([]string, 0, len(artifactStateFields))
+	for _, field := range artifactStateFields {
+		if field.declaredBy(store) {
+			keys = append(keys, field.key)
+		}
+	}
+	return keys
+}
+
+// statesFor builds the artifact map for one store. A field left unset means
+// the resolver never found that artifact, which is exactly ArtifactMissing, so
+// a caller cannot produce a key with an illegal state by omission.
+func (states artifactStates) statesFor(store ArtifactStore) map[string]ArtifactState {
+	built := make(map[string]ArtifactState, len(artifactStateFields))
+	for _, field := range artifactStateFields {
+		if !field.declaredBy(store) {
+			continue
+		}
+		state := *field.field(&states)
+		if state == "" {
+			state = ArtifactMissing
+		}
+		built[field.key] = state
+	}
+	return built
+}

--- a/internal/sddstatus/artifact_states_test.go
+++ b/internal/sddstatus/artifact_states_test.go
@@ -1,0 +1,244 @@
+package sddstatus
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// engramWorkspaceWithArchivedChangesOnly builds the shape issue #2346 reports:
+// a hybrid workspace whose openspec/changes holds only archive/, while the
+// Engram store still carries observations from previously finished changes.
+func engramWorkspaceWithArchivedChangesOnly(t *testing.T, changes ...string) string {
+	t.Helper()
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+	workspace := t.TempDir()
+	mkdir(t, filepath.Join(workspace, "openspec", "changes", "archive"))
+	write(t, filepath.Join(workspace, "openspec", "config.yaml"), "artifact_store: hybrid\n")
+
+	observations := []engramObservation{}
+	for _, change := range changes {
+		observations = append(observations, engramPlanningRoute(change, "tasks")...)
+	}
+	t.Cleanup(stubEngramExport(t, observations))
+	return workspace
+}
+
+// TestEmptyWorkspaceStatusProjectsV1 pins issue #2346 property 1: a workspace
+// with nothing but archive/ must return a usable status on both the JSON and
+// the markdown path, for every artifact store the resolver can land on.
+func TestEmptyWorkspaceStatusProjectsV1(t *testing.T) {
+	tests := []struct {
+		name      string
+		workspace func(t *testing.T) string
+		wantStore ArtifactStore
+		wantNext  string
+	}{
+		{
+			name: "openspec store with no engram changes",
+			workspace: func(t *testing.T) string {
+				return engramWorkspaceWithArchivedChangesOnly(t)
+			},
+			wantStore: ArtifactStoreOpenSpec,
+			wantNext:  "sdd-new",
+		},
+		{
+			name: "engram store with only archived engram changes",
+			workspace: func(t *testing.T) string {
+				return engramWorkspaceWithArchivedChangesOnly(t, "alpha-change", "beta-change")
+			},
+			wantStore: ArtifactStoreEngram,
+			wantNext:  "select-change",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := tt.workspace(t)
+			before := snapshotWorkspace(t, workspace)
+
+			status, err := Resolve(ResolveOptions{WorkspaceRoot: workspace, IncludeInstructions: true})
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+			if status.ArtifactStore != tt.wantStore {
+				t.Fatalf("ArtifactStore = %q, want %q", status.ArtifactStore, tt.wantStore)
+			}
+			if status.NextRecommended != tt.wantNext {
+				t.Fatalf("NextRecommended = %q, want %q", status.NextRecommended, tt.wantNext)
+			}
+
+			projected, err := ProjectStatusV1(status)
+			if err != nil {
+				t.Fatalf("ProjectStatusV1() error = %v", err)
+			}
+			payload, err := json.Marshal(projected)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if !strings.Contains(string(payload), `"schemaName":"gentle-ai.sdd-status"`) {
+				t.Fatalf("projected JSON lost its identity: %s", payload)
+			}
+
+			markdown := RenderMarkdown(status)
+			if strings.Contains(markdown, "\n{}\n") {
+				t.Fatalf("markdown fell back to the empty projection:\n%s", markdown)
+			}
+			if !strings.Contains(markdown, `"schemaName": "gentle-ai.sdd-status"`) {
+				t.Fatalf("markdown omitted the projected status:\n%s", markdown)
+			}
+
+			// Property 3: sdd-status is read-only.
+			assertWorkspaceUnchanged(t, workspace, before)
+		})
+	}
+}
+
+// TestEveryArtifactMapBuilderSatisfiesTheV1Projection pins issue #2346
+// property 2. It names no artifact key: each case hands the projection the map
+// a production builder actually produced for the store that same builder was
+// asked for, and then proves the projection genuinely demands every key in it
+// by deleting one at a time. A builder that forgets a key its store declares,
+// or a status whose store no longer matches the map it carries, fails here
+// rather than at a user's terminal.
+func TestEveryArtifactMapBuilderSatisfiesTheV1Projection(t *testing.T) {
+	for _, built := range artifactMapsFromEveryBuilder(t) {
+		t.Run(built.builder, func(t *testing.T) {
+			if len(built.artifacts) == 0 {
+				t.Fatal("builder produced no artifact states")
+			}
+			if _, err := projectArtifactsV1(built.store, built.artifacts); err != nil {
+				t.Fatalf("projectArtifactsV1(%q, <%s output>) error = %v", built.store, built.builder, err)
+			}
+			for key := range built.artifacts {
+				withhold := make(map[string]ArtifactState, len(built.artifacts))
+				for existing, state := range built.artifacts {
+					if existing != key {
+						withhold[existing] = state
+					}
+				}
+				if _, err := projectArtifactsV1(built.store, withhold); err == nil {
+					t.Fatalf("projectArtifactsV1(%q) accepted a map missing %q, so the builder and the projection do not agree on the key set", built.store, key)
+				}
+			}
+		})
+	}
+}
+
+type builtArtifactMap struct {
+	builder   string
+	store     ArtifactStore
+	artifacts map[string]ArtifactState
+}
+
+// artifactMapsFromEveryBuilder collects the artifact map produced by every
+// production path that builds one, through the real entry points rather than
+// by restating the literals.
+func artifactMapsFromEveryBuilder(t *testing.T) []builtArtifactMap {
+	t.Helper()
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+	collected := []builtArtifactMap{}
+
+	for _, store := range []ArtifactStore{ArtifactStoreOpenSpec, ArtifactStoreEngram, ArtifactStoreNone} {
+		status := baseStatus(store, "/repo", nil, nil, "sdd-new", nil)
+		if status.ArtifactStore != store {
+			t.Fatalf("baseStatus(%q) produced store %q", store, status.ArtifactStore)
+		}
+		collected = append(collected, builtArtifactMap{
+			builder:   "baseStatus/" + string(store),
+			store:     status.ArtifactStore,
+			artifacts: status.Artifacts,
+		})
+	}
+
+	openspec := t.TempDir()
+	write(t, filepath.Join(openspec, "openspec", "changes", "live-change", "proposal.md"), "# Proposal\n")
+	write(t, filepath.Join(openspec, "openspec", "changes", "live-change", "tasks.md"), "- [ ] 1.1 Work\n")
+	resolved, err := Resolve(ResolveOptions{WorkspaceRoot: openspec})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	collected = append(collected, builtArtifactMap{
+		builder:   "Resolve",
+		store:     resolved.ArtifactStore,
+		artifacts: resolved.Artifacts,
+	})
+
+	engram := t.TempDir()
+	mkdir(t, filepath.Join(engram, "openspec", "changes", "archive"))
+	mkdir(t, filepath.Join(engram, ".engram"))
+	defer stubEngramExport(t, engramPlanningRoute("engram-change", "tasks"))()
+	engramStatus, err := Resolve(ResolveOptions{WorkspaceRoot: engram})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if engramStatus.ArtifactStore != ArtifactStoreEngram {
+		t.Fatalf("engram fixture resolved to store %q; the case would not exercise the Engram builder", engramStatus.ArtifactStore)
+	}
+	collected = append(collected, builtArtifactMap{
+		builder:   "resolveEngramStatus",
+		store:     engramStatus.ArtifactStore,
+		artifacts: engramStatus.Artifacts,
+	})
+
+	blocked := blockedEngramStatus(engram, nil, "select-change", []string{"ambiguous"}, false)
+	if blocked.ArtifactStore != ArtifactStoreEngram {
+		t.Fatalf("blockedEngramStatus produced store %q", blocked.ArtifactStore)
+	}
+	collected = append(collected, builtArtifactMap{
+		builder:   "blockedEngramStatus",
+		store:     blocked.ArtifactStore,
+		artifacts: blocked.Artifacts,
+	})
+
+	return collected
+}
+
+func snapshotWorkspace(t *testing.T, root string) map[string]string {
+	t.Helper()
+	snapshot := map[string]string{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			snapshot[relative] = "dir"
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		snapshot[relative] = string(content)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk workspace: %v", err)
+	}
+	return snapshot
+}
+
+func assertWorkspaceUnchanged(t *testing.T, root string, before map[string]string) {
+	t.Helper()
+	after := snapshotWorkspace(t, root)
+	for path, content := range after {
+		previous, existed := before[path]
+		if !existed {
+			t.Fatalf("sdd-status created %q; the command must be read-only", path)
+		}
+		if previous != content {
+			t.Fatalf("sdd-status mutated %q; the command must be read-only", path)
+		}
+	}
+	for path := range before {
+		if _, still := after[path]; !still {
+			t.Fatalf("sdd-status removed %q; the command must be read-only", path)
+		}
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -420,11 +420,11 @@ func Resolve(options ResolveOptions) (Status, error) {
 			if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, reviewDisabled); ok || err != nil {
 				return status, err
 			}
-			return blockedStatus(workspaceRoot, nil, nil, "sdd-new", []string{"No active OpenSpec changes found under openspec/changes."}, options.IncludeInstructions), nil
+			return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, nil, "sdd-new", []string{"No active OpenSpec changes found under openspec/changes."}, options.IncludeInstructions), nil
 		case 1:
 			changeName = activeChanges[0]
 		default:
-			return blockedStatus(workspaceRoot, nil, nil, "select-change", []string{fmt.Sprintf("Change selection is ambiguous: %s.", strings.Join(activeChanges, ", "))}, options.IncludeInstructions), nil
+			return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, nil, "select-change", []string{fmt.Sprintf("Change selection is ambiguous: %s.", strings.Join(activeChanges, ", "))}, options.IncludeInstructions), nil
 		}
 	}
 
@@ -432,7 +432,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 		if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, reviewDisabled); ok || err != nil {
 			return status, err
 		}
-		return blockedStatus(workspaceRoot, &changeName, nil, "sdd-new", []string{fmt.Sprintf("Active OpenSpec change not found: %s.", changeName)}, options.IncludeInstructions), nil
+		return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, &changeName, nil, "sdd-new", []string{fmt.Sprintf("Active OpenSpec change not found: %s.", changeName)}, options.IncludeInstructions), nil
 	}
 
 	changeRoot := filepath.Join(changesDir, changeName)
@@ -440,19 +440,20 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	artifacts := map[string]ArtifactState{
-		"proposal":      singleArtifactState(artifactPaths.Proposal),
-		"specs":         multiArtifactState(artifactPaths.Specs, filepath.Join(changeRoot, "specs")),
-		"design":        singleArtifactState(artifactPaths.Design),
-		"tasks":         singleArtifactState(artifactPaths.Tasks),
-		"applyProgress": singleArtifactState(artifactPaths.ApplyProgress),
-		"verifyReport":  singleArtifactState(artifactPaths.VerifyReport),
-		"reviewLedger":  singleArtifactState(artifactPaths.ReviewLedger),
-		"reviewReceipt": singleArtifactState(artifactPaths.ReviewReceipt),
-		"reviewBundle":  singleArtifactState(artifactPaths.ReviewBundle),
-		"reviewContext": singleArtifactState(artifactPaths.ReviewContext),
-		"reviewState":   singleArtifactState(artifactPaths.ReviewState),
-	}
+	artifacts := artifactStates{
+		Proposal:      singleArtifactState(artifactPaths.Proposal),
+		Specs:         multiArtifactState(artifactPaths.Specs, filepath.Join(changeRoot, "specs")),
+		Design:        singleArtifactState(artifactPaths.Design),
+		Tasks:         singleArtifactState(artifactPaths.Tasks),
+		ApplyProgress: singleArtifactState(artifactPaths.ApplyProgress),
+		VerifyReport:  singleArtifactState(artifactPaths.VerifyReport),
+		ReviewPolicy:  singleArtifactState(artifactPaths.ReviewPolicy),
+		ReviewLedger:  singleArtifactState(artifactPaths.ReviewLedger),
+		ReviewReceipt: singleArtifactState(artifactPaths.ReviewReceipt),
+		ReviewBundle:  singleArtifactState(artifactPaths.ReviewBundle),
+		ReviewContext: singleArtifactState(artifactPaths.ReviewContext),
+		ReviewState:   singleArtifactState(artifactPaths.ReviewState),
+	}.statesFor(ArtifactStoreOpenSpec)
 	taskProgress, err := countTaskProgress(firstPath(artifactPaths.Tasks))
 	if err != nil {
 		return Status{}, err
@@ -590,7 +591,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if remediationState.Reason != "" {
 		blockedReasons.genuine = append(blockedReasons.genuine, remediationState.Reason)
 	}
-	status := baseStatus(workspaceRoot, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))
+	status := baseStatus(ArtifactStoreOpenSpec, workspaceRoot, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))
 	status.ArtifactPaths = artifactPaths
 	status.ContextFiles = artifactPaths
 	status.Artifacts = artifacts
@@ -797,20 +798,20 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	}
 
 	artifactPaths := engramArtifactPaths(changeName, artifactsByType)
-	artifacts := map[string]ArtifactState{
-		"proposal":      engramArtifactState(artifactsByType["proposal"]),
-		"specs":         engramArtifactState(artifactsByType["spec"]),
-		"design":        engramArtifactState(artifactsByType["design"]),
-		"tasks":         engramArtifactState(artifactsByType["tasks"]),
-		"applyProgress": engramArtifactState(artifactsByType["apply-progress"]),
-		"verifyReport":  engramArtifactState(artifactsByType["verify-report"]),
-		"reviewLedger":  engramArtifactState(artifactsByType["review/ledger"]),
-		"reviewPolicy":  engramArtifactState(artifactsByType["review/policy"]),
-		"reviewReceipt": engramArtifactState(artifactsByType["review/receipt"]),
-		"reviewBundle":  engramArtifactState(artifactsByType["review/chain-bundle"]),
-		"reviewContext": engramArtifactState(artifactsByType["review/gate-context"]),
-		"reviewState":   engramArtifactState(artifactsByType["review/transaction"]),
-	}
+	artifacts := artifactStates{
+		Proposal:      engramArtifactState(artifactsByType["proposal"]),
+		Specs:         engramArtifactState(artifactsByType["spec"]),
+		Design:        engramArtifactState(artifactsByType["design"]),
+		Tasks:         engramArtifactState(artifactsByType["tasks"]),
+		ApplyProgress: engramArtifactState(artifactsByType["apply-progress"]),
+		VerifyReport:  engramArtifactState(artifactsByType["verify-report"]),
+		ReviewPolicy:  engramArtifactState(artifactsByType["review/policy"]),
+		ReviewLedger:  engramArtifactState(artifactsByType["review/ledger"]),
+		ReviewReceipt: engramArtifactState(artifactsByType["review/receipt"]),
+		ReviewBundle:  engramArtifactState(artifactsByType["review/chain-bundle"]),
+		ReviewContext: engramArtifactState(artifactsByType["review/gate-context"]),
+		ReviewState:   engramArtifactState(artifactsByType["review/transaction"]),
+	}.statesFor(ArtifactStoreEngram)
 	taskProgress := countTaskProgressText(artifactsByType["tasks"].Content)
 	specCounts := countSpecRequirementsAndScenarios([]string{artifactsByType["spec"].Content})
 	verifyResult := parseVerifyResult(artifactsByType["verify-report"].Content, specCounts)
@@ -899,8 +900,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	}
 
 	changeRoot := fmt.Sprintf("engram:sdd/%s", changeName)
-	status := baseStatus(workspaceRoot, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))
-	status.ArtifactStore = ArtifactStoreEngram
+	status := baseStatus(ArtifactStoreEngram, workspaceRoot, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))
 	status.PlanningHome = PlanningHome{Mode: ActionModeRepoLocal, Path: "engram:sdd"}
 	status.ArtifactPaths = artifactPaths
 	status.ContextFiles = artifactPaths
@@ -950,8 +950,7 @@ func compactBridgeableReviewArtifact(state ArtifactState, reason string) bool {
 }
 
 func blockedEngramStatus(workspaceRoot string, changeName *string, next string, reasons []string, includeInstructions bool) Status {
-	status := blockedStatus(workspaceRoot, changeName, nil, next, reasons, includeInstructions)
-	status.ArtifactStore = ArtifactStoreEngram
+	status := blockedStatus(ArtifactStoreEngram, workspaceRoot, changeName, nil, next, reasons, includeInstructions)
 	status.PlanningHome = PlanningHome{Mode: ActionModeRepoLocal, Path: "engram:sdd"}
 	return status
 }
@@ -1311,8 +1310,8 @@ func absOrCWD(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
-func blockedStatus(workspaceRoot string, changeName *string, changeRoot *string, next string, reasons []string, includeInstructions bool) Status {
-	status := baseStatus(workspaceRoot, changeName, changeRoot, next, reasons)
+func blockedStatus(store ArtifactStore, workspaceRoot string, changeName *string, changeRoot *string, next string, reasons []string, includeInstructions bool) Status {
+	status := baseStatus(store, workspaceRoot, changeName, changeRoot, next, reasons)
 	if includeInstructions {
 		instructions := renderPhaseInstructions(status)
 		status.PhaseInstructions = &instructions
@@ -1320,7 +1319,11 @@ func blockedStatus(workspaceRoot string, changeName *string, changeRoot *string,
 	return status
 }
 
-func baseStatus(workspaceRoot string, changeName *string, changeRoot *string, next string, reasons []string) Status {
+// baseStatus takes the artifact store as an input so the artifact map is built
+// for the store the status actually reports. Issue #2346: it used to hardcode
+// ArtifactStoreOpenSpec and leave callers to relabel the store afterwards,
+// which produced an Engram status carrying an OpenSpec-shaped map.
+func baseStatus(store ArtifactStore, workspaceRoot string, changeName *string, changeRoot *string, next string, reasons []string) Status {
 	emptyPaths := emptyArtifactPaths()
 	if reasons == nil {
 		reasons = []string{}
@@ -1329,7 +1332,7 @@ func baseStatus(workspaceRoot string, changeName *string, changeRoot *string, ne
 		SchemaName:    SchemaName,
 		SchemaVersion: SchemaVersion,
 		ChangeName:    changeName,
-		ArtifactStore: ArtifactStoreOpenSpec,
+		ArtifactStore: store,
 		PlanningHome: PlanningHome{
 			Mode: ActionModeRepoLocal,
 			Path: filepath.Join(workspaceRoot, "openspec"),
@@ -1337,20 +1340,8 @@ func baseStatus(workspaceRoot string, changeName *string, changeRoot *string, ne
 		ChangeRoot:    changeRoot,
 		ArtifactPaths: emptyPaths,
 		ContextFiles:  emptyPaths,
-		Artifacts: map[string]ArtifactState{
-			"proposal":      ArtifactMissing,
-			"specs":         ArtifactMissing,
-			"design":        ArtifactMissing,
-			"tasks":         ArtifactMissing,
-			"applyProgress": ArtifactMissing,
-			"verifyReport":  ArtifactMissing,
-			"reviewLedger":  ArtifactMissing,
-			"reviewReceipt": ArtifactMissing,
-			"reviewBundle":  ArtifactMissing,
-			"reviewContext": ArtifactMissing,
-			"reviewState":   ArtifactMissing,
-		},
-		TaskProgress: TaskProgress{},
+		Artifacts:     artifactStates{}.statesFor(store),
+		TaskProgress:  TaskProgress{},
 		Dependencies: Dependencies{
 			Proposal: DependencyBlocked,
 			Specs:    DependencyBlocked,

--- a/internal/sddstatus/status_v1.go
+++ b/internal/sddstatus/status_v1.go
@@ -211,13 +211,7 @@ func marshalStatusV1Indent(status Status) ([]byte, error) {
 }
 
 func projectArtifactsV1(store ArtifactStore, source map[string]ArtifactState) (map[string]ArtifactState, error) {
-	keys := []string{
-		"proposal", "specs", "design", "tasks", "applyProgress", "verifyReport",
-		"reviewLedger", "reviewReceipt", "reviewBundle", "reviewContext", "reviewState",
-	}
-	if store == ArtifactStoreEngram {
-		keys = append(keys, "reviewPolicy")
-	}
+	keys := artifactStateKeys(store)
 	projected := make(map[string]ArtifactState, len(keys))
 	for _, key := range keys {
 		state, ok := source[key]

--- a/internal/sddstatus/status_v1_test.go
+++ b/internal/sddstatus/status_v1_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestProjectStatusV1FreezesExactLegacyShape(t *testing.T) {
-	status := baseStatus("/repo", nil, nil, "apply", nil)
+	status := baseStatus(ArtifactStoreOpenSpec, "/repo", nil, nil, "apply", nil)
 	status.RuntimeStatus = &RuntimeStatus{Schema: RuntimeStatusSchema, Change: "internal-only"}
 	status.RemediationState.CorrectionBudgetRemaining = 7
 	status.RemediationState.CorrectionBudgetTotal = 10
@@ -81,7 +81,7 @@ func TestProjectStatusV1RejectsNonLegacyValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status := baseStatus("/repo", nil, nil, "apply", nil)
+			status := baseStatus(ArtifactStoreOpenSpec, "/repo", nil, nil, "apply", nil)
 			tt.mutate(&status)
 			_, err := ProjectStatusV1(status)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
@@ -92,7 +92,7 @@ func TestProjectStatusV1RejectsNonLegacyValues(t *testing.T) {
 }
 
 func TestStatusRenderersEmbedOnlyStatusV1Projection(t *testing.T) {
-	status := baseStatus("/repo", nil, nil, "apply", nil)
+	status := baseStatus(ArtifactStoreOpenSpec, "/repo", nil, nil, "apply", nil)
 	status.RuntimeStatus = &RuntimeStatus{Schema: RuntimeStatusSchema, Change: "internal-only"}
 	status.RemediationState.CorrectionBudgetRemaining = 7
 	status.RemediationState.CorrectionBudgetTotal = 10


### PR DESCRIPTION
`sdd-status` failed on an Engram-backed workspace with no active OpenSpec changes, blocking the next change from starting. Reported by @JuAGarHi against 2.2.3 and still live on `main`.

```
Error: project SDD status v1: unsupported SDD v1 artifact "reviewPolicy" state ""
```

## The mechanism, sharper than the issue states it

That `state ""` is not an invalid state. `engramArtifactState` can only return missing, partial or done, and the projection accepts exactly those three. It is the Go zero value for a **key absent from the map**.

The initial analysis was that three artifact-map builders disagree. That is true, but only one is actually reachable with the defect, and it is not the obvious one. The full Engram path calls `baseStatus` and then overwrites `status.Artifacts` wholesale with its own map, which does contain `reviewPolicy`, so it never drifts.

The reachable producer is `blockedEngramStatus` at `status.go:923`. It built an OpenSpec-shaped map through `blockedStatus` and `baseStatus`, then **relabelled `status.ArtifactStore = ArtifactStoreEngram` and returned without rebuilding**.

So the real disagreement is not three literals. It is **a store chosen after the map was built**.

That also explains why it looks intermittent from outside. The trigger needs an archive-only OpenSpec side **and** two or more changes in the Engram store, which routes to `select-change` ambiguity. A workspace with zero Engram changes falls back to the OpenSpec blocked status and works fine.

## The change

One builder, with the store as a build-time input rather than a label applied afterwards.

A new `artifactStateFields` is the single authority for the key set. `artifactStateKeys(store)` feeds the v1 projection and `statesFor(store)` feeds every builder. `baseStatus` and `blockedStatus` now take an `ArtifactStore` parameter, and both post-hoc reassignments are gone.

What that removes: the projection's own key list, three map literals, and the ability to label a status with a store it was not built for. An artifact added to `artifactStateFields` now reaches every builder and the projection together, or reaches neither.

The store-conditional `reviewPolicy` key stays, because it is ratified contract: `internal/assets/skills/_shared/sdd-status-contract.md:125` says its entry is present only for Engram status and omitted otherwise. Dropping the conditional so every store carries every key would be cleaner, but it changes the OpenSpec wire shape and needs a contract amendment plus consumer coordination. That is a compatibility change, not a bugfix.

## The guard is verified by mutation, not by assertion

`TestEveryArtifactMapBuilderSatisfiesTheV1Projection` **names no artifact key**. It collects the map each production path actually produced, asserts the projection accepts it, then deletes one key at a time and asserts the projection rejects each deletion. That pins both directions of the key set without restating it, so a test listing the keys by hand cannot recreate the drift one layer up.

It was proved non-vacuous by re-introducing the original defect shape on top of the fix and watching it fail with the reporter's exact message.

Read-only behavior is pinned by a full filesystem snapshot walk before and after `Resolve`, asserting nothing created, modified or removed.

## Verification

Root `go test ./... -count=1` exit 0, bench module clean, gofmt and vet clean, deadcode ratchet reports no new unreachable functions, refusal and guard-population ratchets pass.

Goldens regenerated produced **zero diff**, then reverified without the flags, confirming byte-identical wire output on every path that already worked.

## Known

`Status.ArtifactStore` is still a public mutable field, so the type system cannot prevent a future caller from reassigning it without rebuilding. The mutation test catches that in CI rather than at a user's terminal, which is the best available short of making the field unexported.

Closes #2346

Part of #2471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status views now accurately identify whether artifacts belong to OpenSpec or Engram.
  * Engram-specific review policy information is now included where applicable.
  * Missing artifacts consistently appear as missing instead of being omitted or misclassified.
  * Empty-workspace status reports now provide complete artifact information.
  * JSON and Markdown status outputs now consistently reflect the same artifact states.
  * Status checks no longer modify workspace files when inspecting artifact state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->