### PR TITLE
fix(update): derive the advertisement from what the installer delivers

### DIFF
--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -69,6 +70,13 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 		}
 	}
 
+	// The advertisement must name a target the effective installer can deliver.
+	// A brew-owned install only ever receives the tap's stable formula, so a
+	// main-head beta target is advertised only when Homebrew does not own the
+	// tool (issue #2323: checker advertised main@sha while the instruction
+	// installed stable).
+	betaMainHead := usesBetaMainHeadCheck(tool, currentBuildVersion) && homebrewOwnership == HomebrewNone
+
 	// Run local detection and remote fetch concurrently.
 	var wg sync.WaitGroup
 	var localVersion string
@@ -90,7 +98,7 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 
 	go func() {
 		defer wg.Done()
-		if usesBetaMainHeadCheck(tool, currentBuildVersion) {
+		if betaMainHead {
 			mainCommit, fetchErr = fetchMainCommit(ctx, tool.Owner, tool.Repo)
 			return
 		}
@@ -109,7 +117,7 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 		return result
 	}
 
-	if usesBetaMainHeadCheck(tool, currentBuildVersion) {
+	if betaMainHead {
 		return applyBetaMainHeadStatus(result, localVersion, mainCommit)
 	}
 
@@ -186,6 +194,11 @@ func applyBetaMainHeadStatus(result UpdateResult, localVersion string, commit gi
 
 	result.LatestVersion = "main@" + shortRemote
 	result.ReleaseURL = strings.TrimSpace(commit.HTMLURL)
+	// Derive the instruction from the advertised target: the only installer
+	// that delivers main@<sha> is `go install ...@main`. The per-OS stable
+	// hint would silently replace this beta build with the latest stable
+	// release (issue #2323).
+	result.UpdateHint = GentleAISourceInstallCommand(result.LatestVersion)
 
 	if strings.TrimSpace(localVersion) == "" {
 		result.Status = VersionUnknown
@@ -207,9 +220,40 @@ func applyBetaMainHeadStatus(result UpdateResult, localVersion string, commit gi
 		return result
 	}
 
+	// Ordering guard: a prefix mismatch alone does not mean the local build is
+	// behind main. When the local pseudo-version timestamp is newer than the
+	// fetched commit's date, offering an "update" advertises a downgrade
+	// (issue #2319 offer half). Unknown dates fail open and keep the offer.
+	if localTime, ok := pseudoVersionTime(localVersion); ok {
+		remoteTime := commit.Commit.Committer.Date
+		if !remoteTime.IsZero() && localTime.After(remoteTime) {
+			result.Status = UpToDate
+			return result
+		}
+	}
+
 	result.Status = UpdateAvailable
 	result.ReleaseURL = fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", result.Tool.Owner, result.Tool.Repo, shortCommit(localSHA), shortRemote)
 	return result
+}
+
+// pseudoVersionTime extracts the UTC timestamp a Go pseudo-version embeds
+// (vX.Y.Z-0.yyyymmddhhmmss-abcdefabcdef). It reports false for any version
+// that does not carry a well-formed 14-digit timestamp.
+func pseudoVersionTime(version string) (time.Time, bool) {
+	if !isGoPseudoVersionWithCommit(version) {
+		return time.Time{}, false
+	}
+	parts := strings.Split(strings.TrimSpace(version), "-")
+	timestampPart := parts[len(parts)-2]
+	if idx := strings.LastIndex(timestampPart, "."); idx >= 0 {
+		timestampPart = timestampPart[idx+1:]
+	}
+	ts, err := time.Parse("20060102150405", timestampPart)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ts.UTC(), true
 }
 
 func localBuildCommit(version string) string {

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -537,6 +537,181 @@ func TestCheckSingleToolGentleAIBetaAcceptsLocalCommitPrefix(t *testing.T) {
 	}
 }
 
+func TestCheckSingleToolBrewOwnedGentleAIAdvertisesStableChannel(t *testing.T) {
+	// A brew-owned install can only ever receive the tap's stable formula, so
+	// the checker must not advertise a main-head beta target it cannot deliver
+	// (issue #2323 / #2319 offer half: advertisement derived from the installer's
+	// actual resolution).
+	unsetUpdateChannelEnv(t)
+
+	origDetector := homebrewOwnershipDetector
+	homebrewOwnershipDetector = func(string) (HomebrewOwnership, error) { return HomebrewFormula, nil }
+	t.Cleanup(func() { homebrewOwnershipDetector = origDetector })
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+
+	var mainHeadRequested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/Gentleman-Programming/gentle-ai/releases/latest":
+			json.NewEncoder(w).Encode(githubRelease{TagName: "v1.40.4", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.40.4"})
+		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
+			// Record the prohibited request; the assertion runs on the
+			// main goroutine after the check completes.
+			mainHeadRequested.Store(true)
+			http.NotFound(w, r)
+		default:
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+	result := checkSingleTool(context.Background(), Tools[0], "1.40.3-0.20260614151827-6eff4a1ba110", profile)
+
+	if mainHeadRequested.Load() {
+		t.Fatal("brew-owned gentle-ai must not request main HEAD: brew cannot deliver a main@sha target")
+	}
+	if strings.HasPrefix(result.LatestVersion, "main@") {
+		t.Fatalf("LatestVersion = %q, want the stable release brew would deliver, not a main-head advertisement", result.LatestVersion)
+	}
+	if result.LatestVersion != "1.40.4" {
+		t.Fatalf("LatestVersion = %q, want 1.40.4", result.LatestVersion)
+	}
+	if result.Status != UpdateAvailable {
+		t.Fatalf("status = %q, want %q", result.Status, UpdateAvailable)
+	}
+	if result.UpdateHint != "brew upgrade --formula gentle-ai" {
+		t.Fatalf("UpdateHint = %q, want the brew instruction that delivers the advertised target", result.UpdateHint)
+	}
+}
+
+func TestCheckSingleToolGentleAIBetaHintNamesAdvertisedTarget(t *testing.T) {
+	// When the checker advertises main@<sha>, the printed instruction must
+	// install that channel. The stable install.sh hint silently replaces a beta
+	// build with the latest stable release (issue #2323).
+	unsetUpdateChannelEnv(t)
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/Gentleman-Programming/gentle-ai/releases/latest":
+			json.NewEncoder(w).Encode(githubRelease{TagName: "v1.40.3", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.40.3"})
+		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
+			json.NewEncoder(w).Encode(githubCommit{SHA: "972997650b51abcdef0123456789abcdef012345", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/commit/972997650b51abcdef0123456789abcdef012345"})
+		default:
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	result := checkSingleTool(context.Background(), Tools[0], "1.40.3-0.20260614151827-6eff4a1ba110", profile)
+
+	if result.Status != UpdateAvailable {
+		t.Fatalf("status = %q, want %q", result.Status, UpdateAvailable)
+	}
+	if result.LatestVersion != "main@972997650b51" {
+		t.Fatalf("LatestVersion = %q, want main@972997650b51", result.LatestVersion)
+	}
+	derived := GentleAISourceInstallCommand(result.LatestVersion)
+	if result.UpdateHint != derived {
+		t.Fatalf("UpdateHint = %q, want the instruction derived from the advertised target: %q", result.UpdateHint, derived)
+	}
+	if result.UpdateHint != "go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main" {
+		t.Fatalf("UpdateHint = %q, want the go install @main command", result.UpdateHint)
+	}
+}
+
+func TestCheckSingleToolGentleAIBetaNewerLocalPseudoVersionIsNotOffered(t *testing.T) {
+	// A local build whose pseudo-version timestamp is newer than the remote
+	// main-head commit date is not behind main: offering "update available" on
+	// a bare prefix mismatch advertises a downgrade as an upgrade (issue #2319
+	// offer half).
+	unsetUpdateChannelEnv(t)
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/Gentleman-Programming/gentle-ai/releases/latest":
+			json.NewEncoder(w).Encode(githubRelease{TagName: "v1.40.3", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.40.3"})
+		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
+			// Real API shape: the commit date rides inside commit.committer.date.
+			fmt.Fprint(w, `{"sha":"aaaabbbbcccc0123456789abcdef0123456789ab","html_url":"https://github.com/Gentleman-Programming/gentle-ai/commit/aaaabbbbcccc0123456789abcdef0123456789ab","commit":{"committer":{"date":"2026-07-25T10:00:00Z"}}}`)
+		default:
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+
+	// Local pseudo-version timestamp 2026-08-01 15:26:09 UTC is newer than the
+	// remote commit date 2026-07-25.
+	result := checkSingleTool(context.Background(), Tools[0], "1.40.3-0.20260801152609-6eff4a1ba110", system.PlatformProfile{})
+
+	if result.Status != UpToDate {
+		t.Fatalf("status = %q, want %q: local build is newer than remote main HEAD", result.Status, UpToDate)
+	}
+}
+
+func TestCheckSingleToolGentleAIBetaOlderLocalPseudoVersionStillOffered(t *testing.T) {
+	// The ordering guard must not suppress the genuine offer: a local build
+	// older than the remote main-head commit keeps UpdateAvailable.
+	unsetUpdateChannelEnv(t)
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/Gentleman-Programming/gentle-ai/releases/latest":
+			json.NewEncoder(w).Encode(githubRelease{TagName: "v1.40.3", HTMLURL: "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.40.3"})
+		case "/repos/Gentleman-Programming/gentle-ai/commits/main":
+			fmt.Fprint(w, `{"sha":"aaaabbbbcccc0123456789abcdef0123456789ab","html_url":"https://github.com/Gentleman-Programming/gentle-ai/commit/aaaabbbbcccc0123456789abcdef0123456789ab","commit":{"committer":{"date":"2026-08-01T00:00:00Z"}}}`)
+		default:
+			// Stray or misdirected request: reply 404 and let the test's
+			// main-goroutine assertions decide (see simulateStrayForeignRequest).
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+
+	// Local pseudo-version timestamp 2026-06-14 predates the remote commit.
+	result := checkSingleTool(context.Background(), Tools[0], "1.40.3-0.20260614151827-6eff4a1ba110", system.PlatformProfile{})
+
+	if result.Status != UpdateAvailable {
+		t.Fatalf("status = %q, want %q", result.Status, UpdateAvailable)
+	}
+	if result.LatestVersion != "main@aaaabbbbcccc" {
+		t.Fatalf("LatestVersion = %q, want main@aaaabbbbcccc", result.LatestVersion)
+	}
+	if !strings.Contains(result.ReleaseURL, "/compare/6eff4a1ba110...aaaabbbbcccc") {
+		t.Fatalf("ReleaseURL = %q, want compare URL with local and remote commits", result.ReleaseURL)
+	}
+}
+
 func TestParseVersionFromOutput_DevSentinel(t *testing.T) {
 	if got := parseVersionFromOutput("engram dev"); got != "dev" {
 		t.Fatalf("parseVersionFromOutput(engram dev) = %q, want %q", got, "dev")

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -33,6 +33,14 @@ type githubRelease struct {
 type githubCommit struct {
 	SHA     string `json:"sha"`
 	HTMLURL string `json:"html_url"`
+	// Commit carries the committer date so the beta main-head check can tell
+	// whether a local pseudo-version build is already ahead of the fetched
+	// commit instead of offering every prefix mismatch as an update.
+	Commit struct {
+		Committer struct {
+			Date time.Time `json:"date"`
+		} `json:"committer"`
+	} `json:"commit"`
 }
 
 // resolveGitHubToken returns a GitHub token for API auth, trying in order:

--- a/internal/update/instructions.go
+++ b/internal/update/instructions.go
@@ -53,6 +53,10 @@ func openCodeRegisteredNotMaterializedHint(tool ToolInfo) string {
 	return fmt.Sprintf("registered in ~/.config/opencode/tui.json; pending npm dependency materialization for %s. Run gentle-ai upgrade to install/update ~/.config/opencode dependencies, then restart or reload OpenCode; if it stays pending, check OpenCode logs for package or peer dependency errors.", pkg)
 }
 
+// gentleAIHint is the stable-channel instruction only. When the checker
+// resolves a main-head beta target, applyBetaMainHeadStatus overrides this
+// hint with GentleAISourceInstallCommand so the printed instruction installs
+// the advertised target instead of the latest stable release.
 func gentleAIHint(profile system.PlatformProfile) string {
 	if profile.PackageManager == "brew" && homebrewPackageInstalled("gentle-ai") {
 		return "brew upgrade gentle-ai"


### PR DESCRIPTION
## What

The update checker computed its advertisement in parallel with the instruction that installs it, and the two disagreed. This PR derives the advertisement and the hint from what the effective installer actually delivers, in `internal/update/check.go` and `internal/update/instructions.go` only.

Three behaviors, each landed RED first:

1. **Brew-owned installs never get a `main@sha` advertisement.** `checkSingleTool` now consults the already-resolved Homebrew ownership before choosing the main-head channel: brew can only deliver the tap's stable formula, so that is what gets advertised (and the hint is the matching `brew upgrade --formula gentle-ai`).
2. **The beta hint is derived from the resolved target.** When the checker advertises `main@<sha>`, the printed instruction is `GentleAISourceInstallCommand(result.LatestVersion)`, the exact command that installs that channel. The channel-blind `curl install.sh | bash` hint survives only for stable, where it and the checker agree by construction.
3. **Ordering guard.** A bare commit-prefix mismatch no longer produces `UpdateAvailable` when the local pseudo-version timestamp is newer than the fetched main-head commit date. Unknown dates fail open and keep the offer.

No new channel field, no version field on `Advisory`, no reconciliation step: derivation only. `githubCommit` gains the committer date already present in the same API response, threaded to the decision point.

## RED, verbatim

```text
=== RUN   TestCheckSingleToolBrewOwnedGentleAIAdvertisesStableChannel
    check_test.go:579: brew-owned gentle-ai must not request main HEAD: brew cannot deliver a main@sha target
--- FAIL: TestCheckSingleToolBrewOwnedGentleAIAdvertisesStableChannel (0.04s)
=== RUN   TestCheckSingleToolGentleAIBetaHintNamesAdvertisedTarget
    check_test.go:632: UpdateHint = "curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash", want the instruction derived from the advertised target: "go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main"
--- FAIL: TestCheckSingleToolGentleAIBetaHintNamesAdvertisedTarget (0.04s)
=== RUN   TestCheckSingleToolGentleAIBetaNewerLocalPseudoVersionIsNotOffered
    check_test.go:672: status = "update-available", want "up-to-date": local build is newer than remote main HEAD
--- FAIL: TestCheckSingleToolGentleAIBetaNewerLocalPseudoVersionIsNotOffered (0.04s)
=== RUN   TestCheckSingleToolGentleAIBetaOlderLocalPseudoVersionStillOffered
--- PASS: TestCheckSingleToolGentleAIBetaOlderLocalPseudoVersionStillOffered (0.03s)
```

The fourth test pins the fail-open direction: a genuinely older local build keeps its offer.

## Built-binary transcript, real check against real GitHub

Binaries built with `-ldflags "-X main.version=<pseudo-version>"`, run as `gentle-ai update` with `GENTLE_AI_NO_SELF_UPDATE=1`.

Issue #2323 shape (beta pseudo-version, Linux non-brew). Before, on unmodified base b89bbd89, the advertisement and the instruction name different installables:

```text
[UP] gentle-ai  installed: 2.2.5-0.20260722011252-c4b764d09274  latest: main@41080e0076c5  curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash
```

After, this branch: the printed instruction installs the advertised target:

```text
[UP] gentle-ai  installed: 2.2.5-0.20260722011252-c4b764d09274  latest: main@41080e0076c5  go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main
```

Issue #2319 offer shape (local build newer than main HEAD, mismatching sha). Before, the base binary offers a downgrade as an upgrade:

```text
[UP] gentle-ai  installed: 2.3.0-0.20260804235959-deadbeefdead  latest: main@41080e0076c5  curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash
```

After: no offer.

```text
[ok] gentle-ai  installed: 2.3.0-0.20260804235959-deadbeefdead  latest: main@41080e0076c5
```

## Verification

- `go test ./... -count=1` at root: exit 0, zero FAIL lines
- `go test ./... -count=1` in `bench`: exit 0
- `gofmt -l internal/update/`: clean
- `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- Refusal-resolution ratchet (`TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`): pass

## Scope notes

- Closes #2323.
- Refs #2319: the **offer half** is fixed here (a downgrade is no longer advertised as an upgrade). The **swap half** (silent atomic-replace failure on Windows, stranded `.new.exe` files) is root 12: PR #2486 plus #724. #2319 stays open for that half.
- `internal/update/upgrade/download.go` and `download_durability_test.go` (owned by open PR #2486), `strategy.go`, `internal/tui/*`, `cooldown.go`, and `app/selfupdate.go` are deliberately untouched. The executor already derives its route from `LatestVersion`, so the ownership-aware checker makes it consistent with no change there.
- Advisory (#2368) and Scoop (#2386) are out of this PR by design.
