### PR TITLE
fix(sdd): derive the unmanaged-remediation binding from the immutable attempt chain

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -515,6 +515,7 @@ var abandonCapability = &Capability{Verb: []string{"review", "abandon"}, Flags: 
 func Journeys() []Journey {
 	journeys := append(coreJourneys(), edgeJourneys()...)
 	journeys = append(journeys, sddJourneys()...)
+	journeys = append(journeys, sddChainJourneys()...)
 	journeys = append(journeys, waveOneJourneys()...)
 	journeys = append(journeys, waveThreeJourneys()...)
 	return append(journeys, waveFiveJourneys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -25,6 +25,7 @@ func journeySources() []journeySource {
 		{"journeys.go", coreJourneys()},
 		{"journeys_edge.go", edgeJourneys()},
 		{"journeys_sdd.go", sddJourneys()},
+		{"journeys_sdd_chain.go", sddChainJourneys()},
 		{"journeys_wave1.go", waveOneJourneys()},
 		{"journeys_wave3.go", waveThreeJourneys()},
 		{"journeys_wave5.go", waveFiveJourneys()},

--- a/bench/journeys_sdd_chain.go
+++ b/bench/journeys_sdd_chain.go
@@ -1,0 +1,94 @@
+package main
+
+import "fmt"
+
+// journeys_sdd_chain.go pins #1974 slice 2 (#2565): the unmanaged-remediation
+// binding derives from the immutable attempt chain, so an audited reset
+// between the failed settle and the correction acquire no longer orphans the
+// correction. It is the j63 variant from the fix design, in its own file so
+// the collision-guarded corpus grows without touching journeys_sdd.go. The
+// anti-laundering budget (one passed correction per failed evidence) is
+// pinned at the unit level in runtime_ledger_chain_binding_test.go.
+
+// sddChainVerifyObjective exhausts its budget on the single failed
+// verification attempt, which is exactly the decision-required state the
+// audited reset exists to escape (#1974 field report).
+var sddChainVerifyObjective = []string{
+	"--work-unit", "bench chain verification",
+	"--evidence-goal", "admit the verification failure",
+	"--max-attempts", "1", "--max-changed-lines", "20",
+}
+
+// sddChainFailedVerificationExhaustsBudget settles the admitted verification
+// failure and proves the runtime demands a maintainer decision.
+func sddChainFailedVerificationExhaustsBudget(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-chain-begin-verification", sddChainVerifyObjective...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-chain-finish-verification",
+		append([]string{"--outcome", "failed", "--evidence-revision", sddFailedEvidence}, sddTerminalEvidence...)...), false)
+	proved, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if proved.ActiveAttempt != nil || len(proved.Attempts) != 1 || proved.Attempts[0].Outcome != "failed" || proved.NextAction != "reset" {
+		return fmt.Errorf("exhausted failed verification did not demand a maintainer decision: %#v", proved)
+	}
+	return nil
+}
+
+// sddChainAuditedReset records the maintainer decision between the failed
+// settle and the correction acquire. The reset wipes the live evidence
+// pointer; only the immutable attempt chain remembers the failed evidence.
+func sddChainAuditedReset(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "reset", status.Revision, "bench-chain-reset",
+		"--reason", "maintainer decision: remediate the admitted failure under a fresh objective",
+		"--actor", "bench"), false)
+	proved, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if proved.NextAction != "begin" || proved.EvidenceRevision != "" {
+		return fmt.Errorf("audited reset did not clear the live evidence pointer: %#v", proved)
+	}
+	return nil
+}
+
+// sddChainJourneys is the corpus slice this file registers.
+func sddChainJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j64-unmanaged-remediation-survives-audited-reset",
+			Title:  "An audited reset between the failed settle and the correction acquire no longer orphans the correction",
+			Source: "#1974 slice 2 (#2565): chain-derived failed-evidence binding",
+			Steps: []Step{
+				{Name: "fixture: completed change with admitted failed verification", Fixture: sddPlanningArtifacts(sddFailedVerifyReport)},
+				{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+				{Name: "failed verification exhausts its objective budget", Requires: sddAttemptBeginCapability, Composite: sddChainFailedVerificationExhaustsBudget},
+				{Name: "audited reset records the maintainer decision", Requires: sddAttemptResetCapability, Composite: sddChainAuditedReset},
+				{Name: "acquire the one bounded correction after the reset", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedAcquireCorrection},
+				{Name: "fixture: correction changes the candidate", Fixture: sddBoundedCorrection},
+				{Name: "settle the evidence-bound correction across the reset", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedCorrectionCompletes},
+				{Name: "replay cannot acquire another correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedReplayIsComplete},
+				{Name: "fixture: fresh independent verification passes", Fixture: sddReplaceFailedVerifyReport},
+				{Name: "archive is ready without review authority", Requires: sddStatusCapability,
+					Args: productArgs("sdd-status", sddChange, "--json"),
+					After: sddStatusAssertion("disabled archive after the reset-crossing correction", func(status sddStatusV1) error {
+						if status.Dependencies.Archive != "ready" || status.NextRecommended != "archive" || status.ReviewGate != nil || status.ReviewOffer != nil {
+							return fmt.Errorf("disabled archive = archive %q next %q gate=%+v offer=%+v", status.Dependencies.Archive, status.NextRecommended, status.ReviewGate, status.ReviewOffer)
+						}
+						return nil
+					})},
+			},
+		},
+	}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 62 {
-		t.Errorf("core journey count = %d, want 62", got)
+	if got := len(seen); got != 63 {
+		t.Errorf("core journey count = %d, want 63", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -815,14 +815,20 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 				return runtimeRecord{}, fmt.Errorf("failed evidence revision %q does not match native runtime evidence %q", request.RemediatesEvidenceRevision, status.EvidenceRevision)
 			}
 		}
+		// #1974 slice 2: the unmanaged-remediation binding derives from the
+		// immutable attempt chain, never from status.EvidenceRevision -- the
+		// live pointer Reset, Rescope, and Advance wipe. An audited reset or an
+		// honest interrupted settlement between the failure and its correction
+		// is an audit record, not a semantic successor, so neither severs the
+		// binding; the first passed settlement after the failure does.
+		chainFailedEvidence, chainHasFailedEvidence := runtimeChainFailedEvidence(status.Attempts)
 		if unmanagedRemediation {
 			if !store.ReviewDisabled || currentBinding != nil {
 				// refusal:by-design human-authority: unmanaged remediation is valid only while receipt authority is absent and explicitly disabled.
 				return runtimeRecord{}, errors.New("unmanaged remediation requires disabled delivery without a review binding")
 			}
-			if len(status.Attempts) < 2 || status.EvidenceRevision != request.RemediatesEvidenceRevision ||
-				status.Attempts[len(status.Attempts)-2].Outcome != AttemptFailed {
-				// refusal:by-design operator-knowledge: the native ledger admits one final correction only for its current failed evidence.
+			if !chainHasFailedEvidence || chainFailedEvidence != request.RemediatesEvidenceRevision {
+				// refusal:by-design operator-knowledge: the native ledger admits one final correction only for the chain's unremediated failed evidence.
 				return runtimeRecord{}, errors.New("unmanaged remediation requires the current failed evidence and a direct correction attempt")
 			}
 		}
@@ -858,9 +864,8 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 				return runtimeRecord{}, fmt.Errorf("validate unchanged bound SDD candidate: %w", validateErr)
 			}
 		}
