### PR TITLE
fix(messages): render reclaim refusal paths verbatim with pathquote

### DIFF
--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
 )
 
 const CompactReclaimRecordSchema = "gentle-ai.review-reclaim-record/v1"
@@ -198,12 +200,12 @@ func compactReclaimAuthorityRefusal(ctx context.Context, repo, dir, lineageID, a
 	if loadErr != nil {
 		if os.IsNotExist(loadErr) {
 			return fmt.Errorf("%s The entry holds no readable review-state.json beside that artifact, so nothing can prove the artifact never carried authority, and no advertised operation admits this shape today."+
-				" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %q` and escalate that report", refused, repo)
+				" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %s` and escalate that report", refused, pathquote.Quote(repo))
 		}
 		return fmt.Errorf("%s Its record cannot be loaded (%v) — inspection classifies it %s, which an interrupted write leaves behind — and no advertised operation admits an unreadable record:"+
 			" reconciliation re-derives its proof from readable state, and admitting bytes that can prove nothing is a maintainer policy decision, not a repair."+
-			" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %q` and escalate that report",
-			refused, loadErr, compactRecoveryEntryProblem(loadErr), repo)
+			" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %s` and escalate that report",
+			refused, loadErr, compactRecoveryEntryProblem(loadErr), pathquote.Quote(repo))
 	}
 	eligibility, eligibilityErr := InspectCompactPristineAbandonment(ctx, repo, lineageID)
 	if eligibilityErr == nil && eligibility.Eligible {
@@ -212,8 +214,8 @@ func compactReclaimAuthorityRefusal(ctx context.Context, repo, dir, lineageID, a
 	}
 	return fmt.Errorf("%s No advertised operation admits it: %s."+
 		" Nothing quarantines this shape today; the entry stays exactly as persisted."+
-		" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %q` and escalate that report",
-		refused, compactAbandonBlockerText(record.State), repo)
+		" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %s` and escalate that report",
+		refused, compactAbandonBlockerText(record.State), pathquote.Quote(repo))
 }
 
 // quarantineCompactStoreEntry runs the shared two-phase audited move for one

