### PR TITLE
feat(cli): canonicalize unambiguous SHA-256 revision input at the sdd-attempt boundary

### DIFF
--- a/bench/classify.go
+++ b/bench/classify.go
@@ -467,6 +467,9 @@ var unsupportedPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)unknown [a-z-]+ command "`),
 	regexp.MustCompile(`(?i)flag provided but not defined`),
 	regexp.MustCompile(`(?i)unknown (flag|shorthand flag|option)`),
+	// sdd-attempt refuses an operation a build does not have with `unknown
+	// sdd-attempt operation "..."`: a missing surface (j62's settle probe).
+	regexp.MustCompile(`(?i)unknown [a-z-]+ operation "`),
 	regexp.MustCompile(`(?i)unrecognized (flag|option|argument)`),
 	regexp.MustCompile(`(?i)unexpected [a-z ]+ argument "`),
 	regexp.MustCompile(`(?i)unknown [a-z-]+ "--`),

--- a/bench/journeys_revision_canon.go
+++ b/bench/journeys_revision_canon.go
@@ -1,0 +1,112 @@
+package main
+
+// Issue #2523, the surviving CLI-boundary half of PR #2308: both unambiguous
+// non-canonical spellings of a SHA-256 evidence revision (the bare uppercase
+// hex PowerShell's Get-FileHash prints, and the bare lowercase form) must
+// settle identically to the canonical sha256:<64-lowercase-hex> input. The
+// ledger contract stays byte-for-byte strict (#2395); only the argument
+// boundary respells. waveFiveJourneys appends this file's registrar because
+// the central aggregator was owned by open pull requests when it landed.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// canonEvidenceDigest is the journey's content digest in canonical lowercase
+// hex, unprefixed so each step can spell it its own way.
+const canonEvidenceDigest = "27a44ad82d6e4f1d9f2c3b4a5d6e7f8091a2b3c4d5e6f70818293a4b5c6d7e8f"
+
+// The compact acquire/settle operations reject `--help` like every other
+// sdd-attempt operation, so both capabilities carry probe argvs that fail on
+// state in a build that has them. A build that predates the compact surface
+// answers `unknown sdd-attempt operation "..."`, which IsUnsupported reads
+// as a missing surface.
+var sddAttemptAcquireCapability = &Capability{
+	Verb:  []string{"sdd-attempt", "acquire"},
+	Probe: []string{"sdd-attempt", "acquire", "--work-unit=probe", "--evidence-goal=probe", "--max-attempts=1", "--max-changed-lines=1"},
+}
+var sddAttemptSettleCapability = &Capability{
+	Verb:  []string{"sdd-attempt", "settle"},
+	Probe: []string{"sdd-attempt", "settle", "--outcome=failed", "--evidence-revision=probe", "--harness-disposition=reused", "--cleanup-evidence=probe", "--process-evidence=probe"},
+}
+
+// sddAcquireCompactToken spends one counted acquire and returns the token
+// settle must present to continue that same attempt.
+func sddAcquireCompactToken(r *journeyRun, requestID string) (string, error) {
+	observation := r.run([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", requestID,
+		"--work-unit", "canonical evidence spelling objective",
+		"--evidence-goal", "both SHA-256 spellings settle identically",
+		"--max-attempts", "4", "--max-changed-lines", "20",
+	}, false)
+	var result struct {
+		State string `json:"state"`
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return "", fmt.Errorf("parse sdd-attempt acquire: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if result.State != "proceed" || result.Token == "" {
+		return "", fmt.Errorf("acquire = %+v, want proceed with a token", result)
+	}
+	return result.Token, nil
+}
+
+// sddSettleEvidenceSpelling acquires, settles with the given spelling of
+// canonEvidenceDigest, and proves the runtime recorded the canonical form —
+// so every spelling this journey drives lands on the identical settlement.
+func sddSettleEvidenceSpelling(spelling, requestID string) func(*journeyRun) error {
+	return func(r *journeyRun) error {
+		token, err := sddAcquireCompactToken(r, requestID+"-acquire")
+		if err != nil {
+			return err
+		}
+		observation := r.run([]string{
+			"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange,
+			"--token", token, "--request-id", requestID + "-settle", "--outcome", "failed",
+			"--evidence-revision", spelling,
+			"--diagnosis", "the benchmark drove this attempt to a terminal outcome",
+			"--harness-disposition", "reused",
+			"--cleanup-evidence", "workspace clean",
+			"--process-evidence", "no stray processes",
+		}, false)
+		if observation.ExitCode != 0 {
+			return fmt.Errorf("settle with evidence revision %q blocked: %s", spelling, firstLine(observation.Stderr))
+		}
+		status, err := proveRuntime(r.sandbox)
+		if err != nil {
+			return err
+		}
+		canonical := "sha256:" + canonEvidenceDigest
+		if status.EvidenceRevision != canonical {
+			return fmt.Errorf("settle with %q recorded evidence revision %q, want the canonical %q", spelling, status.EvidenceRevision, canonical)
+		}
+		return nil
+	}
+}
+
+func revisionCanonJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j62-sdd-settle-canonicalizes-unambiguous-evidence-revision",
+			Title:  "Compact settle: the PowerShell uppercase digest and the canonical form settle identically",
+			Source: "issue #2523 + the maintainer scoping comment on PR #2308 (idea: @decode2; uppercase report: @adgarboc on #2294)",
+			// Expected: before the CLI-boundary canonicalization, the uppercase
+			// settle blocks with the ledger's canonical-format refusal — an
+			// in_band block, because the refusal names the runnable rerun. After
+			// it, both spellings proceed and the runtime records the identical
+			// canonical sha256:<64-lowercase-hex> evidence revision, which the
+			// composite proves through `sdd-attempt status` after each settle.
+			Steps: []Step{
+				{Name: "fixture: repository with a committed OpenSpec change", Fixture: sddRuntimeRepo},
+				{Name: "settle with the PowerShell-style uppercase digest", Requires: sddAttemptSettleCapability,
+					Composite: sddSettleEvidenceSpelling(strings.ToUpper(canonEvidenceDigest), "bench-canon-upper")},
+				{Name: "settle with the canonical lowercase prefixed digest", Requires: sddAttemptSettleCapability,
+					Composite: sddSettleEvidenceSpelling("sha256:"+canonEvidenceDigest, "bench-canon-lower")},
+			},
+		},
+	}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 60 {
-		t.Errorf("core journey count = %d, want 60", got)
+	if got := len(seen); got != 61 {
+		t.Errorf("core journey count = %d, want 61", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/journeys_wave5.go
+++ b/bench/journeys_wave5.go
@@ -51,8 +51,12 @@ func requirePrePRMultiSegmentDenialNamesRunnableNextStep(_ *Sandbox, observation
 	return nil
 }
 
+// waveFiveJourneys also carries the revision-canonicalization registrar from
+// journeys_revision_canon.go: the central aggregator in journeys.go was owned
+// by an open pull request when j62 landed, and this is the nearest registrar
+// that was not.
 func waveFiveJourneys() []Journey {
-	return []Journey{
+	journeys := []Journey{
 		{
 			ID:     "j61-pre-pr-multi-segment-delivery-denies-without-composition",
 			Title:  "Pre-PR multi-segment delivery composition used to rescue now denies, naming a runnable next step",
@@ -82,4 +86,5 @@ func waveFiveJourneys() []Journey {
 			},
 		},
 	}
+	return append(journeys, revisionCanonJourneys()...)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -92,7 +92,8 @@ func RunArgs(args []string, stdout io.Writer) error {
 		case "sdd-continue":
 			return cli.RunSDDContinue(args[1:], stdout)
 		case "sdd-attempt":
-			return cli.RunSDDAttempt(args[1:], stdout)
+			// Content digests canonicalize at this boundary (#2523); the ledger stays strict (#2395).
+			return cli.RunSDDAttempt(cli.CanonicalizeSDDAttemptRevisionArgs(args[1:]), stdout)
 		case "sdd-verify-validate":
 			return cli.RunSDDVerifyValidate(args[1:], stdout)
 		case "codegraph":

--- a/internal/app/sdd_attempt_revision_canon_test.go
+++ b/internal/app/sdd_attempt_revision_canon_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #2523: RunArgs is the exact dispatch the shipped binary runs, so the
+// argvs below take the same path a user's shell invocation takes. The two
+// unambiguous SHA-256 spellings (64-hex containing uppercase, prefixed or
+// bare, as PowerShell's Get-FileHash prints, and bare lowercase 64-hex)
+// canonicalize at the argument boundary; every other value still refuses
+// with the ledger's own message (#2395).
+
+const canonSDDChange = "revision-canon-change"
+const canonEvidenceHexLower = "27a44ad82d6e4f1d9f2c3b4a5d6e7f8091a2b3c4d5e6f70818293a4b5c6d7e8f"
+
+func initCanonRepo(t *testing.T) string {
+	t.Helper()
+	repo, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q"}, {"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"}, {"config", "core.autocrlf", "false"},
+		{"add", "tracked.txt"}, {"commit", "-qm", "base"},
+	} {
+		command := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+	}
+	return repo
+}
+
+func canonRunJSON(t *testing.T, target any, args ...string) {
+	t.Helper()
+	var output bytes.Buffer
+	if err := RunArgs(args, &output); err != nil {
+		t.Fatalf("RunArgs(%v): %v", args, err)
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output.String())), target); err != nil {
+		t.Fatalf("parse %v output: %v\n%s", args, err, output.String())
+	}
+}
+
+func canonAcquireToken(t *testing.T, repo, requestID string) string {
+	t.Helper()
+	var result struct {
+		State string `json:"state"`
+		Token string `json:"token"`
+	}
+	canonRunJSON(t, &result, "sdd-attempt", "acquire", "--cwd", repo, "--change", canonSDDChange,
+		"--request-id", requestID, "--work-unit", "canon-unit",
+		"--evidence-goal", "prove canonical revision input",
+		"--max-attempts", "4", "--max-changed-lines", "20")
+	if result.State != "proceed" || result.Token == "" {
+		t.Fatalf("acquire = %+v, want proceed with a token", result)
+	}
+	return result.Token
+}
+
+func canonSettle(repo, token, requestID, evidenceRevision string) error {
+	return RunArgs([]string{
+		"sdd-attempt", "settle", "--cwd", repo, "--change", canonSDDChange,
+		"--token", token, "--request-id", requestID, "--outcome", "failed",
+		"--evidence-revision", evidenceRevision,
+		"--diagnosis", "attempt produced conclusive evidence", "--harness-disposition", "reused",
+		"--cleanup-evidence", "process group exited", "--process-evidence", "no descendants remained",
+	}, &bytes.Buffer{})
+}
+
+// TestSDDAttemptSettleRevisionInputCanonicalization pins both sides of the
+// boundary: the unambiguous non-canonical spellings settle identically to the
+// canonical one with the ledger recording the canonical form, and everything
+// else reaches the ledger byte-for-byte and refuses exactly as before.
+func TestSDDAttemptSettleRevisionInputCanonicalization(t *testing.T) {
+	canonical := "sha256:" + canonEvidenceHexLower
+	cases := []struct {
+		name    string
+		input   string
+		refused bool
+	}{
+		{"uppercase prefixed (sha256: plus Get-FileHash case)", "sha256:" + strings.ToUpper(canonEvidenceHexLower), false},
+		{"uppercase bare (PowerShell Get-FileHash default)", strings.ToUpper(canonEvidenceHexLower), false},
+		{"lowercase bare (shasum default)", canonEvidenceHexLower, false},
+		{"canonical passthrough", canonical, false},
+		{"63 hex chars", canonEvidenceHexLower[:63], true},
+		{"non-hex", "g" + canonEvidenceHexLower[1:], true},
+		{"wrong prefix", "sha1:" + canonEvidenceHexLower, true},
+	}
+	for index, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initCanonRepo(t)
+			token := canonAcquireToken(t, repo, fmt.Sprintf("canon-acquire-%d", index))
+			err := canonSettle(repo, token, fmt.Sprintf("canon-settle-%d", index), tt.input)
+			if tt.refused {
+				if err == nil || !strings.Contains(err.Error(), "evidence_revision must be sha256:<64-lowercase-hex>") {
+					t.Fatalf("settle with %s = %v, want the unchanged canonical-format refusal", tt.name, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("settle with %s = %v, want success", tt.name, err)
+			}
+			var status struct {
+				EvidenceRevision string `json:"evidence_revision"`
+			}
+			canonRunJSON(t, &status, "sdd-attempt", "status", "--cwd", repo, "--change", canonSDDChange)
+			if status.EvidenceRevision != canonical {
+				t.Fatalf("recorded evidence revision = %q, want %q", status.EvidenceRevision, canonical)
+			}
+		})
+	}
+}

--- a/internal/cli/sdd_attempt_revision.go
+++ b/internal/cli/sdd_attempt_revision.go
@@ -1,0 +1,71 @@
+package cli
+
+import "strings"
+
+// sddAttemptContentDigestFlags names the sdd-attempt flags whose value is a
+// caller-computed SHA-256 content digest, which is the only revision kind the
+// CLI boundary may respell (#2523). The other revision-shaped flags stay
+// byte-for-byte: --expected-revision, --expected-binding-revision, and
+// --token carry ledger-issued identities the caller copies from product
+// output, so a non-canonical spelling of any of them is a transcription
+// fault the strict ledger contract (#2395) must keep refusing.
+var sddAttemptContentDigestFlags = map[string]bool{
+	"evidence-revision":            true,
+	"remediates-evidence-revision": true,
+}
+
+// CanonicalizeSDDAttemptRevisionArgs rewrites, at argument-parsing time, the
+// value of every content-digest sdd-attempt flag to the canonical
+// sha256:<64-lowercase-hex> form when the value is one of the two unambiguous
+// SHA-256 spellings: 64 hexadecimal digits with the sha256: prefix, or 64
+// bare hexadecimal digits. Hex is case-insensitive by definition, so both
+// spellings name the same digest the canonical form names; PowerShell's
+// Get-FileHash prints the bare uppercase one by default (#2294). Every other
+// value passes through byte-for-byte and refuses downstream exactly as
+// before. The ledger stays a pure validator with no normalization of its own.
+func CanonicalizeSDDAttemptRevisionArgs(args []string) []string {
+	canonical := append([]string(nil), args...)
+	for index := 0; index < len(canonical); index++ {
+		argument := canonical[index]
+		if !strings.HasPrefix(argument, "--") {
+			continue
+		}
+		name := strings.TrimPrefix(argument, "--")
+		if separator := strings.IndexByte(name, '='); separator >= 0 {
+			value := name[separator+1:]
+			name = name[:separator]
+			if sddAttemptContentDigestFlags[name] {
+				canonical[index] = "--" + name + "=" + canonicalSHA256Revision(value)
+			}
+			continue
+		}
+		// The flag package consumes the next argument as this flag's value,
+		// and validateSDDAttemptOperationFlags scans argv the same way.
+		if sddAttemptContentDigestFlags[name] && index+1 < len(canonical) {
+			canonical[index+1] = canonicalSHA256Revision(canonical[index+1])
+			index++
+		}
+	}
+	return canonical
+}
+
+// canonicalSHA256Revision maps the two unambiguous SHA-256 spellings to
+// sha256:<64-lowercase-hex> and returns every other value unchanged, so the
+// downstream refusal for ambiguous input is exactly the one shipped today.
+// Surrounding whitespace is ignored for recognition because runSDDAttempt
+// already trims these values before validation.
+func canonicalSHA256Revision(value string) string {
+	digest := strings.TrimPrefix(strings.TrimSpace(value), "sha256:")
+	if len(digest) != 64 {
+		return value
+	}
+	for _, character := range digest {
+		hexadecimal := (character >= '0' && character <= '9') ||
+			(character >= 'a' && character <= 'f') ||
+			(character >= 'A' && character <= 'F')
+		if !hexadecimal {
+			return value
+		}
+	}
+	return "sha256:" + strings.ToLower(digest)
+}

--- a/internal/cli/sdd_attempt_revision_test.go
+++ b/internal/cli/sdd_attempt_revision_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const revisionCanonHexLower = "27a44ad82d6e4f1d9f2c3b4a5d6e7f8091a2b3c4d5e6f70818293a4b5c6d7e8f"
+
+func TestCanonicalSHA256Revision(t *testing.T) {
+	canonical := "sha256:" + revisionCanonHexLower
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"uppercase prefixed", "sha256:" + strings.ToUpper(revisionCanonHexLower), canonical},
+		{"uppercase bare", strings.ToUpper(revisionCanonHexLower), canonical},
+		{"lowercase bare", revisionCanonHexLower, canonical},
+		{"canonical passthrough", canonical, canonical},
+		{"whitespace-wrapped uppercase bare", "  " + strings.ToUpper(revisionCanonHexLower) + "\n", canonical},
+		{"63 hex chars unchanged", revisionCanonHexLower[:63], revisionCanonHexLower[:63]},
+		{"non-hex unchanged", "g" + revisionCanonHexLower[1:], "g" + revisionCanonHexLower[1:]},
+		{"wrong prefix unchanged", "sha1:" + revisionCanonHexLower, "sha1:" + revisionCanonHexLower},
+		{"uppercase prefix unchanged", "SHA256:" + revisionCanonHexLower, "SHA256:" + revisionCanonHexLower},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalSHA256Revision(tt.input); got != tt.want {
+				t.Fatalf("canonicalSHA256Revision(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeSDDAttemptRevisionArgs(t *testing.T) {
+	upper := strings.ToUpper(revisionCanonHexLower)
+	canonical := "sha256:" + revisionCanonHexLower
+	cases := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"separate value form",
+			[]string{"settle", "--evidence-revision", upper, "--outcome", "failed"},
+			[]string{"settle", "--evidence-revision", canonical, "--outcome", "failed"}},
+		{"inline value form",
+			[]string{"finish", "--evidence-revision=" + upper},
+			[]string{"finish", "--evidence-revision=" + canonical}},
+		{"remediates flag both forms",
+			[]string{"finish", "--remediates-evidence-revision", upper, "--remediates-evidence-revision=" + upper},
+			[]string{"finish", "--remediates-evidence-revision", canonical, "--remediates-evidence-revision=" + canonical}},
+		{"ledger-issued revisions untouched",
+			[]string{"finish", "--expected-revision", upper, "--expected-binding-revision=" + upper, "--token", upper},
+			[]string{"finish", "--expected-revision", upper, "--expected-binding-revision=" + upper, "--token", upper}},
+		{"ambiguous value untouched",
+			[]string{"settle", "--evidence-revision", "sha1:" + revisionCanonHexLower},
+			[]string{"settle", "--evidence-revision", "sha1:" + revisionCanonHexLower}},
+		{"trailing flag without value untouched",
+			[]string{"settle", "--evidence-revision"},
+			[]string{"settle", "--evidence-revision"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			input := append([]string(nil), tt.args...)
+			if got := CanonicalizeSDDAttemptRevisionArgs(input); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("CanonicalizeSDDAttemptRevisionArgs(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+			if !reflect.DeepEqual(input, tt.args) {
+				t.Fatalf("input argv mutated: %v, want %v", input, tt.args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2523

Refs #2294 #2395

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

The surviving half of PR #2308, exactly as the maintainer comment there scoped it: canonicalize SHA-256 revision input at the CLI boundary. `internal/sddstatus` changes zero bytes; the ledger, its validator, and its refusal text are untouched.

At argument-parsing time only, the two unambiguous spellings of a SHA-256 content digest canonicalize to `sha256:<64-lowercase-hex>`:

- 64 hex digits containing uppercase, with or without the `sha256:` prefix (PowerShell's `Get-FileHash` prints the bare uppercase form by default, the shape @adgarboc reported on #2294)
- bare lowercase 64-hex

Everything else (63 hex chars, non-hex, any other prefix including `SHA256:`) passes through byte-for-byte and refuses with exactly the message shipped today. One small helper carries the whole rule: `canonicalSHA256Revision` in `internal/cli/sdd_attempt_revision.go`, applied by `CanonicalizeSDDAttemptRevisionArgs` to every content-digest flag in both `--flag value` and `--flag=value` forms.

**Why boundary normalization is right here.** Hex is case-insensitive by definition: `27A4...` and `27a4...` are two spellings of the same number, so refusing the uppercase one rejects a value that is already valid. The `sha256:` prefix is our format convention, not information. Accepting the two unambiguous spellings relaxes the input grammar rather than adding to it, which is this repo's stated bias. The honest counter-argument: normalizing at the edge makes two differently-written revisions compare equal, and in a content-addressed system that must always be a deliberate decision. Here it is deliberate, because the two spellings are the same hash, not two values. The decider: under the strict boundary, the user who wrote the hash in uppercase pays a refusal for something that is not wrong; with boundary canonicalization it works. The ledger's canonical identity stays byte-for-byte strict either way; only the boundary respells.

**Flag inventory, decided from the code.** The canonicalized set is exactly the two caller-computed content digests:

| Flag | Kind | Canonicalized |
|---|---|---|
| `--evidence-revision` | caller-computed content digest (the `Get-FileHash` case from #2294) | yes |
| `--remediates-evidence-revision` | caller-computed content digest; must byte-match a previously recorded evidence revision, which the ledger already stores canonically | yes |
| `--expected-revision` | ledger revision: the optimistic-concurrency token `store.mutate` compares against `replay.Status.Revision`, copied from status output | no |
| `--expected-binding-revision` | ledger-issued binding revision, compared to `currentBinding.Revision` (`runtime_ledger.go`) | no |
| `--token` | opaque compact continuation | no |

`--expected-revision` is a ledger revision, not a content digest, per the issue's own criterion, so it stays byte-for-byte.

**RED first.** `TestSDDAttemptSettleRevisionInputCanonicalization` drives the real CLI boundary (`app.RunArgs`, the exact dispatch the shipped binary runs) through a real acquire/settle sequence. Verbatim failure on pre-change main for the PowerShell shape:

```
settle with uppercase bare (PowerShell Get-FileHash default) = sdd-attempt settle: evidence_revision must be sha256:<64-lowercase-hex> (received length=64, sha256: prefix=false, non-lowercase-hex characters=true); rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --evidence-revision sha256:<64-lowercase-hex>, want success
```

Uppercase prefixed failed the same way with `received length=71, sha256: prefix=true`, and lowercase bare with `non-lowercase-hex characters=false`. Canonical passthrough and the three refusal cases (63 hex chars, non-hex, wrong prefix) passed before the change and still pass after it, pinning that only the two unambiguous shapes gained admission.

**Structural notes on open-PR ownership.** `internal/cli/sdd_attempt.go` is owned by open PR #2226, so the canonicalizer wires at the only other production seam: the `sdd-attempt` dispatch in `internal/app/app.go`, still before any flag parsing; PR #2305's only `app.go` hunk is in a different function, so no textual conflict. The journey lives in its own file and registers through `waveFiveJourneys` because `bench/journeys.go` and `journeys_wave1.go` are owned by open PRs. The corpus count pin in `bench/journeys_sdd_test.go` moves 60 to 61; every journey-adding PR must touch that line (open PR #2444 bumps it too), so a trivial count reconciliation is expected with whichever lands second.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/sdd_attempt_revision.go` | New: the canonicalization helper and the content-digest flag set |
| `internal/cli/sdd_attempt_revision_test.go` | New: unit tables for the helper and the argv rewrite |
| `internal/app/app.go` | One-line wiring at the `sdd-attempt` dispatch |
| `internal/app/sdd_attempt_revision_canon_test.go` | New: end-to-end acquire/settle table through `RunArgs` (RED first) |
| `bench/journeys_revision_canon.go` | New: j62 plus acquire/settle capabilities in a self-contained registrar |
| `bench/journeys_wave5.go` | Registers the new journeys |
| `bench/classify.go` | New unsupported pattern: `unknown [a-z-]+ operation "` |
| `bench/journeys_sdd_test.go` | Corpus count pin 60 to 61 |

---

## 🧪 Test Plan

All run in the foreground and read personally:

- `go test ./... -count=1` at root: all packages ok
- `go test ./... -count=1` in `bench/`: ok (includes the journey ID collision guard and the corpus count pin)
- `go run ./internal/gofmtcheck`: clean
- `go vet ./...` in both modules: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- refusal-resolution ratchet and guard-population tests: pass
- **Benchmark validation**: j62 driven end-to-end against two binaries. Built from this branch: `completed`, with `sdd-attempt status` proving both spellings recorded the identical canonical evidence revision. Built from pre-change main: `failed`, quoting the canonical-format refusal on the uppercase settle, which is the before/after this journey pins. A binary predating the compact surface reads as `unsupported` via the new classifier pattern.
- E2E Docker suite left to CI.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Benchmark validation completed
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No qualifying security/integrity/admission guard is added or changed: the helper only widens an input grammar at the argument boundary and never rejects anything new, and `.guard-population-baseline.txt` is untouched.

Idea from PR #2308 by @decode2; this lands the CLI-boundary half the maintainer scoped there.
