### PR TITLE
fix(sdd): bind disabled remediation evidence

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -1882,6 +1882,22 @@ func sddJourneys() []Journey {
 						}
 						return nil
 					})},
+				{Name: "mode enable after unmanaged correction", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--json")},
+				{Name: "enabled archive requires bounded review authority", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: sddStatusAssertion("re-enabled unmanaged correction", func(status sddStatusV1) error {
+						if status.Dependencies.Verify != "all_done" || status.Dependencies.Archive != "blocked" || status.NextRecommended != "resolve-review" {
+							return fmt.Errorf("re-enabled archive = verify %q archive %q next %q", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
+						}
+						if status.ReviewGate == nil || status.ReviewGate.Result != "invalidated" ||
+							!strings.Contains(status.ReviewGate.Reason, "disabled/unmanaged correction") ||
+							!strings.Contains(status.ReviewGate.Reason, "gentle-ai review start") {
+							return fmt.Errorf("re-enabled archive omitted bounded review authority: %+v", status.ReviewGate)
+						}
+						if status.ReviewOffer == nil || !status.ReviewOffer.Available || !strings.Contains(status.ReviewOffer.Invocation, "review start") {
+							return fmt.Errorf("re-enabled archive omitted executable review offer: %+v", status.ReviewOffer)
+						}
+						return nil
+					})},
 			},
 		},
 		{

--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -53,6 +53,7 @@ const sddChange = "bench-change"
 const (
 	sddFailedEvidence    = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	sddCorrectedEvidence = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	sddWrongEvidence     = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 )
 
 // sddSuccessorLineage is the name a recovery successor is minted under. The CLI
@@ -83,9 +84,10 @@ type sddRuntimeStatus struct {
 		Outcome            string `json:"outcome"`
 	} `json:"active_attempt"`
 	Attempts []struct {
-		Ordinal          int    `json:"ordinal"`
-		Outcome          string `json:"outcome"`
-		EvidenceRevision string `json:"evidence_revision"`
+		Ordinal                    int    `json:"ordinal"`
+		Outcome                    string `json:"outcome"`
+		EvidenceRevision           string `json:"evidence_revision"`
+		RemediatesEvidenceRevision string `json:"remediates_evidence_revision"`
 	} `json:"attempts"`
 	EvidenceRevision string `json:"evidence_revision"`
 	BindingRevision  string `json:"binding_revision"`
@@ -95,6 +97,11 @@ type sddRuntimeStatus struct {
 	} `json:"binding"`
 	NextAction string `json:"next_action"`
 	Complete   bool   `json:"complete"`
+}
+
+type sddCompactAttemptResult struct {
+	State string `json:"state"`
+	Token string `json:"token"`
 }
 
 // sddStatusV1 is the subset of `sdd-status --json` the kill-switch journeys read.
@@ -115,8 +122,11 @@ type sddStatusV1 struct {
 		LineageID  string `json:"lineageId"`
 		Invocation string `json:"invocation"`
 	} `json:"reviewOffer"`
