### PR TITLE
test(e2e): stop set -e leak from truncating suite reporting

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -989,8 +989,8 @@ test_qwen_engram_idempotency() {
 
     local settings="$HOME/.qwen/settings.json"
 
-    # First run — `|| true` keeps `set -e` from aborting the suite if install
-    # errors out (e.g. transient npm failure); we assert on the resulting file.
+    # First run — the install's exit code is irrelevant here (e.g. transient
+    # npm failure); we assert on the resulting file.
     $BINARY install --agent qwen-code --component engram --persona neutral > /dev/null 2>&1 || true
     if [ ! -f "$settings" ]; then
         log_fail "Qwen settings.json missing after first install"
@@ -1839,7 +1839,10 @@ test_codex_context7_in_toml() {
     # Idempotent: re-running must not duplicate the block.
     $BINARY install --agent codex --component context7 --persona neutral 2>&1 || true
     local count
-    count=$(grep -c "\[mcp_servers.context7\]" "$config_toml" 2>/dev/null || echo 0)
+    # `grep -c` prints "0" AND exits 1 on zero matches, so `|| echo 0` would
+    # yield the two-line string "0\n0" and break the numeric comparison below.
+    count=$(grep -c "\[mcp_servers.context7\]" "$config_toml" 2>/dev/null || true)
+    count=${count:-0}
     if [ "$count" -eq 1 ]; then
         log_pass "Codex context7 block is idempotent (exactly 1 entry)"
     else

--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # lib.sh — shared test helpers for gentle-ai E2E tests
 # Sourced by e2e_test.sh; never executed directly.
-set -euo pipefail
+#
+# Deliberately NO `set -e` here: `source` shares shell options with the
+# caller, and this suite counts failures and continues (log_fail counters +
+# print_summary). Under a leaked `-e`, the first unguarded failing assertion
+# aborts the whole script — no remaining tests, no summary, no totals
+# (issue #2466). Failures still fail the run: print_summary returns nonzero
+# when FAILED > 0.
+set -uo pipefail
 
 # ---------------------------------------------------------------------------
 # Colors
@@ -18,13 +25,16 @@ NC='\033[0m' # No Color
 PASSED=0
 FAILED=0
 SKIPPED=0
+# Labels of every failed check, replayed by print_summary so a long run
+# ends with the full list of what failed, not just a count.
+FAILED_CHECKS=()
 
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
 log_test()  { printf "${YELLOW}[TEST]${NC}  %s\n" "$1"; }
 log_pass()  { printf "${GREEN}[PASS]${NC}  %s\n" "$1"; PASSED=$((PASSED + 1)); }
-log_fail()  { printf "${RED}[FAIL]${NC}  %s\n" "$1"; FAILED=$((FAILED + 1)); }
+log_fail()  { printf "${RED}[FAIL]${NC}  %s\n" "$1"; FAILED=$((FAILED + 1)); FAILED_CHECKS+=("$1"); }
 log_skip()  { printf "${BLUE}[SKIP]${NC}  %s\n" "$1"; SKIPPED=$((SKIPPED + 1)); }
 log_info()  { printf "${BLUE}[INFO]${NC}  %s\n" "$1"; }
 
@@ -382,7 +392,10 @@ assert_no_duplicate_section() {
     fi
     local marker="<!-- gentle-ai:${section_id} -->"
     local count
-    count=$(grep -c "$marker" "$file" 2>/dev/null || echo "0")
+    # `grep -c` prints "0" AND exits 1 on zero matches, so `|| echo 0` would
+    # yield the two-line string "0\n0" and break the numeric comparisons below.
+    count=$(grep -c "$marker" "$file" 2>/dev/null || true)
+    count=${count:-0}
     if [ "$count" -eq 1 ]; then
         log_pass "$label"
         return 0
@@ -437,6 +450,11 @@ print_summary() {
     echo "========================================"
 
     if [ "$FAILED" -gt 0 ]; then
+        printf "\n%bFailed checks:%b\n" "$RED" "$NC"
+        local check
+        for check in "${FAILED_CHECKS[@]}"; do
+            printf "  - %s\n" "$check"
+        done
         printf "\n%bSome tests failed.%b\n" "$RED" "$NC"
         return 1
     fi


### PR DESCRIPTION
Fixes the reporting-truncation half of #2466: `e2e/lib.sh` sets `set -euo pipefail` and is sourced by `e2e/e2e_test.sh`, so `-e` leaks into the whole suite even though the runner's own header declares only `set -uo pipefail`. The suite is count-and-continue by design (`log_fail` counters plus `print_summary`), so under the leaked `-e` the first unguarded failing assertion aborts the script on the spot: no remaining tests, no summary, no totals.

## What changed

- `e2e/lib.sh`: dropped `-e` from the sourced helper (now `set -uo pipefail`, matching `e2e_test.sh`), with a comment explaining why it must never come back. Failures still fail the run: `print_summary` returns nonzero when `FAILED > 0`, and that is the script's exit status.
- `print_summary` now replays every failed check by name, so a long run ends with the full list of what failed instead of only a count.
- Fixed two `grep -c ... || echo 0` patterns (`assert_no_duplicate_section` in `lib.sh`, `test_codex_context7_in_toml` in `e2e_test.sh`): `grep -c` prints `0` and still exits 1 on zero matches, so `|| echo 0` produced a two-line `0` string, which broke the numeric comparisons and garbled those failure messages.

No `set -e` was removed from a script that relied on it for failure, no blanket `|| true` was added, and no per-assertion guards were sprinkled: removing the leak restores the suite's own declared error model, under which every assertion already reports and counts.

## RED: truncation reproduced before the fix

Injected one unguarded failing assertion right after the first Tier 1 test:

```bash
assert_file_exists "/nonexistent/red-truncation-probe" "RED truncation probe"
```

`bash e2e/e2e_test.sh` output, complete and verbatim (ANSI colors stripped), exit code 1:

```
[INFO]  Using binary: /home/gentleman/work/gentle-ai-worktrees/fix-2466-e2e-report/gentle-ai
[INFO]  === Tier 1: Basic binary & dry-run tests ===
[TEST]  Binary exists and is executable
[PASS]  Binary is executable
[FAIL]  File NOT found: RED truncation probe (/nonexistent/red-truncation-probe)
```

That is the entire output. The remaining Tier 1 tests never ran, and there is no summary and no totals. In a tier where later tests fail, this is exactly the under-reporting described in the issue.

## After the fix: same injection, full run

Same injected failure, same command, exit code 1, 139 lines of output ending with:

```
[SKIP]  Tier 2 tests (set RUN_FULL_E2E=1 to enable)
[SKIP]  Tier 3 tests (set RUN_BACKUP_TESTS=1 to enable)

========================================
  PASSED: 79
  FAILED: 1
  SKIPPED: 2
  TOTAL : 82
========================================

Failed checks:
  - File NOT found: RED truncation probe (/nonexistent/red-truncation-probe)

Some tests failed.
```

The injection was removed before committing. A clean Tier 1 run then passes: `PASSED: 79, FAILED: 0, SKIPPED: 2`, exit code 0.

## Deferred: ci.yml owned by #2479

The other half of #2466 (the PR gate running Tier 1 only while the required check's name promises the full suite) lives entirely in `.github/workflows/ci.yml`, which open PR #2479 currently owns, so this PR does not touch it. Nothing in the shell scripts selects tiers from the event; they only read `RUN_FULL_E2E` / `RUN_BACKUP_TESTS`.

The change ci.yml needs, at the `Run E2E tests` step of the `e2e-tests` job (currently lines 373-374):

```yaml
RUN_FULL_E2E: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && '1' || '0' }}
RUN_BACKUP_TESTS: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && '1' || '0' }}
```

Either set both to `'1'` unconditionally so pull requests run the same Tier 1+2+3 suite as push/schedule (the required checks then deliver what their name promises), or, if PR cost is the concern, rename the required checks to state the reduced scope (for example `E2E Tier 1 (ubuntu)`). The failure mode to eliminate is a required green check whose name implies more coverage than it delivered.

## Verification

- Local Tier 1 executed for real (it is dry-run only, no side effects): RED run, injected run after fix, and clean run shown above.
- `shellcheck e2e/e2e_test.sh e2e/lib.sh e2e/docker-test.sh`: identical finding count before and after the change (pre-existing style/info findings only, none introduced).
- `gofmt -l .`: clean. `go vet ./...`: clean. `go test ./... -count=1` at root: green (one flake in `internal/update` unrelated to this shell-only change; the package passes with `-count=1` on rerun). `go test ./... -count=1` in `bench/`: green. `scripts/deadcode-ratchet.sh`: no new unreachable functions. The refusal-resolution ratchet runs inside the root suite (`internal/cli/refusal_resolution_ratchet_test.go`): green.
- Not verified: the 3-platform Docker matrix (`e2e/docker-test.sh`) was not run locally; the fix was exercised by direct Tier 1 execution instead.

Closes #2466 (the ci.yml tier-selection half is split out as #2527, sequenced behind PR #2479) (the ci.yml tier-scope half remains open and is deferred to #2479)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - End-to-end test runs now continue after individual assertion failures, allowing more checks to complete in a single run.
  - Test summaries now accurately report failed checks and correctly handle cases where no matching results are found.
  - Updated test guidance clarifies handling of ignored installation exit codes and zero-result checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
