### PR TITLE
test(app): a runtime's rendered surface never names another runtime's identity

### DIFF
--- a/internal/app/documented_provenance_test.go
+++ b/internal/app/documented_provenance_test.go
@@ -1,0 +1,130 @@
+package app_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// Provenance rule (#2524, root 4 of #2440): a runtime's rendered surface must
+// never tell it to identify as another runtime. Before #2484, codex's rendered
+// AGENTS.md carried `--agent claude-code` and nothing went red. This rule
+// closes that class.
+//
+// Both sides are DERIVED, never enumerated (#2471, root 10):
+//
+//   - the surfaces are every *.golden under testdata/golden, the pinned
+//     renders of each runtime's installed instruction surface;
+//   - the owning runtime comes from matching the golden's filename tokens
+//     against the slug each model.AgentID projects (its first hyphen
+//     segment: "claude-code" -> "claude", "gemini-cli" -> "gemini"), with
+//     the slug set built from catalog.AllAgents() at run time.
+//
+// Occurrences are read from the same extracted-invocation corpus PR #2522
+// introduced, and a raw-bytes count cross-checks the extraction so an
+// `--agent` binding outside any extractable invocation cannot hide.
+
+var rawAgentBindingRegexp = regexp.MustCompile(`--agent[= ]+[A-Za-z0-9._{}-]+`)
+
+// agentFlagValues returns every value bound to --agent in one documented
+// command, including the `--agent=value` spelling. A trailing bare --agent
+// is returned as an empty value so the caller can reject it.
+func agentFlagValues(command string) []string {
+	words := strings.Fields(command)
+	var out []string
+	for index, word := range words {
+		if word == "--agent" {
+			if index+1 < len(words) {
+				out = append(out, words[index+1])
+			} else {
+				out = append(out, "")
+			}
+			continue
+		}
+		if value, ok := strings.CutPrefix(word, "--agent="); ok {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// goldenOwners derives which runtimes a golden filename names, by exact
+// token match against the derived slug set.
+func goldenOwners(name string, slugToAgent map[string]model.AgentID) []model.AgentID {
+	tokens := strings.FieldsFunc(strings.TrimSuffix(name, ".golden"), func(r rune) bool {
+		return r == '-' || r == '.'
+	})
+	seen := map[model.AgentID]bool{}
+	var owners []model.AgentID
+	for _, token := range tokens {
+		if id, ok := slugToAgent[token]; ok && !seen[id] {
+			seen[id] = true
+			owners = append(owners, id)
+		}
+	}
+	return owners
+}
+
+func TestRenderedSurfaceNamesOnlyItsOwnRuntime(t *testing.T) {
+	slugToAgent := map[string]model.AgentID{}
+	for _, agent := range catalog.AllAgents() {
+		slug := strings.SplitN(string(agent.ID), "-", 2)[0]
+		if other, duplicate := slugToAgent[slug]; duplicate {
+			t.Fatalf("agents %s and %s project the same filename slug %q; the derivation is ambiguous and must be repaired before this rule can decide ownership", other, agent.ID, slug)
+		}
+		slugToAgent[slug] = agent.ID
+	}
+
+	goldenDir := filepath.Join("..", "..", "testdata", "golden")
+	entries, err := os.ReadDir(goldenDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verified := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".golden") {
+			continue
+		}
+		content, readErr := os.ReadFile(filepath.Join(goldenDir, name))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		owners := goldenOwners(name, slugToAgent)
+
+		found := 0
+		for _, invocation := range extractInvocations("golden:"+name, string(content)) {
+			for _, value := range agentFlagValues(invocation.command) {
+				found++
+				if value == "" {
+					t.Errorf("%s documents a bare --agent with no value\n  command: %s", invocation.source, invocation.command)
+					continue
+				}
+				if len(owners) != 1 {
+					t.Errorf("%s binds --agent %s but its filename derives %d owning runtimes instead of exactly one; provenance cannot be decided", invocation.source, value, len(owners))
+					continue
+				}
+				expected := string(owners[0])
+				if value != expected {
+					t.Errorf("%s binds --agent %s inside %s's rendered surface; a runtime's surface must name its own identity\n  command: %s", invocation.source, value, expected, invocation.command)
+					continue
+				}
+				verified++
+			}
+		}
+
+		if raw := len(rawAgentBindingRegexp.FindAllString(string(content), -1)); raw != found {
+			t.Errorf("golden:%s carries %d --agent bindings but only %d sit inside extractable gentle-ai invocations; the difference is invisible to this rule and must be moved into a documented invocation or removed", name, raw, found)
+		}
+	}
+
+	if verified == 0 {
+		t.Fatal("verified no --agent binding in any rendered golden; either the surfaces stopped binding identity or the scanner went stale")
+	}
+}


### PR DESCRIPTION
Closes #2524
Refs #2440, #2506, PR #2484 (sequencing dependency, merged), PR #2522 (corpus machinery this rule extends)

## Summary

One new sibling test beside the documented-invocation corpus: `TestRenderedSurfaceNamesOnlyItsOwnRuntime` in `internal/app/documented_provenance_test.go`. An `--agent X` appearing inside runtime R's rendered surface must satisfy X == R, and drift fails naming file, line, found identity, and expected identity.

## Derivation, no hand-maintained list

The surfaces are every `*.golden` under `testdata/golden/` (the pinned renders of each runtime's installed instruction surface), and the owning runtime is derived by matching the golden's filename tokens against the slug each `model.AgentID` projects (its first hyphen segment: `claude-code` -> `claude`, `gemini-cli` -> `gemini`), with the slug set built from `catalog.AllAgents()` at run time and the test failing fast if two agents ever project the same slug. Occurrences are read through PR #2522's `extractInvocations` corpus extractor, and a raw-bytes count per golden cross-checks the extraction so an `--agent` binding sitting outside any extractable `gentle-ai` invocation cannot silently escape the rule.

## RED evidence 1: the historical defect (#2440 root 4)

With `testdata/golden/sdd-codex-agentsmd.golden` locally reverted to its pre-#2484 bytes (`git show d8c77082^1:testdata/golden/sdd-codex-agentsmd.golden`) and nothing else changed:

```
--- FAIL: TestRenderedSurfaceNamesOnlyItsOwnRuntime (0.01s)
    documented_provenance_test.go:115: golden:sdd-codex-agentsmd.golden:95 binds --agent claude-code inside codex's rendered surface; a runtime's surface must name its own identity
          command: gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent claude-code --next-transition
    documented_provenance_test.go:115: golden:sdd-codex-agentsmd.golden:106 binds --agent claude-code inside codex's rendered surface; a runtime's surface must name its own identity
          command: gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent claude-code --next-transition
    documented_provenance_test.go:115: golden:sdd-codex-agentsmd.golden:107 binds --agent claude-code inside codex's rendered surface; a runtime's surface must name its own identity
          command: gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent claude-code --next-transition
    documented_provenance_test.go:115: golden:sdd-codex-agentsmd.golden:141 binds --agent claude-code inside codex's rendered surface; a runtime's surface must name its own identity
          command: gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent claude-code --next-transition
FAIL
FAIL	github.com/gentleman-programming/gentle-ai/v2/internal/app	0.009s
FAIL
```

This is the exact defect that shipped as #2440: codex's rendered AGENTS.md told codex to identify as claude-code.

## RED evidence 2: synthetic injection

With one line appended to `testdata/golden/sdd-claude-claudemd.golden` binding a foreign identity:

```
--- FAIL: TestRenderedSurfaceNamesOnlyItsOwnRuntime (0.01s)
    documented_provenance_test.go:115: golden:sdd-claude-claudemd.golden:171 binds --agent windsurf inside claude-code's rendered surface; a runtime's surface must name its own identity
          command: gentle-ai review status --cwd <repo> --agent windsurf --next-transition
FAIL
FAIL	github.com/gentleman-programming/gentle-ai/v2/internal/app	0.012s
FAIL
```

Both reverts were restored; the diff touches only the new test file.

## GREEN on current main

On the untouched tree (base `9a81024d`), the rule passes and verifies all 54 `--agent` bindings across the goldens, each matching its owning runtime. PR #2484 satisfied the rule as designed; current main is clean.

## Verification (all foreground)

- [x] `go test ./... -count=1` at root: 64 packages ok, zero FAIL
- [x] bench module: `go vet ./...` and `go test ./... -count=1` green
- [x] `gofmt -l` clean, `go vet ./...` clean
- [x] `scripts/deadcode-ratchet.sh`: no new unreachable functions, no baseline change (test-only file)
- [x] Refusal-resolution ratchet (`internal/cli/refusal_resolution_ratchet_test.go`): green inside the root suite; this change adds no refusal sites


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure runtime command-line bindings are correctly associated with their owning runtime.
  * Added coverage for both supported `--agent` argument formats.
  * Added checks to detect missing, ambiguous, or cross-runtime bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->