### PR TITLE
fix(review): name the cause instead of collapsing it into one string

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -478,7 +478,7 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 		`"--repository-context", binding.repository_context`,
 		`"--expected-revision", binding.revision`,
 		`return ["--cwd", cwd]`,
-		`const current = fields === "lens,lineage,order,repository_context,revision,subject_hash,target"`,
+		`["lens,lineage,order,repository_context,revision,subject_hash,target", { revision: true, subjectHash: true }]`,
 		`typeof subject.subject_hash !== "string"`,
 		`subject.subject_hash !== binding.subject_hash`,
 		`artifact_subject`,
@@ -491,13 +491,15 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 		`"--order", String(binding.order)`,
 		`"--input", "-"`,
 		`"--preflight"`,
-		`GENTLE_AI_REVIEW_CWD`,
 		`"tool.execute.before"`,
 		`output.args.background === true`,
 		`!BINDING.test(input.args.prompt)`,
 		`const lens = input.args.subagent_type`,
 		`const binding = parseBinding(input.args.prompt, lens)`,
-		`const cwd = captureCwd(worktree, directory)`,
+		// The OpenCode anchor is the sole source of the capture working
+		// directory. The GENTLE_AI_REVIEW_CWD override that used to outrank it,
+		// with no check that it named the same repository, is deleted (#2446).
+		`const cwd = worktree || directory`,
 		// The replayable payload is extracted exactly once before capture, so a
 		// capture failure preserves the extracted strict JSON, never the task
 		// envelope that `review capture-result --input` would reject on replay.

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -54,6 +54,55 @@ interface ReviewCapturePreflight {
   changed_path_manifest: ChangedPathManifestEntry[]
 }
 
+const LINEAGE_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const SHA256_TOKEN = /^sha256:[a-f0-9]{64}$/
+const REPOSITORY_CONTEXT_HANDLE = /^rctx1_[a-f0-9]{64}$/
+const LENS_TOKEN = /^[a-z][a-z0-9-]{0,63}$/
+
+// BINDING_SHAPES are the four field sets the native transitions emit, mapped to
+// which optional fields that shape then requires. Keeping the shape explicit is
+// what lets a rejection say WHICH set arrived and which ones exist, instead of
+// "does not match the selected lens".
+const BINDING_SHAPES = new Map<string, { revision: boolean, subjectHash: boolean }>([
+  ["lens,lineage,order,target", { revision: false, subjectHash: false }],
+  ["lens,lineage,order,subject_hash,target", { revision: false, subjectHash: true }],
+  ["lens,lineage,order,repository_context,revision,target", { revision: true, subjectHash: false }],
+  ["lens,lineage,order,repository_context,revision,subject_hash,target", { revision: true, subjectHash: true }],
+])
+
+const BINDING_REBUILD =
+  "rebuild the prompt prefix from the exact fields of the provider-returned transition " +
+  "(gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --next-transition)"
+
+// observedValue describes what arrived without echoing it. The binding is
+// authored by a model, so its values are untrusted text that must not be
+// pasted into the transcript; the type, and for strings the length, is what
+// distinguishes the reported causes (a quoted number, a truncated digest, an
+// absent field) from each other.
+function observedValue(value: unknown): string {
+  if (value === undefined) return "no value"
+  if (value === null) return "null"
+  if (Array.isArray(value)) return `an array of length ${value.length}`
+  if (typeof value === "string") return `a string of length ${value.length}`
+  if (typeof value === "number") return Number.isSafeInteger(value) ? `the integer ${value}` : `the number ${value}`
+  return `a ${typeof value}`
+}
+
+function bindingRefusal(field: string, requirement: string, value: unknown): Error {
+  return new Error(
+    `review task binding field "${field}" ${requirement}; received ${observedValue(value)}; ${BINDING_REBUILD}`,
+  )
+}
+
+// parseBinding rejects one field at a time and names it.
+//
+// It used to evaluate thirteen conditions in a single boolean OR and throw one
+// sentence, "review task binding does not match the selected lens", for every
+// one of them (#2442). #2461 reported all four lenses rejected with exactly
+// that sentence while the real cause was an unexpected field set. A refusal
+// that forces the reader to open the validator's source is a dead end with
+// extra steps, so each check below states the field, the expected shape, a
+// redacted observation of what arrived, and the executable next step.
 function parseBinding(prompt: unknown, lens: string): ReviewBinding {
   const match = BINDING.exec(typeof prompt === "string" ? prompt : "")
   if (!match) throw new Error("review task is missing GENTLE_AI_REVIEW_BINDING")
@@ -69,18 +118,44 @@ function parseBinding(prompt: unknown, lens: string): ReviewBinding {
   }
   const value = binding as Record<string, unknown>
   const fields = Object.keys(value).sort().join(",")
-  const legacy = fields === "lens,lineage,order,target"
-  const legacyBound = fields === "lens,lineage,order,subject_hash,target"
-  const priorCurrent = fields === "lens,lineage,order,repository_context,revision,target"
-  const current = fields === "lens,lineage,order,repository_context,revision,subject_hash,target"
-  if ((!legacy && !legacyBound && !priorCurrent && !current) ||
-      typeof value.lineage !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value.lineage) ||
-      typeof value.target !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value.target) ||
-      ((priorCurrent || current) && (typeof value.revision !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value.revision) ||
-        typeof value.repository_context !== "string" || !/^rctx1_[a-f0-9]{64}$/.test(value.repository_context))) ||
-      ((legacyBound || current) && (typeof value.subject_hash !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value.subject_hash))) ||
-      value.lens !== lens || !Number.isSafeInteger(value.order) || (value.order as number) < 0) {
-    throw new Error("review task binding does not match the selected lens")
+  const shape = BINDING_SHAPES.get(fields)
+  if (!shape) {
+    throw new Error(
+      `review task binding has an unexpected field set; received {${scrubText(fields)}}; ` +
+      `expected exactly one of ${[...BINDING_SHAPES.keys()].map((set) => `{${set}}`).join(", ")}; ` +
+      `${BINDING_REBUILD}`,
+    )
+  }
+  if (typeof value.lineage !== "string" || !LINEAGE_ID.test(value.lineage)) {
+    throw bindingRefusal("lineage", "must be a lowercase hyphen-separated identifier", value.lineage)
+  }
+  if (typeof value.target !== "string" || !SHA256_TOKEN.test(value.target)) {
+    throw bindingRefusal("target", "must be sha256: followed by 64 lowercase hex characters", value.target)
+  }
+  if (shape.revision) {
+    if (typeof value.revision !== "string" || !SHA256_TOKEN.test(value.revision)) {
+      throw bindingRefusal("revision", "must be sha256: followed by 64 lowercase hex characters", value.revision)
+    }
+    if (typeof value.repository_context !== "string" || !REPOSITORY_CONTEXT_HANDLE.test(value.repository_context)) {
+      throw bindingRefusal("repository_context", "must be rctx1_ followed by 64 lowercase hex characters", value.repository_context)
+    }
+  }
+  if (shape.subjectHash && (typeof value.subject_hash !== "string" || !SHA256_TOKEN.test(value.subject_hash))) {
+    throw bindingRefusal("subject_hash", "must be sha256: followed by 64 lowercase hex characters", value.subject_hash)
+  }
+  if (value.lens !== lens) {
+    const received = typeof value.lens === "string" && LENS_TOKEN.test(value.lens)
+      ? `"${value.lens}"`
+      : observedValue(value.lens)
+    throw new Error(
+      `review task binding field "lens" must equal the launched lens "${lens}"; received ${received}; ${BINDING_REBUILD}`,
+    )
+  }
+  if (!Number.isSafeInteger(value.order)) {
+    throw bindingRefusal("order", "must be a JSON number, not a quoted string, and a safe integer", value.order)
+  }
+  if ((value.order as number) < 0) {
+    throw bindingRefusal("order", "must be zero or greater", value.order)
   }
   return value as ReviewBinding
 }
