### PR TITLE
fix(bench): loud journey ID collisions and honest dead_end reporting

### DIFF
--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// journeySource is one journeys_*.go file and the journeys it contributes.
+// Journey IDs are hand-assigned across these files, so the collision check
+// must be able to name the two defining files: a failure that cannot say
+// where both definitions live sends the author on a repo-wide grep.
+type journeySource struct {
+	File     string
+	Journeys []Journey
+}
+
+// journeySources maps every journeys_*.go corpus file to its constructor.
+// Adding a new journeys_*.go file means registering its constructor here;
+// TestJourneySourcesCoverTheWholeCorpus fails until it is registered, so a
+// new file cannot bypass the collision check silently.
+func journeySources() []journeySource {
+	return []journeySource{
+		{"journeys.go", coreJourneys()},
+		{"journeys_edge.go", edgeJourneys()},
+		{"journeys_sdd.go", sddJourneys()},
+		{"journeys_wave1.go", waveOneJourneys()},
+		{"journeys_wave3.go", waveThreeJourneys()},
+		{"journeys_wave5.go", waveFiveJourneys()},
+	}
+}
+
+// TestJourneyIDsAreUniqueAcrossSourceFiles is the focused duplicate-ID check.
+// Before it existed, a colliding ID was only caught downstream by the
+// registration test, whose seen[journey.ID] failure is generic and arrives
+// next to an unrelated count mismatch. This failure names both defining
+// files at the point of the mistake.
+func TestJourneyIDsAreUniqueAcrossSourceFiles(t *testing.T) {
+	owners := map[string]string{}
+	for _, source := range journeySources() {
+		for _, journey := range source.Journeys {
+			owner, taken := owners[journey.ID]
+			if !taken {
+				owners[journey.ID] = source.File
+				continue
+			}
+			t.Errorf("journey ID %q is defined in both %s and %s; pick an ID no journeys_*.go file uses yet",
+				journey.ID, owner, source.File)
+		}
+	}
+}
+
+// TestJourneySourcesCoverTheWholeCorpus pins journeySources to Journeys().
+// Without it, a new journeys_*.go file appended to Journeys() but not
+// registered above would sit outside the collision check, which would put
+// the corpus right back where it started: duplicates caught late, by a
+// message about something else.
+func TestJourneySourcesCoverTheWholeCorpus(t *testing.T) {
+	counted := map[string]int{}
+	for _, source := range journeySources() {
+		for _, journey := range source.Journeys {
+			counted[journey.ID]++
+		}
+	}
+	for _, journey := range Journeys() {
+		counted[journey.ID]--
+	}
+	disagreements := []string{}
+	for id, count := range counted {
+		if count != 0 {
+			disagreements = append(disagreements, fmt.Sprintf("%s (%+d)", id, -count))
+		}
+	}
+	sort.Strings(disagreements)
+	if len(disagreements) > 0 {
+		t.Fatalf("journeySources and Journeys() disagree on: %s\nEvery journeys_*.go file must be registered in journeySources so the ID-collision check covers it.",
+			strings.Join(disagreements, ", "))
+	}
+}

