### PR TITLE
fix(messages): render workspace paths verbatim in sddstatus refusals and instructions

### DIFF
--- a/internal/sddstatus/path_quote_render_test.go
+++ b/internal/sddstatus/path_quote_render_test.go
@@ -1,6 +1,8 @@
 package sddstatus
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -17,5 +19,129 @@ func TestArchiveReVerifyContinuationRendersWindowsPathVerbatim(t *testing.T) {
 	want := `--cwd "C:\Users\dev\repo"`
 	if occurrences := strings.Count(got, want); occurrences != 2 {
 		t.Fatalf("begin+finish continuation renders --cwd twice and both must carry the verbatim path:\nwant 2 occurrences of %s, got %d\ngot: %s", want, occurrences, got)
+	}
+}
+
+func TestApplyNativeRuntimeErrorRoutingRendersWindowsPathVerbatim(t *testing.T) {
+	change := "my-change"
+	status := &Status{ChangeName: &change}
+	status.ActionContext.WorkspaceRoot = `C:\Users\dev\repo`
+	applyNativeRuntimeErrorRouting(status, errors.New("ledger unreadable"))
+	got := strings.Join(status.BlockedReasons, "\n")
+	want := `--cwd "C:\Users\dev\repo"`
+	if !strings.Contains(got, want) {
+		t.Fatalf("corrupt-authority diagnostic does not contain the path as the filesystem knows it:\nwant substring: %s\ngot: %s", want, got)
+	}
+}
+
+func TestApplyNativeRuntimeRoutingRendersWindowsPathVerbatim(t *testing.T) {
+	status := &Status{RuntimeStatus: &RuntimeStatus{Change: "my-change", DecisionRequired: true}}
+	status.ActionContext.WorkspaceRoot = `C:\Users\dev\repo`
+	applyNativeRuntimeRouting(status)
+	got := strings.Join(status.BlockedReasons, "\n")
+	want := `in "C:\Users\dev\repo"`
+	if !strings.Contains(got, want) {
+		t.Fatalf("blocked-runtime reason does not contain the path as the filesystem knows it:\nwant substring: %s\ngot: %s", want, got)
+	}
+}
+
+func TestNativeRuntimeInstructionsRenderWindowsPathVerbatim(t *testing.T) {
+	status := Status{
+		RemediationState: RemediationState{Required: true, FailedEvidenceRevision: "sha256:aa"},
+		RuntimeStatus: &RuntimeStatus{
+			Objective: &RuntimeObjective{WorkUnit: "unit", EvidenceGoal: "goal", MaxAttempts: 2, MaxChangedLines: 200},
+		},
+	}
+	status.ActionContext.WorkspaceRoot = `C:\Users\dev\repo`
+	got := strings.Join(nativeRuntimeInstructions(status, "my-change"), "\n")
+	want := `--cwd "C:\Users\dev\repo"`
+	if occurrences := strings.Count(got, want); occurrences != 3 {
+		t.Fatalf("acquire, settle, and correction-acquire instructions must all carry the verbatim path:\nwant 3 occurrences of %s, got %d\ngot: %s", want, occurrences, got)
+	}
+}
+
+func TestNonPhaseRoutingInstructionsRenderWindowsPathVerbatim(t *testing.T) {
+	want := `--cwd "C:\Users\dev\repo"`
+	tests := []struct {
+		next        string
+		occurrences int
+	}{
+		{next: "resolve-review", occurrences: 1},
+		{next: "select-change", occurrences: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.next, func(t *testing.T) {
+			status := Status{NextRecommended: tt.next}
+			status.ActionContext.WorkspaceRoot = `C:\Users\dev\repo`
+			instructions, ok := nonPhaseRoutingInstructions(status)
+			if !ok {
+				t.Fatalf("nonPhaseRoutingInstructions(%q) returned no instructions", tt.next)
+			}
+			got := strings.Join(instructions, "\n")
+			if occurrences := strings.Count(got, want); occurrences != tt.occurrences {
+				t.Fatalf("routing instructions must carry the verbatim path:\nwant %d occurrences of %s, got %d\ngot: %s", tt.occurrences, want, occurrences, got)
+			}
+		})
+	}
+}
+
+func TestRuntimeStrandedSuccessorRefusalRendersWindowsPathVerbatim(t *testing.T) {
+	store := RuntimeStore{Workspace: `C:\Users\dev\repo`}
+	err := store.runtimeStrandedSuccessorRefusal(
+		ReviewBinding{Lineage: "lineage-1", Revision: "rev-1"},
+		RuntimeStrandedSuccessor{Lineage: "lineage-2", Revision: "rev-2", SnapshotIdentity: "snap-1"},
+		1,
+	)
+	want := `--cwd "C:\Users\dev\repo"`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("stranded-successor abandon invocation does not contain the path as the filesystem knows it:\nwant substring: %s\ngot: %s", want, err)
+	}
+}
+
+func TestRuntimeWorktreeMismatchRefusalRendersWindowsPathVerbatim(t *testing.T) {
+	store := RuntimeStore{Workspace: `C:\Users\dev\elsewhere`}
+	err := store.runtimeWorktreeMismatchRefusal(1, `C:\Users\dev\repo`)
+	for _, want := range []string{
+		`began in "C:\Users\dev\repo"`,
+		`running from "C:\Users\dev\elsewhere"`,
+		`--cwd "C:\Users\dev\repo"`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("worktree-mismatch refusal does not contain the path as the filesystem knows it:\nwant substring: %s\ngot: %s", want, err)
+		}
+	}
+}
+
+func TestRuntimeObjectiveChangeRefusalRendersWindowsPathVerbatim(t *testing.T) {
+	want := `--cwd "C:\Users\dev\repo"`
+	objective := &RuntimeObjective{WorkUnit: "unit", EvidenceGoal: "goal", MaxAttempts: 2, MaxChangedLines: 200}
+	tests := []struct {
+		name        string
+		status      RuntimeStatus
+		occurrences int
+	}{
+		{
+			// DecisionRequired makes reset structurally permitted and admissible
+			// without touching Git, so the reset branch renders.
+			name:        "reset branch",
+			status:      RuntimeStatus{Revision: "rev-1", DecisionRequired: true, Objective: objective},
+			occurrences: 2,
+		},
+		{
+			// No attempts, not decision-required, not complete: reset and rescope
+			// are both structurally refused, so the fail-closed default renders.
+			name:        "fail-closed default branch",
+			status:      RuntimeStatus{Revision: "rev-1", Objective: objective},
+			occurrences: 1,
+		},
+	}
+	store := RuntimeStore{Workspace: `C:\Users\dev\repo`, Change: "my-change"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.runtimeObjectiveChangeRefusal(context.Background(), tt.status)
+			if occurrences := strings.Count(err.Error(), want); occurrences != tt.occurrences {
+				t.Fatalf("objective-change refusal must carry the verbatim path:\nwant %d occurrences of %s, got %d\ngot: %s", tt.occurrences, want, occurrences, err)
+			}
+		})
 	}
 }

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -871,9 +872,9 @@ func (store RuntimeStore) runtimeRemediationExitRefusal(
 			return store.runtimeStrandedSuccessorRefusal(binding, stranded, ordinal)
 		}
 		return fmt.Errorf(
-			"%w: the candidate changed after attempt %d began, and lineage %q does not currently hold the approved review of this candidate, so it cannot be its own successor: get this candidate approved first with `gentle-ai review status --cwd %q --contract %s --next-transition`, which names the next review action, then re-run this finish adding --expected-binding-revision, --successor-lineage, and --remediates-evidence-revision for the lineage that then holds it; %s",
+			"%w: the candidate changed after attempt %d began, and lineage %q does not currently hold the approved review of this candidate, so it cannot be its own successor: get this candidate approved first with `gentle-ai review status --cwd %s --contract %s --next-transition`, which names the next review action, then re-run this finish adding --expected-binding-revision, --successor-lineage, and --remediates-evidence-revision for the lineage that then holds it; %s",
 			ErrRuntimeRemediationSuccessorRequired, ordinal, binding.Lineage,
-			store.Workspace, runtimeReviewIntegrationContract, provenance,
+			pathquote.Quote(store.Workspace), runtimeReviewIntegrationContract, provenance,
 		)
 	}
 	// An objective with no recorded failed evidence still needs a repaired
