### PR TITLE
fix(system): pin child commands to an existing working directory

### DIFF
--- a/internal/cli/child_cwd_test.go
+++ b/internal/cli/child_cwd_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestHelperProcessGetwd is not a real test: the deleted-working-directory
+// tests below re-execute the test binary so this function runs as a child
+// process. It mimics a Node.js child, which resolves its working directory
+// during bootstrap and crashes with an ENOENT uv_cwd error when that
+// directory no longer exists (issue #2148).
+func TestHelperProcessGetwd(t *testing.T) {
+	if os.Getenv("GENTLE_AI_WANT_GETWD_HELPER") != "1" {
+		return
+	}
+	if _, err := os.Getwd(); err != nil {
+		fmt.Fprintf(os.Stderr, "getwd failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("child working directory is valid")
+	os.Exit(0)
+}
+
+// helperGetwdArgv returns the argv that re-executes this test binary as the
+// getwd helper child, and arms the helper via the environment.
+func helperGetwdArgv(t *testing.T) []string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	t.Setenv("GENTLE_AI_WANT_GETWD_HELPER", "1")
+	return []string{exe, "-test.run=^TestHelperProcessGetwd$"}
+}
+
+// chdirIntoDeletedDir moves the test process into a directory that is then
+// removed, reproducing a shell left sitting inside a deleted Git worktree or
+// temporary directory (issue #2148). t.Chdir restores the original working
+// directory when the test finishes.
+func chdirIntoDeletedDir(t *testing.T) {
+	t.Helper()
+	gone := filepath.Join(t.TempDir(), "gone")
+	if err := os.Mkdir(gone, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(gone)
+	if err := os.Remove(gone); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExecuteCommandSurvivesDeletedWorkingDirectory(t *testing.T) {
+	argv := helperGetwdArgv(t)
+	chdirIntoDeletedDir(t)
+
+	if err := executeCommand(argv[0], argv[1:]...); err != nil {
+		t.Fatalf("executeCommand from deleted working directory: %v", err)
+	}
+}
+
+func TestCodeGraphInitSurvivesDeletedWorkingDirectory(t *testing.T) {
+	argv := helperGetwdArgv(t)
+	chdirIntoDeletedDir(t)
+
+	if err := codeGraphInit(argv[0], argv[1:]...); err != nil {
+		t.Fatalf("codeGraphInit from deleted working directory: %v", err)
+	}
+}
+
+func TestCodeGraphHomeRunnerSurvivesDeletedWorkingDirectory(t *testing.T) {
+	argv := helperGetwdArgv(t)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory available: %v", err)
+	}
+	chdirIntoDeletedDir(t)
+
+	runner := codeGraphHomeRunner{homeDir: home}
+	if err := runner.Run(argv[0], argv[1:]...); err != nil {
+		t.Fatalf("codeGraphHomeRunner from deleted working directory: %v", err)
+	}
+}
+
+func TestDefaultGoEnvSurvivesDeletedWorkingDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires the real go toolchain")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not on PATH: %v", err)
+	}
+	chdirIntoDeletedDir(t)
+
+	if _, err := defaultGoEnv("GOBIN"); err != nil {
+		t.Fatalf("defaultGoEnv from deleted working directory: %v", err)
+	}
+}

