### PR TITLE
fix(system): probe for a package manager instead of enumerating distributions

### DIFF
--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -33,6 +33,39 @@ const (
 	LinuxDistroFedora  = "fedora"
 )
 
+// linuxPackageManagers is the ordered list of package managers gentle-ai
+// probes on PATH to decide whether a Linux machine is usable. What makes a
+// machine usable is a manager that answers, not membership in a list of
+// distributions somebody has to keep editing: every distribution that is
+// missing from such a list is a dead end for its users, and there is always
+// another distribution.
+//
+// The order is preference, not correctness. The first manager found wins.
+// brew stays first because it was already the short-circuit that made any
+// Linux distribution supported, and it is the manager with the widest
+// install coverage here. The rest are ordered by how many machines run them.
+//
+// Adding a distribution never needs a change here. Adding a manager does,
+// and the refusal in EnsureSupportedPlatform names this exact list so a user
+// on a machine with none of them knows what to install.
+var linuxPackageManagers = []string{
+	"brew",   // any distribution, via Homebrew on Linux
+	"apt",    // Debian, Ubuntu, Mint, Pop!_OS, Deepin, UOS
+	"dnf",    // Fedora, RHEL, CentOS Stream, Rocky, AlmaLinux, Nobara
+	"pacman", // Arch, Manjaro, EndeavourOS
+	"apk",    // Alpine
+	"zypper", // openSUSE, SUSE Linux Enterprise
+	"nix",    // NixOS
+	"emerge", // Gentoo, Calculate
+}
+
+// detectedToolNames is the fixed probe list passed to DetectTools: the tools
+// other detection reads, plus every Linux package manager.
+func detectedToolNames() []string {
+	names := []string{"git", "curl", "node", "go"}
+	return append(names, linuxPackageManagers...)
+}
+
 type DetectionResult struct {
 	System       SystemInfo
 	Tools        map[string]ToolStatus
@@ -50,7 +83,7 @@ func Detect(ctx context.Context) (DetectionResult, error) {
 		return DetectionResult{}, err
 	}
 
-	tools := DetectTools(ctx, []string{"git", "curl", "brew", "node", "go"})
+	tools := DetectTools(ctx, detectedToolNames())
 	configs := ScanConfigs(homeDir)
 	osReleaseContent, _ := osReleaseContent(runtime.GOOS)
 
@@ -128,30 +161,20 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		profile.Supported = true
 		return profile
 	case "linux":
-		distro := detectLinuxDistro(linuxOSRelease)
-		profile.LinuxDistro = distro
+		// The distro is reported, never gated on. It is what the machine
+		// calls itself, for humans reading logs and error messages.
+		profile.LinuxDistro = osReleaseID(linuxOSRelease)
 
-		// Check if brew is available on Linux
-		if brew, ok := tools["brew"]; ok && brew.Installed {
-			profile.PackageManager = "brew"
-			profile.Supported = true
-			return profile
+		for _, manager := range linuxPackageManagers {
+			if tool, ok := tools[manager]; ok && tool.Installed {
+				profile.PackageManager = manager
+				profile.Supported = true
+				return profile
+			}
 		}
 
-		switch distro {
-		case LinuxDistroUbuntu, LinuxDistroDebian:
-			profile.PackageManager = "apt"
-			profile.Supported = true
-		case LinuxDistroArch:
-			profile.PackageManager = "pacman"
-			profile.Supported = true
-		case LinuxDistroFedora:
-			profile.PackageManager = "dnf"
-			profile.Supported = true
-		default:
-			profile.PackageManager = ""
-			profile.Supported = false
-		}
+		profile.PackageManager = ""
+		profile.Supported = false
 
 		return profile
 	case "windows":
@@ -164,87 +187,32 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 	}
 }
 
