### PR TITLE
fix(installcmd): trust the package manager probe instead of re-enumerating apt/pacman/dnf

### DIFF
--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -123,8 +123,15 @@ func TestInstallCommand(t *testing.T) {
 			want:    [][]string{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@latest"}},
 		},
 		{
-			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
+			// Issue #2499: the probe (#2493) accepts any Linux package manager
+			// on PATH, so zypper resolves like every other probed manager.
+			name:    "opensuse resolves npm install",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: "opensuse-leap", PackageManager: "zypper"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@latest"}},
+		},
+		{
+			name:    "linux without package manager returns error",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: ""},
 			wantErr: true,
 		},
 	}

--- a/internal/components/gga/install_test.go
+++ b/internal/components/gga/install_test.go
@@ -110,10 +110,12 @@ func TestInstallCommandByProfile(t *testing.T) {
 			},
 		},
 		{
-			name: "unsupported package manager returns error",
+			// Issue #2499: the probe (#2493) accepts any Linux package manager
+			// on PATH; only a probe-rejected profile (no manager found) errors.
+			name: "linux without package manager returns error",
 			profile: system.PlatformProfile{
 				OS:             "linux",
-				PackageManager: "zypper",
+				PackageManager: "",
 			},
 			wantErr: true,
 		},

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -252,15 +252,21 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		return CommandSequence{
 			{"brew", "install", "anomalyco/tap/opencode"},
 		}, nil
-	case "apt", "pacman", "dnf":
-		if profile.NpmWritable {
-			return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
-		}
-		return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}, nil
 	case "winget":
 		// On Windows, npm global installs do not require sudo.
 		return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
 	default:
+		// Any package manager the system probe accepted is enough here: the
+		// install runs through npm, never through the manager itself, so
+		// re-enumerating managers would silently narrow the probe's list
+		// (issue #2499). The gate keeps a probe-rejected Linux profile
+		// (empty PackageManager) on the unsupported arm.
+		if profile.OS == "linux" && profile.PackageManager != "" {
+			if profile.NpmWritable {
+				return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
+			}
+			return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}, nil
+		}
 		return nil, fmt.Errorf(
 			"unsupported platform for opencode: os=%q distro=%q pm=%q",
 			profile.OS, profile.LinuxDistro, profile.PackageManager,
@@ -278,17 +284,6 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
-		const tmpDir = "/tmp/gentleman-guardian-angel"
-		tagRef := "refs/tags/v" + versions.GGAVersion
-		return CommandSequence{
-			{"rm", "-rf", tmpDir},
-			{"mkdir", "-p", tmpDir},
-			{"git", "init", tmpDir},
-			{"git", "-C", tmpDir, "fetch", "--depth=1", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tagRef + ":" + tagRef},
-			{"git", "-C", tmpDir, "checkout", "-f", tagRef},
-			{"bash", tmpDir + "/install.sh"},
-		}, nil
 	case "winget":
 		// On Windows, use Git Bash explicitly to avoid bare "bash" resolving to
 		// C:\Windows\System32\bash.exe (WSL), which cannot run the script.
@@ -301,6 +296,23 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{bash, bashScriptPath(profile, filepath.Join(cloneDst, "install.sh"))},
 		}, nil
 	default:
+		// Any package manager the system probe accepted is enough here: the
+		// Linux install is git clone + install.sh and never touches the
+		// manager, so re-enumerating managers would silently narrow the
+		// probe's list (issue #2499). The gate keeps a probe-rejected Linux
+		// profile (empty PackageManager) on the unsupported arm.
+		if profile.OS == "linux" && profile.PackageManager != "" {
+			const tmpDir = "/tmp/gentleman-guardian-angel"
+			tagRef := "refs/tags/v" + versions.GGAVersion
+			return CommandSequence{
+				{"rm", "-rf", tmpDir},
+				{"mkdir", "-p", tmpDir},
+				{"git", "init", tmpDir},
+				{"git", "-C", tmpDir, "fetch", "--depth=1", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tagRef + ":" + tagRef},
+				{"git", "-C", tmpDir, "checkout", "-f", tagRef},
+				{"bash", tmpDir + "/install.sh"},
+			}, nil
+		}
 		return nil, fmt.Errorf(
 			"unsupported platform for gga: os=%q distro=%q pm=%q",
 			profile.OS, profile.LinuxDistro, profile.PackageManager,

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -361,6 +361,28 @@ func TestResolveAgentInstall(t *testing.T) {
 			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@latest"}},
 		},
 		{
+			// Issue #2499: the probe (#2493) accepts any Linux package manager
+			// on PATH; the resolver must not re-enumerate a subset of that list.
+			name:    "opencode on alpine system npm uses sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: "alpine", PackageManager: "apk", Supported: true},
+			agent:   model.AgentOpenCode,
+			want:    CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@latest"}},
+		},
+		{
+			name:    "opencode on opensuse nvm skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: "opensuse-leap", PackageManager: "zypper", Supported: true, NpmWritable: true},
+			agent:   model.AgentOpenCode,
+			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@latest"}},
+		},
+		{
+			// A Linux profile the probe rejected (no manager on PATH) must keep
+			// erroring: the default arm is gated on a non-empty PackageManager.
+			name:    "opencode on linux without package manager returns error",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: "unknown", PackageManager: ""},
+			agent:   model.AgentOpenCode,
+			wantErr: true,
+		},
+		{
 			name:    "claude-code on windows uses npm without sudo",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget", NpmWritable: true},
 			agent:   model.AgentClaudeCode,
@@ -657,6 +679,40 @@ func TestResolveComponentInstall(t *testing.T) {
 				{"git", "-C", "/tmp/gentleman-guardian-angel", "checkout", "-f", "refs/tags/v" + versions.GGAVersion},
 				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
 			},
+		},
+		{
+			// Issue #2499: GGA's Linux install is git clone + install.sh and
+			// never touches the package manager, so any probed manager works.
+			name:      "gga on alpine uses git clone and install.sh",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: "alpine", PackageManager: "apk", Supported: true},
+			component: model.ComponentGGA,
+			want: CommandSequence{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"mkdir", "-p", "/tmp/gentleman-guardian-angel"},
+				{"git", "init", "/tmp/gentleman-guardian-angel"},
+				{"git", "-C", "/tmp/gentleman-guardian-angel", "fetch", "--depth=1", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "refs/tags/v" + versions.GGAVersion + ":refs/tags/v" + versions.GGAVersion},
+				{"git", "-C", "/tmp/gentleman-guardian-angel", "checkout", "-f", "refs/tags/v" + versions.GGAVersion},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
+			name:      "gga on nixos uses git clone and install.sh",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: "nixos", PackageManager: "nix", Supported: true},
+			component: model.ComponentGGA,
+			want: CommandSequence{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"mkdir", "-p", "/tmp/gentleman-guardian-angel"},
+				{"git", "init", "/tmp/gentleman-guardian-angel"},
+				{"git", "-C", "/tmp/gentleman-guardian-angel", "fetch", "--depth=1", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "refs/tags/v" + versions.GGAVersion + ":refs/tags/v" + versions.GGAVersion},
+				{"git", "-C", "/tmp/gentleman-guardian-angel", "checkout", "-f", "refs/tags/v" + versions.GGAVersion},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
+			name:      "gga on linux without package manager returns error",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: "unknown", PackageManager: ""},
+			component: model.ComponentGGA,
+			wantErr:   true,
 		},
 		{
 			name:      "engram on windows returns error (uses DownloadLatestBinary instead)",


### PR DESCRIPTION
## What

`internal/installcmd/resolver.go` hardcoded `case "apt", "pacman", "dnf":` in both `resolveOpenCodeInstall` and `resolveGGAInstall`. With #2493 merged, the system probe admits any Linux package manager on PATH (brew, apt, dnf, pacman, apk, zypper, nix, emerge), so an Alpine (`apk`) or openSUSE (`zypper`) user now passes the platform guard on main and is then stranded at the resolver: detection says supported, resolution refuses.

This PR makes each hardcoded arm the `default` arm gated on `profile.OS == "linux" && profile.PackageManager != ""`. Both Linux arms are package-manager-agnostic (OpenCode installs through npm; GGA is git clone + install.sh), so the resolver now trusts the probe instead of re-enumerating a subset of it. No per-manager cases were added; the fix deletes an enumeration rather than extending it.

## Why the gate has two conditions

The issue proposed gating on `profile.OS == "linux"` alone. The merged probe can return a Linux profile with `PackageManager: ""` and `Supported: false` (nothing found on PATH). A bare OS gate would hand that machine an install command instead of the unsupported error, so the default arm also requires a non-empty `PackageManager`. Table cases pin that refusal for both functions.

Out of scope, deliberately: `ResolveDependencyInstall` and `uvInstallHint` also enumerate managers, but their commands genuinely differ per manager (`apk add` vs `zypper install`), so a gated default cannot express them. They keep their current fallbacks.

## Caller tests that asserted the stranding

Two caller-package tests used `PackageManager: "zypper"` as their canonical "unsupported" manager, i.e. they asserted the exact bug this fix deletes. Both were updated to the shape that is genuinely unsupported now (Linux with empty `PackageManager`, the probe-rejected profile), and the opencode adapter gained a zypper-resolves case:

- `internal/agents/opencode/adapter_test.go` (`TestInstallCommand`)
- `internal/components/gga/install_test.go` (`TestInstallCommandByProfile`)

## RED (verbatim, before the fix)

```
--- FAIL: TestResolveAgentInstall (0.00s)
    --- FAIL: TestResolveAgentInstall/opencode_on_alpine_system_npm_uses_sudo (0.00s)
        resolver_test.go:428: ResolveAgentInstall() error = unsupported platform for opencode: os="linux" distro="alpine" pm="apk", wantErr false
    --- FAIL: TestResolveAgentInstall/opencode_on_opensuse_nvm_skips_sudo (0.00s)
        resolver_test.go:428: ResolveAgentInstall() error = unsupported platform for opencode: os="linux" distro="opensuse-leap" pm="zypper", wantErr false
--- FAIL: TestResolveComponentInstall (0.00s)
    --- FAIL: TestResolveComponentInstall/gga_on_alpine_uses_git_clone_and_install.sh (0.00s)
        resolver_test.go:744: ResolveComponentInstall() error = unsupported platform for gga: os="linux" distro="alpine" pm="apk", wantErr false
    --- FAIL: TestResolveComponentInstall/gga_on_nixos_uses_git_clone_and_install.sh (0.00s)
        resolver_test.go:744: ResolveComponentInstall() error = unsupported platform for gga: os="linux" distro="nixos" pm="nix", wantErr false
FAIL
FAIL	github.com/gentleman-programming/gentle-ai/v2/internal/installcmd	0.002s
```

All four pass after the fix, plus new guards that a probe-rejected Linux profile (empty `PackageManager`) still errors.

## Verification

- `go test ./... -count=1` at root: pass
- `go test ./... -count=1` in bench module: pass
- `gofmt -l .`: clean
- `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- Refusal-resolution ratchet (`TestRefusalRatchet*`, `TestEveryProductionRefusal*`): pass (no new refusal strings; both existing `fmt.Errorf` arms preserved verbatim)

Closes #2499
Refs #2493 #1944


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux installation support across additional distributions, including Alpine, openSUSE, and NixOS.
  * Installation now adapts to any supported package manager detected by the system.
  * Added clearer failures when no package manager is available.
  * OpenCode installation now selects npm commands based on whether elevated permissions are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->