### PR TITLE
fix(ci): strip HTML comments before parsing linked issues in PR gates

### DIFF
--- a/.github/scripts/parse-linked-issues.cjs
+++ b/.github/scripts/parse-linked-issues.cjs
@@ -1,0 +1,28 @@
+'use strict';
+
+// Shared parser for closing issue references in PR bodies.
+// Single seam used by every pr-check.yml gate that reads linked issues:
+// both check-issue-reference and check-issue-approved consume this parse.
+
+const CLOSING_REFERENCE_PATTERN = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
+
+// An HTML comment runs from `<!--` to the next `-->`, or to the end of the
+// body when unclosed. The unclosed case matches how GitHub renders Markdown
+// (the HTML spec closes an open comment at end of input), so everything after
+// an unclosed `<!--` is invisible to reviewers and must not count.
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
+
+// Removes HTML comments so only reviewer-visible text remains.
+function stripHtmlComments(body) {
+  return (body || '').replace(HTML_COMMENT_PATTERN, '');
+}
+
+// Returns the linked issue numbers referenced by closing keywords in the
+// visible (non-comment) PR body, in order of first appearance.
+function parseLinkedIssues(body) {
+  const visible = stripHtmlComments(body);
+  const matches = [...visible.matchAll(CLOSING_REFERENCE_PATTERN)];
+  return matches.map((m) => parseInt(m[1], 10));
+}
+
+module.exports = { parseLinkedIssues, stripHtmlComments };

--- a/.github/scripts/parse-linked-issues.test.cjs
+++ b/.github/scripts/parse-linked-issues.test.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseLinkedIssues } = require('./parse-linked-issues.cjs');
+
+test('a closing reference that only appears inside an HTML comment is not a linked issue', () => {
+  const body = [
+    '## Summary',
+    '',
+    '<!--',
+    'Link the approved issue this PR resolves, e.g.:',
+    'Closes #42',
+    '-->',
+    '',
+    'Some visible description without any reference.',
+  ].join('\n');
+
+  assert.deepEqual(parseLinkedIssues(body), []);
+});
+
+test('a real reference outside a comment plus the template example inside one finds exactly the real one', () => {
+  const body = [
+    'Closes #1770',
+    '',
+    '<!--',
+    'Example: Closes #42',
+    '-->',
+  ].join('\n');
+
+  assert.deepEqual(parseLinkedIssues(body), [1770]);
+});
+
+test('a single-line HTML comment is also ignored', () => {
+  const body = 'Fixes #7\n<!-- Closes #42 --> trailing visible text';
+
+  assert.deepEqual(parseLinkedIssues(body), [7]);
+});
+
+test('multiple visible closing references are all preserved, in order', () => {
+  const body = 'Closes #10\nFixes #11\nResolves #12';
+
+  assert.deepEqual(parseLinkedIssues(body), [10, 11, 12]);
+});
+
+// Documented behavior: an unclosed `<!--` hides everything through the end of
+// the body. This matches how GitHub renders Markdown (the HTML spec closes an
+// open comment at end of input), so a reference after an unclosed `<!--` is
+// invisible to reviewers and must not count as a linked issue.
+test('an unclosed HTML comment hides the rest of the body, matching rendered output', () => {
+  const body = 'Closes #1770\n<!-- forgot to close this comment\nCloses #42';
+
+  assert.deepEqual(parseLinkedIssues(body), [1770]);
+});
+
+test('an empty or missing body yields no linked issues', () => {
+  assert.deepEqual(parseLinkedIssues(''), []);
+  assert.deepEqual(parseLinkedIssues(null), []);
+  assert.deepEqual(parseLinkedIssues(undefined), []);
+});

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,29 +42,49 @@ jobs:
 
             core.setFailed(`❌ ${message}`);
 
+  check-workflow-scripts:
+    name: Check Workflow Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - name: Run workflow script tests
+        run: node --test .github/scripts/parse-linked-issues.test.cjs
+
   check-issue-reference:
     name: Check Issue Reference
     runs-on: ubuntu-latest