@@ -883,9 +884,9 @@ func (store RuntimeStore) runtimeRemediationExitRefusal(
 		remediates = "<repaired-evidence-sha256>"
 	}
 	return fmt.Errorf(
-		"%w: the candidate changed after attempt %d began, and lineage %q already holds the approved review of the corrected candidate, so that same lineage IS the successor — re-run this finish with the remediation trio: `gentle-ai sdd-attempt finish --cwd %q --change %q --expected-revision %q --request-id \"<unique-request-id>\" --outcome passed --evidence-revision \"<corrected-evidence-sha256>\" --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<cleanup-evidence>\" --process-evidence \"<process-evidence>\" --expected-binding-revision %q --successor-lineage %q --remediates-evidence-revision %s`; %s, and --evidence-revision must differ from --remediates-evidence-revision",
+		"%w: the candidate changed after attempt %d began, and lineage %q already holds the approved review of the corrected candidate, so that same lineage IS the successor — re-run this finish with the remediation trio: `gentle-ai sdd-attempt finish --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --outcome passed --evidence-revision \"<corrected-evidence-sha256>\" --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<cleanup-evidence>\" --process-evidence \"<process-evidence>\" --expected-binding-revision %q --successor-lineage %q --remediates-evidence-revision %s`; %s, and --evidence-revision must differ from --remediates-evidence-revision",
 		ErrRuntimeRemediationSuccessorRequired, ordinal, binding.Lineage,
-		store.Workspace, store.Change, status.Revision,
+		pathquote.Quote(store.Workspace), store.Change, status.Revision,
 		binding.Revision, binding.Lineage, runtimeRemediatesArgument(remediates), provenance,
 	)
 }
