### PR TITLE
fix(review): let Judgment Day start without delivery-receipt machinery

### DIFF
--- a/internal/assets/judgment_day_standalone_test.go
+++ b/internal/assets/judgment_day_standalone_test.go
@@ -1,0 +1,37 @@
+package assets
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestJudgmentDaySkillStartsWithoutReviewTransaction guards the separation
+// from issue #2487: Judgment Day is a developer tool, so its skill body must
+// never route judges through the delivery-receipt machinery. The negotiated
+// review lifecycle stays the only producer of delivery authority, and a
+// judgment must disclaim that authority instead of impersonating it.
+func TestJudgmentDaySkillStartsWithoutReviewTransaction(t *testing.T) {
+	body := MustRead("skills/judgment-day/SKILL.md")
+	lower := strings.ToLower(body)
+
+	for _, phrase := range []string{
+		// The fused step that held the tool hostage to the authority.
+		"review/start",
+		"mode=judgment_day",
+		"persist the transaction",
+		// The unconditional authority half: terminal transaction states and
+		// the terminal receipt belong to the negotiated lifecycle only. The
+		// shared review-ledger-contract reference may remain, but only scoped
+		// to the opt-in delivery-authority route.
+		"terminal transaction states",
+		"terminal receipt",
+	} {
+		if strings.Contains(lower, phrase) {
+			t.Errorf("skills/judgment-day/SKILL.md routes the tool into delivery-receipt machinery via %q", phrase)
+		}
+	}
+
+	if !strings.Contains(lower, "issues no receipt") {
+		t.Error("skills/judgment-day/SKILL.md must state that a judgment issues no receipt and carries no delivery authority")
+	}
+}

--- a/internal/assets/skills/judgment-day/SKILL.md
+++ b/internal/assets/skills/judgment-day/SKILL.md
@@ -4,12 +4,12 @@ description: "Trigger: judgment day, dual review, adversarial review, juzgar. Ru
 license: Apache-2.0
 metadata:
   author: gentleman-programming
-  version: "1.6"
+  version: "1.7"
 ---
 
 ## Activation Contract
 
-Load only when the user explicitly requests Judgment Day or equivalent dual/adversarial review for a concrete target. Judgment Day replaces ordinary 4R for that target; never run both.
+Load only when the user explicitly requests Judgment Day or equivalent dual/adversarial review for a concrete target. Judgment Day is a standalone developer tool: judges run whenever asked, on any runtime, and need no review transaction, runtime identity, or delivery-receipt machinery to start. It replaces ordinary 4R as the adversarial method for that target; never run both.
 
 ## Hard Rules
 
@@ -17,10 +17,11 @@ Load only when the user explicitly requests Judgment Day or equivalent dual/adve
 - Build one complete immutable target, then launch two blind read-only judges in parallel with identical scope and criteria.
 - Each judge returns one neutral findings result and terminates. Wait for both; never accept a partial judgment.
 - Never launch `review-refuter`; two-judge agreement is the corroboration mechanism.
-- Only the parent orchestrator merges/persists findings, launches the fix actor, launches scoped re-judgment, and updates native counters.
+- Only the parent orchestrator merges/persists findings, launches the fix actor, and launches scoped re-judgment.
 - Fix only severe findings confirmed by both judges. WARNING/SUGGESTION rows remain `info`.
 - Permit at most two fix rounds and two scoped re-judgments. Re-judgment sees only the frozen ledger plus fix delta and may record fix-caused defects.
-- Terminal transaction states are only `approved | escalated`; never reset or extend an exhausted lineage.
+- The only terminal verdicts are `APPROVED | ESCALATED`; never reset or extend an exhausted round budget.
+- A judgment issues no receipt and carries no delivery authority: it satisfies no commit, push, PR, or release gate. When the caller explicitly wants delivery authority for the same target, run the ordinary negotiated review lifecycle as its own step; a runtime that cannot uphold receipt guarantees loses the receipt, not the judgment.
 
 ## Decision Gates
 
