### PR TITLE
test: deflake update check servers and Commit A byte-equivalence fixture

### DIFF
--- a/internal/cli/review_byte_equivalence_commit_a_test.go
+++ b/internal/cli/review_byte_equivalence_commit_a_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -18,10 +20,13 @@ import (
 // bytes for the unnegotiated `review start` -> `review finalize` ->
 // `review status` -> all-five-gates journey, using a fully deterministic
 // fixture (fixed tracked content, fixed lineage name) so the resulting Git
-// tree/blob hashes -- and therefore every downstream digest -- are
-// byte-stable across machines and runs. WU18 re-runs the identical fixture
-// switch-free and diffs against these exact golden files; any divergence is
-// a defect signal (design decision 4), never a golden-update task.
+// tree/blob hashes -- and therefore every downstream digest except the
+// path-bound authority revision, which the comparison normalizes (see
+// byteEquivalenceCommitARevisionPlaceholder) -- are byte-stable across
+// machines and runs. WU18 re-runs the identical fixture switch-free and
+// diffs against these exact golden files under the same normalization; any
+// divergence is a defect signal (design decision 4), never a golden-update
+// task.
 //
 // Scope note (disclosed deviation from the design's full "every entry
 // surface" list): this Commit A only records the unnegotiated start form.
@@ -36,26 +41,35 @@ var updateReviewByteEquivalenceCommitAGolden = flag.Bool("update-byte-equivalenc
 
 const byteEquivalenceCommitALineage = "byte-equivalence-commit-a-lineage"
 
-// byteEquivalenceCommitAFixturePath is a FIXED absolute path, not
-// t.TempDir()'s randomized one. RepositoryIdentity (repository_locator.go)
+// byteEquivalenceCommitARevisionPlaceholder replaces the one path-dependent
+// digest in the recorded goldens. RepositoryIdentity (repository_locator.go)
 // deliberately binds to the repository's absolute filesystem path (its CAS
-// locking identity), so authority_revision and every hash derived from it
-// are only byte-stable across independent test runs when the repository
-// root itself is byte-identical -- a randomized temp path defeats that by
-// design, not by bug. WU18's Commit B re-evaluation MUST reuse this exact
-// same path (never a fresh t.TempDir()) for its diff against these goldens
-// to mean anything.
+// locking identity), so authority_revision -- surfaced as
+// `authority_revision` by finalize and echoed as `store_revision` by every
+// gate -- can never be byte-stable across machines (issue #2476: os.TempDir()
+// differs per OS) and a shared fixed path makes concurrent test runs delete
+// each other's fixture (issue #2483). Every OTHER byte of every golden is
+// path-independent and stays under exact byte comparison. The excluded digest
+// keeps two real assertions instead of the byte diff: it must be a
+// well-formed sha256 digest, and only the exact value captured from THIS
+// run's finalize receipt is substituted, so status and all five gates still
+// fail loudly unless they echo that same revision (the receipt-binding
+// property). WU18's Commit B re-evaluation diffs the identical fixture
+// switch-free under this same normalization; divergence in any
+// path-independent byte remains a defect signal, never a golden-update task.
+const byteEquivalenceCommitARevisionPlaceholder = "sha256:{{path-dependent-authority-revision}}"
+
+var byteEquivalenceCommitARevisionPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// byteEquivalenceCommitAFixturePath is a fresh per-test directory. The
+// repository's absolute path feeds only the authority revision digest, which
+// the golden comparison normalizes (see
+// byteEquivalenceCommitARevisionPlaceholder), so a randomized path no longer
+// breaks byte stability -- and it removes the shared fixed path that let
+// concurrent runs destroy each other's fixture.
 func byteEquivalenceCommitAFixturePath(t *testing.T) string {
 	t.Helper()
-	path := filepath.Join(os.TempDir(), "gentle-ai-wave7-byte-equivalence-commit-a-fixture")
-	if err := os.RemoveAll(path); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(path) })
-	resolved, err := filepath.EvalSymlinks(path)
+	resolved, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,11 +77,13 @@ func byteEquivalenceCommitAFixturePath(t *testing.T) string {
 }
 
 // byteEquivalenceCommitAFixture creates the exact deterministic candidate
-// (same repository path, tracked content, and commit identity every run)
-// that this file's goldens are derived from, and finalizes it to an
-// approved, receipted tier-0 (RiskLow) new-lineage authority -- the
-// terminal state every one of the five gates requires to ever allow.
-func byteEquivalenceCommitAFixture(t *testing.T) string {
+// (same tracked content and commit identity every run) that this file's
+// goldens are derived from, and finalizes it to an approved, receipted
+// tier-0 (RiskLow) new-lineage authority -- the terminal state every one of
+// the five gates requires to ever allow. It returns the repository path and
+// the authority revision digest captured from the finalize receipt; every
+// later surface must echo exactly that digest for its golden to match.
+func byteEquivalenceCommitAFixture(t *testing.T) (string, string) {
 	t.Helper()
 	reviewModeHome(t)
 	repo := byteEquivalenceCommitAFixturePath(t)
@@ -103,33 +119,55 @@ func byteEquivalenceCommitAFixture(t *testing.T) string {
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", byteEquivalenceCommitALineage}, &startOut); err != nil {
 		t.Fatalf("byte-equivalence fixture start: %v\n%s", err, startOut.String())
 	}
-	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "start.golden.json"), startOut.Bytes())
+	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "start.golden.json"), startOut.Bytes(), "")
 
 	var finalizeOut bytes.Buffer
 	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", byteEquivalenceCommitALineage}, &finalizeOut); err != nil {
 		t.Fatalf("byte-equivalence fixture finalize: %v\n%s", err, finalizeOut.String())
 	}
