### PR TITLE
fix(sdd): archived-name reuse must not resurrect granted roots (S5 of #2540)

### DIFF
--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -55,6 +55,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	actor := flags.String("actor", "", "explicit reset actor")
 	var roots sddAttemptRootList
 	flags.Var(&roots, "root", "repository root receiving per-change edit authority (repeatable)")
+	changeInstance := flags.String("change-instance", "", "opaque caller-owned change-instance identity; mint one token per change instance, reuse that exact token for widening grants within the same change lifecycle, and mint a fresh one for a recreated change so an archived name's grants never resurrect (required for grant; optional projection scope for status)")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
 	}
@@ -69,6 +70,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	// own.
 	*expected = strings.TrimSpace(*expected)
 	*token = strings.TrimSpace(*token)
+	*changeInstance = strings.TrimSpace(*changeInstance)
 	*evidenceRevision = strings.TrimSpace(*evidenceRevision)
 	*expectedBindingRevision = strings.TrimSpace(*expectedBindingRevision)
 	*remediatesEvidenceRevision = strings.TrimSpace(*remediatesEvidenceRevision)
@@ -91,6 +93,15 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	var result any
 	switch operation {
 	case "status":
+		// An optional --change-instance scopes the granted-roots projection
+		// to that instance (#2540 S5); without it, status projects no granted
+		// roots at all, which is the conservative containment for readers
+		// that have not declared which change instance they serve.
+		if *changeInstance != "" {
+			if store, err = store.ForInstance(*changeInstance); err != nil {
+				return fmt.Errorf("sdd-attempt status: %w", err)
+			}
+		}
 		result, err = store.Status()
 	case "begin":
 		if missing := missingSDDAttemptFlags(args[1:], "expected-revision", "request-id", "work-unit", "evidence-goal"); len(missing) != 0 {
@@ -160,10 +171,20 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 		// "empty or sha256"), which matches exactly the fresh pre-attempt
 		// ledger the consent flow grants against; a later widening grant
 		// chains the exact committed revision like every sibling mutation.
-		if missing := missingSDDAttemptFlags(args[1:], "root", "request-id", "actor", "reason"); len(missing) != 0 {
+		if missing := missingSDDAttemptFlags(args[1:], "root", "change-instance", "request-id", "actor", "reason"); len(missing) != 0 {
 			return fmt.Errorf("sdd-attempt grant requires %s; rerun `gentle-ai sdd-attempt grant` with those missing flags", strings.Join(missing, ", "))
 		}
-		result, err = store.Grant(ctx, sddstatus.GrantRootsRequest{
+		// The grant binds the caller-owned change-instance identity (#2540
+		// S5): the ledger digest-binds it into the record and replay projects
+		// the grant only for the same identity, so an archived name's reuse
+		// cannot resurrect it. Until S4b derives markers natively, the caller
+		// mints the opaque token and must reuse it for widening grants within
+		// this change's lifecycle.
+		var grantStore sddstatus.RuntimeStore
+		if grantStore, err = store.ForInstance(*changeInstance); err != nil {
+			return fmt.Errorf("sdd-attempt grant: %w", err)
+		}
+		result, err = grantStore.Grant(ctx, sddstatus.GrantRootsRequest{
 			ExpectedRevision: *expected, RequestID: *requestID, Roots: roots, Reason: *reason, Actor: *actor,
 		})
 	}
@@ -218,7 +239,8 @@ func validateSDDAttemptOperationFlags(operation string, args []string) error {
 		"rescope": {"expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor"},
 		"acquire": {"request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "token"},
 		"settle":  {"token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "successor-lineage", "remediates-evidence-revision"},
-		"grant":   {"expected-revision", "request-id", "root", "actor", "reason"},
+		"grant":   {"expected-revision", "request-id", "root", "change-instance", "actor", "reason"},
+		"status":  {"change-instance"},
 	}[operation] {
 		allowed[name] = true
 	}

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -123,9 +123,9 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 		{name: "positional argument", args: []string{"status", "--cwd", repo, "--change", "thin", "extra"}, want: "unexpected sdd-attempt argument"},
 		// Grant's missing-flag refusal follows acquire/settle: it enumerates
 		// every missing flag and names the rerunnable continuation.
-		{name: "missing grant roots", args: []string{"grant", "--cwd", repo, "--change", "thin", "--request-id", "grant", "--actor", "maintainer", "--reason", "rollout"}, want: "sdd-attempt grant requires --root; rerun `gentle-ai sdd-attempt grant` with those missing flags"},
-		{name: "missing grant audit fields", args: []string{"grant", "--cwd", repo, "--change", "thin", "--root", repo}, want: "sdd-attempt grant requires --request-id, --actor, --reason"},
-		{name: "irrelevant grant flag", args: []string{"grant", "--cwd", repo, "--change", "thin", "--root", repo, "--request-id", "grant", "--actor", "maintainer", "--reason", "rollout", "--work-unit", "unit"}, want: "flag provided but not defined"},
+		{name: "missing grant roots", args: []string{"grant", "--cwd", repo, "--change", "thin", "--change-instance", "instance-token", "--request-id", "grant", "--actor", "maintainer", "--reason", "rollout"}, want: "sdd-attempt grant requires --root; rerun `gentle-ai sdd-attempt grant` with those missing flags"},
+		{name: "missing grant instance and audit fields", args: []string{"grant", "--cwd", repo, "--change", "thin", "--root", repo}, want: "sdd-attempt grant requires --change-instance, --request-id, --actor, --reason"},
+		{name: "irrelevant grant flag", args: []string{"grant", "--cwd", repo, "--change", "thin", "--root", repo, "--change-instance", "instance-token", "--request-id", "grant", "--actor", "maintainer", "--reason", "rollout", "--work-unit", "unit"}, want: "flag provided but not defined"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -163,22 +163,29 @@ func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T)
 }
 
 // TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI is the CLI dispatch
-// proof for the `grant` operation (#2540 S3): a first grant on a fresh ledger
-// needs no --expected-revision (the S2 API admits an empty CAS token against
-// an empty chain), the persisted roots round-trip through `sdd-attempt
-// status`, an exact duplicate --request-id replays the committed revision
-// idempotently, and a second grant chains --expected-revision on the first
-// and accumulates roots in grant order, deduplicating already-granted ones.
+// proof for the `grant` operation (#2540 S3) under #2557's instance-identity
+// containment: a first grant on a fresh ledger needs no --expected-revision
+// (the S2 API admits an empty CAS token against an empty chain) but always
+// needs --change-instance, the persisted roots round-trip through
+// `sdd-attempt status --change-instance`, an exact duplicate --request-id
+// replays the committed revision idempotently, and a second grant reusing
+// the SAME instance token chains --expected-revision on the first and
+// accumulates roots in grant order, deduplicating already-granted ones.
+// The interim contract before S4b derives markers natively: the caller
+// mints one opaque token per change instance and reuses that exact token
+// for widening grants within the change lifecycle; a different token (a
+// recreated change, or a reader that declares none) projects nothing.
 func TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	change := "cli-grant"
+	instance := "cli-grant-instance-token"
 	sibling, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	grantArgs := []string{
-		"grant", "--cwd", repo, "--change", change, "--root", sibling,
+		"grant", "--cwd", repo, "--change", change, "--root", sibling, "--change-instance", instance,
 		"--actor", "maintainer", "--reason", "sequential multi-repository rollout", "--request-id", "cli-grant-1",
 	}
 	granted := runSDDAttemptStatus(t, grantArgs)
@@ -186,11 +193,26 @@ func TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI(t *testing.T) {
 		t.Fatalf("grant CLI status = %#v, want granted root %q with a committed revision", granted, sibling)
 	}
 
-	// Status replays the persisted chain: the grant survives the process
-	// boundary between the mutating call and a later read.
-	status := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	// Status with the same instance token replays the persisted chain: the
+	// grant survives the process boundary between the mutating call and a
+	// later read that declares the instance it serves.
+	status := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change, "--change-instance", instance})
 	if !reflect.DeepEqual(status.GrantedRoots, []string{sibling}) || status.Revision != granted.Revision {
 		t.Fatalf("post-grant CLI status = %#v, want granted roots [%q] at revision %s", status, sibling, granted.Revision)
+	}
+
+	// Status WITHOUT an instance declaration projects no granted roots: the
+	// conservative containment for undeclared readers (#2557).
+	undeclared := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	if undeclared.GrantedRoots != nil {
+		t.Fatalf("undeclared-instance CLI status projected granted roots: %#v", undeclared.GrantedRoots)
+	}
+
+	// Status under a DIFFERENT instance token projects nothing either: a
+	// recreated change reusing this archived name inherits no authority.
+	recreated := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change, "--change-instance", "recreated-instance-token"})
+	if recreated.GrantedRoots != nil {
+		t.Fatalf("recreated-instance CLI status resurrected granted roots: %#v", recreated.GrantedRoots)
 	}
 
 	// An exact duplicate request-id is idempotent through the CLI: same
@@ -200,15 +222,16 @@ func TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI(t *testing.T) {
 		t.Fatalf("grant CLI replay = %#v, want committed revision %s", replayed, granted.Revision)
 	}
 
-	// A second grant chains on the first revision, accumulates the new root
-	// after the already-granted one, and deduplicates the repeat.
+	// A widening grant reusing the SAME instance token chains on the first
+	// revision, accumulates the new root after the already-granted one, and
+	// deduplicates the repeat.
 	second, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	accumulated := runSDDAttemptStatus(t, []string{
 		"grant", "--cwd", repo, "--change", change, "--expected-revision", granted.Revision,
-		"--root", second, "--root", sibling,
+		"--root", second, "--root", sibling, "--change-instance", instance,
 		"--actor", "maintainer", "--reason", "maintainer widened the change to a second sibling", "--request-id", "cli-grant-2",
 	})
 	if !reflect.DeepEqual(accumulated.GrantedRoots, []string{sibling, second}) {

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -366,6 +366,11 @@ type GrantRootsRequest struct {
 	Roots            []string `json:"roots"`
 	Reason           string   `json:"reason"`
 	Actor            string   `json:"actor"`
+	// ChangeInstance is filled by Grant from the store's own ForInstance
+	// identity (#2540 S5) so the request digest binds the exact instance the
+	// grant belongs to. A caller-supplied value must equal the store's; Grant
+	// refuses a mismatch rather than silently rebinding authority.
+	ChangeInstance string `json:"change_instance"`
 }
 
 // BindReviewRequest performs a binding-only compare-and-swap. The expected
@@ -402,6 +407,36 @@ type RuntimeStore struct {
 	// switch is not a disabled switch and resolves to false.
 	ReviewDisabled bool
 	commonDir      string
+	// instance is the change-instance identity this store session serves
+	// (#2540 S5). The ledger directory is keyed by change name alone and
+	// archive never touches it, so a future change reusing an archived name
+	// reopens the SAME chain: without an instance boundary, the archived
+	// change's grants would resurrect as workspace-permanent authority. The
+	// chain itself cannot observe that boundary — the genesis revision
+	// survives name reuse and a recreated change's first Begin is
+	// indistinguishable from a legitimate next-work-unit advance — so the
+	// identity is caller-owned and opaque here: ForInstance sets it, Grant
+	// binds it into each grant record's digest, and replay projects a grant
+	// into GrantedRoots only when the record's identity equals this one. The
+	// zero value is the conservative containment: a store opened without an
+	// instance identity projects no granted roots at all.
+	instance string
+}
+
+// ForInstance derives a store bound to one change-instance identity. The
+// value is opaque to the ledger; the caller (the status layer that also
+// derives the consent envelope) owns its meaning, which must be stable
+// across one change instance's life and distinct across recreations of the
+// same change name.
+func (store RuntimeStore) ForInstance(instance string) (RuntimeStore, error) {
+	if instance == "" {
+		return RuntimeStore{}, errors.New("change-instance identity must not be empty") // refusal:by-design operator-knowledge: only the caller knows the change instance this session serves; retry with the instance identity the status layer derived
+	}
+	if err := validateRuntimeText(instance, 128); err != nil {
+		return RuntimeStore{}, fmt.Errorf("invalid change-instance identity: %w", err)
+	}
+	store.instance = instance
+	return store, nil
 }
 
 type runtimeRecord struct {
@@ -437,6 +472,17 @@ type runtimeGrantEvent struct {
 	Actor     string   `json:"actor"`
 	Reason    string   `json:"reason"`
 	GrantedAt string   `json:"granted_at"`
+	// Instance is the change-instance identity this grant belongs to (#2540
+	// S5), digest-bound like Roots/Actor/Reason: a record whose identity was
+	// altered, stripped, or forged after publication no longer matches the
+	// bound RequestDigest, so replay refuses the chain. Replay projects the
+	// grant into GrantedRoots only for a store bound to the same identity,
+	// which is what makes an archived name's reuse unable to resurrect the
+	// archived change's authority. Required: no released writer ever emitted
+	// an instance-less grant record (RuntimeStore.Grant was unreachable
+	// between #2553 and this slice), so an empty value is a mutated record,
+	// not a legacy one.
+	Instance string `json:"instance"`
 }
 
 // runtimeAdvanceEvent accompanies the successor's begin event in one atomic
@@ -535,6 +581,10 @@ type runtimeReplay struct {
 	Status        RuntimeStatus
 	Requests      map[string]runtimeRequestReceipt
 	AttemptTokens map[int]string
+	// Instance carries the store's ForInstance identity into replay (#2540
+	// S5): applyRuntimeGrantEvent projects a grant into GrantedRoots only
+	// when the record's identity equals this one. Empty projects nothing.
+	Instance string
 }
 
 func OpenRuntimeStore(ctx context.Context, repo, change string) (RuntimeStore, error) {
@@ -1120,6 +1170,13 @@ var runtimeGrantClock = func() string { return time.Now().UTC().Format(time.RFC3
 // the CLI verb are later slices. A grant has no structural precondition,
 // because authorizing roots is orthogonal to attempt state.
 func (store RuntimeStore) Grant(ctx context.Context, request GrantRootsRequest) (RuntimeStatus, error) {
+	if store.instance == "" {
+		return RuntimeStatus{}, errors.New("grant requires a change-instance identity; derive the store with ForInstance first") // refusal:by-design operator-knowledge: only the caller knows which change instance this grant authorizes; derive the store with ForInstance and retry
+	}
+	if request.ChangeInstance != "" && request.ChangeInstance != store.instance {
+		return RuntimeStatus{}, errors.New("grant request change-instance does not equal the store's instance identity") // refusal:by-design operator-knowledge: the request and the store name different change instances; retry with one coherent instance identity
+	}
+	request.ChangeInstance = store.instance
 	request, err := normalizeGrantRootsRequest(request)
 	if err != nil {
 		return RuntimeStatus{}, err
@@ -1129,6 +1186,7 @@ func (store RuntimeStore) Grant(ctx context.Context, request GrantRootsRequest) 
 	return store.mutate(ctx, request.ExpectedRevision, request.RequestID, digest, func(runtimeReplay) (runtimeRecord, error) {
 		return runtimeRecord{Operation: runtimeOperationGrant, Grant: &runtimeGrantEvent{
 			Roots: request.Roots, Actor: request.Actor, Reason: request.Reason, GrantedAt: grantedAt,
+			Instance: request.ChangeInstance,
 		}}, nil
 	})
 }
@@ -1518,6 +1576,7 @@ func (store RuntimeStore) load() (runtimeReplay, error) {
 		},
 		Requests:      map[string]runtimeRequestReceipt{},
 		AttemptTokens: map[int]string{},
+		Instance:      store.instance,
 	}
 	head, exists, err := readRuntimeHead(filepath.Join(store.Dir, "HEAD"))
 	if err != nil || !exists {
@@ -1900,8 +1959,17 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 // identities. It has no structural precondition and returns no error: every
 // integrity guard a grant needs already ran in validateRuntimeRecordShape,
 // and a chain with no grant records never reaches it, so legacy chains
-// replay unchanged.
+// replay unchanged. A grant projects only into a replay bound to its own
+// change-instance identity (#2540 S5): the chain outlives the change it
+// served, so a recreated change reusing an archived name replays the same
+// records under a different identity and inherits none of its authority. A
+// replay without an identity — every reader that has not called ForInstance,
+// including the status.go embedding until S4b threads one — projects no
+// granted roots at all.
 func applyRuntimeGrantEvent(replay *runtimeReplay, event *runtimeGrantEvent) {
+	if replay.Instance == "" || event.Instance != replay.Instance {
+		return
+	}
 	for _, root := range event.Roots {
 		duplicate := false
 		for _, granted := range replay.Status.GrantedRoots {
@@ -2158,6 +2226,9 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			validateRuntimeText(event.Reason, 500) != nil || validateRuntimeText(event.Actor, 128) != nil {
 			return errors.New("invalid SDD runtime grant event") // refusal:by-design world-action: bounds and audit fields are enforced before publication, so a violation is a mutated record and the exit is restoring the store
 		}
+		if event.Instance == "" || validateRuntimeText(event.Instance, 128) != nil {
+			return errors.New("invalid SDD runtime grant change-instance identity") // refusal:by-design world-action: every writer binds the store's ForInstance identity before publication and no released writer ever emitted an instance-less grant, so a violation is a mutated record and the exit is restoring the store
+		}
 		seen := make(map[string]struct{}, len(event.Roots))
 		for _, root := range event.Roots {
 			if validateRuntimeText(root, 4096) != nil || !filepath.IsAbs(root) {
@@ -2177,6 +2248,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		request := GrantRootsRequest{
 			ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID,
 			Roots: event.Roots, Reason: event.Reason, Actor: event.Actor,
+			ChangeInstance: event.Instance,
 		}
 		if runtimeValueHash("gentle-ai.sdd-runtime-grant-request/v1", request) != record.RequestDigest {
 			return errors.New("SDD runtime grant request digest does not match record") // refusal:by-design world-action: the digest binds the granted roots at write time, so a widened or altered record fails this recompute and the exit is restoring the store
@@ -2374,6 +2446,12 @@ func normalizeGrantRootsRequest(request GrantRootsRequest) (GrantRootsRequest, e
 	}
 	if err := validateRuntimeText(request.Actor, 128); err != nil {
 		return GrantRootsRequest{}, fmt.Errorf("invalid grant actor: %w", err)
+	}
+	if request.ChangeInstance == "" {
+		return GrantRootsRequest{}, errors.New("grant requires a change-instance identity") // refusal:by-design operator-knowledge: only the caller knows which change instance this grant authorizes; derive the store with ForInstance and retry
+	}
+	if err := validateRuntimeText(request.ChangeInstance, 128); err != nil {
+		return GrantRootsRequest{}, fmt.Errorf("invalid grant change-instance identity: %w", err)
 	}
 	return request, nil
 }

--- a/internal/sddstatus/runtime_ledger_grant_test.go
+++ b/internal/sddstatus/runtime_ledger_grant_test.go
@@ -16,7 +16,11 @@ import (
 // grant chains and accumulates.
 func TestRuntimeLedgerGrantCommitsAndProjectsGrantedRoots(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
-	store, err := OpenRuntimeStore(context.Background(), repo, "grant-roots")
+	opened, err := OpenRuntimeStore(context.Background(), repo, "grant-roots")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := opened.ForInstance("grant-roots-instance")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +83,11 @@ func TestRuntimeLedgerGrantCommitsAndProjectsGrantedRoots(t *testing.T) {
 // revision without a new record; reuse with different inputs is refused.
 func TestRuntimeLedgerGrantDuplicateRequestIsIdempotent(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
-	store, err := OpenRuntimeStore(context.Background(), repo, "grant-idempotent")
+	opened, err := OpenRuntimeStore(context.Background(), repo, "grant-idempotent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := opened.ForInstance("grant-idempotent-instance")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +126,11 @@ func TestRuntimeLedgerGrantDuplicateRequestIsIdempotent(t *testing.T) {
 // digest recompute refuses the chain.
 func TestRuntimeLedgerGrantReplayRefusesForgedWidenedRecord(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
-	store, err := OpenRuntimeStore(context.Background(), repo, "grant-forged-replay")
+	opened, err := OpenRuntimeStore(context.Background(), repo, "grant-forged-replay")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := opened.ForInstance("grant-forged-instance")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,6 +154,7 @@ func TestRuntimeLedgerGrantReplayRefusesForgedWidenedRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	request.ExpectedRevision, request.RequestID = granted.Revision, "grant-forge-2"
+	request.ChangeInstance = "grant-forged-instance"
 	forgedRecord := runtimeRecord{
 		Schema: runtimeRecordSchema, Change: store.Change, PreviousRevision: granted.Revision,
 		Operation: runtimeOperationGrant, RequestID: request.RequestID,
@@ -149,6 +162,7 @@ func TestRuntimeLedgerGrantReplayRefusesForgedWidenedRecord(t *testing.T) {
 		Grant: &runtimeGrantEvent{
 			Roots: []string{root, widened}, Actor: "attacker",
 			Reason: "forged widened grant", GrantedAt: "2026-08-05T00:00:00Z",
+			Instance: "grant-forged-instance",
 		},
 	}
 	revision, payload, err := runtimeRecordRevision(forgedRecord)
@@ -209,5 +223,197 @@ func TestRuntimeLedgerLegacyChainWithoutGrantsReplaysUnchanged(t *testing.T) {
 	}
 	if strings.Contains(string(payload), "granted_roots") {
 		t.Fatalf("grant-free status serialized a granted_roots member: %s", payload)
+	}
+}
+
+// TestRuntimeLedgerArchivedNameReuseDoesNotResurrectGrantedRoots is #2557's
+// hazard fixture (S5 of #2540): archive is agent-side artifact movement that
+// never touches the per-change runtime ledger, and the ledger directory is
+// keyed by change name alone, so a future change reusing an archived name
+// reopens the SAME chain. Its reader must not inherit the archived change's
+// grants: per-change authority must not become workspace-permanent authority
+// through the back door.
+func TestRuntimeLedgerArchivedNameReuseDoesNotResurrectGrantedRoots(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	opened, err := OpenRuntimeStore(context.Background(), repo, "reused-change-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := opened.ForInstance("first-change-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	granted, err := first.Grant(context.Background(), GrantRootsRequest{
+		ExpectedRevision: "", RequestID: "grant-first-instance", Roots: []string{root},
+		Reason: "maintainer authorized sibling repository edits for the first change", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(granted.GrantedRoots) != 1 || granted.GrantedRoots[0] != root {
+		t.Fatalf("first instance projected %#v, want its own granted root %q", granted.GrantedRoots, root)
+	}
+
+	// The first change is archived: only openspec artifacts move; the ledger
+	// chain stays exactly where it is. A recreated change with the same name
+	// resolves the same directory and replays the same chain, and before this
+	// slice its reader inherited the archived change's grants verbatim. A
+	// reader with no instance identity (every current caller, including the
+	// status.go embedding until S4b threads one) must project nothing.
+	reused, err := OpenRuntimeStore(context.Background(), repo, "reused-change-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := reused.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.GrantedRoots) != 0 {
+		t.Fatalf("archived-name reuse resurrected granted roots: %#v", status.GrantedRoots)
+	}
+
+	// The recreated change carries its own instance identity: the archived
+	// change's grants stay bound to the identity the human consented to.
+	second, err := reused.ForInstance("second-change-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err = second.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.GrantedRoots) != 0 {
+		t.Fatalf("recreated change instance resurrected granted roots: %#v", status.GrantedRoots)
+	}
+
+	// The original instance keeps its authority: containment narrows the
+	// projection to the consented instance, it revokes nothing.
+	replayedFirst, err := reused.ForInstance("first-change-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err = replayedFirst.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.GrantedRoots) != 1 || status.GrantedRoots[0] != root {
+		t.Fatalf("original instance projected %#v, want its granted root %q", status.GrantedRoots, root)
+	}
+}
+
+// TestRuntimeLedgerGrantRequiresChangeInstance contains the write path: a
+// store that never declared which change instance it serves cannot record
+// authority at all, and an incoherent caller-supplied instance is refused
+// rather than silently rebound.
+func TestRuntimeLedgerGrantRequiresChangeInstance(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	opened, err := OpenRuntimeStore(context.Background(), repo, "grant-instance-required")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := GrantRootsRequest{
+		ExpectedRevision: "", RequestID: "grant-no-instance", Roots: []string{root},
+		Reason: "maintainer authorized sibling repository edits", Actor: "maintainer",
+	}
+	if _, err := opened.Grant(context.Background(), request); err == nil ||
+		!strings.Contains(err.Error(), "requires a change-instance identity") {
+		t.Fatalf("instance-less grant = %v, want the ForInstance refusal", err)
+	}
+	if _, err := opened.ForInstance(""); err == nil {
+		t.Fatal("empty change-instance identity was accepted")
+	}
+
+	store, err := opened.ForInstance("declared-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.ChangeInstance = "some-other-instance"
+	if _, err := store.Grant(context.Background(), request); err == nil ||
+		!strings.Contains(err.Error(), "does not equal the store's instance identity") {
+		t.Fatalf("incoherent grant instance = %v, want the mismatch refusal", err)
+	}
+	if countRuntimeRecords(t, store.Dir) != 0 {
+		t.Fatalf("refused grants recorded %d records, want none", countRuntimeRecords(t, store.Dir))
+	}
+}
+
+// TestRuntimeLedgerGrantReplayRefusesForgedInstanceMarker applies the sibling
+// forgery discipline to the instance identity: a record whose identity was
+// rebound or stripped after publication no longer matches the digest the
+// original request bound, so replay refuses the chain instead of projecting
+// the grant into another instance.
+func TestRuntimeLedgerGrantReplayRefusesForgedInstanceMarker(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	opened, err := OpenRuntimeStore(context.Background(), repo, "grant-instance-forgery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := opened.ForInstance("consented-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := GrantRootsRequest{
+		ExpectedRevision: "", RequestID: "grant-instance-1", Roots: []string{root},
+		Reason: "maintainer authorized one sibling repository", Actor: "maintainer",
+		ChangeInstance: "consented-instance",
+	}
+	granted, err := store.Grant(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Forged: the digest still binds the consented instance, but the record
+	// claims the grant belongs to a different one — the exact rebinding a
+	// name-reuse attacker would need to resurrect authority.
+	forge := func(t *testing.T, requestID, instance string) error {
+		t.Helper()
+		forgedRequest := request
+		forgedRequest.ExpectedRevision, forgedRequest.RequestID = granted.Revision, requestID
+		forgedRecord := runtimeRecord{
+			Schema: runtimeRecordSchema, Change: store.Change, PreviousRevision: granted.Revision,
+			Operation: runtimeOperationGrant, RequestID: requestID,
+			RequestDigest: runtimeValueHash("gentle-ai.sdd-runtime-grant-request/v1", forgedRequest),
+			Grant: &runtimeGrantEvent{
+				Roots: []string{root}, Actor: "maintainer",
+				Reason: "maintainer authorized one sibling repository", GrantedAt: "2026-08-05T00:00:00Z",
+				Instance: instance,
+			},
+		}
+		revision, payload, err := runtimeRecordRevision(forgedRecord)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.publishRecord(revision, payload); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.publishHead(revision); err != nil {
+			t.Fatal(err)
+		}
+		_, statusErr := store.Status()
+		if headErr := store.publishHead(granted.Revision); headErr != nil {
+			t.Fatal(headErr)
+		}
+		return statusErr
+	}
+
+	if err := forge(t, "grant-instance-rebound", "second-change-instance"); err == nil ||
+		!strings.Contains(err.Error(), "grant request digest does not match record") {
+		t.Fatalf("replay of rebound instance marker = %v, want the digest-recompute rejection", err)
+	}
+	if err := forge(t, "grant-instance-stripped", ""); err == nil ||
+		!strings.Contains(err.Error(), "invalid SDD runtime grant change-instance identity") {
+		t.Fatalf("replay of stripped instance marker = %v, want the invalid-identity rejection", err)
 	}
 }


### PR DESCRIPTION
## Description

S5 of #2540, mandatory per the phase-1 finding: nothing deletes the per-change runtime ledger and change identity is name-only, so a future change reusing an archived name inherited the old grants, turning per-change authority into workspace-permanent authority through the back door.

This PR also reconciles the `sdd-attempt grant` verb (#2558, S3) in the same change: merging the verb and the containment separately would have shipped a window where the verb cannot grant at all (the verb called `Grant` without an instance; the containment refuses instance-less grants). Two individually green PRs, red combination; the seam never exists on main in a broken state.

**Base note:** #2558 merged while this PR was being reconciled; the branch is rebased onto post-#2558 main (b65cc3a4) and carries exactly one commit. The full verification battery and the built-binary transcript were repeated on the rebased result.

Closes #2557
Refs #2540

## Shape choice and measurement

Both candidate shapes were measured against the real archive flow and ledger mechanics before writing code:

**(a) Archive-time revocation/tombstone: confirmed unenforceable, as phase-1 suspected.** No native code path runs at archive time. Archive is agent-side artifact movement (the sdd-archive skill moves `openspec/changes/<name>` into `archive/`) plus consultative status reads; the supported lifecycle CLI gates are post-apply, pre-commit, pre-push, pre-pr, and release, and none of them fires at archive. A revocation record would depend on the archiving agent remembering to write it, and a forgotten or crashed archive would leave the authority alive, which is exactly the hazard.

**(b) Change-instance identity: chosen, with one honest amendment to the issue's lean.** The chain itself cannot observe the instance boundary, so neither of the hinted chain-derived markers works:

- The ledger chain's genesis revision survives name reuse. The directory is keyed by change name alone (`runtimeChangeLedgerDir`, runtime_ledger.go), so a recreated change reopens the SAME chain with the same genesis.
- The Begin that opened the current lifecycle cannot be distinguished either: a recreated change whose predecessor finished Complete enters through `runtimeObjectiveAdvanceAdmissible` as an ordinary objective advance, indistinguishable from a legitimate next-work-unit Begin inside one change. Expiring grants at that boundary would also break the per-change grant semantics (re-consent per work unit, contradicting the #2540 design decision that grants are per-change).

So the instance identity is **caller-owned and opaque to the ledger**: `RuntimeStore.ForInstance(instance)` binds a store session to one change instance; `Grant` refuses without it and digest-binds the identity into each grant record exactly like Roots/Actor/Reason; replay projects a grant into `GrantedRoots` only for a store bound to the same identity. A store without an identity (including the status.go runtime embedding until S4b threads one) projects no granted roots at all, which is the conservative containment and means nothing can resurrect regardless of what marker derivation S4b later chooses.

**Tradeoff:** the boundary's meaning moves to the caller. S4b, which owns consent-envelope emission and `AllowedEditRoots` expansion, must derive a marker that is stable across one instance's life and distinct across recreations, and thread it through both the grant invocation it names in the envelope and its own projection read. The ledger enforces the binding and the filter; it does not define the derivation. This is the relaxation shape: replay narrows what it projects, no cleanup obligation is added, and no archive hook is required.

`runtimeGrantEvent.Instance` is required, not optional: `RuntimeStore.Grant` was unreachable between #2553 and this slice (deadcode-baselined, no CLI verb), so no released writer ever emitted an instance-less grant record and an empty identity is a mutated record, not a legacy one. Legacy chains in the wild are chains without grant records, and those replay unchanged (pinned by the existing `TestRuntimeLedgerLegacyChainWithoutGrantsReplaysUnchanged`, untouched and green).

## The verb contract (`--change-instance`)

Where does a CLI caller get an instance value today, before S4b derives markers natively? **The caller mints one opaque token per change instance and must reuse that exact token for widening grants within the same change lifecycle.** A recreated change mints a fresh token, so an archived name's grants never resurrect; a reader that declares no token projects nothing. This contract is stated in the flag's help text and pinned by `TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI`: grant with instance A, widening grant with instance A succeeds and accumulates, instance B projects nothing, undeclared projects nothing.

- `sdd-attempt grant`: `--change-instance` required, routed through `RuntimeStore.ForInstance`.
- `sdd-attempt status`: `--change-instance` optional projection scope; without it, status projects no granted roots (the conservative containment for undeclared readers).

## RED evidence

**Ledger hazard (the issue's fixture, run on unmodified origin/main 80c8b829 before any implementation):**

```
--- FAIL: TestRuntimeLedgerArchivedNameReuseDoesNotResurrectGrantedRoots (0.06s)
    runtime_ledger_grant_test.go:251: archived-name reuse resurrected granted roots: []string{"/tmp/TestRuntimeLedgerArchivedNameReuseDoesNotResurrectGrantedRoots4090436634/002"}
```

The hazard verbatim: grant roots to a change, reopen the same name (all a recreated change does, since archive never touches the ledger), and the grants resurrect. After the fix the same fixture projects nothing for an instance-less reader, nothing for the recreated instance, and still projects the granted root for the original consented instance. The fixture evolved to grant through `ForInstance` because the fix makes instance-less granting impossible; the resurrection assertions are unchanged.

**Verb seam (run on this branch after rebasing onto #2558's head, before the verb reconciliation):**

```
--- FAIL: TestRunSDDAttemptGrantPersistsAndReplaysThroughTheCLI (0.02s)
    sdd_attempt_test.go:184: RunSDDAttempt([grant --cwd ... --change cli-grant --root ... --actor maintainer --reason sequential multi-repository rollout --request-id cli-grant-1]): sdd-attempt grant: grant requires a change-instance identity; derive the store with ForInstance first
```

This is exactly the broken combination that merging the two PRs separately would have shipped. Both REDs are green on the combined result.

Coverage beyond the fixtures:
- `TestRuntimeLedgerGrantRequiresChangeInstance`: instance-less and incoherent grant requests are refused before any record exists.
- `TestRuntimeLedgerGrantReplayRefusesForgedInstanceMarker`: a record whose identity is rebound to another instance fails the digest recompute like sibling-event forgeries; a stripped identity fails the invalid-identity shape check.

## Built-binary transcript (scratch planning repo + two sibling repos)

```
== missing --change-instance refusal ==
Error: sdd-attempt grant requires --change-instance; rerun `gentle-ai sdd-attempt grant` with those missing flags
== first grant (fresh ledger, minted instance token) ==
  "revision": "sha256:4f75f4fd3d758d0007b9e7e1f33746df174750f979c8efc05b4d29f52039b4df",
  "granted_roots": [
    ".../proof/service-a"
== status round-trip with the same instance token (separate process) ==
  "revision": "sha256:4f75f4fd3d758d0007b9e7e1f33746df174750f979c8efc05b4d29f52039b4df",
  "granted_roots": [
    ".../proof/service-a"
== status without an instance token projects nothing ==
(no granted_roots member serialized)
== status under a recreated change's fresh token projects nothing ==
(no granted_roots member serialized)
== duplicate request-id idempotent ==
  "revision": "sha256:4f75f4fd3d758d0007b9e7e1f33746df174750f979c8efc05b4d29f52039b4df",
== chained widening grant (same instance token, --expected-revision, repeatable --root, dedup) ==
  "granted_roots": [
    ".../proof/service-a",
    ".../proof/service-b"
```

## Verification (all foreground, on the combined rebased result)

- `go test ./... -count=1` (root module): pass
- `go test ./... -count=1` (bench module): pass
- `gofmt -l internal/cli internal/sddstatus`: clean
- `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions (`ForInstance`, `Grant`, and `normalizeGrantRootsRequest` are all reachable through the verb, so no baseline entries remain)
- refusal-resolution ratchet (`internal/cli/refusal_resolution_ratchet_test.go`): pass

This PR's own commit: `internal/sddstatus/runtime_ledger.go`, its grant test file, `internal/cli/sdd_attempt.go`, its test file, and the deadcode baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--change-instance` support to status and grant commands.
  * Grants are now associated with a specific change instance and require a matching identity.
  * Status projections show granted roots only for the selected instance.

* **Bug Fixes**
  * Prevented forged, missing, mismatched, or reused instance identities from restoring grants during replay.
  * Improved validation for instance-scoped grant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->