@@ -35,12 +36,12 @@ Load only when the user explicitly requests Judgment Day or equivalent dual/adve
 
 ## Execution Steps
 
-1. Start `review/start(target, mode=judgment_day)` and persist the transaction.
+1. Build the complete immutable target and freeze the scope both judges will inspect.
 2. Launch both read-only judges against the same immutable target.
 3. Merge findings into the frozen ledger and persist it through the selected artifact store.
 4. Ask before round-one correction; run the fix actor only for confirmed severe IDs.
 5. Run both judges again only over the frozen ledger plus immutable fix delta.
-6. Repeat once at most, then run independent final verification and emit the terminal receipt.
+6. Repeat once at most, then run independent final verification and return the terminal verdict.
 
 ## Output Contract
 
@@ -48,5 +49,5 @@ Return target identity, round, confirmed/suspect/contradiction/INFO counts, corr
 
 ## References
 
-- [../_shared/review-ledger-contract.md](../_shared/review-ledger-contract.md) — canonical transaction, ledger, persistence, and lifecycle contract.
 - [references/prompts-and-formats.md](references/prompts-and-formats.md) — compact judge/fix prompts and verdict shape.
+- [../_shared/review-ledger-contract.md](../_shared/review-ledger-contract.md) — delivery-authority route only: consult it when the caller explicitly opts into the ordinary negotiated review lifecycle; never required to run judges.


### PR DESCRIPTION
## What

Judgment Day is a developer tool, but its skill body routed step 1 through `review/start(target, mode=judgment_day)`, so a request for a second opinion was blocked by the delivery-receipt preflight (runtime identity, transport capability) that only the receipt needs. This PR separates the tool from the authority, as issue #2487 proposes: judges run whenever asked; delivery authority stays exactly where it already lives, in the ordinary negotiated review lifecycle.

Investigation showed the coupling is asset-layer only. The string `mode=judgment_day` existed in exactly one file in the repository: `internal/assets/skills/judgment-day/SKILL.md`. No golden embeds the skill body (skills deploy as verbatim copies), and no CLI path can create a judgment_day transaction (see the follow-up finding below).

## Change

`internal/assets/skills/judgment-day/SKILL.md` (8 insertions, 7 deletions, version 1.6 to 1.7):

- Deleted step 1's `review/start(target, mode=judgment_day)`; step 1 now builds the immutable target directly, which Hard Rule 2 already mandated.
- Deleted the unconditional "emit the terminal receipt" from step 6; the run ends with the terminal verdict the Output Contract already defines.
- Reworded "Terminal transaction states" to terminal verdicts and dropped "updates native counters" (transaction vocabulary).
- Added one Hard Rule making the split explicit: a judgment issues no receipt and carries no delivery authority; a caller who wants delivery authority runs the ordinary negotiated review lifecycle as its own step. A runtime that cannot uphold receipt guarantees loses the receipt, not the judgment.
- Scoped the `_shared/review-ledger-contract.md` reference to the opt-in delivery-authority route instead of deleting it, exactly the "conditional on the same distinction" shape the issue's scope note calls for. An earlier draft deleted it outright, which failed `TestSkillRelativeSharedLinksResolveAfterInject`: that guard uses judgment-day's `../_shared/` link as its probe that shared assets deploy and resolve on disk. Scoping keeps the guard meaningful with no test edits.

Named anti-patterns avoided: no flag that bypasses the receipt, no second judgment-day pipeline. The receipt path is untouched and stays exactly as strict; opting into authority is the existing negotiated route, unchanged.

`internal/assets/skills/judgment-day/references/prompts-and-formats.md` is intentionally untouched: its judge and fix prompts are already lifecycle-free (the repo enforces this via `assertNoReviewerLifecycleInstructions`), and its wording is pinned in sync with `boundedreview.go` by `reviewer_envelope_guard_test.go` and `bounded_review_contract_test.go`, which a parallel change owns.

