### PR TITLE
fix(uninstall): commit per agent, and stop passing codegraph targets blind

### DIFF
--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -82,7 +82,15 @@ func RunUninstallWithSelectionAndProfiles(homeDir, workspaceDir string, agentIDs
 func RenderUninstallReport(result componentuninstall.Result) string {
 	var b strings.Builder
 
-	_, _ = fmt.Fprintln(&b, "Managed uninstall complete")
+	// The header states what actually happened. A batch that failed for one
+	// agent still commits the agents that succeeded (see Result.FailedAgents),
+	// so "complete" would be a lie the user reads before the failure detail
+	// printed further down under manual cleanup.
+	if len(result.FailedAgents) > 0 {
+		_, _ = fmt.Fprintf(&b, "Managed uninstall partially complete: %s failed\n", strings.Join(agentLabels(result.FailedAgents), ", "))
+	} else {
+		_, _ = fmt.Fprintln(&b, "Managed uninstall complete")
+	}
 	if result.Manifest.ID != "" {
 		_, _ = fmt.Fprintf(&b, "Backup: %s (%s)\n", result.Manifest.ID, result.Manifest.DisplayLabel())
 		_, _ = fmt.Fprintf(&b, "Backup path: %s\n", result.BackupPath)

--- a/internal/cli/uninstall_report_header_test.go
+++ b/internal/cli/uninstall_report_header_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	componentuninstall "github.com/gentleman-programming/gentle-ai/v2/internal/components/uninstall"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// A batch that failed for one agent must not open with "complete". The user
+// reads the header before the manual-cleanup detail printed further down.
+func TestRenderUninstallReportHeaderNamesAPartialBatch(t *testing.T) {
+	report := RenderUninstallReport(componentuninstall.Result{
+		FailedAgents: []model.AgentID{model.AgentHermes},
+	})
+	header := strings.SplitN(report, "\n", 2)[0]
+	if !strings.Contains(header, "partially complete") {
+		t.Fatalf("header = %q, want it to name the batch as partial", header)
+	}
+	if !strings.Contains(header, "Hermes") && !strings.Contains(header, "hermes") {
+		t.Fatalf("header = %q, want it to name the failed agent", header)
+	}
+}
+
+func TestRenderUninstallReportHeaderStaysCompleteWhenNothingFailed(t *testing.T) {
+	report := RenderUninstallReport(componentuninstall.Result{})
+	header := strings.SplitN(report, "\n", 2)[0]
+	if header != "Managed uninstall complete" {
+		t.Fatalf("header = %q, want the unchanged complete header", header)
+	}
+}

--- a/internal/components/communitytool/codegraph_version.go
+++ b/internal/components/communitytool/codegraph_version.go
@@ -1,0 +1,79 @@
+package communitytool
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// codeGraphInstalledVersion probes the CodeGraph binary that DetectStatus
+// already resolved and reports its version. It is a package var so tests
+// never shell out to a real binary, and it takes the resolved absolute path
+// rather than a bare command name so the probe cannot pick up a different
+// binary than the one the install step will invoke.
+var codeGraphInstalledVersion = defaultCodeGraphInstalledVersion
+
+// codeGraphVersionPattern matches the dotted numeric core of a version string.
+// The upstream CLI prints its version inside a decorated banner
+// ("┌  CodeGraph v0.9.3"), so anchoring on the digits is what survives the
+// decoration changing.
+var codeGraphVersionPattern = regexp.MustCompile(`\d+(?:\.\d+)+`)
+
+func defaultCodeGraphInstalledVersion(cliPath string) (string, bool) {
+	cliPath = strings.TrimSpace(cliPath)
+	if cliPath == "" {
+		return "", false
+	}
+	// A nonzero exit still carries usable output on CLIs that print the
+	// banner before rejecting the flag, so the output is parsed either way
+	// and only an unparseable result counts as "cannot determine".
+	output, err := exec.Command(cliPath, "--version").CombinedOutput()
+	if err != nil && len(output) == 0 {
+		return "", false
+	}
+	return parseCodeGraphVersion(string(output))
+}
+
+func parseCodeGraphVersion(output string) (string, bool) {
+	match := codeGraphVersionPattern.FindString(output)
+	if match == "" {
+		return "", false
+	}
+	return match, true
+}
+
+// codeGraphVersionLess reports whether version a precedes version b, comparing
+// dotted components numerically. Missing trailing components read as zero, so
+// "1.4" precedes "1.4.1".
+func codeGraphVersionLess(a, b string) bool {
+	left := codeGraphVersionComponents(a)
+	right := codeGraphVersionComponents(b)
+	for i := 0; i < len(left) || i < len(right); i++ {
+		leftPart := 0
+		if i < len(left) {
+			leftPart = left[i]
+		}
+		rightPart := 0
+		if i < len(right) {
+			rightPart = right[i]
+		}
+		if leftPart != rightPart {
+			return leftPart < rightPart
+		}
+	}
+	return false
+}
+
+func codeGraphVersionComponents(version string) []int {
+	fields := strings.Split(strings.TrimPrefix(strings.TrimSpace(version), "v"), ".")
+	components := make([]int, 0, len(fields))
+	for _, field := range fields {
+		component, err := strconv.Atoi(field)
+		if err != nil {
+			break
+		}
+		components = append(components, component)
+	}
+	return components
+}

--- a/internal/components/communitytool/codegraph_version_test.go
+++ b/internal/components/communitytool/codegraph_version_test.go
@@ -1,0 +1,204 @@
+package communitytool
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func TestParseCodeGraphVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+		wantOK bool
+	}{
+		{name: "banner form printed by the upstream CLI", output: "┌  CodeGraph v0.9.3\n", want: "0.9.3", wantOK: true},
+		{name: "bare semver", output: "1.4.1\n", want: "1.4.1", wantOK: true},
+		{name: "v prefix", output: "v1.4.1", want: "1.4.1", wantOK: true},
+		{name: "two component version", output: "codegraph 2.0", want: "2.0", wantOK: true},
+		{name: "no version anywhere", output: "unknown flag: --version", want: "", wantOK: false},
+		{name: "empty output", output: "", want: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCodeGraphVersion(tt.output)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("parseCodeGraphVersion(%q) = (%q, %v), want (%q, %v)", tt.output, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCodeGraphVersionLess(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "reported 0.9.3 predates the target contract", a: "0.9.3", b: codeGraphUpstreamVersion, want: true},
+		{name: "exact contract version is not older", a: "1.4.1", b: codeGraphUpstreamVersion, want: false},
+		{name: "newer patch is not older", a: "1.4.2", b: codeGraphUpstreamVersion, want: false},
+		{name: "newer major is not older", a: "2.0.0", b: codeGraphUpstreamVersion, want: false},
+		{name: "minor compares numerically not lexicographically", a: "1.10.0", b: codeGraphUpstreamVersion, want: false},
+		{name: "older minor", a: "1.3.9", b: codeGraphUpstreamVersion, want: true},
+		{name: "shorter version pads with zeroes", a: "1.4", b: codeGraphUpstreamVersion, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := codeGraphVersionLess(tt.a, tt.b); got != tt.want {
+				t.Fatalf("codeGraphVersionLess(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubCodeGraphVersion swaps the installed-version probe for the duration of a
+// test so no test ever shells out to a real codegraph binary.
+func stubCodeGraphVersion(t *testing.T, version string, ok bool) {
+	t.Helper()
+	previous := codeGraphInstalledVersion
+	codeGraphInstalledVersion = func(string) (string, bool) { return version, ok }
+	t.Cleanup(func() { codeGraphInstalledVersion = previous })
+}
+
+// installHomeWithTwoNativeTargets mirrors the reporter's machine: an already
+// available CodeGraph CLI plus two detected native-target agents, one of which
+// is not yet wired.
+func installHomeWithTwoNativeTargets(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, ".claude", "settings.json"), `{}`)
+	mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `{}`)
+	return home
+}
+
+func TestInstallDropsBlindTargetsWhenInstalledCodeGraphPredatesTheContract(t *testing.T) {
+	home := installHomeWithTwoNativeTargets(t)
+	stubCodeGraphVersion(t, "0.9.3", true)
+
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(string, ...string) error {
+		mustWrite(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+		mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"codegraph":{"command":"codegraph"}}}`)
+		return nil
+	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }))
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+
+	want := []string{"codegraph install --yes"}
+	if !reflect.DeepEqual(result.CommandsRun, want) {
+		t.Fatalf("CommandsRun = %#v, want %#v (target ids must not be passed blind to an older CodeGraph)", result.CommandsRun, want)
+	}
+	if !hasManualActionContaining(result.ManualActions, "0.9.3") || !hasManualActionContaining(result.ManualActions, codeGraphUpstreamVersion) {
+		t.Fatalf("ManualActions = %#v, want the version gap named", result.ManualActions)
+	}
+}
+
+func TestInstallKeepsExplicitTargetsWhenInstalledCodeGraphMeetsTheContract(t *testing.T) {
+	home := installHomeWithTwoNativeTargets(t)
+	stubCodeGraphVersion(t, codeGraphUpstreamVersion, true)
+
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(string, ...string) error {
+		mustWrite(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+		mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"codegraph":{"command":"codegraph"}}}`)
+		return nil
+	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }))
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+
+	want := []string{"codegraph install --target claude,cursor --location global --yes"}
+	if !reflect.DeepEqual(result.CommandsRun, want) {
+		t.Fatalf("CommandsRun = %#v, want %#v", result.CommandsRun, want)
+	}
+	if hasManualActionContaining(result.ManualActions, "older than") {
+		t.Fatalf("ManualActions = %#v, want no version-gap note", result.ManualActions)
+	}
+}
+
+func TestInstallKeepsExplicitTargetsWhenVersionProbeCannotDetermineAVersion(t *testing.T) {
+	home := installHomeWithTwoNativeTargets(t)
+	stubCodeGraphVersion(t, "", false)
+
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(string, ...string) error {
+		mustWrite(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+		mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"codegraph":{"command":"codegraph"}}}`)
+		return nil
+	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }))
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+
+	want := []string{"codegraph install --target claude,cursor --location global --yes"}
+	if !reflect.DeepEqual(result.CommandsRun, want) {
+		t.Fatalf("CommandsRun = %#v, want unchanged behaviour when the probe is inconclusive", result.CommandsRun)
+	}
+}
+
+func TestInstallProbesTheResolvedCLIPathNotABareName(t *testing.T) {
+	home := installHomeWithTwoNativeTargets(t)
+	previous := codeGraphInstalledVersion
+	probed := make([]string, 0, 1)
+	codeGraphInstalledVersion = func(cliPath string) (string, bool) {
+		probed = append(probed, cliPath)
+		return codeGraphUpstreamVersion, true
+	}
+	t.Cleanup(func() { codeGraphInstalledVersion = previous })
+
+	if _, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(string, ...string) error {
+		mustWrite(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+		mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"codegraph":{"command":"codegraph"}}}`)
+		return nil
+	}), DetectorFunc(func(string) (string, error) { return "/opt/tools/codegraph", nil })); err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(probed, []string{"/opt/tools/codegraph"}) {
+		t.Fatalf("probed = %#v, want the detector-resolved CLI path", probed)
+	}
+}
+
+func TestInstallSkipsTheVersionProbeWhenTheCLIIsNotYetInstalled(t *testing.T) {
+	home := installHomeWithTwoNativeTargets(t)
+	previous := codeGraphInstalledVersion
+	probeCalls := 0
+	codeGraphInstalledVersion = func(string) (string, bool) {
+		probeCalls++
+		return "0.9.3", true
+	}
+	t.Cleanup(func() { codeGraphInstalledVersion = previous })
+
+	available := false
+	if _, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(string, ...string) error {
+		available = true
+		mustWrite(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+		mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"codegraph":{"command":"codegraph"}}}`)
+		return nil
+	}), DetectorFunc(func(string) (string, error) {
+		if !available {
+			return "", errors.New("codegraph not found in PATH")
+		}
+		return "/bin/codegraph", nil
+	})); err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+
+	if probeCalls != 0 {
+		t.Fatalf("probe calls = %d, want 0: a freshly installed @latest CLI already meets the contract", probeCalls)
+	}
+}
+
+func hasManualActionContaining(actions []string, needle string) bool {
+	for _, action := range actions {
+		if strings.Contains(action, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/components/communitytool/codegraph_version_test.go
+++ b/internal/components/communitytool/codegraph_version_test.go
@@ -194,6 +194,28 @@ func TestInstallSkipsTheVersionProbeWhenTheCLIIsNotYetInstalled(t *testing.T) {
 	}
 }
 
+// TestInstallCarriesTheVersionGapNoteThroughTheRollbackPath keeps the version
+// gap reportable on the path where it matters most. A step that fails still
+// returns the Result, so the reason and the resolving command survive the
+// rollback rather than being replaced by a raw upstream error.
+func TestInstallCarriesTheVersionGapNoteThroughTheRollbackPath(t *testing.T) {
+	home := installHomeWithTwoNativeTargets(t)
+	stubCodeGraphVersion(t, "0.9.3", true)
+
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(string, ...string) error {
+		return errors.New("upstream install rejected the invocation")
+	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }))
+	if err == nil {
+		t.Fatal("InstallWithHome() error = nil, want the runner failure surfaced")
+	}
+	if !hasManualActionContaining(result.ManualActions, "0.9.3") {
+		t.Fatalf("ManualActions = %#v, want the version gap reported on the failure path", result.ManualActions)
+	}
+	if !hasManualActionContaining(result.ManualActions, "@colbymchenry/codegraph@latest") {
+		t.Fatalf("ManualActions = %#v, want the resolving command named", result.ManualActions)
+	}
+}
+
 func hasManualActionContaining(actions []string, needle string) bool {
 	for _, action := range actions {
 		if strings.Contains(action, needle) {

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -175,9 +175,30 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 	}
 
 	targets := detectedCodeGraphTargets(homeDir)
+	// The target ids come from a compatibility table written against
+	// codeGraphUpstreamVersion. Upstream rejects the whole comma-separated
+	// list when it does not recognise a single id, so passing them to an
+	// older CodeGraph takes down the targets it does support along with the
+	// ones it does not. When the installed CLI is provably older, drop the
+	// ids and let CodeGraph select targets itself instead of guessing which
+	// of ours it understands. A CLI that is not installed yet is exempt: the
+	// install command below fetches @latest, which meets the contract.
+	droppedBlindTargets := false
+	if before.CLI == AvailabilityAvailable && len(targets) > 0 {
+		if installed, ok := codeGraphInstalledVersion(before.CLIPath); ok && codeGraphVersionLess(installed, codeGraphUpstreamVersion) {
+			targets = nil
+			droppedBlindTargets = true
+			result.ManualActions = append(result.ManualActions, fmt.Sprintf(
+				"CodeGraph %s is older than the %s target contract Gentle AI is written against, so agent targets were left to CodeGraph's own detection. Run `npm install -g @colbymchenry/codegraph@latest` (or `pnpm add -g @colbymchenry/codegraph@latest`) and rerun Gentle AI to get explicit target selection.",
+				installed, codeGraphUpstreamVersion))
+		}
+	}
 	commands := make([][]string, 0, 2)
-	if len(targets) > 0 {
+	switch {
+	case len(targets) > 0:
 		commands = append(commands, []string{"codegraph", "install", "--target", strings.Join(targets, ","), "--location", "global", "--yes"})
+	case droppedBlindTargets:
+		commands = append(commands, []string{"codegraph", "install", "--yes"})
 	}
 	if before.CLI != AvailabilityAvailable {
 		var err error

--- a/internal/components/uninstall/batch_boundary_test.go
+++ b/internal/components/uninstall/batch_boundary_test.go
@@ -1,0 +1,225 @@
+package uninstall
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+)
+
+// TestPartialUninstallCommitsSucceededAgentsWhenAnotherAgentFails reproduces
+// the reporter's batch: two managed agents, one of whose settings files is not
+// JSON, uninstalled in a single invocation. The batch must not abandon the
+// remaining agent, and the state file it leaves behind must describe the disk.
+func TestPartialUninstallCommitsSucceededAgentsWhenAnotherAgentFails(t *testing.T) {
+	home := t.TempDir()
+	claudeSettings := filepath.Join(home, ".claude", "settings.json")
+	hermesConfig := filepath.Join(home, ".hermes", "config.yaml")
+	hermesSoul := filepath.Join(home, ".hermes", "SOUL.md")
+
+	writeBatchFile(t, claudeSettings, `{"theme":"gentleman","outputStyle":"gentleman","env":{"MY_VAR":"1"}}`)
+	writeBatchFile(t, hermesConfig, "providers:\n  - name: hermes\n")
+	writeBatchFile(t, hermesSoul, "<!-- gentle-ai:persona -->\nmanaged\n<!-- /gentle-ai:persona -->\n")
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"claude-code", "hermes"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := NewService(home, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	result, err := svc.PartialUninstall([]model.AgentID{model.AgentClaudeCode, model.AgentHermes}, nil)
+	if err == nil {
+		t.Fatal("PartialUninstall() error = nil, want the hermes cleanup failure surfaced")
+	}
+	if !strings.Contains(err.Error(), hermesConfig) {
+		t.Fatalf("PartialUninstall() error = %v, want it to name %q", err, hermesConfig)
+	}
+
+	if !slices.Equal(result.FailedAgents, []model.AgentID{model.AgentHermes}) {
+		t.Fatalf("FailedAgents = %v, want [hermes]", result.FailedAgents)
+	}
+	if !slices.Equal(result.AgentsRemovedFromState, []model.AgentID{model.AgentClaudeCode}) {
+		t.Fatalf("AgentsRemovedFromState = %v, want [claude-code]", result.AgentsRemovedFromState)
+	}
+
+	// The report must describe the disk: the succeeded agent's managed keys are
+	// gone, so it commits; the failed agent stays recorded as installed.
+	current, err := state.Read(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(current.InstalledAgents, []string{"hermes"}) {
+		t.Fatalf("state.json installed_agents = %v, want only the agent that failed", current.InstalledAgents)
+	}
+
+	settings := string(mustReadServiceFile(t, claudeSettings))
+	if strings.Contains(settings, "theme") || strings.Contains(settings, "outputStyle") {
+		t.Fatalf("claude settings = %s, want managed keys removed: the batch must not abandon later agents", settings)
+	}
+	if !strings.Contains(settings, "MY_VAR") {
+		t.Fatalf("claude settings = %s, want the user-owned key preserved", settings)
+	}
+
+	if !slices.ContainsFunc(result.ManualActions, func(action string) bool {
+		return strings.Contains(action, "hermes") && strings.Contains(action, hermesConfig)
+	}) {
+		t.Fatalf("ManualActions = %v, want the failed agent and its path reported", result.ManualActions)
+	}
+}
+
+// TestExecutePlanReportsPerAgentOutcomesInsteadOfAbortingOnTheFirstFailure
+// pins the boundary itself: a failing operation must not stop the operations
+// that belong to other agents, and only agents with no failed operation may
+// commit their state removal.
+func TestExecutePlanReportsPerAgentOutcomesInsteadOfAbortingOnTheFirstFailure(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"claude-code", "codex", "hermes"}}); err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(home, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	failure := errors.New("clean json file: invalid character 'p'")
+	ranAfterFailure := false
+	plan := plan{operations: []operation{
+		{typeID: opRewriteFile, path: filepath.Join(home, "a-fails"), agents: []model.AgentID{model.AgentHermes}, apply: func(string) (bool, bool, error) {
+			return false, false, failure
+		}},
+		{typeID: opRewriteFile, path: filepath.Join(home, "b-succeeds"), agents: []model.AgentID{model.AgentClaudeCode}, apply: func(string) (bool, bool, error) {
+			ranAfterFailure = true
+			return true, false, nil
+		}},
+	}}
+
+	result, err := svc.executePlan(plan, []model.AgentID{model.AgentClaudeCode, model.AgentCodex, model.AgentHermes})
+	if err == nil {
+		t.Fatal("executePlan() error = nil, want the failure surfaced")
+	}
+	if !errors.Is(err, failure) {
+		t.Fatalf("executePlan() error = %v, want it to wrap the operation failure", err)
+	}
+	if !ranAfterFailure {
+		t.Fatal("operations after the failing one did not run: the batch still aborts on first failure")
+	}
+	if !slices.Equal(result.FailedAgents, []model.AgentID{model.AgentHermes}) {
+		t.Fatalf("FailedAgents = %v, want [hermes]", result.FailedAgents)
+	}
+	if !slices.Equal(result.AgentsRemovedFromState, []model.AgentID{model.AgentClaudeCode, model.AgentCodex}) {
+		t.Fatalf("AgentsRemovedFromState = %v, want the two agents with no failed operation", result.AgentsRemovedFromState)
+	}
+	if !slices.Contains(result.ChangedFiles, filepath.Join(home, "b-succeeds")) {
+		t.Fatalf("ChangedFiles = %v, want the operation that ran after the failure", result.ChangedFiles)
+	}
+
+	current, err := state.Read(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(current.InstalledAgents, []string{"hermes"}) {
+		t.Fatalf("state.json installed_agents = %v, want only the failed agent retained", current.InstalledAgents)
+	}
+}
+
+// TestExecutePlanWithholdsEveryAgentWhenAnUnattributedOperationFails keeps the
+// commit boundary conservative: an operation nobody owns cannot be blamed on
+// one agent, so no agent may claim a clean uninstall.
+func TestExecutePlanWithholdsEveryAgentWhenAnUnattributedOperationFails(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"claude-code", "codex"}}); err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(home, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	plan := plan{operations: []operation{
+		{typeID: opRemoveFile, path: filepath.Join(home, "shared"), apply: func(string) (bool, bool, error) {
+			return false, false, errors.New("permission denied")
+		}},
+	}}
+
+	result, err := svc.executePlan(plan, []model.AgentID{model.AgentClaudeCode, model.AgentCodex})
+	if err == nil {
+		t.Fatal("executePlan() error = nil, want the failure surfaced")
+	}
+	if len(result.AgentsRemovedFromState) != 0 {
+		t.Fatalf("AgentsRemovedFromState = %v, want none", result.AgentsRemovedFromState)
+	}
+	if !slices.Equal(result.FailedAgents, []model.AgentID{model.AgentClaudeCode, model.AgentCodex}) {
+		t.Fatalf("FailedAgents = %v, want every agent in the batch", result.FailedAgents)
+	}
+
+	current, err := state.Read(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(current.InstalledAgents, []string{"claude-code", "codex"}) {
+		t.Fatalf("state.json installed_agents = %v, want untouched", current.InstalledAgents)
+	}
+}
+
+// TestBuildPlanAttributesOperationsToTheAgentsThatContributedThem is what makes
+// the commit boundary meaningful: without attribution every failure blocks the
+// whole batch.
+func TestBuildPlanAttributesOperationsToTheAgentsThatContributedThem(t *testing.T) {
+	home := t.TempDir()
+	svc, err := NewService(home, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	built, err := svc.buildPlan([]model.AgentID{model.AgentClaudeCode, model.AgentHermes}, []model.ComponentID{model.ComponentTheme, model.ComponentPersona})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(built.operations) == 0 {
+		t.Fatal("buildPlan() produced no operations")
+	}
+	for _, op := range built.operations {
+		if len(op.agents) == 0 {
+			t.Fatalf("operation %q has no agent attribution", op.path)
+		}
+	}
+
+	claudeSettings := filepath.Join(home, ".claude", "settings.json")
+	hermesConfig := filepath.Join(home, ".hermes", "config.yaml")
+	assertOperationAgents(t, built, claudeSettings, []model.AgentID{model.AgentClaudeCode})
+	assertOperationAgents(t, built, hermesConfig, []model.AgentID{model.AgentHermes})
+}
+
+func assertOperationAgents(t *testing.T, built plan, path string, want []model.AgentID) {
+	t.Helper()
+	for _, op := range built.operations {
+		if op.path != path {
+			continue
+		}
+		if !slices.Equal(op.agents, want) {
+			t.Fatalf("operation %q agents = %v, want %v", path, op.agents, want)
+		}
+		return
+	}
+	t.Fatalf("buildPlan() has no operation for %q", path)
+}
+
+func writeBatchFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -2,6 +2,7 @@ package uninstall
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -41,6 +42,11 @@ type Result struct {
 	RemovedDirectories     []string
 	ManualActions          []string
 	AgentsRemovedFromState []model.AgentID
+	// FailedAgents lists the agents whose cleanup did not complete. They are
+	// deliberately left in state.json so the recorded state keeps matching the
+	// disk, and each one is named in ManualActions with the command that
+	// retries it.
+	FailedAgents []model.AgentID
 }
 
 type Service struct {
@@ -137,7 +143,21 @@ var (
 type operation struct {
 	typeID opType
 	path   string
+	// agents records which agents' cleanup contributed this operation. It is
+	// what turns a flat operation list into a per-agent commit boundary: an
+	// operation that fails only blocks the agents that own it. An operation
+	// nobody owns blocks the whole batch, because nothing distinguishes whose
+	// cleanup it was.
+	agents []model.AgentID
 	apply  func(path string) (changed bool, removed bool, err error)
+}
+
+// operationFailure records one operation that did not complete, so the run can
+// keep going and still report exactly what was left undone.
+type operationFailure struct {
+	path   string
+	agents []model.AgentID
+	err    error
 }
 
 func NewService(homeDir, workspaceDir, appVersion string) (*Service, error) {
@@ -344,14 +364,23 @@ func (s *Service) buildPlan(agentIDs []model.AgentID, componentIDs []model.Compo
 				}
 			}
 			for _, op := range ops {
+				op.agents = []model.AgentID{agentID}
 				key := operationKey(op)
-				if existing, ok := operationsByKey[key]; ok && op.typeID == opRewriteFile {
+				existing, ok := operationsByKey[key]
+				if !ok {
+					operationsByKey[key] = op
+					continue
+				}
+				if op.typeID == opRewriteFile {
 					// Merge rewrite operations on the same file so both
 					// mutations apply (e.g. persona + engram on system prompt).
 					operationsByKey[key] = mergeRewriteOps(existing, op)
-				} else {
-					operationsByKey[key] = op
+					continue
 				}
+				// Deduplicated non-rewrite operation: one apply still stands
+				// for every agent that asked for it, so ownership widens.
+				existing.agents = appendUniqueAgents(existing.agents, op.agents...)
+				operationsByKey[key] = existing
 			}
 		}
 	}
@@ -406,22 +435,35 @@ func (s *Service) executePlan(p plan, agentsToRemove []model.AgentID) (Result, e
 		Manifest:   manifest,
 		BackupPath: snapshotDir,
 	}
+	// A batch has no per-agent transaction, so aborting at the first failure
+	// left later agents untouched, state.json stale, and no record of how far
+	// the run got. Every operation is attempted, failures are attributed to the
+	// agents that own them, and only agents with no failed operation commit
+	// their state removal.
+	failures := make([]operationFailure, 0)
+
 	// Pi ownership hashes include the shared MCP file. Remove its managed entry
 	// before other component cleanup (notably Engram) mutates that file, otherwise
 	// an unrelated mutation is indistinguishable from user drift.
 	if slices.Contains(agentsToRemove, model.AgentPi) {
 		piResult, piErr := communitytool.UninstallPiCodeGraph(s.homeDir)
 		if piErr != nil {
-			return result, fmt.Errorf("remove Pi CodeGraph integration: %w", piErr)
+			failures = append(failures, operationFailure{
+				path:   firstOrEmpty(communitytool.PiCodeGraphPaths(s.homeDir, s.workspaceDir)),
+				agents: []model.AgentID{model.AgentPi},
+				err:    fmt.Errorf("remove Pi CodeGraph integration: %w", piErr),
+			})
+		} else {
+			result.ChangedFiles = append(result.ChangedFiles, piResult.Files...)
+			result.ManualActions = append(result.ManualActions, piResult.ManualActions...)
 		}
-		result.ChangedFiles = append(result.ChangedFiles, piResult.Files...)
-		result.ManualActions = append(result.ManualActions, piResult.ManualActions...)
 	}
 
 	for _, op := range p.operations {
 		changed, removed, err := op.apply(op.path)
 		if err != nil {
-			return result, err
+			failures = append(failures, operationFailure{path: op.path, agents: op.agents, err: err})
+			continue
 		}
 		if op.typeID == opRemoveIfEmpty && !removed {
 			if note, ok := manualActionForNonEmptyDirectory(op.path); ok {
@@ -445,13 +487,110 @@ func (s *Service) executePlan(p plan, agentsToRemove []model.AgentID) (Result, e
 		}
 	}
 
-	removed, err := updateStateAfterUninstall(s.homeDir, agentsToRemove)
-	if err != nil {
-		return result, err
+	result.FailedAgents = failedAgents(failures, agentsToRemove)
+	result.ManualActions = append(result.ManualActions, failureManualActions(failures, agentsToRemove, s.homeDir)...)
+
+	committable := make([]model.AgentID, 0, len(agentsToRemove))
+	for _, agentID := range agentsToRemove {
+		if !slices.Contains(result.FailedAgents, agentID) {
+			committable = append(committable, agentID)
+		}
 	}
+
+	removed, stateErr := updateStateAfterUninstall(s.homeDir, committable)
 	result.AgentsRemovedFromState = removed
 	result.ManualActions = dedupeSortedStrings(result.ManualActions)
+
+	errs := make([]error, 0, len(failures)+1)
+	for _, failure := range failures {
+		errs = append(errs, failure.err)
+	}
+	if stateErr != nil {
+		errs = append(errs, stateErr)
+	}
+	if len(errs) > 0 {
+		return result, errors.Join(errs...)
+	}
 	return result, nil
+}
+
+// failedAgents reports which agents cannot claim a completed uninstall. A
+// failure that no agent owns blocks every agent in the batch: nothing
+// distinguishes whose cleanup it belonged to, so none of them may be recorded
+// as removed.
+func failedAgents(failures []operationFailure, batch []model.AgentID) []model.AgentID {
+	if len(failures) == 0 {
+		return nil
+	}
+	blocked := make([]model.AgentID, 0, len(batch))
+	for _, failure := range failures {
+		if len(failure.agents) == 0 {
+			blocked = appendUniqueAgents(blocked, batch...)
+			continue
+		}
+		blocked = appendUniqueAgents(blocked, failure.agents...)
+	}
+	if len(blocked) == 0 {
+		return nil
+	}
+
+	// Report in the order the caller named the agents so the summary reads in
+	// the same order as the invocation, with any agent outside the batch last.
+	ordered := make([]model.AgentID, 0, len(blocked))
+	for _, agentID := range batch {
+		if slices.Contains(blocked, agentID) {
+			ordered = append(ordered, agentID)
+		}
+	}
+	return appendUniqueAgents(ordered, blocked...)
+}
+
+func failureManualActions(failures []operationFailure, batch []model.AgentID, homeDir string) []string {
+	actions := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		owners := failure.agents
+		if len(owners) == 0 {
+			owners = batch
+		}
+		labels := make([]string, 0, len(owners))
+		retry := make([]string, 0, len(owners))
+		for _, agentID := range owners {
+			labels = append(labels, string(agentID))
+			retry = append(retry, "--agent "+string(agentID))
+		}
+		scope := strings.Join(labels, ", ")
+		if scope == "" {
+			scope = "this uninstall"
+		}
+		location := failure.path
+		if location == "" {
+			location = homeDir
+		}
+		command := "gentle-ai uninstall --all --yes"
+		if len(retry) > 0 {
+			command = "gentle-ai uninstall " + strings.Join(retry, " ") + " --yes"
+		}
+		actions = append(actions, fmt.Sprintf(
+			"Uninstall did not complete for %s at %s: %v. Those agents are still recorded in %s. Resolve the file, then rerun `%s`.",
+			scope, location, failure.err, state.Path(homeDir), command))
+	}
+	return actions
+}
+
+func appendUniqueAgents(existing []model.AgentID, additions ...model.AgentID) []model.AgentID {
+	for _, agentID := range additions {
+		if !slices.Contains(existing, agentID) {
+			existing = append(existing, agentID)
+		}
+	}
+	return existing
+}
+
+func firstOrEmpty(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	return items[0]
 }
 
 func manualActionForNonEmptyDirectory(path string) (string, bool) {
@@ -1314,6 +1453,7 @@ func mergeRewriteOps(a, b operation) operation {
 	return operation{
 		typeID: opRewriteFile,
 		path:   a.path,
+		agents: appendUniqueAgents(slices.Clone(a.agents), b.agents...),
 		apply: func(path string) (bool, bool, error) {
 			changed1, removed1, err1 := a.apply(path)
 			if err1 != nil {


### PR DESCRIPTION
Two fixes in the install and uninstall pipelines, plus the reasoning on a third that could not be implemented from here.

## #2355, codegraph targets passed blind

`codeGraphUpstreamVersion = "1.4.1"` had exactly two references in the whole repository: its own declaration and its own test. Nothing in the production path read it, and no `--version` probe existed anywhere. Targets were passed blind, the upstream `--target` is all-or-nothing, and the step failed.

Now the installed CLI is probed. When it is provably older than the contract, the target ids are dropped in favor of the untargeted `codegraph install --yes` shape the package already emits, plus a manual action naming the gap and the upgrade command. A CLI that is not installed yet is exempt, since that path installs `@latest`. An inconclusive probe changes nothing.

The gate is "older than the contract, drop all ids" rather than a per-target minimum-version table, because which upstream version introduced `gemini`, `antigravity` and `kiro` could not be verified, and inventing those numbers would have been worse than the coarse gate. The tradeoff: a 1.4.0 user loses explicit target selection they might have partly supported, and upstream auto-detect covers them.

## #2306, no per-agent commit boundary

`buildPlan` flattened every agent and component pair into one deduplicated, path-sorted operation list, so `executePlan` had **no agent boundary at all**. The loop returned at the first failing operation and the state update never ran.

Now operations carry agent attribution, the batch does not abort, `Result.FailedAgents` records what failed, and state removal commits only for agents with zero failed operations. An operation no agent owns blocks the whole batch, which is the safe default.

The header is fixed too. `RenderUninstallReport` printed "Managed uninstall complete" unconditionally, before the failure detail further down. It now names a partial batch and the agents that failed. That was a separate one-line change with its own RED, since the file sat outside the agent's scope.

## #2232, the reasoning rather than the code

Two factual corrections to the issue first. The hardcoded key list is **not** in `cleaners.go`, which holds only generic mechanics. The 21 `jsonPath{...}` literals live in `service.go`.

**The argument for an install-time manifest is stronger than the issue makes it, because the pattern already exists here and this uninstaller already consumes it.** `internal/components/opencodedefault/ownership.go` does exactly what #2232 proposes, for one key: it records the user's previous `default_agent` at install and **restores it** at uninstall rather than deleting. `service.go` already calls into it. Separately, `internal/components/mutationjournal` already defines `OwnedFile` with a `Before` field, documented verbatim as what an external manifest would serialize.

So this is not a new mechanism. It is one existing mechanism generalized from one key to twenty-one, and the type to serialize is already written.

The decisive evidence is an asymmetry no list can fix. Install does `MergeJSONObjects(base, overlay)`, a deep merge into whatever the user already had. Uninstall does `delete(root, "permissions")`, the whole subtree. Install is merge-shaped and uninstall is delete-shaped. Only a record of what was merged closes that.

What it would delete: all 21 path literals, the `managedPersonaFingerprints` heuristic, and `looksLikeManagedPersonaPrefix`, which is the "did the user rename this heading" guessing that #2232's second bug is about. Net removal of guessing.

Not implemented, for a hard reason: an install-time manifest requires writing at install time, and every writer lives outside the two directories this branch was confined to. It is also correctly labelled `status:needs-design`, and the owner should decide restore-previous-value versus warn-on-mismatch before code lands.

## The property, proved on the reporter's actual batch

`TestPartialUninstallCommitsSucceededAgentsWhenAnotherAgentFails` is not synthetic. Real `claude-code` plus real `hermes`, hermes's real `config.yaml` holding YAML, driven through the real `PartialUninstall`. It asserts the error names the failing path, `FailedAgents` holds only hermes, `AgentsRemovedFromState` holds only claude-code, **`state.json` on disk contains only hermes**, claude's theme and output style are actually gone from disk while the user's own `env` key survives, and the manual action names both agent and path. Operation ordering puts `SOUL.md` before `config.yaml`, matching the reporter's log exactly.

## Not fixed

**#2356 cannot be reached from this scope.** `communityToolInstallStep.Run()` discards `result` entirely on error, so nothing a community tool records on its failure path reaches the user. The in-scope half is pinned by a test proving the version-gap note survives the rollback return, so the data is provably there for whenever that discard is removed.

**#2164 belongs to a different cluster.** Its error comes from `filemerge/writer.go` via the gga runtime, and it is a Windows reparse-point classification bug rather than a batch-boundary or ownership problem.

## Verification

Root `go test ./... -count=1` with zero failures, bench module ok, gofmt and vet clean, deadcode ratchet reports no new unreachable functions, refusal and guard-population ratchets pass. Rebased onto current main and everything re-run on the rebased tree.

Docker E2E was **not** run, and that was checked rather than assumed: the shell E2E contains zero uninstall coverage, so it cannot exercise either fix.

Closes #2355
Closes #2306

Part of #2471