--- a/internal/reviewtransaction/path_quote_render_test.go
+++ b/internal/reviewtransaction/path_quote_render_test.go
@@ -1,6 +1,9 @@
 package reviewtransaction
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -34,5 +37,60 @@ func TestCompactRepairCommandTextRendersWindowsPathVerbatim(t *testing.T) {
 	want := `--cwd "C:\Users\dev\repo"`
 	if got := strings.Count(text, want); got != 2 {
 		t.Fatalf("repair invocation renders --cwd twice and both must carry the verbatim path:\nwant 2 occurrences of %s, got %d\ngot: %s", want, got, text)
+	}
+}
+
+func TestCompactReclaimAuthorityRefusalRendersWindowsPathVerbatim(t *testing.T) {
+	repo := `C:\Users\dev\repo`
+	want := `--cwd "C:\Users\dev\repo"`
+	tests := []struct {
+		name     string
+		populate func(t *testing.T, dir string)
+	}{
+		{
+			// No review-state.json beside the artifact: nothing can prove the
+			// artifact never carried authority, so the refusal names the
+			// inspect-authority escalation.
+			name:     "missing record",
+			populate: func(*testing.T, string) {},
+		},
+		{
+			// A record an interrupted write left unreadable also routes to the
+			// inspect-authority escalation.
+			name: "unreadable record",
+			populate: func(t *testing.T, dir string) {
+				writeReclaimFixtureFile(t, filepath.Join(dir, compactStateFileName), "{malformed")
+			},
+		},
+		{
+			// A readable record whose abandonment eligibility cannot be proven
+			// falls through to the no-advertised-operation escalation. The
+			// eligibility probe runs against the rendered repo path, which
+			// does not exist here, so the fail-closed default renders.
+			name: "no advertised operation",
+			populate: func(t *testing.T, dir string) {
+				state := newCompactTestState(t, initSnapshotRepo(t), "reclaim-audit")
+				_, payload, err := makeCompactRecord(state)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, compactStateFileName), payload, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.populate(t, dir)
+			err := compactReclaimAuthorityRefusal(context.Background(), repo, dir, "reclaim-audit", "review-receipt.json")
+			if err == nil {
+				t.Fatal("reclaim accepted a store entry holding an authoritative artifact")
+			}
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("reclaim refusal does not contain the path as the filesystem knows it:\nwant substring: %s\ngot: %s", want, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Final slice of #2498. Converts the last 3 `%q` path sites in `internal/reviewtransaction/compact_reclaim.go` (the three inspect-authority escalations in `compactReclaimAuthorityRefusal`) to the `internal/pathquote.Quote` helper, so the printed `--cwd <path>` invocation carries the path as the filesystem knows it instead of a Go string literal with doubled Windows separators.

Closes #2544
Refs #2498

## RED evidence

New `TestCompactReclaimAuthorityRefusalRendersWindowsPathVerbatim` in `internal/reviewtransaction/path_quote_render_test.go` drives the real renderer through all three refusal branches with a literal `C:\Users\dev\repo` and failed before the fix:

```
--- FAIL: TestCompactReclaimAuthorityRefusalRendersWindowsPathVerbatim (0.04s)
    --- FAIL: TestCompactReclaimAuthorityRefusalRendersWindowsPathVerbatim/missing_record (0.00s)
        path_quote_render_test.go:92: reclaim refusal does not contain the path as the filesystem knows it:
            want substring: --cwd "C:\Users\dev\repo"
            got: review reclaim refused: store entry "reclaim-audit" holds authoritative artifact "review-receipt.json", and reclaim only quarantines entries that never held authority. The entry holds no readable review-state.json beside that artifact, so nothing can prove the artifact never carried authority, and no advertised operation admits this shape today. Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd "C:\\Users\\dev\\repo"` and escalate that report
    --- FAIL: TestCompactReclaimAuthorityRefusalRendersWindowsPathVerbatim/unreadable_record (0.00s)
        path_quote_render_test.go:92: reclaim refusal does not contain the path as the filesystem knows it:
            want substring: --cwd "C:\Users\dev\repo"
            got: review reclaim refused: [...] Its record cannot be loaded (invalid character 'm' looking for beginning of object key string) [...] Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd "C:\\Users\\dev\\repo"` and escalate that report
    --- FAIL: TestCompactReclaimAuthorityRefusalRendersWindowsPathVerbatim/no_advertised_operation (0.04s)
        path_quote_render_test.go:92: reclaim refusal does not contain the path as the filesystem knows it:
            want substring: --cwd "C:\Users\dev\repo"
            got: review reclaim refused: [...] No advertised operation admits it: [...] Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd "C:\\Users\\dev\\repo"` and escalate that report
FAIL
```

All three subtests pass after the conversion.

## Argument classification on the touched lines

Every format-verb argument on the three touched statements, classified:

| Statement (old line) | Verb | Argument | Class | Action |
|---|---|---|---|---|
| ~201 | `%q` | `repo` | path | converted to `%s` + `pathquote.Quote` |
| ~201 | `%s` | `refused` | prose preamble | byte-identical |
| ~205 | `%q` | `repo` | path | converted to `%s` + `pathquote.Quote` |
| ~205 | `%s` | `refused` | prose preamble | byte-identical |
| ~205 | `%v` | `loadErr` | error value | byte-identical |
| ~205 | `%s` | `compactRecoveryEntryProblem(loadErr)` | classification token | byte-identical |
| ~215 | `%q` | `repo` | path | converted to `%s` + `pathquote.Quote` |
| ~215 | `%s` | `refused` | prose preamble | byte-identical |
| ~215 | `%s` | `compactAbandonBlockerText(record.State)` | diagnosis text | byte-identical |

The `%q` renderings of `lineageID` and `artifact` live on line 196 (the `refused` preamble construction), which this PR does not touch: identifiers stay Go-string territory per the `pathquote` package doc.

## Known overlaps

Open PR #2316 also touches `compact_reclaim.go`. Maintainer ruling: proceed anyway; this conversion is a format-verb swap plus wrapper, so whichever merges second resolves a trivial textual conflict (precedent: #2546, #2519, #2516).

## Verification (all foreground)

- `go test ./... -count=1` at root: pass
- `go test ./... -count=1` in `bench/`: pass
- `gofmt -l .`: clean
- `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- refusal-resolution ratchet (`internal/cli/refusal_resolution_ratchet_test.go`): pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reclaim refusal messages so repository paths, including Windows paths, are displayed accurately and safely.
  * Corrected path rendering across missing, unreadable, and ineligible state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->