--- a/bench/report.go
+++ b/bench/report.go
@@ -15,6 +15,12 @@ import (
 type dimensionRow struct {
 	Label string
 	Value func(MetricSet) (int, bool, string) // value, present, derivation
+	// Unmeasured reports that this run never exercised the dimension, so its
+	// value is an absence rather than a measurement. nil means the dimension
+	// is always measured. UnmeasuredNote is the legend sentence that says why
+	// the column reads n/a instead of a number.
+	Unmeasured     func(Results) bool
+	UnmeasuredNote string
 }
 
 func dimensionRows() []dimensionRow {
@@ -31,20 +37,43 @@ func dimensionRows() []dimensionRow {
 		return func(set MetricSet) (int, bool, string) { return get(set.Blocks), true, set.BlocksDerivation }
 	}
 	return []dimensionRow{
-		{"1 human_prompts", pick(func(s MetricSet) Dimension { return s.HumanPrompts })},
-		{"2 manual_tokens", pick(func(s MetricSet) Dimension { return s.ManualTokens })},
-		{"3 commands_to_completion", pick(func(s MetricSet) Dimension { return s.CommandsToCompletion })},
-		{"4 blocks (total)", blocks(func(b BlockCounts) int { return b.Total() })},
-		{"4a   self_recovered", blocks(func(b BlockCounts) int { return b.SelfRecovered })},
-		{"4b   in_band", blocks(func(b BlockCounts) int { return b.InBand })},
-		{"4c   out_of_band", blocks(func(b BlockCounts) int { return b.OutOfBand })},
-		{"4d   by_design", blocks(func(b BlockCounts) int { return b.ByDesign })},
-		{"4e   dead_end", blocks(func(b BlockCounts) int { return b.DeadEnd })},
-		{"5 recovery_round_trips", pick(func(s MetricSet) Dimension { return s.RecoveryRoundTrips })},
-		{"6 model_runs", pick(func(s MetricSet) Dimension { return s.ModelRuns })},
-		{"7 human_surface_bytes", pick(func(s MetricSet) Dimension { return s.HumanSurfaceBytes })},
-		{"- git_subprocesses (info)", pick(func(s MetricSet) Dimension { return s.GitSubprocesses })},
+		{Label: "1 human_prompts", Value: pick(func(s MetricSet) Dimension { return s.HumanPrompts })},
+		{Label: "2 manual_tokens", Value: pick(func(s MetricSet) Dimension { return s.ManualTokens })},
+		{Label: "3 commands_to_completion", Value: pick(func(s MetricSet) Dimension { return s.CommandsToCompletion })},
+		{Label: "4 blocks (total)", Value: blocks(func(b BlockCounts) int { return b.Total() })},
+		{Label: "4a   self_recovered", Value: blocks(func(b BlockCounts) int { return b.SelfRecovered })},
+		{Label: "4b   in_band", Value: blocks(func(b BlockCounts) int { return b.InBand })},
+		{Label: "4c   out_of_band", Value: blocks(func(b BlockCounts) int { return b.OutOfBand })},
+		{Label: "4d   by_design", Value: blocks(func(b BlockCounts) int { return b.ByDesign })},
+		{
+			Label:      "4e   dead_end",
+			Value:      blocks(func(b BlockCounts) int { return b.DeadEnd }),
+			Unmeasured: deadEndUnexercised,
+			UnmeasuredNote: "n/a because no journey in this run declared a dead end; " +
+				"an unexercised 0 would read as a measured absence",
+		},
+		{Label: "5 recovery_round_trips", Value: pick(func(s MetricSet) Dimension { return s.RecoveryRoundTrips })},
+		{Label: "6 model_runs", Value: pick(func(s MetricSet) Dimension { return s.ModelRuns })},
+		{Label: "7 human_surface_bytes", Value: pick(func(s MetricSet) Dimension { return s.HumanSurfaceBytes })},
+		{Label: "- git_subprocesses (info)", Value: pick(func(s MetricSet) Dimension { return s.GitSubprocesses })},
 	}
+}
+
+// deadEndUnexercised reports whether the run carries no dead-end declaration
+// at all: no command holds a DeadEndOutcome, applied or stale. dead_end can
+// only ever count through a declaration (Step.DeadEnd), so a run without one
+// has not measured the dimension, and its 0 is an absence. A stale
+// declaration is still an exercise of the classifier, and the genuine 0 it
+// produces keeps printing as a number.
+func deadEndUnexercised(results Results) bool {
+	for _, journey := range results.Journeys {
+		for _, command := range journey.Commands {
+			if command.DeadEnd != nil {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func writeRunReport(out io.Writer, results Results) {
@@ -59,6 +88,14 @@ func writeRunReport(out io.Writer, results Results) {
 	fmt.Fprintln(out)
 
 	rows := dimensionRows()
+	// unmeasured marks the rows this run never exercised, so their cells read
+	// n/a instead of a 0 that would invite the reading "measured, none found".
+	unmeasured := map[int]bool{}
+	for i, row := range rows {
+		if row.Unmeasured != nil && row.Unmeasured(results) {
+			unmeasured[i] = true
+		}
+	}
 	// The axis column appears only when a run selected one, so a core-only
 	// report is byte-for-byte the report it has always been.
 	withAxis := len(results.Axes) > 0
@@ -72,7 +109,11 @@ func writeRunReport(out io.Writer, results Results) {
 	table := [][]string{headers}
 	for _, journey := range results.Journeys {
 		line := []string{journey.ID, journey.Status}
-		for _, row := range rows {
+		for i, row := range rows {
+			if unmeasured[i] && journey.Status == StatusCompleted {
+				line = append(line, "n/a")
+				continue
+			}
 			line = append(line, cell(journey, row))
 		}
 		if withAxis {
@@ -81,7 +122,11 @@ func writeRunReport(out io.Writer, results Results) {
 		table = append(table, line)
 	}
 	total := []string{"TOTAL (completed only)", ""}
-	for _, row := range rows {
+	for i, row := range rows {
+		if unmeasured[i] {
+			total = append(total, "n/a")
+			continue
+		}
 		value, present, _ := row.Value(results.Totals)
 		total = append(total, format(value, present))
 	}
@@ -92,10 +137,13 @@ func writeRunReport(out io.Writer, results Results) {
 	renderTable(out, table)
 
 	fmt.Fprintf(out, "\nDimension legend\n")
-	for _, row := range rows {
+	for i, row := range rows {
 		value, present, derivation := row.Value(results.Totals)
 		_ = value
 		_ = present
+		if unmeasured[i] {
+			derivation += "; " + row.UnmeasuredNote
+		}
 		fmt.Fprintf(out, "  %-26s %s\n", row.Label, derivation)
 	}
 

--- a/bench/report_dead_end_test.go
+++ b/bench/report_dead_end_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// deadEndColumnCell extracts the dead_end cell of the journey row whose ID is
+// given, locating the column from the table header rather than hardcoding an
+// index, so a reordered table cannot silently make these tests assert on the
+// wrong dimension.
+func deadEndColumnCell(t *testing.T, report, journeyID string) string {
+	t.Helper()
+	column := -1
+	for _, line := range strings.Split(report, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if fields[0] == "journey" {
+			for i, field := range fields {
+				if field == "dead" {
+					column = i
+				}
+			}
+			continue
+		}
+		if column >= 0 && fields[0] == journeyID {
+			if len(fields) <= column {
+				t.Fatalf("row for %q has %d fields, dead_end column is %d\n%s", journeyID, len(fields), column, report)
+			}
+			return fields[column]
+		}
+	}
+	t.Fatalf("no journey row %q under a header naming a dead column\n%s", journeyID, report)
+	return ""
+}
+
+// TestDeadEndReadsUnmeasuredWhenNothingDeclaresOne is the guard on issue
+// #2490: a corpus in which no journey declares a dead end has not measured
+// anything, and printing 0 invites the reading "measured, and there are
+// none". The column must say the measurement never happened.
+func TestDeadEndReadsUnmeasuredWhenNothingDeclaresOne(t *testing.T) {
+	results := byDesignResults() // no command carries a dead-end declaration
+	buffer := &bytes.Buffer{}
+	writeRunReport(buffer, results)
+	report := buffer.String()
+
+	if got := deadEndColumnCell(t, report, "j17-bare-repository"); got != "n/a" {
+		t.Errorf("dead_end cell = %q, want %q: an unexercised dead_end must not read as a measured 0", got, "n/a")
+	}
+	totalLine := ""
+	for _, line := range strings.Split(report, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "TOTAL") {
+			totalLine = line
+		}
+	}
+	if totalLine == "" {
+		t.Fatalf("no TOTAL row in the report\n%s", report)
+	}
+	if !strings.Contains(totalLine, "n/a") {
+		t.Errorf("TOTAL row %q holds no n/a: the unexercised dead_end total still reads as a measurement", totalLine)
+	}
+	if !strings.Contains(report, "no journey in this run declared a dead end") {
+		t.Errorf("legend does not say why dead_end is n/a; the reader is left to guess\n%s", report)
+	}
+}
+
+// TestDeadEndStaysNumericWhenADeclarationApplied proves the column is still a
+// real measurement the moment a journey exercises a declaration: a driven
+// dead end must count, not read as n/a.
+func TestDeadEndStaysNumericWhenADeclarationApplied(t *testing.T) {
+	results := byDesignResults()
+	results.Journeys[0].Commands[1].Block = BlockDeadEnd
+	results.Journeys[0].Commands[1].DeadEnd = &DeadEndOutcome{Applied: true}
+	results.Journeys[0].Metrics.Blocks = BlockCounts{ByDesign: 1, DeadEnd: 1}
+	results.Totals, results.JourneysCounted, results.JourneysUnsupported, results.JourneysFailed = aggregate(results.Journeys)
+
+	buffer := &bytes.Buffer{}
+	writeRunReport(buffer, results)
+	report := buffer.String()
+
+	if got := deadEndColumnCell(t, report, "j17-bare-repository"); got != "1" {
+		t.Errorf("dead_end cell = %q, want %q: an exercised declaration is a measurement", got, "1")
+	}
+	if strings.Contains(report, "no journey in this run declared a dead end") {
+		t.Errorf("legend claims dead_end is unmeasured while a declaration applied\n%s", report)
+	}
+}
+
+// TestDeadEndMeasuredZeroPrintsZero is the distinction the issue asks for: a
+// stale declaration means the classifier was exercised and found no dead end,
+// so its 0 is a genuine measurement and must keep printing as 0, unlike the
+// undeclared case above.
+func TestDeadEndMeasuredZeroPrintsZero(t *testing.T) {
+	results := byDesignResults()
+	results.Journeys[0].Commands[1].DeadEnd = &DeadEndOutcome{
+		Applied: false,
+		Reason:  "the product named a runnable continuation, so the declaration is stale and should be removed",
+	}
+	results.Totals, results.JourneysCounted, results.JourneysUnsupported, results.JourneysFailed = aggregate(results.Journeys)
+
+	buffer := &bytes.Buffer{}
+	writeRunReport(buffer, results)
+	report := buffer.String()
+
+	if got := deadEndColumnCell(t, report, "j17-bare-repository"); got != "0" {
+		t.Errorf("dead_end cell = %q, want %q: a measured zero is a real result, not an absence", got, "0")
+	}
+	if strings.Contains(report, "no journey in this run declared a dead end") {
+		t.Errorf("legend claims dead_end is unmeasured while a stale declaration proves it was exercised\n%s", report)
+	}
+}


### PR DESCRIPTION
Closes #2489
Closes #2490

## Summary

- #2489: adds a focused duplicate-ID test that fails at the point of the mistake and names both defining `journeys_*.go` files, plus a completeness guard so a new journeys file cannot sit outside the check. The silent-collision mechanism is gone, not renamed around.
- #2490: the run report now prints the `4e dead_end` cells and total as `n/a`, with a legend note saying why, whenever no command in the run carries a dead-end declaration. A stale declaration still counts as exercising the classifier, so its genuine measured 0 keeps printing as `0`. No value is fabricated and no synthetic journey is added.

## Changes

| File | Change |
|------|--------|
| `bench/journeys_id_collision_test.go` | New: per-source-file uniqueness check naming both defining files; completeness guard pinning `journeySources` to `Journeys()` |
| `bench/report.go` | `dimensionRow` gains an `Unmeasured` predicate and legend note; dead_end row keys on `deadEndUnexercised` (no `DeadEndOutcome` anywhere in the run) |
| `bench/report_dead_end_test.go` | New: undeclared run reads `n/a`; applied declaration reads its count; stale declaration reads a genuine `0` |

## RED evidence (strict TDD, captured before the fix)

#2489, with a collision injected into `journeys_edge.go` reusing the exact ID from the issue report (reverted after capture; today's corpus has no live collision, so the committed test is green):

```
--- FAIL: TestJourneyIDsAreUniqueAcrossSourceFiles (0.00s)
    journeys_id_collision_test.go:48: journey ID "j60-new-lineage-unstaged-drift-denies-post-apply-allows-pre-commit" is defined in both journeys_edge.go and journeys_wave3.go; pick an ID no journeys_*.go file uses yet
```

#2490, against unmodified `report.go`:

```
--- FAIL: TestDeadEndReadsUnmeasuredWhenNothingDeclaresOne (0.00s)
    report_dead_end_test.go:51: dead_end cell = "0", want "n/a": an unexercised dead_end must not read as a measured 0
    report_dead_end_test.go:63: TOTAL row "  TOTAL (completed only)             0       0      2     2    0     0   1    1       0     0      0      10       1" holds no n/a: the unexercised dead_end total still reads as a measurement
    report_dead_end_test.go:66: legend does not say why dead_end is n/a; the reader is left to guess
```

## What was NOT changed, and why

- `bench/README.md` (lines 197-199 and 456 still describe the always-0 column) is owned by open PRs #2444 and #2305, so it was left untouched; the doc lines will need a follow-up touch once those land.
- The comparison report (`buildComparison`) still emits numeric dead_end rows; the issue scopes the false reading to the run scoreline, and its first option was chosen deliberately as the smallest truthful change.
- `bench/results.json` is a recorded artifact of a past run and was not regenerated; the `n/a` rendering is derived at report time from the presence of `DeadEndOutcome` records, so re-rendered old results read truthfully too.
- No corpus expectations were altered: no journey was added, renamed, or taught to declare a dead end.

## Test plan

- [x] `go test ./... -count=1` in `bench/` (full module green)
- [x] `go test ./... -count=1` at repo root
- [x] `gofmt -l .` clean, `go vet ./...` clean in both modules
- [x] `scripts/deadcode-ratchet.sh`: no new unreachable functions
- [x] Refusal-resolution ratchet tests (`TestRefusalRatchet*`, `TestEveryProductionRefusal*`) green