-func detectLinuxDistro(linuxOSRelease string) string {
-	if strings.TrimSpace(linuxOSRelease) == "" {
-		return LinuxDistroUnknown
-	}
-
-	fields := map[string]string{}
+// osReleaseID returns the lower-cased ID field of an /etc/os-release file, or
+// LinuxDistroUnknown when the file is absent, empty, or declares no ID.
+//
+// Values may be quoted with either double or single quotes per the os-release
+// spec (https://www.freedesktop.org/software/systemd/man/latest/os-release.html).
+// Stripping only double quotes left Gentoo's `ID='gentoo'` as the literal
+// value `'gentoo'`, which matched nothing.
+func osReleaseID(linuxOSRelease string) string {
 	for _, line := range strings.Split(linuxOSRelease, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
+		key, value, found := strings.Cut(line, "=")
+		if !found || strings.ToUpper(strings.TrimSpace(key)) != "ID" {
 			continue
 		}
 
-		key := strings.ToUpper(strings.TrimSpace(parts[0]))
-		value := strings.Trim(strings.TrimSpace(parts[1]), `"`)
-		fields[key] = strings.ToLower(value)
-	}
-
-	id := fields["ID"]
-	idLike := fields["ID_LIKE"]
-
-	if isUbuntuLike(id, idLike) {
-		if id == LinuxDistroDebian {
-			return LinuxDistroDebian
+		id := strings.ToLower(strings.Trim(strings.TrimSpace(value), `"'`))
+		if id == "" {
+			continue
 		}
-		return LinuxDistroUbuntu
-	}
 
-	if isArchLike(id, idLike) {
-		return LinuxDistroArch
-	}
-
-	if isFedoraLike(id, idLike) {
-		return LinuxDistroFedora
+		return id
 	}
 
 	return LinuxDistroUnknown
-}
-
-func isUbuntuLike(id, idLike string) bool {
-	if id == LinuxDistroUbuntu || id == LinuxDistroDebian {
-		return true
-	}
-
-	for _, token := range strings.Fields(idLike) {
-		if token == LinuxDistroUbuntu || token == LinuxDistroDebian {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isArchLike(id, idLike string) bool {
-	if id == LinuxDistroArch {
-		return true
-	}
-
-	for _, token := range strings.Fields(idLike) {
-		if token == LinuxDistroArch {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isFedoraLike(id, idLike string) bool {
-	if id == LinuxDistroFedora || id == "rhel" || id == "centos" || id == "rocky" || id == "almalinux" || id == "nobara" {
-		return true
-	}
-
-	for _, token := range strings.Fields(idLike) {
-		if token == LinuxDistroFedora || token == "rhel" || token == "centos" || token == "rocky" || token == "almalinux" || token == "nobara" {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/system/detect_linux_probe_test.go
+++ b/internal/system/detect_linux_probe_test.go
@@ -1,0 +1,228 @@
+package system
+
+import (
+	"strings"
+	"testing"
+)
+
+// The fixtures below are shaped like the real /etc/os-release each
+// distribution ships, including the details that broke detection before:
+// Deepin's capitalised ID, Gentoo's single-quoted ID, and openSUSE's
+// hyphenated ID. They exist so a distribution nobody anticipated is a test
+// case, not a support ticket.
+
+const (
+	osReleaseOpenSUSE = `NAME="openSUSE Tumbleweed"
+# VERSION="20240115"
+ID="opensuse-tumbleweed"
+ID_LIKE="opensuse suse"
+VERSION_ID="20240115"
+PRETTY_NAME="openSUSE Tumbleweed"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:tumbleweed:20240115"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+LOGO="distributor-logo-Tumbleweed"
+`
+
+	osReleaseAlpine = `NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.19.1
+PRETTY_NAME="Alpine Linux v3.19"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
+`
+
+	osReleaseNixOS = `ANSI_COLOR="1;34"
+BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
+BUILD_ID="24.05.20240115.abcdef0"
+CPE_NAME="cpe:/o:nixos:nixos:24.05"
+DEFAULT_HOSTNAME=nixos
+DOCUMENTATION_URL="https://nixos.org/learn.html"
+HOME_URL="https://nixos.org/"
+ID=nixos
+IMAGE_ID=""
+IMAGE_VERSION=""
+LOGO="nix-snowflake"
+NAME=NixOS
+PRETTY_NAME="NixOS 24.05 (Uakari)"
+SUPPORT_URL="https://nixos.org/community.html"
+VERSION="24.05 (Uakari)"
+VERSION_CODENAME=uakari
+VERSION_ID="24.05"
+`
+
+	// Deepin ships ID with a capital D on 20.x. Lower-casing is what keeps
+	// the reported distro stable across their releases.
+	osReleaseDeepin = `PRETTY_NAME="Deepin 23"
+NAME="Deepin"
+VERSION_ID="23"
+VERSION="23"
+ID=Deepin
+HOME_URL="https://www.deepin.org/"
+BUG_REPORT_URL="https://bbs.deepin.org/"
+`
+
+	osReleaseUOS = `PRETTY_NAME="UnionTech OS Desktop 20 Pro"
+NAME="UOS"
+VERSION_ID="20"
+VERSION="20"
+ID=uos
+HOME_URL="https://www.chinauos.com/"
+`
+
+	// The os-release spec allows single quotes. Gentoo uses them, and the
+	// double-quote-only parser left the value as `'gentoo'`, which matched
+	// nothing.
+	osReleaseGentoo = `NAME=Gentoo
+ID='gentoo'
+PRETTY_NAME="Gentoo Linux"
+ANSI_COLOR="1;32"
+HOME_URL="https://www.gentoo.org/"
+SUPPORT_URL="https://www.gentoo.org/support/"
+BUG_REPORT_URL="https://bugs.gentoo.org/"
+VERSION_ID="2.17"
+`
+
+	osReleaseUbuntu = `NAME="Ubuntu"
+VERSION="22.04.3 LTS (Jammy Jellyfish)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 22.04.3 LTS"
+VERSION_ID="22.04"
+`
+)
+
+// toolsOnPath builds the tool map DetectTools would produce when exactly the
+// named binaries resolve on PATH.
+func toolsOnPath(names ...string) map[string]ToolStatus {
+	tools := make(map[string]ToolStatus, len(names))
+	for _, name := range names {
+		tools[name] = ToolStatus{Name: name, Installed: true, Path: "/usr/bin/" + name}
+	}
+	return tools
+}
+
+// TestLinuxIsSupportedWheneverAPackageManagerIsOnPath is the whole point: what
+// makes a Linux machine usable is a package manager that answers, not
+// membership in a list somebody has to keep editing.
+func TestLinuxIsSupportedWheneverAPackageManagerIsOnPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		osRelease string
+		onPath    []string
+		wantPM    string
+	}{
+		{name: "opensuse tumbleweed with zypper (#140)", osRelease: osReleaseOpenSUSE, onPath: []string{"zypper"}, wantPM: "zypper"},
+		{name: "alpine with apk (#334)", osRelease: osReleaseAlpine, onPath: []string{"apk"}, wantPM: "apk"},
+		{name: "nixos with nix (#110)", osRelease: osReleaseNixOS, onPath: []string{"nix"}, wantPM: "nix"},
+		{name: "deepin with apt (#926)", osRelease: osReleaseDeepin, onPath: []string{"apt"}, wantPM: "apt"},
+		{name: "uos with apt (#926)", osRelease: osReleaseUOS, onPath: []string{"apt"}, wantPM: "apt"},
+		{name: "gentoo with emerge (#1669)", osRelease: osReleaseGentoo, onPath: []string{"emerge"}, wantPM: "emerge"},
+		// Distributions the deleted enum recognised, plus the derivatives it
+		// recognised only through ID_LIKE. None of them needs to be named now.
+		{name: "ubuntu with apt stays supported", osRelease: osReleaseUbuntu, onPath: []string{"apt"}, wantPM: "apt"},
+		{name: "debian with apt", osRelease: "ID=debian\nVERSION_ID=\"12\"\n", onPath: []string{"apt"}, wantPM: "apt"},
+		{name: "linux mint with apt", osRelease: "ID=linuxmint\nID_LIKE=\"ubuntu debian\"\n", onPath: []string{"apt"}, wantPM: "apt"},
+		{name: "pop os with apt", osRelease: "ID=pop\nID_LIKE=\"ubuntu debian\"\n", onPath: []string{"apt"}, wantPM: "apt"},
+		{name: "arch with pacman", osRelease: "ID=arch\n", onPath: []string{"pacman"}, wantPM: "pacman"},
+		{name: "manjaro with pacman", osRelease: "ID=manjaro\nID_LIKE=arch\n", onPath: []string{"pacman"}, wantPM: "pacman"},
+		{name: "endeavouros with pacman", osRelease: "ID=endeavouros\nID_LIKE=arch\n", onPath: []string{"pacman"}, wantPM: "pacman"},
+		{name: "fedora with dnf", osRelease: "ID=fedora\nID_LIKE=\"rhel fedora\"\n", onPath: []string{"dnf"}, wantPM: "dnf"},
+		{name: "rocky with dnf", osRelease: "ID=rocky\nID_LIKE=\"rhel fedora\"\n", onPath: []string{"dnf"}, wantPM: "dnf"},
+		{name: "almalinux with dnf", osRelease: "ID=almalinux\nID_LIKE=\"rhel fedora\"\n", onPath: []string{"dnf"}, wantPM: "dnf"},
+		{name: "nobara with dnf", osRelease: "ID=nobara\nID_LIKE=\"fedora\"\n", onPath: []string{"dnf"}, wantPM: "dnf"},
+		{name: "distro nobody has heard of, with dnf", osRelease: "ID=some-future-distro\n", onPath: []string{"dnf"}, wantPM: "dnf"},
+		{name: "no os-release at all, with pacman", osRelease: "", onPath: []string{"pacman"}, wantPM: "pacman"},
+		{name: "brew keeps winning over the native manager", osRelease: osReleaseAlpine, onPath: []string{"apk", "brew"}, wantPM: "brew"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := resolvePlatformProfile("linux", tc.osRelease, toolsOnPath(tc.onPath...))
+
+			if !profile.Supported {
+				t.Fatalf("Supported = false, want true (package manager %q is on PATH)", tc.wantPM)
+			}
+			if profile.PackageManager != tc.wantPM {
+				t.Fatalf("PackageManager = %q, want %q", profile.PackageManager, tc.wantPM)
+			}
+			if err := EnsureSupportedPlatform(profile); err != nil {
+				t.Fatalf("EnsureSupportedPlatform() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestLinuxDistroReportsTheOSReleaseIDVerbatim covers the second half of
+// #1669: single-quoted values were left quoted, so `ID='gentoo'` matched
+// nothing. The distro is reported for humans, so it must be the ID the
+// machine actually declares.
+func TestLinuxDistroReportsTheOSReleaseIDVerbatim(t *testing.T) {
+	tests := []struct {
+		name       string
+		osRelease  string
+		wantDistro string
+	}{
+		{name: "unquoted id", osRelease: osReleaseAlpine, wantDistro: "alpine"},
+		{name: "double-quoted id", osRelease: osReleaseOpenSUSE, wantDistro: "opensuse-tumbleweed"},
+		{name: "single-quoted id (#1669)", osRelease: osReleaseGentoo, wantDistro: "gentoo"},
+		{name: "capitalised id is lower-cased", osRelease: osReleaseDeepin, wantDistro: "deepin"},
+		{name: "uos", osRelease: osReleaseUOS, wantDistro: "uos"},
+		{name: "nixos", osRelease: osReleaseNixOS, wantDistro: "nixos"},
+		{name: "ubuntu", osRelease: osReleaseUbuntu, wantDistro: "ubuntu"},
+		{name: "missing os-release", osRelease: "", wantDistro: LinuxDistroUnknown},
+		{name: "comments only", osRelease: "# nothing here\n", wantDistro: LinuxDistroUnknown},
+		{name: "malformed lines are skipped", osRelease: "no-equals-sign\nID='gentoo'\n", wantDistro: "gentoo"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := resolvePlatformProfile("linux", tc.osRelease, toolsOnPath("apt"))
+			if profile.LinuxDistro != tc.wantDistro {
+				t.Fatalf("LinuxDistro = %q, want %q", profile.LinuxDistro, tc.wantDistro)
+			}
+		})
+	}
+}
+
+// TestLinuxRefusalNamesTheProbedManagersAndARunnableCheck is the dead-end
+// guard. A machine with no package manager at all is still a refusal, but it
+// must be a refusal the reader can act on without editing /etc/os-release to
+// lie about the distribution (which is what #334's reporter had to do).
+func TestLinuxRefusalNamesTheProbedManagersAndARunnableCheck(t *testing.T) {
+	profile := resolvePlatformProfile("linux", osReleaseGentoo, nil)
+	if profile.Supported {
+		t.Fatal("Supported = true with no package manager on PATH, want false")
+	}
+
+	err := EnsureSupportedPlatform(profile)
+	if err == nil {
+		t.Fatal("EnsureSupportedPlatform() = nil, want a refusal")
+	}
+	message := err.Error()
+
+	// Every manager the probe looks for must be named, so the reader knows
+	// exactly which one to install.
+	for _, manager := range []string{"brew", "apt", "dnf", "pacman", "apk", "zypper", "nix", "emerge"} {
+		if !strings.Contains(message, manager) {
+			t.Errorf("refusal does not name probed package manager %q:\n%s", manager, message)
+		}
+	}
+
+	// The exit has to be runnable, not a description of a policy.
+	if !strings.Contains(message, `for m in brew apt dnf pacman apk zypper nix emerge; do command -v "$m"; done`) {
+		t.Errorf("refusal does not print the runnable probe check:\n%s", message)
+	}
+	if !strings.Contains(message, "PATH") {
+		t.Errorf("refusal does not say that PATH is what it searched:\n%s", message)
+	}
+	if !strings.Contains(message, "gentoo") {
+		t.Errorf("refusal does not report the detected distro:\n%s", message)
+	}
+
+	// The old message named a closed list and no exit at all. It must be gone.
+	if strings.Contains(message, "Linux support is limited to") {
+		t.Errorf("refusal still names a closed distro list:\n%s", message)
+	}
+}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -41,7 +41,7 @@ func TestDetectFromInputsMarksSupportedMacOS(t *testing.T) {
 
 func TestDetectFromInputsMarksFedoraSupported(t *testing.T) {
 	osRelease := "ID=fedora\nID_LIKE=rhel fedora\n"
-	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, toolsOnPath("dnf"), nil)
 
 	if !result.System.Supported {
 		t.Fatalf("expected supported system for fedora linux distro")
@@ -58,7 +58,7 @@ func TestDetectFromInputsMarksFedoraSupported(t *testing.T) {
 
 func TestDetectFromInputsMarksUbuntuSupported(t *testing.T) {
 	osRelease := "ID=ubuntu\nID_LIKE=debian\n"
-	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, toolsOnPath("apt"), nil)
 
 	if !result.System.Supported {
 		t.Fatalf("expected ubuntu linux to be supported")
@@ -75,7 +75,7 @@ func TestDetectFromInputsMarksUbuntuSupported(t *testing.T) {
 
 func TestDetectFromInputsMarksArchSupported(t *testing.T) {
 	osRelease := "ID=arch\nID_LIKE=archlinux\n"
-	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, toolsOnPath("pacman"), nil)
 
 	if !result.System.Supported {
 		t.Fatalf("expected arch linux to be supported")
@@ -91,119 +91,12 @@ func TestDetectFromInputsMarksArchSupported(t *testing.T) {
 }
 
 // --- Batch E: Comprehensive platform detection matrix ---
-
-func TestDetectLinuxDistroMatrix(t *testing.T) {
-	tests := []struct {
-		name       string
-		osRelease  string
-		wantDistro string
-	}{
-		{
-			name:       "ubuntu 22.04",
-			osRelease:  "ID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"22.04\"\n",
-			wantDistro: LinuxDistroUbuntu,
-		},
-		{
-			name:       "debian 12",
-			osRelease:  "ID=debian\nVERSION_ID=\"12\"\n",
-			wantDistro: LinuxDistroDebian,
-		},
-		{
-			name:       "linux mint derivative of ubuntu",
-			osRelease:  "ID=linuxmint\nID_LIKE=\"ubuntu debian\"\nVERSION_ID=\"21.3\"\n",
-			wantDistro: LinuxDistroUbuntu,
-		},
-		{
-			name:       "pop os derivative of ubuntu",
-			osRelease:  "ID=pop\nID_LIKE=\"ubuntu debian\"\n",
-			wantDistro: LinuxDistroUbuntu,
-		},
-		{
-			name:       "arch linux",
-			osRelease:  "ID=arch\nID_LIKE=archlinux\n",
-			wantDistro: LinuxDistroArch,
-		},
-		{
-			name:       "manjaro derivative of arch",
-			osRelease:  "ID=manjaro\nID_LIKE=arch\n",
-			wantDistro: LinuxDistroArch,
-		},
-		{
-			name:       "endeavouros derivative of arch",
-			osRelease:  "ID=endeavouros\nID_LIKE=arch\n",
-			wantDistro: LinuxDistroArch,
-		},
-		{
-			name:       "fedora",
-			osRelease:  "ID=fedora\nID_LIKE=\"rhel fedora\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "centos stream derivative of rhel/fedora",
-			osRelease:  "ID=centos\nID_LIKE=\"rhel fedora\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "rhel",
-			osRelease:  "ID=rhel\nID_LIKE=\"fedora\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "rocky linux",
-			osRelease:  "ID=rocky\nID_LIKE=\"rhel fedora\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "alma linux",
-			osRelease:  "ID=almalinux\nID_LIKE=\"rhel fedora\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "nobara",
-			osRelease:  "ID=nobara\nID_LIKE=\"fedora\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "nobara via id_like token",
-			osRelease:  "ID=custom-linux\nID_LIKE=\"nobara\"\n",
-			wantDistro: LinuxDistroFedora,
-		},
-		{
-			name:       "empty os-release",
-			osRelease:  "",
-			wantDistro: LinuxDistroUnknown,
-		},
-		{
-			name:       "whitespace-only os-release",
-			osRelease:  "   \n  \n",
-			wantDistro: LinuxDistroUnknown,
-		},
-		{
-			name:       "comment-only os-release",
-			osRelease:  "# This is a comment\n# Another comment\n",
-			wantDistro: LinuxDistroUnknown,
-		},
-		{
-			name:       "malformed lines are ignored",
-			osRelease:  "no-equals-sign\nID=ubuntu\n",
-			wantDistro: LinuxDistroUbuntu,
-		},
-		{
-			name:       "quoted values are handled",
-			osRelease:  "ID=\"ubuntu\"\nID_LIKE=\"debian\"\n",
-			wantDistro: LinuxDistroUbuntu,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := detectLinuxDistro(tc.osRelease)
-			if got != tc.wantDistro {
-				t.Fatalf("detectLinuxDistro() = %q, want %q", got, tc.wantDistro)
-			}
-		})
-	}
-}
+//
+// The distro-family matrix that used to live here (mint => ubuntu,
+// manjaro => arch, rocky => fedora, and so on) is gone with the enum it
+// classified into. Its replacement is behavioural, in
+// detect_linux_probe_test.go: every distribution, named or not, is supported
+// exactly when a package manager answers on PATH.
 
 func TestResolvePlatformProfileMatrix(t *testing.T) {
 	tests := []struct {
@@ -237,6 +130,7 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			name:          "ubuntu profile",
 			goos:          "linux",
 			osRelease:     "ID=ubuntu\nID_LIKE=debian\n",
+			tools:         toolsOnPath("apt"),
 			wantOS:        "linux",
 			wantPM:        "apt",
 			wantDistro:    LinuxDistroUbuntu,
@@ -246,6 +140,7 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			name:          "debian profile",
 			goos:          "linux",
 			osRelease:     "ID=debian\n",
+			tools:         toolsOnPath("apt"),
 			wantOS:        "linux",
 			wantPM:        "apt",
 			wantDistro:    LinuxDistroDebian,
@@ -255,6 +150,7 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			name:          "arch profile",
 			goos:          "linux",
 			osRelease:     "ID=arch\n",
+			tools:         toolsOnPath("pacman"),
 			wantOS:        "linux",
 			wantPM:        "pacman",
 			wantDistro:    LinuxDistroArch,
@@ -264,6 +160,7 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			name:          "fedora profile",
 			goos:          "linux",
 			osRelease:     "ID=fedora\n",
+			tools:         toolsOnPath("dnf"),
 			wantOS:        "linux",
 			wantPM:        "dnf",
 			wantDistro:    LinuxDistroFedora,
@@ -277,7 +174,17 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			wantSupported: true,
 		},
 		{
-			name:          "linux without os-release is unsupported",
+			name:          "linux with no package manager on PATH is unsupported",
+			goos:          "linux",
+			osRelease:     "ID=ubuntu\n",
+			tools:         toolsOnPath("git", "curl", "node", "go"),
+			wantOS:        "linux",
+			wantPM:        "",
+			wantDistro:    LinuxDistroUbuntu,
+			wantSupported: false,
+		},
+		{
+			name:          "linux without os-release and without a manager is unsupported",
 			goos:          "linux",
 			osRelease:     "",
 			wantOS:        "linux",
@@ -339,7 +246,7 @@ func TestGoAvailableInPlatformProfile(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile := resolvePlatformProfile("linux", "ID=ubuntu\nID_LIKE=debian\n", tc.tools)
+			profile := resolvePlatformProfile("linux", "ID=ubuntu\n", tc.tools)
 			if profile.GoAvailable != tc.wantGoAvail {
 				t.Fatalf("GoAvailable = %v, want %v", profile.GoAvailable, tc.wantGoAvail)
 			}
@@ -379,7 +286,7 @@ func TestDetectFromInputsMarksWindowsSupported(t *testing.T) {
 
 func TestDetectFromInputsProfileIsPopulatedInSystem(t *testing.T) {
 	osRelease := "ID=ubuntu\nID_LIKE=debian\n"
-	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, toolsOnPath("apt"), nil)
 
 	if result.System.Profile.OS != "linux" {
 		t.Fatalf("Profile.OS = %q, want linux", result.System.Profile.OS)

--- a/internal/system/guard.go
+++ b/internal/system/guard.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 var ErrUnsupportedOS = errors.New("unsupported operating system")
@@ -27,7 +28,25 @@ func EnsureSupportedPlatform(profile PlatformProfile) error {
 	}
 
 	if profile.OS == "linux" && !profile.Supported {
-		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
+		distro := strings.TrimSpace(profile.LinuxDistro)
+		if distro == "" {
+			distro = LinuxDistroUnknown
+		}
+
+		// A refusal that names no exit is why users edited /etc/os-release to
+		// lie about their distribution. This one names what was searched,
+		// where, and the single thing that resolves it.
+		return fmt.Errorf(
+			"%w: no package manager found on PATH (detected distro %s).\n"+
+				"gentle-ai looks for these, in order: %s\n"+
+				"See which ones this machine already has:\n"+
+				"  for m in %s; do command -v \"$m\"; done\n"+
+				"Install one of them, or add the directory holding it to PATH, then run gentle-ai again.",
+			ErrUnsupportedLinuxDistro,
+			distro,
+			strings.Join(linuxPackageManagers, ", "),
+			strings.Join(linuxPackageManagers, " "),
+		)
 	}
 
 	return nil

--- a/internal/system/guard_test.go
+++ b/internal/system/guard_test.go
@@ -57,7 +57,7 @@ func TestEnsureSupportedPlatformRejectsUnsupportedLinuxDistro(t *testing.T) {
 		t.Fatalf("expected ErrUnsupportedLinuxDistro, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family") {
-		t.Fatalf("expected distro guard message, got %q", err.Error())
+	if !strings.Contains(err.Error(), "no package manager found on PATH") {
+		t.Fatalf("expected package-manager guard message, got %q", err.Error())
 	}
 }


### PR DESCRIPTION
Linux support was a closed compile-time enum ending in a refusal that named no exit. Any distribution nobody had anticipated became a dead end, which is why #334's reporter edited `/etc/os-release` to lie about their distribution and #140's filed a one-line ticket and gave up.

## The fix is a deletion

`detect.go:135-139` **already** short-circuited to supported whenever `brew` was on PATH, bypassing the enum entirely. The mechanism existed and was already trusted. Generalizing that one probe removes the need for the enum.

Gone: `detectLinuxDistro`, `isUbuntuLike`, `isArchLike`, `isFedoraLike`, and the 14-line distro switch. 84 lines of branch logic.

Back: a 29-line `/etc/os-release` ID parser and a 24-line package-manager table, most of which is comment and data.

Production net is **-13 lines**, and that understates it: what left was branching, what arrived is data.

```go
var linuxPackageManagers = []string{
	"brew",   // any distribution, via Homebrew on Linux
	"apt",    // Debian, Ubuntu, Mint, Pop!_OS, Deepin, UOS
	"dnf",    // Fedora, RHEL, CentOS Stream, Rocky, AlmaLinux, Nobara
	"pacman", // Arch, Manjaro, EndeavourOS
	"apk",    // Alpine
	"zypper", // openSUSE, SUSE Linux Enterprise
	"nix",    // NixOS
	"emerge", // Gentoo, Calculate
}
```

`brew` first because it was already the trusted bypass. `apt`, `dnf` and `pacman` reproduce exactly what the enum resolved to, so no existing user changes behavior. `emerge` was added beyond the brief because without it #1669 still refuses on a Gentoo box with no brew, and a name in a data table is not the additive smell the enum was.

## An unplanned finding: the old gate lied

The baseline binary, with only a fake `apk` on PATH and no `apt` anywhere on the machine:

```
Platform decision: os=linux distro=ubuntu package-manager=apt status=supported
```

It read `/etc/os-release`, concluded Ubuntu, and advertised `apt`, a binary that did not exist there. The probe cannot produce that, because it names the manager it actually found. Same PATH, new binary: `package-manager=apk`.

## The refusal, and how its advice was verified

Printed by the real compiled binary under an empty PATH:

```
Error: unsupported linux distro: no package manager found on PATH (detected distro ubuntu).
gentle-ai looks for these, in order: brew, apt, dnf, pacman, apk, zypper, nix, emerge
See which ones this machine already has:
  for m in brew apt dnf pacman apk zypper nix emerge; do command -v "$m"; done
Install one of them, or add the directory holding it to PATH, then run gentle-ai again.
```

The printed line was executed in three shells and works in all three. It was first drafted as `command -v brew apt dnf ...` and that was killed: bash prints all matches while dash prints only the first, so the advice would have been silently wrong on Alpine's ash. The loop form is what ships.

No config flag and no override variable. The only way to become supported is to actually have a package manager.

## RED

Behavioral, run before any production edit:

```
--- FAIL: .../opensuse_tumbleweed_with_zypper_(#140)  Supported = false, want true
--- FAIL: .../alpine_with_apk_(#334)                  Supported = false, want true
--- FAIL: .../nixos_with_nix_(#110)                   Supported = false, want true
--- FAIL: .../deepin_with_apt_(#926)                  Supported = false, want true
--- FAIL: .../gentoo_with_emerge_(#1669)              Supported = false, want true
--- FAIL: TestLinuxDistroReportsTheOSReleaseIDVerbatim/single-quoted_id_(#1669)
    LinuxDistro = "unknown", want "gentoo"
```

That last one is #1669's second half: the parser stripped double quotes only, so Gentoo's `ID='gentoo'` never matched any constant even if one had existed.

Two cases passed at RED and were meant to, `ubuntu with apt` and `brew wins over the native manager`, which is the already-trusted mechanism showing up green before the change.

## Verification

gofmt and vet clean on both modules, root `go test ./... -count=1` with no failures, bench module ok, deadcode ratchet reports no new unreachable functions, refusal ratchet green. Tier 1 shell E2E under an isolated HOME: 79 passed, 0 failed.

## Known, and it matters for these issues

**These four issues do not fully close until one more slice lands.** `internal/installcmd/resolver.go` still hardcodes the same three managers in two live paths, `resolveOpenCodeInstall:255` and `resolveGGAInstall:281`, both `case "apt", "pacman", "dnf":`. An Alpine or openSUSE user now passes the platform guard and then hits `unsupported platform for gga`. Both bodies are generic-Linux, so the fix is one word each: make it the `default` arm gated on `profile.OS == "linux"`.

Docker E2E was not run; the socket is not accessible to this account. Tier 1 ran locally and the container matrix is Ubuntu, Arch and Fedora only, so it would not have covered the four new distributions anyway. The distribution fixtures are proven at unit level.

`#276` Termux is deliberately untouched: `runtime.GOOS` is `android` there, so it fails before any of this runs, and its other four failure points are unaddressed.

The `LinuxDistro*` constants remain as display strings with no production reader, referenced by roughly 50 test lines across packages outside this scope. Retiring them is a follow-up.

Closes #140
Closes #334
Closes #110
Closes #926
Closes #1669

Part of #2471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Linux support to detect a broader range of package managers.
  * Linux compatibility is now determined by available package-manager tools rather than distribution family.
  * Distribution reporting preserves the operating system’s reported identifier.

* **Bug Fixes**
  * Improved handling of quoted and malformed distribution metadata.
  * Enhanced unsupported-system messages with detected distribution details, package-manager checks, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->