### PR TITLE
test(app): execute the commands the product documents

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -20,6 +20,8 @@ internal/cli/review_facade.go	facadeValidationResult.native
 internal/cli/review_narration.go	reviewNarrationContainsWord
 internal/cli/review_narration.go	reviewNarrationStripCodeSpans
 internal/cli/review_operation_contract.go	reviewNamedArgument
+internal/cli/review_printed_command.go	ReviewOperationFlagSurface
+internal/cli/review_printed_command.go	SplitPrintedCommandWords
 internal/cli/run.go	BuildRealStagePlan
 internal/cli/run.go	componentPathDir
 internal/cli/run.go	componentPaths

--- a/internal/app/documented_invocation_test.go
+++ b/internal/app/documented_invocation_test.go
@@ -1,0 +1,455 @@
+package app_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/app"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/cli"
+)
+
+// This corpus exists because of #2506: the product states runnable commands
+// in shipped assets and docs, and none of them was ever executed by a test.
+// The invocation #2473 broke lived only in documentation, so it broke without
+// a single test going red. The corpus is EXTRACTED, never enumerated: adding
+// a command to an asset or doc adds it to the corpus automatically.
+//
+// Every extracted invocation lands in exactly one tier, decided mechanically:
+//
+//   - executed: a verb app.RunArgs dispatches without system detection, with
+//     no placeholder left after the repository slot is filled. It runs
+//     in-process against a fresh repository and must not be refused by the
+//     parser or answered with a non-retryable stop failure envelope.
+//   - parse-only: same safe verbs, but state-bearing placeholders remain
+//     (<lineage>, <token>, ...) whose valid values a test cannot invent.
+//     Placeholders are dummy-filled and the REAL parser must accept the flag
+//     surface; negotiated review verbs are additionally checked against the
+//     operation registry's declared flags.
+//   - presence-only: everything a test cannot honestly run: shell-composed
+//     examples (redirection, expansion, alternation), verbs that reach the
+//     network, prompt, or another binary. Counted so the tiers stay visible.
+
+type documentedInvocation struct {
+	source  string
+	command string
+}
+
+// --- extraction -----------------------------------------------------------
+
+var inlineInvocationRegexp = regexp.MustCompile("`(gentle-ai [^`\n]+)`")
+
+func extractInvocations(source, content string) []documentedInvocation {
+	var out []documentedInvocation
+	lines := strings.Split(content, "\n")
+	fenced := false
+	for index := 0; index < len(lines); index++ {
+		trimmed := strings.TrimSpace(lines[index])
+		at := fmt.Sprintf("%s:%d", source, index+1)
+		if strings.HasPrefix(trimmed, "```") {
+			fenced = !fenced
+			continue
+		}
+		if fenced {
+			command := strings.TrimPrefix(trimmed, "$ ")
+			for strings.HasSuffix(command, "\\") && index+1 < len(lines) {
+				index++
+				command = strings.TrimSuffix(command, "\\") + " " + strings.TrimSpace(lines[index])
+			}
+			if strings.HasPrefix(command, "gentle-ai ") {
+				out = append(out, documentedInvocation{source: at, command: command})
+			}
+			continue
+		}
+		for _, match := range inlineInvocationRegexp.FindAllStringSubmatch(lines[index], -1) {
+			out = append(out, documentedInvocation{source: at, command: match[1]})
+		}
+	}
+	return out
+}
+
+func collectDocumentedInvocations(t *testing.T) []documentedInvocation {
+	t.Helper()
+	var corpus []documentedInvocation
+	// Embedded assets: the channel rendered into every installed agent's rules.
+	err := fs.WalkDir(assets.FS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		content, readErr := fs.ReadFile(assets.FS, path)
+		if readErr != nil {
+			return readErr
+		}
+		corpus = append(corpus, extractInvocations("assets:"+path, string(content))...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// docs/: the human-facing instruction surface. docs/audits are dated
+	// snapshots of past investigations, not living instructions, so they are
+	// deliberately outside the runnable corpus.
+	err = filepath.WalkDir(filepath.Join("..", "..", "docs"), func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == "audits" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		corpus = append(corpus, extractInvocations(filepath.ToSlash(path), string(content))...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(corpus) == 0 {
+		t.Fatal("extracted no documented invocations from assets or docs; the extractor is stale")
+	}
+	return corpus
+}
+
+// --- classification -------------------------------------------------------
+
+var placeholderRegexp = regexp.MustCompile(`<[a-zA-Z][a-zA-Z0-9_ .-]*>`)
+var optionalWordRegexp = regexp.MustCompile(`^\[[a-z-]+\]$`)
+
+func wordNeedsShell(word string) bool {
+	switch word {
+	case ">", ">>", "2>", "<", "|", "||", "&&", ";":
+		return true
+	}
+	return strings.ContainsAny(word, "$`|;&<>")
+}
+
+// platformIndependentVerbs extracts the case labels app.RunArgs dispatches
+// BEFORE system detection, straight from app.go's own dispatch source, the
+// same way review_integration_contract_guard_test.go extracts dispatch verbs.
+// The set is derived, not maintained; a verb added to the switch joins it.
+func platformIndependentVerbs(t *testing.T) map[string]bool {
+	t.Helper()
+	source, err := os.ReadFile("app.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	begin := strings.Index(text, "// Platform-independent commands")
+	end := strings.Index(text, "ensureCurrentOSSupported(")
+	if begin < 0 || end < 0 || end < begin {
+		t.Fatal("app.go's platform-independent dispatch section moved; update the extraction anchors")
+	}
+	verbs := map[string]bool{}
+	for _, match := range regexp.MustCompile(`case "([a-z][a-z-]*)"`).FindAllStringSubmatch(text[begin:end], -1) {
+		verbs[match[1]] = true
+	}
+	if len(verbs) == 0 {
+		t.Fatal("extracted no platform-independent verbs from app.go")
+	}
+	return verbs
+}
+
+// documentedInvocationExecutionExclusions holds the platform-independent
+// verbs still kept out of in-process execution, each with its reason. This is
+// a policy judgment, not a mirror of truth computed elsewhere: nothing else
+// in the tree records which verbs prompt, shell out, or fall through.
+var documentedInvocationExecutionExclusions = map[string]string{
+	"install":   "its case only prints help; a real install falls through to system detection and the TUI",
+	"uninstall": "may prompt interactively and mutates installed agent state",
+	"codegraph": "proxies to the external codegraph binary, which CI does not install",
+}
+
+type invocationTier string
+
+const (
+	tierExecuted invocationTier = "executed"
+	tierParse    invocationTier = "parse-only"
+	tierPresence invocationTier = "presence-only"
+)
+
+// classifyWords rewrites the repository slot to repo, drops optional
+// positional words, and reports the tier plus the words to run. The shell
+// check runs on each word with its placeholders stripped, so a templated
+// value never reads as shell syntax while real redirection and expansion do.
+func classifyWords(words []string, safeVerbs map[string]bool, repo string) ([]string, invocationTier) {
+	if len(words) < 2 || !safeVerbs[words[1]] || documentedInvocationExecutionExclusions[words[1]] != "" {
+		return nil, tierPresence
+	}
+	rewritten := make([]string, 0, len(words))
+	placeholders := false
+	for index := 0; index < len(words); index++ {
+		word := words[index]
+		if optionalWordRegexp.MatchString(word) {
+			continue
+		}
+		switch {
+		case word == "--cwd" && index+1 < len(words):
+			rewritten = append(rewritten, word, repo)
+			index++
+			continue
+		case strings.HasPrefix(word, "--cwd="):
+			rewritten = append(rewritten, "--cwd="+repo)
+			continue
+		}
+		if wordNeedsShell(placeholderRegexp.ReplaceAllString(word, "")) {
+			return nil, tierPresence
+		}
+		if placeholderRegexp.MatchString(word) {
+			// A placeholder is only substitutable where a value belongs: in a
+			// --flag word or as the value of the bare flag before it. In a
+			// verb or positional slot the command's own identity is
+			// templated ("gentle-ai review <verb>"), a reference to a family
+			// of commands rather than a runnable claim.
+			bareFlagBefore := index > 0 && strings.HasPrefix(words[index-1], "--") && !strings.Contains(words[index-1], "=")
+			if !strings.HasPrefix(word, "--") && !bareFlagBefore {
+				return nil, tierPresence
+			}
+			placeholders = true
+			word = placeholderRegexp.ReplaceAllString(word, "dummy")
+		}
+		rewritten = append(rewritten, word)
+	}
+	if placeholders {
+		return rewritten, tierParse
+	}
+	return rewritten, tierExecuted
+}
+
+// --- predicates -----------------------------------------------------------
+
+// isParseRejection reports whether the CLI refused the invocation at the
+// parser, which means the documented command does not run as printed. A
+// semantic refusal (missing state, absent lineage) proves the opposite: the
+// parser accepted every documented flag before the refusal happened.
+func isParseRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	for _, signature := range []string{
+		"flag provided but not defined",
+		"unknown command",
+		"unknown review command",
+		"unknown review mode command",
+		"unexpected review",
+	} {
+		if strings.Contains(message, signature) {
+			return true
+		}
+	}
+	return false
+}
+
+// nonRetryableStop scans every JSON document in output for the failure-
+// envelope signature #2473 shipped with: retry_safe false with next_action
+// "stop". A negotiated next_transition of kind "stop" is a routed answer and
+// deliberately not matched; the guard hunts dead ends, not routing.
+func nonRetryableStop(output []byte) (string, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	for {
+		var document any
+		if err := decoder.Decode(&document); err != nil {
+			return "", false
+		}
+		if found, ok := findNonRetryableStop(document); ok {
+			return found, true
+		}
+	}
+}
+
+func findNonRetryableStop(document any) (string, bool) {
+	switch value := document.(type) {
+	case map[string]any:
+		retry, hasRetry := value["retry_safe"].(bool)
+		action, hasAction := value["next_action"].(string)
+		if hasRetry && hasAction && !retry && action == "stop" {
+			encoded, _ := json.Marshal(value)
+			return string(encoded), true
+		}
+		for _, child := range value {
+			if found, ok := findNonRetryableStop(child); ok {
+				return found, true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if found, ok := findNonRetryableStop(child); ok {
+				return found, true
+			}
+		}
+	}
+	return "", false
+}
+
+// --- sandbox --------------------------------------------------------------
+
+func newDocumentedInvocationSandbox(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	home := filepath.Join(root, "home")
+	for _, dir := range []string{repo, home} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	git := func(args ...string) {
+		command := exec.Command("git", args...)
+		command.Dir = repo
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	git("init", "-q")
+	git("config", "user.email", "corpus@example.invalid")
+	git("config", "user.name", "corpus")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "seed")
+	t.Chdir(repo)
+	return repo
+}
+
+// registrySurfaceViolation cross-checks a documented negotiated review verb
+// against the operation registry's declared flag surface. --contract is the
+// facade's own routing flag and is declared on the FlagSets, not the rows.
+func registrySurfaceViolation(words []string) string {
+	if len(words) < 3 || words[1] != "review" {
+		return ""
+	}
+	surface, found := cli.ReviewOperationFlagSurface(words[2])
+	if !found {
+		return ""
+	}
+	for _, word := range words[3:] {
+		if !strings.HasPrefix(word, "--") {
+			continue
+		}
+		name := strings.TrimPrefix(word, "--")
+		if index := strings.Index(name, "="); index >= 0 {
+			name = name[:index]
+		}
+		if name != "contract" && !surface[name] {
+			return fmt.Sprintf("documents --%s, which the operation registry does not declare for review %s", name, words[2])
+		}
+	}
+	return ""
+}
+
+// --- the guard ------------------------------------------------------------
+
+// documentedInvocationKnownFailures is the quarantined worklist for #2506:
+// commands the product documents today that do not survive their own tier on
+// current main. Every entry is a defect to burn down, never an accepted
+// state. An entry whose invocation starts passing must be removed; the guard
+// fails on stale entries so the list can only shrink.
+var documentedInvocationKnownFailures = map[string]string{
+	"gentle-ai review repair-legacy-alias":         "docs/review-authority-threat-model.md:67 documents it as a live compatibility verb; the CLI refuses it as an unknown review command (the machinery ships behind review repair --class)",
+	"gentle-ai review quarantine-legacy-fix-scope": "docs/review-authority-threat-model.md:75 documents it as a live maintenance operation; the CLI refuses it as an unknown review command",
+}
+
+func TestDocumentedInvocationsRunAsDocumented(t *testing.T) {
+	corpus := collectDocumentedInvocations(t)
+	safeVerbs := platformIndependentVerbs(t)
+
+	// Identical command text is exercised once; sources accumulate so a
+	// failure names every place the broken form is documented.
+	sources := map[string][]string{}
+	var unique []string
+	for _, invocation := range corpus {
+		if _, seen := sources[invocation.command]; !seen {
+			unique = append(unique, invocation.command)
+		}
+		sources[invocation.command] = append(sources[invocation.command], invocation.source)
+	}
+	sort.Strings(unique)
+
+	counts := map[invocationTier]int{}
+	quarantined := 0
+	staleQuarantine := map[string]bool{}
+	for command := range documentedInvocationKnownFailures {
+		staleQuarantine[command] = true
+	}
+
+	for _, command := range unique {
+		words, err := cli.SplitPrintedCommandWords(command)
+		if err != nil {
+			counts[tierPresence]++
+			continue
+		}
+		repo := "<repo>"
+		args, tier := classifyWords(words, safeVerbs, repo)
+		counts[tier]++
+		if tier == tierPresence {
+			continue
+		}
+		t.Run(string(tier)+"/"+strings.Join(words[1:min(3, len(words))], " "), func(t *testing.T) {
+			failure := ""
+			if violation := registrySurfaceViolation(words); violation != "" {
+				failure = violation
+			} else {
+				sandbox := newDocumentedInvocationSandbox(t)
+				for index, arg := range args {
+					args[index] = strings.ReplaceAll(arg, repo, sandbox)
+				}
+				var output bytes.Buffer
+				runErr := app.RunArgs(args[1:], &output)
+				if isParseRejection(runErr) {
+					failure = fmt.Sprintf("the parser refuses it as printed: %v", runErr)
+				} else if tier == tierExecuted {
+					if envelope, dead := nonRetryableStop(output.Bytes()); dead {
+						failure = "answers a non-retryable stop on a fresh repository: " + envelope
+					}
+				}
+			}
+			if reason, known := documentedInvocationKnownFailures[command]; known {
+				delete(staleQuarantine, command)
+				if failure == "" {
+					t.Errorf("quarantined invocation now passes; remove it from documentedInvocationKnownFailures (%s)", reason)
+					return
+				}
+				quarantined++
+				t.Logf("quarantined (#2506 worklist, %s): %s", reason, failure)
+				return
+			}
+			if failure != "" {
+				t.Errorf("documented at %s\n  %s\n  %s", strings.Join(sources[command], ", "), command, failure)
+			}
+		})
+	}
+
+	for command := range staleQuarantine {
+		t.Errorf("documentedInvocationKnownFailures names %q, which the corpus no longer contains", command)
+	}
+	if counts[tierExecuted] == 0 {
+		t.Error("no documented invocation reached the executed tier; the classification is stale")
+	}
+	t.Logf("documented invocation corpus: %d unique commands (%d occurrences): executed %d, parse-only %d, presence-only %d, quarantined %d",
+		len(unique), len(corpus), counts[tierExecuted], counts[tierParse], counts[tierPresence], quarantined)
+}

--- a/internal/cli/review_printed_command.go
+++ b/internal/cli/review_printed_command.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitPrintedCommandWords splits one printed command line into the argv a
+// POSIX shell would hand the product.
+//
+// It understands exactly the quoting reviewTransitionShellWord emits and
+// nothing more: POSIX single quotes, and a backslash escape for the one
+// character single quotes cannot contain (an embedded quote renders as '\”).
+// Anything else, such as an unterminated quote or a trailing escape, is a
+// line that would not run as printed, and saying so is the point.
+//
+// This is the same grammar bench's splitPrintedCommandWords enforces for
+// envelope-printed commands (issue #1865). It lives here, beside the emitter
+// it inverts, because the bench module cannot import the product module's
+// internals; the two implementations must stay in step with
+// reviewTransitionShellWord and with each other.
+func SplitPrintedCommandWords(line string) ([]string, error) {
+	words := []string{}
+	var word strings.Builder
+	quoted, escaped, started := false, false, false
+	for _, char := range line {
+		switch {
+		case quoted && char == '\'':
+			quoted = false
+		case quoted:
+			word.WriteRune(char)
+		case escaped:
+			word.WriteRune(char)
+			escaped = false
+		case char == '\\':
+			escaped, started = true, true
+		case char == '\'':
+			quoted, started = true, true
+		case char == ' ' || char == '\t' || char == '\n' || char == '\r':
+			if started {
+				words = append(words, word.String())
+				word.Reset()
+				started = false
+			}
+		default:
+			word.WriteRune(char)
+			started = true
+		}
+	}
+	if quoted {
+		return nil, fmt.Errorf("printed a command with an unterminated quote: %q", line) // refusal:by-design world-action: the defect is the printed line itself; the exit is fixing its source, not a command
+	}
+	if escaped {
+		return nil, fmt.Errorf("printed a command with a trailing escape: %q", line) // refusal:by-design world-action: the defect is the printed line itself; the exit is fixing its source, not a command
+	}
+	if started {
+		words = append(words, word.String())
+	}
+	return words, nil
+}
+
+// ReviewOperationFlagSurface returns the set of flag names the negotiated
+// review operation owning the given CLI verb declares in
+// reviewIntegrationOperationRegistry, or found=false when no negotiated row
+// with a declared flag surface owns that verb. The registry is the single
+// policy source for the negotiated route (see its own comment), so a
+// documented invocation of a negotiated verb can be checked against the
+// exact flags negotiated routing recognises without re-deriving them.
+func ReviewOperationFlagSurface(verb string) (map[string]bool, bool) {
+	for _, metadata := range reviewIntegrationOperationRegistry {
+		if !metadata.Negotiated || metadata.Command != verb {
+			continue
+		}
+		flags := map[string]bool{}
+		for _, name := range metadata.ValueFlags {
+			flags[name] = true
+		}
+		for _, name := range metadata.BoolFlags {
+			flags[name] = true
+		}
+		for _, name := range metadata.IntFlags {
+			flags[name] = true
+		}
+		if len(flags) == 0 {
+			return nil, false
+		}
+		return flags, true
+	}
+	return nil, false
+}


### PR DESCRIPTION
Closes #2506 (the provenance rule is split out as #2524, sequenced behind PR #2484; the two quarantined doc defects are #2525)

Deliberately `Refs`, not `Closes`: the provenance rule (an `--agent` value inside runtime R's rendered asset must name R) is explicitly out of this PR and ships as a second PR after #2484 merges, so #2506 must stay open. Note for the maintainer: the PR-validation gate requires a `Closes/Fixes/Resolves #N` keyword and will report this body as unlinked; that is a deliberate consequence of keeping #2506 open, not an oversight. Waive it or convert the linkage as you prefer.

## Summary

- Extracts every backtick-quoted and fenced `gentle-ai` invocation from the embedded assets and `docs/` into one derived corpus; nothing is hand-enumerated, so a command added to an asset or doc joins the guard automatically.
- Executes every invocation whose only unfilled slot is the repository, in-process through `app.RunArgs` against a fresh sandboxed repository (HOME/USERPROFILE/XDG redirected). Failure conditions: parser rejection, or a failure envelope with `retry_safe: false` and `next_action: "stop"`, the exact signature #2473 shipped with.
- Parse-validates state-bearing templates (`<lineage>`, `<token>`, ...) that a test cannot honestly execute: dummy-filled through the real parser, plus a cross-check of documented flags against `reviewIntegrationOperationRegistry` for negotiated review verbs.
- Counts what remains as presence-only (shell composition, network verbs, external binaries) so per-tier coverage stays visible and cannot silently degrade.

## Corpus, on current main

116 unique commands (280 documented occurrences): **51 executed, 9 parse-only, 56 presence-only, 2 quarantined.**

## Retro-RED: this guard catches what shipped

With the #2472 fix (`1eeeab9d`) reverted in the working tree and nothing else changed, the guard fails exactly on root 2 of #2471, naming both shipped sources, captured verbatim:

```
--- FAIL: TestDocumentedInvocationsRunAsDocumented/executed/review_status#04 (0.02s)
    documented_invocation_test.go:441: documented at assets:claude/commands/sdd-apply.md:51, assets:opencode/commands/sdd-apply.md:40
          gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --next-transition
          answers a non-retryable stop on a fresh repository: {"authority_applicability":"not_evaluated","cause":"negotiated lifecycle STATUS requires exactly one generated runtime identity","code":"immutable_review_transport_unsupported","contract":"gentle-ai.review-integration/v2","message":"The active runtime cannot provide immutable receipt-review transport.","mutation_outcome":"not_started","next_action":"stop","operation":"review.status","phase":"preflight","replayability":"not_replayable","required_inputs":[],"retry_safe":false,"schema":"gentle-ai.review-integration.failure/v2"}
FAIL
```

Restoring the fix returns the guard to green. The invocation that broke #2473 had exactly one caller, shipped documentation, and nothing executed it; now something does.

## Defects found on current main, quarantined not fixed

The corpus surfaced two commands documented as live that the CLI refuses as unknown review commands. Both sit in `documentedInvocationKnownFailures`, a counted worklist whose entries must be removed the moment they pass (the guard fails on stale entries, so the list can only shrink):

| Documented at | Command | Reality |
|---|---|---|
| `docs/review-authority-threat-model.md:67` | `gentle-ai review repair-legacy-alias` | "remains a compatibility command for established automation"; the CLI answers `unknown review command` (the machinery ships behind `review repair --class`) |
| `docs/review-authority-threat-model.md:75` | `gentle-ai review quarantine-legacy-fix-scope` | described as a live maintenance operation; the CLI answers `unknown review command` |

## Changes

| File | Change |
|------|--------|
| `internal/app/documented_invocation_test.go` | new: extraction, mechanical tier classification, sandboxed execution, registry cross-check, counted quarantine |
| `internal/cli/review_printed_command.go` | new: `SplitPrintedCommandWords` (the grammar `reviewTransitionShellWord` emits, kept in step with bench's splitter, which lives in a module this one cannot import) and `ReviewOperationFlagSurface` (read-only registry accessor) |
| `.deadcode-baseline.txt` | +2: the two helpers above are reachable only from the guard; the call-graph walker does not traverse test binaries |

Out of scope, by instruction: the provenance rule (second PR after #2484), README extraction, `docs/audits/` (dated snapshots, not living instructions), and fixing the two quarantined defects.

## Size

547 added lines, over the 400 target. The offered split (defer `docs/*.md` extraction) removes only ~24 lines (the docs walk plus the two quarantine entries) and would land around 520 while discarding the two-defect evidence, so it does not buy the cap and was not taken. The mechanism itself is the mass; happy to split along a different seam on request.

## Test plan

- [x] Guard green on unmodified main plus these files; retro-RED verified against reverted `1eeeab9d` (output above)
- [x] `go test ./... -count=1` at root: exit 0, 63 packages ok
- [x] bench module: `go vet ./... && go test ./...` green
- [x] `gofmt -l` clean, `go vet ./...` clean
- [x] `scripts/deadcode-ratchet.sh` green (baseline delta is exactly the two new helpers)
- [x] Refusal-resolution ratchet green: the two new refusal sites carry `refusal:by-design world-action` annotations, no baseline churn
- [x] No shell scripts modified, shellcheck not applicable