@@ -105,12 +180,6 @@ function reviewerResult(output: unknown): string {
 function extractionClass(cause: unknown): string | undefined {
   const value = (cause as { reviewClass?: unknown } | null)?.reviewClass
   return typeof value === "string" ? value : undefined
-}
-
-function captureCwd(worktree: string | undefined, directory: string): string {
-  const override = process.env["GENTLE_AI_REVIEW_CWD"]
-  if (typeof override === "string" && override.trim() !== "") return override.trim()
-  return worktree || directory
 }
 
 function runNative(cwd: string, args: string[], stdin: string): Promise<string> {
@@ -194,8 +263,10 @@ async function preflightCapture(cwd: string, binding: ReviewBinding): Promise<Re
       ? GIT_TRUST_REFUSAL_RECOVERY
       : binding.repository_context
       ? `Refresh the exact native next_transition for lineage ${binding.lineage} before relaunching the lens.`
-      : `If lineage ${binding.lineage} was started in a different repository (for example a nested one), ` +
-        `set GENTLE_AI_REVIEW_CWD to that repository and relaunch the lens.`
+      : `If lineage ${binding.lineage} was started in a different repository (for example a nested one), run ` +
+        `gentle-ai review status --cwd <that repository> --contract gentle-ai.review-integration/v2 --next-transition ` +
+        `and relaunch the lens from the binding it returns: that binding carries a provider-issued repository ` +
+        `context, which resolves independently of this session's working directory.`
     throw new Error(
       `review capture preflight failed for lens ${binding.lens} under ${scope}: ` +
       `${sessionErrorMessage(binding, cause, "repository_context_preflight_failed")}. ` +
@@ -249,6 +320,33 @@ function preserveResult(cwd: string, binding: ReviewBinding, raw: string, cls?: 
 
 function errorMessage(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause)
+}
+
+// The privacy gate a forwarded cause passes through. It mirrors
+// reviewScrubDefectReportField in internal/cli/review_defect_report.go field
+// for field -- same three patterns, same marker, same first-line-only rule --
+// because the plugin cannot call into Go and the two surfaces must redact the
+// same things. The native side scrubs what it forwards; this scrubs what the
+// native side did not author, such as an OS-level spawn failure.
+const REDACTION_MARKER = "<redacted>"
+const ENV_ASSIGNMENT = /\b[A-Z][A-Z0-9_]{2,}=\S+/g
+const EMAIL_ADDRESS = /[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g
+const ABSOLUTE_PATH = /(?:[A-Za-z]:)?[\\/][^\s"'`]+/g
+// Bounds a cause bound for a session transcript. Native failures can quote
+// reviewer payload fragments, so this is a limit, not a formatting preference.
+const CAUSE_LIMIT = 512
+
+function scrubText(value: string): string {
+  const scrubbed = value.split("\n", 1)[0]
+    .replace(ENV_ASSIGNMENT, REDACTION_MARKER)
+    .replace(EMAIL_ADDRESS, REDACTION_MARKER)
+    .replace(ABSOLUTE_PATH, REDACTION_MARKER)
+    .trim()
+  return scrubbed.length > CAUSE_LIMIT ? `${scrubbed.slice(0, CAUSE_LIMIT)} (truncated)` : scrubbed
+}
+
+function scrubbedCause(cause: unknown): string {
+  return scrubText(errorMessage(cause))
 }
 
 // GIT_TRUST_REFUSAL_CODE is the typed, path-free code the native CLI emits
@@ -373,8 +471,17 @@ function claimAdmissionRecovery(store: AdmissionRecoveryStore, sessionID: string
   return ADMISSION_RECOVERY_STATUS.RELAUNCH
 }
 
+// sessionErrorMessage renders one native failure for the session transcript.
+//
+// It used to answer every opaque-binding failure that was neither a Git trust
+// refusal nor a structured admission rejection with one constant sentence, so a
+// strict-decode rejection (#2227), an unreachable authority (#2461) and a
+// failed durable publish (#2411) all arrived identically. The rule that no
+// unscrubbed native text reaches a transcript stays; what changes is that
+// dropping the cause is no longer how that rule is kept. Everything now takes
+// the same path -- scrub, then report -- so there is no branch left in which a
+// cause can be silently discarded.
 function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: string, recovery?: AdmissionRecoveryContext): string {
-  if (!binding.repository_context) return errorMessage(cause)
   if (gitTrustRefusal(binding, cause)) return GIT_TRUST_REFUSAL_MESSAGE
   const admission = admissionRejection(cause)
   if (admission) {
@@ -400,7 +507,9 @@ function sessionErrorMessage(binding: ReviewBinding, cause: unknown, code: strin
     return `${code}: native admission rejected the reviewer result as ${admission.decision}${detail}; ` +
       `retrying capture with the same result cannot succeed${correction}; relaunch this lens reviewer exactly once to produce a corrected result`
   }
-  return `${code}: provider-owned review operation failed; refresh the exact native next_transition or retry the same opaque binding`
+  const scrubbed = scrubbedCause(cause)
+  return `${code}: provider-owned review operation failed${scrubbed === "" ? "" : `; cause: ${scrubbed}`}; ` +
+    "refresh the exact native next_transition or retry the same binding"
 }
 
 function preservedReference(manifest: string): string {
@@ -475,7 +584,16 @@ const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => {
     if (typeof input.args.prompt !== "string" || !BINDING.test(input.args.prompt)) return
     const lens = input.args.subagent_type
     const binding = parseBinding(input.args.prompt, lens)
-    const cwd = captureCwd(worktree, directory)
+    // The OpenCode anchor is the only source of the capture working directory.
+    // A GENTLE_AI_REVIEW_CWD override used to win over it with no check that it
+    // named the same repository, so a value left behind by an earlier session
+    // silently redirected every capture into an unrelated checkout and stranded
+    // every lens result as a preserved incident there (#2446). It is deleted
+    // rather than validated: an opaque binding resolves its repository from the
+    // provider-issued handle and never needed it, and a legacy binding is
+    // recovered by refreshing the transition, which the preflight refusal now
+    // names.
+    const cwd = worktree || directory
     const recovery = { sessionID: input.sessionID, store: admissionRecoveries }
     // Extract the replayable payload exactly once, BEFORE capture: recovery
     // re-runs `review capture-result --input <preserved file>`, whose strict

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -33,6 +33,17 @@ if (scenario === "before-substitute") prompt += ` + "`" + `base_tree=${"9".repea
 if (scenario === "before-missing") prompt = "review the frozen candidate\n"
 if (scenario === "before-equals") prompt = ` + "`" + `GENTLE_AI_REVIEW_BINDING=${JSON.stringify(binding)}\nreview the frozen candidate\n` + "`" + `
 if (scenario === "before-malformed") prompt = "GENTLE_AI_REVIEW_BINDING {not-json}\nreview the frozen candidate\n"
+const rebind = (overrides: Record<string, unknown>, drop: string[] = []) => {
+  const next: Record<string, unknown> = { ...opaque, ...overrides }
+  for (const field of drop) delete next[field]
+  return ` + "`" + `GENTLE_AI_REVIEW_BINDING ${JSON.stringify(next)}\nreview the frozen candidate\n` + "`" + `
+}
+if (scenario === "before-quoted-order") prompt = rebind({ order: "0" })
+if (scenario === "before-negative-order") prompt = rebind({ order: -1 })
+if (scenario === "before-unknown-shape") prompt = rebind({}, ["repository_context"])
+if (scenario === "before-short-target") prompt = rebind({ target: "sha256:dead" })
+if (scenario === "before-other-lens") prompt = rebind({ lens: "review-reliability" })
+if (scenario === "before-bad-context") prompt = rebind({ repository_context: "/home/someone/private/repo" })
 
 const capture = async (activeHooks: typeof hooks, sessionID: string, marker: string, boundPrompt: string = prompt) => {
   const input = { tool: "task", sessionID, callID: "call-" + marker, args: { subagent_type: "review-risk", prompt: boundPrompt } }
@@ -119,6 +130,14 @@ func runReviewPluginScenarioWithNative(t *testing.T, scenario, nativeStdout, nat
 
 func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, nativeStdout, nativeStderr, preserveStdout string) string {
 	t.Helper()
+	return runReviewPluginScenarioWithEnv(t, scenario, nativeStdout, nativeStderr, preserveStdout)
+}
+
+// runReviewPluginScenarioWithEnv is the same harness with extra environment
+// entries, so a scenario can prove what the plugin does with a hostile ambient
+// environment rather than only with a hostile native binary.
+func runReviewPluginScenarioWithEnv(t *testing.T, scenario, nativeStdout, nativeStderr, preserveStdout string, extraEnv ...string) string {
+	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub native binary requires a POSIX shell")
 	}
@@ -139,6 +158,7 @@ func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, na
 		}
 	}
 	stub := "#!/bin/sh\npayload=$(cat)\n" +
+		"if [ -n \"$GENTLE_AI_STUB_CWD_LOG\" ]; then printf '%s\\n' \"$PWD\" >> \"$GENTLE_AI_STUB_CWD_LOG\"; fi\n" +
 		"if [ \"$2\" = \"capture-result\" ]; then case \"$payload\" in *capture-success*) printf '%s\\n' 'CAPTURED'; exit 0;; esac; fi\n" +
 		"if [ \"$2\" = \"preserve-result\" ] && [ -n \"$GENTLE_AI_STUB_PRESERVE_STDOUT\" ]; then printf '%s\\n' \"$GENTLE_AI_STUB_PRESERVE_STDOUT\"; exit 0; fi\n" +
 		"if [ -n \"$GENTLE_AI_STUB_STDOUT\" ]; then printf '%s\\n' \"$GENTLE_AI_STUB_STDOUT\"; exit 0; fi\n" +
@@ -154,13 +174,14 @@ func runReviewPluginScenarioWithNativeAndPreservation(t *testing.T, scenario, na
 	}
 	command := exec.Command(node, "harness.mts", scenario, workDir)
 	command.Dir = root
-	command.Env = append(os.Environ(),
+	command.Env = append(append(os.Environ(),
 		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GENTLE_AI_STUB_STDOUT="+nativeStdout,
 		"GENTLE_AI_STUB_STDERR="+nativeStderr,
 		"GENTLE_AI_STUB_PRESERVE_STDOUT="+preserveStdout,
 		"GENTLE_AI_REVIEW_CWD=",
-	)
+		"GENTLE_AI_STUB_CWD_LOG=",
+	), extraEnv...)
 	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Skipf("node could not run the TypeScript plugin harness (%v): %s", err, output)
@@ -267,7 +288,7 @@ func TestReviewPluginTerminatesUnstructuredAdmissionRejection(t *testing.T) {
 	if !strings.Contains(message, "reviewer_admission_recovery_unavailable") || !strings.Contains(message, "stop relaunching") {
 		t.Fatalf("unstructured admission rejection was not terminal: %s", message)
 	}
-	if strings.Contains(message, "relaunch this lens reviewer") || strings.Contains(message, "retry the same opaque binding") {
+	if strings.Contains(message, "relaunch this lens reviewer") || strings.Contains(message, "retry the same binding") {
 		t.Fatalf("unstructured admission rejection authorized a blind retry: %s", message)
 	}
 	if strings.Contains(message, "severe findings must anchor") {

--- a/internal/assets/review_plugin_typed_cause_test.go
+++ b/internal/assets/review_plugin_typed_cause_test.go
@@ -1,0 +1,196 @@
+package assets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The plugin half of the same defect. sessionErrorMessage answered every
+// opaque-binding failure that was neither a Git trust refusal nor a structured
+// admission rejection with one constant sentence, so a strict-decode rejection
+// (#2227), an unreachable authority (#2461) and a failed durable publish
+// (#2411) all reached the transcript identically. These tests drive genuinely
+// different native failures through the one collapse point and require the
+// outputs to differ, which a "message contains substring" assertion cannot do.
+
+// TestReviewPluginNamesDistinctNativeCauses is the two-distinct-causes proof.
+func TestReviewPluginNamesDistinctNativeCauses(t *testing.T) {
+	cases := []struct {
+		name   string
+		native string
+		want   string
+	}{
+		{
+			name:   "strict-decode-rejection",
+			native: `Error: decode reviewer result: json: unknown field "inspection_note"`,
+			want:   `unknown field "inspection_note"`,
+		},
+		{
+			name: "durable-publish-refusal",
+			native: "Error: repository_context_capture_failed: provider-issued review repository context operation failed; " +
+				"cause: publish reviewer result atomically: operation not supported; retry capture-result with the same exact binding or refresh status",
+			want: "operation not supported",
+		},
+	}
+	messages := make(map[string]string, len(cases))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			message := runReviewPluginScenario(t, "after-opaque", tt.native)
+			if message == "NO_ERROR" {
+				t.Fatal("plugin did not fail despite an always-failing native binary")
+			}
+			if !strings.Contains(message, "repository_context_capture_failed") {
+				t.Fatalf("failure lost its typed code: %s", message)
+			}
+			if !strings.Contains(message, tt.want) {
+				t.Fatalf("failure does not name its own cause %q: %s", tt.want, message)
+			}
+			messages[tt.name] = message
+		})
+	}
+	if len(messages) != len(cases) {
+		t.Fatalf("both roots must reach the collapse point; captured %d", len(messages))
+	}
+	if messages["strict-decode-rejection"] == messages["durable-publish-refusal"] {
+		t.Fatalf("two genuinely different native failures collapsed into one message: %s", messages["strict-decode-rejection"])
+	}
+}
+
+// TestReviewPluginScrubsForwardedNativeCause is the other half: forwarding a
+// cause must not become a path leak. The absolute path must be gone and the
+// cause must still be there. Dropping both would also make the path absent,
+// which is why the second assertion exists.
+func TestReviewPluginScrubsForwardedNativeCause(t *testing.T) {
+	const private = "/home/someone/private/repo/.git/gentle-ai/review-transactions/v2/lineage/review-state.json"
+	native := "Error: load compact facade review lineage: open " + private + " no such file or directory"
+
+	message := runReviewPluginScenario(t, "after-opaque", native)
+	if message == "NO_ERROR" {
+		t.Fatal("plugin did not fail despite an always-failing native binary")
+	}
+	if strings.Contains(message, private) || strings.Contains(message, "/home/someone") {
+		t.Fatalf("forwarded native cause leaked an absolute path: %s", message)
+	}
+	if !strings.Contains(message, "load compact facade review lineage") {
+		t.Fatalf("scrubbing removed the cause along with the path: %s", message)
+	}
+	if !strings.Contains(message, "<redacted>") {
+		t.Fatalf("the leaked path was dropped rather than redacted: %s", message)
+	}
+}
+
+// TestReviewPluginNamesRejectedBindingField covers #2442 and #2461: thirteen
+// conditions used to share the sentence "review task binding does not match the
+// selected lens", which names none of them. #2461 reported all four lenses
+// rejected with exactly that sentence.
+func TestReviewPluginNamesRejectedBindingField(t *testing.T) {
+	cases := []struct {
+		name     string
+		scenario string
+		want     []string
+		reject   []string
+	}{
+		{
+			name:     "quoted-order",
+			scenario: "before-quoted-order",
+			want:     []string{`field "order"`, "not a quoted string", "a string of length 1"},
+		},
+		{
+			name:     "negative-order",
+			scenario: "before-negative-order",
+			want:     []string{`field "order"`, "zero or greater", "the integer -1"},
+		},
+		{
+			name:     "unexpected-field-set",
+			scenario: "before-unknown-shape",
+			want:     []string{"unexpected field set", "lens,lineage,order,revision,subject_hash,target", "expected exactly one of"},
+		},
+		{
+			name:     "short-target",
+			scenario: "before-short-target",
+			want:     []string{`field "target"`, "64 lowercase hex", "a string of length 11"},
+		},
+		{
+			name:     "wrong-lens",
+			scenario: "before-other-lens",
+			want:     []string{`field "lens"`, `must equal the launched lens "review-risk"`, `received "review-reliability"`},
+		},
+		{
+			name:     "path-shaped-context",
+			scenario: "before-bad-context",
+			want:     []string{`field "repository_context"`, "rctx1_"},
+			reject:   []string{"/home/someone/private/repo"},
+		},
+	}
+	messages := make(map[string]string, len(cases))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			message := runReviewPluginScenario(t, tt.scenario, "NATIVE-PROCESS-MUST-NOT-RUN")
+			if message == "NO_ERROR" {
+				t.Fatal("plugin accepted a binding it must reject")
+			}
+			if message == "review task binding does not match the selected lens" {
+				t.Fatal("binding refusal still names no field")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(message, want) {
+					t.Fatalf("binding refusal does not contain %q: %s", want, message)
+				}
+			}
+			for _, reject := range tt.reject {
+				if strings.Contains(message, reject) {
+					t.Fatalf("binding refusal echoed untrusted content %q: %s", reject, message)
+				}
+			}
+			if !strings.Contains(message, "gentle-ai review status") {
+				t.Fatalf("binding refusal names no executable continuation: %s", message)
+			}
+			messages[tt.name] = message
+		})
+	}
+	seen := make(map[string]string, len(messages))
+	for name, message := range messages {
+		if other, collapsed := seen[message]; collapsed {
+			t.Fatalf("binding causes %q and %q collapsed into one message: %s", other, name, message)
+		}
+		seen[message] = name
+	}
+	if len(messages) != len(cases) {
+		t.Fatalf("every binding cause must produce its own refusal; captured %d of %d", len(messages), len(cases))
+	}
+}
+
+// TestReviewPluginIgnoresStaleReviewCwdOverride covers #2446. A
+// GENTLE_AI_REVIEW_CWD value left behind by an earlier session used to outrank
+// the OpenCode anchor with no check that it named the same repository, so
+// capture silently ran against an unrelated checkout and stranded every lens
+// result there. The override is deleted, so the only observable working
+// directory is the anchor.
+func TestReviewPluginIgnoresStaleReviewCwdOverride(t *testing.T) {
+	foreign := t.TempDir()
+	log := filepath.Join(t.TempDir(), "native-cwd.log")
+
+	message := runReviewPluginScenarioWithEnv(t, "after-opaque", "", "resolve failed", "",
+		"GENTLE_AI_REVIEW_CWD="+foreign, "GENTLE_AI_STUB_CWD_LOG="+log)
+	if message == "NO_ERROR" {
+		t.Fatal("plugin did not fail despite an always-failing native binary")
+	}
+	recorded, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("the native binary was never invoked, so the working directory is unproven: %v", err)
+	}
+	directories := strings.Fields(strings.TrimSpace(string(recorded)))
+	if len(directories) == 0 {
+		t.Fatal("the native binary recorded no working directory")
+	}
+	for _, directory := range directories {
+		if directory == foreign {
+			t.Fatalf("a stale GENTLE_AI_REVIEW_CWD redirected capture to an unrelated repository: %q", directory)
+		}
+		if filepath.Base(directory) != "work" {
+			t.Fatalf("capture ran outside the OpenCode anchor: %q", directory)
+		}
+	}
+}

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -290,7 +290,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	}
 	if err != nil {
 		if contextHandle != "" {
-			return reviewOpaqueContextFailure("repository_context_authority_unavailable", "refresh the exact native next_transition before retrying")
+			return reviewOpaqueContextCause("repository_context_authority_unavailable", "refresh the exact native next_transition before retrying", err)
 		}
 		return reviewPreflightError(fmt.Errorf("resolve reviewing authority for lineage %q under %s: %w; if the review was started in a different repository (for example a nested one), re-run with --cwd set to that repository", *lineage, repositoryDescription, err))
 	}
@@ -408,14 +408,15 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 			err = fmt.Errorf("%w; a different reviewer result already occupies this slot — decide with `review dispose-result` (discard it) or `review preserve-result` (keep it and quarantine this new submission)", reviewerResultSlotConflictError)
 		}
 		if contextHandle != "" {
-			return reviewOpaqueContextFailure("repository_context_capture_failed", "retry capture-result with the same exact binding or refresh status")
+			return reviewOpaqueContextCause("repository_context_capture_failed", "retry capture-result with the same exact binding or refresh status", err)
 		}
 		return reviewPreflightError(err)
 	}
 	published, _, err := readPrivateReviewerFile(path, reviewResultArtifactLimit)
 	if err != nil {
 		if contextHandle != "" {
-			return reviewOpaqueContextFailure("repository_context_capture_failed", "retry capture-result with the same exact binding or refresh status")
+			return reviewOpaqueContextCause("repository_context_capture_failed", "retry capture-result with the same exact binding or refresh status",
+				fmt.Errorf("read published reviewer result: %w", err))
 		}
 		return reviewPreflightError(fmt.Errorf("read published reviewer result: %w", err))
 	}