@@ -911,9 +912,9 @@ func (store RuntimeStore) runtimeStrandedSuccessorRefusal(binding ReviewBinding,
 	// The sentinel stays in the %w position in every branch: callers that
 	// route on errors.Is must keep working no matter which exit is named.
 	return fmt.Errorf(
-		"%w: the candidate changed after attempt %d began, and lineage %q cannot hold the approved review of this candidate because recovery successor %q supersedes it and froze a target this candidate no longer has, so that successor can never be finalized — quarantine it, then re-run this finish: `gentle-ai review abandon --cwd %q --lineage %q --expected-revision %q --reason \"<why-it-is-abandoned>\" --actor \"<actor>\" --maintainer-authorization \"<maintainer-authorization>\"`; the abandonment quarantines the pristine successor and destroys nothing, because %q keeps the approved review of the corrected candidate. --maintainer-authorization is exactly these six lines, joined by LF, with no trailing newline, using the same --actor and --reason with surrounding whitespace trimmed:\n%s",
+		"%w: the candidate changed after attempt %d began, and lineage %q cannot hold the approved review of this candidate because recovery successor %q supersedes it and froze a target this candidate no longer has, so that successor can never be finalized — quarantine it, then re-run this finish: `gentle-ai review abandon --cwd %s --lineage %q --expected-revision %q --reason \"<why-it-is-abandoned>\" --actor \"<actor>\" --maintainer-authorization \"<maintainer-authorization>\"`; the abandonment quarantines the pristine successor and destroys nothing, because %q keeps the approved review of the corrected candidate. --maintainer-authorization is exactly these six lines, joined by LF, with no trailing newline, using the same --actor and --reason with surrounding whitespace trimmed:\n%s",
 		ErrRuntimeRemediationSuccessorRequired, ordinal, binding.Lineage, stranded.Lineage,
-		store.Workspace, stranded.Lineage, stranded.Revision, binding.Lineage,
+		pathquote.Quote(store.Workspace), stranded.Lineage, stranded.Revision, binding.Lineage,
 		reviewtransaction.RenderCompactAbandonAuthorization(
 			stranded.Lineage, stranded.Revision, stranded.SnapshotIdentity, "<--actor>", "<--reason>"))
 }
@@ -945,8 +946,8 @@ func runtimeRemediatesArgument(remediates string) string {
 // there is only one message to construct.
 func (store RuntimeStore) runtimeWorktreeMismatchRefusal(ordinal int, beginWorktree string) error {
 	return fmt.Errorf(
-		"%w: attempt %d began in %q, and its base candidate tree is pinned to that exact linked worktree, but this finish is running from %q — rerun with --cwd %q so the candidate capture and changed-line measurement use the worktree that actually did the work",
-		ErrRuntimeWorktreeMismatch, ordinal, beginWorktree, store.Workspace, beginWorktree)
+		"%w: attempt %d began in %s, and its base candidate tree is pinned to that exact linked worktree, but this finish is running from %s — rerun with --cwd %s so the candidate capture and changed-line measurement use the worktree that actually did the work",
+		ErrRuntimeWorktreeMismatch, ordinal, pathquote.Quote(beginWorktree), pathquote.Quote(store.Workspace), pathquote.Quote(beginWorktree))
 }
 
 // runtimeObjectiveChangeRefusal turns the changed-objective begin demand into
