### PR TITLE
fix(sdd): report blocked(edit_authority_missing) for out-of-authority task targets

### DIFF
--- a/internal/sddstatus/edit_authority.go
+++ b/internal/sddstatus/edit_authority.go
@@ -1,0 +1,174 @@
+package sddstatus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
+)
+
+// Issue #2547 (S1 of #2540): work units carry no structured target field, so
+// the only honest signal that a task plan edits another repository is the
+// prose itself. Detection is deliberately conservative: it inspects only
+// backticked tokens inside markdown checkbox lines, and it flags a token only
+// when the token resolves to a real Git repository different from the
+// planning repository and outside every authorized edit root. It catches the
+// reported scenario (explicit `../sibling/...` and absolute paths); it cannot
+// catch pure prose ("update the billing service"), and a context reference
+// can raise a false block — acceptable because the consequence is an honest
+// blocked status naming its exits, never silent authority.
+//
+// This derivation deliberately lives outside the #2515 runtime-readiness
+// triple (RuntimeStatus.Complete/DecisionRequired/ActiveAttempt): edit
+// authority is a property of the task plan, not of runtime execution, so
+// TestOneReadinessPredicateHasNoRivalDerivations stays green by design.
+
+var backtickedSpan = regexp.MustCompile("`([^`]+)`")
+
+// detectUnauthorizedEditRoots scans tasks text (both status paths have text;
+// the Engram store has no tasks.md path) for path-like tokens in checkbox
+// lines, resolves each against workspaceRoot to its nearest existing
+// ancestor, and reports every resolved Git root that is neither the planning
+// repository's own Git root nor inside allowedEditRoots. allowedEditRoots is
+// a parameter so a later slice can extend it with persisted per-change
+// grants without touching detection (#2540 S2-S4).
+func detectUnauthorizedEditRoots(tasksText string, workspaceRoot string, allowedEditRoots []string) []string {
+	planningGitRoot := gitRootOf(resolveExistingPath(workspaceRoot))
+	allowed := make([]string, 0, len(allowedEditRoots))
+	for _, root := range allowedEditRoots {
+		allowed = append(allowed, resolveExistingPath(root))
+	}
+
+	unauthorized := map[string]bool{}
+	for _, line := range strings.Split(tasksText, "\n") {
+		if len(taskCheckbox.FindStringSubmatch(line)) == 0 {
+			continue
+		}
+		for _, token := range pathLikeTokens(line) {
+			resolved := token
+			if !filepath.IsAbs(resolved) {
+				resolved = filepath.Join(workspaceRoot, resolved)
+			}
+			resolved = resolveExistingPath(filepath.Clean(resolved))
+			target := gitRootOf(resolved)
+			if target == "" || target == planningGitRoot || withinAnyRoot(target, allowed) {
+				continue
+			}
+			unauthorized[target] = true
+		}
+	}
+
+	roots := make([]string, 0, len(unauthorized))
+	for root := range unauthorized {
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+// pathLikeTokens extracts the conservative candidate set from one checkbox
+// line: backticked tokens that contain a path separator (which subsumes
+// `../` prefixes and absolute paths). Tokens with whitespace are commands or
+// prose, and URL-like tokens are references, not filesystem targets.
+func pathLikeTokens(line string) []string {
+	var tokens []string
+	for _, match := range backtickedSpan.FindAllStringSubmatch(line, -1) {
+		token := match[1]
+		if strings.ContainsAny(token, " \t") || strings.Contains(token, "://") {
+			continue
+		}
+		if !strings.ContainsRune(token, '/') && !strings.ContainsRune(token, filepath.Separator) {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+// resolveExistingPath walks up to the nearest existing ancestor (task prose
+// routinely names files that do not exist yet, like `../service-a/...`) and
+// then evaluates symlinks so root comparisons happen on the paths the
+// filesystem knows.
+func resolveExistingPath(path string) string {
+	current := path
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			break
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	if resolved, err := filepath.EvalSymlinks(current); err == nil {
+		return resolved
+	}
+	return current
+}
+
+// gitRootOf walks up from path to the nearest directory containing a `.git`
+// entry (a directory for ordinary repositories, a file for worktrees). An
+// empty result means the path belongs to no repository and can never be an
+// unauthorized edit target.
+func gitRootOf(path string) string {
+	current := path
+	if info, err := os.Stat(current); err != nil || !info.IsDir() {
+		current = filepath.Dir(current)
+	}
+	for {
+		if _, err := os.Lstat(filepath.Join(current, ".git")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+func withinAnyRoot(target string, roots []string) bool {
+	for _, root := range roots {
+		if target == root || strings.HasPrefix(target, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// editAuthorityBlockedReason names each unauthorized root and both exits:
+// keep the plan inside the authorized roots, or grant authority (the grant
+// command is a later slice of #2540; until it exists the only authorized
+// root is the planning repository).
+func editAuthorityBlockedReason(roots []string) string {
+	quoted := make([]string, 0, len(roots))
+	for _, root := range roots {
+		quoted = append(quoted, pathquote.Quote(root))
+	}
+	return fmt.Sprintf(
+		"blocked(edit_authority_missing): tasks.md targets repositories outside the authorized edit roots: %s; edit tasks.md so every work unit stays inside the authorized edit roots, or grant this change edit authority for those repositories",
+		strings.Join(quoted, ", "),
+	)
+}
+
+// applyEditAuthorityBlock forces applyState blocked before dependencies and
+// nextRecommended derive from it, so a plan whose work units the sdd-apply
+// outside-root guard would refuse never reports ready/apply. It runs only
+// when apply would otherwise be ready: completed work needs no forward edit
+// authority, and planning-blocked changes already carry their own reasons.
+func applyEditAuthorityBlock(applyState ApplyState, reasons *blockerReasons, tasksText string, workspaceRoot string, allowedEditRoots []string) ApplyState {
+	if applyState != ApplyReady {
+		return applyState
+	}
+	roots := detectUnauthorizedEditRoots(tasksText, workspaceRoot, allowedEditRoots)
+	if len(roots) == 0 {
+		return applyState
+	}
+	reasons.genuine = append(reasons.genuine, editAuthorityBlockedReason(roots))
+	return ApplyBlocked
+}

--- a/internal/sddstatus/edit_authority_test.go
+++ b/internal/sddstatus/edit_authority_test.go
@@ -1,0 +1,186 @@
+package sddstatus
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #2547 (S1 of #2540): a multi-repository change whose tasks target
+// sibling Git repositories must not report applyState ready while
+// allowedEditRoots names only the planning repository. On the unfixed base
+// this fixture reports ready/apply with zero blockers — the contradictory
+// route: native status authorizes apply, but the sdd-apply outside-root guard
+// forbids every first work unit.
+
+// initEditAuthorityGitRepo turns dir into a Git repository. Only the planning
+// repository needs a commit (the native runtime store resolves its repository
+// root); sibling service repositories only need a `.git` for root detection.
+func initEditAuthorityGitRepo(t *testing.T, dir string, commit bool) {
+	t.Helper()
+	mkdir(t, dir)
+	runRuntimeLedgerGit(t, dir, "init", "-q")
+	if !commit {
+		return
+	}
+	runRuntimeLedgerGit(t, dir, "config", "user.email", "edit-authority@example.com")
+	runRuntimeLedgerGit(t, dir, "config", "user.name", "Edit Authority Test")
+	write(t, filepath.Join(dir, "tracked.txt"), "base\n")
+	runRuntimeLedgerGit(t, dir, "add", "tracked.txt")
+	runRuntimeLedgerGit(t, dir, "commit", "-qm", "base")
+}
+
+func realPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func TestMultiRepoTaskTargetsBlockApplyWithoutEditAuthority(t *testing.T) {
+	workspace := t.TempDir() // the workspace itself is NOT a Git repository
+	planning := filepath.Join(workspace, "planning")
+	serviceA := filepath.Join(workspace, "service-a")
+	serviceB := filepath.Join(workspace, "service-b")
+	initEditAuthorityGitRepo(t, planning, true)
+	initEditAuthorityGitRepo(t, serviceA, false)
+	initEditAuthorityGitRepo(t, serviceB, false)
+
+	seedReadyChange(t, planning, "multi-repo-rollout", strings.Join([]string{
+		"- [ ] 1.1 Update `../service-a/internal/api/handler.go` to accept the new header",
+		"- [ ] 1.2 Update `../service-b/internal/worker/consume.go` to forward the header",
+		"- [ ] 1.3 Record the rollout order in `openspec/changes/multi-repo-rollout/design.md`",
+		"",
+	}, "\n"))
+
+	status, err := Resolve(ResolveOptions{CWD: planning, ChangeName: "multi-repo-rollout"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantA := realPath(t, serviceA)
+	wantB := realPath(t, serviceB)
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if status.ApplyState != ApplyBlocked {
+		t.Fatalf("multi-repo change reported applyState = %q, nextRecommended = %q, blockedReasons = %v; want applyState blocked with blocked(edit_authority_missing) naming %s and %s",
+			status.ApplyState, status.NextRecommended, status.BlockedReasons, wantA, wantB)
+	}
+	if status.NextRecommended == "apply" {
+		t.Fatalf("nextRecommended = %q for a change whose every first work unit is outside the authorized edit roots", status.NextRecommended)
+	}
+	if !strings.Contains(reasons, "blocked(edit_authority_missing)") {
+		t.Fatalf("blocked reasons lack the edit-authority reason code: %s", reasons)
+	}
+	if !strings.Contains(reasons, wantA) || !strings.Contains(reasons, wantB) {
+		t.Fatalf("blocked reasons must name each unauthorized target root %q and %q: %s", wantA, wantB, reasons)
+	}
+}
+
+// TestSingleRepoTasksKeepStatusByteIdentical pins the no-false-positive
+// contract: for an ordinary single-repository change, detection matches
+// nothing and the wiring mutates nothing, so the status an operator sees is
+// byte-identical to the pre-#2547 status. The wiring only touches applyState
+// and blockedReasons when at least one unauthorized root is found, so an
+// empty JSON footprint here proves the whole fixture is untouched.
+func TestSingleRepoTasksKeepStatusByteIdentical(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	seedReadyChange(t, repo, "single-repo-change", strings.Join([]string{
+		"- [ ] 1.1 Update `internal/auth/login.go` with the new claim check",
+		"- [x] 1.2 Extend `openspec/changes/single-repo-change/tasks.md` after review",
+		"- [ ] 1.3 Run `go test ./...` and fix regressions",
+		"",
+	}, "\n"))
+
+	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "single-repo-change"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.ApplyState != ApplyReady || status.NextRecommended != "apply" {
+		t.Fatalf("single-repo change lost apply readiness: applyState = %q nextRecommended = %q blockedReasons = %v",
+			status.ApplyState, status.NextRecommended, status.BlockedReasons)
+	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("single-repo change gained blocked reasons: %v", status.BlockedReasons)
+	}
+	encoded, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "edit_authority_missing") {
+		t.Fatalf("single-repo status carries an edit-authority footprint: %s", encoded)
+	}
+}
+
+// TestDetectUnauthorizedEditRootsHonorsAllowedRoots pins the seam a later
+// slice of #2540 plugs into: persisted per-change grants extend the
+// allowed-roots parameter, and detection needs no rework. It also pins the
+// nearest-existing-ancestor rule (task prose names files that do not exist
+// yet) and that non-path prose stays invisible.
+func TestDetectUnauthorizedEditRootsHonorsAllowedRoots(t *testing.T) {
+	workspace := t.TempDir()
+	planning := filepath.Join(workspace, "planning")
+	serviceA := filepath.Join(workspace, "service-a")
+	initEditAuthorityGitRepo(t, planning, false)
+	initEditAuthorityGitRepo(t, serviceA, false)
+	tasks := strings.Join([]string{
+		"- [ ] 1.1 Update `../service-a/does/not/exist/yet.go` for the rollout",
+		"- [ ] 1.2 Update the billing service and run `go test ./...`",
+		"- [ ] 1.3 Read https://example.com/service-b/docs first",
+		"",
+	}, "\n")
+
+	wantA := realPath(t, serviceA)
+	flagged := detectUnauthorizedEditRoots(tasks, planning, []string{planning})
+	if len(flagged) != 1 || flagged[0] != wantA {
+		t.Fatalf("detectUnauthorizedEditRoots() = %v, want exactly [%s]", flagged, wantA)
+	}
+
+	granted := detectUnauthorizedEditRoots(tasks, planning, []string{planning, serviceA})
+	if len(granted) != 0 {
+		t.Fatalf("granting %s must clear the block without detector rework, got %v", serviceA, granted)
+	}
+}
+
+// TestEngramTasksTextBlocksApplyOnUnauthorizedTargets drives the same
+// detection through resolveEngramStatus, which has no tasks.md path — only
+// the tasks artifact text — so the detector must accept text plus the
+// workspace root.
+func TestEngramTasksTextBlocksApplyOnUnauthorizedTargets(t *testing.T) {
+	workspace := t.TempDir() // the workspace itself is NOT a Git repository
+	planning := filepath.Join(workspace, "planning")
+	serviceA := filepath.Join(workspace, "service-a")
+	initEditAuthorityGitRepo(t, planning, true)
+	initEditAuthorityGitRepo(t, serviceA, false)
+	mkdir(t, filepath.Join(planning, ".engram"))
+	runRuntimeLedgerGit(t, planning, "remote", "add", "origin", "git@github.com:Gentleman-Programming/gentle-ai.git")
+
+	restore := stubEngramExport(t, []engramObservation{
+		{Title: "sdd/cross-repo/proposal", Content: "## Proposal\nRoll out the header", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/cross-repo/spec", Content: "## Requirements\n- SHALL forward the header", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/cross-repo/design", Content: "## Design\nSequential rollout", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/cross-repo/tasks", Content: "- [ ] 1.1 Update `../service-a/internal/api/handler.go` first\n", Project: "gentle-ai", Scope: "project"},
+	})
+	defer restore()
+
+	status, err := Resolve(ResolveOptions{CWD: planning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ArtifactStore != ArtifactStoreEngram {
+		t.Fatalf("ArtifactStore = %q, want %q", status.ArtifactStore, ArtifactStoreEngram)
+	}
+
+	wantA := realPath(t, serviceA)
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if status.ApplyState != ApplyBlocked || status.NextRecommended == "apply" {
+		t.Fatalf("engram-path change reported applyState = %q, nextRecommended = %q, blockedReasons = %v; want applyState blocked with blocked(edit_authority_missing) naming %s",
+			status.ApplyState, status.NextRecommended, status.BlockedReasons, wantA)
+	}
+	if !strings.Contains(reasons, "blocked(edit_authority_missing)") || !strings.Contains(reasons, wantA) {
+		t.Fatalf("blocked reasons must carry the reason code and name %q: %s", wantA, reasons)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -473,6 +473,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress)
+	applyState = applyEditAuthorityBlock(applyState, &blockedReasons, readText(firstPath(artifactPaths.Tasks)), workspaceRoot, []string{workspaceRoot})
 	var governingRef *reviewtransaction.SDDReceiptRef
 	if runtimeStatusErr == nil {
 		var refErr error
@@ -859,6 +860,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress)
+	applyState = applyEditAuthorityBlock(applyState, &blockedReasons, artifactsByType["tasks"].Content, workspaceRoot, []string{workspaceRoot})
 	var governingRef *reviewtransaction.SDDReceiptRef
 	if runtimeStatusErr == nil {
 		var refErr error


### PR DESCRIPTION
## What

Slice 1 of #2540: SDD status stops reporting `applyState: ready` when the task plan targets Git repositories outside `allowedEditRoots`, and instead reports `blocked(edit_authority_missing)` naming each unauthorized target root. `nextRecommended` routes to `resolve-blockers`, never `apply`.

## RED (verbatim, on unmodified base)

The new fixture (t.TempDir workspace, three `git init` repos: `planning/`, `service-a/`, `service-b/`; workspace root itself not a Git repo; complete OpenSpec artifacts in `planning/`; tasks referencing `../service-a/...` and `../service-b/...` in backticked prose) reproduces the contradictory ready from #2540 on both status paths:

```
--- FAIL: TestMultiRepoTaskTargetsBlockApplyWithoutEditAuthority (0.03s)
    edit_authority_test.go:68: multi-repo change reported applyState = "ready", nextRecommended = "apply", blockedReasons = []; want applyState blocked with blocked(edit_authority_missing) naming /tmp/.../service-a and /tmp/.../service-b
--- FAIL: TestEngramTasksTextBlocksApplyOnUnauthorizedTargets (0.02s)
    edit_authority_test.go:150: engram-path change reported applyState = "ready", nextRecommended = "apply", blockedReasons = []; want applyState blocked with blocked(edit_authority_missing) naming /tmp/.../service-a
```

## Detection rule (conservative, from the phase-1 report)

Work units carry no structured target field, so detection reads the prose: backticked tokens containing a path separator inside markdown checkbox lines (which subsumes `../` prefixes and absolute paths), resolved against the workspace root to the nearest existing ancestor, symlink-evaluated, then mapped to the nearest `.git` root. A token is unauthorized only when that root differs from the planning repository's git root and falls outside every allowed edit root.

| Catches | Cannot catch |
|---|---|
| Explicit `../sibling/...` references (the reported scenario) | Pure prose targets ("update the billing service") |
| Absolute paths into another repository | Paths that never resolve inside any Git repository |
| Paths to files that do not exist yet (nearest-existing-ancestor) | — |
| A context reference can raise a false block | acceptable: the consequence is an honest blocked status naming its exits, never silent authority |

Blocked reason names both exits: edit tasks.md so every work unit stays inside the authorized roots, or grant edit authority (the grant command is #2540 S3; until then the only authorized root is the workspace root, and the detector takes the allowed-roots slice as a parameter so persisted grants plug in without rework — pinned by `TestDetectUnauthorizedEditRootsHonorsAllowedRoots`).

## Constraints held

- The block derives outside the #2515 runtime-readiness triple; `TestOneReadinessPredicateHasNoRivalDerivations` passes unchanged.
- Single-repo changes stay byte-identical: the wiring mutates nothing when detection is empty (`TestSingleRepoTasksKeepStatusByteIdentical`).
- `runtime_ledger.go`, assets, and goldens untouched (owned by sibling slices).

## Verification

- `go test ./... -count=1` root module: all packages ok
- `go test ./... -count=1` bench module: ok
- gofmt clean, `go vet` clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- Refusal-resolution ratchet (`TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`): PASS, no baseline change needed (the new blocked reason names its resolution in-line)

Closes #2547. Refs #2540.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edit-authority checks for task plans that identify repositories outside approved editing locations.
  * Status results now report unauthorized repository roots and suggest remediation options.
  * Plans that would otherwise be ready to apply are marked as blocked when required edit access is unavailable.
* **Bug Fixes**
  * Improved handling of repository paths, symlinks, nonexistent targets, and task-text links.
  * Preserved existing status behavior and output for single-repository plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->