## TDD evidence

New guard: `internal/assets/judgment_day_standalone_test.go`, asserting the skill body contains none of the coupling phrases (`review/start`, `mode=judgment_day`, `persist the transaction`, `terminal transaction states`, `terminal receipt`) and explicitly disclaims delivery authority. Genuine RED against the pre-edit file:

```
--- FAIL: TestJudgmentDaySkillStartsWithoutReviewTransaction (0.00s)
    judgment_day_standalone_test.go:30: ... routes the tool into delivery-receipt machinery via "review/start"
    judgment_day_standalone_test.go:30: ... routes the tool into delivery-receipt machinery via "mode=judgment_day"
    judgment_day_standalone_test.go:30: ... routes the tool into delivery-receipt machinery via "persist the transaction"
    judgment_day_standalone_test.go:30: ... routes the tool into delivery-receipt machinery via "terminal transaction states"
    judgment_day_standalone_test.go:30: ... routes the tool into delivery-receipt machinery via "terminal receipt"
    judgment_day_standalone_test.go:35: ... must state that a judgment issues no receipt and carries no delivery authority
FAIL
```

GREEN after the edit. The RED run also flagged the `review-ledger-contract` string; that assertion was removed when the reference became scoped rather than deleted, per the deployment-guard finding above.

## Verification

All run in this branch's worktree, foreground, `-count=1`:

- `go test ./...` across all 66 packages (grouped runs to fit resource limits): every package ok, including `internal/cli` (254s), `internal/reviewtransaction` (222s), `internal/sddstatus`, `e2e/organicruntime`, and `internal/components/sdd` (44s, includes the shared-link deployment guard)
- `go test ./...` in `bench/`: ok
- `gofmt -l`: clean; `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: "no new unreachable functions"
- Refusal-resolution ratchet tests (`TestRefusalRatchet*`, `TestEveryProductionRefusal*`): pass
- Goldens: zero regenerated, verified by execution; after the full suite, `git status` shows only the two intended paths and `git diff -- testdata/` is empty. As phase 1 predicted, goldens embed generated orchestrator and ledger-contract text, never the skill body, so there is no collision with #2484's golden set.

## Follow-up finding: JD transaction machinery is production-unreachable

Out of scope for this PR by orchestrator ruling, documented here so a follow-up issue can be filed from it.

No production code path can start, advance, or finalize a judgment_day review transaction. `internal/cli` contains zero references to `judgment_day`, `ModeJudgmentDay`, or judge proofs. The legacy `review start --mode` flag is parsed and discarded (`internal/cli/review.go:433`), and the negotiated facade hardcodes `ModeOrdinaryBounded` (`internal/cli/review_facade.go:1159`, `:1783`). The following machinery is therefore reachable only from its own tests:

- `internal/reviewtransaction/transaction.go`: 13 `ModeJudgmentDay` sites, including the mode constant (line 22), judge-proof recording (~441), fix-round budgets (~701, ~1283), and state validation (~1135, ~1439-1488, ~1638, ~1723)
- `internal/reviewtransaction/receipt.go:396,430`: JD receipt validation (two immutable judge proofs, coherent counters)
- `internal/reviewtransaction/store.go:578,638,823`: successor rules for JD proofs
- `internal/sddstatus/review_gate.go:284-288`: remediation case requiring a persisted JD transaction

Deleting it would be a genuine net deletion, but it forecloses ever issuing JD-mode receipts, so it deserves its own decision and issue rather than riding along here.

Closes #2487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Judgment Day evaluations now start directly by freezing the target, without requiring review transactions, runtime identity, persistence, or delivery receipts.
  * Terminal verdicts are standardized as `APPROVED` or `ESCALATED`.
  * Findings, fixes, and re-judgment remain managed by the parent review process.

* **Bug Fixes**
  * Clarified that Judgment Day issues no delivery receipt and does not initiate delivery actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->