### PR TITLE
fix(sdd): derive status and acquire readiness from one predicate

### DIFF
--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -1227,7 +1227,7 @@ func TestResolveRejectsCompactRemediationWhenFrozenBudgetIsZero(t *testing.T) {
 		LineageID: "compact-thin", Generation: 1, State: reviewtransaction.StateApproved,
 		CorrectionBudget: 2, CumulativeCorrectionLines: 2,
 	}
-	state := resolveBoundedRemediation(true, verifyResultEvaluation{
+	state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 		EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 	}, nil, &compact, "bounded review transaction is missing", "")
 
@@ -1242,7 +1242,7 @@ func TestResolveRejectsCompactRemediationAfterSingleConsumedAttempt(t *testing.T
 		CorrectionBudget: 10, CumulativeCorrectionLines: 1,
 		CorrectionAttempts: []reviewtransaction.CompactCorrectionAttempt{{ActualLines: 1}},
 	}
-	state := resolveBoundedRemediation(true, verifyResultEvaluation{
+	state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 		EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 	}, nil, &compact, "bounded review transaction is missing", "")
 
@@ -1256,7 +1256,7 @@ func TestResolveBoundedRemediationExposesUnambiguousRemainingAndTotalBudget(t *t
 		LineageID: "compact-thin", Generation: 1, State: reviewtransaction.StateApproved,
 		CorrectionBudget: 10, CumulativeCorrectionLines: 3,
 	}
-	state := resolveBoundedRemediation(true, verifyResultEvaluation{
+	state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 		EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 	}, nil, &compact, "bounded review transaction is missing", "")
 
@@ -1306,7 +1306,7 @@ func TestResolveBoundedRemediationSurfacesEscalationAccountingForAlreadyEscalate
 			LineageID: "compact-thin", Generation: 1, State: reviewtransaction.StateEscalated,
 			CorrectionBudget: 10, CumulativeCorrectionLines: 12,
 		}
-		state := resolveBoundedRemediation(true, verifyResultEvaluation{
+		state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 			EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 		}, nil, &compact, "bounded review transaction is missing", "")
 
@@ -1328,7 +1328,7 @@ func TestResolveBoundedRemediationSurfacesEscalationAccountingForAlreadyEscalate
 			CorrectionBudget: 10, CumulativeCorrectionLines: 3,
 			OriginalCriteria: &originalFailed, CorrectionRegression: &regressionPassed,
 		}
-		state := resolveBoundedRemediation(true, verifyResultEvaluation{
+		state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 			EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 		}, nil, &compact, "bounded review transaction is missing", "")
 
@@ -1357,7 +1357,7 @@ func TestEscalationAccountingReasonTemplateKeepsSDDBoundOutputByteIdentical(t *t
 		LineageID: "compact-thin", Generation: 1, State: reviewtransaction.StateEscalated,
 		CorrectionBudget: 10, CumulativeCorrectionLines: 12,
 	}
-	state := resolveBoundedRemediation(true, verifyResultEvaluation{
+	state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 		EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 	}, nil, &compact, "bounded review transaction is missing", "")
 	const want = "compact review authority is escalated (budget_exceeded): spent 12, remaining 0, total 10 correction lines"
@@ -1394,7 +1394,7 @@ func TestResolveBoundedRemediationNoCorrectionBudgetGuardNeverPopulatesRemaining
 				LineageID: "compact-thin", Generation: 1, State: reviewtransaction.StateApproved,
 				CorrectionBudget: test.correctionBudget, CumulativeCorrectionLines: test.cumulativeCorrectionLines,
 			}