@@ -980,14 +981,14 @@ func (store RuntimeStore) runtimeObjectiveChangeRefusal(ctx context.Context, sta
 	// route on errors.Is must keep working no matter which exit is named.
 	if store.runtimeObjectiveResetAdmissible(ctx, status) {
 		return fmt.Errorf(
-			"%w: reset the objective, then begin again — `gentle-ai sdd-attempt reset --cwd %q --change %q --expected-revision %q --request-id \"<unique-request-id>\" --reason \"<why-the-objective-changed>\" --actor \"<actor>\"`; the reset publishes a new ledger revision, so take the begin's --expected-revision from `gentle-ai sdd-attempt status --cwd %q --change %q` after it commits",
-			ErrRuntimeObjectiveChange, store.Workspace, store.Change, status.Revision, store.Workspace, store.Change)
+			"%w: reset the objective, then begin again — `gentle-ai sdd-attempt reset --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --reason \"<why-the-objective-changed>\" --actor \"<actor>\"`; the reset publishes a new ledger revision, so take the begin's --expected-revision from `gentle-ai sdd-attempt status --cwd %s --change %q` after it commits",
+			ErrRuntimeObjectiveChange, pathquote.Quote(store.Workspace), store.Change, status.Revision, pathquote.Quote(store.Workspace), store.Change)
 	}
 	if store.runtimeObjectiveRescopeAdmissible(ctx, status) {
 		objective := status.Objective
 		return fmt.Errorf(
-			"%w: this objective's candidate has not drifted, so resetting it is refused as an elective budget reset, but a maintainer may authorize a narrower successor scope instead — `gentle-ai sdd-attempt rescope --cwd %q --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit \"<narrower-work-unit>\" --evidence-goal \"<narrower-evidence-goal>\" --max-attempts \"<n, at most %d>\" --max-changed-lines \"<n, at most %d>\" --reason \"<why-the-objective-is-narrowing>\" --actor \"<actor>\"`; rescope carries cumulative_attempts and cumulative_changed_lines forward unchanged and refuses any max_attempts or max_changed_lines above the current objective's %d and %d",
-			ErrRuntimeObjectiveChange, store.Workspace, store.Change, status.Revision,
+			"%w: this objective's candidate has not drifted, so resetting it is refused as an elective budget reset, but a maintainer may authorize a narrower successor scope instead — `gentle-ai sdd-attempt rescope --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit \"<narrower-work-unit>\" --evidence-goal \"<narrower-evidence-goal>\" --max-attempts \"<n, at most %d>\" --max-changed-lines \"<n, at most %d>\" --reason \"<why-the-objective-is-narrowing>\" --actor \"<actor>\"`; rescope carries cumulative_attempts and cumulative_changed_lines forward unchanged and refuses any max_attempts or max_changed_lines above the current objective's %d and %d",
+			ErrRuntimeObjectiveChange, pathquote.Quote(store.Workspace), store.Change, status.Revision,
 			objective.MaxAttempts, objective.MaxChangedLines, objective.MaxAttempts, objective.MaxChangedLines)
 	}
 	objective := status.Objective
@@ -998,8 +999,8 @@ func (store RuntimeStore) runtimeObjectiveChangeRefusal(ctx context.Context, sta
 		return ErrRuntimeObjectiveChange
 	}
 	return fmt.Errorf(
-		"%w: this objective is still open on its recorded scope and its candidate has not moved, so resetting it is refused as an elective budget reset; begin against the scope the ledger holds — `gentle-ai sdd-attempt begin --cwd %q --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d`; `sdd-attempt status` publishes those four as objective.work_unit, objective.evidence_goal, objective.max_attempts, and objective.max_changed_lines",
-		ErrRuntimeObjectiveChange, store.Workspace, store.Change, status.Revision,
+		"%w: this objective is still open on its recorded scope and its candidate has not moved, so resetting it is refused as an elective budget reset; begin against the scope the ledger holds — `gentle-ai sdd-attempt begin --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d`; `sdd-attempt status` publishes those four as objective.work_unit, objective.evidence_goal, objective.max_attempts, and objective.max_changed_lines",
+		ErrRuntimeObjectiveChange, pathquote.Quote(store.Workspace), store.Change, status.Revision,
 		objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines)
 }
 
