### PR TITLE
feat(sdd): per-change grant event in the runtime ledger with GrantedRoots projection (S2 of #2540)

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -201,6 +201,8 @@ internal/sddstatus/legacy_binding_read.go	parseLegacyBinding
 internal/sddstatus/review_binding.go	bindingPath
 internal/sddstatus/review_door.go	resetReviewEntryHookCallCountForTest
 internal/sddstatus/review_door.go	reviewEntryHookCallCountForTest
+internal/sddstatus/runtime_ledger.go	RuntimeStore.Grant
+internal/sddstatus/runtime_ledger.go	normalizeGrantRootsRequest
 internal/sddstatus/runtime_receipt.go	ReceiptRevisionConflictError.Error
 internal/sddstatus/runtime_receipt.go	RuntimeStore.readLegacyReceiptRef
 internal/sddstatus/runtime_receipt.go	RuntimeStore.recordPreparedReceipt

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -40,6 +41,8 @@ const (
 	runtimeOperationRescope           = "objective/rescope"
 	runtimeOperationAdvance           = "objective/advance"
 	runtimeOperationBind              = "binding/set"
+	runtimeOperationGrant             = "authority/grant"
+	maximumRuntimeGrantRoots          = 32
 	runtimeLockAcquireAttempts        = 3
 
 	// runtimeLedgerStatusPointer suffixes every ledger refusal an ordinary
@@ -291,8 +294,14 @@ type RuntimeStatus struct {
 	LastReset              *RuntimeReset     `json:"last_reset,omitempty"`
 	LastAdvance            *RuntimeAdvance   `json:"last_advance,omitempty"`
 	LastRescope            *RuntimeRescope   `json:"last_rescope,omitempty"`
-	BindingRevision        string            `json:"binding_revision"`
-	Binding                *ReviewBinding    `json:"binding,omitempty"`
+	// GrantedRoots is the per-change edit-authority projection (#2540 S2):
+	// canonical absolute symlink-evaluated roots accumulated from grant
+	// records in chain order. AllowedEditRoots consumption is a later slice.
+	// omitempty is load-bearing: a chain without grant records serializes
+	// byte-identically to every projection before this field existed.
+	GrantedRoots    []string       `json:"granted_roots,omitempty"`
+	BindingRevision string         `json:"binding_revision"`
+	Binding         *ReviewBinding `json:"binding,omitempty"`
 	// Receipt is Wave 4 S5's terminal pointer (design.md decision 1),
 	// recorded additively alongside Binding/BindingRevision — see
 	// runtime_receipt.go.
@@ -347,6 +356,18 @@ type RescopeObjectiveRequest struct {
 	Actor            string `json:"actor"`
 }
 
+// GrantRootsRequest records a per-change edit-authority grant (#2540 S2).
+// Reason/Actor mirror ResetObjectiveRequest's audit fields. Roots are
+// canonicalized (absolute, symlink-evaluated) before the request digest is
+// computed, so the digest binds the exact identities the record carries.
+type GrantRootsRequest struct {
+	ExpectedRevision string   `json:"expected_revision"`
+	RequestID        string   `json:"request_id"`
+	Roots            []string `json:"roots"`
+	Reason           string   `json:"reason"`
+	Actor            string   `json:"actor"`
+}
+
 // BindReviewRequest performs a binding-only compare-and-swap. The expected
 // value is the current ReviewBinding.Revision, not the runtime ledger HEAD and
 // not the review authority revision.
@@ -397,6 +418,25 @@ type runtimeRecord struct {
 	Advance          *runtimeAdvanceEvent `json:"advance,omitempty"`
 	Binding          *runtimeBindingEvent `json:"binding,omitempty"`
 	Receipt          *runtimeReceiptEvent `json:"receipt,omitempty"`
+	Grant            *runtimeGrantEvent   `json:"grant,omitempty"`
+}
+
+// runtimeGrantEvent is the persisted per-change edit-authority grant (#2540
+// S2): a maintainer-authorized record that this change's apply actor may edit
+// the named repository roots, recorded as canonical absolute symlink-evaluated
+// paths following BeginWorktree's canonicalization precedent. GrantedAt is
+// the ledger's FIRST wall-clock field: digest-safe (the content-addressed
+// record revision binds it immutably) but excluded from the request digest
+// and from determinism-replay expectations, which validate only that it
+// parses. Like runtimeRescopeEvent, the REAL forgery guard is replay's digest
+// recompute in validateRuntimeRecordShape: Roots, Actor, or Reason widened or
+// altered after publication no longer match the bound RequestDigest, so
+// replay refuses the chain.
+type runtimeGrantEvent struct {
+	Roots     []string `json:"roots"`
+	Actor     string   `json:"actor"`
+	Reason    string   `json:"reason"`
+	GrantedAt string   `json:"granted_at"`
 }
 
 // runtimeAdvanceEvent accompanies the successor's begin event in one atomic
@@ -1071,6 +1111,28 @@ func runtimeObjectiveAdvanceAdmissible(status RuntimeStatus, request BeginAttemp
 		!last.ChangedLineBudgetExceeded && last.FinishCandidateIdentity != "" && last.FinishCandidateTree != ""
 }
 
+// runtimeGrantClock is the ledger's only wall-clock source (#2540 S2), a
+// package variable solely so tests can pin it; production records UTC.
+var runtimeGrantClock = func() string { return time.Now().UTC().Format(time.RFC3339Nano) }
+
+// Grant commits a per-change edit-authority grant record (#2540 S2). It only
+// records and projects: AllowedEditRoots expansion, the consent envelope, and
+// the CLI verb are later slices. A grant has no structural precondition,
+// because authorizing roots is orthogonal to attempt state.
+func (store RuntimeStore) Grant(ctx context.Context, request GrantRootsRequest) (RuntimeStatus, error) {
+	request, err := normalizeGrantRootsRequest(request)
+	if err != nil {
+		return RuntimeStatus{}, err
+	}
+	digest := runtimeValueHash("gentle-ai.sdd-runtime-grant-request/v1", request)
+	grantedAt := runtimeGrantClock()
+	return store.mutate(ctx, request.ExpectedRevision, request.RequestID, digest, func(runtimeReplay) (runtimeRecord, error) {
+		return runtimeRecord{Operation: runtimeOperationGrant, Grant: &runtimeGrantEvent{
+			Roots: request.Roots, Actor: request.Actor, Reason: request.Reason, GrantedAt: grantedAt,
+		}}, nil
+	})
+}
+
 // Reset closes a terminal objective scope without deleting its immutable
 // attempts. The next Begin receives a new generation and budget while global
 // ordinals and lifetime charges continue monotonically.
@@ -1586,6 +1648,8 @@ func applyRuntimeRecord(replay *runtimeReplay, revision string, record runtimeRe
 		if err := applyRuntimeReceiptEvent(replay, record.Receipt); err != nil {
 			return err
 		}
+	case runtimeOperationGrant:
+		applyRuntimeGrantEvent(replay, record.Grant)
 	default:
 		return errors.New("unsupported SDD runtime record operation")
 	}
@@ -1831,6 +1895,27 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 	return nil
 }
 
+// applyRuntimeGrantEvent accumulates a grant's canonical roots into the
+// GrantedRoots projection in chain order, deduplicating already-granted
+// identities. It has no structural precondition and returns no error: every
+// integrity guard a grant needs already ran in validateRuntimeRecordShape,
+// and a chain with no grant records never reaches it, so legacy chains
+// replay unchanged.
+func applyRuntimeGrantEvent(replay *runtimeReplay, event *runtimeGrantEvent) {
+	for _, root := range event.Roots {
+		duplicate := false
+		for _, granted := range replay.Status.GrantedRoots {
+			if granted == root {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			replay.Status.GrantedRoots = append(replay.Status.GrantedRoots, root)
+		}
+	}
+}
+
 func applyRuntimeBindingEvent(replay *runtimeReplay, event *runtimeBindingEvent) error {
 	current := ""
 	if replay.Status.Binding != nil {
@@ -1881,14 +1966,14 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 	}
 	switch record.Operation {
 	case runtimeOperationBegin:
-		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil {
+		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime begin record shape")
 		}
 		if err := validateRuntimeBeginEvent(record); err != nil {
 			return err
 		}
 	case runtimeOperationAdvance:
-		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Binding != nil || record.Receipt != nil {
+		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime objective advance record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		advance := record.Advance
@@ -1902,7 +1987,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return err
 		}
 	case runtimeOperationFinish:
-		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil {
+		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime finish record shape")
 		}
 		event := record.Finish
@@ -1924,7 +2009,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime finish request digest does not match record")
 		}
 	case runtimeOperationFinishRemediation:
-		if record.Finish == nil || record.Binding == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Receipt != nil {
+		if record.Finish == nil || record.Binding == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid atomic SDD runtime remediation record shape")
 		}
 		finish, binding := record.Finish, record.Binding
@@ -1963,7 +2048,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("atomic SDD runtime remediation request digest does not match record")
 		}
 	case runtimeOperationReset:
-		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil {
+		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime reset record shape")
 		}
 		event := record.Reset
@@ -1979,7 +2064,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime reset request digest does not match record")
 		}
 	case runtimeOperationRescope:
-		if record.Rescope == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil {
+		if record.Rescope == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime rescope record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		event := record.Rescope
@@ -2010,7 +2095,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime rescope request digest does not match record") // refusal:by-design world-action: the digest is computed from the same request at write time, so a mismatch is a mutated record and the exit is restoring the store
 		}
 	case runtimeOperationBind:
-		if record.Binding == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Receipt != nil {
+		if record.Binding == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime binding record shape")
 		}
 		event := record.Binding
@@ -2037,7 +2122,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime binding request digest does not match record")
 		}
 	case runtimeOperationReceipt:
-		if record.Receipt == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil {
+		if record.Receipt == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime receipt record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		event := record.Receipt
@@ -2063,6 +2148,38 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		}
 		if runtimeValueHash("gentle-ai.sdd-runtime-receipt-request/v1", request) != record.RequestDigest {
 			return errors.New("SDD runtime receipt request digest does not match record") // refusal:by-design world-action: the digest is computed from the same request at write time, so a mismatch is a mutated record and the exit is restoring the store
+		}
+	case runtimeOperationGrant:
+		if record.Grant == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil {
+			return errors.New("invalid SDD runtime grant record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
+		}
+		event := record.Grant
+		if len(event.Roots) < 1 || len(event.Roots) > maximumRuntimeGrantRoots ||
+			validateRuntimeText(event.Reason, 500) != nil || validateRuntimeText(event.Actor, 128) != nil {
+			return errors.New("invalid SDD runtime grant event") // refusal:by-design world-action: bounds and audit fields are enforced before publication, so a violation is a mutated record and the exit is restoring the store
+		}
+		seen := make(map[string]struct{}, len(event.Roots))
+		for _, root := range event.Roots {
+			if validateRuntimeText(root, 4096) != nil || !filepath.IsAbs(root) {
+				return errors.New("invalid SDD runtime grant root") // refusal:by-design world-action: roots are canonicalized before publication, so a violation is a mutated record and the exit is restoring the store
+			}
+			if _, duplicate := seen[root]; duplicate {
+				return errors.New("duplicate SDD runtime grant root") // refusal:by-design world-action: canonical duplicates collapse before publication, so a violation is a mutated record and the exit is restoring the store
+			}
+			seen[root] = struct{}{}
+		}
+		// GrantedAt is the ledger's first wall-clock field: validated for
+		// parseability only, never recomputed or compared against a clock, so
+		// it stays excluded from determinism-replay expectations.
+		if _, err := time.Parse(time.RFC3339Nano, event.GrantedAt); err != nil {
+			return errors.New("invalid SDD runtime grant timestamp") // refusal:by-design world-action: the timestamp is rendered by the authority's own clock at publication, so a violation is a mutated record and the exit is restoring the store
+		}
+		request := GrantRootsRequest{
+			ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID,
+			Roots: event.Roots, Reason: event.Reason, Actor: event.Actor,
+		}
+		if runtimeValueHash("gentle-ai.sdd-runtime-grant-request/v1", request) != record.RequestDigest {
+			return errors.New("SDD runtime grant request digest does not match record") // refusal:by-design world-action: the digest binds the granted roots at write time, so a widened or altered record fails this recompute and the exit is restoring the store
 		}
 	default:
 		return errors.New("invalid SDD runtime record operation")
@@ -2210,6 +2327,53 @@ func normalizeResetObjectiveRequest(request ResetObjectiveRequest) (ResetObjecti
 	}
 	if err := validateRuntimeText(request.Actor, 128); err != nil {
 		return ResetObjectiveRequest{}, fmt.Errorf("invalid reset actor: %w", err)
+	}
+	return request, nil
+}
+
+// normalizeGrantRootsRequest mirrors normalizeResetObjectiveRequest's
+// CAS/audit-field validation and canonicalizes every requested root the way
+// OpenRuntimeStore canonicalizes the workspace for BeginWorktree: absolute,
+// then symlink-evaluated, so a link and its target record one identity.
+// Canonical duplicates collapse, keeping the digest identical to the event.
+func normalizeGrantRootsRequest(request GrantRootsRequest) (GrantRootsRequest, error) {
+	if request.ExpectedRevision != "" && !runtimeRevisionPattern.MatchString(request.ExpectedRevision) {
+		return GrantRootsRequest{}, errors.New("expected runtime revision must be empty or sha256")
+	}
+	if !runtimeRequestIDPattern.MatchString(request.RequestID) {
+		return GrantRootsRequest{}, errors.New("request_id must be a canonical lowercase identifier")
+	}
+	if len(request.Roots) < 1 || len(request.Roots) > maximumRuntimeGrantRoots {
+		return GrantRootsRequest{}, fmt.Errorf("grant requires between 1 and %d roots", maximumRuntimeGrantRoots) // refusal:by-design operator-knowledge: only the caller knows which repository roots this change needs; retry with a bounded non-empty root list
+	}
+	canonical := make([]string, 0, len(request.Roots))
+	seen := make(map[string]struct{}, len(request.Roots))
+	for _, root := range request.Roots {
+		if err := validateRuntimeText(root, 4096); err != nil {
+			return GrantRootsRequest{}, fmt.Errorf("invalid grant root: %w", err)
+		}
+		resolved, err := filepath.Abs(root)
+		if err == nil {
+			resolved, err = filepath.EvalSymlinks(resolved)
+		}
+		if err != nil {
+			return GrantRootsRequest{}, fmt.Errorf("resolve grant root %s: %w", pathquote.Quote(root), err)
+		}
+		if err := validateRuntimeText(resolved, 4096); err != nil {
+			return GrantRootsRequest{}, fmt.Errorf("invalid canonical grant root: %w", err)
+		}
+		if _, duplicate := seen[resolved]; duplicate {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		canonical = append(canonical, resolved)
+	}
+	request.Roots = canonical
+	if err := validateRuntimeText(request.Reason, 500); err != nil {
+		return GrantRootsRequest{}, fmt.Errorf("invalid grant reason: %w", err)
+	}
+	if err := validateRuntimeText(request.Actor, 128); err != nil {
+		return GrantRootsRequest{}, fmt.Errorf("invalid grant actor: %w", err)
 	}
 	return request, nil
 }

--- a/internal/sddstatus/runtime_ledger_grant_test.go
+++ b/internal/sddstatus/runtime_ledger_grant_test.go
@@ -1,0 +1,213 @@
+package sddstatus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRuntimeLedgerGrantCommitsAndProjectsGrantedRoots is #2540 S2's core
+// round-trip: a committed grant projects its canonical absolute
+// symlink-evaluated roots into RuntimeStatus.GrantedRoots, and a second
+// grant chains and accumulates.
+func TestRuntimeLedgerGrantCommitsAndProjectsGrantedRoots(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "grant-roots")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sibling, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "sibling-link")
+	if err := os.Symlink(sibling, link); err != nil {
+		t.Fatal(err)
+	}
+
+	// The caller passes the SYMLINK path; the recorded and projected root must
+	// be the canonical evaluated target, following BeginWorktree's precedent.
+	granted, err := store.Grant(context.Background(), GrantRootsRequest{
+		ExpectedRevision: "", RequestID: "grant-1", Roots: []string{link},
+		Reason: "maintainer authorized sibling repository edits", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("grant refused: %v", err)
+	}
+	if len(granted.GrantedRoots) != 1 || granted.GrantedRoots[0] != sibling ||
+		granted.Revision == "" || countRuntimeRecords(t, store.Dir) != 1 {
+		t.Fatalf("granted status = %#v records=%d, want one chained record granting %q",
+			granted, countRuntimeRecords(t, store.Dir), sibling)
+	}
+
+	// Status() replays the persisted chain: the projection round-trips.
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.GrantedRoots) != 1 || status.GrantedRoots[0] != sibling {
+		t.Fatalf("replayed granted roots = %#v, want [%q]", status.GrantedRoots, sibling)
+	}
+
+	// A second grant chains PreviousRevision on the first and accumulates,
+	// deduplicating the already-granted root.
+	second, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	accumulated, err := store.Grant(context.Background(), GrantRootsRequest{
+		ExpectedRevision: granted.Revision, RequestID: "grant-2", Roots: []string{second, sibling},
+		Reason: "maintainer widened the change to a second sibling", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("second grant refused: %v", err)
+	}
+	if len(accumulated.GrantedRoots) != 2 || accumulated.GrantedRoots[0] != sibling ||
+		accumulated.GrantedRoots[1] != second || countRuntimeRecords(t, store.Dir) != 2 {
+		t.Fatalf("accumulated granted roots = %#v records=%d, want [%q %q] over 2 records",
+			accumulated.GrantedRoots, countRuntimeRecords(t, store.Dir), sibling, second)
+	}
+}
+
+// TestRuntimeLedgerGrantDuplicateRequestIsIdempotent proves the sibling-event
+// RequestID/RequestDigest contract: an exact replay returns the committed
+// revision without a new record; reuse with different inputs is refused.
+func TestRuntimeLedgerGrantDuplicateRequestIsIdempotent(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "grant-idempotent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := GrantRootsRequest{
+		ExpectedRevision: "", RequestID: "grant-once", Roots: []string{root},
+		Reason: "maintainer authorized sibling repository edits", Actor: "maintainer",
+	}
+	granted, err := store.Grant(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replayed, err := store.Grant(context.Background(), request)
+	if err != nil || replayed.Revision != granted.Revision || countRuntimeRecords(t, store.Dir) != 1 {
+		t.Fatalf("grant replay = %#v err=%v records=%d, want committed revision %q and 1 record",
+			replayed, err, countRuntimeRecords(t, store.Dir), granted.Revision)
+	}
+
+	other, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Roots = []string{other}
+	if _, err := store.Grant(context.Background(), request); !errors.Is(err, ErrRuntimeRequestConflict) {
+		t.Fatalf("conflicting grant reuse = %v, want ErrRuntimeRequestConflict", err)
+	}
+}
+
+// TestRuntimeLedgerGrantReplayRefusesForgedWidenedRecord is the
+// runtimeRescopeEvent forgery pattern applied to grants: widened Roots no
+// longer match the RequestDigest the original request bound, so replay's
+// digest recompute refuses the chain.
+func TestRuntimeLedgerGrantReplayRefusesForgedWidenedRecord(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "grant-forged-replay")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := GrantRootsRequest{
+		ExpectedRevision: "", RequestID: "grant-forge-1", Roots: []string{root},
+		Reason: "maintainer authorized one sibling repository", Actor: "maintainer",
+	}
+	granted, err := store.Grant(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Forged: the record claims the SAME request granted a widened root set,
+	// keeping the digest the original single-root request produced.
+	widened, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.ExpectedRevision, request.RequestID = granted.Revision, "grant-forge-2"
+	forgedRecord := runtimeRecord{
+		Schema: runtimeRecordSchema, Change: store.Change, PreviousRevision: granted.Revision,
+		Operation: runtimeOperationGrant, RequestID: request.RequestID,
+		RequestDigest: runtimeValueHash("gentle-ai.sdd-runtime-grant-request/v1", request),
+		Grant: &runtimeGrantEvent{
+			Roots: []string{root, widened}, Actor: "attacker",
+			Reason: "forged widened grant", GrantedAt: "2026-08-05T00:00:00Z",
+		},
+	}
+	revision, payload, err := runtimeRecordRevision(forgedRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ensureDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishRecord(revision, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishHead(revision); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Status(); err == nil || !strings.Contains(err.Error(), "grant request digest does not match record") {
+		t.Fatalf("replay of forged widened grant = %v, want the digest-recompute rejection", err)
+	}
+}
+
+// TestRuntimeLedgerLegacyChainWithoutGrantsReplaysUnchanged pins the phase-1
+// compatibility constraint: a chain recorded before grant records existed
+// replays exactly as before, projects no granted roots, and serializes no
+// granted_roots member (omitempty is load-bearing).
+func TestRuntimeLedgerLegacyChainWithoutGrantsReplaysUnchanged(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "grant-legacy-chain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "legacy-begin-1", WorkUnit: "legacy-scope",
+		EvidenceGoal: "prove grant-free chains replay unchanged", MaxAttempts: 2, MaxChangedLines: 100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	finished, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "legacy-finish-1", Outcome: AttemptInterrupted,
+		EvidenceRevision: runtimeTestHash('7'), Diagnosis: "interrupted with the workspace unchanged",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "no executor process was ever spawned",
+		ProcessEvidence: "pre-launch process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finished.GrantedRoots != nil {
+		t.Fatalf("grant-free chain projected granted roots: %#v", finished.GrantedRoots)
+	}
+	status, err := store.Status()
+	if err != nil {
+		t.Fatalf("grant-free chain replay = %v, want unchanged success", err)
+	}
+	payload, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(payload), "granted_roots") {
+		t.Fatalf("grant-free status serialized a granted_roots member: %s", payload)
+	}
+}


### PR DESCRIPTION
Slice 2 of #2540 (design comment and phase-1 report on the parent issue). Adds the per-change grant record to the SDD runtime ledger and its projection. Recording and projection only: no CLI verb, no AllowedEditRoots consumption, no consent envelope, no archive containment. Those are later slices (S3, S4a/S4b, S5).

Closes #2548
Refs #2540

## What this adds

- `authority/grant` ledger operation with `runtimeGrantEvent`: `Roots []string` (canonical absolute symlink-evaluated, following the `BeginWorktree` canonicalization precedent), `Actor`, `Reason`, `GrantedAt`.
- `GrantRootsRequest` with the sibling-event contract: `RequestID`/`RequestDigest` idempotency and `PreviousRevision` chaining through the same `mutate` CAS path every other event uses.
- Shape validation and replay application; `RuntimeStatus.GrantedRoots []string` accumulates canonical roots in chain order, deduplicated, `omitempty`.
- `RuntimeStore.Grant` and `normalizeGrantRootsRequest` enter the deadcode baseline: exported API exercised only by tests until S3 wires the `sdd-attempt grant` verb.

## Phase-1 constraints honored

- `GrantedAt` is the ledger's first wall-clock field. It is digest-safe (the content-addressed record revision binds it immutably) but excluded from the request digest and from determinism-replay expectations: replay validates only that it parses, and never recomputes it or compares it against a clock.
- Legacy chains without grant records replay unchanged, project no `GrantedRoots`, and serialize no `granted_roots` member (pinned by test).
- A forged or widened grant record fails replay exactly like forged sibling events, via the `runtimeRescopeEvent` pattern: replay recomputes the request digest from the persisted event's `Roots`/`Reason`/`Actor` plus the record's own chain identity, so a record whose roots were widened after publication no longer matches its bound `RequestDigest` and the chain is refused instead of projecting authority nobody granted.

## RED first

All four tests were written and run before any implementation. Verbatim RED output:

```text
# github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus [github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus.test]
internal/sddstatus/runtime_ledger_grant_test.go:35:24: store.Grant undefined (type RuntimeStore has no field or method Grant)
internal/sddstatus/runtime_ledger_grant_test.go:35:52: undefined: GrantRootsRequest
internal/sddstatus/runtime_ledger_grant_test.go:54:16: status.GrantedRoots undefined (type RuntimeStatus has no field or method GrantedRoots)
internal/sddstatus/runtime_ledger_grant_test.go:55:62: status.GrantedRoots undefined (type RuntimeStatus has no field or method GrantedRoots)
internal/sddstatus/runtime_ledger_grant_test.go:64:28: store.Grant undefined (type RuntimeStore has no field or method Grant)
internal/sddstatus/runtime_ledger_grant_test.go:64:56: undefined: GrantRootsRequest
internal/sddstatus/runtime_ledger_grant_test.go:93:13: undefined: GrantRootsRequest
internal/sddstatus/runtime_ledger_grant_test.go:97:24: store.Grant undefined (type RuntimeStore has no field or method Grant)
internal/sddstatus/runtime_ledger_grant_test.go:102:25: store.Grant undefined (type RuntimeStore has no field or method Grant)
internal/sddstatus/runtime_ledger_grant_test.go:114:21: store.Grant undefined (type RuntimeStore has no field or method Grant)
internal/sddstatus/runtime_ledger_grant_test.go:114:21: too many errors
FAIL    github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus [build failed]
FAIL
```

GREEN after implementation:

- `TestRuntimeLedgerGrantCommitsAndProjectsGrantedRoots`: grant through a symlink projects the evaluated target; `Status()` round-trips; a second grant chains and accumulates with dedup.
- `TestRuntimeLedgerGrantDuplicateRequestIsIdempotent`: exact replay returns the committed revision with no new record; request-id reuse with different roots is `ErrRuntimeRequestConflict`.
- `TestRuntimeLedgerGrantReplayRefusesForgedWidenedRecord`: a published record claiming the same request granted a widened root set fails replay with the digest-recompute rejection.
- `TestRuntimeLedgerLegacyChainWithoutGrantsReplaysUnchanged`: a grant-free begin/finish chain replays cleanly with no `granted_roots` member.

## Verification (all foreground)

- `gofmt -l internal/` clean, `go vet ./...` clean (root and bench)
- `go test ./... -count=1` at root: all packages pass
- `go test ./... -count=1` in `bench/`: pass
- `scripts/deadcode-ratchet.sh`: no new unreachable functions (two baselined entries, named above)
- Refusal-resolution ratchet (`TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`): pass; the one new no-command refusal is annotated `refusal:by-design operator-knowledge`

Diff is 399 changed lines (389 insertions, 10 deletions).

## Known Overlaps

- Open PR #2072 (slop label) also rewrites `internal/sddstatus/runtime_ledger.go`. The maintainer ruled this overlap acceptable for this slice; proceeding was explicitly authorized.
- The `.deadcode-baseline.txt` addition may conflict trivially with #2516's baseline removals; resolution is a one-line union.