-		previousAttemptFailed := len(status.Attempts) >= 2 && status.Attempts[len(status.Attempts)-2].Outcome == AttemptFailed
-		if store.ReviewDisabled && currentBinding == nil && request.Outcome == AttemptPassed && previousAttemptFailed && !unmanagedRemediation {
-			return runtimeRecord{}, fmt.Errorf("disabled failed verification requires --remediates-evidence-revision %q on the correction settle; rerun `gentle-ai sdd-attempt settle` with that flag", status.EvidenceRevision)
+		if store.ReviewDisabled && currentBinding == nil && request.Outcome == AttemptPassed && chainHasFailedEvidence && !unmanagedRemediation {
+			return runtimeRecord{}, fmt.Errorf("disabled failed verification requires --remediates-evidence-revision %q on the correction settle; rerun `gentle-ai sdd-attempt settle` with that flag", chainFailedEvidence)
 		}
 		if unmanagedRemediation {
 			if snapshot.Identity == active.BeginCandidateIdentity || snapshot.CandidateTree == active.BeginCandidateTree {
@@ -1916,9 +1921,13 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		return errors.New("finish record changed-line budget decision does not match replay state")
 	}
 	if unmanagedRemediation {
-		if replay.Status.Binding != nil || len(replay.Status.Attempts) < 2 || event.Outcome != AttemptPassed ||
-			replay.Status.EvidenceRevision != event.RemediatesEvidenceRevision ||
-			replay.Status.Attempts[len(replay.Status.Attempts)-2].Outcome != AttemptFailed ||
+		// Lockstep twin of the write-time guard in Finish: the binding derives
+		// from the immutable chain, so replayed corrections recorded across an
+		// audited reset stay valid. The chain walk requires a settled failed
+		// predecessor, which subsumes the former len(Attempts) < 2 conjunct.
+		chainFailedEvidence, chainHasFailedEvidence := runtimeChainFailedEvidence(replay.Status.Attempts)
+		if replay.Status.Binding != nil || event.Outcome != AttemptPassed ||
+			!chainHasFailedEvidence || chainFailedEvidence != event.RemediatesEvidenceRevision ||
 			event.FinishCandidateIdentity == active.BeginCandidateIdentity || event.FinishCandidateTree == active.BeginCandidateTree ||
 			event.EvidenceRevision == event.RemediatesEvidenceRevision {
 			// refusal:by-design world-action: a replayed event that breaks immutable evidence/candidate binding can only be repaired by restoring the authority.
@@ -2595,6 +2604,31 @@ func runtimeResetStructurallyPermitted(status RuntimeStatus) bool {
 	}
 	last := status.Attempts[len(status.Attempts)-1]
 	return last.Outcome == AttemptFailed || last.Outcome == AttemptInterrupted
+}
+
+// runtimeChainFailedEvidence derives the unmanaged-remediation binding from
+// the immutable attempt chain (#1974 slice 2): the most recent settled
+// AttemptFailed attempt's EvidenceRevision, provided no AttemptPassed
+// settlement follows it. Running and interrupted attempts between the failure
+// and its correction are honest audit records, not semantic successors, and
+// audited resets, rescopes, and advances never appear in the chain at all, so
+// none of them sever the binding. The first passed settlement after the
+// failure DOES sever it: that pass is the one correction the failed evidence
+// admits, so a later correction claiming the same revision finds no failed
+// evidence in the chain and is refused -- the same anti-laundering budget the
+// live evidence pointer used to enforce, now immune to that pointer being
+// wiped. Evaluated by RuntimeStore.Finish and applyRuntimeFinishEvent in
+// lockstep, so a committed correction always replays deterministically.
+func runtimeChainFailedEvidence(attempts []RuntimeAttempt) (string, bool) {
+	for index := len(attempts) - 1; index >= 0; index-- {
+		switch attempts[index].Outcome {
+		case AttemptPassed:
+			return "", false
+		case AttemptFailed:
+			return attempts[index].EvidenceRevision, true
+		}
+	}
+	return "", false
 }
 
 func runtimeObjectiveID(change, workUnit, evidenceGoal, candidateIdentity string, generation int) string {

--- a/internal/sddstatus/runtime_ledger_chain_binding_test.go
+++ b/internal/sddstatus/runtime_ledger_chain_binding_test.go
@@ -1,0 +1,247 @@
+package sddstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// #1974 slice 2 (#2565): the unmanaged-remediation binding derives from the
+// immutable attempt chain -- the most recent settled failed attempt with no
+// passed settlement after it -- never from the live evidence pointer that
+// Reset, Rescope, and Advance wipe. An audited reset or an honest interrupted
+// settlement between the failure and its correction is an audit record, not a
+// semantic successor, so neither severs the binding.
+
+func TestRuntimeUnmanagedRemediationBindsAcrossAuditedReset(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "chain-binding")
+	store.ReviewDisabled = true
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "chain-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 1, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "chain-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failed.DecisionRequired || failed.NextAction != RuntimeActionReset {
+		t.Fatalf("exhausted failed verification = %#v", failed)
+	}
+	// The audited reset is the documented escape from decision-required. It
+	// wipes the live evidence pointer; only the attempt chain remembers.
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "chain-audited-reset",
+		Reason: "maintainer decision: blockers understood, remediate under a fresh objective",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reset.EvidenceRevision != "" {
+		t.Fatalf("audited reset kept the live evidence pointer: %#v", reset)
+	}
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: reset.Revision, RequestID: "chain-begin-correction", WorkUnit: "remediate",
+		EvidenceGoal: "repair admitted verification failure", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "bounded correction across the audited reset\n")
+	request := FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "chain-finish-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "bounded correction passed focused checks",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	}
+	unbound := request
+	unbound.RequestID = "chain-finish-unbound"
+	unbound.RemediatesEvidenceRevision = ""
+	if _, err := store.Finish(context.Background(), unbound); err == nil || !strings.Contains(err.Error(), failedEvidence) {
+		t.Fatalf("plain pass across the reset = %v, want a refusal naming the chain's failed evidence %s", err, failedEvidence)
+	}
+	wrongEvidence := request
+	wrongEvidence.RequestID = "chain-finish-wrong-evidence"
+	wrongEvidence.RemediatesEvidenceRevision = runtimeTestHash('c')
+	if _, err := store.Finish(context.Background(), wrongEvidence); err == nil {
+		t.Fatal("wrong failed evidence satisfied the chain-derived binding")
+	}
+	completed, err := store.Finish(context.Background(), request)
+	if err != nil {
+		t.Fatalf("correction across the audited reset was refused: %v", err)
+	}
+	if !completed.Complete || completed.ActiveAttempt != nil || completed.Binding != nil || len(completed.Attempts) != 2 {
+		t.Fatalf("correction across the audited reset = %#v", completed)
+	}
+	last := completed.Attempts[len(completed.Attempts)-1]
+	if last.RemediatesEvidenceRevision != failedEvidence || last.FinishCandidateIdentity == last.BeginCandidateIdentity ||
+		last.FinishCandidateTree == last.BeginCandidateTree {
+		t.Fatalf("correction did not bind the failed evidence to a changed candidate: %#v", last)
+	}
+	if replay, err := store.Finish(context.Background(), request); err != nil || replay.Revision != completed.Revision {
+		t.Fatalf("exact correction replay = %#v err=%v", replay, err)
+	}
+	// The replay twin must accept the same chain the write guard admitted:
+	// a fresh store replays every record from genesis.
+	reopened := mustRuntimeStore(t, repo, "chain-binding")
+	replayed, err := reopened.Status()
+	if err != nil || replayed.Revision != completed.Revision || !replayed.Complete {
+		t.Fatalf("full-chain replay across the audited reset = %#v err=%v", replayed, err)
+	}
+}
+
+func TestRuntimeUnmanagedRemediationSkipsInterruptedAuditRecords(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "chain-interrupt")
+	store.ReviewDisabled = true
+	objective := BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "interrupt-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 3, MaxChangedLines: 40,
+	}
+	first, err := store.Begin(context.Background(), objective)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "interrupt-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An honest interrupted settlement between the failure and its correction
+	// is an audit record, not a semantic successor.
+	stalled := objective
+	stalled.ExpectedRevision = failed.Revision
+	stalled.RequestID = "interrupt-begin-stalled"
+	stalledStatus, err := store.Begin(context.Background(), stalled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	interrupted, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: stalledStatus.Revision, RequestID: "interrupt-finish-stalled", Outcome: AttemptInterrupted,
+		EvidenceRevision: runtimeTestHash('c'), Diagnosis: "transport ended before the correction settled",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "stalled process group cleanup completed",
+		ProcessEvidence: "stalled process scan found no surviving descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	correction := objective
+	correction.ExpectedRevision = interrupted.Revision
+	correction.RequestID = "interrupt-begin-correction"
+	active, err := store.Begin(context.Background(), correction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "bounded correction after an interrupted audit record\n")
+	completed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "interrupt-finish-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "bounded correction passed focused checks",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatalf("correction after an interrupted audit record was refused: %v", err)
+	}
+	if !completed.Complete || len(completed.Attempts) != 3 ||
+		completed.Attempts[2].RemediatesEvidenceRevision != failedEvidence {
+		t.Fatalf("correction after an interrupted audit record = %#v", completed)
+	}
+	reopened := mustRuntimeStore(t, repo, "chain-interrupt")
+	replayed, err := reopened.Status()
+	if err != nil || replayed.Revision != completed.Revision || !replayed.Complete {
+		t.Fatalf("full-chain replay across the interrupted record = %#v err=%v", replayed, err)
+	}
+}
+
+// The anti-laundering budget stays exact: the first passed settlement after a
+// failure is the one correction that failed evidence admits. Walking the chain
+// backward, that pass is reached before the failure, so a second correction
+// claiming the same revision finds no failed evidence and is refused.
+func TestRuntimeUnmanagedRemediationRefusesASecondCorrectionForSettledEvidence(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "chain-launder")
+	store.ReviewDisabled = true
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "launder-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "launder-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: failed.Revision, RequestID: "launder-begin-correction", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "first bounded correction\n")
+	settled, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "launder-finish-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "bounded correction passed focused checks",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !settled.Complete {
+		t.Fatalf("first bounded correction did not settle: %#v", settled)
+	}
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: settled.Revision, RequestID: "launder-reset",
+		Reason: "attempt to reopen the settled correction",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: reset.Revision, RequestID: "launder-begin-second", WorkUnit: "remediate",
+		EvidenceGoal: "repair admitted verification failure", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "second correction attempt\n")
+	before := countRuntimeRecords(t, store.Dir)
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: second.Revision, RequestID: "launder-finish-second", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('d'), Diagnosis: "second correction claims the settled evidence",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err == nil || err.Error() != "unmanaged remediation requires the current failed evidence and a direct correction attempt" {
+		t.Fatalf("second correction against settled evidence = %v, want the exact direct-correction refusal", err)
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil || status.Revision != second.Revision || status.ActiveAttempt == nil ||
+		countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("laundering refusal mutated runtime: status=%#v err=%v records=%d", status, statusErr, countRuntimeRecords(t, store.Dir))
+	}
+}


