### PR TITLE
ci(e2e): run full Tier 1+2+3 suite on every event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
           GENTLE_AI_REQUIRE_DISTINCT_WINDOWS_TOKEN_OWNER: "1"
         run: go test -v ./internal/cli ./internal/reviewtransaction ./internal/sddstatus -run '^(TestRARSharedOwnerAcceptsOnlyCurrentWindowsPrincipals|TestRARPrivateOwnerRemainsTokenUserOnly|TestWindowsSecureOpenRetriesDirectDriveDeviceWithoutWeakeningFlags|TestWindowsSecureOpenDriveFallbackFailsClosed|TestWindowsSecureOpenDoesNotRetryOtherErrors|TestWindowsStoreLockUsesExistingInodeAdvisoryTruth|TestRunGitBoundsLocalAndRemoteCommands|TestRunGitDistinguishesAggregateDeadlineAndTypedExit|TestStoreLockReportsLiveOwnerAndCannotBeStolen|TestStoreLockRecoversCrashAndCorruptOwnerRecords|TestStoreLockIsReleasedWhenOwnerProcessExits|TestConcurrentStoreLockRecoverersCannotBothWin|TestCompactStoresShareRepositoryWriteLock|TestCompactStoreRejectsConcurrentLockedWriter|TestAuthorityLockCancellationPreservesSentinelAndCallerDeadline|TestCompactStatusLoadContextCancelsUnderExclusiveMaintenance|TestRepairClassifiedAuthorityConcurrentExecutionCommitsAndReplays|TestRepairClassifiedAuthorityResumesEachDurablePhase|TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState|TestReviewFacadeFinalizeRejectsCorrectionCreatedUntrackedPath|TestRejectFacadeCorrectionUntrackedRespectsStagedProjection|TestMainBinaryAcceptsCorrectedCandidateFromLinkedWorktree|TestWindowsPowerShell51ArtifactManifestFileFinalize|TestNegotiatedStatusUnderUnavailableProcessTempOffersFreshStartOnBothContracts|TestNegotiatedStatusUnderUnavailableProcessTempResolvesWorkspaceOverlayBaseRef|TestNegotiatedStatusUnderUnavailableProcessTempContinuesCompactCorrection|TestNegotiatedStatusLeavesNoTemporaryGitArtifactsAfterFailure|TestNegotiatedReviewStatusFreshLargeDirtyCandidateOffersStart)$' -count=1 -timeout=8m
 
-      # PR runs the release-blocker subset only; push to main and the nightly
-      # schedule run the full Windows suite, mirroring the E2E tier policy.
+      # PR runs the release-blocker subset only; the full Windows suite runs
+      # in the separate, honestly-named "Windows Full Suite" workflow.
   # Native Darwin release blockers (#1853). Four macOS defects (#1773, #1781,
   # #1804, #1850) and the #1872 RAR lock convoy shipped because no CI lane
   # executes Darwin semantics; GOOS=darwin cross-builds prove compilation, not
@@ -362,16 +362,18 @@ jobs:
           cache-from: type=gha,scope=e2e-${{ matrix.platform.name }}
           cache-to: type=gha,mode=max,scope=e2e-${{ matrix.platform.name }}
 
-      # PR runs Tier 1 only (binary + dry-run); push to main and the nightly
-      # schedule run the full Tier 1+2+3 suite. The ruleset still requires all
-      # 3 platform checks, so the matrix runs everywhere — only the test scope
-      # changes by event.
+      # Full Tier 1+2+3 on every event (#2527): these checks are required by
+      # the ruleset under the name "E2E Tests", so they must deliver the full
+      # suite wherever they gate. Tiers 2-3 write only inside the container,
+      # and push/schedule already prove they fit the step budget on the same
+      # runners. Do not reintroduce per-event tier selection here without
+      # renaming the checks to state the reduced scope.
       - name: Run E2E tests
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_FULL_E2E: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && '1' || '0' }}
-          RUN_BACKUP_TESTS: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && '1' || '0' }}
+          RUN_FULL_E2E: "1"
+          RUN_BACKUP_TESTS: "1"
         run: |
           docker run --rm \
             -e RUN_FULL_E2E \


### PR DESCRIPTION
Implements the ci.yml half of #2466, deferred by PR #2507 (its body section "Deferred: ci.yml owned by #2479" documents the exact change) and tracked as #2527. The `e2e-tests` job selected tiers by event: full Tier 1+2+3 on `push`/`schedule`, Tier 1 only on `pull_request` and `workflow_dispatch`. The required checks are named `E2E Tests (<platform>)`, so on PRs a green required check promised more coverage than the event delivered.

## Choice: run the full suite, not rename

Of the two options #2507 laid out, this PR takes the first: `RUN_FULL_E2E` and `RUN_BACKUP_TESTS` are now `"1"` unconditionally, so every event the checks gate runs the same Tier 1+2+3 suite. Reasons:

- The tier can simply run. Tiers 2 and 3 write only inside the Docker container (no host side effects), and push/schedule have long proven the full suite fits the 30-minute step budget on identical `ubuntu-latest` runners.
- Renaming instead would require a maintainer-side ruleset edit (required check names cannot be changed from the workflow file), and a per-event dynamic name would desynchronize from the static required-check names.
- Unconditional also fixes `workflow_dispatch`: that trigger exists precisely to re-run CI on main after the workflow file changed, yet it ran less coverage (Tier 1) than the push run it replaces.

The replaced comment now states the invariant and forbids reintroducing per-event tier selection without renaming the checks. The `windows-runtime` comment that said its subset policy was "mirroring the E2E tier policy" is reworded, since that mirror no longer exists; the full Windows suite runs in the separate, honestly-named `Windows Full Suite` workflow (push to main, schedule, dispatch), unchanged here.

## Known overlaps

- Open PR #2444 also touches `.github/workflows/ci.yml`, ruled acceptable by the maintainer: its hunk is bench-related (around the bench job near line 95), far from the `e2e-tests` job edited here. Whichever merges second resolves trivially.

## Verification

- `actionlint .github/workflows/ci.yml`: clean (includes a full YAML parse).
- `go run ./internal/gofmtcheck`: clean. `go vet ./...`: clean.
- `go test ./... -count=1` at root: green (includes the refusal-resolution ratchet in `internal/cli`). `go test ./... -count=1` in `bench/`: green.
- `scripts/deadcode-ratchet.sh`: no new unreachable functions.
- Prove-only-in-CI: a workflow change cannot be fully executed locally. The proving runs are (1) this PR's own CI, where each `E2E Tests (<platform>)` check should now log `=== Tier 2: Component injection tests ===` and `=== Tier 3: Backup/restore tests ===` instead of `[SKIP] Tier 2/3`, with totals well above the ~79 Tier 1 checks; and (2) the first post-merge push to main, which should behave exactly as push events always have (full suite, unchanged).

Closes #2527
Refs #2466 #2507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Windows pull request checks now run a release-blocker subset, with the complete suite handled separately.
  * End-to-end testing now runs the full Tier 1–3 suite for every event.
  * Backup and full end-to-end test coverage is consistently enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->