+    outputs:
+      issue-numbers: ${{ steps.parse.outputs.issue-numbers }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - name: Verify PR body references an issue
+        id: parse
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
-            const body = context.payload.pull_request.body || '';
-            const pattern = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
-            const matches = [...body.matchAll(pattern)];
+            const { parseLinkedIssues } = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/parse-linked-issues.cjs`
+            );
 
-            if (matches.length === 0) {
+            // Parse the visible body once; HTML comments (like the PR
+            // template's `Closes #42` example) are stripped by the shared
+            // parser, and check-issue-approved reuses this exact result.
+            const issueNumbers = parseLinkedIssues(context.payload.pull_request.body);
+            core.setOutput('issue-numbers', JSON.stringify(issueNumbers));
+
+            if (issueNumbers.length === 0) {
               core.setFailed(
                 '❌ PR body must reference a linked issue using one of:\n' +
                 '  - Closes #<number>\n' +
                 '  - Fixes #<number>\n' +
                 '  - Resolves #<number>\n\n' +
+                'References inside HTML comments (<!-- ... -->) do not count.\n' +
                 'Every PR must be linked to an approved issue.'
               );
             } else {
-              const numbers = matches.map(m => `#${m[1]}`).join(', ');
-              console.log(`✅ Found issue reference(s): ${numbers}`);
+              console.log(`✅ Found issue reference(s): ${issueNumbers.map(n => `#${n}`).join(', ')}`);
             }
 
   check-issue-approved:
@@ -74,19 +94,19 @@ jobs:
     steps:
       - name: Verify linked issue(s) have status:approved label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        env:
+          ISSUE_NUMBERS: ${{ needs.check-issue-reference.outputs.issue-numbers }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const body = context.payload.pull_request.body || '';
-            const pattern = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
-            const matches = [...body.matchAll(pattern)];
+            // Reuse the single parse from check-issue-reference; do not
+            // re-scan the raw body here (see issue #1770).
+            const issueNumbers = JSON.parse(process.env.ISSUE_NUMBERS || '[]');
 
-            if (matches.length === 0) {
+            if (issueNumbers.length === 0) {
               core.setFailed('❌ Could not find issue reference in PR body.');
               return;
             }
-
-            const issueNumbers = matches.map(m => parseInt(m[1], 10));
             const failures = [];
 
             for (const issueNumber of issueNumbers) {


### PR DESCRIPTION
## Summary

The PR template ships a commented-out closing-reference example (issue 42) inside an HTML comment, and the PR gates scanned the raw PR body without stripping HTML comments, so the commented example counted as a real linked issue and failed otherwise valid PRs (confirmed on #1080 and #1069; #2471's working notes confirmed the impact by execution when linked-issue labels wrongly labelled a closed Debian install report).

Closes #1770

## Gate inventory

Every consumer that parses linked issues from a PR body was located before fixing:

- `check-issue-reference` in `.github/workflows/pr-check.yml`: parsed the raw body with `/(?:closes|fixes|resolves)\s+#(\d+)/gi`.
- `check-issue-approved` in `.github/workflows/pr-check.yml`: re-parsed the raw body with its own copy of the same regex.
- No other consumers exist: `ci.yml` only mentions issue numbers in comments and a Go test name in a `-run` filter, and no Go code outside `// Closes #N` doc comments in tests parses PR bodies. Nothing is deferred to the open `ci.yml` PRs (#2479 and siblings).

The issue's "both PR gates" claim checks out: exactly two, both in `pr-check.yml`.

## Fix shape

- HTML comments are stripped once, at a single seam: new shared module `.github/scripts/parse-linked-issues.cjs` exposing `parseLinkedIssues` (strip, then scan). Both duplicated inline regex copies are deleted.
- `check-issue-reference` parses once and publishes the numbers as a job output; `check-issue-approved` consumes the output instead of re-scanning the body.
- The PR template is intentionally unchanged: the example is fine, the parser was wrong.
- Documented behavior for an unclosed `<!--`: it hides everything through the end of the body, matching how GitHub renders Markdown (the HTML spec closes an open comment at end of input), so a reference after an unclosed `<!--` never counts. A test pins this.
- New `check-workflow-scripts` job runs the `node:test` coverage (zero dependencies) on every PR.

## RED evidence (verbatim)

The current parsing logic was first extracted verbatim (no stripping) and the tests run against it. 4 of 6 failed:

```
✖ a closing reference that only appears inside an HTML comment is not a linked issue (25.836948ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

  + [
  +   42
  + ]
  - []
```

and the mixed case (real reference plus commented example):

```
✖ a real reference outside a comment plus the template example inside one finds exactly the real one (0.685762ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

    [
      1770,
  +   42
    ]
```

After adding the stripping: 6/6 pass, including multiple visible references preserved in order and the unclosed-comment case.

## Verification

- `node --test .github/scripts/parse-linked-issues.test.cjs`: 6 pass, 0 fail.
- `actionlint .github/workflows/pr-check.yml`: clean.
- Root `go test ./... -count=1`: green. One pre-existing flake surfaced on the first run (`TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets` in `internal/components/engram`, "unexpected request: /?"); it passes 3/3 in isolation and in the full rerun, and this diff touches no Go code.
- Bench module `go test ./... -count=1`: green.
- `gofmt -l`: clean. `go vet ./...`: clean.
- `scripts/deadcode-ratchet.sh`: "no new unreachable functions".
- Refusal-resolution ratchet (`internal/cli/refusal_resolution_ratchet_test.go`): green within the root suite; baseline untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linked issue detection by ignoring references inside HTML comments, including unclosed comments.
  * Preserved the order of visible issue references and handled empty PR descriptions reliably.
  * Improved consistency between issue-reference and approval checks.

* **Tests**
  * Added coverage for multiline, single-line, and unclosed HTML comments, along with empty and null descriptions.

* **Chores**
  * Added automated validation for linked-issue parsing in pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
