### PR TITLE
feat(cli): add sdd-attempt grant fronting the ledger grant event (S3 of #2540)

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -201,8 +201,6 @@ internal/sddstatus/legacy_binding_read.go	parseLegacyBinding
 internal/sddstatus/review_binding.go	bindingPath
 internal/sddstatus/review_door.go	resetReviewEntryHookCallCountForTest
 internal/sddstatus/review_door.go	reviewEntryHookCallCountForTest
-internal/sddstatus/runtime_ledger.go	RuntimeStore.Grant
-internal/sddstatus/runtime_ledger.go	normalizeGrantRootsRequest
 internal/sddstatus/runtime_receipt.go	ReceiptRevisionConflictError.Error
 internal/sddstatus/runtime_receipt.go	RuntimeStore.readLegacyReceiptRef
 internal/sddstatus/runtime_receipt.go	RuntimeStore.recordPreparedReceipt

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -13,8 +13,8 @@ import (
 )
 
 // RunSDDAttempt exposes the artifact-store-agnostic native runtime authority.
-// Legacy operations emit RuntimeStatus; acquire and settle emit its bounded
-// orchestration projection.
+// Legacy operations and grant emit RuntimeStatus; acquire and settle emit its
+// bounded orchestration projection.
 func RunSDDAttempt(args []string, stdout io.Writer) error {
 	return runSDDAttempt(context.Background(), args, stdout)
 }
@@ -53,6 +53,8 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	remediatesEvidenceRevision := flags.String("remediates-evidence-revision", "", "failed evidence revision repaired by the successor")
 	reason := flags.String("reason", "", "explicit objective reset reason")
 	actor := flags.String("actor", "", "explicit reset actor")
+	var roots sddAttemptRootList
+	flags.Var(&roots, "root", "repository root receiving per-change edit authority (repeatable)")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
 	}
@@ -152,6 +154,18 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
 			SuccessorLineageID: *successorLineage, RemediatesEvidenceRevision: *remediatesEvidenceRevision,
 		})