@@ -1419,7 +1420,7 @@ func (store RuntimeStore) acquireLock() (*reviewtransaction.AuthorityFileLock, e
 			return nil, err
 		}
 	}
-	return nil, fmt.Errorf("acquire SDD runtime ledger lock %q after %d attempts: %w", lockPath, runtimeLockAcquireAttempts, lastErr)
+	return nil, fmt.Errorf("acquire SDD runtime ledger lock %s after %d attempts: %w", pathquote.Quote(lockPath), runtimeLockAcquireAttempts, lastErr)
 }
 
 func (store RuntimeStore) commitRecordLocked(record runtimeRecord) (RuntimeStatus, error) {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -272,7 +273,7 @@ func applyReviewOfferRouting(ctx context.Context, status *Status, workspaceRoot,
 	status.ReviewOffer = &ReviewOfferBlock{
 		Available:  offer.Available,
 		LineageID:  offer.LineageID,
-		Invocation: fmt.Sprintf("gentle-ai review start --cwd %q", workspaceRoot),
+		Invocation: fmt.Sprintf("gentle-ai review start --cwd %s", pathquote.Quote(workspaceRoot)),
 	}
 }
 
@@ -738,8 +739,8 @@ func applyNativeRuntimeErrorRouting(status *Status, runtimeErr error) {
 		change = *status.ChangeName
 	}
 	reason := fmt.Sprintf(
-		"native SDD runtime authority is unreadable and execution is blocked: %v; do not launch another actor or edit the Git-common-dir authority manually; the compact attempt path reports blocked(corrupt_authority), and full `gentle-ai sdd-attempt status --cwd %q --change %q` is a maintainer diagnostic only",
-		runtimeErr, status.ActionContext.WorkspaceRoot, change,
+		"native SDD runtime authority is unreadable and execution is blocked: %v; do not launch another actor or edit the Git-common-dir authority manually; the compact attempt path reports blocked(corrupt_authority), and full `gentle-ai sdd-attempt status --cwd %s --change %q` is a maintainer diagnostic only",
+		runtimeErr, pathquote.Quote(status.ActionContext.WorkspaceRoot), change,
 	)
 	status.Dependencies.Apply = DependencyBlocked
 	status.Dependencies.Verify = DependencyBlocked
@@ -777,8 +778,8 @@ func applyNativeRuntimeRouting(status *Status) {
 		change = *status.ChangeName
 	}
 	reason := fmt.Sprintf(
-		"native SDD runtime execution is blocked(%s) for %q in %q; compact acquire reports the same: %s",
-		readiness.Reason, change, status.ActionContext.WorkspaceRoot, readiness.Exit,
+		"native SDD runtime execution is blocked(%s) for %q in %s; compact acquire reports the same: %s",
+		readiness.Reason, change, pathquote.Quote(status.ActionContext.WorkspaceRoot), readiness.Exit,
 	)
 	status.Dependencies.Apply = DependencyBlocked
 	status.Dependencies.Verify = DependencyBlocked
@@ -1805,15 +1806,15 @@ func renderPhaseInstructions(status Status) PhaseInstructions {
 func nativeRuntimeInstructions(status Status, change string) []string {
 	workspace := status.ActionContext.WorkspaceRoot
 	instructions := []string{
-		fmt.Sprintf("Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd %q --change %q --request-id \"<unique-request-id>\" --work-unit \"<label>\" --evidence-goal \"<stable-goal>\" --max-attempts <count> --max-changed-lines <count>`.", workspace, change),
+		fmt.Sprintf("Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd %s --change %q --request-id \"<unique-request-id>\" --work-unit \"<label>\" --evidence-goal \"<stable-goal>\" --max-attempts <count> --max-changed-lines <count>`.", pathquote.Quote(workspace), change),
 		"Launch only for state proceed and retain its opaque token. State blocked or complete stops the launch; full runtime status is a diagnostic escape hatch, not normal model context.",
-		fmt.Sprintf("After the external run, call `gentle-ai sdd-attempt settle --cwd %q --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome <passed|failed|interrupted> --evidence-revision <sha256> --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`; add --successor-lineage only for a distinct approved remediation successor.", workspace, change),
+		fmt.Sprintf("After the external run, call `gentle-ai sdd-attempt settle --cwd %s --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome <passed|failed|interrupted> --evidence-revision <sha256> --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`; add --successor-lineage only for a distinct approved remediation successor.", pathquote.Quote(workspace), change),
 		"Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic.",
 	}
 	if status.RemediationState.Required && status.RemediationState.LineageID == "" && status.RuntimeStatus != nil && status.RuntimeStatus.Objective != nil {
 		objective := status.RuntimeStatus.Objective
 		instructions = append(instructions,
-			fmt.Sprintf("Disabled/unmanaged remediation has one bounded correction attempt: run `gentle-ai sdd-attempt acquire --cwd %q --change %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d`.", workspace, change, objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines),
+			fmt.Sprintf("Disabled/unmanaged remediation has one bounded correction attempt: run `gentle-ai sdd-attempt acquire --cwd %s --change %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d`.", pathquote.Quote(workspace), change, objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines),
 			fmt.Sprintf("After the candidate changes, settle that token with `--remediates-evidence-revision %s`; a fresh independent verification is required before archive.", status.RemediationState.FailedEvidenceRevision),
 		)
 	}
@@ -1852,7 +1853,7 @@ func nonPhaseRoutingInstructions(status Status) ([]string, bool) {
 		return []string{
 			"",
 			"### Next Review Operation",
-			fmt.Sprintf("- Run `gentle-ai review start --cwd %q`; the facade derives intended untracked scope, lineage, tier, lenses, and correction budget from live Git.", status.ActionContext.WorkspaceRoot),
+			fmt.Sprintf("- Run `gentle-ai review start --cwd %s`; the facade derives intended untracked scope, lineage, tier, lenses, and correction budget from live Git.", pathquote.Quote(status.ActionContext.WorkspaceRoot)),
 			"- Pass reviewer result and verification evidence to `gentle-ai review finalize`; do not hand-author lifecycle operation JSON.",
 			"- Continue discovered authority instead of starting another budget, and reconcile existing terminal mirrors only after `gentle-ai review validate --gate post-apply` allows.",
 		}, true
@@ -1860,7 +1861,7 @@ func nonPhaseRoutingInstructions(status Status) ([]string, bool) {
 		return []string{
 			"",
 			"### Next Selection Operation",
-			fmt.Sprintf("- Rerun with an explicit change name from Blocked Reasons above: `gentle-ai sdd-status --cwd %q <change-name>` or `gentle-ai sdd-continue --cwd %q <change-name>`.", status.ActionContext.WorkspaceRoot, status.ActionContext.WorkspaceRoot),
+			fmt.Sprintf("- Rerun with an explicit change name from Blocked Reasons above: `gentle-ai sdd-status --cwd %s <change-name>` or `gentle-ai sdd-continue --cwd %s <change-name>`.", pathquote.Quote(status.ActionContext.WorkspaceRoot), pathquote.Quote(status.ActionContext.WorkspaceRoot)),
 		}, true
 	default:
 		return nil, false


### PR DESCRIPTION
Finishes #2498: converts the remaining path-rendering `%q` sites in `internal/sddstatus/status.go` and `internal/sddstatus/runtime_ledger.go` to `%s` + `internal/pathquote.Quote`, following the pattern PR #2509 established. A Windows workspace path now renders with single separators in every printed invocation, so the command the operator copies is the command that runs.

The last 3 sites of #2498 live in `internal/reviewtransaction/compact_reclaim.go`, are owned by open PR #2316, and are deliberately untouched here (tracked as #2544).

## RED (verbatim, before the conversion)

All seven new tests drive the real renderers with a literal `C:\Users\dev\repo` and failed on origin/main (9a81024d) with the doubled-separator output:

<details>
<summary>Full failing run of <code>go test ./internal/sddstatus/ -run 'WindowsPathVerbatim' -count=1</code></summary>

```
--- FAIL: TestApplyNativeRuntimeErrorRoutingRendersWindowsPathVerbatim (0.00s)
    path_quote_render_test.go:33: corrupt-authority diagnostic does not contain the path as the filesystem knows it:
        want substring: --cwd "C:\Users\dev\repo"
        got: native SDD runtime authority is unreadable and execution is blocked: ledger unreadable; do not launch another actor or edit the Git-common-dir authority manually; the compact attempt path reports blocked(corrupt_authority), and full `gentle-ai sdd-attempt status --cwd "C:\\Users\\dev\\repo" --change "my-change"` is a maintainer diagnostic only
--- FAIL: TestApplyNativeRuntimeRoutingRendersWindowsPathVerbatim (0.00s)
    path_quote_render_test.go:44: blocked-runtime reason does not contain the path as the filesystem knows it:
        want substring: in "C:\Users\dev\repo"
        got: native SDD runtime execution is blocked(maintainer_decision) for "my-change" in "C:\\Users\\dev\\repo"; compact acquire reports the same: [...]
--- FAIL: TestNativeRuntimeInstructionsRenderWindowsPathVerbatim (0.00s)
    path_quote_render_test.go:59: acquire, settle, and correction-acquire instructions must all carry the verbatim path:
        want 3 occurrences of --cwd "C:\Users\dev\repo", got 0
        got: Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd "C:\\Users\\dev\\repo" --change "my-change" [...]
        After the external run, call `gentle-ai sdd-attempt settle --cwd "C:\\Users\\dev\\repo" --change "my-change" [...]
        Disabled/unmanaged remediation has one bounded correction attempt: run `gentle-ai sdd-attempt acquire --cwd "C:\\Users\\dev\\repo" --change "my-change" [...]
--- FAIL: TestNonPhaseRoutingInstructionsRenderWindowsPathVerbatim (0.00s)
    --- FAIL: TestNonPhaseRoutingInstructionsRenderWindowsPathVerbatim/resolve-review (0.00s)
        path_quote_render_test.go:82: routing instructions must carry the verbatim path:
            want 1 occurrences of --cwd "C:\Users\dev\repo", got 0
            got: - Run `gentle-ai review start --cwd "C:\\Users\\dev\\repo"`; the facade derives intended untracked scope, lineage, tier, lenses, and correction budget from live Git.
    --- FAIL: TestNonPhaseRoutingInstructionsRenderWindowsPathVerbatim/select-change (0.00s)
        path_quote_render_test.go:82: routing instructions must carry the verbatim path:
            want 2 occurrences of --cwd "C:\Users\dev\repo", got 0
            got: - Rerun with an explicit change name from Blocked Reasons above: `gentle-ai sdd-status --cwd "C:\\Users\\dev\\repo" <change-name>` or `gentle-ai sdd-continue --cwd "C:\\Users\\dev\\repo" <change-name>`.
--- FAIL: TestRuntimeStrandedSuccessorRefusalRendersWindowsPathVerbatim (0.00s)
    path_quote_render_test.go:97: stranded-successor abandon invocation does not contain the path as the filesystem knows it:
        want substring: --cwd "C:\Users\dev\repo"
        got: [...] re-run this finish: `gentle-ai review abandon --cwd "C:\\Users\\dev\\repo" --lineage "lineage-2" --expected-revision "rev-2" [...]
--- FAIL: TestRuntimeWorktreeMismatchRefusalRendersWindowsPathVerbatim (0.00s)
    path_quote_render_test.go:110: worktree-mismatch refusal does not contain the path as the filesystem knows it:
        want substring: began in "C:\Users\dev\repo"
        got: SDD runtime attempt began in a different linked worktree than this finish is running from: attempt 1 began in "C:\\Users\\dev\\repo", and its base candidate tree is pinned to that exact linked worktree, but this finish is running from "C:\\Users\\dev\\elsewhere" [...] rerun with --cwd "C:\\Users\\dev\\repo" [...]
--- FAIL: TestRuntimeObjectiveChangeRefusalRendersWindowsPathVerbatim (0.00s)
    --- FAIL: TestRuntimeObjectiveChangeRefusalRendersWindowsPathVerbatim/reset_branch (0.00s)
        path_quote_render_test.go:143: objective-change refusal must carry the verbatim path:
            want 2 occurrences of --cwd "C:\Users\dev\repo", got 0
            got: [...] `gentle-ai sdd-attempt reset --cwd "C:\\Users\\dev\\repo" --change "my-change" [...] `gentle-ai sdd-attempt status --cwd "C:\\Users\\dev\\repo" --change "my-change"` after it commits
    --- FAIL: TestRuntimeObjectiveChangeRefusalRendersWindowsPathVerbatim/fail-closed_default_branch (0.00s)
        path_quote_render_test.go:143: objective-change refusal must carry the verbatim path:
            want 1 occurrences of --cwd "C:\Users\dev\repo", got 0
            got: [...] `gentle-ai sdd-attempt begin --cwd "C:\\Users\\dev\\repo" --change "my-change" [...]
FAIL
FAIL	github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus	0.003s
```

The `[...]` elisions shorten repeated long invocation text only; every `got:` line is otherwise verbatim from the failing run.

</details>

## Per-site classification (line numbers on origin/main 9a81024d)

Every `%q` in both files was classified before touching it. Converted means the argument is a filesystem path; kept means it is Go-string territory (lineage names, change names, revisions, work-unit labels, CLI args) and stays `%q` exactly as it was.

### internal/sddstatus/status.go

| Line | Argument | Classification |
|---|---|---|
| 275 | `workspaceRoot` in review-offer invocation | converted |
| 741 | `WorkspaceRoot` in corrupt-authority diagnostic | converted (`--change %q` on the same line kept) |
| 780 | `WorkspaceRoot` in blocked-runtime reason | converted (change name `%q` kept) |
| 1808 | `workspace` in acquire instruction | converted (`--change %q` kept) |
| 1810 | `workspace` in settle instruction | converted (`--change %q` kept) |
| 1816 | `workspace` in correction-acquire instruction | converted (`--change %q`, `--work-unit %q`, `--evidence-goal %q` kept) |
| 1855 | `WorkspaceRoot` in review-start routing | converted |
| 1863 | `WorkspaceRoot` twice in select-change routing | converted (both) |
| 362, 367, 378 | CLI argument / contract name | kept `%q` |

### internal/sddstatus/runtime_ledger.go

| Line | Argument | Classification |
|---|---|---|
| 874 | `store.Workspace` in successor-required refusal | converted (lineage `%q` kept) |
| 886 | `store.Workspace` in remediation-trio refusal | converted (change, revisions, lineage `%q` kept) |
| 914 | `store.Workspace` in stranded-successor abandon invocation | converted (lineage, revision `%q` kept) |
| 948 | `beginWorktree` twice and `store.Workspace` in worktree-mismatch refusal | converted (all 3 path args) |
| 983 | `store.Workspace` twice in reset refusal | converted (change, revision `%q` kept) |
| 989 | `store.Workspace` in rescope refusal | converted (change, revision `%q` kept) |
| 1001 | `store.Workspace` in fail-closed begin refusal | converted (change, work-unit, evidence-goal `%q` kept) |
| 1422 | `lockPath` in lock-acquire failure | converted |
| 136, 151, 501, 724, 772, 927 | revisions / change name | kept `%q` |

Total: 16 path arguments converted across 16 format-string lines; every non-path `%q` byte-identical.

Sites converted without a dedicated new test: status.go 275 (needs live review-offer state), runtime_ledger.go 874/886 (need Git-backed successor probes), 989 (rescope branch needs a Git candidate capture), 1422 (needs repeated lock-acquire failure). Each is the identical mechanical swap covered by the pattern tests above, and the full suite exercises the surrounding code paths.

## Known overlaps

Both files are currently touched by open PRs; shipping this fix anyway follows the precedent already on main (#2519 shipped over #2464/#2300/#2273's files, #2516 over #2343/#2305's, each with a rebase note):

- **#2185** overlaps 2 of the 8 status.go sites (lines 741, 780, inside its `Resolve`/`resolveEngramStatus` rework). This conversion is a format-verb swap plus a wrapper call, so whichever PR merges second resolves a two-line textual conflict.
- **#2072** rewrites large parts of runtime_ledger.go under the `slop` label; a large rewrite under that label is unlikely to merge as-is, and freezing runtime_ledger.go on it indefinitely is the wrong trade for a Windows-correctness fix.
- **#2222** overlaps only a comment block in status.go.

## Verification (all foreground, all green)

- `go test ./internal/sddstatus/ -count=1`: ok
- `go test ./... -count=1` at root: exit 0, 64 packages ok (includes the refusal-resolution ratchet in `internal/cli`)
- `cd bench && go test ./... -count=1`: ok
- `gofmt -l internal/sddstatus/`: clean
- `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions

Closes #2498
Refs #2544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows path rendering in status messages, runtime instructions, and error guidance.
  - Preserved single backslashes in displayed filesystem paths.
  - Corrected shell command examples and workspace path references across routing, recovery, and validation scenarios.
  - Added regression coverage for path formatting in continuation, review, runtime, worktree, and objective-change flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->