--- a/internal/cli/codegraph.go
+++ b/internal/cli/codegraph.go
@@ -7,11 +7,17 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
 var (
 	codeGraphGitTopLevel = defaultCodeGraphGitTopLevel
-	codeGraphInit        = func(name string, args ...string) error { return exec.Command(name, args...).Run() }
+	codeGraphInit        = func(name string, args ...string) error {
+		cmd := exec.Command(name, args...)
+		system.EnsureCommandDir(cmd)
+		return cmd.Run()
+	}
 	codeGraphUserHomeDir = os.UserHomeDir
 	codeGraphTempDir     = os.TempDir
 )

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -440,7 +440,9 @@ func goInstallBinDir() string {
 
 func defaultGoEnv(keys ...string) (map[string]string, error) {
 	args := append([]string{"env"}, keys...)
-	out, err := exec.Command("go", args...).Output()
+	cmd := exec.Command("go", args...)
+	system.EnsureCommandDir(cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
@@ -1730,6 +1732,7 @@ func runCommandSequence(commands [][]string) error {
 
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
+	system.EnsureCommandDir(cmd)
 
 	if streamCommandOutput {
 		cmd.Stdout = os.Stdout

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/verify"
 )
 
@@ -822,6 +823,7 @@ type codeGraphHomeRunner struct {
 
 func (r codeGraphHomeRunner) Run(name string, args ...string) error {
 	command := exec.Command(name, args...)
+	system.EnsureCommandDir(command)
 	actualHome, _ := os.UserHomeDir()
 	if filepath.Clean(r.homeDir) != filepath.Clean(actualHome) {
 		command.Env = overrideCommandEnvironment(os.Environ(), map[string]string{

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -19,6 +19,7 @@ import (
 
 	piagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
 const (
@@ -518,6 +519,7 @@ func probePiCodeGraphMCPWithAgentDirContext(ctx context.Context, mcpPath, agentD
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter extension is unavailable at %q: %w", adapterPath, err)
 	}
 	command := exec.CommandContext(ctx, "codegraph", "serve", "--mcp")
+	system.EnsureCommandDir(command)
 	stdin, err := command.StdinPipe()
 	if err != nil {
 		return PiCodeGraphMCPProbeResult{}, err

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -11,6 +11,7 @@ import (
 	piagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
 type Availability string
@@ -484,7 +485,9 @@ func CodeGraphCommandsForDetectorAndTargets(detector Detector, targets []string)
 }
 
 func defaultPnpmGlobalBin() (string, error) {
-	output, err := exec.Command("pnpm", "bin", "-g").CombinedOutput()
+	command := exec.Command("pnpm", "bin", "-g")
+	system.EnsureCommandDir(command)
+	output, err := command.CombinedOutput()
 	if err != nil {
 		message := strings.TrimSpace(string(output))
 		if message == "" {

--- a/internal/system/cwd.go
+++ b/internal/system/cwd.go
@@ -1,0 +1,43 @@
+package system
+
+import (
+	"os"
+	"os/exec"
+)
+
+// EnsureCommandDir pins cmd to a working directory that still exists on disk.
+//
+// A child process inherits the parent's working directory whenever cmd.Dir is
+// empty. If that directory was deleted underneath the parent (for example a
+// removed Git worktree or temporary directory), Node.js-based children crash
+// during bootstrap with "ENOENT: process.cwd failed ... uv_cwd" and the Go
+// toolchain refuses to run at all (issue #2148).
+//
+// When the inherited working directory is healthy, or cmd.Dir is already set,
+// this is a no-op, so relative-path behavior is unchanged. When the inherited
+// working directory is gone, the child runs in the user's home directory,
+// falling back to the system temporary directory.
+func EnsureCommandDir(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Dir != "" {
+		return
+	}
+	if wd, err := os.Getwd(); err == nil && dirExists(wd) {
+		return
+	}
+	if home, err := os.UserHomeDir(); err == nil && dirExists(home) {
+		cmd.Dir = home
+		return
+	}
+	if tmp := os.TempDir(); dirExists(tmp) {
+		cmd.Dir = tmp
+	}
+}
+
+// dirExists reports whether path names an existing directory.
+func dirExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/system/cwd_test.go
+++ b/internal/system/cwd_test.go
@@ -1,0 +1,131 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHelperProcessGetwd is not a real test: the deleted-working-directory
+// tests below re-execute the test binary so this function runs as a child
+// process. It mimics a Node.js child, which resolves its working directory
+// during bootstrap and crashes with an ENOENT uv_cwd error when that
+// directory no longer exists (issue #2148).
+func TestHelperProcessGetwd(t *testing.T) {
+	if os.Getenv("GENTLE_AI_WANT_GETWD_HELPER") != "1" {
+		return
+	}
+	if _, err := os.Getwd(); err != nil {
+		fmt.Fprintf(os.Stderr, "getwd failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("v1.2.3")
+	os.Exit(0)
+}
+
+// helperGetwdArgv returns the argv that re-executes this test binary as the
+// getwd helper child, and arms the helper via the environment.
+func helperGetwdArgv(t *testing.T) []string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	t.Setenv("GENTLE_AI_WANT_GETWD_HELPER", "1")
+	return []string{exe, "-test.run=^TestHelperProcessGetwd$"}
+}
+
+// chdirIntoDeletedDir moves the test process into a directory that is then
+// removed, reproducing a shell left sitting inside a deleted Git worktree or
+// temporary directory (issue #2148). t.Chdir restores the original working
+// directory when the test finishes.
+func chdirIntoDeletedDir(t *testing.T) {
+	t.Helper()
+	gone := filepath.Join(t.TempDir(), "gone")
+	if err := os.Mkdir(gone, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(gone)
+	if err := os.Remove(gone); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureCommandDir(t *testing.T) {
+	t.Run("keeps a healthy inherited working directory", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		cmd := exec.Command(os.Args[0])
+		EnsureCommandDir(cmd)
+		if cmd.Dir != "" {
+			t.Fatalf("cmd.Dir = %q, want empty so the child inherits the healthy working directory", cmd.Dir)
+		}
+	})
+
+	t.Run("respects an explicitly set cmd.Dir", func(t *testing.T) {
+		explicit := t.TempDir()
+		chdirIntoDeletedDir(t)
+		cmd := exec.Command(os.Args[0])
+		cmd.Dir = explicit
+		EnsureCommandDir(cmd)
+		if cmd.Dir != explicit {
+			t.Fatalf("cmd.Dir = %q, want explicit %q preserved", cmd.Dir, explicit)
+		}
+	})
+
+	t.Run("falls back to the home directory when the working directory is deleted", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("no home directory available: %v", err)
+		}
+		chdirIntoDeletedDir(t)
+		cmd := exec.Command(os.Args[0])
+		EnsureCommandDir(cmd)
+		if cmd.Dir != home {
+			t.Fatalf("cmd.Dir = %q, want home fallback %q", cmd.Dir, home)
+		}
+		info, err := os.Stat(cmd.Dir)
+		if err != nil || !info.IsDir() {
+			t.Fatalf("fallback %q is not an existing directory: %v", cmd.Dir, err)
+		}
+	})
+
+	t.Run("tolerates a nil command", func(t *testing.T) {
+		EnsureCommandDir(nil)
+	})
+}
+
+func TestDetectSingleDepSurvivesDeletedWorkingDirectory(t *testing.T) {
+	argv := helperGetwdArgv(t)
+	chdirIntoDeletedDir(t)
+
+	dep := detectSingleDep(context.Background(), Dependency{Name: "probe", DetectCmd: argv})
+
+	if !dep.Installed {
+		t.Fatalf("probe dependency not marked installed")
+	}
+	if dep.Version != "1.2.3" {
+		t.Fatalf("version probe failed from deleted working directory: got version %q, want %q", dep.Version, "1.2.3")
+	}
+}
+
+func TestPowerShellRunnerSurvivesDeletedWorkingDirectory(t *testing.T) {
+	argv := helperGetwdArgv(t)
+	chdirIntoDeletedDir(t)
+
+	runner := NewPowerShellRunner()
+	runner.LookPath = func(host string) (string, error) {
+		if host == "pwsh" {
+			return argv[0], nil
+		}
+		return "", fmt.Errorf("%s is not present in this test", host)
+	}
+
+	out, err := runner.Run(context.Background(), argv[1:]...)
+	if err != nil {
+		t.Fatalf("PowerShell runner failed from deleted working directory: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+}

--- a/internal/system/deps.go
+++ b/internal/system/deps.go
@@ -143,6 +143,7 @@ func detectSingleDep(ctx context.Context, dep Dependency) Dependency {
 
 	// Run version command to extract version string.
 	cmd := exec.CommandContext(ctx, dep.DetectCmd[0], dep.DetectCmd[1:]...)
+	EnsureCommandDir(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		// Binary exists but version command failed — still mark as installed.

--- a/internal/system/powershell.go
+++ b/internal/system/powershell.go
@@ -33,7 +33,9 @@ func NewPowerShellRunner() PowerShellRunner {
 	return PowerShellRunner{
 		LookPath: exec.LookPath,
 		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
-			return exec.CommandContext(ctx, name, args...).CombinedOutput()
+			cmd := exec.CommandContext(ctx, name, args...)
+			EnsureCommandDir(cmd)
+			return cmd.CombinedOutput()
 		},
 	}
 }

--- a/internal/tui/child_cwd_test.go
+++ b/internal/tui/child_cwd_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestHelperProcessGetwd is not a real test: the deleted-working-directory
+// test below re-executes the test binary so this function runs as a child
+// process. It mimics a Node.js child, which resolves its working directory
+// during bootstrap and crashes with an ENOENT uv_cwd error when that
+// directory no longer exists (issue #2148).
+func TestHelperProcessGetwd(t *testing.T) {
+	if os.Getenv("GENTLE_AI_WANT_GETWD_HELPER") != "1" {
+		return
+	}
+	if _, err := os.Getwd(); err != nil {
+		fmt.Fprintf(os.Stderr, "getwd failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("child working directory is valid")
+	os.Exit(0)
+}
+
+func TestExecuteExternalCommandSurvivesDeletedWorkingDirectory(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	t.Setenv("GENTLE_AI_WANT_GETWD_HELPER", "1")
+
+	gone := filepath.Join(t.TempDir(), "gone")
+	if err := os.Mkdir(gone, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(gone)
+	if err := os.Remove(gone); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := executeExternalCommand(exec.Command, exe, "-test.run=^TestHelperProcessGetwd$"); err != nil {
+		t.Fatalf("external command runner from deleted working directory: %v", err)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2909,6 +2909,7 @@ func runCommunityToolCommand(name string, args ...string) error {
 
 func executeExternalCommand(commandFn func(string, ...string) *exec.Cmd, name string, args ...string) error {
 	cmd := commandFn(name, args...)
+	system.EnsureCommandDir(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if len(output) > 0 {


### PR DESCRIPTION
## Problem

When the invoking shell sits in a directory that no longer exists (deleted Git worktree, removed temp dir), every child process inherits that dead working directory. Node.js-based children (`npm`, `pnpm`, `pi`, `codegraph`) crash during bootstrap:

```
Error: ENOENT: process.cwd failed with error no such file or directory, the current working directory was likely removed without changing the working directory, uv_cwd
```

and the Go toolchain refuses to run at all (`go: cannot determine current directory`). This breaks install, sync, and community tool flows. Reproduced locally with real `node` and `go env` from a deleted cwd before writing any code.

## Measurement

- `internal/system` has exactly 3 exec sites (`detect.go:105`, `deps.go:145`, `powershell.go:36`) and zero `cmd.Dir` assignments anywhere in the package. The issue's premise is confirmed.
- There is no single shared command runner: the affected flows go through per-package runner seams (`cli.executeCommand`, `cli.defaultGoEnv`, `cli.codeGraphInit`, `codeGraphHomeRunner.Run`, `tui.executeExternalCommand`, `communitytool.defaultPnpmGlobalBin`, the Pi CodeGraph MCP probe, `system.detectSingleDep`, the PowerShell runner).

## Fix

One new validated helper owns the invariant: `system.EnsureCommandDir(cmd)` (`internal/system/cwd.go`).

- No-op when `cmd.Dir` is already set or the inherited working directory still exists, so relative-path behavior is unchanged.
- When the inherited working directory is gone, the child runs in the user's home directory, falling back to the system temp directory.

Applied one line per runner seam listed above. No config option, no env var, no `os.Chdir` of the parent process.

## RED evidence (captured before the fix, verbatim)

```
--- FAIL: TestDetectSingleDepSurvivesDeletedWorkingDirectory (0.00s)
    cwd_test.go:67: version probe failed from deleted working directory: got version "", want "1.2.3"
--- FAIL: TestPowerShellRunnerSurvivesDeletedWorkingDirectory (0.00s)
    cwd_test.go:85: PowerShell runner failed from deleted working directory: PowerShell command failed: run pwsh (/tmp/go-build638500831/b001/system.test): exit status 1 (output: getwd failed: getwd: no such file or directory) (output: getwd failed: getwd: no such file or directory)
--- FAIL: TestExecuteCommandSurvivesDeletedWorkingDirectory (0.03s)
    child_cwd_test.go:61: executeCommand from deleted working directory: exit status 1
--- FAIL: TestCodeGraphInitSurvivesDeletedWorkingDirectory (0.01s)
    child_cwd_test.go:70: codeGraphInit from deleted working directory: exit status 1
--- FAIL: TestCodeGraphHomeRunnerSurvivesDeletedWorkingDirectory (0.03s)
    child_cwd_test.go:84: codeGraphHomeRunner from deleted working directory: exit status 1: getwd failed: getwd: no such file or directory
--- FAIL: TestDefaultGoEnvSurvivesDeletedWorkingDirectory (0.01s)
    child_cwd_test.go:98: defaultGoEnv from deleted working directory: exit status 1
--- FAIL: TestExecuteExternalCommandSurvivesDeletedWorkingDirectory (0.02s)
    child_cwd_test.go:45: external command runner from deleted working directory: exit status 1
        output:
        getwd failed: getwd: no such file or directory
```

The test children mimic Node: they resolve their working directory at startup and exit 1 when it is gone, which is exactly what `uv_cwd` does. All 7 tests pass after the fix, plus 4 unit subtests pinning the helper's fallback rule.

## Verified by execution

- RED runs above, then GREEN runs of the same tests
- `go test ./... -count=1` at repo root: fully green (exit 0, 63 packages ok) on the branch based on ba95a709. After rebasing onto 2fdf7fcc, one full-suite run flaked in `internal/update` (`TestCheckSingleToolGentleAIPseudoVersionComparesMainHeadWithoutChannel`, `check_test.go:372: unexpected GitHub path: /`). That flake is pre-existing: clean `origin/main` at the same 2fdf7fcc, run on an idle machine, fails its own full suite the same way (`TestFetchLatestReleaseMatchingPatternSkipsPiChannel`, `check_test.go:617: unexpected path: /`). Both tests pass in isolation on both trees, this PR never touches `internal/update`, and `go test ./internal/update ./internal/cli ./internal/system ./internal/tui ./internal/components/communitytool -count=1` on the rebased head is green.
- `go test ./... -count=1` in `bench/`: green
- `gofmt -l .` clean
- `go vet ./...` clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- refusal-resolution ratchet tests (`TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`, `TestEveryNamedReviewContinuationIsStructurallyReal`) pass

Asserted, not executed: the Windows PowerShell host path (the runner change is exercised through the injectable seam on Linux); the real `pi`/`pnpm`/`codegraph` binaries were not run from a deleted cwd, their seams are covered by the helper's tests.

## Known residual gap

`internal/system/detect.go:105` (`detectNpmWritable`, runs `npm config get prefix`) still inherits the dead cwd. Its failure mode is a non-crashing degradation (returns false, so installs may fall back to the sudo path); it sits in a detection file this fix deliberately stays out of, and it has no injectable seam for a TDD-clean change. Follow-up candidate.

Closes #2148