+	case "grant":
+		// --expected-revision stays optional, unlike begin/finish/reset: the
+		// S2 ledger API admits an empty CAS token (normalizeGrantRootsRequest,
+		// "empty or sha256"), which matches exactly the fresh pre-attempt
+		// ledger the consent flow grants against; a later widening grant
+		// chains the exact committed revision like every sibling mutation.
+		if missing := missingSDDAttemptFlags(args[1:], "root", "request-id", "actor", "reason"); len(missing) != 0 {
+			return fmt.Errorf("sdd-attempt grant requires %s; rerun `gentle-ai sdd-attempt grant` with those missing flags", strings.Join(missing, ", "))
+		}
+		result, err = store.Grant(ctx, sddstatus.GrantRootsRequest{
+			ExpectedRevision: *expected, RequestID: *requestID, Roots: roots, Reason: *reason, Actor: *actor,
+		})
 	}
 	if err != nil {
 		return fmt.Errorf("sdd-attempt %s: %w", operation, err)
@@ -167,7 +181,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 // accepted values and the values a message names can never drift apart.
 // Mirrors reviewIntegrationGatesInOrder / reviewIntegrationGateNames in
 // review_operation_contract.go.
-var sddAttemptOperationsInOrder = []string{"status", "begin", "finish", "reset", "rescope", "acquire", "settle"}
+var sddAttemptOperationsInOrder = []string{"status", "begin", "finish", "reset", "rescope", "acquire", "settle", "grant"}
 
 func validSDDAttemptOperation(operation string) bool {
 	for _, valid := range sddAttemptOperationsInOrder {
@@ -204,6 +218,7 @@ func validateSDDAttemptOperationFlags(operation string, args []string) error {
 		"rescope": {"expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor"},
 		"acquire": {"request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "token"},
 		"settle":  {"token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "successor-lineage", "remediates-evidence-revision"},
+		"grant":   {"expected-revision", "request-id", "root", "actor", "reason"},
 	}[operation] {
 		allowed[name] = true
 	}
@@ -252,4 +267,18 @@ func missingSDDAttemptFlags(args []string, names ...string) []string {
 func presentSDDAttemptFlags(args []string, names ...string) int {
 	present := len(names) - len(missingSDDAttemptFlags(args, names...))
 	return present
+}
+
+// sddAttemptRootList is grant's repeatable --root flag (#2540 S3). stdlib
+// flag has no repeatable string flag, so the bounded multi-root grant shape
+// needs this minimal flag.Value: each occurrence appends in caller order, and
+// the ledger owns canonicalization, deduplication, and the bounded count
+// (normalizeGrantRootsRequest).
+type sddAttemptRootList []string
+
+func (roots *sddAttemptRootList) String() string { return strings.Join(*roots, ", ") }
+
+func (roots *sddAttemptRootList) Set(value string) error {
+	*roots = append(*roots, value)
+	return nil
 }

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -108,11 +108,11 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "missing operation", args: nil, want: "requires status, begin, finish, reset, rescope, acquire, or settle"},
+		{name: "missing operation", args: nil, want: "requires status, begin, finish, reset, rescope, acquire, settle, or grant"},
 		// The no-args refusal already enumerates every valid operation; the
 		// unknown-operation refusal must do the same instead of naming only
 		// the bad value with no route to the valid set.
-		{name: "unknown operation", args: []string{"begn"}, want: `unknown sdd-attempt operation "begn"; want one of status, begin, finish, reset, rescope, acquire, or settle`},
+		{name: "unknown operation", args: []string{"begn"}, want: `unknown sdd-attempt operation "begn"; want one of status, begin, finish, reset, rescope, acquire, settle, or grant`},
 		{name: "missing change", args: []string{"status", "--cwd", repo}, want: "--change"},
 		{name: "unknown flag", args: []string{"status", "--cwd", repo, "--change", "thin", "--mystery"}, want: "flag provided but not defined"},
 		{name: "irrelevant flag", args: []string{"status", "--cwd", repo, "--change", "thin", "--outcome", "failed"}, want: "flag provided but not defined"},
@@ -121,6 +121,11 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 		{name: "missing finish evidence", args: []string{"finish", "--cwd", repo, "--change", "thin", "--expected-revision", cliAttemptHash('b'), "--request-id", "finish", "--outcome", "failed", "--diagnosis", "diagnosis", "--harness-disposition", "reused", "--cleanup-evidence", "cleanup", "--process-evidence", "process"}, want: "--evidence-revision"},
 		{name: "partial remediation successor", args: []string{"finish", "--cwd", repo, "--change", "thin", "--expected-revision", cliAttemptHash('b'), "--request-id", "finish", "--outcome", "passed", "--evidence-revision", cliAttemptHash('c'), "--diagnosis", "diagnosis", "--harness-disposition", "reused", "--cleanup-evidence", "cleanup", "--process-evidence", "process", "--successor-lineage", "review-successor"}, want: "remediation successor requires --expected-binding-revision, --successor-lineage, and --remediates-evidence-revision together"},
 		{name: "positional argument", args: []string{"status", "--cwd", repo, "--change", "thin", "extra"}, want: "unexpected sdd-attempt argument"},
+		// Grant's missing-flag refusal follows acquire/settle: it enumerates
+		// every missing flag and names the rerunnable continuation.
+		{name: "missing grant roots", args: []string{"grant", "--cwd", repo, "--change", "thin", "--request-id", "grant", "--actor", "maintainer", "--reason", "rollout"}, want: "sdd-attempt grant requires --root; rerun `gentle-ai sdd-attempt grant` with those missing flags"},
+		{name: "missing grant audit fields", args: []string{"grant", "--cwd", repo, "--change", "thin", "--root", repo}, want: "sdd-attempt grant requires --request-id, --actor, --reason"},
+		{name: "irrelevant grant flag", args: []string{"grant", "--cwd", repo, "--change", "thin", "--root", repo, "--request-id", "grant", "--actor", "maintainer", "--reason", "rollout", "--work-unit", "unit"}, want: "flag provided but not defined"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -140,7 +145,7 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 // all four). Mirrors the reviewIntegrationGatesInOrder /
 // reviewIntegrationGateNames pattern in review_operation_contract.go.
 func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T) {
-	want := []string{"status", "begin", "finish", "reset", "rescope", "acquire", "settle"}
+	want := []string{"status", "begin", "finish", "reset", "rescope", "acquire", "settle", "grant"}
 	if !reflect.DeepEqual(sddAttemptOperationsInOrder, want) {
 		t.Fatalf("sddAttemptOperationsInOrder = %v, want %v", sddAttemptOperationsInOrder, want)
 	}
@@ -152,8 +157,62 @@ func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T)
 	if validSDDAttemptOperation("begn") {
 		t.Fatal(`validSDDAttemptOperation("begn") = true, want false`)
 	}
-	if got := joinSDDAttemptOperations(); got != "status, begin, finish, reset, rescope, acquire, or settle" {
-		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, reset, rescope, acquire, or settle")
+	if got := joinSDDAttemptOperations(); got != "status, begin, finish, reset, rescope, acquire, settle, or grant" {
+		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, reset, rescope, acquire, settle, or grant")
+	}
+}
+
+// TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI is the CLI dispatch
+// proof for the `grant` operation (#2540 S3): a first grant on a fresh ledger
+// needs no --expected-revision (the S2 API admits an empty CAS token against
+// an empty chain), the persisted roots round-trip through `sdd-attempt
+// status`, an exact duplicate --request-id replays the committed revision
+// idempotently, and a second grant chains --expected-revision on the first
+// and accumulates roots in grant order, deduplicating already-granted ones.
+func TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	change := "cli-grant"
+	sibling, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grantArgs := []string{
+		"grant", "--cwd", repo, "--change", change, "--root", sibling,
+		"--actor", "maintainer", "--reason", "sequential multi-repository rollout", "--request-id", "cli-grant-1",
+	}
+	granted := runSDDAttemptStatus(t, grantArgs)
+	if len(granted.GrantedRoots) != 1 || granted.GrantedRoots[0] != sibling || granted.Revision == "" {
+		t.Fatalf("grant CLI status = %#v, want granted root %q with a committed revision", granted, sibling)
+	}
+
+	// Status replays the persisted chain: the grant survives the process
+	// boundary between the mutating call and a later read.
+	status := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	if !reflect.DeepEqual(status.GrantedRoots, []string{sibling}) || status.Revision != granted.Revision {
+		t.Fatalf("post-grant CLI status = %#v, want granted roots [%q] at revision %s", status, sibling, granted.Revision)
+	}
+
+	// An exact duplicate request-id is idempotent through the CLI: same
+	// committed revision, no second record.
+	replayed := runSDDAttemptStatus(t, grantArgs)
+	if replayed.Revision != granted.Revision || !reflect.DeepEqual(replayed.GrantedRoots, []string{sibling}) {
+		t.Fatalf("grant CLI replay = %#v, want committed revision %s", replayed, granted.Revision)
+	}
+
+	// A second grant chains on the first revision, accumulates the new root
+	// after the already-granted one, and deduplicates the repeat.
+	second, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	accumulated := runSDDAttemptStatus(t, []string{
+		"grant", "--cwd", repo, "--change", change, "--expected-revision", granted.Revision,
+		"--root", second, "--root", sibling,
+		"--actor", "maintainer", "--reason", "maintainer widened the change to a second sibling", "--request-id", "cli-grant-2",
+	})
+	if !reflect.DeepEqual(accumulated.GrantedRoots, []string{sibling, second}) {
+		t.Fatalf("accumulated CLI granted roots = %#v, want [%q %q]", accumulated.GrantedRoots, sibling, second)
 	}
 }
 


### PR DESCRIPTION
Closes #2556. Refs #2540 (parent, S3 of the slice plan) and PR #2555 (S4a provisional pin).

## What

Adds the `grant` operation to the `sdd-attempt` CLI family, fronting the S2 ledger grant event (`RuntimeStore.Grant`, merged via PR #2553):

- `sddAttemptOperationsInOrder` gains `grant`; both enumeration refusals pick it up automatically from the single ordered source.
- `validateSDDAttemptOperationFlags` allows `--expected-revision --request-id --root --actor --reason` for grant.
- Repeatable `--root` via a minimal custom `flag.Value` (`sddAttemptRootList`); the ledger owns canonicalization, dedup, and the bounded count (`normalizeGrantRootsRequest`).
- Missing-flag refusal follows the acquire/settle continuation shape, satisfying the refusal-resolution ratchet: ``sdd-attempt grant requires --root; rerun `gentle-ai sdd-attempt grant` with those missing flags``.
- Wiring the real caller made `RuntimeStore.Grant` and `normalizeGrantRootsRequest` reachable; their two baselined deadcode entries are removed (`scripts/deadcode-ratchet.sh --update`, diff shrinks by exactly those 2 lines).

## Flag decision: `--expected-revision` is accepted but OPTIONAL

The S2 ledger API is the source of truth: `normalizeGrantRootsRequest` admits "empty or sha256" for the CAS token, and S2's own tests grant with `""` on a fresh chain and chain the exact committed revision for the widening grant. The empty token matches exactly the fresh pre-attempt ledger the consent flow grants against; a later widening grant chains `--expected-revision` like every sibling mutation. Begin/finish/reset REQUIRE the flag because their normalizers refuse an empty token; grant's deliberately does not.

## S4a coordination (PR #2555 NOT merged at branch time)

Per the issue, the pinned fixture, schema regex, and `sddConsentGrantInvocationShape` are untouched. Final flag set for the S4a rebase:

- Required: `--cwd <repo> --change <name> --root <path>...` (repeatable) `--actor <actor> --reason <reason> --request-id <id>`
- Optional: `--expected-revision <sha256>` (empty admits only the fresh chain)

The provisional pin `gentle-ai sdd-attempt grant --cwd <repo> --change <name> --root <path>... --actor <actor> --reason <reason>` does NOT carry `--request-id`, which the ledger requires for idempotency identity (`request_id must be a canonical lowercase identifier`). The S4a envelope's granted invocation must append `--request-id <id>` (and update the regex to `--reason \S+ --request-id \S+` or equivalent), or the relayed invocation will be refused by the real verb.

## RED (verbatim, before the switch case existed)

```
--- FAIL: TestRunSDDAttemptRejectsMissingOrAmbiguousInputs (0.04s)
    --- FAIL: TestRunSDDAttemptRejectsMissingOrAmbiguousInputs/missing_operation (0.00s)
        sdd_attempt_test.go:135: RunSDDAttempt([]) = output "", err sdd-attempt requires status, begin, finish, reset, rescope, acquire, or settle, want "requires status, begin, finish, reset, rescope, acquire, settle, or grant"
    --- FAIL: TestRunSDDAttemptRejectsMissingOrAmbiguousInputs/missing_grant_roots (0.00s)
        sdd_attempt_test.go:135: ... err unknown sdd-attempt operation "grant"; want one of status, begin, finish, reset, rescope, acquire, or settle, want "sdd-attempt grant requires --root; rerun `gentle-ai sdd-attempt grant` with those missing flags"
    --- FAIL: TestRunSDDAttemptRejectsMissingOrAmbiguousInputs/missing_grant_audit_fields (0.00s)
    --- FAIL: TestRunSDDAttemptRejectsMissingOrAmbiguousInputs/irrelevant_grant_flag (0.00s)
--- FAIL: TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently (0.00s)
    sdd_attempt_test.go:150: sddAttemptOperationsInOrder = [status begin finish reset rescope acquire settle], want [status begin finish reset rescope acquire settle grant]
--- FAIL: TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI (0.01s)
    sdd_attempt_test.go:184: RunSDDAttempt([grant --cwd ... --root ... --actor maintainer --reason sequential multi-repository rollout --request-id cli-grant-1]): unknown sdd-attempt operation "grant"; want one of status, begin, finish, reset, rescope, acquire, or settle
FAIL	github.com/gentleman-programming/gentle-ai/v2/internal/cli	0.084s
```

## Built-binary transcript (scratch planning repo + two sibling repos)

```
== missing-flag refusal ==
Error: sdd-attempt grant requires --root; rerun `gentle-ai sdd-attempt grant` with those missing flags
== first grant (fresh ledger, no --expected-revision) ==
  "revision": "sha256:cdc26f0dc051ba3bf8066554d67d04e4f1b169b50582028d8b99d6d76fda213b",
  "granted_roots": [
    ".../proof/service-a"
  ],
== status round-trip (separate process) ==
  "revision": "sha256:cdc26f0dc051ba3bf8066554d67d04e4f1b169b50582028d8b99d6d76fda213b",
  "granted_roots": [
    ".../proof/service-a"
  ],
== duplicate request-id idempotent ==
  "revision": "sha256:cdc26f0dc051ba3bf8066554d67d04e4f1b169b50582028d8b99d6d76fda213b",
== chained second grant (--expected-revision, repeatable --root, dedup) ==
  "granted_roots": [
    ".../proof/service-a",
    ".../proof/service-b"
  ],
```

## Verification (all foreground)

- `go test ./... -count=1` at root: pass
- `go test ./... -count=1` in `bench/`: pass
- `gofmt -l internal/cli`: clean; `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: "no new unreachable functions", 2 baselined entries tightened away
- Refusal-resolution ratchet (`TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`): pass, new refusal names its continuation

Out of scope, per the slice plan: status/AllowedEditRoots consumption (S4b), archive containment (S5, `runtime_ledger.go` untouched), consent envelope files (S4a, PR #2555).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `grant` operation to the `sdd-attempt` command.
  * Supports multiple root paths, request metadata, and optional expected revisions.
  * Grant records can be replayed safely and linked through revision history.
  * Duplicate roots are automatically handled consistently.

* **Bug Fixes**
  * Improved command validation and error reporting for grant arguments and supported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->