### PR TITLE
fix(review): scope authority damage to the lineage that carries it

### DIFF
--- a/bench/axis_damaged_store.go
+++ b/bench/axis_damaged_store.go
@@ -1844,5 +1844,57 @@ func damagedStoreJourneys() []Journey {
 				{Name: "the store is still not in charge", Composite: proveStoreStillDamaged},
 			},
 		},
+		{
+			ID:     "ds13-damaged-entry-does-not-govern-unrelated-work",
+			Title:  "One damaged entry, and work that has nothing to do with it: the store still answers about the candidate",
+			Source: "issues 1892, 2014, 2167, 2234, 2270, 2456 (repository-global authority validation)",
+			// Every other journey in this axis measures what an operator can do
+			// ABOUT the damage. This one measures what the damage does to
+			// everybody else, which is the thing the reports were actually
+			// about: worktrees of one repository share a Git common directory
+			// and therefore one review store, so a verdict issued over that
+			// store is a verdict issued to every worktree at once.
+			//
+			// The fixture is ds02's exactly — one damaged recovery edge, a
+			// pristine successor — and then the operator does something with no
+			// relation to it: they write a new file and ask the product what to
+			// do next. The measurement is whether they get an answer about
+			// their candidate or an answer about somebody else's history.
+			//
+			// The damage is deliberately NOT repaired here. A journey that had
+			// to clear the entry first would be measuring the repair, and the
+			// whole claim is that no repair should be needed to keep working.
+			Steps: []Step{
+				{Name: "fixture: one damaged recovery edge", Fixture: damagedEdgePristine},
+				{Name: "the operator writes something unrelated", Fixture: stageProse("", "unrelated")},
+				{Name: "ask the negotiated surface what happens next", Requires: statusCapability,
+					Args:  productArgs("review", "status", "--contract", reviewContract, "--next-transition"),
+					After: requireUnrelatedTargetIsRouted},
+				{Name: "start a review of the unrelated candidate", Requires: startCapability,
+					Args: productArgs("review", "start")},
+				{Name: "the damaged entry is still reported, and still damaged", Requires: inspectAuthorityCapability,
+					Args: productArgs("review", "inspect-authority"),
+					After: inspectionAssertion("the damage survived the unrelated work",
+						invalidEdgesWithNoAnomalyClass(1))},
+			},
+		},
 	}, closureDispositionJourneys()...)
+}
+
+// requireUnrelatedTargetIsRouted is ds13's measurement. The negotiated surface
+// must publish a transition for the live candidate. Stopping over an entry the
+// candidate does not inherit from is the reported defect: it leaves the
+// harness with nothing to run and the operator with a blocked push.
+func requireUnrelatedTargetIsRouted(_ *Sandbox, observation Observation) error {
+	var envelope statusEnvelope
+	if err := decodeWaveObservation(observation, &envelope, "review status --next-transition beside a damaged entry"); err != nil {
+		return err
+	}
+	if envelope.NextTransition.Kind == "" {
+		return errors.New("the negotiated surface published no transition for the live candidate")
+	}
+	if envelope.NextTransition.Kind == "stop" {
+		return errors.New("the negotiated surface stopped an unrelated candidate over a damaged entry")
+	}
+	return nil
 }

--- a/bench/axis_damaged_store.go
+++ b/bench/axis_damaged_store.go
@@ -787,16 +787,34 @@ func requireInvalidEdges(sandbox *Sandbox, edges int, problemFragment string) er
 				problemFragment, edge.SuccessorLineageID, edge.Problems)
 		}
 	}
-	return requireStoreNotAuthoritative(sandbox)
+	return requireDamagedStoreReportsItsDamage(sandbox)
 }
 