-			state := resolveBoundedRemediation(true, verifyResultEvaluation{
+			state := resolveBoundedRemediation(true, false, verifyResultEvaluation{
 				EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
 			}, nil, &compact, "bounded review transaction is missing", "")
 

--- a/internal/sddstatus/review_disabled_remediation_test.go
+++ b/internal/sddstatus/review_disabled_remediation_test.go
@@ -1,0 +1,71 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDisabledReviewAdmitsUnmanagedRemediationForAdmittedFailure reproduces
+// #2182. With receipt-driven review globally disabled, an admitted failed
+// verification could not enter remediation: status refused on "bounded review
+// transaction is missing", a transaction that policy itself prevented from
+// existing, and left remediationState.required false with no correction route
+// at all.
+//
+// A kill switch that a downstream check overrides is not a kill switch. The
+// switch already gates the review authority lookup; it did not gate the
+// classification that consumes the absence of what the lookup would have found.
+func TestDisabledReviewAdmitsUnmanagedRemediationForAdmittedFailure(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("fail", 1, 0, "1/1", "1/1", 0, 0))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", ReviewDisabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if strings.Contains(reasons, "bounded review transaction") {
+		t.Fatalf("a disabled switch still demanded review authority: %v", status.BlockedReasons)
+	}
+	if !status.RemediationState.Required {
+		t.Fatalf("admitted failure exposed no correction route under a disabled switch: %#v", status.RemediationState)
+	}
+	if status.RemediationState.FailedEvidenceRevision == "" {
+		t.Fatalf("unmanaged remediation lost the failed evidence it corrects: %#v", status.RemediationState)
+	}
+	if status.NextRecommended != "remediate" {
+		t.Fatalf("nextRecommended = %q, want remediate", status.NextRecommended)
+	}
+	// The switch removes the review obligation; it must never fabricate the
+	// approval that obligation would have produced.
+	if status.ReviewGate != nil {
+		t.Fatalf("disabled review published a gate result: %#v", status.ReviewGate)
+	}
+	if state := status.RemediationState; state.LineageID != "" || state.Generation != 0 || state.FixBatch != 0 ||
+		state.CorrectionBudgetTotal != 0 || state.CorrectionBudgetRemaining != 0 {
+		t.Fatalf("unmanaged remediation invented review-authority provenance: %#v", state)
+	}
+}
+
+// TestEnabledReviewStillRequiresItsBoundedTransaction is the converse: the gate
+// is scoped to the switch being off, and turning it on keeps the original
+// refusal exactly.
+func TestEnabledReviewStillRequiresItsBoundedTransaction(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("fail", 1, 0, "1/1", "1/1", 0, 0))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reasons := strings.Join(status.BlockedReasons, "\n"); !strings.Contains(reasons, "bounded review transaction is missing") {
+		t.Fatalf("enabled review stopped requiring its bounded transaction: %v", status.BlockedReasons)
+	}
+	if status.RemediationState.Required {
+		t.Fatalf("enabled review admitted remediation with no transaction: %#v", status.RemediationState)
+	}
+}

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -224,12 +224,35 @@ func readReviewTransaction(path, content string) (*reviewtransaction.Transaction
 // sddstatus-qualified name working unchanged for both remaining consumers.
 const EscalationAccountingReasonTemplate = reviewtransaction.EscalationAccountingReasonTemplate
 
-func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, transaction *reviewtransaction.Transaction, compact *reviewtransaction.CompactState, transactionReason, applyProgress string) RemediationState {
+func resolveBoundedRemediation(required, reviewDisabled bool, verify verifyResultEvaluation, transaction *reviewtransaction.Transaction, compact *reviewtransaction.CompactState, transactionReason, applyProgress string) RemediationState {
 	if !required {
 		return RemediationState{}
 	}
 	if verify.EvidenceRevision == "" && strings.Contains(verify.Reason, "evidence_revision") {
 		return RemediationState{Reason: fmt.Sprintf("verify evidence cannot enter remediation: %s", verify.Reason)}
+	}
+	// #2182: the kill switch already gates the review authority LOOKUP at the
+	// call site; without this it did not gate the classification that consumes
+	// the absence of what that lookup would have found, so an admitted failure
+	// was refused for missing a bounded review transaction that policy itself
+	// prevented from existing. A kill switch a downstream check overrides is not
+	// a kill switch.
+	//
+	// Correction proceeds unmanaged: bound to the failed evidence, and carrying
+	// none of the lineage, generation, fix-batch or budget fields that only a
+	// review authority can issue. Those stay zero rather than fabricated,
+	// because no path may report or imply review approval while review is off.
+	// Completion stays review-independent too: the runtime ledger already
+	// settles it through nativeRuntimeCompletesRemediation.
+	if reviewDisabled {
+		return RemediationState{
+			Required:               true,
+			FailedEvidenceRevision: verify.EvidenceRevision,
+			Reason: fmt.Sprintf(
+				"verify evidence requires unmanaged remediation for %s: %s; receipt-driven review is disabled, so this correction is bounded by the native runtime attempt budget alone",
+				verify.EvidenceRevision, verify.Reason,
+			),
+		}
 	}
 	if transaction == nil && compact != nil {
 		if compact.State == reviewtransaction.StateEscalated {

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -79,6 +79,78 @@ type CompactSettleRequest struct {
 	RemediatesEvidenceRevision string
 }
 
+// runtimeReadinessInput is everything the one readiness predicate reads. It
+// carries the whole AttemptTokens map rather than a pre-resolved token so the
+// predicate stays the only code that inspects the readiness triple; a caller
+// that had to resolve the active attempt's ordinal first would be deciding a
+// little bit of the answer on its own, which is the drift this collapses.
+//
+// Request and PresentedToken are optional. A caller that names neither (status,
+// and Settle's post-mutation projection) gets the request-blind, token-blind
+// answer, which is exactly what it is entitled to state.
+type runtimeReadinessInput struct {
+	Status         RuntimeStatus
+	AttemptTokens  map[int]string
+	Request        BeginAttemptRequest
+	PresentedToken string
+}
+
+// runtimeReadiness answers "may this work proceed?" exactly once, for every
+// consumer. It reports the compact result plus whether that result is terminal;
+// a non-terminal answer means nothing blocks, and each caller then does its own
+// thing with that permission (Acquire begins an attempt and mints a token,
+// Settle reports proceed, status leaves routing to the artifacts).
+//
+// Before this, three call sites derived the same verdict separately and
+// disagreed: compactAcquireBlock (request-aware), compactSettleResult
+// (request-blind), and status's applyNativeRuntimeRouting, which was
+// request-blind AND token-blind and asserted acquire's answer in a hand-written
+// string it never checked. #2463 is that string being wrong: acquire returned
+// proceed and handed back a token, and status reported the very same attempt as
+// an active blocker whose "external execution" could only be settled, for an
+// execution the caller was about to launch.
+//
+// The ordering is the ledger's own. applyRuntimeFinishEvent sets exactly one of
+// Complete or DecisionRequired and clears ActiveAttempt in both branches, so
+// checking Complete first is not a precedence choice among reachable states.
+func runtimeReadiness(in runtimeReadinessInput) (CompactAttemptResult, bool) {
+	activeToken := ""
+	if in.Status.ActiveAttempt != nil {
+		activeToken = in.AttemptTokens[in.Status.ActiveAttempt.Ordinal]
+	}
+
+	// Zero-mutation ownership check (#2291): a distinct call or process launched
+	// by a parent that already holds a proceed-state acquire presents that exact
+	// token to prove it continues the SAME attempt rather than colliding with
+	// it. A non-matching token falls to the ordinary block naming the REAL
+	// active token. An empty token leaves every other path unchanged.
+	if in.PresentedToken != "" && in.Status.ActiveAttempt != nil {
+		if in.PresentedToken == activeToken {
+			return CompactAttemptResult{State: CompactStateProceed, Token: activeToken}, true
+		}
+		return compactForeignAcquireToken(activeToken), true
+	}
+
+	switch {
+	case in.Status.Complete:
+		// Completion is scoped to one objective: a passed apply is terminal for
+		// its own work unit while remaining an ordinary predecessor for the
+		// distinct verification the SDD graph still owes. A caller that names no
+		// work unit has named no successor scope, so completion stays terminal
+		// for it.
+		if in.Request.WorkUnit != "" && runtimeObjectiveAdvanceAdmissible(in.Status, in.Request) {
+			return CompactAttemptResult{}, false
+		}
+		return CompactAttemptResult{State: CompactStateComplete}, true
+	case in.Status.DecisionRequired:
+		return compactBlocked(CompactBlockMaintainerDecision, ""), true
+	case in.Status.ActiveAttempt != nil:
+		return compactBlocked(CompactBlockActiveAttempt, activeToken), true
+	default:
+		return CompactAttemptResult{}, false
+	}
+}
+
 // Acquire claims one native attempt without exposing the growing runtime
 // history. The returned token identifies that exact begin record for Settle.
 func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireRequest) (CompactAttemptResult, error) {
@@ -110,20 +182,10 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 		return compactAcquireResult(current, begin, receipt.Revision), nil
 	}
 
-	// Zero-mutation ownership check (#2291): this is a pure read-then-compare
-	// against the already-loaded replay, modeled after the request-ID replay
-	// dedup above — neither branch calls store.Begin or touches the ledger
-	// chain. It only applies when an attempt is actually live; an inert
-	// Token with no active attempt falls through to the normal begin flow.
-	if request.Token != "" && replay.Status.ActiveAttempt != nil {
-		activeToken := replay.AttemptTokens[replay.Status.ActiveAttempt.Ordinal]
-		if request.Token == activeToken {
-			return CompactAttemptResult{State: CompactStateProceed, Token: activeToken}, nil
-		}
-		return compactForeignAcquireToken(activeToken), nil
-	}
-
-	if result, terminal := compactAcquireBlock(replay, begin); terminal {
+	if result, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: replay.Status, AttemptTokens: replay.AttemptTokens,
+		Request: begin, PresentedToken: request.Token,
+	}); terminal {
 		return result, nil
 	}
 	begin.ExpectedRevision = replay.Status.Revision
@@ -161,21 +223,21 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		return store.compactSettleResult()
 	}
 
-	status := replay.Status
-	if status.Complete {
-		return CompactAttemptResult{State: CompactStateComplete}, nil
-	}
-	if status.DecisionRequired {
-		return compactBlocked(CompactBlockMaintainerDecision, ""), nil
-	}
-	if status.ActiveAttempt == nil {
+	// Settle asks the same predicate the same question and interprets the same
+	// answer for its own purpose: a proceed means this token owns the live
+	// attempt and may close it, and a non-terminal answer means there is no
+	// active attempt to close at all.
+	readiness, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: replay.Status, AttemptTokens: replay.AttemptTokens, PresentedToken: request.Token,
+	})
+	if !terminal {
 		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 	}