### PR DESCRIPTION
## Summary

Slice 2 of the #1974 fix design (see the fix-design comment there). The unmanaged direct-correction guard in `RuntimeStore.Finish` and its byte-identical replay twin (`applyRuntimeFinishEvent`) compared `status.EvidenceRevision`, the live pointer wiped by Reset/Rescope/Advance, plus `Attempts[len-2]` adjacency. Any audited reset or honest interrupted settlement between the failed settle and the correction orphaned the correction permanently.

The binding now derives from the immutable attempt chain via `runtimeChainFailedEvidence`: the most recent settled `AttemptFailed` attempt's `EvidenceRevision`, provided no `AttemptPassed` settlement follows it. Write guard and replay twin change in lockstep. The changed-candidate and distinct-fresh-evidence checks are untouched.

**Successor-check derivation:** the backward chain walk terminates at the first passed settlement, so once a passed remediation lands, the chain offers no failed evidence and a second correction against the same revision is refused with the same guard message. This replaces the pointer-wipe side effect as the anti-laundering mechanism and is reset-immune (deliberately not `status.Complete`, which Reset also wipes). Exactly one passed correction can bind a given failed evidence revision.

The `requires --remediates-evidence-revision` prompt derives from the same chain, so after a reset it names the real failed evidence instead of rendering `""`, and an interleaved interrupted attempt can no longer let a plain pass settle past an unremediated failure.