--- a/internal/cli/review_incident.go
+++ b/internal/cli/review_incident.go
@@ -60,14 +60,78 @@ type reviewIncidentArtifact struct {
 type reviewOpaqueContextOperationError struct {
 	Code   string
 	Action string
+	// Cause is the scrubbed one-line reason this operation failed, empty when
+	// the code alone already identifies the failure exactly (a Git trust
+	// refusal, for example, has exactly one cause).
+	Cause string
 }
 
 func (err *reviewOpaqueContextOperationError) Error() string {
-	return fmt.Sprintf("%s: provider-issued review repository context operation failed; %s", err.Code, err.Action)
+	if err.Cause == "" {
+		return fmt.Sprintf("%s: provider-issued review repository context operation failed; %s", err.Code, err.Action)
+	}
+	return fmt.Sprintf("%s: provider-issued review repository context operation failed; cause: %s; %s", err.Code, err.Cause, err.Action)
 }
 
 func reviewOpaqueContextFailure(code, action string) error {
 	return reviewPreflightError(&reviewOpaqueContextOperationError{Code: code, Action: action})
+}
+
+// reviewOpaqueContextCause reports the same typed code and instruction as
+// reviewOpaqueContextFailure and additionally names the scrubbed cause.
+//
+// Why this exists: the opaque path used to answer every distinct failure behind
+// one code with one constant sentence, so a missing authority record, an
+// unparsable one, a Git setup refusal, and a stale binding all reached the
+// reporter as the same string. That is the mechanism behind community reports
+// #2227, #2411 and #2461: different roots, one message, and no way for the
+// reporter or the maintainer to tell them apart. The opacity itself is not
+// the defect -- an absolute path must never reach a session transcript -- so
+// the cause is forwarded through the SAME privacy gate the defect reporter
+// already uses (reviewScrubDefectReportField) rather than dropped.
+func reviewOpaqueContextCause(code, action string, cause error) error {
+	return reviewPreflightError(&reviewOpaqueContextOperationError{
+		Code: code, Action: action, Cause: reviewScrubOpaqueContextCause(cause),
+	})
+}
+
+// reviewOpaqueContextCauseLimit bounds a forwarded cause. Native errors can
+// quote reviewer payload fragments, and the destination is a session
+// transcript, not a log file.
+const reviewOpaqueContextCauseLimit = 512
+
+func reviewScrubOpaqueContextCause(cause error) string {
+	scrubbed := reviewScrubDefectReportField(reviewOpaqueContextCauseChain(cause))
+	if runes := []rune(scrubbed); len(runes) > reviewOpaqueContextCauseLimit {
+		return string(runes[:reviewOpaqueContextCauseLimit]) + " (truncated)"
+	}
+	return scrubbed
+}
+
+// reviewOpaqueContextCauseChain flattens an error chain into one line.
+//
+// Walking the chain instead of reading only the outermost Error() is
+// load-bearing, not defensive: reviewtransaction deliberately flattens some
+// failures behind a fixed public sentence and keeps the real cause reachable
+// only through Unwrap (reviewRepositoryContextIdentityError and
+// reviewRepositoryContextTargetedValidationError both do this). Reading the
+// surface alone would re-collapse exactly the failures this change exists to
+// separate. A link whose message is already contained in what has been
+// collected is skipped, so ordinary %w wrapping does not repeat itself.
+func reviewOpaqueContextCauseChain(cause error) string {
+	message := ""
+	for err := cause; err != nil; err = errors.Unwrap(err) {
+		next := strings.TrimSpace(err.Error())
+		if next == "" || strings.Contains(message, next) {
+			continue
+		}
+		if message == "" {
+			message = next
+			continue
+		}
+		message += ": " + next
+	}
+	return message
 }
 
 const (
@@ -116,7 +180,7 @@ func reviewRepositoryContextResolutionFailure(err error) error {
 	if reviewGitOwnershipRefusal(err) {
 		return reviewOpaqueContextFailure(reviewGitTrustRefusalCode, reviewGitTrustRefusalAction)
 	}
-	return reviewOpaqueContextFailure("repository_context_unavailable", "refresh the exact native next_transition before retrying")
+	return reviewOpaqueContextCause("repository_context_unavailable", "refresh the exact native next_transition before retrying", err)
 }
 
 // reviewGitOwnershipRefusal reports whether err was caused by Git refusing a
@@ -230,7 +294,7 @@ func RunReviewPreserveResult(args []string, stdout io.Writer) error {
 	_, record, err := discoverCompactFacadeReview(ctx, repo, *lineage, false)
 	if err != nil {
 		if contextHandle != "" {
-			return reviewOpaqueContextFailure("repository_context_authority_unavailable", "refresh the exact native next_transition before retrying")
+			return reviewOpaqueContextCause("repository_context_authority_unavailable", "refresh the exact native next_transition before retrying", err)
 		}
 		return reviewPreflightError(fmt.Errorf("resolve reviewing authority for preserve-result: %w", err))
 	}
@@ -246,7 +310,7 @@ func RunReviewPreserveResult(args []string, stdout io.Writer) error {
 	dir, err := reviewtransaction.CompactIncidentsDir(ctx, repo, *lineage)
 	if err != nil {
 		if contextHandle != "" {
-			return reviewOpaqueContextFailure("repository_context_preserve_unavailable", "retry preserve-result with the same exact binding")
+			return reviewOpaqueContextCause("repository_context_preserve_unavailable", "retry preserve-result with the same exact binding", err)
 		}
 		return reviewPreflightError(fmt.Errorf("resolve incident preservation directory: %w", err))
 	}
@@ -260,7 +324,7 @@ func RunReviewPreserveResult(args []string, stdout io.Writer) error {
 	artifact, err := preserveIncidentArtifact(dir, *lineage, *target, *lens, *order, payload, reviewtransaction.ResultIncidentClass(*class))
 	if err != nil {
 		if contextHandle != "" {
-			return reviewOpaqueContextFailure("repository_context_preserve_failed", "retry preserve-result with the same exact binding")
+			return reviewOpaqueContextCause("repository_context_preserve_failed", "retry preserve-result with the same exact binding", err)
 		}
 		return reviewPreflightError(err)
 	}

--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -1,0 +1,297 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// The defect these tests pin: on the provider-issued repository-context path
+// every failure was replaced by one constant sentence per typed code. Nine-plus
+// community reports (#2227, #2382, #2411, #2461) describe genuinely different
+// roots and quote the same string, so the report cannot distinguish them and
+// neither can the maintainer reading it.
+//
+// The opacity itself is legitimate: an absolute path must never reach the
+// session transcript. So the property proven here is not "stop being opaque",
+// it is "keep the typed code AND name a scrubbed cause", and the proof shape is
+// always the same: drive TWO genuinely different roots into ONE collapse point
+// and require the two outputs to differ and each to name its own cause. A test
+// that asserts one message contains one substring would pass against the
+// collapsed constant and prove nothing.
+
+// gitObjectPermissionStderr is a second, unrelated Git setup failure. It shares
+// the collapse point with gitMissingRepositoryStderr and is neither an
+// ownership refusal nor a missing repository, so the two can only be told apart
+// by a forwarded cause.
+const gitObjectPermissionStderr = "fatal: cannot access the object database: Permission denied"
+
+// TestOpaqueRepositoryContextResolutionNamesDistinctCauses covers the widest
+// collapse point, reviewRepositoryContextResolutionFailure in
+// review_incident.go. Every non-trust resolution failure answered with the same
+// repository_context_unavailable sentence, and resolution front-runs authority
+// discovery (ResolveReviewRepositoryContext itself loads the compact record
+// through validateLiveReviewRepositoryContext), so an environmental Git
+// refusal, an absent authority record and an unparsable one all converge here.
+// Four genuinely different roots, one string.
+func TestOpaqueRepositoryContextResolutionNamesDistinctCauses(t *testing.T) {
+	cases := []struct {
+		name    string
+		arrange func(t *testing.T, repo, lineage string)
+		want    string
+	}{
+		{
+			name:    "git-missing-repository",
+			arrange: func(t *testing.T, _, _ string) { installFailingGitShim(t, gitMissingRepositoryStderr) },
+			want:    "not a git repository",
+		},
+		{
+			name:    "git-object-permission",
+			arrange: func(t *testing.T, _, _ string) { installFailingGitShim(t, gitObjectPermissionStderr) },
+			want:    "cannot access the object database",
+		},
+		{
+			name: "authority-record-absent",
+			arrange: func(t *testing.T, repo, lineage string) {
+				if err := os.Remove(reviewCLICompactStatePath(repo, lineage)); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "no such file or directory",
+		},
+		{
+			name: "authority-record-unparsable",
+			arrange: func(t *testing.T, repo, lineage string) {
+				if err := os.WriteFile(reviewCLICompactStatePath(repo, lineage), []byte("{not json"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "invalid character",
+		},
+	}
+	messages := make(map[string]string, len(cases))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			lineage := "opaque-cause-" + tt.name
+			args, _, repo := startedOpaqueCaptureBinding(t, lineage)
+			tt.arrange(t, repo, lineage)
+
+			err := RunReviewCaptureResult(append(append([]string{}, args...), "--preflight"), io.Discard)
+			if err == nil {
+				t.Fatal("preflight succeeded despite an unresolvable repository context")
+			}
+			message := err.Error()
+			assertOpaqueFailureNamesCause(t, message, "repository_context_unavailable", tt.want, repo)
+			messages[tt.name] = message
+		})
+	}
+	assertPairwiseDistinct(t, messages, len(cases))
+}
+
+// TestOpaqueRepositoryContextCaptureNamesDistinctCauses covers the collapse
+// point reported as #2411: everything past admission answered with one
+// repository_context_capture_failed sentence, which is why a preflight that
+// cannot reach any of these paths appeared to "pass" while capture "failed".
+func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
+	cases := []struct {
+		name    string
+		arrange func(t *testing.T, repo, lineage string, binding []string)
+		want    string
+	}{
+		{
+			name: "slot-occupied",
+			arrange: func(t *testing.T, _, _ string, binding []string) {
+				first := admissibleOpaqueReviewerResult(t, binding, "first reviewer evidence")
+				if err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", first), io.Discard); err != nil {
+					t.Fatalf("first capture failed: %v", err)
+				}
+			},
+			want: "different canonical bytes",
+		},
+		{
+			name: "results-directory-unusable",
+			arrange: func(t *testing.T, repo, lineage string, _ []string) {
+				blocked := filepath.Join(reviewCLICompactStoreDir(repo, lineage), reviewtransaction.CompactReviewerResultsDir)
+				if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "not a directory",
+		},
+	}
+	messages := make(map[string]string, len(cases))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			lineage := "opaque-capture-" + tt.name
+			binding, _, repo := startedOpaqueCaptureBinding(t, lineage)
+			result := admissibleOpaqueReviewerResult(t, binding, "second reviewer evidence")
+			tt.arrange(t, repo, lineage, binding)
+
+			err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", result), io.Discard)
+			if err == nil {
+				t.Fatal("capture succeeded despite an unusable authority store")
+			}
+			message := err.Error()
+			assertOpaqueFailureNamesCause(t, message, "repository_context_capture_failed", tt.want, repo)
+			messages[tt.name] = message
+		})
+	}
+	assertPairwiseDistinct(t, messages, len(cases))
+}
+
+// TestOpaqueRepositoryContextCauseIsScrubbed is the other half of the contract:
+// a cause that WOULD leak an absolute path must reach the caller with the path
+// gone and the rest of the cause intact. Forwarding an unscrubbed cause and
+// forwarding nothing are both failures.
+func TestOpaqueRepositoryContextCauseIsScrubbed(t *testing.T) {
+	lineage := "opaque-scrub-cause"
+	args, _, repo := startedOpaqueCaptureBinding(t, lineage)
+	if err := os.Remove(reviewCLICompactStatePath(repo, lineage)); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunReviewCaptureResult(append(append([]string{}, args...), "--preflight"), io.Discard)
+	if err == nil {
+		t.Fatal("preflight succeeded despite a removed authority record")
+	}
+	message := err.Error()
+	// The underlying os error names the absolute state-file path, so this cause
+	// is exactly the shape the opacity exists to contain.
+	if strings.Contains(message, repo) || strings.Contains(message, lineage+"/review-state.json") {
+		t.Fatalf("forwarded cause leaked an absolute path: %s", message)
+	}
+	if !strings.Contains(message, "no such file or directory") {
+		t.Fatalf("scrubbing removed the cause along with the path: %s", message)
+	}
+	if scrubbed := reviewScrubDefectReportField(message); scrubbed != message {
+		t.Fatalf("failure is not path-safe; the privacy gate rewrote it to %q", scrubbed)
+	}
+}
+
+func assertOpaqueFailureNamesCause(t *testing.T, message, code, wantCause, repo string) {
+	t.Helper()
+	if !strings.Contains(message, code) {
+		t.Fatalf("failure lost its typed code %q: %s", code, message)
+	}
+	if !strings.Contains(message, wantCause) {
+		t.Fatalf("failure does not name its own cause %q: %s", wantCause, message)
+	}
+	if strings.Contains(message, repo) {
+		t.Fatalf("failure leaked a private path: %s", message)
+	}
+}
+
+// assertPairwiseDistinct is the whole point of these tests: every root that
+// reaches one collapse point must leave it with its own message. Asserting a
+// single message contains a single substring would pass against a constant.
+func assertPairwiseDistinct(t *testing.T, messages map[string]string, want int) {
+	t.Helper()
+	if len(messages) != want {
+		t.Fatalf("every root must reach the collapse point; captured %d of %d", len(messages), want)
+	}
+	seen := make(map[string]string, len(messages))
+	for name, message := range messages {
+		if other, collapsed := seen[message]; collapsed {
+			t.Fatalf("roots %q and %q collapsed into one message: %s", other, name, message)
+		}
+		seen[message] = name
+	}
+}
+
+func reviewCLICompactStoreDir(repo, lineage string) string {
+	return filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "v2", lineage)
+}
+
+func reviewCLICompactStatePath(repo, lineage string) string {
+	return filepath.Join(reviewCLICompactStoreDir(repo, lineage), "review-state.json")
+}
+
+// admissibleOpaqueReviewerResult writes a reviewer result the native admission
+// accepts for the supplied opaque binding, reading the subject hash and the
+// inspected manifest back from the product's own preflight.
+func admissibleOpaqueReviewerResult(t *testing.T, binding []string, evidence string) string {
+	t.Helper()
+	var preflightOutput bytes.Buffer
+	if err := RunReviewCaptureResult(append(append([]string{}, binding...), "--preflight"), &preflightOutput); err != nil {
+		t.Fatalf("capture preflight failed: %v", err)
+	}
+	var preflight reviewCapturePreflightResult
+	if err := json.Unmarshal(preflightOutput.Bytes(), &preflight); err != nil {
+		t.Fatal(err)
+	}
+	paths := make([]string, len(preflight.ChangedPathManifest))
+	for index, entry := range preflight.ChangedPathManifest {
+		paths[index] = entry.Path
+	}
+	path := filepath.Join(t.TempDir(), "reviewer-result.json")
+	writeReviewCLIJSON(t, path, facadeReviewerResult{
+		SubjectHash: preflight.ArtifactSubject.SubjectHash,
+		Inspection: reviewtransaction.ArtifactInspection{
+			Status: reviewtransaction.ArtifactInspectionCompleted, Paths: paths,
+		},
+		Findings: []facadeFinding{},
+		Evidence: []string{evidence},
+	})
+	return path
+}
+
+// TestOpaqueRepositoryContextPreserveNamesDistinctCauses covers the preserve
+// path, which is where reviewer payloads land when capture fails. It shares the
+// same defect: every preservation failure answered with one sentence, so a
+// reporter whose lens results were all stranded as incidents (#2446) had no way
+// to say why.
+func TestOpaqueRepositoryContextPreserveNamesDistinctCauses(t *testing.T) {
+	cases := []struct {
+		name    string
+		arrange func(t *testing.T, incidents string)
+		want    string
+	}{
+		{
+			name: "incidents-path-is-a-file",
+			arrange: func(t *testing.T, incidents string) {
+				if err := os.MkdirAll(filepath.Dir(incidents), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(incidents, []byte("not a directory\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "not a directory",
+		},
+		{
+			name: "incidents-directory-is-shared",
+			arrange: func(t *testing.T, incidents string) {
+				if err := os.MkdirAll(incidents, 0o777); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(incidents, 0o777); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "not a private native directory",
+		},
+	}
+	messages := make(map[string]string, len(cases))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			lineage := "opaque-preserve-" + tt.name
+			args, input, repo := startedOpaqueCaptureBinding(t, lineage)
+			tt.arrange(t, filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "incidents", lineage))
+
+			err := RunReviewPreserveResult(append(append([]string{}, args...), "--input", input), io.Discard)
+			if err == nil {
+				t.Fatal("preserve-result succeeded despite an unusable incidents directory")
+			}
+			message := err.Error()
+			assertOpaqueFailureNamesCause(t, message, "repository_context_preserve_failed", tt.want, repo)
+			messages[tt.name] = message
+		})
+	}
+	assertPairwiseDistinct(t, messages, len(cases))
+}


### PR DESCRIPTION
When a provider-issued repository context was bound, the real error was discarded and replaced with a fixed string. Several genuinely different failures reached the user as one message, which is why nine-plus reporters with different roots all filed what looks like the same bug.

## The part the plan did not anticipate

Reading `err.Error()` was not enough. `reviewtransaction` **deliberately** flattens two failures behind fixed public sentences and keeps the real cause reachable only through `Unwrap`. Forwarding the surface message would have re-collapsed exactly the Git failures this change exists to separate.

So the cause is assembled by walking the chain, skipping links already contained in what has been collected so `%w` wrapping does not repeat itself. It goes through `reviewScrubDefectReportField`, the scrubber that already existed rather than a second one, bounded to 512 runes.

The opacity stays. What changes is that the code now carries a scrubbed typed cause beside it.

## Sites

Go: `reviewRepositoryContextResolutionFailure`, the three preserve sites in `RunReviewPreserveResult`, `repository_context_authority_unavailable`, and both `repository_context_capture_failed` sites.

Plugin: `sessionErrorMessage` loses `if (!binding.repository_context) return errorMessage(cause)`. Every path now scrubs then reports, with a scrubber mirroring the Go one field for field since the plugin cannot call into Go. The thirteen-condition binding refusal now names **which** condition failed.

## The proof, pairwise rather than substring

Four distinct roots reach one Go collapse point and are now pairwise distinct. Resolution turned out wider than expected: `ResolveReviewRepositoryContext` loads the compact record itself, so authority-record failures land here too.

```
git-missing        cause: ... fatal: not a git repository ...
git-permission     cause: ... fatal: cannot access the object database: Permission denied ...
record-absent      cause: open <redacted> no such file or directory
record-unparsable  cause: invalid character 'n' looking for beginning of object key string
```

Capture, on #2411's exact string: a slot occupied by different canonical bytes, and an unusable results directory, previously identical and now each naming its own cause.

Scrubbing is proven in both directions: the absolute path absent, `<redacted>` present, **and the cause text surviving**. That third assertion is what makes "dropped it entirely" fail rather than pass.

## `GENTLE_AI_REVIEW_CWD` is deleted, not validated

The reasoning, because #2446 asks for validation:

It is undocumented, appearing in exactly four places repo-wide and in no docs, skill or bench. It is only reachable for legacy `--cwd` bindings, since opaque handles are cwd-independent. And **same-git-dir validation would reject the one use its own error message advertises**: that message tells you to set it when the lineage was started in a different repository, for example a nested one, and a nested repository has a different `.git`. Validating would keep the code while making it useless.

Deleting does not orphan the refusal, because the advertised use has a real replacement: the recovery line now names a `review status` invocation whose binding carries a provider-issued repository context that resolves independently of the working directory.

Proof is mechanical rather than textual: a stub binary logs `$PWD`, the test sets the variable to a foreign directory, and asserts every recorded directory is the OpenCode anchor.

## #2411, verified structurally

`--preflight` returns at `review_artifact.go:313-335`, **before** `readFacadeBytes`, `validateReviewerResultPayload`, `AdmitArtifact` and `CaptureAdmittedReviewerResult`. Preflight cannot exercise any path that fails at capture, so the reported "preflight passes, capture fails" is structurally guaranteed rather than incidental.

The quoted string is verbatim the two capture constants, and everything between decode and admission already returned its real error even on the opaque path. So the reporter's root was inside admission or the published-file readback, consistent with a network mount refusing an atomic publish or readback. That cause is now named.

## Dispositions, and two deliberate non-closures

**Closes #2227**, whose strict-decode rejection now names the offending field. **Closes #2446**. **Closes #2461**, both reported symptoms.

**#2411 is referenced, not closed.** The dead end is gone and the cause is named, but if their root is a real publish refusal that failure still exists and deserves its own issue once named. Closing on diagnosability alone would over-claim.

**#2442 is referenced, not closed.** Its field-level refusals are done; its second step, sourcing the binding from the provider so a quoted number cannot exist, is transport work the issue explicitly sequenced separately.

## Verification

gofmt and vet clean, root `go test ./... -count=1` with no failures, bench module ok, deadcode ratchet reports no new unreachable functions, refusal ratchet passes including the structural continuation test.

## Known

**There is no TypeScript check in this repository.** No tsconfig, no test runner, and `package.json`'s test script is `exit 1`. Node runs the plugin by type-stripping, which does not typecheck. Plugin behavior is proven by execution through the existing Node harness that loads the real embedded file exactly as OpenCode does, but a type error would be caught by nothing here.

`repository_context_authority_unavailable` is structurally shadowed: resolution loads the same record before discovery runs, so no input reaches that branch except by a race. The cause was applied for uniformity with no reachability proof, and none was fabricated.

The refusal-ratchet baseline carries one stale entry, verified by stashing to pre-exist on main. Left untouched rather than absorbing another slice's net-negative into this one.

Closes #2227
Closes #2446
Closes #2461

Part of #2471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository-context error messages with distinct, actionable causes while preserving machine-readable error details.
  * Redacted sensitive paths, emails, environment values, and overly long messages from session output.
  * Enforced clearer validation for review-result bindings, including field-specific guidance.
  * Repository capture now consistently uses the active OpenCode workspace context.
  * Improved recovery guidance for nested repositories and invalid review bindings.

* **Tests**
  * Added coverage for error redaction, binding validation, repository capture, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->