-	activeToken := replay.AttemptTokens[status.ActiveAttempt.Ordinal]
-	if request.Token != activeToken {
-		return compactBlocked(CompactBlockActiveAttempt, activeToken), nil
+	if readiness.State != CompactStateProceed {
+		return readiness, nil
 	}
 
+	status := replay.Status
 	finish := FinishAttemptRequest{
 		ExpectedRevision: status.Revision, RequestID: request.RequestID, Outcome: request.Outcome,
 		EvidenceRevision: request.EvidenceRevision, Diagnosis: request.Diagnosis,
@@ -264,31 +326,15 @@ func compactSettleReplayRequest(replay runtimeReplay, record runtimeRecord, requ
 	return finish, matches
 }
 
-// compactAcquireBlock needs the request because completion is scoped to one
-// objective: a passed apply is terminal for its own work unit while remaining an
-// ordinary predecessor for the distinct verification the SDD graph still owes.
-func compactAcquireBlock(replay runtimeReplay, request BeginAttemptRequest) (CompactAttemptResult, bool) {
-	status := replay.Status
-	switch {
-	case status.Complete:
-		if runtimeObjectiveAdvanceAdmissible(status, request) {
-			return CompactAttemptResult{}, false
-		}
-		return CompactAttemptResult{State: CompactStateComplete}, true
-	case status.DecisionRequired:
-		return compactBlocked(CompactBlockMaintainerDecision, ""), true
-	case status.ActiveAttempt != nil:
-		return compactBlocked(CompactBlockActiveAttempt, replay.AttemptTokens[status.ActiveAttempt.Ordinal]), true
-	default:
-		return CompactAttemptResult{}, false
-	}
-}
-
+// compactAcquireResult reconciles a committed begin whose publication the
+// caller could not observe. The already-committed record's revision IS the
+// caller's ownership proof, so it presents that token to the same predicate
+// rather than re-deriving the active-attempt comparison here.
 func compactAcquireResult(replay runtimeReplay, request BeginAttemptRequest, ownedToken string) CompactAttemptResult {
-	if result, terminal := compactAcquireBlock(replay, request); terminal {
-		if result.Reason == CompactBlockActiveAttempt && result.Token == ownedToken {
-			return CompactAttemptResult{State: CompactStateProceed, Token: ownedToken}
-		}
+	if result, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: replay.Status, AttemptTokens: replay.AttemptTokens,
+		Request: request, PresentedToken: ownedToken,
+	}); terminal {
 		return result
 	}
 	return compactBlocked(CompactBlockInvalidContinuation, "")
@@ -299,20 +345,15 @@ func (store RuntimeStore) compactSettleResult(expected ...string) (CompactAttemp
 	if err != nil {
 		return compactBlocked(CompactBlockCorruptAuthority, ""), nil
 	}
-	status := replay.Status
-	if len(expected) == 1 && status.Revision != expected[0] {
+	if len(expected) == 1 && replay.Status.Revision != expected[0] {
 		return compactBlocked(CompactBlockCorruptAuthority, ""), nil
 	}
-	switch {
-	case status.Complete:
-		return CompactAttemptResult{State: CompactStateComplete}, nil
-	case status.DecisionRequired:
-		return compactBlocked(CompactBlockMaintainerDecision, ""), nil
-	case status.ActiveAttempt != nil:
-		return compactBlocked(CompactBlockActiveAttempt, replay.AttemptTokens[status.ActiveAttempt.Ordinal]), nil
-	default:
-		return CompactAttemptResult{State: CompactStateProceed}, nil
+	if result, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: replay.Status, AttemptTokens: replay.AttemptTokens,
+	}); terminal {
+		return result, nil
 	}
+	return CompactAttemptResult{State: CompactStateProceed}, nil
 }
 
 func (store RuntimeStore) compactMutationFailure(err error, settle bool, begin BeginAttemptRequest) CompactAttemptResult {

--- a/internal/sddstatus/runtime_readiness_test.go
+++ b/internal/sddstatus/runtime_readiness_test.go
@@ -1,0 +1,218 @@
+package sddstatus
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestSDDStatusReportsWhatAcquireReturnsForAnAcquiredAttempt reproduces #2463's
+// exact sequence: acquire returns proceed and hands back a token, and status is
+// queried before any executor launches. The token the caller was just handed is
+// what status used to report as an active blocker, telling it to "settle only
+// the external execution already associated with that token" for an execution
+// that was never launched, with nextRecommended resolve-blockers and every
+// dependency blocked.
+//
+// The ratified contract (internal/assets/skills/_shared/sdd-status-contract.md
+// lines 20, 21 and 142) already makes compact acquire the launch authority and
+// full runtime status a diagnostic. Status therefore has no standing to refuse
+// a launch that acquire admitted; when an attempt is active it reports the
+// continuation acquire itself names (--token <live token>) and leaves routing
+// to the phase the artifacts select.
+func TestSDDStatusReportsWhatAcquireReturnsForAnAcquiredAttempt(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	seedReadyChange(t, repo, "acquired-not-launched", "- [ ] 1.1 Work\n")
+	store := mustRuntimeStore(t, repo, "acquired-not-launched")
+
+	acquired, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "acquire-before-launch", WorkUnit: "apply-license",
+			EvidenceGoal: "prove the license work unit", MaxAttempts: 1, MaxChangedLines: 800,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acquired.State != CompactStateProceed || acquired.Token == "" {
+		t.Fatalf("acquire = %#v, want proceed with a token", acquired)
+	}
+
+	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "acquired-not-launched", IncludeInstructions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.NextRecommended == "resolve-blockers" {
+		t.Fatalf("status stopped a caller that acquire admitted: next=%q blocked=%v", status.NextRecommended, status.BlockedReasons)
+	}
+	if status.Dependencies.Apply == DependencyBlocked {
+		t.Fatalf("status blocked apply for an attempt acquire admitted: dependencies=%#v", status.Dependencies)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if strings.Contains(reasons, "settle only the external execution") {
+		t.Fatalf("status still demands settlement of an execution that was never launched: %s", reasons)
+	}
+	instructions := strings.Join(status.PhaseInstructions.Apply, "\n")
+	if !strings.Contains(instructions, "--token "+acquired.Token) {
+		t.Fatalf("apply instructions omit the live attempt's own continuation:\n%s", instructions)
+	}
+}
+
+// TestSDDStatusStillStopsForAMaintainerDecision is the converse guard: the one
+// predicate must not turn a genuine maintainer-scope block into a launch. This
+// case has no self-service exit, so it stays a hard stop.
+func TestSDDStatusStillStopsForAMaintainerDecision(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	seedReadyChange(t, repo, "decision-required", "- [ ] 1.1 Work\n")
+	store := mustRuntimeStore(t, repo, "decision-required")
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "begin-decision", WorkUnit: "apply-auth",
+		EvidenceGoal: "prove the auth runtime", MaxAttempts: 1, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "finish-decision", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('7'), Diagnosis: "bounded runtime reproduced the failure",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "runtime process group exited",
+		ProcessEvidence: "post-run scan found no descendants",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "decision-required"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.NextRecommended != "resolve-blockers" || status.Dependencies.Apply != DependencyBlocked {
+		t.Fatalf("maintainer decision stopped being a stop: next=%q dependencies=%#v", status.NextRecommended, status.Dependencies)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if !strings.Contains(reasons, "blocked(maintainer_decision)") {
+		t.Fatalf("blocked reasons lost the compact reason code: %s", reasons)
+	}
+	// Status reports what acquire returns, so it also carries acquire's own
+	// named exit rather than a hand-written paraphrase.
+	if !strings.Contains(reasons, compactBlockedExitText(CompactBlockMaintainerDecision, "")) {
+		t.Fatalf("blocked reasons did not carry the predicate's own exit: %s", reasons)
+	}
+}
+
+// readinessTripleFields are the three RuntimeStatus fields that together answer
+// "may this work proceed?". Every issue in this family (#2463, #2350, #2182)
+// is one consumer reading them and reaching a different conclusion than
+// another consumer reading the same bytes.
+var readinessTripleFields = map[string]bool{
+	"Complete":         true,
+	"DecisionRequired": true,
+	"ActiveAttempt":    true,
+}
+
+// readinessDecisionFiles are the two files that answer the readiness question
+// for a CALLER. runtime_ledger.go is deliberately excluded: its handlers
+// re-check the same fields as mutation preconditions inside the lock, which is
+// a different question asked at a different layer.
+var readinessDecisionFiles = []string{"runtime_compact.go", "status.go"}
+
+// readinessTripleReaders names every function permitted to read the triple in
+// those files. It is a closed set of exactly one entry on purpose: the point of
+// this change is that "may this work proceed?" has one answer, derived once.
+//
+// Enumerating the reachable states in a test would recreate the drift one layer
+// up, which is the trap this package's artifact-map collapse (#2346) avoided in
+// the same way. This walks the package for rival producers instead, so a fourth
+// derivation added later fails here rather than in a user's terminal.
+var readinessTripleReaders = map[string]bool{
+	"runtimeReadiness": true,
+}
+
+func TestOneReadinessPredicateHasNoRivalDerivations(t *testing.T) {
+	fileSet := token.NewFileSet()
+	for _, name := range readinessDecisionFiles {
+		parsed, err := parser.ParseFile(fileSet, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil || readinessTripleReaders[function.Name.Name] {
+				continue
+			}
+			runtimeValues := runtimeStatusIdentifiers(function)
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				selector, ok := node.(*ast.SelectorExpr)
+				if !ok || !readinessTripleFields[selector.Sel.Name] || !isRuntimeStatusExpression(selector.X, runtimeValues) {
+					return true
+				}
+				t.Errorf(
+					"%s: %s reads the readiness field %q on a RuntimeStatus; only runtimeReadiness may decide whether work proceeds",
+					fileSet.Position(selector.Pos()), function.Name.Name, selector.Sel.Name,
+				)
+				return true
+			})
+		}
+	}
+}
+
+// runtimeStatusIdentifiers collects the local names bound to a RuntimeStatus in
+// one function: its parameters and results, plus short variable declarations
+// whose right-hand side is already a RuntimeStatus expression. That is enough
+// to tell `runtimeStatus.Complete` from `remediationState.Complete` without
+// dragging a type checker into a test.
+func runtimeStatusIdentifiers(function *ast.FuncDecl) map[string]bool {
+	bound := map[string]bool{}
+	declaresRuntimeStatus := func(fieldType ast.Expr) bool {
+		if star, ok := fieldType.(*ast.StarExpr); ok {
+			fieldType = star.X
+		}
+		identifier, ok := fieldType.(*ast.Ident)
+		return ok && identifier.Name == "RuntimeStatus"
+	}
+	for _, list := range []*ast.FieldList{function.Type.Params, function.Type.Results} {
+		if list == nil {
+			continue
+		}
+		for _, field := range list.List {
+			if !declaresRuntimeStatus(field.Type) {
+				continue
+			}
+			for _, name := range field.Names {
+				bound[name.Name] = true
+			}
+		}
+	}
+	ast.Inspect(function.Body, func(node ast.Node) bool {
+		assignment, ok := node.(*ast.AssignStmt)
+		if !ok || assignment.Tok != token.DEFINE || len(assignment.Lhs) != len(assignment.Rhs) {
+			return true
+		}
+		for index, right := range assignment.Rhs {
+			left, ok := assignment.Lhs[index].(*ast.Ident)
+			if ok && isRuntimeStatusExpression(right, bound) {
+				bound[left.Name] = true
+			}
+		}
+		return true
+	})
+	return bound
+}
+
+// isRuntimeStatusExpression reports whether an expression denotes a
+// RuntimeStatus: a bound local name, or any `X.Status` / `X.RuntimeStatus`
+// selector, which is how the replay and the SDD status document both expose it.
+func isRuntimeStatusExpression(expression ast.Expr, bound map[string]bool) bool {
+	switch node := expression.(type) {
+	case *ast.Ident:
+		return bound[node.Name]
+	case *ast.StarExpr:
+		return isRuntimeStatusExpression(node.X, bound)
+	case *ast.SelectorExpr:
+		return node.Sel.Name == "Status" || node.Sel.Name == "RuntimeStatus"
+	}
+	return false
+}

--- a/internal/sddstatus/runtime_status_remediation_advice_test.go
+++ b/internal/sddstatus/runtime_status_remediation_advice_test.go
@@ -6,15 +6,25 @@ import (
 	"testing"
 )
 
-func TestActiveAttemptBlockerUsesOnlyOpaqueCompactContinuation(t *testing.T) {
+// TestActiveAttemptGuidanceUsesOnlyOpaqueCompactContinuation keeps the original
+// non-leak property while following the guidance to the channel it now belongs
+// to. An active attempt stopped being a blocker in #2463 (status has no
+// standing to refuse a launch compact acquire admits, and it cannot know
+// whether its reader holds the token), so the continuation is published as
+// runtime instructions instead. What it may say is unchanged: the opaque token
+// and nothing else.
+func TestActiveAttemptGuidanceUsesOnlyOpaqueCompactContinuation(t *testing.T) {
 	fixture := newRuntimeSelfRemediationFixture(t)
-	status, err := Resolve(ResolveOptions{CWD: fixture.repo, ChangeName: "runtime-self-remediation"})
+	status, err := Resolve(ResolveOptions{CWD: fixture.repo, ChangeName: "runtime-self-remediation", IncludeInstructions: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	reasons := strings.Join(status.BlockedReasons, "\n")
-	if !strings.Contains(reasons, "blocked(active_attempt)") || !strings.Contains(reasons, "opaque settle token") {
-		t.Fatalf("active bound attempt published no compact blocker: %v", status.BlockedReasons)
+	guidance := activeAttemptGuidance(t, status)
+	if !strings.Contains(guidance, "--token ") {
+		t.Fatalf("active bound attempt published no compact continuation:\n%s", guidance)
+	}
+	if reasons := strings.Join(status.BlockedReasons, "\n"); strings.Contains(reasons, "active_attempt") {
+		t.Fatalf("an attempt compact acquire admits was published as a blocker: %v", status.BlockedReasons)
 	}
 	for _, fragment := range []string{
 		fixture.binding.Revision,
@@ -22,16 +32,16 @@ func TestActiveAttemptBlockerUsesOnlyOpaqueCompactContinuation(t *testing.T) {
 		fixture.failedEvidence,
 		"sdd-attempt finish",
 	} {
-		if strings.Contains(reasons, fragment) {
-			t.Fatalf("active bound attempt blocker leaked %s:\n%s", fragment, reasons)
+		if strings.Contains(guidance, fragment) {
+			t.Fatalf("active bound attempt guidance leaked %s:\n%s", fragment, guidance)
 		}
 	}
 }
 
-// TestActiveAttemptBlockerStaysShortWithoutABinding keeps the addition
+// TestActiveAttemptGuidanceStaysShortWithoutABinding keeps the addition
 // proportional: an unbound attempt owes no review obligation, so naming
 // remediation flags there would advertise a route that does not apply.
-func TestActiveAttemptBlockerStaysShortWithoutABinding(t *testing.T) {
+func TestActiveAttemptGuidanceStaysShortWithoutABinding(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	seedReadyChange(t, repo, "unbound-active", "- [ ] 1.1 Work\n")
 	store := mustRuntimeStore(t, repo, "unbound-active")
@@ -41,15 +51,30 @@ func TestActiveAttemptBlockerStaysShortWithoutABinding(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "unbound-active"})
+	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "unbound-active", IncludeInstructions: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	reasons := strings.Join(status.BlockedReasons, "\n")
-	if !strings.Contains(reasons, "blocked(active_attempt)") {
-		t.Fatalf("active unbound attempt published no compact blocker: %v", status.BlockedReasons)
+	guidance := activeAttemptGuidance(t, status)
+	if strings.Contains(guidance, "--successor-lineage") {
+		t.Fatalf("unbound active attempt advertised remediation flags it cannot use:\n%s", guidance)
 	}
-	if strings.Contains(reasons, "--successor-lineage") {
-		t.Fatalf("unbound active attempt advertised remediation flags it cannot use:\n%s", reasons)
+}
+
+// activeAttemptGuidance returns the single apply instruction that names a live
+// attempt's continuation. Scoping to that line keeps these assertions about
+// what the readiness predicate published, not about the unconditional
+// acquire/settle boilerplate that surrounds it.
+func activeAttemptGuidance(t *testing.T, status Status) string {
+	t.Helper()
+	if status.PhaseInstructions == nil {
+		t.Fatal("status carries no phase instructions")
 	}
+	for _, instruction := range status.PhaseInstructions.Apply {
+		if strings.HasPrefix(instruction, "An attempt is already active") {
+			return instruction
+		}
+	}
+	t.Fatalf("apply instructions name no live attempt continuation:\n%s", strings.Join(status.PhaseInstructions.Apply, "\n"))
+	return ""
 }

--- a/internal/sddstatus/runtime_status_test.go
+++ b/internal/sddstatus/runtime_status_test.go
@@ -239,7 +239,7 @@ func TestMissingEvidenceRevisionPreservesStrictParserReasonBeforeLegacyTransacti
 	)
 	verify := parseVerifyResult(report, SpecCounts{Requirements: 1, Scenarios: 1})
 	transaction := &reviewtransaction.Transaction{FailedEvidenceRevision: runtimeTestHash('e')}
-	remediation := resolveBoundedRemediation(true, verify, transaction, nil, "", "")
+	remediation := resolveBoundedRemediation(true, false, verify, transaction, nil, "", "")
 	const want = "verify evidence cannot enter remediation: missing evidence_revision in verify result envelope"
 	if remediation.Reason != want {
 		t.Fatalf("missing evidence remediation reason = %q, want %q", remediation.Reason, want)

--- a/internal/sddstatus/runtime_status_test.go
+++ b/internal/sddstatus/runtime_status_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestResolveEmbedsAndRoutesNativeRuntimeAuthority(t *testing.T) {
-	t.Run("OpenSpec active attempt blocks a second continuation", func(t *testing.T) {
+	t.Run("OpenSpec active attempt names its own continuation without stopping the caller", func(t *testing.T) {
 		repo := initRuntimeLedgerRepo(t)
 		seedReadyChange(t, repo, "active-runtime", "- [ ] 1.1 Work\n")
 		store := mustRuntimeStore(t, repo, "active-runtime")
@@ -32,7 +32,7 @@ func TestResolveEmbedsAndRoutesNativeRuntimeAuthority(t *testing.T) {
 		if status.RuntimeStatus.ActiveAttempt == nil || status.RuntimeStatus.ActiveAttempt.Ordinal != 1 {
 			t.Fatalf("runtime status = %#v, want active ordinal 1", status.RuntimeStatus)
 		}
-		assertRuntimeContinuationBlocked(t, status, "blocked(active_attempt)")
+		assertRuntimeContinuationOffered(t, status, active.Revision)
 		if instructions := strings.Join(status.PhaseInstructions.Apply, "\n"); !strings.Contains(instructions, "gentle-ai sdd-attempt acquire") ||
 			!strings.Contains(instructions, "gentle-ai sdd-attempt settle") {
 			t.Fatalf("apply instructions omit native runtime commands:\n%s", instructions)
@@ -133,7 +133,7 @@ func TestResolveEngramUsesTheSameNativeRuntimeAuthority(t *testing.T) {
 		t.Fatalf("artifact store = %q, want engram", status.ArtifactStore)
 	}
 	assertRuntimeStatusRevision(t, status, active.Revision)
-	assertRuntimeContinuationBlocked(t, status, "blocked(active_attempt)")
+	assertRuntimeContinuationOffered(t, status, active.Revision)
 	payload, err := json.Marshal(status)
 	if err != nil {
 		t.Fatal(err)
@@ -288,6 +288,24 @@ func assertRuntimeStatusRevision(t *testing.T, status Status, revision string) {
 	t.Helper()
 	if status.RuntimeStatus == nil || status.RuntimeStatus.Revision != revision {
 		t.Fatalf("RuntimeStatus = %#v, want revision %q", status.RuntimeStatus, revision)
+	}
+}
+
+// assertRuntimeContinuationOffered is the active-attempt counterpart of
+// assertRuntimeContinuationBlocked after #2463. A live attempt is not a stop:
+// compact acquire admits the holder of that attempt's token, so status names
+// the same continuation acquire names and leaves routing to the artifacts.
+func assertRuntimeContinuationOffered(t *testing.T, status Status, activeToken string) {
+	t.Helper()
+	if status.NextRecommended == "resolve-blockers" || status.Dependencies.Apply == DependencyBlocked {
+		t.Fatalf("live attempt stopped a caller compact acquire admits: next=%q dependencies=%#v blocked=%v",
+			status.NextRecommended, status.Dependencies, status.BlockedReasons)
+	}
+	if reasons := strings.Join(status.BlockedReasons, "\n"); strings.Contains(reasons, "active_attempt") {
+		t.Fatalf("live attempt was published as a blocker: %v", status.BlockedReasons)
+	}
+	if guidance := activeAttemptGuidance(t, status); !strings.Contains(guidance, "--token "+activeToken) {
+		t.Fatalf("apply instructions omit the live attempt's own token continuation:\n%s", guidance)
 	}
 }
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -230,6 +230,13 @@ type Status struct {
 	PhaseInstructions *PhaseInstructions `json:"phaseInstructions,omitempty"`
 	NextRecommended   string             `json:"nextRecommended"`
 	BlockedReasons    []string           `json:"blockedReasons"`
+	// runtimeAttemptTokens carries the ledger's live attempt tokens alongside
+	// RuntimeStatus so status can ask the one readiness predicate the same
+	// question compact acquire asks, and name the same continuation acquire
+	// names. It is unexported on purpose: the tokens are an input to the
+	// answer, not part of the SDD v1 wire document, and the ratified contract
+	// keeps full runtime payload off that document.
+	runtimeAttemptTokens map[int]string
 }
 
 // ReviewOfferBlock carries what an orchestrator needs to present the
@@ -459,7 +466,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	runtimeStatus, runtimeStatusErr := loadNativeRuntimeStatus(context.Background(), workspaceRoot, changeName)
+	runtimeStatus, runtimeAttemptTokens, runtimeStatusErr := loadNativeRuntimeStatus(context.Background(), workspaceRoot, changeName)
 	reviewState, reviewStateReason := readReviewTransaction(firstPath(artifactPaths.ReviewState), "")
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
@@ -506,7 +513,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 			blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
 		}
 	}
-	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, verifyResult)
+	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult)
 	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
 	var compactRemediation *reviewtransaction.CompactState
 	if !reviewDisabled {
@@ -591,6 +598,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	status.ApplyState = applyState
 	status.RemediationState = remediationState
 	status.RuntimeStatus = runtimeStatus
+	status.runtimeAttemptTokens = runtimeAttemptTokens
 	status.ReviewTransaction = reviewState
 	if governingRef == nil {
 		if staleAllowAuthority != nil {
@@ -625,25 +633,30 @@ func Resolve(options ResolveOptions) (Status, error) {
 	return status, nil
 }
 
-func loadNativeRuntimeStatus(ctx context.Context, workspaceRoot, changeName string) (*RuntimeStatus, error) {
+// loadNativeRuntimeStatus returns the runtime status together with the ledger's
+// attempt tokens. Status needs the tokens because it now reports what compact
+// acquire would return, and acquire's answer for a live attempt names that
+// attempt's own token as the caller's continuation (#2463).
+func loadNativeRuntimeStatus(ctx context.Context, workspaceRoot, changeName string) (*RuntimeStatus, map[int]string, error) {
 	// SDD status remains useful for non-Git planning fixtures and repositories.
 	// A native runtime chain cannot exist without a Git common-dir, so the
 	// absence of a repository means there is no runtime authority to embed.
 	if _, err := (reviewtransaction.SnapshotBuilder{Repo: workspaceRoot}).ResolveRepositoryRoot(ctx); err != nil {
 		if workspaceHasGitMetadata(workspaceRoot) {
-			return nil, fmt.Errorf("resolve Git repository for native SDD runtime authority: %w", err)
+			return nil, nil, fmt.Errorf("resolve Git repository for native SDD runtime authority: %w", err)
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 	store, err := OpenRuntimeStore(ctx, workspaceRoot, changeName)
 	if err != nil {
-		return nil, fmt.Errorf("open native SDD runtime authority: %w", err)
+		return nil, nil, fmt.Errorf("open native SDD runtime authority: %w", err)
 	}
-	status, err := store.Status()
+	replay, err := store.load()
 	if err != nil {
-		return nil, fmt.Errorf("read native SDD runtime authority: %w", err)
+		return nil, nil, fmt.Errorf("read native SDD runtime authority: %w", err)
 	}
-	return &status, nil
+	status := replay.Status
+	return &status, replay.AttemptTokens, nil
 }
 
 func workspaceHasGitMetadata(workspaceRoot string) bool {
@@ -660,9 +673,14 @@ func workspaceHasGitMetadata(workspaceRoot string) bool {
 	}
 }
 
-func nativeRuntimeCompletesRemediation(runtimeStatus *RuntimeStatus, verify verifyResultEvaluation) bool {
-	if runtimeStatus == nil || !runtimeStatus.Complete || runtimeStatus.DecisionRequired || runtimeStatus.ActiveAttempt != nil ||
-		runtimeStatus.Binding == nil || verify.EvidenceRevision == "" || len(runtimeStatus.Attempts) == 0 {
+func nativeRuntimeCompletesRemediation(runtimeStatus *RuntimeStatus, attemptTokens map[int]string, verify verifyResultEvaluation) bool {
+	if runtimeStatus == nil || runtimeStatus.Binding == nil || verify.EvidenceRevision == "" || len(runtimeStatus.Attempts) == 0 {
+		return false
+	}
+	// "The runtime finished this objective cleanly" is the readiness question,
+	// so it is asked through the one predicate rather than re-derived here.
+	readiness, terminal := runtimeReadiness(runtimeReadinessInput{Status: *runtimeStatus, AttemptTokens: attemptTokens})
+	if !terminal || readiness.State != CompactStateComplete {
 		return false
 	}
 	last := runtimeStatus.Attempts[len(runtimeStatus.Attempts)-1]
@@ -690,30 +708,38 @@ func applyNativeRuntimeErrorRouting(status *Status, runtimeErr error) {
 	status.BlockedReasons = append(status.BlockedReasons, reason)
 }
 
+// applyNativeRuntimeRouting reports what compact acquire would return. It no
+// longer derives that verdict, and it no longer asserts it in prose: the reason
+// text is the predicate's own named exit.
+//
+// An active attempt is deliberately not a stop (#2463). The ratified contract
+// (internal/assets/skills/_shared/sdd-status-contract.md lines 20, 21 and 142)
+// makes acquire the launch authority and full runtime status a diagnostic, and
+// acquire's own exit for this state is self-service: the holder of the token
+// adds --token to its own call and continues that exact attempt. Status cannot
+// know whether its reader holds that token, and it does not need to, because
+// acquire checks. Blocking here stopped the one caller that was entitled to
+// proceed, and every caller reaches acquire before launching anyway.
+//
+// A maintainer decision has no self-service exit, so it stays a hard stop.
 func applyNativeRuntimeRouting(status *Status) {
 	if status == nil || status.RuntimeStatus == nil {
 		return
 	}
-	runtimeStatus := status.RuntimeStatus
-	change := runtimeStatus.Change
+	readiness, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: *status.RuntimeStatus, AttemptTokens: status.runtimeAttemptTokens,
+	})
+	if !terminal || readiness.State != CompactStateBlocked || readiness.Reason == CompactBlockActiveAttempt {
+		return
+	}
+	change := status.RuntimeStatus.Change
 	if status.ChangeName != nil {
 		change = *status.ChangeName
 	}
-	var reason string
-	switch {
-	case runtimeStatus.DecisionRequired:
-		reason = fmt.Sprintf(
-			"native SDD runtime execution requires an explicit maintainer scope decision; compact acquire reports blocked(maintainer_decision). Reset remains exceptional and may be run only after explicit maintainer authorization; full status is diagnostic only for %q in %q",
-			change, status.ActionContext.WorkspaceRoot,
-		)
-	case runtimeStatus.ActiveAttempt != nil:
-		reason = fmt.Sprintf(
-			"native SDD runtime attempt %d is active; compact acquire reports blocked(active_attempt) with its opaque settle token. Do not launch another continuation; settle only the external execution already associated with that token for %q in %q",
-			runtimeStatus.ActiveAttempt.Ordinal, change, status.ActionContext.WorkspaceRoot,
-		)
-	default:
-		return
-	}
+	reason := fmt.Sprintf(
+		"native SDD runtime execution is blocked(%s) for %q in %q; compact acquire reports the same: %s",
+		readiness.Reason, change, status.ActionContext.WorkspaceRoot, readiness.Exit,
+	)
 	status.Dependencies.Apply = DependencyBlocked
 	status.Dependencies.Verify = DependencyBlocked
 	status.Dependencies.Archive = DependencyBlocked
@@ -787,7 +813,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	taskProgress := countTaskProgressText(artifactsByType["tasks"].Content)
 	specCounts := countSpecRequirementsAndScenarios([]string{artifactsByType["spec"].Content})
 	verifyResult := parseVerifyResult(artifactsByType["verify-report"].Content, specCounts)
-	runtimeStatus, runtimeStatusErr := loadNativeRuntimeStatus(context.Background(), workspaceRoot, changeName)
+	runtimeStatus, runtimeAttemptTokens, runtimeStatusErr := loadNativeRuntimeStatus(context.Background(), workspaceRoot, changeName)
 	reviewState, reviewStateReason := readReviewTransaction("", artifactsByType["review/transaction"].Content)
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
@@ -817,7 +843,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 			blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
 		}
 	}
-	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, verifyResult)
+	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult)
 	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
 	var compactRemediation *reviewtransaction.CompactState
 	if !reviewDisabled {
@@ -882,6 +908,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	status.ApplyState = applyState
 	status.RemediationState = remediationState
 	status.RuntimeStatus = runtimeStatus
+	status.runtimeAttemptTokens = runtimeAttemptTokens
 	status.ReviewTransaction = reviewState
 	if governingRef == nil {
 		if staleAllowAuthority != nil {
@@ -1742,12 +1769,31 @@ func renderPhaseInstructions(status Status) PhaseInstructions {
 
 func nativeRuntimeInstructions(status Status, change string) []string {
 	workspace := status.ActionContext.WorkspaceRoot
-	return []string{
+	return append([]string{
 		fmt.Sprintf("Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd %q --change %q --request-id \"<unique-request-id>\" --work-unit \"<label>\" --evidence-goal \"<stable-goal>\" --max-attempts <count> --max-changed-lines <count>`.", workspace, change),
 		"Launch only for state proceed and retain its opaque token. State blocked or complete stops the launch; full runtime status is a diagnostic escape hatch, not normal model context.",
 		fmt.Sprintf("After the external run, call `gentle-ai sdd-attempt settle --cwd %q --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome <passed|failed|interrupted> --evidence-revision <sha256> --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`; add --successor-lineage only for a distinct approved remediation successor.", workspace, change),
 		"Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic.",
+	}, liveRuntimeAttemptInstructions(status)...)
+}
+
+// liveRuntimeAttemptInstructions names the continuation for an attempt that is
+// already active. This is the informational half of #2463: status stops
+// blocking a live attempt, and instead hands the caller the exact exit compact
+// acquire itself names, including that attempt's own token. A caller that owns
+// the token continues it; a caller that does not learns it must settle first.
+// The text is the predicate's, never a paraphrase.
+func liveRuntimeAttemptInstructions(status Status) []string {
+	if status.RuntimeStatus == nil {
+		return nil
 	}
+	readiness, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: *status.RuntimeStatus, AttemptTokens: status.runtimeAttemptTokens,
+	})
+	if !terminal || readiness.Reason != CompactBlockActiveAttempt {
+		return nil
+	}
+	return []string{"An attempt is already active for this change: " + readiness.Exit}
 }
 
 // nonPhaseRoutingInstructions renders actionable continuations for

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -524,6 +524,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	}
 	remediationState := resolveBoundedRemediation(
 		remediationRequired,
+		reviewDisabled,
 		verifyResult,
 		reviewState,
 		compactRemediation,
@@ -854,6 +855,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	}
 	remediationState := resolveBoundedRemediation(
 		remediationRequired,
+		reviewDisabled,
 		verifyResult,
 		reviewState,
 		compactRemediation,

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -383,10 +383,23 @@ func TestResolveRuntimeOverrideRestoresExpectedPlanningBlockersForBothStores(t *
 				restore := stubEngramExport(t, engramPlanningRoute("thin", "propose"))
 				t.Cleanup(restore)
 			}
+			// A maintainer decision is the runtime state that still overrides
+			// routing to a final route. An active attempt stopped overriding in
+			// #2463: compact acquire admits its own token holder, so status has
+			// no standing to refuse that launch.
 			store := mustRuntimeStore(t, root, "thin")
-			if _, err := store.Begin(context.Background(), BeginAttemptRequest{
+			active, err := store.Begin(context.Background(), BeginAttemptRequest{
 				ExpectedRevision: "", RequestID: "begin-thin", WorkUnit: "apply",
-				EvidenceGoal: "prove final-route blocker filtering", MaxAttempts: 2, MaxChangedLines: 20,
+				EvidenceGoal: "prove final-route blocker filtering", MaxAttempts: 1, MaxChangedLines: 20,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.Finish(context.Background(), FinishAttemptRequest{
+				ExpectedRevision: active.Revision, RequestID: "finish-thin", Outcome: AttemptFailed,
+				EvidenceRevision: runtimeTestHash('4'), Diagnosis: "bounded runtime reproduced the failure",
+				HarnessDisposition: HarnessReused, CleanupEvidence: "runtime process group exited",
+				ProcessEvidence: "post-run scan found no descendants",
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -399,7 +412,7 @@ func TestResolveRuntimeOverrideRestoresExpectedPlanningBlockersForBothStores(t *
 				t.Fatalf("NextRecommended = %q, want resolve-blockers", status.NextRecommended)
 			}
 			reasons := strings.Join(status.BlockedReasons, "\n")
-			for _, want := range []string{"proposal.md is missing or partial.", "native SDD runtime attempt 1 is active"} {
+			for _, want := range []string{"proposal.md is missing or partial.", "blocked(maintainer_decision)"} {
 				if !strings.Contains(reasons, want) {
 					t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
 				}


### PR DESCRIPTION
Two things answered "may this work proceed?" and derived the answer separately, so they disagreed. #2463 is the sharpest form: `acquire` returns `proceed` and hands you a token, then `sdd-status` reports that same attempt as an active blocker and says only the external execution already associated with it may be settled. The execution was never launched, because the caller was about to launch it. **The token you were just handed is what blocks you.**

## The one line that says why this needed fixing

`renderPhaseInstructions` emits guidance telling the caller to run acquire and launch only on `proceed`, **in the same document** where `applyNativeRuntimeRouting` set `resolve-blockers` and blocked apply, verify and archive.

The status document contradicted itself.

## The premise the plan rested on did not hold

The decision was made expecting a costly separation: status cannot call acquire because acquire mutates, so the decision would have to be extracted from the mutation.

Measurement first found that **`compactAcquireBlock` was already a pure free function** with no receiver and no I/O, and the mutation happens strictly after it. Nothing needed extracting. It simply had one caller. The expensive part turned out to be that status has no request to ask with.

There were also **three** derivations of this verdict, not two: acquire's is request-aware, settle's is request-blind, and status's is request-blind and token-blind.

## The shape

`runtimeReadiness` is now the only thing that answers the question. Six consumers call it, and `compactAcquireBlock` is deleted.

The detail that let one function serve four callers with no reconciliation layer: it returns `(result, terminal)`, and non-terminal means "nothing blocks". Each caller interprets that permission its own way. Acquire begins an attempt and mints a token, Settle reports proceed, Settle with nothing active reads the same non-terminal as an invalid continuation, and status leaves routing to the artifacts. No third layer, so nothing to drift.

One guard is load-bearing: the complete branch admits an objective advance only when the request carries a work unit. Without it the request-blind callers would have flipped a completed objective to proceed.

An active attempt stops being a status stop. It publishes **acquire's own exit**, which names the live token, as apply guidance. A maintainer decision keeps blocking and now carries the predicate's named exit rather than a hand-written paraphrase of what acquire would have said.

## #2182, the kill switch

`resolveBoundedRemediation` was called unconditionally while the review authority lookup above it was gated. With the switch off, transaction and compact were both nil and the classification fired on their absence, refusing with `bounded review transaction is missing` **while review was disabled**.

It now takes the gate. Correction proceeds unmanaged: required and bound to the failed evidence, with lineage, generation, fix-batch and budget left at zero rather than fabricated. Completion was already review-independent through the runtime ledger.

## The structural guard, and what it found

`TestOneReadinessPredicateHasNoRivalDerivations` walks both files by AST for any function other than the predicate reading the readiness triple. **Its RED run found 22 rival readings.**

It needed a small syntactic dataflow pass, because a name-only check false-positives on an unrelated `Complete` field. No new dependency was added for it.

That is the property that matters: it does not enumerate states, so a future fourth derivation fails the test rather than shipping.

## Verification

Genuine RED on all three new tests before any production edit, and a decisive re-proof after: stripping the one active-attempt branch reproduces #2463 exactly, with status returning `resolve-blockers` against an acquire that had just returned proceed. Restored, the tree is byte-identical to HEAD.

Root `go test ./... -count=1` green across 63 packages, bench module green, gofmt and vet clean, deadcode ratchet reports no new unreachable functions, refusal ratchet green. Goldens regenerated across all four owning packages produced **zero** diffs, then reverified without `-update`.

## Deliberately not included

#2469 and #2348 were kept out, and #2469's diagnosis is corrected rather than inherited. Its lock claim is false as written: the `flock` is real and the mutation releases it with `defer`. The real defect is that `release()` never truncates the owner payload, so the LOCK file permanently names the last acquirer, which is the phantom PID the reporter inspected. Filed as #2504, with the measurements posted on #2469 and a suggestion to narrow it to the part that is still unexplained.

Closes #2463
Closes #2182

Part of #2471