## RED (verbatim, on unchanged base)

Reset between failed settle and correction acquire (unit equivalent of the j63 variant):

```
--- FAIL: TestRuntimeUnmanagedRemediationBindsAcrossAuditedReset (0.09s)
    runtime_ledger_chain_binding_test.go:83: correction across the audited reset was refused: unmanaged remediation requires the current failed evidence and a direct correction attempt
```

The wiped-pointer prompt on base (same test, plain pass across the reset):

```
    runtime_ledger_chain_binding_test.go:71: plain pass across the reset = disabled failed verification requires --remediates-evidence-revision "" on the correction settle; rerun `gentle-ai sdd-attempt settle` with that flag, want a refusal naming the chain's failed evidence sha256:aaaa...
```

Interrupted audit record between failure and correction (the #1974 field-report shape):

```
--- FAIL: TestRuntimeUnmanagedRemediationSkipsInterruptedAuditRecords (0.11s)
    runtime_ledger_chain_binding_test.go:158: correction after an interrupted audit record was refused: unmanaged remediation requires the current failed evidence and a direct correction attempt
```

## Laundering regression evidence

`TestRuntimeUnmanagedRemediationRefusesASecondCorrectionForSettledEvidence` passes on base AND after the fix: failed settle, passed evidence-bound correction, audited reset, second correction claiming the same failed evidence is refused with exactly `unmanaged remediation requires the current failed evidence and a direct correction attempt`, and the refusal mutates nothing (revision, active attempt, and record count pinned).

All three new tests reopen the store and replay the full chain from genesis, proving the replay twin admits exactly what the write guard admits.

## Bench

New journey `j64-unmanaged-remediation-survives-audited-reset` in a new file `bench/journeys_sdd_chain.go` (new-file route to avoid `journeys_sdd.go` owned by open PRs #2444/#2185): failed verification exhausts its budget, audited reset records the maintainer decision and provably wipes the live pointer, the bounded correction acquires and settles across the reset, replay reports complete, and archive is ready under disabled/unmanaged. Journey-count pin bumped 62 to 63; the new file is registered in `Journeys()` and `journeySources()`.

## Verification (all foreground)

- `go test ./... -count=1` at root: pass
- `go test ./... -count=1` in `bench/`: pass
- `gofmt -l`, `go vet`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- refusal-resolution ratchet (`internal/cli -run Refusal`): pass

Based on the head of `fix/2557-grant-name-reuse` (PR #2559, same `runtime_ledger.go` surface, still open); will re-rebase once #2559 merges.

Closes #2565
Refs #1974


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remediation tracking across resets, scope changes, and interrupted attempts.
  * Ensured corrections remain linked to the original failed verification evidence.
  * Prevented duplicate corrections after failed evidence has been resolved.
  * Preserved consistent validation during live operations and replay.

* **Tests**
  * Added coverage for audited resets, interrupted settlements, invalid evidence references, replay consistency, and refused operations.
  * Added a new verification journey covering correction and archive-readiness workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->