-	BlockedReasons []string `json:"blockedReasons"`
-	TaskProgress   struct {
+	BlockedReasons    []string `json:"blockedReasons"`
+	PhaseInstructions struct {
+		Remediate []string `json:"remediate"`
+	} `json:"phaseInstructions"`
+	TaskProgress struct {
 		Total       int  `json:"total"`
 		Completed   int  `json:"completed"`
 		AllComplete bool `json:"allComplete"`
@@ -825,6 +835,22 @@ const sddVerifyReport = "```yaml\n" +
 	"build_output_hash: sha256:3333333333333333333333333333333333333333333333333333333333333333\n" +
 	"```\n"
 
+const sddFailedVerifyReport = "```yaml\n" +
+	"schema: gentle-ai.verify-result/v1\n" +
+	"evidence_revision: " + sddFailedEvidence + "\n" +
+	"verdict: fail\n" +
+	"blockers: 1\n" +
+	"critical_findings: 0\n" +
+	"requirements: 1/1\n" +
+	"scenarios: 1/1\n" +
+	"test_command: go test ./internal/example\n" +
+	"test_exit_code: 1\n" +
+	"test_output_hash: sha256:2222222222222222222222222222222222222222222222222222222222222222\n" +
+	"build_command: go test ./cmd/gentle-ai\n" +
+	"build_exit_code: 0\n" +
+	"build_output_hash: sha256:3333333333333333333333333333333333333333333333333333333333333333\n" +
+	"```\n"
+
 // ---------------------------------------------------------------------------
 // Counted operator work
 // ---------------------------------------------------------------------------
@@ -871,6 +897,12 @@ var sddObjective = []string{
 	"--max-attempts", "6", "--max-changed-lines", "600",
 }
 
+var sddUnmanagedObjective = []string{
+	"--work-unit", "bench unmanaged correction",
+	"--evidence-goal", "repair admitted verification failure",
+	"--max-attempts", "2", "--max-changed-lines", "20",
+}
+
 // sddTerminalEvidence is the bounded evidence every finish must carry.
 var sddTerminalEvidence = []string{
 	"--diagnosis", "the benchmark drove this attempt to a terminal outcome",
@@ -901,6 +933,105 @@ func sddBeginFailBegin(r *journeyRun) error {
 	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-begin-two", sddObjective...), false)
 
 	return proveActiveAttempt(r.sandbox, 2, sddFailedEvidence)
+}
+
+func sddBeginFailedUnmanagedVerification(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-unmanaged-begin-verification", sddUnmanagedObjective...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-unmanaged-finish-verification",
+		append([]string{"--outcome", "failed", "--evidence-revision", sddFailedEvidence}, sddTerminalEvidence...)...), false)
+	status, err = proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if status.ActiveAttempt != nil || len(status.Attempts) != 1 || status.Attempts[0].Outcome != "failed" || status.NextAction != "begin" {
+		return fmt.Errorf("failed verification did not leave exactly one bounded successor: %#v", status)
+	}
+	return nil
+}
+
+func sddUnmanagedAcquireCorrection(r *journeyRun) error {
+	observation := r.run(append([]string{"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "bench-unmanaged-acquire"}, sddUnmanagedObjective...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse unmanaged correction acquire: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if observation.ExitCode != 0 || result.State != "proceed" || result.Token == "" {
+		return fmt.Errorf("unmanaged correction acquire = %#v exit=%d", result, observation.ExitCode)
+	}
+	r.sandbox.Scratch["unmanaged-token"] = result.Token
+	return nil
+}
+
+func sddUnmanagedSettle(r *journeyRun, requestID, failedEvidence string, wantSuccess bool) error {
+	token := r.sandbox.Scratch["unmanaged-token"]
+	observation := r.run(append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange, "--token", token,
+		"--request-id", requestID, "--outcome", "passed", "--evidence-revision", sddCorrectedEvidence,
+		"--remediates-evidence-revision", failedEvidence,
+	}, sddTerminalEvidence...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse unmanaged correction settle: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if wantSuccess && (observation.ExitCode != 0 || result.State != "complete") {
+		return fmt.Errorf("bounded unmanaged correction did not settle: %#v exit=%d", result, observation.ExitCode)
+	}
+	if !wantSuccess && result.State != "blocked" {
+		return fmt.Errorf("invalid unmanaged correction = %#v, want blocked", result)
+	}
+	return nil
+}
+
+func sddUnmanagedCorrectionRemainsBounded(r *journeyRun) error {
+	if err := sddUnmanagedSettle(r, "bench-unmanaged-unchanged", sddFailedEvidence, false); err != nil {
+		return err
+	}
+	return proveActiveAttempt(r.sandbox, 2, sddFailedEvidence)
+}
+
+func sddUnmanagedWrongEvidenceIsRejected(r *journeyRun) error {
+	if err := sddUnmanagedSettle(r, "bench-unmanaged-wrong-evidence", sddWrongEvidence, false); err != nil {
+		return err
+	}
+	return proveActiveAttempt(r.sandbox, 2, sddFailedEvidence)
+}
+
+func sddUnmanagedCorrectionCompletes(r *journeyRun) error {
+	if err := sddUnmanagedSettle(r, "bench-unmanaged-correct", sddFailedEvidence, true); err != nil {
+		return err
+	}
+	status, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if status.Binding != nil || status.BindingRevision != "" || len(status.Attempts) != 2 ||
+		status.Attempts[1].RemediatesEvidenceRevision != sddFailedEvidence {
+		return fmt.Errorf("unmanaged correction invented review authority or lost failed evidence: %#v", status)
+	}
+	return nil
+}
+
+func sddUnmanagedReplayIsComplete(r *journeyRun) error {
+	observation := r.run(append([]string{"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "bench-unmanaged-replay"}, sddUnmanagedObjective...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse unmanaged correction replay: %w", err)
+	}
+	if observation.ExitCode != 0 || result.State != "complete" {
+		return fmt.Errorf("unmanaged correction replay = %#v exit=%d", result, observation.ExitCode)
+	}
+	return nil
+}
+
+func sddReplaceFailedVerifyReport(sandbox *Sandbox) error {
+	return sandbox.write(filepath.Join(sddChangeRoot(sandbox), "verify-report.md"), sddVerifyReport)
 }
 
 // sddBeginThenInterrupt closes the first attempt as interrupted with budget to
@@ -1698,6 +1829,56 @@ func sddJourneys() []Journey {
 						}
 						if status.ReviewOffer != nil {
 							return fmt.Errorf("reviewOffer = %+v, want structural absence while the kill switch is off", status.ReviewOffer)
+						}
+						return nil
+					})},
+			},
+		},
+		{
+			ID:     "j63-disabled-failed-verification-unmanaged-remediation",
+			Title:  "Disabled failed verification admits one evidence-bound correction, then requires a fresh verification",
+			Source: "#2182 acceptance: disabled/unmanaged remediation successor",
+			Steps: []Step{
+				{Name: "fixture: completed change with admitted failed verification", Fixture: sddPlanningArtifacts(sddFailedVerifyReport)},
+				{Name: "enabled mode still refuses missing review authority", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: sddStatusAssertion("enabled remediation", func(status sddStatusV1) error {
+						if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "bounded review transaction is missing") {
+							return fmt.Errorf("enabled remediation lost its bounded review refusal: %v", status.BlockedReasons)
+						}
+						return nil
+					})},
+				{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+				{Name: "failed verification enters unmanaged remediation", Requires: sddAttemptBeginCapability, Composite: sddBeginFailedUnmanagedVerification},
+				{Name: "disabled status names remediation without review authority", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json", "--instructions"), After: sddStatusAssertion("disabled remediation", func(status sddStatusV1) error {
+						if status.NextRecommended != "remediate" || status.ReviewGate != nil {
+							return fmt.Errorf("disabled failed verification = next %q reviewGate=%+v", status.NextRecommended, status.ReviewGate)
+						}
+						instructions := strings.Join(status.PhaseInstructions.Remediate, "\n")
+						if !strings.Contains(instructions, "gentle-ai sdd-attempt acquire") ||
+							!strings.Contains(instructions, "--remediates-evidence-revision "+sddFailedEvidence) {
+							return fmt.Errorf("disabled remediation emitted no executable evidence-bound continuation: %s", instructions)
+						}
+						return nil
+					})},
+				{Name: "acquire the one bounded correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedAcquireCorrection},
+				{Name: "unchanged candidate cannot satisfy correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedCorrectionRemainsBounded},
+				{Name: "fixture: correction changes the candidate", Fixture: sddBoundedCorrection},
+				{Name: "wrong failed evidence cannot satisfy correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedWrongEvidenceIsRejected},
+				{Name: "settle the evidence-bound correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedCorrectionCompletes},
+				{Name: "replay cannot acquire another correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedReplayIsComplete},
+				{Name: "fresh verification is required before archive", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: sddStatusAssertion("fresh verification", func(status sddStatusV1) error {
+						if status.Dependencies.Verify != "ready" || status.Dependencies.Archive != "blocked" || status.NextRecommended != "verify" {
+							return fmt.Errorf("post-correction status = verify %q archive %q next %q", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
+						}
+						return nil
+					})},
+				{Name: "fixture: fresh independent verification passes", Fixture: sddReplaceFailedVerifyReport},
+				{Name: "archive is ready without review authority", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"), After: sddStatusAssertion("disabled archive", func(status sddStatusV1) error {
+						if status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" || status.ReviewGate != nil || status.ReviewOffer != nil {
+							return fmt.Errorf("disabled archive = archive %q next %q gate=%+v offer=%+v", status.Dependencies.Archive, status.NextRecommended, status.ReviewGate, status.ReviewOffer)
 						}
 						return nil
 					})},

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 61 {
-		t.Errorf("core journey count = %d, want 61", got)
+	if got := len(seen); got != 62 {
+		t.Errorf("core journey count = %d, want 62", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -103,7 +103,8 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			return fmt.Errorf("sdd-attempt finish requires %s", strings.Join(missing, ", "))
 		}
 		remediationFlags := presentSDDAttemptFlags(args[1:], "expected-binding-revision", "successor-lineage", "remediates-evidence-revision")
-		if remediationFlags != 0 && remediationFlags != 3 {
+		unmanagedRemediation := *expectedBindingRevision == "" && *successorLineage == "" && *remediatesEvidenceRevision != ""
+		if remediationFlags != 0 && remediationFlags != 3 && !unmanagedRemediation {
 			return errors.New("remediation successor requires --expected-binding-revision, --successor-lineage, and --remediates-evidence-revision together")
 		}
 		result, err = store.Finish(ctx, sddstatus.FinishAttemptRequest{

--- a/internal/sddstatus/review_disabled_remediation_test.go
+++ b/internal/sddstatus/review_disabled_remediation_test.go
@@ -69,3 +69,23 @@ func TestEnabledReviewStillRequiresItsBoundedTransaction(t *testing.T) {
 		t.Fatalf("enabled review admitted remediation with no transaction: %#v", status.RemediationState)
 	}
 }
+
+// TestDisabledStatusWithoutAnUnmanagedCorrectionDoesNotBlockAfterReenable is
+// the scope control: merely having used disabled status does not make a fresh
+// passing verification wait for review authority after the mode changes back.
+func TestDisabledStatusWithoutAnUnmanagedCorrectionDoesNotBlockAfterReenable(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	changeRoot := seedReadyChange(t, repo, "thin", "- [x] 1.1 Work\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("pass", 0, 0, "1/1", "1/1", 0, 0))
+
+	if _, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "thin", ReviewDisabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	reenabled, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reenabled.Dependencies.Archive != DependencyReady || reenabled.NextRecommended != "archive" || reenabled.ReviewGate != nil {
+		t.Fatalf("re-enabled status without an unmanaged correction = archive %q next %q gate=%#v", reenabled.Dependencies.Archive, reenabled.NextRecommended, reenabled.ReviewGate)
+	}
+}

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -259,6 +259,8 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 			finish.SuccessorLineageID = status.Binding.Lineage
 		}
 		finish.RemediatesEvidenceRevision = failedEvidence
+	} else if store.ReviewDisabled && !explicitSuccessor && request.RemediatesEvidenceRevision != "" {
+		finish.RemediatesEvidenceRevision = request.RemediatesEvidenceRevision
 	} else if explicitSuccessor || request.RemediatesEvidenceRevision != "" {
 		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 	}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -702,10 +702,11 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			return runtimeRecord{}, store.runtimeWorktreeMismatchRefusal(active.Ordinal, active.BeginWorktree)
 		}
 		remediation := finishRequestsRemediation(request)
+		unmanagedRemediation := finishRequestsUnmanagedRemediation(request)
 		currentBinding := status.Binding
 		var legacyBinding *ReviewBinding
 		var legacyDigest string
-		if request.Outcome == AttemptPassed && currentBinding == nil {
+		if request.Outcome == AttemptPassed && currentBinding == nil && (!store.ReviewDisabled || remediation) {
 			legacyBinding, legacyDigest, err = store.readLegacyBinding()
 			if err != nil {
 				return runtimeRecord{}, fmt.Errorf("read legacy SDD review binding for remediation: %w", err)
@@ -721,6 +722,17 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			}
 			if status.EvidenceRevision != "" && status.EvidenceRevision != request.RemediatesEvidenceRevision {
 				return runtimeRecord{}, fmt.Errorf("failed evidence revision %q does not match native runtime evidence %q", request.RemediatesEvidenceRevision, status.EvidenceRevision)
+			}
+		}
+		if unmanagedRemediation {
+			if !store.ReviewDisabled || currentBinding != nil {
+				// refusal:by-design human-authority: unmanaged remediation is valid only while receipt authority is absent and explicitly disabled.
+				return runtimeRecord{}, errors.New("unmanaged remediation requires disabled delivery without a review binding")
+			}
+			if len(status.Attempts) < 2 || status.EvidenceRevision != request.RemediatesEvidenceRevision ||
+				status.Attempts[len(status.Attempts)-2].Outcome != AttemptFailed {
+				// refusal:by-design operator-knowledge: the native ledger admits one final correction only for its current failed evidence.
+				return runtimeRecord{}, errors.New("unmanaged remediation requires the current failed evidence and a direct correction attempt")
 			}
 		}
 		// Issue #2394: the runtime candidate is the same declared candidate
@@ -753,6 +765,20 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			}
 			if validateErr := validateRuntimeBoundCandidate(ctx, store.Repo, *currentBinding, snapshot.CandidateTree); validateErr != nil {
 				return runtimeRecord{}, fmt.Errorf("validate unchanged bound SDD candidate: %w", validateErr)
+			}
+		}
+		previousAttemptFailed := len(status.Attempts) >= 2 && status.Attempts[len(status.Attempts)-2].Outcome == AttemptFailed
+		if store.ReviewDisabled && currentBinding == nil && request.Outcome == AttemptPassed && previousAttemptFailed && !unmanagedRemediation {
+			return runtimeRecord{}, fmt.Errorf("disabled failed verification requires --remediates-evidence-revision %q on the correction settle; rerun `gentle-ai sdd-attempt settle` with that flag", status.EvidenceRevision)
+		}
+		if unmanagedRemediation {
+			if snapshot.Identity == active.BeginCandidateIdentity || snapshot.CandidateTree == active.BeginCandidateTree {
+				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed by the active correction attempt.
+				return runtimeRecord{}, errors.New("unmanaged remediation requires a changed correction candidate")
+			}
+			if request.EvidenceRevision == request.RemediatesEvidenceRevision {
+				// refusal:by-design operator-knowledge: the correction's verification evidence must be fresh and distinct from the failed evidence it repairs.
+				return runtimeRecord{}, errors.New("unmanaged remediation requires fresh corrected evidence")
 			}
 		}
 		event := &runtimeFinishEvent{
@@ -1491,7 +1517,7 @@ func applyRuntimeRecord(replay *runtimeReplay, revision string, record runtimeRe
 		}
 
 	case runtimeOperationFinish:
-		if err := applyRuntimeFinishEvent(replay, record.Finish); err != nil {
+		if err := applyRuntimeFinishEvent(replay, record.Finish, record.Finish.RemediatesEvidenceRevision != ""); err != nil {
 			return err
 		}
 
@@ -1514,7 +1540,7 @@ func applyRuntimeRecord(replay *runtimeReplay, revision string, record runtimeRe
 			// its corrected evidence differs from the failed evidence it repairs.
 			return errors.New("atomic remediation binding does not select a distinct successor or corrected self-successor")
 		}
-		if err := applyRuntimeFinishEvent(replay, record.Finish); err != nil {
+		if err := applyRuntimeFinishEvent(replay, record.Finish, false); err != nil {
 			return err
 		}
 		if !record.Finish.ChangedLineBudgetExceeded {
@@ -1755,7 +1781,7 @@ func applyRuntimeAdvanceEvent(replay *runtimeReplay, revision string, record run
 	return applyRuntimeBeginEvent(replay, revision, record)
 }
 
-func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent) error {
+func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, unmanagedRemediation bool) error {
 	active := replay.Status.ActiveAttempt
 	if active == nil || active.Ordinal != event.Ordinal || len(replay.Status.Attempts) == 0 ||
 		replay.Status.Attempts[len(replay.Status.Attempts)-1].Outcome != AttemptRunning {
@@ -1764,6 +1790,16 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent) e
 	budgetExceeded := replay.Status.CumulativeChangedLines+event.ChangedLines > replay.Status.Objective.MaxChangedLines
 	if event.ChangedLineBudgetExceeded != budgetExceeded {
 		return errors.New("finish record changed-line budget decision does not match replay state")
+	}
+	if unmanagedRemediation {
+		if replay.Status.Binding != nil || len(replay.Status.Attempts) < 2 || event.Outcome != AttemptPassed ||
+			replay.Status.EvidenceRevision != event.RemediatesEvidenceRevision ||
+			replay.Status.Attempts[len(replay.Status.Attempts)-2].Outcome != AttemptFailed ||
+			event.FinishCandidateIdentity == active.BeginCandidateIdentity || event.FinishCandidateTree == active.BeginCandidateTree ||
+			event.EvidenceRevision == event.RemediatesEvidenceRevision {
+			// refusal:by-design world-action: a replayed event that breaks immutable evidence/candidate binding can only be repaired by restoring the authority.
+			return errors.New("unmanaged remediation finish does not bind the final failed-evidence correction")
+		}
 	}
 	attempt := &replay.Status.Attempts[len(replay.Status.Attempts)-1]
 	attempt.FinishCandidateIdentity = event.FinishCandidateIdentity
@@ -1874,13 +1910,14 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			!runtimeRevisionPattern.MatchString(event.FinishCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.FinishCandidateTree) ||
 			validateRuntimeText(event.Diagnosis, 500) != nil || !validHarnessDisposition(event.HarnessDisposition) ||
 			validateRuntimeText(event.CleanupEvidence, 500) != nil || validateRuntimeText(event.ProcessEvidence, 500) != nil ||
-			event.RemediatesEvidenceRevision != "" {
+			(event.RemediatesEvidenceRevision != "" && (!runtimeRevisionPattern.MatchString(event.RemediatesEvidenceRevision) || event.Outcome != AttemptPassed)) {
 			return errors.New("invalid SDD runtime finish event")
 		}
 		request := FinishAttemptRequest{
 			ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID, Outcome: event.Outcome,
 			EvidenceRevision: event.EvidenceRevision, Diagnosis: event.Diagnosis, HarnessDisposition: event.HarnessDisposition,
 			CleanupEvidence: event.CleanupEvidence, ProcessEvidence: event.ProcessEvidence,
+			RemediatesEvidenceRevision: event.RemediatesEvidenceRevision,
 		}
 		if runtimeValueHash("gentle-ai.sdd-runtime-finish-request/v1", request) != record.RequestDigest {
 			return errors.New("SDD runtime finish request digest does not match record")
@@ -2109,16 +2146,16 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 	if err := validateRuntimeText(request.ProcessEvidence, 500); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid process_evidence: %w", err)
 	}
-	remediationFields := 0
-	for _, value := range []string{request.ExpectedBindingRevision, request.SuccessorLineageID, request.RemediatesEvidenceRevision} {
+	managedRemediationFields := 0
+	for _, value := range []string{request.ExpectedBindingRevision, request.SuccessorLineageID} {
 		if value != "" {
-			remediationFields++
+			managedRemediationFields++
 		}
 	}
-	if remediationFields != 0 && remediationFields != 3 {
+	if managedRemediationFields != 0 && (managedRemediationFields != 2 || request.RemediatesEvidenceRevision == "") {
 		return FinishAttemptRequest{}, errors.New("remediation successor requires expected_binding_revision, successor_lineage_id, and remediates_evidence_revision together")
 	}
-	if remediationFields == 3 {
+	if managedRemediationFields == 2 {
 		if request.Outcome != AttemptPassed {
 			return FinishAttemptRequest{}, errors.New("an atomic remediation successor is valid only for a passed attempt")
 		}
@@ -2137,12 +2174,27 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 				runtimeRevisionShapeObservation(request.RemediatesEvidenceRevision),
 			)
 		}
+	} else if request.RemediatesEvidenceRevision != "" {
+		if request.Outcome != AttemptPassed {
+			// refusal:by-design operator-knowledge: the caller alone knows whether its correction passed and must supply that outcome truthfully.
+			return FinishAttemptRequest{}, errors.New("unmanaged remediation is valid only for a passed attempt")
+		}
+		if !runtimeRevisionPattern.MatchString(request.RemediatesEvidenceRevision) {
+			return FinishAttemptRequest{}, fmt.Errorf(
+				"remediates_evidence_revision must be sha256:<64-lowercase-hex> for unmanaged remediation (%s); rerun `gentle-ai sdd-attempt finish` with --remediates-evidence-revision sha256:<64-lowercase-hex>",
+				runtimeRevisionShapeObservation(request.RemediatesEvidenceRevision),
+			)
+		}
 	}
 	return request, nil
 }
 
 func finishRequestsRemediation(request FinishAttemptRequest) bool {
-	return request.ExpectedBindingRevision != "" || request.SuccessorLineageID != "" || request.RemediatesEvidenceRevision != ""
+	return request.ExpectedBindingRevision != "" || request.SuccessorLineageID != ""
+}
+
+func finishRequestsUnmanagedRemediation(request FinishAttemptRequest) bool {
+	return request.ExpectedBindingRevision == "" && request.SuccessorLineageID == "" && request.RemediatesEvidenceRevision != ""
 }
 
 func normalizeResetObjectiveRequest(request ResetObjectiveRequest) (ResetObjectiveRequest, error) {

--- a/internal/sddstatus/runtime_ledger_review_disabled_test.go
+++ b/internal/sddstatus/runtime_ledger_review_disabled_test.go
@@ -102,3 +102,79 @@ func TestRuntimeFinishStillValidatesAnExplicitSuccessorWhileReviewIsDisabled(t *
 	}
 	assertRuntimeRemediationUnchanged(t, fixture, before)
 }
+
+func TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "unmanaged-remediation")
+	store.ReviewDisabled = true
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "unmanaged-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "unmanaged-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: failed.Revision, RequestID: "unmanaged-begin-correction", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "unmanaged-finish-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "bounded correction passed focused checks",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	}
+	before := countRuntimeRecords(t, store.Dir)
+	if _, err := store.Finish(context.Background(), request); err == nil {
+		t.Fatal("unchanged candidate satisfied unmanaged remediation")
+	}
+	if status, err := store.Status(); err != nil || status.Revision != active.Revision || status.ActiveAttempt == nil || countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("unchanged remediation refusal mutated runtime: status=%#v err=%v records=%d", status, err, countRuntimeRecords(t, store.Dir))
+	}
+	appendRuntimeLedgerFile(t, repo, "bounded unmanaged correction\n")
+	withoutBinding := request
+	withoutBinding.RequestID = "unmanaged-finish-unbound"
+	withoutBinding.RemediatesEvidenceRevision = ""
+	if _, err := store.Finish(context.Background(), withoutBinding); err == nil {
+		t.Fatal("generic passing finish satisfied disabled remediation")
+	}
+	wrongEvidence := request
+	wrongEvidence.RequestID = "unmanaged-finish-wrong-evidence"
+	wrongEvidence.RemediatesEvidenceRevision = runtimeTestHash('c')
+	if _, err := store.Finish(context.Background(), wrongEvidence); err == nil {
+		t.Fatal("wrong failed evidence satisfied unmanaged remediation")
+	}
+	completed, err := store.Finish(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !completed.Complete || completed.ActiveAttempt != nil || completed.Binding != nil || len(completed.Attempts) != 2 {
+		t.Fatalf("unmanaged remediation completion = %#v", completed)
+	}
+	last := completed.Attempts[len(completed.Attempts)-1]
+	if last.RemediatesEvidenceRevision != failedEvidence || last.FinishCandidateIdentity == last.BeginCandidateIdentity || last.FinishCandidateTree == last.BeginCandidateTree {
+		t.Fatalf("unmanaged remediation did not bind the failed evidence to a changed candidate: %#v", last)
+	}
+	if replay, err := store.Finish(context.Background(), request); err != nil || replay.Revision != completed.Revision {
+		t.Fatalf("exact remediation replay = %#v err=%v", replay, err)
+	}
+	result, err := store.Acquire(context.Background(), CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{
+		RequestID: "unmanaged-replay-correction", WorkUnit: "verify", EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	}})
+	if err != nil || result.State != CompactStateComplete {
+		t.Fatalf("second unmanaged correction = %#v err=%v", result, err)
+	}
+}

--- a/internal/sddstatus/runtime_ledger_review_disabled_test.go
+++ b/internal/sddstatus/runtime_ledger_review_disabled_test.go
@@ -3,6 +3,8 @@ package sddstatus
 import (
 	"context"
 	"errors"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -105,6 +107,7 @@ func TestRuntimeFinishStillValidatesAnExplicitSuccessorWhileReviewIsDisabled(t *
 
 func TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
+	changeRoot := seedReadyChange(t, repo, "unmanaged-remediation", "- [x] 1.1 Work\n")
 	store := mustRuntimeStore(t, repo, "unmanaged-remediation")
 	store.ReviewDisabled = true
 	first, err := store.Begin(context.Background(), BeginAttemptRequest{
@@ -124,6 +127,7 @@ func TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(failedEvidence, "fail"))
 	active, err := store.Begin(context.Background(), BeginAttemptRequest{
 		ExpectedRevision: failed.Revision, RequestID: "unmanaged-begin-correction", WorkUnit: "verify",
 		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
@@ -176,5 +180,24 @@ func TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt(t *t
 	}})
 	if err != nil || result.State != CompactStateComplete {
 		t.Fatalf("second unmanaged correction = %#v err=%v", result, err)
+	}
+
+	// Re-enabling receipt-driven delivery must not turn a valid disabled
+	// correction into archive authority. The fresh PASS is preserved, but the
+	// existing bounded-review route must own archive admission from here.
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(request.EvidenceRevision, "pass"))
+	reenabled, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "unmanaged-remediation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reenabled.Dependencies.Verify != DependencyAllDone || reenabled.Dependencies.Archive != DependencyBlocked || reenabled.NextRecommended != "resolve-review" {
+		t.Fatalf("re-enabled unmanaged correction routed verify=%q archive=%q next=%q", reenabled.Dependencies.Verify, reenabled.Dependencies.Archive, reenabled.NextRecommended)
+	}
+	if reenabled.ReviewGate == nil || !strings.Contains(reenabled.ReviewGate.Reason, "disabled/unmanaged correction") ||
+		!strings.Contains(reenabled.ReviewGate.Reason, reviewGateFreshReviewContinuation) {
+		t.Fatalf("re-enabled unmanaged correction omitted bounded-review authority: %#v", reenabled.ReviewGate)
+	}
+	if reenabled.ReviewOffer == nil || !reenabled.ReviewOffer.Available || !strings.Contains(reenabled.ReviewOffer.Invocation, "review start") {
+		t.Fatalf("re-enabled unmanaged correction omitted the executable review offer: %#v", reenabled.ReviewOffer)
 	}
 }

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -621,6 +621,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if boundGate != nil {
 		status.ReviewGate = boundGate
 	}
+	applyEnabledUnmanagedRemediationAuthorityRouting(&status, reviewDisabled)
 	applyReviewOfferRouting(context.Background(), &status, workspaceRoot, changeName, reviewDisabled)
 	if governingRef != nil {
 		applyTargetedReVerifyRouting(context.Background(), &status, workspaceRoot, changeName, governingRef, runtimeStatus, reviewDisabled)
@@ -693,6 +694,39 @@ func nativeRuntimeCompletesRemediation(runtimeStatus *RuntimeStatus, attemptToke
 	return last.Outcome == AttemptPassed && !last.ChangedLineBudgetExceeded &&
 		last.RemediatesEvidenceRevision == verify.EvidenceRevision &&
 		last.EvidenceRevision != "" && last.EvidenceRevision == runtimeStatus.EvidenceRevision
+}
+
+// nativeRuntimeCompletedUnmanagedCorrection recognizes the exact terminal
+// record Finish admits only while review authority is disabled: a direct failed
+// attempt followed by a changed, distinct-evidence correction with no binding.
+func nativeRuntimeCompletedUnmanagedCorrection(runtimeStatus *RuntimeStatus) bool {
+	if runtimeStatus == nil || runtimeStatus.Binding != nil || runtimeStatus.Receipt != nil || len(runtimeStatus.Attempts) < 2 {
+		return false
+	}
+	correction := runtimeStatus.Attempts[len(runtimeStatus.Attempts)-1]
+	failed := runtimeStatus.Attempts[len(runtimeStatus.Attempts)-2]
+	return failed.Outcome == AttemptFailed && correction.Outcome == AttemptPassed &&
+		correction.RemediatesEvidenceRevision != "" && correction.RemediatesEvidenceRevision == failed.EvidenceRevision &&
+		correction.EvidenceRevision != "" && correction.EvidenceRevision == runtimeStatus.EvidenceRevision &&
+		correction.FinishCandidateIdentity != correction.BeginCandidateIdentity && correction.FinishCandidateTree != correction.BeginCandidateTree
+}
+
+// applyEnabledUnmanagedRemediationAuthorityRouting preserves a disabled-mode
+// correction and its fresh verification, but never promotes it into enabled
+// receipt authority. A valid existing gate remains authoritative on its own.
+func applyEnabledUnmanagedRemediationAuthorityRouting(status *Status, reviewDisabled bool) {
+	if reviewDisabled || status == nil || status.Dependencies.Verify != DependencyAllDone || status.ReviewGate != nil ||
+		!nativeRuntimeCompletedUnmanagedCorrection(status.RuntimeStatus) {
+		return
+	}
+	readiness, terminal := runtimeReadiness(runtimeReadinessInput{
+		Status: *status.RuntimeStatus, AttemptTokens: status.runtimeAttemptTokens,
+	})
+	if !terminal || readiness.State != CompactStateComplete {
+		return
+	}
+	blockReviewGate(status, reviewtransaction.GateInvalidated,
+		"a disabled/unmanaged correction repaired failed evidence without a bounded review transaction or receipt; enabled receipt-driven delivery requires bounded review authority for the corrected candidate; "+reviewGateFreshReviewContinuation)
 }
 
 func applyNativeRuntimeErrorRouting(status *Status, runtimeErr error) {
@@ -935,6 +969,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	if boundGate != nil {
 		status.ReviewGate = boundGate
 	}
+	applyEnabledUnmanagedRemediationAuthorityRouting(&status, reviewDisabled)
 	applyReviewOfferRouting(context.Background(), &status, workspaceRoot, changeName, reviewDisabled)
 	if governingRef != nil {
 		applyTargetedReVerifyRouting(context.Background(), &status, workspaceRoot, changeName, governingRef, runtimeStatus, reviewDisabled)

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -514,7 +514,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 			blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
 		}
 	}
-	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult)
+	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult, reviewDisabled)
 	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
 	var compactRemediation *reviewtransaction.CompactState
 	if !reviewDisabled {
@@ -534,10 +534,13 @@ func Resolve(options ResolveOptions) (Status, error) {
 	)
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
-	if staleAllowAuthority != nil || staleEvidenceUnmanaged {
+	if staleAllowAuthority != nil || staleEvidenceUnmanaged || (reviewDisabled && runtimeRemediationComplete) {
 		dependencies.Verify = DependencyReady
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
+		if runtimeRemediationComplete {
+			remediationState = RemediationState{}
+		}
 	}
 	var boundGate *ReviewGateState
 	bridge := compactPreVerifyBridge{}
@@ -675,8 +678,9 @@ func workspaceHasGitMetadata(workspaceRoot string) bool {
 	}
 }
 
-func nativeRuntimeCompletesRemediation(runtimeStatus *RuntimeStatus, attemptTokens map[int]string, verify verifyResultEvaluation) bool {
-	if runtimeStatus == nil || runtimeStatus.Binding == nil || verify.EvidenceRevision == "" || len(runtimeStatus.Attempts) == 0 {
+func nativeRuntimeCompletesRemediation(runtimeStatus *RuntimeStatus, attemptTokens map[int]string, verify verifyResultEvaluation, reviewDisabled bool) bool {
+	if runtimeStatus == nil || verify.EvidenceRevision == "" || len(runtimeStatus.Attempts) == 0 ||
+		(reviewDisabled && runtimeStatus.Binding != nil) || (!reviewDisabled && runtimeStatus.Binding == nil) {
 		return false
 	}
 	// "The runtime finished this objective cleanly" is the readiness question,
@@ -845,7 +849,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 			blockedReasons.genuine = append(blockedReasons.genuine, evaluation.Reason)
 		}
 	}
-	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult)
+	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult, reviewDisabled)
 	remediationRequired := staleAllowAuthority == nil && !staleEvidenceUnmanaged && !runtimeRemediationComplete && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
 	var compactRemediation *reviewtransaction.CompactState
 	if !reviewDisabled {
@@ -868,10 +872,13 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	}
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
-	if staleAllowAuthority != nil || staleEvidenceUnmanaged {
+	if staleAllowAuthority != nil || staleEvidenceUnmanaged || (reviewDisabled && runtimeRemediationComplete) {
 		dependencies.Verify = DependencyReady
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
+		if runtimeRemediationComplete {
+			remediationState = RemediationState{}
+		}
 	}
 	var boundGate *ReviewGateState
 	if !reviewDisabled && governingRef != nil {
@@ -1762,12 +1769,20 @@ func renderPhaseInstructions(status Status) PhaseInstructions {
 
 func nativeRuntimeInstructions(status Status, change string) []string {
 	workspace := status.ActionContext.WorkspaceRoot
-	return append([]string{
+	instructions := []string{
 		fmt.Sprintf("Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd %q --change %q --request-id \"<unique-request-id>\" --work-unit \"<label>\" --evidence-goal \"<stable-goal>\" --max-attempts <count> --max-changed-lines <count>`.", workspace, change),
 		"Launch only for state proceed and retain its opaque token. State blocked or complete stops the launch; full runtime status is a diagnostic escape hatch, not normal model context.",
 		fmt.Sprintf("After the external run, call `gentle-ai sdd-attempt settle --cwd %q --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome <passed|failed|interrupted> --evidence-revision <sha256> --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`; add --successor-lineage only for a distinct approved remediation successor.", workspace, change),
 		"Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic.",
-	}, liveRuntimeAttemptInstructions(status)...)
+	}
+	if status.RemediationState.Required && status.RemediationState.LineageID == "" && status.RuntimeStatus != nil && status.RuntimeStatus.Objective != nil {
+		objective := status.RuntimeStatus.Objective
+		instructions = append(instructions,
+			fmt.Sprintf("Disabled/unmanaged remediation has one bounded correction attempt: run `gentle-ai sdd-attempt acquire --cwd %q --change %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d`.", workspace, change, objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines),
+			fmt.Sprintf("After the candidate changes, settle that token with `--remediates-evidence-revision %s`; a fresh independent verification is required before archive.", status.RemediationState.FailedEvidenceRevision),
+		)
+	}
+	return append(instructions, liveRuntimeAttemptInstructions(status)...)
 }
 
 // liveRuntimeAttemptInstructions names the continuation for an attempt that is


### PR DESCRIPTION
## Linked Issue

Closes #2182

## PR Type

- [x] `type:bug` Bug fix
- [ ] `type:feature` New feature
- [ ] `type:docs` Documentation only
- [ ] `type:refactor` Code refactoring
- [ ] `type:chore` Maintenance/tooling
- [ ] `type:breaking-change` Breaking change

## Summary

- Requires a failed verification correction in disabled/unmanaged delivery to name the failed evidence it repairs.
- Reuses the native runtime ledger for budget, candidate, evidence, and replay authority.
- Keeps fresh PASS evidence but blocks archive after re-enabling RDD until the corrected candidate receives existing bounded review authority.
- Extends black-box journey j63 across the real disable, correction, fresh PASS, re-enable, and refusal boundary.

Root context: #1974. This maintainer PR replaces the bounded correction that cannot safely be fast-forwarded into conflicted PR #2226.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus` | Admits only one evidence-bound disabled correction, requires fresh verification, and routes a re-enabled unbound correction through the existing bounded-review gate. |
| `internal/cli/sdd_attempt.go` | Accepts the remediates-evidence form only for the disabled unmanaged path. |
| `bench/journeys_sdd.go` | Covers j63 admission, negative controls, replay, fresh verification, disabled archive readiness, re-enable refusal, and the executable review offer. |

## Test Plan

- [x] Focused RED evidence on `c32ff87f`: the new runtime test reported `verify=all_done`, `archive=ready`, `next=archive`; the built binary failed j63 at the re-enable assertion.
- [x] Final focused tests: `go test ./internal/sddstatus -count=1 -run '^(TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt|TestDisabledStatusWithoutAnUnmanagedCorrectionDoesNotBlockAfterReenable)$'`.
- [x] Package tests: `go test ./internal/sddstatus -count=1` and `go test ./internal/cli -count=1`.
- [x] Root tests: `go test ./... -count=1`.
- [x] Bench tests: `cd bench && go test ./... -count=1`.
- [x] Vet passes: `go vet ./...` and `cd bench && go vet ./...`.
- [x] Format and ratchets pass: `go run ./internal/gofmtcheck`, `./scripts/deadcode-ratchet.sh`, and `go test ./internal/cli -count=1 -run '^TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign$'`.
- [x] Built binary: `go build -o /tmp/opencode/gentle-ai-19bdd9fe ./cmd/gentle-ai`, then `cd bench && go run . run --binary /tmp/opencode/gentle-ai-19bdd9fe --only j63-disabled-failed-verification-unmanaged-remediation --out /tmp/opencode/j63-19bdd9fe.json` completed all 16 commands.
- [ ] Docker E2E could not run locally because access to `/var/run/docker.sock` is denied.

## Contributor Checklist

- [x] PR is linked to approved issue #2182.
- [x] PR is 475 changed lines: 448 additions plus 27 deletions. The maintainer-authorized `size:exception` label is applied because the status guard, exact history predicate, RED regression, and black-box proof form one authority invariant and cannot be split without leaving the bypass or its acceptance proof separate.
- [x] Exactly one `type:*` label is applied.
- [x] Unit tests and Go format pass.
- [x] Benchmark validation completed.
- [x] Documentation is not needed because executable SDD status instructions describe the continuation.
- [x] Commits follow Conventional Commits with no `Co-Authored-By` trailer.

## Notes for Reviewers

The review integration remains disabled/unmanaged during the correction. This change neither starts nor invents review authority. The persisted-state integrity boundary still admits only disabled mode, no binding, the direct prior failed attempt, current failed evidence, a changed declared candidate, and fresh corrected evidence. Wrong, stale, replay, and fresh-verification controls remain unchanged.

After a fresh PASS, re-enabling RDD no longer promotes that unmanaged history to archive authority. Status preserves the PASS, reports `verify: all_done`, blocks archive, returns `nextRecommended: resolve-review`, publishes the existing executable `review start` offer, and requires an actual bounded review gate before archive. A disabled-status-only history with no completed unmanaged correction remains archive-ready, and a valid existing review gate is left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for completing bounded remediation workflows when review mode is disabled.
  * Added failed-evidence tracking, correction guidance, and fresh verification requirements.
  * Added review routing after re-enabling review mode before archival or delivery.

* **Bug Fixes**
  * Improved validation for remediation evidence, candidate changes, and replayed attempts.
  * Prevented invalid remediation attempts from changing runtime state.
  * Preserved remediation context when no successor is specified.

* **Tests**
  * Added coverage for completion, rejection cases, replay prevention, archive readiness, and review re-enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->