-	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "finalize.golden.json"), finalizeOut.Bytes())
+	revision := byteEquivalenceCommitAReceiptRevision(t, finalizeOut.Bytes())
+	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "finalize.golden.json"), finalizeOut.Bytes(), revision)
 
-	return repo
+	return repo, revision
+}
+
+// byteEquivalenceCommitAReceiptRevision extracts and validates the authority
+// revision digest from the finalize response. This is the one value the
+// golden comparison normalizes, so it must at least prove it is a
+// well-formed sha256 digest before it earns the placeholder.
+func byteEquivalenceCommitAReceiptRevision(t *testing.T, finalizeResponse []byte) string {
+	t.Helper()
+	var response struct {
+		Receipt struct {
+			AuthorityRevision string `json:"authority_revision"`
+		} `json:"receipt"`
+	}
+	if err := json.Unmarshal(finalizeResponse, &response); err != nil {
+		t.Fatalf("decode finalize response for authority revision: %v\n%s", err, finalizeResponse)
+	}
+	revision := response.Receipt.AuthorityRevision
+	if !byteEquivalenceCommitARevisionPattern.MatchString(revision) {
+		t.Fatalf("finalize receipt authority_revision = %q, want sha256:<64 hex>", revision)
+	}
+	return revision
 }
 
 // TestReviewByteEquivalenceCommitAUnnegotiatedStartAndFinalize proves the
 // start/finalize response bytes are byte-stable now, at Commit A time.
 func TestReviewByteEquivalenceCommitAUnnegotiatedStartAndFinalize(t *testing.T) {
-	byteEquivalenceCommitAFixture(t)
+	_, _ = byteEquivalenceCommitAFixture(t)
 }
 
 // TestReviewByteEquivalenceCommitAStatus proves `review status`'s response
 // bytes for the terminal (approved, receipted) lineage are byte-stable.
 func TestReviewByteEquivalenceCommitAStatus(t *testing.T) {
-	repo := byteEquivalenceCommitAFixture(t)
+	repo, revision := byteEquivalenceCommitAFixture(t)
 
 	var statusOut bytes.Buffer
 	if err := RunReviewStatus([]string{"--cwd", repo, "--contract", ReviewIntegrationContractV1, "--lineage", byteEquivalenceCommitALineage}, &statusOut); err != nil {
 		t.Fatalf("byte-equivalence fixture status: %v\n%s", err, statusOut.String())
 	}
-	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "status.golden.json"), statusOut.Bytes())
+	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "status.golden.json"), statusOut.Bytes(), revision)
 }
 
 func TestReviewByteEquivalenceCommitAGatePostApply(t *testing.T) {
@@ -154,7 +192,7 @@ func TestReviewByteEquivalenceCommitAGateRelease(t *testing.T) {
 
 func assertReviewByteEquivalenceCommitAGate(t *testing.T, gate reviewtransaction.GateKind) {
 	t.Helper()
-	repo := byteEquivalenceCommitAFixture(t)
+	repo, revision := byteEquivalenceCommitAFixture(t)
 
 	args := []string{"--cwd", repo, "--lineage", byteEquivalenceCommitALineage, "--gate", string(gate)}
 	if gate == reviewtransaction.GateRelease {
@@ -184,17 +222,23 @@ func assertReviewByteEquivalenceCommitAGate(t *testing.T, gate reviewtransaction
 		t.Fatalf("byte-equivalence fixture gate %s: %v\n%s", gate, err, gateOut.String())
 	}
 	assertReviewGateResult(t, gateOut.Bytes(), reviewtransaction.GateAllow)
-	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "gate-"+string(gate)+".golden.json"), gateOut.Bytes())
+	assertByteEquivalenceCommitAGolden(t, filepath.Join("testdata", "byte_equivalence_commit_a", "gate-"+string(gate)+".golden.json"), gateOut.Bytes(), revision)
 }
 
 // assertByteEquivalenceCommitAGolden is the identical -update convention
 // review_new_lineage_switch_off_golden_test.go already established
 // (`reviewNewLineageSwitchOffGolden`), reused under a distinct flag so
 // regenerating Commit A's baseline is a deliberate, separately-named action
-// from regenerating the switch-off goldens.
-func assertByteEquivalenceCommitAGolden(t *testing.T, path string, got []byte) {
+// from regenerating the switch-off goldens. A non-empty revision is the
+// digest captured from this run's finalize receipt: exactly that value is
+// replaced with byteEquivalenceCommitARevisionPlaceholder before comparison,
+// so a surface that emits any OTHER revision still diverges byte-for-byte.
+func assertByteEquivalenceCommitAGolden(t *testing.T, path string, got []byte, revision string) {
 	t.Helper()
 	normalized := append(bytes.TrimRight(got, "\n"), '\n')
+	if revision != "" {
+		normalized = bytes.ReplaceAll(normalized, []byte(revision), []byte(byteEquivalenceCommitARevisionPlaceholder))
+	}
 	if *updateReviewByteEquivalenceCommitAGolden {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)

--- a/internal/cli/testdata/byte_equivalence_commit_a/finalize.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/finalize.golden.json
@@ -4,6 +4,6 @@
   "state": "approved",
   "receipt": {
     "lineage_id": "byte-equivalence-commit-a-lineage",
-    "authority_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192"
+    "authority_revision": "sha256:{{path-dependent-authority-revision}}"
   }
 }

--- a/internal/cli/testdata/byte_equivalence_commit_a/gate-post-apply.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/gate-post-apply.golden.json
@@ -8,7 +8,7 @@
     "gate": "post-apply",
     "lineage_id": "byte-equivalence-commit-a-lineage",
     "generation": 0,
-    "store_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192",
+    "store_revision": "sha256:{{path-dependent-authority-revision}}",
     "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
     "candidate_tree": "dda629df9960312d5fa455c0757f92502d06fcbc",
     "paths_digest": "",

--- a/internal/cli/testdata/byte_equivalence_commit_a/gate-pre-commit.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/gate-pre-commit.golden.json
@@ -8,7 +8,7 @@
     "gate": "pre-commit",
     "lineage_id": "byte-equivalence-commit-a-lineage",
     "generation": 0,
-    "store_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192",
+    "store_revision": "sha256:{{path-dependent-authority-revision}}",
     "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
     "candidate_tree": "dda629df9960312d5fa455c0757f92502d06fcbc",
     "paths_digest": "",

--- a/internal/cli/testdata/byte_equivalence_commit_a/gate-pre-pr.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/gate-pre-pr.golden.json
@@ -8,7 +8,7 @@
     "gate": "pre-pr",
     "lineage_id": "byte-equivalence-commit-a-lineage",
     "generation": 0,
-    "store_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192",
+    "store_revision": "sha256:{{path-dependent-authority-revision}}",
     "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
     "candidate_tree": "dda629df9960312d5fa455c0757f92502d06fcbc",
     "paths_digest": "",

--- a/internal/cli/testdata/byte_equivalence_commit_a/gate-pre-push.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/gate-pre-push.golden.json
@@ -8,7 +8,7 @@
     "gate": "pre-push",
     "lineage_id": "byte-equivalence-commit-a-lineage",
     "generation": 0,
-    "store_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192",
+    "store_revision": "sha256:{{path-dependent-authority-revision}}",
     "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
     "candidate_tree": "dda629df9960312d5fa455c0757f92502d06fcbc",
     "paths_digest": "",

--- a/internal/cli/testdata/byte_equivalence_commit_a/gate-release.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/gate-release.golden.json
@@ -8,7 +8,7 @@
     "gate": "release",
     "lineage_id": "byte-equivalence-commit-a-lineage",
     "generation": 0,
-    "store_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192",
+    "store_revision": "sha256:{{path-dependent-authority-revision}}",
     "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
     "candidate_tree": "dda629df9960312d5fa455c0757f92502d06fcbc",
     "paths_digest": "",

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
@@ -335,7 +336,9 @@ func TestCheckSingleToolGentleAIBetaComparesMainHead(t *testing.T) {
 		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
 			json.NewEncoder(w).Encode(githubCommit{SHA: "972997650b51abcdef0123456789abcdef012345", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/commit/972997650b51abcdef0123456789abcdef012345"})
 		default:
-			t.Fatalf("unexpected GitHub path: %s", r.URL.Path)
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
@@ -369,7 +372,9 @@ func TestCheckSingleToolGentleAIPseudoVersionComparesMainHeadWithoutChannel(t *t
 		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
 			json.NewEncoder(w).Encode(githubCommit{SHA: "b6872c69e3e4abcdef0123456789abcdef012345", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/commit/b6872c69e3e4abcdef0123456789abcdef012345"})
 		default:
-			t.Fatalf("unexpected GitHub path: %s", r.URL.Path)
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
@@ -460,23 +465,34 @@ func TestCheckSingleToolGentleAIStableVersionWithoutChannelComparesLatestRelease
 	origClient := httpClient
 	t.Cleanup(func() { httpClient = origClient })
 
+	var mainHeadRequested atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/repos/Gentleman-Programming/gentle-ai/releases/latest":
 			json.NewEncoder(w).Encode(githubRelease{TagName: "v1.40.4", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.40.4"})
 		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
-			t.Fatalf("stable channel must not request main HEAD")
+			// Record the prohibited request; the assertion runs on the
+			// main goroutine after the check completes.
+			mainHeadRequested.Store(true)
+			http.NotFound(w, r)
 		default:
-			t.Fatalf("unexpected GitHub path: %s", r.URL.Path)
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
 	httpClient = server.Client()
 	httpClient.Transport = &testTransport{server: server}
 
+	simulateStrayForeignRequest(t, server)
+
 	result := checkSingleTool(context.Background(), Tools[0], "1.40.3", system.PlatformProfile{})
 
+	if mainHeadRequested.Load() {
+		t.Fatal("stable channel must not request main HEAD")
+	}
 	if result.Status != UpdateAvailable {
 		t.Fatalf("status = %q, want %q", result.Status, UpdateAvailable)
 	}
@@ -502,7 +518,9 @@ func TestCheckSingleToolGentleAIBetaAcceptsLocalCommitPrefix(t *testing.T) {
 		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
 			json.NewEncoder(w).Encode(githubCommit{SHA: "6eff4a1ba110abcdef0123456789abcdef012345", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/commit/6eff4a1ba110abcdef0123456789abcdef012345"})
 		default:
-			t.Fatalf("unexpected GitHub path: %s", r.URL.Path)
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
@@ -613,11 +631,11 @@ func TestFetchLatestRelease(t *testing.T) {
 func TestFetchLatestReleaseMatchingPatternSkipsPiChannel(t *testing.T) {
 	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/Gentleman-Programming/engram/releases" {
-			t.Fatalf("unexpected path: %s", r.URL.String())
-		}
-		if r.URL.Query().Get("per_page") != "100" {
-			t.Fatalf("per_page = %q, want 100", r.URL.Query().Get("per_page"))
+		if r.URL.Path != "/repos/Gentleman-Programming/engram/releases" || r.URL.Query().Get("per_page") != "100" {
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Query().Get("page") {
@@ -631,7 +649,7 @@ func TestFetchLatestReleaseMatchingPatternSkipsPiChannel(t *testing.T) {
 				{TagName: "v1.15.13", HTMLURL: "https://github.com/Gentleman-Programming/engram/releases/tag/v1.15.13"},
 			})
 		default:
-			t.Fatalf("unexpected page: %s", r.URL.Query().Get("page"))
+			http.NotFound(w, r)
 		}
 	}))
 	serverURL = server.URL
@@ -641,6 +659,8 @@ func TestFetchLatestReleaseMatchingPatternSkipsPiChannel(t *testing.T) {
 	t.Cleanup(func() { httpClient = origClient })
 	httpClient = server.Client()
 	httpClient.Transport = &testTransport{server: server}
+
+	simulateStrayForeignRequest(t, server)
 
 	release, err := fetchLatestReleaseMatchingPattern(context.Background(), "Gentleman-Programming", "engram", `^v[0-9]+\.[0-9]+\.[0-9]+$`)
 	if err != nil {
@@ -862,7 +882,9 @@ func TestCheckSingleTool_EngramUsesBinaryReleaseChannel(t *testing.T) {
 				{TagName: "v1.15.13", HTMLURL: "https://github.com/Gentleman-Programming/engram/releases/tag/v1.15.13"},
 			})
 		default:
-			t.Fatalf("unexpected path: %s", r.URL.String())
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
@@ -1847,6 +1869,22 @@ func unsetUpdateChannelEnv(t *testing.T) {
 			t.Fatalf("restore unset GENTLE_AI_CHANNEL: %v", err)
 		}
 	})
+}
+
+// simulateStrayForeignRequest sends the exact request shape issue #2483
+// observed landing on this package's test servers during overlapping suite
+// runs on one machine: a bare `GET /` from a foreign process whose closed
+// httptest server's ephemeral port was reused by ours. Handlers must
+// tolerate such strays (reply 404, never t.Fatalf, which is also undefined
+// behavior off the test goroutine); only the code under test's own requests
+// and the test's main-goroutine assertions may decide the outcome.
+func simulateStrayForeignRequest(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("stray probe request: %v", err)
+	}
+	resp.Body.Close()
 }
 
 // testTransport redirects all requests to the test server.


### PR DESCRIPTION
## 🔗 Linked Issue

Refs #2483 (items 1 and 3 fixed here; item 2, the TestSnapshotBuilder 15s budget, is `localGitCommandTimeout` in `internal/reviewtransaction/snapshot.go:1473`, owned by open PRs #2491/#2250, and stays open on the issue)
Closes #2476

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Deflakes the two `internal/update` tests by making test server handlers tolerant of stray foreign requests, with a committed probe that reproduces the exact observed failure text as a regression test.
- Fixes the seven Commit A byte-equivalence tests for both #2483 (concurrent runs deleted each other's fixed fixture path) and #2476 (goldens encoded the recording machine's temp prefix): the fixture now uses `t.TempDir()` and the comparison normalizes exactly one path-bound digest without giving up divergence detection.
- Item 2 of #2483 (`TestSnapshotBuilder` 15 second budget) is NOT fixed here: the budget is `localGitCommandTimeout` in `internal/reviewtransaction/snapshot.go:1473`, and both `snapshot.go` (PRs #2491, #2250) and `snapshot_test.go` (PR #2250) are owned by open PRs, so any fix would collide. It needs a follow-up once those land.

## Where the reproductions contradicted the issue

The issue attributes the `internal/update` flakes to concurrent tests colliding on the package-level `httpClient`. That mechanism does not hold up:

- All 21 swap sites have balanced save/restore via `t.Cleanup` (21 saves, 21 restores, verified by count), and the package has zero `t.Parallel`, so same-binary tests cannot interleave on it.
- `go test ./internal/update -race -shuffle=on -count=8` passes (148s) while this machine was concurrently running other agents' full suites.
- Nothing in the package (or the repo) requests a bare URL through `httpClient`, so no code path it controls can produce the observed `unexpected path: /`.

What does produce it, byte-for-byte: a stray `GET /` arriving at the victim's `httptest` server, which is exactly what a foreign process's request to a reused ephemeral port looks like when several suites run on one machine (both original observations were full-suite runs by concurrent agents). The committed probe demonstrates this deterministically.

Fresh observed instance while this PR was being prepared: a sibling agent's unrelated full-suite run had `TestFetchLatestReleaseMatchingPatternSkipsPiChannel` fail once and pass on rerun, with several `go test` suites verifiably running concurrently on the same machine at the time. That test is one of the two probed victims covered by this fix. Its failure text was not captured, so the attribution for that specific instance is consistent with, not proven by, the stray-request mechanism.

## Verbatim RED evidence

**Fix 1, stray request against unfixed handlers (deterministic, was the observed flake text):**

```
--- FAIL: TestCheckSingleToolGentleAIStableVersionWithoutChannelComparesLatestRelease (0.00s)
    check_test.go:471: unexpected GitHub path: /
--- FAIL: TestFetchLatestReleaseMatchingPatternSkipsPiChannel (0.00s)
    check_test.go:619: unexpected path: /
```

**Fix 2a, concurrency (two `go test` processes, 6 of 6 pairs failed):**

```
--- FAIL: TestReviewByteEquivalenceCommitAUnnegotiatedStartAndFinalize (0.00s)
    review_byte_equivalence_commit_a_test.go:120: unlinkat /tmp/gentle-ai-wave7-byte-equivalence-commit-a-fixture/.git: directory not empty
--- FAIL: TestReviewByteEquivalenceCommitAStatus (0.00s)
    review_byte_equivalence_commit_a_test.go:126: git [init -q]: exit status 128: fatal: cannot change to '/tmp/gentle-ai-wave7-byte-equivalence-commit-a-fixture': No such file or directory
```

**Fix 2b, path dependence (#2476 diagnosis confirmed on Linux via alternate TMPDIR):**

```
--- FAIL: TestReviewByteEquivalenceCommitAStatus (0.24s)
    review_byte_equivalence_commit_a_test.go:126: Commit A byte-equivalence output diverged from testdata/byte_equivalence_commit_a/finalize.golden.json:
    got:  "authority_revision": "sha256:bc30f9b54b05bc9ea400a2166006ecc130c8d1222343d2392ce01b942aac8554"
    want: "authority_revision": "sha256:102ea9785165b4b0f59407f0d8b4ad45544d2aab69ce681e1cc0f801db15c192"
```

Regenerating all goldens under the alternate TMPDIR and diffing proved exactly one digest value diverges (`authority_revision` in finalize, echoed as `store_revision` in the five gates); `start` and `status` goldens are fully path-independent.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/check_test.go` | Handlers reply 404 to stray or misdirected requests instead of `t.Fatalf` from the server goroutine; prohibition assertion moved to the main goroutine via an atomic flag; committed stray-request probe in both victim tests |
| `internal/cli/review_byte_equivalence_commit_a_test.go` | Fixture uses `t.TempDir()`; finalize receipt's `authority_revision` is captured, validated as `sha256:<64 hex>`, and substituted with a fixed placeholder before golden comparison; doc comments updated |
| `internal/cli/testdata/byte_equivalence_commit_a/*.golden.json` | The six path-bound digest lines now hold the placeholder; every other byte unchanged |

## ✅ Test Plan (verified by execution)

- [x] RED reproduced for both fixes before the change (outputs above)
- [x] `go test ./internal/update -race -count=1` and `-race -shuffle=on -count=8` pass
- [x] Victim tests pass `-count=5` with the stray probe committed
- [x] Byte-equivalence tests pass plain, under an alternate `TMPDIR`, and in 6 of 6 concurrent process pairs after the fix
- [x] Goldens regenerated with `-update-byte-equivalence-commit-a`, reverified without the flag, regenerated bytes read
- [x] `go test ./... -count=1` at repo root: green; `bench` module: green
- [x] `gofmt -l .` clean, `go vet ./...` clean, `scripts/deadcode-ratchet.sh`: no new unreachable functions; refusal-resolution ratchet ran green inside `./internal/cli`

**Asserted, not verified here:** Windows behavior of the byte-equivalence fix (no Windows machine in this environment; the mechanism #2476 describes is confirmed on Linux by TMPDIR substitution) and the cross-process port-reuse attribution for the historical `internal/update` failures (the committed probe reproduces the identical failure text, but the original events were not captured live).

## ✔️ Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck: N/A, no shell scripts modified
- [x] Docs updated: N/A, test-only change
- [x] Conventional commit format
- [x] No Co-Authored-By trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of repository revisions in status and gate checks.
  * Test servers now handle unexpected requests safely without disrupting test execution.
  * Stable-version checks now verify that unsupported endpoint requests are not made.

* **Tests**
  * Updated receipt comparisons to support repository-specific revisions while preserving deterministic results.
  * Expanded coverage for revision binding and unexpected HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