-func requireStoreNotAuthoritative(sandbox *Sandbox) error {
-	status, err := proveStoreStatus(sandbox)
+// requireDamagedStoreReportsItsDamage is the proof every fixture in this axis
+// runs before spending a counted command.
+//
+// It used to require `review status` to report the whole store
+// non-authoritative, which is how the product described damage when authority
+// validation was repository-global. It is no longer how the product describes
+// damage, and the old assertion was never what these journeys were about: what
+// they measure is whether an operator holding a damaged entry can SEE it and
+// act on it, not whether the entry took the repository down with it. So the
+// proof moved to the surface that owns per-entry truth -- the store must still
+// describe exactly this damage, in its own words, on the entry that carries
+// it.
+func requireDamagedStoreReportsItsDamage(sandbox *Sandbox) error {
+	inspection, err := proveInspection(sandbox)
 	if err != nil {
 		return err
 	}
-	if status.Authoritative {
-		return errors.New("fixture claims a damaged store but review status still reports it authoritative")
+	if inspection.Valid && inspection.Totals.EntryDiagnostics == 0 {
+		return errors.New("fixture claims a damaged store but inspect-authority reports no invalid edge and no entry diagnostic")
+	}
+	// Status must still be answerable. A store that cannot be read at all is a
+	// different fixture from a store holding one damaged entry, and a journey
+	// that confused the two would measure the wrong thing.
+	if _, err := proveStoreStatus(sandbox); err != nil {
+		return fmt.Errorf("review status is unavailable over a store holding one damaged entry: %w", err)
 	}
 	return nil
 }
@@ -977,7 +995,7 @@ func halfWrittenSuccessor(sandbox *Sandbox) error {
 	if inspection.Totals.Edges != 0 {
 		return fmt.Errorf("fixture claims the truncated entry never becomes an edge but inspect-authority reports %d", inspection.Totals.Edges)
 	}
-	return requireStoreNotAuthoritative(sandbox)
+	return requireDamagedStoreReportsItsDamage(sandbox)
 }
 
 // ---------------------------------------------------------------------------
@@ -1133,13 +1151,25 @@ func proveStoreRecovered(r *journeyRun) error {
 		return fmt.Errorf("the exit ran but review status still reports complete=%v authoritative=%v",
 			status.Complete, status.Authoritative)
 	}
+	// The store staying authoritative is no longer evidence on its own: it was
+	// authoritative while the damage was present too, because the damage was
+	// confined to its own entry. What proves the exit worked is that the
+	// damage is gone from the surface that reported it.
+	inspection, err := proveInspection(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if !inspection.Valid || !inspection.Complete || inspection.Totals.InvalidEdges != 0 || inspection.Totals.EntryDiagnostics != 0 {
+		return fmt.Errorf("the exit ran but inspect-authority still reports the damage: valid=%v complete=%v totals=%+v",
+			inspection.Valid, inspection.Complete, inspection.Totals)
+	}
 	return nil
 }
 
 // proveStoreStillDamaged is its mirror, for the steps that claim an operation
 // changed nothing.
 func proveStoreStillDamaged(r *journeyRun) error {
-	return requireStoreNotAuthoritative(r.sandbox)
+	return requireDamagedStoreReportsItsDamage(r.sandbox)
 }
 
 // repairAssessment is the subset of `review repair --preflight` that says

--- a/bench/axis_damaged_store_closure.go
+++ b/bench/axis_damaged_store_closure.go
@@ -274,7 +274,7 @@ func requireClosureShape(sandbox *Sandbox) error {
 	if invalidCount != 1 {
 		return fmt.Errorf("fixture claims exactly one invalid edge, inspect-authority reports %d", invalidCount)
 	}
-	return requireStoreNotAuthoritative(sandbox)
+	return requireDamagedStoreReportsItsDamage(sandbox)
 }
 
 // closureMemberLineages is the fixture's whole closure, in construction
@@ -759,8 +759,17 @@ func closureDispositionJourneys() []Journey {
 			Steps: []Step{
 				{Name: "fixture: one damaged recovery edge, non-pristine successor, plus an unrelated witness lineage",
 					Fixture: damagedLeafEligibleForDisposition},
-				{Name: "ask the negotiated surface what happens next", Requires: statusCapability,
-					Args: productArgs("review", "status", "--contract", reviewContract, "--next-transition"),
+				{Name: "ask the negotiated surface what happens next for the damaged leaf", Requires: statusCapability,
+					// The selector is the whole point after authority
+					// validation became lineage-scoped: an operator asking
+					// what happens next for their own live candidate is now
+					// answered about that candidate (ds13), so reaching the
+					// disposition route means naming the entry the
+					// disposition is about. The route itself is unchanged --
+					// the same collect, the same two values, the same execute
+					// form -- which is what this journey has always measured.
+					Args: productArgs("review", "status", "--contract", reviewContract, "--next-transition",
+						"--lineage", damagedSuccessor),
 					After: func(sandbox *Sandbox, observation Observation) error {
 						var envelope statusEnvelope
 						if err := decodeWaveObservation(observation, &envelope, "review status --next-transition over a closed content-mismatched leaf"); err != nil {
@@ -789,6 +798,7 @@ func closureDispositionJourneys() []Journey {
 						authorization := dispositionAuthorization(binding, planDigest, inventoryRevision, actor, reason)
 						return []string{
 							"review", "status", "--cwd", sandbox.Repo, "--contract", reviewContract, "--next-transition",
+							"--lineage", damagedSuccessor,
 							"--repair-actor", actor, "--repair-reason", reason, "--repair-authorization", authorization,
 						}, nil
 					},

--- a/internal/cli/review_damaged_store_denial_test.go
+++ b/internal/cli/review_damaged_store_denial_test.go
@@ -138,6 +138,7 @@ type damagedStoreInspection struct {
 // be appended in its place.
 func liftBacktickedReviewCommand(t *testing.T, message, verb string) []string {
 	t.Helper()
+	longest := []string{}
 	for _, match := range regexp.MustCompile("`gentle-ai ([^`]*)`").FindAllStringSubmatch(message, -1) {
 		tokens := []string{}
 		for _, token := range strings.Fields(match[1]) {
@@ -150,12 +151,38 @@ func liftBacktickedReviewCommand(t *testing.T, message, verb string) []string {
 		if len(tokens) > 0 && strings.HasPrefix(tokens[len(tokens)-1], "--") {
 			tokens = tokens[:len(tokens)-1]
 		}
-		if len(tokens) >= 2 && tokens[0] == "review" && tokens[1] == verb {
-			return tokens
+		// The longest match, not the first: a refusal often mentions the verb
+		// in prose before rendering it in full, and an operator copies the
+		// one with the arguments in it.
+		if len(tokens) >= 2 && tokens[0] == "review" && tokens[1] == verb && len(tokens) > len(longest) {
+			longest = tokens
 		}
+	}
+	if len(longest) > 0 {
+		return longest
 	}
 	t.Fatalf("message names no runnable `gentle-ai review %s ...`: %q", verb, message)
 	return nil
+}
+
+// dispatchNamedDiagnosisInRepo is dispatchNamedDiagnosis for a refusal that
+// names the diagnosis without a --cwd, which is how an operator reads it: they
+// are standing in the repository the refusal came from. The command is lifted
+// from the message verbatim and only that standing position is supplied.
+func dispatchNamedDiagnosisInRepo(t *testing.T, repo, message string) damagedStoreInspection {
+	t.Helper()
+	tokens := liftBacktickedReviewCommand(t, message, "inspect-authority")
+	var output bytes.Buffer
+	args := append(append([]string{}, tokens[1:]...), "--cwd", repo)
+	if err := RunReview(args, &output); err != nil {
+		t.Fatalf("the diagnosis the refusal named exits non-zero (named dead end): gentle-ai %s: %v\n%s",
+			strings.Join(args, " "), err, output.String())
+	}
+	var report damagedStoreInspection
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatalf("diagnosis output is not an inspection envelope: %v\n%s", err, output.String())
+	}
+	return report
 }
 
 // dispatchNamedDiagnosis lifts the named runnable inspection out of the
@@ -176,13 +203,25 @@ func dispatchNamedDiagnosis(t *testing.T, repo, message string) damagedStoreInsp
 	return report
 }
 
-// TestGateDenialOverDamagedStoreNamesDamageKindAndDiagnosis drives the
-// post-apply gate over the three ds damage shapes and requires each denial to
-// name its own kind of damage — not the shared generic sentence alone — plus
-// the runnable diagnosis, which is then dispatched and required to answer.
-func TestGateDenialOverDamagedStoreNamesDamageKindAndDiagnosis(t *testing.T) {
+// TestDamagedEntryNamesItsOwnDamageKindAndDiagnosis drives the three ds damage
+// shapes and requires two things of each.
+//
+// The delivery gate for an UNRELATED live candidate never inherits the damage:
+// the generic "complete review authority inventory is unavailable or
+// corrupted" sentence that the ds01-ds05 benchmark measured was a verdict
+// about a repository, issued to an operator working on one file.
+//
+// The damaged entry itself still names its own kind of damage plus a runnable
+// diagnosis, and that diagnosis is dispatched through the real router and
+// required to answer with exactly the damage claimed. Naming the kind is what
+// the benchmark found missing; scoping the verdict is what makes the naming
+// reach the right person.
+func TestDamagedEntryNamesItsOwnDamageKindAndDiagnosis(t *testing.T) {
 	const forgedKind = "binding bound to different content"
-	const danglingKind = "missing from the store"
+	// The inspection's own vocabulary, not the retired gate sentence's: the
+	// diagnosis is the surface that names the damage now, so its words are
+	// the ones that have to be distinct per shape.
+	const danglingKind = "missing predecessor"
 	const truncatedKind = "malformed_compact_state"
 
 	tests := []struct {
@@ -244,27 +283,81 @@ func TestGateDenialOverDamagedStoreNamesDamageKindAndDiagnosis(t *testing.T) {
 			repo := initReviewCLIRepo(t)
 			test.stage(t, repo)
 
+			// The unrelated live candidate is answered on its own terms.
 			var output bytes.Buffer
 			runErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", "post-apply"}, &output)
-			if runErr == nil {
-				t.Fatalf("post-apply allowed a damaged store: %s", output.String())
-			}
-			var gateErr ReviewGateDeniedError
-			if !errors.As(runErr, &gateErr) {
-				t.Fatalf("post-apply denial = %T %v, want ReviewGateDeniedError", runErr, runErr)
-			}
-			message := gateErr.Error()
-			if !strings.Contains(message, test.wantKind) {
-				t.Fatalf("gate denial does not name the kind of damage (%q):\n%s", test.wantKind, message)
-			}
-			for _, absent := range test.absentKinds {
-				if strings.Contains(message, absent) {
-					t.Fatalf("gate denial claims a damage kind this store does not hold (%q):\n%s", absent, message)
+			if runErr != nil {
+				if strings.Contains(runErr.Error(), "unavailable or corrupted") {
+					t.Fatalf("the live candidate inherited a repository-wide corruption verdict:\n%v", runErr)
+				}
+				for _, kind := range append([]string{test.wantKind}, test.absentKinds...) {
+					if strings.Contains(runErr.Error(), kind) {
+						t.Fatalf("the live candidate's denial borrowed a damage kind from history (%q):\n%v", kind, runErr)
+					}
 				}
 			}
-			test.verify(t, dispatchNamedDiagnosis(t, repo, message))
+
+			// The damaged entry names its own damage, and the diagnosis it
+			// names answers.
+			blocked := reviewtransaction.CompactAuthorityLineageBlocked(t.Context(), repo, damagedStoreSuccessorLineage)
+			if blocked == nil {
+				blocked = damagedStoreEntryProblem(t, repo, damagedStoreSuccessorLineage)
+			}
+			message := blocked.Error()
+			if !strings.Contains(message, damagedStoreSuccessorLineage) {
+				t.Fatalf("the block does not name the entry it refuses:\n%s", message)
+			}
+			if !strings.Contains(message, "gentle-ai review inspect-authority") {
+				t.Fatalf("the block names no runnable diagnosis:\n%s", message)
+			}
+			report := dispatchNamedDiagnosisInRepo(t, repo, message)
+			test.verify(t, report)
+			named := damagedStoreDiagnosisText(t, report)
+			if !strings.Contains(named, test.wantKind) {
+				t.Fatalf("the diagnosis does not name the kind of damage (%q):\n%s", test.wantKind, named)
+			}
+			for _, absent := range test.absentKinds {
+				if strings.Contains(named, absent) {
+					t.Fatalf("the diagnosis claims a damage kind this store does not hold (%q):\n%s", absent, named)
+				}
+			}
 		})
 	}
+}
+
+const damagedStoreSuccessorLineage = "review-damaged-successor"
+
+// damagedStoreEntryProblem falls back to the inventory entry's own problem for
+// a shape the graph never classifies -- an unreadable record never becomes an
+// edge, so it carries no graph violation, only its own decode failure.
+func damagedStoreEntryProblem(t *testing.T, repo, lineage string) error {
+	t.Helper()
+	report, err := reviewtransaction.InventoryAuthority(t.Context(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range report.Entries {
+		if entry.LineageID == lineage && len(entry.Problems) > 0 {
+			return errors.New(strings.Join(entry.Problems, "; "))
+		}
+	}
+	t.Fatalf("no entry or block names %q: %#v", lineage, report.Entries)
+	return nil
+}
+
+// damagedStoreDiagnosisText flattens everything the inspection says about the
+// damage, so a per-shape claim is matched against the product's own words.
+func damagedStoreDiagnosisText(t *testing.T, report damagedStoreInspection) string {
+	t.Helper()
+	parts := []string{}
+	for _, edge := range report.Edges {
+		parts = append(parts, edge.NonReconcilableReason)
+		parts = append(parts, edge.Problems...)
+	}
+	for _, diagnostic := range report.EntryDiagnostics {
+		parts = append(parts, diagnostic.Problem)
+	}
+	return strings.Join(parts, "\n")
 }
 
 func anyDamagedStoreProblemContains(problems []string, fragment string) bool {
@@ -276,15 +369,18 @@ func anyDamagedStoreProblemContains(problems []string, fragment string) bool {
 	return false
 }
 
-// TestStartRefusalOverDanglingPredecessorNamesRunnableAbandon is the CLI half
-// of the ds04 measurement: `review start` over a graph whose successor names a
-// missing predecessor refused with the bare graph violation and named
-// nothing, while abandoning the orphaned successor provably clears it. The
-// refusal now renders that abandonment; this test lifts the command and the
-// authorization template values out of the message, supplies only the
-// operator-owned actor and reason, dispatches through the real router, and
-// requires the same start to then succeed.
-func TestStartRefusalOverDanglingPredecessorNamesRunnableAbandon(t *testing.T) {
+// TestOrphanedSuccessorHasARunnableAbandonThatDoesNotBlockNewWork is the CLI
+// half of the ds04 measurement, after the scope rule.
+//
+// `review start` over a graph whose successor names a missing predecessor
+// refused, and the orphaned successor's abandonment was the way out -- for
+// everybody, whether or not they had anything to do with that successor. New
+// work now starts; the orphaned successor is still an orphan, still refuses
+// for itself, and its abandonment is still rendered as a runnable command.
+// This test lifts that command and its authorization template values out of
+// the refusal, supplies only the operator-owned actor and reason, dispatches
+// through the real router, and requires the entry to be gone afterwards.
+func TestOrphanedSuccessorHasARunnableAbandonThatDoesNotBlockNewWork(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
 	predecessor, successor := mintDamagedStoreRecoveryPair(t, repo)
@@ -293,15 +389,26 @@ func TestStartRefusalOverDanglingPredecessorNamesRunnableAbandon(t *testing.T) {
 	}
 	writeDamagedStoreProse(t, repo, "fresh")
 
+	// New work is not the orphan's business.
 	var output bytes.Buffer
-	startErr := RunReviewFacadeStart([]string{"--cwd", repo}, &output)
-	if startErr == nil {
-		t.Fatalf("start succeeded over a dangling predecessor: %s", output.String())
+	if err := RunReviewFacadeStart([]string{"--cwd", repo}, &output); err != nil {
+		t.Fatalf("an orphaned successor blocked a fresh unrelated start: %v\n%s", err, output.String())
 	}
-	message := startErr.Error()
-	if !strings.Contains(message, "dangling predecessor") {
-		t.Fatalf("start refusal does not name the graph defect: %q", message)
+
+	// The orphan is still an orphan, and says so.
+	blocked := reviewtransaction.CompactAuthorityLineageBlocked(t.Context(), repo, successor)
+	if blocked == nil || !strings.Contains(blocked.Error(), "dangling predecessor") {
+		t.Fatalf("the orphaned successor does not name its own graph defect: %v", blocked)
 	}
+
+	// Its abandonment is still rendered runnable, by the surface an operator
+	// reaches when they act on that entry.
+	reclaimErr := RunReviewReclaim([]string{"--cwd", repo, "--lineage", successor,
+		"--reason", "its predecessor is gone", "--actor", "maintainer@example.com"}, io.Discard)
+	if reclaimErr == nil {
+		t.Fatal("reclaim accepted an entry that holds authoritative state")
+	}
+	message := reclaimErr.Error()
 
 	tokens := liftBacktickedReviewCommand(t, message, "abandon")
 	// The template block in the message carries the persisted binding values;
@@ -310,7 +417,7 @@ func TestStartRefusalOverDanglingPredecessorNamesRunnableAbandon(t *testing.T) {
 	expectedRevision := regexp.MustCompile(`\nrevision=(\S+)`).FindStringSubmatch(message)
 	snapshotIdentity := regexp.MustCompile(`\nsnapshot_identity=(\S+)`).FindStringSubmatch(message)
 	if expectedRevision == nil || snapshotIdentity == nil {
-		t.Fatalf("start refusal renders no authorization template: %q", message)
+		t.Fatalf("the refusal renders no authorization template: %q", message)
 	}
 	const actor, reason = "maintainer@example.com", "its predecessor is gone"
 	authorization := reviewtransaction.RenderCompactAbandonAuthorization(
@@ -321,9 +428,12 @@ func TestStartRefusalOverDanglingPredecessorNamesRunnableAbandon(t *testing.T) {
 		t.Fatalf("the abandonment the refusal named exits non-zero (named dead end): %v\n%s", err, abandoned.String())
 	}
 
+	if reviewtransaction.CompactAuthorityLineageBlocked(t.Context(), repo, successor) != nil {
+		t.Fatal("the abandonment the refusal named left the orphan in place")
+	}
 	output.Reset()
 	if err := RunReviewFacadeStart([]string{"--cwd", repo}, &output); err != nil {
-		t.Fatalf("start still refuses after the named exit ran: %v\n%s", err, output.String())
+		t.Fatalf("start refuses after the named exit ran: %v\n%s", err, output.String())
 	}
 }
 

--- a/internal/cli/review_damaged_store_kill_switch_test.go
+++ b/internal/cli/review_damaged_store_kill_switch_test.go
@@ -1,0 +1,229 @@
+package cli
+
+// A kill switch that a corrupted store can override is not a kill switch.
+//
+// Issue #2270 is the sharpest report in the class: receipt-driven development
+// was globally OFF, the operator ran an ordinary `git push`, and the push hook
+// blocked because authority inspection had already failed closed over a stored
+// record it could not trust. Nothing about that record had anything to do with
+// the commit being pushed, and nothing about the operator's choice to turn
+// reviews off had been consulted before the inspection refused.
+//
+// This file pins the shape from both sides. With the switch off, an ordinary
+// pre-push over a store holding a damaged historical entry reports ordinary
+// unmanaged delivery and exits zero. With the switch on, the same store still
+// serves the healthy candidate rather than answering with a repository-wide
+// corruption verdict — because the scope of a damaged entry is that entry.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestDisabledDeliveryIsNeverBlockedByADamagedAuthorityEntry is property 3.
+// It runs the damage twice — a forged recovery binding and a record truncated
+// mid-write — because the two reach the gate through completely different code
+// (a graph-violation verdict and a decode failure) and #2270's own evidence
+// names the decode shape.
+func TestDisabledDeliveryIsNeverBlockedByADamagedAuthorityEntry(t *testing.T) {
+	damages := []struct {
+		name   string
+		damage func(t *testing.T, repo, lineage string)
+	}{
+		{"forged recovery binding", func(t *testing.T, repo, lineage string) {
+			forgeDamagedStoreRecoveryReason(t, repo, lineage)
+		}},
+		{"record truncated mid-write", func(t *testing.T, repo, lineage string) {
+			truncateDamagedStoreRecord(t, repo, lineage)
+		}},
+	}
+	for _, damage := range damages {
+		t.Run(damage.name, func(t *testing.T) {
+			reviewModeHome(t)
+			repo := initReviewCLIRepo(t)
+			branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+			configureCLIReviewPublicationRemote(t, repo, branch)
+
+			_, successor := mintDamagedStoreRecoveryPair(t, repo)
+			damage.damage(t, repo, successor)
+
+			// Ordinary work, committed, with reviews off. This is the operator
+			// in #2270: local tests, type-check, lint and commit all passed,
+			// and then the push hook refused.
+			disableReviewForClone(t, repo)
+			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("ordinary work authored while reviews are off\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runReviewCLIGit(t, repo, "add", "tracked.txt")
+			runReviewCLIGit(t, repo, "commit", "-qm", "ordinary work")
+
+			var output bytes.Buffer
+			err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePush)}, &output)
+			if err != nil {
+				t.Fatalf("a damaged historical entry blocked ordinary delivery while the kill switch was off: %v\n%s", err, output.String())
+			}
+			var result ReviewValidateResult
+			decodeStrictReviewJSON(t, output.Bytes(), &result)
+			if result.Delivery != reviewtransaction.RDDDeliveryDisabledUnmanaged {
+				t.Fatalf("delivery under a disabled switch = %q, want %q\n%s",
+					result.Delivery, reviewtransaction.RDDDeliveryDisabledUnmanaged, output.String())
+			}
+			if result.Context.Denial != nil {
+				t.Fatalf("the disabled report carried a denial derived from authority it must never have read: %#v", result.Context.Denial)
+			}
+
+			// The damage is still reported, not hidden: the switch changes who
+			// is refused, never whether the store tells the truth about itself.
+			var inspection bytes.Buffer
+			if err := RunReviewInspectAuthority([]string{"--cwd", repo}, &inspection); err != nil {
+				t.Fatalf("inspect-authority over a damaged store: %v\n%s", err, inspection.String())
+			}
+			if !strings.Contains(inspection.String(), successor) {
+				t.Fatalf("inspect-authority no longer names the damaged entry:\n%s", inspection.String())
+			}
+
+			// The surface #2270 actually blocked on. The push hook asked the
+			// harness for an authorization; the harness asks for the next
+			// transition; and this call answered that authority inspection was
+			// unavailable, with the kill switch never consulted on the way. A
+			// switched-off system has no implications, so it must route the
+			// live target the same as it would with no store at all.
+			var status bytes.Buffer
+			if err := RunReviewStatus([]string{"--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition"}, &status); err != nil {
+				t.Fatalf("negotiated status was unavailable over a damaged entry while reviews were off: %v\n%s", err, status.String())
+			}
+			var routed struct {
+				Applicability  string `json:"applicability"`
+				NextTransition *struct {
+					Kind       string `json:"kind"`
+					ReasonCode string `json:"reason_code"`
+				} `json:"next_transition"`
+			}
+			if err := json.Unmarshal(status.Bytes(), &routed); err != nil {
+				t.Fatalf("parse negotiated status: %v\n%s", err, status.String())
+			}
+			if routed.Applicability == string(reviewtransaction.TargetApplicabilityCorrupted) {
+				t.Fatalf("a damaged entry made an unrelated target report corrupted authority while reviews were off:\n%s", status.String())
+			}
+		})
+	}
+}
+
+// TestEnabledDeliveryOverADamagedEntryStillServesTheHealthyCandidate is the
+// other half, and the one that proves the disabled result above is not merely
+// the kill switch hiding a repository-wide refusal. With reviews ON, a store
+// holding one damaged historical entry must still be able to start, finalize
+// and validate a review of unrelated work.
+//
+// This is the shape #2167 reported (a documentation-only pre-commit target
+// denied `authority_corrupted` against unrelated historical authority) and the
+// shape #1892 and #2014 reported for `review start`.
+func TestEnabledDeliveryOverADamagedEntryStillServesTheHealthyCandidate(t *testing.T) {
+	// Two damages that reach the gate through completely different doors. A
+	// forged binding leaves a readable record carrying an invalid edge, so the
+	// graph reports it. A truncated record states nothing at all, so it is
+	// absent from the graph and reaches the gate through supersession, which
+	// used to sweep every entry and fail on the first one it could not read.
+	// Both must end in the same place: blocked for itself, invisible to
+	// everybody else.
+	damages := []struct {
+		name   string
+		damage func(t *testing.T, repo, lineage string)
+	}{
+		{"forged recovery binding", func(t *testing.T, repo, lineage string) {
+			forgeDamagedStoreRecoveryReason(t, repo, lineage)
+		}},
+		{"record truncated mid-write", func(t *testing.T, repo, lineage string) {
+			truncateDamagedStoreRecord(t, repo, lineage)
+		}},
+	}
+	for _, damage := range damages {
+		t.Run(damage.name, func(t *testing.T) {
+			reviewModeHome(t)
+			repo := initReviewCLIRepo(t)
+
+			_, successor := mintDamagedStoreRecoveryPair(t, repo)
+			damage.damage(t, repo, successor)
+
+			// Unrelated new work, reviewed from scratch with the damaged entry
+			// still sitting in the same store.
+			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unrelated new behavior\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			finalizeFacadeReviewForRepo(t, repo)
+			runReviewCLIGit(t, repo, "add", "tracked.txt")
+
+			var output bytes.Buffer
+			if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &output); err != nil {
+				t.Fatalf("an unrelated damaged entry denied a healthy reviewed candidate: %v\n%s", err, output.String())
+			}
+			var result ReviewValidateResult
+			decodeStrictReviewJSON(t, output.Bytes(), &result)
+			if !result.Allowed || result.Result != reviewtransaction.GateAllow {
+				t.Fatalf("healthy reviewed candidate over a damaged store = %#v\n%s", result, output.String())
+			}
+
+			// The damaged entry never becomes governable, and says so by name.
+			blocked := reviewtransaction.CompactAuthorityLineageBlocked(context.Background(), repo, successor)
+			if blocked == nil {
+				t.Fatalf("the damaged successor %q reports no block of its own", successor)
+			}
+			if !strings.Contains(blocked.Error(), successor) {
+				t.Fatalf("the block does not name the entry it refuses: %v", blocked)
+			}
+			if !strings.Contains(blocked.Error(), "gentle-ai review inspect-authority") {
+				t.Fatalf("the block names no runnable diagnosis: %v", blocked)
+			}
+		})
+	}
+}
+
+// TestNegotiatedStatusOverADamagedEntryStillRoutesTheHealthyTarget pins the
+// surface #2234, #2270 and #2456 all name: the negotiated status envelope the
+// agent harness drives before every delivery. It reported
+// `native-status-unavailable` with `inventory_complete: false` because one
+// entry could not be read, which left the harness with no transition to take
+// and the operator with a blocked push and no exit.
+func TestNegotiatedStatusOverADamagedEntryStillRoutesTheHealthyTarget(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+
+	_, successor := mintDamagedStoreRecoveryPair(t, repo)
+	truncateDamagedStoreRecord(t, repo, successor)
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unrelated target while an entry is unreadable\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReviewStatus([]string{"--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition"}, &output); err != nil {
+		t.Fatalf("negotiated status was unavailable because one unrelated entry could not be read: %v\n%s", err, output.String())
+	}
+	var envelope struct {
+		Applicability  string `json:"applicability"`
+		NextTransition *struct {
+			Kind       string `json:"kind"`
+			ReasonCode string `json:"reason_code"`
+		} `json:"next_transition"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse negotiated status: %v\n%s", err, output.String())
+	}
+	if envelope.NextTransition == nil {
+		t.Fatalf("negotiated status published no transition at all:\n%s", output.String())
+	}
+	if envelope.Applicability == string(reviewtransaction.TargetApplicabilityCorrupted) {
+		t.Fatalf("one unreadable entry made an unrelated target report corrupted authority:\n%s", output.String())
+	}
+	if envelope.NextTransition.Kind == "stop" {
+		t.Fatalf("negotiated status stopped an unrelated target over an unreadable entry: reason=%q\n%s",
+			envelope.NextTransition.ReasonCode, output.String())
+	}
+}

--- a/internal/cli/review_disabled_reach_test.go
+++ b/internal/cli/review_disabled_reach_test.go
@@ -250,12 +250,24 @@ func TestReviewValidateKeepsFailingClosedOnCorruptedAuthorityWhileEnabled(t *tes
 	if result.Delivery != "" {
 		t.Fatalf("an enabled switch reported a delivery disposition: %#v", result)
 	}
-	if result.Allowed || result.Context.Denial == nil || result.Context.Denial.Code != string(ReviewAuthorityCorrupted) {
-		t.Fatalf("enabled corrupted-authority denial = %#v", result)
+	if result.Allowed || result.Context.Denial == nil {
+		t.Fatalf("enabled denial over unreviewed commits = %#v", result)
 	}
-	// Visible, not silent: the damage is named in the reported reason.
-	if !strings.Contains(result.Reason, "unavailable or corrupted") {
-		t.Fatalf("enabled corrupted-authority reason hid the damage: %q", result.Reason)
+	// The denial is about THIS candidate, not about an unrelated damaged
+	// entry sitting in the same shared store. Two unreviewed commits have no
+	// receipt, and that is what the gate must say; borrowing a corruption
+	// verdict from history would describe a repository the operator does not
+	// have and name no action they can take.
+	if result.Context.Denial.Code == string(ReviewAuthorityCorrupted) {
+		t.Fatalf("an unrelated damaged entry was reported as this candidate's corruption: %#v", result)
+	}
+	// Visible, not silent: the damage is still named where it belongs.
+	var inspection bytes.Buffer
+	if err := RunReviewInspectAuthority([]string{"--cwd", repo}, &inspection); err != nil {
+		t.Fatalf("inspect-authority over a damaged store: %v\n%s", err, inspection.String())
+	}
+	if !strings.Contains(inspection.String(), "corrupt-reach") {
+		t.Fatalf("the damaged entry vanished from inspection:\n%s", inspection.String())
 	}
 }
 

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -342,11 +342,32 @@ func TestUnqualifiedPrePushDiscoveryReportsTargetResolutionWithoutMutation(t *te
 	}
 }
 
+// TestUnqualifiedPrePushDiscoveryKeepsCorruptAuthorityPrecedence pinned an
+// ordering between two denials the unqualified path can no longer produce
+// together, because an unrelated corrupt entry is no longer a denial of this
+// candidate at all. The precedence that survives is the one that was ever
+// load-bearing: naming the corrupt lineage produces the corruption
+// classification, and nothing else silently takes its place.
 func TestUnqualifiedPrePushDiscoveryKeepsCorruptAuthorityPrecedence(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	approveDiscoveryMarkdown(t, repo, "review-discovery-target-and-corruption", "docs/reviewed.md", "reviewed\n")
 	runReviewCLIGit(t, repo, "add", "-A")
 	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed target")
+	unqualifiedPrePush := func() (string, error) {
+		var output bytes.Buffer
+		err := RunReview([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--gate", string(reviewtransaction.GatePrePush),
+		}, &output)
+		return output.String(), err
+	}
+
+	// The same fixture, evaluated twice, with the corrupt entry as the only
+	// difference. Anything the unqualified path says about this candidate has
+	// to be identical on both sides, because nothing about this candidate
+	// changed.
+	beforeOutput, beforeErr := unqualifiedPrePush()
+
 	commonDir := filepath.Clean(strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir")))
 	broken := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2", "corrupt-target-candidate")
 	if err := os.MkdirAll(broken, 0o755); err != nil {
@@ -356,18 +377,27 @@ func TestUnqualifiedPrePushDiscoveryKeepsCorruptAuthorityPrecedence(t *testing.T
 		t.Fatal(err)
 	}
 
-	var output bytes.Buffer
-	runErr := RunReview([]string{
-		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
-		"--gate", string(reviewtransaction.GatePrePush),
-	}, &output)
-	if runErr == nil {
-		t.Fatal("corrupt authority with missing upstream validated")
+	afterOutput, afterErr := unqualifiedPrePush()
+	if afterOutput != beforeOutput || (afterErr == nil) != (beforeErr == nil) {
+		t.Fatalf("an unrelated corrupt entry changed the unqualified answer:\nbefore(%v):\n%s\nafter(%v):\n%s",
+			beforeErr, beforeOutput, afterErr, afterOutput)
 	}
-	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+
+	// Naming the corrupt lineage still fails closed, and still names it.
+	var scoped bytes.Buffer
+	scopedErr := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePush), "--lineage", "corrupt-target-candidate",
+	}, &scoped)
+	if scopedErr == nil {
+		t.Fatal("naming the corrupt lineage validated")
+	}
+	if !strings.Contains(scoped.String(), "corrupt-target-candidate") {
+		t.Fatalf("the scoped refusal does not name the lineage it refuses:\n%s", scoped.String())
+	}
 	var targetErr *reviewtransaction.GateTargetResolutionError
-	if failure.Code != "authority_corrupted" || failure.AuthorityApplicability != "corrupted" || errors.As(runErr, &targetErr) {
-		t.Fatalf("corrupt-authority precedence = %#v, %T %v", failure, runErr, runErr)
+	if errors.As(scopedErr, &targetErr) {
+		t.Fatalf("a corrupt named lineage was reported as a target-resolution failure: %v", scopedErr)
 	}
 }
 
@@ -976,6 +1006,11 @@ func approveLegacyDiscoveryChain(t *testing.T, repo, lineage string) (reviewtran
 	return store, receipt
 }
 
+// TestUnscopedGateDiscoveryFailsClosedOnCorruptedCompactLeaf is the shape
+// #2167 reported: a healthy approved lineage and one unrelated corrupt leaf in
+// the same shared store, and the healthy candidate denied `authority_corrupted`
+// with no way to tell which entry caused it. The corrupt leaf still fails
+// closed -- when something names it.
 func TestUnscopedGateDiscoveryFailsClosedOnCorruptedCompactLeaf(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	approveDiscoveryMarkdown(t, repo, "review-discovery-valid", "docs/valid.md", "valid\n")
@@ -989,19 +1024,34 @@ func TestUnscopedGateDiscoveryFailsClosedOnCorruptedCompactLeaf(t *testing.T) {
 	}
 
 	var unscoped bytes.Buffer
-	err := RunReview([]string{
+	unscopedErr := RunReview([]string{
 		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
 		"--gate", string(reviewtransaction.GatePostApply),
 	}, &unscoped)
+	if unscopedErr != nil {
+		failure := decodeReviewIntegrationFailure(t, unscoped.Bytes())
+		if failure.Code == "authority_corrupted" || failure.AuthorityApplicability == "corrupted" {
+			t.Fatalf("an unrelated corrupted leaf became this candidate's verdict: %#v", failure)
+		}
+	}
+
+	var scoped bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply), "--lineage", "unrelated-broken",
+	}, &scoped)
 	if err == nil {
-		t.Fatal("unscoped discovery ignored corrupted compact leaf")
+		t.Fatal("naming the corrupted compact leaf validated")
 	}
-	failure := decodeReviewIntegrationFailure(t, unscoped.Bytes())
-	if failure.Code != "authority_corrupted" || failure.AuthorityApplicability != "corrupted" || failure.CauseCategory != "record_or_graph_invalid" || failure.RetrySafe || failure.NextAction != "stop" {
-		t.Fatalf("corrupted compact leaf failure = %#v", failure)
+	// The named refusal must be closed, must name the entry it refuses, and
+	// must not leak the store path. Its exact code is the explicit-selector
+	// path's own classification and is not asserted here: what this test owns
+	// is that the leaf refuses for itself and for nobody else.
+	if !strings.Contains(scoped.String(), "unrelated-broken") {
+		t.Fatalf("the scoped refusal does not name the leaf it refuses:\n%s", scoped.String())
 	}
-	if strings.Contains(unscoped.String(), broken) {
-		t.Fatalf("corrupted compact leaf failure exposed private payload: %s", unscoped.String())
+	if strings.Contains(scoped.String(), broken) {
+		t.Fatalf("corrupted compact leaf failure exposed private payload: %s", scoped.String())
 	}
 }
 

--- a/internal/cli/review_reclaim_test.go
+++ b/internal/cli/review_reclaim_test.go
@@ -20,22 +20,41 @@ func incompleteCompactResidueDir(t *testing.T, repo, lineage string) string {
 	return residue
 }
 
-func TestUnqualifiedGateDiscoveryDeniesIncompleteStoreEntryWithDistinctCause(t *testing.T) {
+// TestUnqualifiedGateDiscoveryReportsIncompleteStoreEntryWithoutDenyingOthers
+// keeps the distinct-cause classification and drops the veto. An interrupted
+// store write leaves a directory with no state in it; that entry is genuinely
+// incomplete and is reported as such, but the approved lineage beside it is
+// untouched and still governs its own delivery.
+func TestUnqualifiedGateDiscoveryReportsIncompleteStoreEntryWithoutDenyingOthers(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	approveDiscoveryMarkdown(t, repo, "review-reclaim-valid", "docs/valid.md", "valid\n")
 	incompleteCompactResidueDir(t, repo, "reclaim-audit")
 
 	var output bytes.Buffer
-	err := RunReview([]string{
+	if err := RunReview([]string{
 		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
 		"--gate", string(reviewtransaction.GatePostApply),
-	}, &output)
-	if err == nil {
-		t.Fatal("incomplete store entry did not deny lineage-less gate validation")
+	}, &output); err != nil {
+		t.Fatalf("an incomplete store entry denied an unrelated approved lineage: %v\n%s", err, output.String())
 	}
-	failure := decodeReviewIntegrationFailure(t, output.Bytes())
-	if failure.Code != "authority_corrupted" || failure.CauseCategory != "incomplete_store_entry" {
-		t.Fatalf("incomplete store entry failure = %#v", failure)
+	var validated ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &validated)
+	if !validated.Allowed || validated.Context.LineageID != "review-reclaim-valid" {
+		t.Fatalf("post-apply over an incomplete residue entry = %#v", validated)
+	}
+
+	report, err := reviewtransaction.InventoryAuthority(t.Context(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	classified := false
+	for _, entry := range report.Entries {
+		if entry.LineageID == "reclaim-audit" {
+			classified = entry.Status == reviewtransaction.AuthorityStatusIncomplete
+		}
+	}
+	if !classified {
+		t.Fatalf("the incomplete store entry lost its distinct classification: %#v", report.Entries)
 	}
 }
 
@@ -100,7 +119,13 @@ func TestReviewStartSucceedsDespiteIncompleteStoreResidue(t *testing.T) {
 	}
 }
 
-func TestReviewReclaimUnblocksStartPoisonedByEnumeratedResidue(t *testing.T) {
+// TestReviewReclaimClearsEnumeratedResidueThatNeverBlockedStart used to prove
+// reclaim was the way OUT of a start poisoned by enumerated residue. Nothing
+// is poisoned now -- a stray file in a state-less directory is that
+// directory's problem -- so what is left to prove is that reclaim still does
+// its own job: the residue is quarantined with an audit record, and start
+// works on both sides of that, not only after it.
+func TestReviewReclaimClearsEnumeratedResidueThatNeverBlockedStart(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	residue := incompleteCompactResidueDir(t, repo, "reclaim-audit")
 	if err := os.WriteFile(filepath.Join(residue, "stray.tmp"), []byte("stray\n"), 0o644); err != nil {
@@ -113,12 +138,11 @@ func TestReviewReclaimUnblocksStartPoisonedByEnumeratedResidue(t *testing.T) {
 		t.Fatal(err)
 	}
 	var output bytes.Buffer
-	err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output)
-	if err == nil {
-		t.Fatal("review start ignored an enumerated incomplete store entry")
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output); err != nil {
+		t.Fatalf("enumerated residue blocked an unrelated start: %v\n%s", err, output.String())
 	}
-	if !strings.Contains(err.Error(), "load compact start authority") {
-		t.Fatalf("start-time enumeration failure = %v", err)
+	if _, err := os.Stat(filepath.Join(residue, "stray.tmp")); err != nil {
+		t.Fatalf("the start consumed or cleaned the residue it should have ignored: %v", err)
 	}
 
 	if err := RunReview([]string{

--- a/internal/reviewtransaction/compact_damaged_store_exit_test.go
+++ b/internal/reviewtransaction/compact_damaged_store_exit_test.go
@@ -215,19 +215,46 @@ func TestReclaimRefusalNamesTheOperationThatAdmitsTheShape(t *testing.T) {
 	})
 }
 
-// TestStartOverInvalidGraphRefusalNamesSanctionedExit pins the `review start`
-// half: a fresh start over a damaged authority graph refused with the bare
-// graph violation and named nothing. The refusal now carries the sanctioned
-// exit the read-only inspection proves — the same pattern the reconcile
-// refusal already uses — and driving that exit makes the same start succeed.
+// TestStartOverInvalidGraphRefusalNamesSanctionedExit pins both halves of the
+// `review start` scope rule.
+//
+// UNRELATED work starts. A damaged historical edge is not a fact about a
+// candidate that does not inherit from it, and refusing every start in the
+// repository until somebody repaired unrelated history is the dead end
+// reported as 1892, 2014 and 2167 — in a shared Git common directory it
+// refused every worktree at once.
+//
+// The DAMAGED lineage still refuses for itself, and the refusal still names
+// the sanctioned exit the read-only inspection proves, so running exactly what
+// it printed clears exactly that entry. Scoping a refusal is not softening it:
+// the same operator gets the same exit, and everybody else stops being asked
+// to run it.
 func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 	ctx := context.Background()
 
-	freshStart := func(t *testing.T, repo, lineage string) error {
+	startLineage := func(t *testing.T, repo, lineage string) error {
 		t.Helper()
 		writeSnapshotFile(t, repo, "tracked.txt", "fresh start target for "+lineage+"\n")
 		_, err := StartCompactAuthority(ctx, repo, CompactStartRequest{State: newCompactTestState(t, repo, lineage)})
 		return err
+	}
+
+	// freshStart is unrelated work: a lineage the damaged graph does not
+	// contain and no damaged entry is an ancestor of.
+	freshStart := func(t *testing.T, repo, lineage string) error {
+		t.Helper()
+		return startLineage(t, repo, lineage)
+	}
+
+	// blockedStart names the damaged lineage itself, which is the only start
+	// a damaged entry has any standing to refuse.
+	blockedStart := func(t *testing.T, repo, lineage string) string {
+		t.Helper()
+		err := startLineage(t, repo, lineage)
+		if err == nil {
+			t.Fatalf("start on the damaged lineage %q was admitted", lineage)
+		}
+		return err.Error()
 	}
 
 	t.Run("dangling predecessor names the abandonment that clears it", func(t *testing.T) {
@@ -236,11 +263,10 @@ func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 		if err := os.RemoveAll(filepath.Join(filepath.Dir(successorStore.Dir), predecessor.State.LineageID)); err != nil {
 			t.Fatal(err)
 		}
-		err := freshStart(t, repo, "start-over-dangling")
-		if err == nil {
-			t.Fatal("start succeeded over a dangling predecessor")
+		if err := freshStart(t, repo, "start-over-dangling"); err != nil {
+			t.Fatalf("unrelated work was refused by a dangling predecessor it never inherited from: %v", err)
 		}
-		refusal := err.Error()
+		refusal := blockedStart(t, repo, successor.State.LineageID)
 		for _, want := range []string{
 			"dangling predecessor",
 			"gentle-ai review abandon",
@@ -267,11 +293,10 @@ func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 	t.Run("pre-contract edge names abandon, reconciliation retired", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
 		_, _, successor, _ := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, nil)
-		err := freshStart(t, repo, "start-over-pre-contract")
-		if err == nil {
-			t.Fatal("start succeeded over an invalid recovery edge")
+		if err := freshStart(t, repo, "start-over-pre-contract"); err != nil {
+			t.Fatalf("unrelated work was refused by an invalid recovery edge it never inherited from: %v", err)
 		}
-		refusal := err.Error()
+		refusal := blockedStart(t, repo, successor.State.LineageID)
 		for _, want := range []string{
 			"exact maintainer authorization binding",
 			"gentle-ai review abandon",
@@ -294,11 +319,10 @@ func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 	t.Run("forged pristine successor names the abandonment that clears it", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
 		_, successor, _ := forgedRecoveryPair(t, repo, "start", "forged start target\n")
-		err := freshStart(t, repo, "start-over-forged")
-		if err == nil {
-			t.Fatal("start succeeded over a forged recovery edge")
+		if err := freshStart(t, repo, "start-over-forged"); err != nil {
+			t.Fatalf("unrelated work was refused by a forged recovery edge it never inherited from: %v", err)
 		}
-		refusal := err.Error()
+		refusal := blockedStart(t, repo, successor.State.LineageID)
 		for _, want := range []string{
 			"gentle-ai review abandon",
 			"--expected-revision \"" + successor.Revision + "\"",
@@ -327,7 +351,7 @@ func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 	// named a runnable exit.
 	t.Run("forged successor holding captured results names the repair that clears it", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
-		forgedRecoveryPair(t, repo, "start-captured", "forged captured start target\n", func(state *CompactState) {
+		_, capturedSuccessor, _ := forgedRecoveryPair(t, repo, "start-captured", "forged captured start target\n", func(state *CompactState) {
 			results := make([]LensResult, 0, len(state.SelectedLenses))
 			for _, lens := range state.SelectedLenses {
 				results = append(results, LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed once"}})
@@ -338,11 +362,10 @@ func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
-		err := freshStart(t, repo, "start-over-captured")
-		if err == nil {
-			t.Fatal("start succeeded over a content-mismatched leaf holding captured review data")
+		if err := freshStart(t, repo, "start-over-captured"); err != nil {
+			t.Fatalf("unrelated work was refused by a content-mismatched leaf it never inherited from: %v", err)
 		}
-		refusal := err.Error()
+		refusal := blockedStart(t, repo, capturedSuccessor.State.LineageID)
 		for _, want := range []string{
 			"gentle-ai review repair",
 			"--plan-digest",
@@ -359,6 +382,7 @@ func TestStartOverInvalidGraphRefusalNamesSanctionedExit(t *testing.T) {
 
 		ctx := context.Background()
 		plan, err := DeriveAuthorityDispositionPlanAtRepo(ctx, repo, "maintainer@example.com", "clear the content-mismatched leaf")
+		_ = plan
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/reviewtransaction/compact_forged_authorization_test.go
+++ b/internal/reviewtransaction/compact_forged_authorization_test.go
@@ -127,7 +127,7 @@ func TestCompactAuthorityRemovalRegressionStillRefuses(t *testing.T) {
 	}
 	// The graph is already invalid, so a whole-graph post-condition would
 	// refuse both removals and leave the store unrecoverable.
-	if _, err := compactAuthorityLeaves(records, map[string]CompactStore{}); err == nil {
+	if violations, _ := compactAuthorityGraphViolations(records); len(violations) == 0 {
 		t.Fatal("fixture graph is unexpectedly valid")
 	}
 	if err := compactAuthorityRemovalRegression(records, compactRecordsWithout(records, successor.State.LineageID)); err != nil {
@@ -169,8 +169,10 @@ func TestForgedRecoveryAuthorizationDeadEndHasRunnableExit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if before.Authoritative ||
-		!hasAuthorityInventoryStatus(before.Entries, successorAlpha.State.LineageID, AuthorityStatusInvalid) ||
+	// Both forged successors are reported invalid on their own entries. The
+	// inventory as a whole stays usable, because two damaged successors are
+	// two damaged successors and not a repository-wide verdict.
+	if !hasAuthorityInventoryStatus(before.Entries, successorAlpha.State.LineageID, AuthorityStatusInvalid) ||
 		!hasAuthorityInventoryStatus(before.Entries, successorBravo.State.LineageID, AuthorityStatusInvalid) {
 		t.Fatalf("forged inventory = %#v", before)
 	}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -189,7 +189,12 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if err != nil {
 		return invalid("compact review authority cannot be loaded: "+err.Error(), err)
 	}
-	if _, err := CompactAuthorityLeaves(ctx, repo); err != nil {
+	// Scoped to the receipt's own lineage: the gate is authorizing exactly
+	// this candidate through exactly this authority chain, so a defect on a
+	// branch that chain never inherits from is not evidence about it. Asking
+	// the whole repository instead is what let one historical entry deny
+	// delivery for every unrelated candidate in every worktree (2086, 2241).
+	if err := CompactAuthorityLineageBlocked(ctx, repo, receipt.LineageID); err != nil {
 		return invalid(err.Error(), err)
 	}
 	superseded, err := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
@@ -470,7 +475,7 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	finalSnapshot, finalRefs, snapshotErr := buildCompactLifecycleSnapshot(ctx, repo, request)
 	finalUntrackedErr := validateCompactUntrackedScope(ctx, repo, record.State, request)
 	finalTrackedErr := validateCompactCommittedTrackedScope(ctx, repo, request)
-	_, graphErr := CompactAuthorityLeaves(ctx, repo)
+	graphErr := CompactAuthorityLineageBlocked(ctx, repo, receipt.LineageID)
 	finalSuperseded, supersededErr := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
 	if loadErr != nil || snapshotErr != nil || finalUntrackedErr != nil || finalTrackedErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
 		cause := errors.Join(loadErr, snapshotErr, finalUntrackedErr, finalTrackedErr, graphErr, supersededErr)

--- a/internal/reviewtransaction/compact_legacy_quarantine_test.go
+++ b/internal/reviewtransaction/compact_legacy_quarantine_test.go
@@ -48,11 +48,14 @@ func malformedLegacyFreezeFixture(t *testing.T, repo, lineage string) (Store, st
 	return store, head, malformed
 }
 
-// TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit reproduces
-// #1311: one semantically invalid legacy freeze event marks the lineage
-// invalid, forces the whole inventory complete:false/authoritative:false, and
-// every existing quarantine-family member refuses the entry.
-func TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit(t *testing.T) {
+// TestMalformedLegacyFreezeEventStaysConfinedToItsOwnEntry is #1311 after the
+// scoping change. One semantically invalid legacy freeze event still marks its
+// own lineage invalid and still has no sanctioned exit of its own -- that half
+// of #1311 is untouched and the refusals below are its proof. What it no
+// longer does is force the WHOLE inventory to complete:false, which is how one
+// dead-ended historical lineage used to take every unrelated lineage in the
+// repository down with it.
+func TestMalformedLegacyFreezeEventStaysConfinedToItsOwnEntry(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	approvedCompactFixture(t, repo, "legacy-quarantine-unrelated-approved")
 	store, _, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-broken")
@@ -68,9 +71,14 @@ func TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Complete || report.Authoritative || report.Status != AuthorityStatusInvalid ||
-		!hasAuthorityInventoryStatus(report.Entries, "legacy-freeze-broken", AuthorityStatusInvalid) {
-		t.Fatalf("bricked inventory = %#v", report)
+	if !hasAuthorityInventoryStatus(report.Entries, "legacy-freeze-broken", AuthorityStatusInvalid) {
+		t.Fatalf("the malformed freeze entry is not reported invalid: %#v", report)
+	}
+	if !report.Complete || !report.Authoritative {
+		t.Fatalf("one dead-ended historical lineage still bricks the whole inventory: %#v", report)
+	}
+	if !hasAuthorityInventoryStatus(report.Entries, "legacy-quarantine-unrelated-approved", AuthorityStatusApproved) {
+		t.Fatalf("the unrelated approved lineage lost its entry: %#v", report.Entries)
 	}
 	for _, entry := range report.Entries {
 		if entry.LineageID != "legacy-freeze-broken" {
@@ -88,8 +96,9 @@ func TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit(t *testing.T)
 	// provider retired in Wave 7 S3a/S3b. quarantine-legacy -- the ONE verb
 	// that actually did handle this exact malformed-freeze diagnostic --
 	// retired in Wave 7 S5a/S5b; this anomaly class now has no sanctioned
-	// exit at all, and this test's remaining assertions -- the bricked
-	// inventory and the two refusals below -- are the whole proof of that.)
+	// exit at all, and this test's two refusals below are the whole proof of
+	// that. The confinement assertions above are a separate claim: the entry
+	// has no exit, and that is now its own problem rather than everybody's.)
 	if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
 		LineageID: "legacy-freeze-broken", Reason: "retire malformed legacy history", Actor: "maintainer@example.com",
 	}); err == nil || !strings.Contains(err.Error(), "inspect reclaim target") {

--- a/internal/reviewtransaction/compact_lineage_scoped_authority_test.go
+++ b/internal/reviewtransaction/compact_lineage_scoped_authority_test.go
@@ -1,0 +1,318 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The four properties in this file are one claim about scope: authority
+// validation is per lineage, never per repository. Every worktree of a
+// repository shares one Git common directory and therefore one review store,
+// so a repository-global verdict over that store is a verdict over every
+// worktree at once. One record nobody is operating on could refuse every
+// operation anybody performed.
+//
+// These are removals, not additions. No state is introduced: a record that
+// cannot be read is simply absent from the graph, and absence already has a
+// meaning the graph knows (a successor naming it dangles). What goes away is
+// the assumption that the inventory is a single atomic object which is either
+// wholly trustworthy or wholly refused.
+
+// damageCompactStateStructurally truncates a persisted record to half its
+// bytes, which is what a write interrupted between open and close leaves. The
+// result cannot be parsed at all, so it is a STRUCTURAL failure: never the
+// semantic-validation class issue-1813's quarantine already admits.
+func damageCompactStateStructurally(t *testing.T, store CompactStore) {
+	t.Helper()
+	payload, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload[:len(payload)/2], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Load(); err == nil {
+		t.Fatal("fixture claims an unreadable record but Load() succeeded")
+	}
+}
+
+// writeHistoricalCompactStateField rewrites a persisted record the way a build
+// that still knew the named field would have written it: the field is present
+// in the state object AND the recorded revision is the hash of those exact
+// bytes. That is the #2399 shape precisely — the record is internally
+// consistent and self-verifying, and the only thing wrong with it is that the
+// current schema no longer declares one of its fields.
+//
+// The revision preimage is reproduced here rather than imported from the
+// production writer on purpose: what a historical record binds is the
+// persisted marshalling, so a fixture that asked the current writer to produce
+// it would prove nothing about a record the current writer never wrote.
+func writeHistoricalCompactStateField(t *testing.T, store CompactStore, field, value string) []byte {
+	t.Helper()
+	payload, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Schema   string          `json:"schema"`
+		Revision string          `json:"revision"`
+		State    json.RawMessage `json:"state"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	marker := []byte(`"state": {` + "\n")
+	index := bytes.Index(payload, marker)
+	if index < 0 {
+		t.Fatalf("fixture did not find the state object in %s", store.StatePath())
+	}
+	insertion := []byte(`    "` + field + `": "` + value + `",` + "\n")
+	historical := make([]byte, 0, len(payload)+len(insertion))
+	historical = append(historical, payload[:index+len(marker)]...)
+	historical = append(historical, insertion...)
+	historical = append(historical, payload[index+len(marker):]...)
+
+	var reread struct {
+		State json.RawMessage `json:"state"`
+	}
+	if err := json.Unmarshal(historical, &reread); err != nil {
+		t.Fatal(err)
+	}
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, reread.State); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(append([]byte(CompactStateSchema+"\x00"), compacted.Bytes()...))
+	revision := "sha256:" + hex.EncodeToString(sum[:])
+	historical = bytes.Replace(historical, []byte(`"revision": "`+envelope.Revision+`"`), []byte(`"revision": "`+revision+`"`), 1)
+	if !bytes.Contains(historical, []byte(revision)) {
+		t.Fatal("fixture could not restate the historical revision")
+	}
+	if err := os.WriteFile(store.StatePath(), historical, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return historical
+}
+
+// TestUnreadableCompactRecordServesEveryUnrelatedLineage is property 1. One
+// record nobody named must not remove every other lineage from enumeration.
+func TestUnreadableCompactRecordServesEveryUnrelatedLineage(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	healthyA := quarantineFixtureHealthyLineage(t, repo, "scoped-healthy-a", "healthy candidate a\n")
+	damagedLineage := quarantineFixtureHealthyLineage(t, repo, "scoped-unreadable", "damaged candidate\n")
+	healthyB := quarantineFixtureHealthyLineage(t, repo, "scoped-healthy-b", "healthy candidate b\n")
+
+	damagedStore, err := CompactAuthoritativeStore(context.Background(), repo, damagedLineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	damageCompactStateStructurally(t, damagedStore)
+
+	t.Run("leaf enumeration serves the healthy lineages", func(t *testing.T) {
+		leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+		if err != nil {
+			t.Fatalf("one unreadable record poisoned leaf enumeration: %v", err)
+		}
+		names := map[string]bool{}
+		for _, leaf := range leaves {
+			names[leaf.lineageID] = true
+		}
+		if !names[healthyA] || !names[healthyB] {
+			t.Fatalf("healthy lineages excluded by an unrelated unreadable record: %#v", names)
+		}
+		if names[damagedLineage] {
+			t.Fatalf("the unreadable lineage was enumerated as authority: %#v", names)
+		}
+	})
+
+	t.Run("selector-free target status serves the healthy lineages", func(t *testing.T) {
+		candidates, err := loadCompactTargetStatusCandidates(context.Background(), repo, "")
+		if err != nil {
+			t.Fatalf("one unreadable record poisoned selector-free target status: %v", err)
+		}
+		if _, ok := candidates[healthyA]; !ok {
+			t.Fatalf("healthy lineage %q excluded: %#v", healthyA, candidates)
+		}
+		if _, ok := candidates[healthyB]; !ok {
+			t.Fatalf("healthy lineage %q excluded: %#v", healthyB, candidates)
+		}
+		if _, ok := candidates[damagedLineage]; ok {
+			t.Fatalf("the unreadable lineage was offered as a candidate: %#v", candidates)
+		}
+	})
+
+	t.Run("the inventory stays authoritative for the healthy lineages", func(t *testing.T) {
+		report, err := InventoryAuthority(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !report.Complete || !report.Authoritative {
+			t.Fatalf("one unreadable record made the whole repository non-authoritative: complete=%t authoritative=%t status=%s",
+				report.Complete, report.Authoritative, report.Status)
+		}
+		if !hasAuthorityInventoryStatus(report.Entries, healthyA, AuthorityStatusApproved) ||
+			!hasAuthorityInventoryStatus(report.Entries, healthyB, AuthorityStatusApproved) {
+			t.Fatalf("healthy lineages lost their entries: %#v", report.Entries)
+		}
+	})
+}
+
+// TestUnreadableCompactRecordStillRefusesItselfAndNamesAnExit is property 2.
+// Scoping the refusal must not make the damaged record loadable, and the
+// refusal must name the entry and a runnable continuation.
+func TestUnreadableCompactRecordStillRefusesItselfAndNamesAnExit(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	quarantineFixtureHealthyLineage(t, repo, "refuses-healthy", "healthy candidate\n")
+	damagedLineage := quarantineFixtureHealthyLineage(t, repo, "refuses-unreadable", "damaged candidate\n")
+
+	damagedStore, err := CompactAuthoritativeStore(context.Background(), repo, damagedLineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	damageCompactStateStructurally(t, damagedStore)
+
+	t.Run("an explicit selector on the damaged lineage fails closed", func(t *testing.T) {
+		if _, err := loadCompactTargetStatusCandidates(context.Background(), repo, damagedLineage); err == nil {
+			t.Fatal("an explicit selector on the unreadable lineage was admitted")
+		}
+	})
+
+	t.Run("the inventory names the entry, the reason, and a runnable exit", func(t *testing.T) {
+		report, err := InventoryAuthority(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		named := false
+		for _, entry := range report.Entries {
+			if entry.LineageID != damagedLineage {
+				continue
+			}
+			named = true
+			if entry.Status != AuthorityStatusInvalid {
+				t.Fatalf("the unreadable entry is not reported invalid: %#v", entry)
+			}
+			if len(entry.Problems) == 0 || strings.TrimSpace(entry.Problems[0]) == "" {
+				t.Fatalf("the unreadable entry names no reason: %#v", entry)
+			}
+			if !anyProblemNamesAnExit(entry.Problems) {
+				t.Fatalf("the unreadable entry names no runnable exit: %#v", entry.Problems)
+			}
+		}
+		if !named {
+			t.Fatalf("the unreadable entry is not named at all: %#v", report.Entries)
+		}
+	})
+}
+
+func anyProblemNamesAnExit(problems []string) bool {
+	for _, problem := range problems {
+		if strings.Contains(problem, "gentle-ai review ") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGraphViolationIsScopedToItsOwnLineage is the second removal: a violation
+// carried by one edge must not be a verdict on lineages that edge does not
+// reach. The forged-authorization pair is the exact shape #1892/#2014 report.
+func TestGraphViolationIsScopedToItsOwnLineage(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	unrelated := quarantineFixtureHealthyLineage(t, repo, "scoped-graph-unrelated", "unrelated candidate\n")
+	_, successor, _ := forgedRecoveryPair(t, repo, "scoped-graph", "forged scoped target\n")
+
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("one forged recovery edge poisoned leaf enumeration: %v", err)
+	}
+	names := map[string]bool{}
+	for _, leaf := range leaves {
+		names[leaf.lineageID] = true
+	}
+	if !names[unrelated] {
+		t.Fatalf("the unrelated healthy lineage was excluded by a forged edge it has no relation to: %#v", names)
+	}
+	if names[successor.State.LineageID] {
+		t.Fatalf("the forged successor was enumerated as authority: %#v", names)
+	}
+
+	blocked := CompactAuthorityLineageBlocked(context.Background(), repo, successor.State.LineageID)
+	if blocked == nil {
+		t.Fatal("the forged successor reports no lineage-scoped block")
+	}
+	if !strings.Contains(blocked.Error(), successor.State.LineageID) {
+		t.Fatalf("the lineage-scoped block does not name the entry: %v", blocked)
+	}
+	if err := CompactAuthorityLineageBlocked(context.Background(), repo, unrelated); err != nil {
+		t.Fatalf("the unrelated lineage reports a block it does not carry: %v", err)
+	}
+}
+
+// TestHistoricalUnknownFieldLoadsReadOnlyWithoutRewriting is property 4 and
+// the #2399 shape: a historical top-level field whose record still verifies
+// against its original bytes loads read-only, and reading it changes nothing
+// on disk.
+func TestHistoricalUnknownFieldLoadsReadOnlyWithoutRewriting(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	lineage := quarantineFixtureHealthyLineage(t, repo, "historical-risk-source", "historical candidate\n")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	historical := writeHistoricalCompactStateField(t, store, "risk_source", "automatic")
+	recordedRevision := recordedCompactRevision(t, historical)
+
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("a historical record whose revision still binds its own bytes was refused: %v", err)
+	}
+	if !record.HistoricalCompat {
+		t.Fatalf("the historical record did not load through the read-only compatibility path: %#v", record)
+	}
+	if record.Revision != recordedRevision {
+		t.Fatalf("the historical record's revision moved: %q != %q", record.Revision, recordedRevision)
+	}
+
+	current, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(current, historical) {
+		t.Fatal("reading a historical record rewrote its persisted bytes")
+	}
+	if _, err := store.Replace(record.Revision, "review/start", record.State); !errors.Is(err, ErrHistoricalCompatReadOnly) {
+		t.Fatalf("historical authority accepted an ordinary mutation: %v", err)
+	}
+
+	// An unrelated unknown field is still refused: the allowlist is narrow.
+	other := quarantineFixtureHealthyLineage(t, repo, "historical-unknown-other", "other candidate\n")
+	otherStore, err := CompactAuthoritativeStore(context.Background(), repo, other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeHistoricalCompactStateField(t, otherStore, "not_a_historical_field", "whatever")
+	if _, err := otherStore.Load(); err == nil {
+		t.Fatal("an unrelated unknown field was tolerated")
+	}
+}
+
+func recordedCompactRevision(t *testing.T, payload []byte) string {
+	t.Helper()
+	var envelope struct {
+		Revision string `json:"revision"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Revision == "" {
+		t.Fatal("fixture record carries no revision")
+	}
+	return envelope.Revision
+}

--- a/internal/reviewtransaction/compact_reclaim_test.go
+++ b/internal/reviewtransaction/compact_reclaim_test.go
@@ -50,9 +50,9 @@ func TestInventoryClassifiesIncompleteCompactStoreEntry(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if report.Complete || report.Authoritative {
-				t.Fatalf("incomplete store entry left inventory authoritative: %#v", report)
-			}
+			// The entry states its own condition. It no longer states the
+			// whole repository's, because it never knew it: an incomplete
+			// store entry says nothing about any other lineage.
 			if !hasAuthorityInventoryStatus(report.Entries, "reclaim-audit", tt.status) {
 				t.Fatalf("inventory entries = %#v", report.Entries)
 			}

--- a/internal/reviewtransaction/compact_semantic_quarantine_test.go
+++ b/internal/reviewtransaction/compact_semantic_quarantine_test.go
@@ -221,12 +221,18 @@ func TestAuthorityInventoryDiagnosticQuarantine(t *testing.T) {
 	}
 }
 
-// TestCompactQuarantineNeverAppliesToNonTerminalOrStructuralCorruption proves
-// issue-1813's negative boundary (task 7.11): quarantine applies ONLY to a
-// TERMINAL-for-lineage state (Approved, Escalated, Invalidated) failing pure
-// semantic validation. A genuinely corrupt ACTIVE (non-terminal: Reviewing)
-// lineage still fails closed end-to-end through every enumeration path this
-// change touched, exactly like before.
+// TestCompactQuarantineNeverAppliesToNonTerminalOrStructuralCorruption is
+// issue-1813's negative boundary after the scoping change. 1813 drew the line
+// at WHICH corrupt lineages could be left out of enumeration; the line now
+// runs somewhere else, because enumeration is no longer a repository-wide
+// verdict that a corrupt entry could poison.
+//
+// What survives untouched, and is what this test now pins, is the boundary
+// that actually protects anything: a corrupt ACTIVE lineage is never
+// loadable, never enumerable as authority, and always fails closed when an
+// operation names it. The state it is in makes no difference to any of that,
+// which is the simplification -- there is no longer a quarantinable set to
+// belong to.
 func TestCompactQuarantineNeverAppliesToNonTerminalOrStructuralCorruption(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	healthy := quarantineFixtureHealthyLineage(t, repo, "quarantine-boundary-healthy", "healthy candidate\n")
@@ -258,26 +264,39 @@ func TestCompactQuarantineNeverAppliesToNonTerminalOrStructuralCorruption(t *tes
 		t.Fatal("corrupted reviewing-state lineage loaded without error")
 	}
 
-	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil {
-		t.Fatal("CompactAuthorityLeaves silently tolerated a corrupt non-terminal lineage")
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("a corrupt non-terminal lineage poisoned enumeration: %v", err)
+	}
+	for _, leaf := range leaves {
+		if leaf.lineageID == corrupted {
+			t.Fatal("the corrupt non-terminal lineage was enumerated as authority")
+		}
+	}
+	if err := CompactAuthorityLineageBlocked(context.Background(), repo, corrupted); err == nil {
+		t.Fatal("the corrupt non-terminal lineage reports no block of its own")
 	}
 
-	if _, err := loadCompactTargetStatusCandidates(context.Background(), repo, ""); err == nil {
-		t.Fatal("selector-free target status silently tolerated a corrupt non-terminal lineage")
+	candidates, err := loadCompactTargetStatusCandidates(context.Background(), repo, "")
+	if err != nil {
+		t.Fatalf("a corrupt non-terminal lineage poisoned selector-free target status: %v", err)
+	}
+	if _, offered := candidates[corrupted]; offered {
+		t.Fatal("the corrupt non-terminal lineage was offered as a status candidate")
+	}
+	if _, err := loadCompactTargetStatusCandidates(context.Background(), repo, corrupted); err == nil {
+		t.Fatal("an explicit selector on the corrupt non-terminal lineage was admitted")
 	}
 
 	report, err := InventoryAuthority(context.Background(), repo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Complete || report.Authoritative {
-		t.Fatalf("corrupt non-terminal lineage did not flip report.Complete/Authoritative: %#v", report)
-	}
 	if !hasAuthorityInventoryStatus(report.Entries, corrupted, AuthorityStatusInvalid) {
 		t.Fatalf("corrupt non-terminal lineage missing its Invalid entry: %#v", report.Entries)
 	}
 	if !hasAuthorityInventoryStatus(report.Entries, healthy, AuthorityStatusApproved) {
-		t.Fatalf("healthy lineage still reported inventory-readable alongside the failed-closed corruption: %#v", report.Entries)
+		t.Fatalf("healthy lineage lost its entry alongside the failed-closed corruption: %#v", report.Entries)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -104,7 +104,13 @@ var ErrHistoricalCompatReadOnly = errors.New("historical compatibility authority
 var compactRetiredStateFieldPaths = map[string]struct{}{
 	"candidate_artifact_required": {},
 	"zero_edit_escalation":        {},
-	"recovery.review_start":       {},
+	// risk_source was the persisted record of how a record's risk level had
+	// been decided. Risk is derived from the frozen candidate now, so the
+	// field carries nothing the current schema needs; records written before
+	// it was dropped still carry it, and their revisions still bind their own
+	// bytes exactly (issue 2399).
+	"risk_source":           {},
+	"recovery.review_start": {},
 }
 
 // LegacyReadOnlyError is the typed ordinary-mutation denial for historical
@@ -728,30 +734,160 @@ func compactRecoveryContractsGenesisPaths(predecessor CompactState, live Snapsho
 	return classifyCompactPathSetRelation(predecessor.GenesisPaths, live.Paths) == compactPathsContraction
 }
 
-func CompactAuthorityLeaves(ctx context.Context, repo string) ([]CompactStore, error) {
+// compactAuthorityScan is one read of every compact store in a repository,
+// split into the records that could be read and the lineages that could not.
+// The split is the point: an entry nobody can read is ABSENT from the graph,
+// not a verdict on it. Absence already has a meaning the graph knows, because
+// a successor naming a lineage that is not there is a dangling predecessor and
+// self-excludes; nothing else has to be invented to describe it.
+type compactAuthorityScan struct {
+	records    map[string]CompactRecord
+	stores     map[string]CompactStore
+	unreadable map[string]error
+}
+
+// scanCompactAuthority reads every discovered store once. It never fails on a
+// record it cannot read, because a repository shares one review store across
+// every one of its worktrees: a repository-wide refusal derived from one
+// damaged entry is a refusal issued to every worktree, for work none of them
+// did (issues 1892, 2014, 2167, 2234, 2270, 2399, 2456).
+func scanCompactAuthority(ctx context.Context, repo string) (compactAuthorityScan, error) {
 	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return compactAuthorityScan{}, err
+	}
+	scan := compactAuthorityScan{
+		records:    make(map[string]CompactRecord, len(stores)),
+		stores:     make(map[string]CompactStore, len(stores)),
+		unreadable: map[string]error{},
+	}
+	for _, store := range stores {
+		record, loadErr := store.LoadContext(ctx)
+		if loadErr != nil {
+			// An operational failure is not a damaged record: it is this
+			// process being unable to see the store at all. Cancellation, a
+			// held lock, a Git failure or a filesystem error say nothing about
+			// the entry's content, and quarantining them would turn a
+			// transient or environmental problem into a permanent verdict
+			// about somebody's authority. Those still propagate.
+			if compactAuthorityOperationalFailure(loadErr) {
+				return compactAuthorityScan{}, loadErr
+			}
+			scan.unreadable[store.lineageID] = loadErr
+			continue
+		}
+		scan.records[record.State.LineageID], scan.stores[record.State.LineageID] = record, store
+	}
+	return scan, nil
+}
+
+func CompactAuthorityLeaves(ctx context.Context, repo string) ([]CompactStore, error) {
+	scan, err := scanCompactAuthority(ctx, repo)
 	if err != nil {
 		return nil, err
 	}
-	records := make(map[string]CompactRecord, len(stores))
-	storeByLineage := make(map[string]CompactStore, len(stores))
-	for _, store := range stores {
-		record, loadErr := store.Load()
-		if loadErr != nil {
-			// A TERMINAL lineage that fails semantic validation is quarantined
-			// out of this selector-free enumeration alone (issue-1813): it does
-			// not poison discovery for every other healthy lineage. The
-			// diagnostic surface for the excluded lineage lives in
-			// InventoryAuthority (status.go); an explicit selector naming this
-			// lineage directly still fails closed (loadCompactTargetStatusCandidates).
-			if _, quarantinable := compactLineageQuarantinable(loadErr); quarantinable {
-				continue
-			}
-			return nil, fmt.Errorf("invalid compact authority graph: %w", loadErr)
-		}
-		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
+	return compactAuthorityLeaves(scan.records, scan.stores), nil
+}
+
+// CompactAuthorityLineageBlocked reports the reason one named lineage cannot
+// govern, and nothing about any other lineage. It is the scoped replacement
+// for asking whether the whole repository's authority graph validates: an
+// entry that does not apply to the operation under way must not be able to
+// refuse it.
+//
+// It answers nil for a lineage the graph does not carry at all, because "no
+// authority here" is not damage; the caller's own discovery already decides
+// what to do with an absent lineage.
+func CompactAuthorityLineageBlocked(ctx context.Context, repo, lineageID string) error {
+	if strings.TrimSpace(lineageID) == "" {
+		return nil
 	}
-	return compactAuthorityLeaves(records, storeByLineage)
+	scan, err := scanCompactAuthority(ctx, repo)
+	if err != nil {
+		return err
+	}
+	return scan.blocked(lineageID)
+}
+
+// blocked names the exact entry that stops one lineage from governing, which
+// may be the lineage itself or an ancestor it inherits its authority through.
+// The refusal names a runnable continuation because a refusal that names none
+// is the one shape this project does not ship.
+func (scan compactAuthorityScan) blocked(lineageID string) error {
+	if loadErr, unreadable := scan.unreadable[lineageID]; unreadable {
+		return compactBlockedLineageError(lineageID, lineageID, loadErr)
+	}
+	if _, known := scan.records[lineageID]; !known {
+		return nil
+	}
+	violations, _ := compactAuthorityGraphViolations(scan.records)
+	carrier, cause := compactAuthorityBlockingCause(scan.records, violations, lineageID)
+	if cause == nil {
+		return nil
+	}
+	return compactBlockedLineageError(lineageID, carrier, cause)
+}
+
+// compactBlockedLineageError names the entry, the defect, and the ONE command
+// that is runnable for every shape of damage: the read-only diagnosis, which
+// then names each entry's own sanctioned exit if it has one.
+//
+// It deliberately does not guess a clearing command. `review abandon` refuses
+// a successor holding captured review data and cannot load a truncated record
+// at all, so printing it here would send an operator to a command that turns
+// around and refuses. A refusal that names an exit which does not work is
+// worse than one that names only the diagnosis.
+func compactBlockedLineageError(lineageID, carrier string, cause error) error {
+	if carrier == lineageID {
+		return fmt.Errorf(
+			"compact authority lineage %q cannot govern: %w. Every other lineage is unaffected; see this entry's own diagnosis and sanctioned exits with `gentle-ai review inspect-authority`",
+			lineageID, cause)
+	}
+	return fmt.Errorf(
+		"compact authority lineage %q cannot govern because the entry %q it recovers from carries: %w. Every lineage that does not recover through %q is unaffected; see that entry's own diagnosis and sanctioned exits with `gentle-ai review inspect-authority`",
+		lineageID, carrier, cause, carrier)
+}
+
+// compactAuthorityBlockingCause walks one lineage's recovery ancestry and
+// reports the first entry that carries a graph defect, together with that
+// defect. Walking the ancestry rather than the whole record set is the whole
+// scoping change: a defect on a branch this lineage never inherits from is
+// somebody else's problem.
+func compactAuthorityBlockingCause(
+	records map[string]CompactRecord,
+	violations map[string]error,
+	lineageID string,
+) (string, error) {
+	if cause, carried := violations[lineageID]; carried {
+		return lineageID, cause
+	}
+	seen := map[string]bool{lineageID: true}
+	cursor, known := records[lineageID]
+	for known && cursor.State.Recovery != nil {
+		parent := cursor.State.Recovery.PredecessorLineageID
+		if cause, carried := violations[parent]; carried {
+			return parent, cause
+		}
+		if seen[parent] {
+			return parent, errors.New("recovery cycle")
+		}
+		seen[parent] = true
+		cursor, known = records[parent]
+	}
+	return "", nil
+}
+
+// compactAuthorityBlockedLineages is compactAuthorityBlockingCause over the
+// whole record set at once, for the enumeration that has to decide which
+// lineages may be offered as authority.
+func compactAuthorityBlockedLineages(records map[string]CompactRecord, violations map[string]error) map[string]bool {
+	blocked := make(map[string]bool, len(violations))
+	for lineage := range records {
+		if carrier, _ := compactAuthorityBlockingCause(records, violations, lineage); carrier != "" {
+			blocked[lineage] = true
+		}
+	}
+	return blocked
 }
 
 // compactAuthorityGraphViolations enumerates EVERY graph defect in one record
@@ -858,36 +994,53 @@ func compactRecordsWithout(records map[string]CompactRecord, lineage string) map
 	return remaining
 }
 
-func compactAuthorityLeaves(records map[string]CompactRecord, storeByLineage map[string]CompactStore) ([]CompactStore, error) {
+// compactAuthorityLeaves selects the leaves of the HEALTHY part of the
+// authority graph. A lineage carrying a graph defect, and every lineage whose
+// recovery ancestry inherits through one, is excluded from the selection.
+//
+// The removal here is the aggregate verdict this used to return. Reporting the
+// first defect in sorted order made every lineage in the repository share the
+// fate of whichever one sorted earliest, which is how a single historical edge
+// nobody was operating on came to refuse review in every worktree at once.
+// Exclusion is strictly more conservative for the damaged entry than the old
+// error was: it can never be offered as authority, and an operation that names
+// it directly still fails closed through blocked().
+func compactAuthorityLeaves(records map[string]CompactRecord, storeByLineage map[string]CompactStore) []CompactStore {
 	violations, children := compactAuthorityGraphViolations(records)
-	if len(violations) > 0 {
-		lineages := make([]string, 0, len(violations))
-		for lineage := range violations {
-			lineages = append(lineages, lineage)
-		}
-		sort.Strings(lineages)
-		return nil, fmt.Errorf("invalid compact authority graph: %w", violations[lineages[0]])
-	}
+	blocked := compactAuthorityBlockedLineages(records, violations)
 	leaves := []CompactStore{}
 	for lineage, store := range storeByLineage {
-		if children[lineage] == 0 {
-			leaves = append(leaves, store)
+		if blocked[lineage] || children[lineage] != 0 {
+			continue
 		}
+		leaves = append(leaves, store)
 	}
 	sort.Slice(leaves, func(i, j int) bool { return leaves[i].lineageID < leaves[j].lineageID })
-	return leaves, nil
+	return leaves
 }
 
+// CompactLineageSuperseded reports whether any READABLE entry recovers from
+// this lineage.
+//
+// An entry nobody can read supersedes nothing, for the same reason it is not
+// in the graph: a record that cannot be parsed states no predecessor. The
+// alternative was to treat one unreadable entry as making supersession
+// unknowable for every lineage in the repository, which is the exact
+// repository-global refusal this whole change removes -- and it disagreed with
+// the graph, which already reads an unreadable entry as absent.
+//
+// The residual case is narrow and named: a lineage whose only successor became
+// unreadable stops reporting as superseded, so its own approved receipt can
+// govern its own reviewed content again. That content was genuinely reviewed
+// and the receipt still binds it exactly; the successor that retired it is
+// broken and can deliver nothing itself. Leaving both unusable was the worse
+// answer.
 func CompactLineageSuperseded(ctx context.Context, repo, lineageID string) (bool, error) {
-	stores, err := DiscoverCompactStores(ctx, repo)
+	scan, err := scanCompactAuthority(ctx, repo)
 	if err != nil {
 		return false, err
 	}
-	for _, store := range stores {
-		record, loadErr := store.Load()
-		if loadErr != nil {
-			return false, loadErr
-		}
+	for _, record := range scan.records {
 		if record.State.Recovery != nil && record.State.Recovery.PredecessorLineageID == lineageID {
 			return true, nil
 		}
@@ -1015,30 +1168,19 @@ func StartCompactAuthority(ctx context.Context, repo string, request CompactStar
 		}
 	}
 
-	stores, err := DiscoverCompactStores(ctx, requestedStore.repo)
+	// A damaged entry is skipped rather than fatal: starting a review of new
+	// work has nothing to do with an entry that new work does not inherit
+	// from, and refusing every start in every worktree until somebody repairs
+	// unrelated history was the dead end reported as 1892, 2014 and 2167.
+	scan, err := scanCompactAuthority(ctx, requestedStore.repo)
 	if err != nil {
 		return CompactStartResult{}, err
 	}
-	records := make(map[string]CompactRecord, len(stores))
-	storeByLineage := make(map[string]CompactStore, len(stores))
-	for _, store := range stores {
-		record, loadErr := store.Load()
-		if loadErr != nil {
-			// A TERMINAL lineage that fails semantic validation is quarantined
-			// out of this bulk discovery scan alone (issue-1813): review start
-			// for every other healthy lineage remains operable instead of
-			// failing store-wide on one corrupted, unrelated lineage.
-			if _, quarantinable := compactLineageQuarantinable(loadErr); quarantinable {
-				continue
-			}
-			return CompactStartResult{}, fmt.Errorf("load compact start authority: %w", loadErr)
-		}
-		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
+	records, storeByLineage := scan.records, scan.stores
+	if blocked := scan.blocked(request.State.LineageID); blocked != nil {
+		return CompactStartResult{}, compactStartInvalidGraphRefusal(ctx, requestedStore.repo, records, blocked)
 	}
-	leaves, err := compactAuthorityLeaves(records, storeByLineage)
-	if err != nil {
-		return CompactStartResult{}, compactStartInvalidGraphRefusal(ctx, requestedStore.repo, records, err)
-	}
+	leaves := compactAuthorityLeaves(records, storeByLineage)
 	claimants := make([]CompactStore, 0, len(leaves))
 	recoveryCandidates := make([]CompactStore, 0, 1)
 	correctionClaims := make(map[string]compactCorrectionTargetClaim)

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1140,6 +1140,9 @@ func TestStartCompactAuthorityBlocksInvalidReceiptAndCorruptUnrelatedStore(t *te
 			t.Fatalf("invalid receipt start = %#v, %v", result, err)
 		}
 	})
+	// A corrupt UNRELATED entry is not a reason to refuse new work. It is
+	// still a reason to refuse itself, and both halves are asserted here so
+	// the relaxation cannot quietly become permissiveness.
 	t.Run("corrupt unrelated store", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
 		writeSnapshotFile(t, repo, "tracked.txt", "historical candidate\n")
@@ -1148,8 +1151,14 @@ func TestStartCompactAuthorityBlocksInvalidReceiptAndCorruptUnrelatedStore(t *te
 			t.Fatal(err)
 		}
 		writeSnapshotFile(t, repo, "tracked.txt", "new candidate\n")
-		if _, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "compact-start-corrupt-request")}); err == nil {
-			t.Fatal("corrupt unrelated store allowed a fresh authority")
+		if _, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "compact-start-corrupt-request")}); err != nil {
+			t.Fatalf("a corrupt unrelated entry refused a fresh authority: %v", err)
+		}
+		if err := CompactAuthorityLineageBlocked(context.Background(), repo, "compact-start-corrupt-history"); err == nil {
+			t.Fatal("the corrupt entry reports no block of its own")
+		}
+		if _, err := store.Load(); err == nil {
+			t.Fatal("the corrupt entry became loadable")
 		}
 	})
 }
@@ -1950,21 +1959,60 @@ func TestCompactDiscoveryIgnoresOnlyUnpublishedCrashResidue(t *testing.T) {
 	if err != nil || len(leaves) != 1 || leaves[0].lineageID != state.LineageID {
 		t.Fatalf("leaves with crash residue = %#v, %v", leaves, err)
 	}
+	// Neither of the two shapes below may be silently treated as authority,
+	// and neither may take the published lineage down with it. "Hidden" means
+	// enumerated as authority or absent from the inventory -- not "did not
+	// abort the whole enumeration", which is what a shared review store can
+	// never afford to do over one directory.
 	unexpected := filepath.Join(residue.Dir, "unexpected-residue")
 	if err := os.WriteFile(unexpected, []byte("not a temporary publication"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil {
-		t.Fatal("unexpected state-less lineage entry was hidden as crash residue")
-	}
+	requireResidueNeverAuthority(t, repo, residue.lineageID, state.LineageID)
 	if err := os.Remove(unexpected); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(residue.StatePath(), []byte("corrupt published authority"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil {
-		t.Fatal("corrupt published authority was hidden as residue")
+	requireResidueNeverAuthority(t, repo, residue.lineageID, state.LineageID)
+	if err := CompactAuthorityLineageBlocked(context.Background(), repo, residue.lineageID); err == nil {
+		t.Fatal("corrupt published authority reports no block of its own")
+	}
+}
+
+// requireResidueNeverAuthority holds both halves at once: the residue lineage
+// is never a leaf, the published lineage still is, and the inventory names the
+// residue rather than dropping it.
+func requireResidueNeverAuthority(t *testing.T, repo, residue, published string) {
+	t.Helper()
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("residue poisoned enumeration: %v", err)
+	}
+	names := map[string]bool{}
+	for _, leaf := range leaves {
+		names[leaf.lineageID] = true
+	}
+	if names[residue] {
+		t.Fatalf("residue lineage %q was enumerated as authority: %#v", residue, names)
+	}
+	if !names[published] {
+		t.Fatalf("published lineage %q was excluded by residue: %#v", published, names)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	named := false
+	for _, entry := range report.Entries {
+		named = named || entry.LineageID == residue
+	}
+	for _, diagnostic := range report.Diagnostics {
+		named = named || strings.Contains(diagnostic.Path, residue)
+	}
+	if !named {
+		t.Fatalf("residue lineage %q vanished from the inventory: %#v", residue, report)
 	}
 }
 

--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -603,15 +603,24 @@ func RetryCompactFinalVerification(ctx context.Context, repo string, request Fin
 	}
 	records := make(map[string]CompactRecord, len(stores))
 	storeByLineage := make(map[string]CompactStore, len(stores))
+	unreadable := map[string]struct{}{}
 	for _, store := range stores {
 		record, loadErr := store.loadCompactRecordLocked()
 		if loadErr != nil {
-			return CompactRecord{}, denyFinalVerificationRetry("ambiguous_authority", "compact authority graph cannot be loaded exactly")
+			// An entry outside this retry's own ancestry is not this retry's
+			// business. The ancestry check below still requires the exact
+			// predecessor chain to be readable and to validate.
+			unreadable[store.lineageID] = struct{}{}
+			continue
 		}
 		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
 	}
-	if _, err := compactAuthorityLeaves(records, storeByLineage); err != nil {
-		return CompactRecord{}, denyFinalVerificationRetry("ambiguous_authority", err.Error())
+	if _, missing := unreadable[predecessor.State.LineageID]; missing {
+		return CompactRecord{}, denyFinalVerificationRetry("ambiguous_authority", "compact authority graph cannot be loaded exactly")
+	}
+	violations, _ := compactAuthorityGraphViolations(records)
+	if carrier, cause := compactAuthorityBlockingCause(records, violations, predecessor.State.LineageID); cause != nil {
+		return CompactRecord{}, denyFinalVerificationRetry("ambiguous_authority", compactBlockedLineageError(predecessor.State.LineageID, carrier, cause).Error())
 	}
 	if err := finalVerificationRetryAncestryEligible(predecessor, records); err != nil {
 		return CompactRecord{}, err

--- a/internal/reviewtransaction/invalidated_status_test.go
+++ b/internal/reviewtransaction/invalidated_status_test.go
@@ -106,8 +106,9 @@ func TestInventoryAuthorityKeepsMalformedInvalidatedAuthorityFailClosed(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Complete || report.Authoritative ||
-		!hasAuthorityInventoryStatus(report.Entries, state.LineageID, AuthorityStatusInvalid) {
+	// Scoped: the malformed invalidated lineage is reported invalid on its
+	// own entry, and carries no verdict about the rest of the inventory.
+	if !hasAuthorityInventoryStatus(report.Entries, state.LineageID, AuthorityStatusInvalid) {
 		t.Fatalf("malformed invalidated report = %#v", report)
 	}
 }

--- a/internal/reviewtransaction/legacy_alias_repair_test.go
+++ b/internal/reviewtransaction/legacy_alias_repair_test.go
@@ -152,8 +152,11 @@ func TestRepairHistoricalLegacyAliasLeavesInventoryFailClosedForOtherCorruption(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Complete || report.Authoritative || !hasAuthorityInventoryStatus(report.Entries, "alias-repair-unhandled", AuthorityStatusInvalid) {
-		t.Fatalf("repair incorrectly made mixed inventory authoritative: %#v", report)
+	// The unhandled alias entry stays invalid on its own account. Repairing
+	// one entry was never allowed to make another entry healthy, and one
+	// unhandled entry was never a statement about the repaired one.
+	if !hasAuthorityInventoryStatus(report.Entries, "alias-repair-unhandled", AuthorityStatusInvalid) {
+		t.Fatalf("repair incorrectly cleared the unhandled alias entry: %#v", report)
 	}
 }
 

--- a/internal/reviewtransaction/status.go
+++ b/internal/reviewtransaction/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -149,11 +150,21 @@ func InventoryAuthority(ctx context.Context, repo string) (AuthorityStatusReport
 	}
 	markCompactGraph(&report)
 	markMixedCollisions(&report)
-	for _, entry := range report.Entries {
-		if entry.Status == AuthorityStatusInvalid || entry.Status == AuthorityStatusIncomplete || entry.Status == AuthorityStatusReset || entry.Status == AuthorityStatusCollision {
-			report.Complete = false
-		}
-	}
+	// Completeness is a statement about the INVENTORY, not about every entry
+	// in it. A per-entry defect already has a per-entry home: the entry keeps
+	// its own Invalid/Incomplete/Reset/Collision status and its own problems,
+	// which is where an operator with a damaged lineage has to look anyway.
+	//
+	// Folding those per-entry verdicts back into one repository-wide boolean
+	// is what this removes. Every worktree of a repository shares one review
+	// store through the Git common directory, so that boolean turned one
+	// unreadable historical record into "complete review authority inventory
+	// is unavailable or corrupted" for every unrelated candidate, in every
+	// worktree, with no exit (1892, 2014, 2167, 2234, 2270, 2456). Complete
+	// now flips only for problems that really are repository-scope: an
+	// unreadable authority root, a prepared batch reconciliation, an
+	// unexpected entry directly under a version root, an ambiguous lock, or a
+	// version root that cannot be listed at all.
 	sortAuthorityReport(&report)
 	report.Authoritative = report.Complete
 	if len(report.Entries) == 0 && report.Complete {
@@ -214,9 +225,6 @@ func inventoryVersion(ctx context.Context, repo, root, directory string, version
 		}
 		result.entries = append(result.entries, entry)
 		result.locks = append(result.locks, locks...)
-		if entry.Status == AuthorityStatusReset {
-			result.complete = false
-		}
 	}
 	return result
 }
@@ -231,6 +239,17 @@ func inventoryUnexpected(result authorityVersionInventory, path, problem string)
 	result.complete = false
 	result.diagnostics = append(result.diagnostics, AuthorityInventoryDiagnostic{Path: path, Problem: problem})
 	return result
+}
+
+// compactUnreadableEntryProblem states one entry's own failure, the fact that
+// it is one entry's failure, and the read-only diagnosis that names whatever
+// sanctioned exit this particular damage has. No clearing command is guessed
+// here: which one applies depends on what the entry holds, and inspection is
+// the surface that already knows.
+func compactUnreadableEntryProblem(lineage string, cause error) string {
+	return fmt.Sprintf(
+		"%v. Lineage %q alone cannot be read and every other lineage is unaffected; see this entry's own diagnosis and sanctioned exits with `gentle-ai review inspect-authority`",
+		cause, lineage)
 }
 
 func inventoryLineage(ctx context.Context, repo string, version AuthorityVersion, path, lineage string) (AuthorityInventoryEntry, []AuthorityLockEvidence, *AuthorityInventoryDiagnostic) {
@@ -272,7 +291,12 @@ func inventoryLineage(ctx context.Context, repo string, version AuthorityVersion
 			if _, quarantinable := compactLineageQuarantinable(err); quarantinable {
 				return entry, locks, &AuthorityInventoryDiagnostic{Path: path, Problem: "quarantined-terminal-lineage: " + err.Error()}
 			}
-			entry.Status, entry.Problems = AuthorityStatusInvalid, []string{err.Error()}
+			// This entry refuses for itself, and now it has to say how to
+			// leave: it is no longer accompanied by a repository-wide refusal
+			// that somebody else was going to have to diagnose. The exit is
+			// named rather than described, because a refusal whose
+			// continuation is a paraphrase is a dead end with better prose.
+			entry.Status, entry.Problems = AuthorityStatusInvalid, []string{compactUnreadableEntryProblem(lineage, err)}
 			return entry, locks, nil
 		}
 		entry.Revision, entry.State, entry.Recovery = record.Revision, record.State.State, record.State.Recovery

--- a/internal/reviewtransaction/status_test.go
+++ b/internal/reviewtransaction/status_test.go
@@ -44,7 +44,7 @@ func TestInventoryAuthorityReportsActiveMalformedAndMixedCollisionWithoutMutatio
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Schema != ReviewAuthorityStatusSchema || report.Complete {
+	if report.Schema != ReviewAuthorityStatusSchema {
 		t.Fatalf("report header = %#v", report)
 	}
 	if !hasAuthorityInventoryStatus(report.Entries, "active-lineage", AuthorityStatusCollision) ||
@@ -255,7 +255,7 @@ func TestInventoryAuthorityRejectsStructurallyValidReceiptsThatMismatchTerminalA
 			if err != nil {
 				t.Fatal(err)
 			}
-			if report.Complete || report.Authoritative || report.Status != AuthorityStatusInvalid || !hasAuthorityInventoryStatus(report.Entries, fixture.lineage, AuthorityStatusInvalid) {
+			if !hasAuthorityInventoryStatus(report.Entries, fixture.lineage, AuthorityStatusInvalid) {
 				t.Fatalf("mismatched receipt report = %#v", report)
 			}
 		})
@@ -320,11 +320,28 @@ func TestInventoryAuthorityReportsRecoveredSuccessorAndSupersededPredecessor(t *
 	if err := os.WriteFile(filepath.Join(filepath.Dir(store.Dir), successor.LineageID, "review-state.json"), payload, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil {
-		t.Fatal("compact leaves accepted a recovery generation gap")
+	// The generation gap invalidates the SUCCESSOR's edge. The successor stops
+	// being authority and its predecessor stops being superseded by it; the
+	// predecessor itself was never damaged and comes back as the leaf.
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("a recovery generation gap poisoned enumeration: %v", err)
+	}
+	names := map[string]bool{}
+	for _, leaf := range leaves {
+		names[leaf.lineageID] = true
+	}
+	if names[successor.LineageID] {
+		t.Fatalf("the generation-gapped successor was enumerated as authority: %#v", names)
+	}
+	if !names[predecessor.LineageID] {
+		t.Fatalf("the undamaged predecessor was excluded: %#v", names)
+	}
+	if err := CompactAuthorityLineageBlocked(context.Background(), repo, successor.LineageID); err == nil {
+		t.Fatal("compact authority accepted a recovery generation gap")
 	}
 	report, err = InventoryAuthority(context.Background(), repo)
-	if err != nil || report.Complete || report.Authoritative || !hasAuthorityInventoryStatus(report.Entries, successor.LineageID, AuthorityStatusInvalid) ||
+	if err != nil || !hasAuthorityInventoryStatus(report.Entries, successor.LineageID, AuthorityStatusInvalid) ||
 		hasAuthorityInventoryStatus(report.Entries, predecessor.LineageID, AuthorityStatusSuperseded) {
 		t.Fatalf("invalid recovery edge report = %#v, %v", report, err)
 	}
@@ -420,8 +437,7 @@ func TestInventoryAuthorityKeepsPresentButMalformedLegacyReceiptInvalid(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Complete || report.Authoritative || report.Status != AuthorityStatusInvalid ||
-		!hasAuthorityInventoryStatus(report.Entries, "legacy-corrupt-receipt", AuthorityStatusInvalid) {
+	if !hasAuthorityInventoryStatus(report.Entries, "legacy-corrupt-receipt", AuthorityStatusInvalid) {
 		t.Fatalf("malformed present receipt report = %#v", report)
 	}
 }

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -57,26 +57,27 @@ func loadCompactTargetStatusCandidates(ctx context.Context, repo, lineageID stri
 		// storeByLineage (needed unfiltered by the explicit-selector branch
 		// below, including for a caller naming this exact quarantined lineage)
 		// must not be the one used here.
+		//
+		// A record this read cannot decode is left out of the graph entirely.
+		// Status is the surface an operator reaches for when something is
+		// wrong, so it is the last surface that may answer "everything is
+		// unavailable" because one entry is (2234, 2270, 2456).
 		healthyStoreByLineage := make(map[string]CompactStore, len(stores))
 		for _, store := range stores {
 			record, loadErr := store.LoadContext(ctx)
 			if loadErr != nil {
-				// Selector-free enumeration quarantines one TERMINAL lineage that
-				// fails semantic validation instead of poisoning every other
-				// healthy lineage's status (issue-1813). An explicit selector
-				// naming this lineage below still fails closed.
-				if _, quarantinable := compactLineageQuarantinable(loadErr); quarantinable {
-					continue
+				// Only content failures quarantine. Not being able to READ the
+				// store is a different fact from an entry being damaged, and
+				// status has to keep saying so.
+				if compactAuthorityOperationalFailure(loadErr) {
+					return nil, loadErr
 				}
-				return nil, loadErr
+				continue
 			}
 			records[record.State.LineageID] = record
 			healthyStoreByLineage[record.State.LineageID] = store
 		}
-		selected, err = compactAuthorityLeaves(records, healthyStoreByLineage)
-		if err != nil {
-			return nil, err
-		}
+		selected = compactAuthorityLeaves(records, healthyStoreByLineage)
 	} else if store, ok := storeByLineage[lineageID]; ok {
 		// An explicit selector keeps unrelated inventory isolated, while still
 		// validating every recovery edge in the selected lineage's ancestry.
@@ -100,12 +101,12 @@ func loadCompactTargetStatusCandidates(ctx context.Context, repo, lineageID stri
 			}
 			cursor = predecessor
 		}
-		chainStores := make(map[string]CompactStore, len(records))
-		for lineage := range records {
-			chainStores[lineage] = storeByLineage[lineage]
-		}
-		if _, graphErr := compactAuthorityLeaves(records, chainStores); graphErr != nil {
-			return nil, graphErr
+		// The named lineage's OWN ancestry still has to validate completely.
+		// Scoping the refusal is not relaxing it: what changes is whose
+		// business a defect is, never whether a defect is tolerated.
+		violations, _ := compactAuthorityGraphViolations(records)
+		if carrier, cause := compactAuthorityBlockingCause(records, violations, lineageID); cause != nil {
+			return nil, compactBlockedLineageError(lineageID, carrier, cause)
 		}
 	}
 

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -209,6 +209,10 @@ func TestAssessTargetStatusClassifiesAllApplicabilityStates(t *testing.T) {
 		}
 	})
 
+	// Corrupted is a verdict about the lineage under assessment, so it is
+	// reached by naming that lineage. A selector-free assessment over the
+	// same store answers about the live target instead, which is the whole
+	// point: unrelated work is not corrupted because history is.
 	t.Run("corrupted", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
 		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
@@ -216,7 +220,16 @@ func TestAssessTargetStatusClassifiesAllApplicabilityStates(t *testing.T) {
 		if err := os.WriteFile(store.StatePath(), []byte("{\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		got, err := AssessTargetStatus(context.Background(), repo, request)
+		unrelated, err := AssessTargetStatus(context.Background(), repo, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if unrelated.Applicability == TargetApplicabilityCorrupted {
+			t.Fatalf("a corrupt unrelated entry made the live target corrupted: %#v", unrelated)
+		}
+		corruptRequest := request
+		corruptRequest.LineageID = "review-corrupt"
+		got, err := AssessTargetStatus(context.Background(), repo, corruptRequest)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -581,7 +594,7 @@ func TestAssessTargetStatusKeepsExplicitCompactLineageCurrentWithInvalidLegacyIn
 	for _, entry := range report.Entries {
 		invalidLegacyEvidence = invalidLegacyEvidence || entry.LineageID == legacyLineage && entry.Status == AuthorityStatusInvalid && len(entry.Problems) > 0
 	}
-	if report.Complete || report.Authoritative || !invalidLegacyEvidence {
+	if !invalidLegacyEvidence {
 		t.Fatalf("invalid legacy inventory diagnostics = %#v", report)
 	}
 	if after := authorityBytes(t, authorityRoot); !reflect.DeepEqual(before, after) {
@@ -1377,13 +1390,25 @@ func TestAssessTargetStatusStillCorruptsMalformedAuthorityGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := AssessTargetStatus(context.Background(), repo, targetStatusCurrentChangesRequest())
+	// The successor whose predecessor is gone is the entry that is corrupted,
+	// and naming it says so. The live target inherits nothing from it and is
+	// assessed on its own terms.
+	scoped := targetStatusCurrentChangesRequest()
+	scoped.LineageID = successor.LineageID
+	got, err := AssessTargetStatus(context.Background(), repo, scoped)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Applicability != TargetApplicabilityCorrupted || got.Action != TargetStatusActionRepairAuthority ||
 		got.Replayability != ReplayabilityManualActionRequired {
 		t.Fatalf("malformed graph status = %#v", got)
+	}
+	unrelated, err := AssessTargetStatus(context.Background(), repo, targetStatusCurrentChangesRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unrelated.Applicability == TargetApplicabilityCorrupted {
+		t.Fatalf("a dangling successor made the live target corrupted: %#v", unrelated)
 	}
 }
 


### PR DESCRIPTION
One unreadable authority entry failed the whole per-repository inventory closed, across every worktree sharing the Git common dir. #2399 measured the blast radius: one historical `risk_source` field on a record whose stored revision still verified against its own bytes made **157 entries** unusable.

## Two subtractions, both at the source

Placed in `internal/reviewtransaction/` so the facade files inherit the fix without edits.

**The inventory stops being a single atomic object.** `compactAuthorityLeaves` computed violations over the whole record set and returned the first one as a verdict on all of it. It now excludes only the defective lineages, plus those whose recovery ancestry inherits through one. The `map[lineage]error` it needed **already existed**; what went away is the collapse to a single error.

An unreadable record is no longer an error at all: it is simply absent from the graph, and absence already had a meaning the graph knew, since a successor naming it dangles and self-excludes. `InventoryAuthority` stops folding per-entry truth back into one repository-wide verdict; `markCompactGraph` already computed that truth and the loop destroying it is deleted.

**No `quarantined` state was added.** That was the smell to avoid and it was avoided.

**Validation is scoped to the lineage under operation.** The gate asked whether the whole repository's graph validated; it now asks about the lineage in the receipt.

Net production code, comments excluded: `compact_store.go` +107/-45, `status.go` +7/-9, `target_status_projection.go` +7/-13, `compact_gate.go` +2/-2, `final_verification_retry.go` +9/-3. The additions are the ancestry walk replacing a repository-wide sweep; the deletions are every place that returned a global verdict.

For #2399, `risk_source` joins the existing retired-field allowlist. One line. The read-only compat path already verified the stored revision against the original bytes and marked the record mutation-denied, so no new machinery.

## A correction to the brief, checked rather than assumed

**The #2270 ordering I was given does not hold.** `RunReviewFacadeValidate` already consults the kill switch at `review_facade.go:3134`, before any authority read. The first version of the kill-switch test **passed on unmodified main**.

The surface that actually blocks is `review status --contract --next-transition`, which calls `AssessTargetStatusWithSnapshot` and **never consults the kill switch at all**. The test was strengthened to drive that, which is where the RED came from. The conclusion in the issue is right; the mechanism is one surface over.

With the damage scoped, status answers about the candidate whether reviews are on or off, so no kill-switch consultation needed adding to a file this branch could not touch.

## RED

```
compact_lineage_scoped_authority_test.go:87: one unreadable record poisoned leaf enumeration:
  invalid compact authority graph: unexpected EOF
compact_lineage_scoped_authority_test.go:123: one unreadable record made the whole repository
  non-authoritative: complete=false authoritative=false status=invalid
compact_lineage_scoped_authority_test.go:171: the unreadable entry names no runnable exit

--- FAIL: TestDisabledDeliveryIsNeverBlockedByADamagedAuthorityEntry/forged_recovery_binding
    a damaged entry made an unrelated target report corrupted authority while reviews were off:
      "applicability": "corrupted"
```

## Corpus, and an honest regression

Core suite identical before and after, which is correct: it never constructs a damaged store.

Damaged-store axis, 71 completed and 0 failed on both sides:

| | blocks | out_of_band | dead_end | stderr |
|---|---|---|---|---|
| before | 45 | 41 | 31 | 31334 B |
| after | **42** | **38** | **28** | **25190 B** |

**ds12 genuinely regressed** and is reported rather than smoothed over: the negotiated route stopped offering the disposition repair because the live candidate is no longer classified corrupted. It is reachable again by naming the damaged lineage explicitly, which is the scoping principle applied to itself, and ds12 passes that way.

Two axis fixtures needed retargeting, and both were treated as findings. Every fixture had proved its premise by asserting the **whole store** non-authoritative, so 18 journeys failed at fixture time until that assertion moved to the surface that owns per-entry truth. `proveStoreRecovered` gained the assertion the old premise had been carrying for it, since a store staying authoritative is no longer evidence an exit ran.

## Issue disposition

Closed with evidence: **#2399**, **#2270**, **#2167**, **#1892** (bench ds04 and ds13 go 1 block to 0), **#2234** for a per-entry cause, **#2014** blocking half, **#1928** via its named dependency.

Explicitly **not** closed, each with a reason rather than a guess. #2241's exact envelope has no source in current main, so the class is addressed but the closure is not claimed. #2086's reporter had a provably healthy inventory, 18 of 18 loaded and 0 diagnostics, so nothing here applies. #1265 is a mixed-lineage judgement, not an unrelated-entry verdict. #1529, #1530, #1688 and #1799 are four distinct roots. #2456 is probably fixed for its v2 half, but `graph-v1` does not exist anywhere in this codebase, so the other half cannot be reproduced and the reporter should re-test.

## Verification

Root `go test ./... -count=1` exit 0, bench module clean, gofmt and vet clean on both modules, deadcode ratchet reports no new unreachable functions, refusal ratchet green.

## Known

Legacy v1 is not scoped: one broken legacy chain still poisons selector-free target status. Same root, deliberately out of scope, and the existing test still proves the old behavior there.

A documented tradeoff in `CompactLineageSuperseded`: a lineage whose only successor becomes unreadable stops reporting as superseded, so its own approved receipt can govern its own reviewed content again. The alternative was one unreadable entry making supersession unknowable repository-wide, which is the exact refusal being removed. Reasoning is in the function doc.

Explicit `review start --lineage <forged successor>` resumes it, because that branch returns before the graph scan. Pre-existing, not a regression, and contained: finalizing still hits the lineage-scoped block at the gate.

Closes #2399
Closes #2270
Closes #2167
Closes #1892

Part of #2471
