### PR TITLE
fix(sdd): refuse unbindable remediation intent at acquire and keep status truthful

### DIFF
--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -152,7 +152,8 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 				RequestID: *requestID, WorkUnit: *workUnit, EvidenceGoal: *evidenceGoal,
 				MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines,
 			},
-			Token: *token,
+			Token:                      *token,
+			RemediatesEvidenceRevision: *remediatesEvidenceRevision,
 		})
 	case "settle":
 		if missing := missingSDDAttemptFlags(args[1:], "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence"); len(missing) != 0 {
@@ -237,7 +238,7 @@ func validateSDDAttemptOperationFlags(operation string, args []string) error {
 		"finish":  {"expected-revision", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "expected-binding-revision", "successor-lineage", "remediates-evidence-revision"},
 		"reset":   {"expected-revision", "request-id", "reason", "actor"},
 		"rescope": {"expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor"},
-		"acquire": {"request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "token"},
+		"acquire": {"request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "token", "remediates-evidence-revision"},
 		"settle":  {"token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "successor-lineage", "remediates-evidence-revision"},
 		"grant":   {"expected-revision", "request-id", "root", "change-instance", "actor", "reason"},
 		"status":  {"change-instance"},

--- a/internal/cli/sdd_attempt_remediation_intent_test.go
+++ b/internal/cli/sdd_attempt_remediation_intent_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
+)
+
+// TestRunSDDAttemptAcquireRemediationIntentFailsFastAfterReset is #2564's CLI
+// RED: the reporter's exact recipe (disabled review, failed verification,
+// audited reset) followed by an acquire that declares its correction intent
+// with --remediates-evidence-revision. Before this slice the flag was
+// settle-only, so the intent was not expressible at acquire at all. With the
+// chain-derived binding (#2565) the reconciled contract is: a declaration the
+// immutable attempt chain does not hold unremediated earns a typed refusal
+// before any correction work runs, while the chain's own failed evidence
+// survives the audited reset and still issues the token.
+func TestRunSDDAttemptAcquireRemediationIntentFailsFastAfterReset(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	disableReviewForClone(t, repo)
+	const change = "remediation-intent"
+
+	acquired, _ := runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "intent-acquire-verification", 1))
+	if acquired.State != "proceed" {
+		t.Fatalf("verification acquire = %#v", acquired)
+	}
+	failedEvidence := cliAttemptHash('a')
+	settled, _ := runCompactSDDAttempt(t, []string{
+		"settle", "--cwd", repo, "--change", change, "--token", acquired.Token,
+		"--request-id", "intent-settle-verification", "--outcome", "failed",
+		"--evidence-revision", failedEvidence,
+		"--diagnosis", "independent verification found a correctable defect", "--harness-disposition", "reused",
+		"--cleanup-evidence", "process group exited", "--process-evidence", "no descendants remained",
+	})
+	if settled.State != "blocked" || settled.Reason != "maintainer_decision" {
+		t.Fatalf("exhausting failed settle = %#v", settled)
+	}
+
+	var legacy bytes.Buffer
+	if err := RunSDDAttempt([]string{"status", "--cwd", repo, "--change", change}, &legacy); err != nil {
+		t.Fatal(err)
+	}
+	var status sddstatus.RuntimeStatus
+	if err := json.Unmarshal(legacy.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	var reset bytes.Buffer
+	if err := RunSDDAttempt([]string{
+		"reset", "--cwd", repo, "--change", change, "--expected-revision", status.Revision,
+		"--request-id", "intent-reset", "--reason", "maintainer authorized bounded remediation", "--actor", "maintainer",
+	}, &reset); err != nil {
+		t.Fatal(err)
+	}
+
+	refused, _ := runCompactSDDAttempt(t, []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", "intent-acquire-stale",
+		"--work-unit", "remediation", "--evidence-goal", "bounded correction",
+		"--max-attempts", "1", "--max-changed-lines", "200",
+		"--remediates-evidence-revision", cliAttemptHash('b'),
+	})
+	if refused.State != "blocked" || refused.Reason != "remediation_unsatisfiable" || refused.Token != "" {
+		t.Fatalf("stale post-reset remediation-intent acquire = %#v, want blocked/remediation_unsatisfiable", refused)
+	}
+	if !strings.Contains(refused.Exit, "gentle-ai sdd-attempt") || refused.Detail == "" {
+		t.Fatalf("remediation-intent refusal does not name a runnable continuation: %#v", refused)
+	}
+
+	// The chain's own failed evidence survives the audited reset (#2565), so
+	// declaring it still issues the correction token.
+	bound, _ := runCompactSDDAttempt(t, []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", "intent-acquire-correction",
+		"--work-unit", "remediation", "--evidence-goal", "bounded correction",
+		"--max-attempts", "1", "--max-changed-lines", "200",
+		"--remediates-evidence-revision", failedEvidence,
+	})
+	if bound.State != "proceed" || bound.Token == "" {
+		t.Fatalf("post-reset chain-bound remediation-intent acquire = %#v, want proceed", bound)
+	}
+}

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -23,6 +23,13 @@ const (
 	CompactBlockRemediationRequired CompactBlockReason = "remediation_required"
 	CompactBlockWorktreeMismatch    CompactBlockReason = "worktree_mismatch"
 	CompactBlockAuthorityFailure    CompactBlockReason = "authority_failure"
+	// CompactBlockRemediationUnsatisfiable is #2564's acquire-time fail-fast:
+	// the caller declared a correction for failed evidence the immutable
+	// attempt chain does not hold unremediated (nothing failed, the failure
+	// was already corrected by a passed settlement, or a different revision
+	// was declared), so the settlement that declaration promises is
+	// structurally impossible and no token may be issued for it.
+	CompactBlockRemediationUnsatisfiable CompactBlockReason = "remediation_unsatisfiable"
 )
 
 // CompactAttemptResult is the bounded orchestration projection. RuntimeStatus
@@ -63,6 +70,16 @@ type CompactAcquireRequest struct {
 	// block, naming the REAL active token. An empty Token leaves every
 	// existing acquire/collide path byte-for-byte unchanged.
 	Token string
+
+	// RemediatesEvidenceRevision declares at acquire the same correction
+	// intent Settle expresses through --remediates-evidence-revision (#2564).
+	// Before this, remediation intent was settle-only: an acquire whose
+	// eventual unmanaged settlement was already structurally unsatisfiable
+	// (no unremediated failed evidence in the immutable attempt chain, or a
+	// different revision declared) still returned proceed, and the refusal
+	// only arrived after the correction work was done. Empty leaves every
+	// existing acquire path unchanged.
+	RemediatesEvidenceRevision string
 }
 
 type CompactSettleRequest struct {
@@ -158,6 +175,9 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 	if err != nil {
 		return CompactAttemptResult{}, err
 	}
+	if request.RemediatesEvidenceRevision != "" && !runtimeRevisionPattern.MatchString(request.RemediatesEvidenceRevision) {
+		return CompactAttemptResult{}, errors.New("remediates_evidence_revision must be sha256; rerun `gentle-ai sdd-attempt acquire` with --remediates-evidence-revision sha256:<64-lowercase-hex>")
+	}
 
 	replay, err := store.load()
 	if err != nil {
@@ -187,6 +207,20 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 		Request: begin, PresentedToken: request.Token,
 	}); terminal {
 		return result, nil
+	}
+	// #2564 fail-fast: a declared unmanaged correction whose settlement is
+	// already structurally unsatisfiable earns its typed refusal HERE, before
+	// any token is issued and before any correction work runs. Satisfiability
+	// follows the chain-derived binding (#2565): the refusal fires only when
+	// the immutable attempt chain holds no unremediated failed evidence
+	// matching the declaration, so an acquire after an audited reset stays
+	// legitimate while the chain still binds. Scoped to the unmanaged regime
+	// (review disabled, no binding): with review enabled or a binding present
+	// the settle routes through managed remediation, whose authority can
+	// still materialize during the attempt.
+	if request.RemediatesEvidenceRevision != "" && store.ReviewDisabled && replay.Status.Binding == nil &&
+		!unmanagedRemediationSettleable(replay.Status, request.RemediatesEvidenceRevision) {
+		return compactBlocked(CompactBlockRemediationUnsatisfiable, ""), nil
 	}
 	begin.ExpectedRevision = replay.Status.Revision
 	started, err := store.Begin(ctx, begin)
@@ -268,6 +302,20 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		return store.compactMutationFailure(err, true, BeginAttemptRequest{}), nil
 	}
 	return store.compactSettleResult()
+}
+
+// unmanagedRemediationSettleable reports whether a settle carrying
+// --remediates-evidence-revision failedEvidence can structurally succeed
+// against this ledger state: the immutable attempt chain must still hold that
+// exact failed evidence unremediated, per runtimeChainFailedEvidence, the
+// same chain-derived binding Finish's unmanaged guard enforces (#1974 slice
+// 2). A changed candidate and fresh distinct evidence remain settle-time
+// facts and are not judged here; nor is "may this work proceed?", which
+// stays runtimeReadiness's question alone -- this reads only the immutable
+// attempt chain.
+func unmanagedRemediationSettleable(status RuntimeStatus, failedEvidence string) bool {
+	chainEvidence, chainHasFailedEvidence := runtimeChainFailedEvidence(status.Attempts)
+	return chainHasFailedEvidence && failedEvidence != "" && chainEvidence == failedEvidence
 }
 
 func normalizeCompactSettleRequest(request CompactSettleRequest) error {
@@ -457,6 +505,9 @@ func compactBlockedExitText(reason CompactBlockReason, token string) string {
 			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` to see it, then add `--token " + token +
 			"` to your own `sdd-attempt acquire` call to continue that exact attempt, or to your " +
 			"`sdd-attempt settle` call to close it before starting a new one"
+	case CompactBlockRemediationUnsatisfiable:
+		return "this acquire declares a correction for failed evidence the attempt chain does not hold unremediated (nothing failed, the failure was already corrected by a passed settlement, or the declared revision differs from the chain's), so its settle could never succeed and no token is issued; run " +
+			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` to read the attempt chain and its most recent unremediated failed evidence, then either reissue this acquire declaring that exact revision, or drop --remediates-evidence-revision and continue through a fresh verification objective whose own failed settlement records new evidence a bounded correction can name"
 	default:
 		return ""
 	}

--- a/internal/sddstatus/runtime_compact_remediation_intent_test.go
+++ b/internal/sddstatus/runtime_compact_remediation_intent_test.go
@@ -1,0 +1,223 @@
+package sddstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// #2564 (slice 1 of #1974): remediation intent becomes visible at acquire
+// through RemediatesEvidenceRevision, and an intent whose settlement is
+// structurally unsatisfiable earns a typed refusal BEFORE any token is issued
+// and any correction work runs. Satisfiability follows the chain-derived
+// binding (#2565): the immutable attempt chain must hold the declared failed
+// evidence unremediated. An audited reset does not sever that binding, so a
+// post-reset correction acquire stays legitimate; a chain with nothing failed,
+// an already-corrected failure, or a different declared revision refuses.
+
+// seedFailedVerificationLedger drives the shared ledger fixture: a disabled
+// store whose first verification attempt settled as failed with maxAttempts
+// bounding the objective. It returns the store, the failed evidence revision,
+// and the runtime status after the finish.
+func seedFailedVerificationLedger(t *testing.T, repo, change string, maxAttempts int) (RuntimeStore, string, RuntimeStatus) {
+	t.Helper()
+	store := mustRuntimeStore(t, repo, change)
+	store.ReviewDisabled = true
+	begun, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: change + "-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: maxAttempts, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: begun.Revision, RequestID: change + "-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, failedEvidence, failed
+}
+
+// TestCompactAcquireRemediationIntentSurvivesAuditedReset pins the slice 1 /
+// slice 2 reconciliation: the reporter's recipe (disabled review, failed
+// verification, audited reset) followed by an acquire that declares the
+// chain's failed evidence must issue a token, because the immutable chain
+// still binds that evidence even though the reset wiped the live pointer.
+func TestCompactAcquireRemediationIntentSurvivesAuditedReset(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, failedEvidence, failed := seedFailedVerificationLedger(t, repo, "intent-after-reset", 1)
+	if !failed.DecisionRequired {
+		t.Fatalf("exhausted failed verification did not require a decision: %#v", failed)
+	}
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "intent-reset",
+		Reason: "maintainer authorized bounded remediation", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reset.Objective != nil || reset.EvidenceRevision != "" {
+		t.Fatalf("audited reset kept a live objective or evidence binding: %#v", reset)
+	}
+
+	// A stale declared evidence still fails fast: the chain binds 'a', not 'c'.
+	before := countRuntimeRecords(t, store.Dir)
+	stale, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "intent-acquire-stale", WorkUnit: "remediation",
+			EvidenceGoal: "bounded correction", MaxAttempts: 1, MaxChangedLines: 200,
+		},
+		RemediatesEvidenceRevision: runtimeTestHash('c'),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.State != CompactStateBlocked || stale.Reason != CompactBlockRemediationUnsatisfiable || stale.Token != "" {
+		t.Fatalf("stale post-reset remediation-intent acquire = %#v, want blocked/%s", stale, CompactBlockRemediationUnsatisfiable)
+	}
+	if !strings.Contains(stale.Exit, "gentle-ai sdd-attempt status") || stale.Detail != stale.Exit {
+		t.Fatalf("remediation-intent refusal broke the Exit/Detail discipline: %#v", stale)
+	}
+	if countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("refused remediation-intent acquire mutated the ledger: before=%d after=%d", before, countRuntimeRecords(t, store.Dir))
+	}
+
+	// The chain-bound declaration survives the audited reset and issues the token.
+	correction, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "intent-acquire-correction", WorkUnit: "remediation",
+			EvidenceGoal: "bounded correction", MaxAttempts: 1, MaxChangedLines: 200,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if correction.State != CompactStateProceed || correction.Token == "" {
+		t.Fatalf("post-reset chain-bound remediation-intent acquire = %#v, want proceed", correction)
+	}
+}
+
+// TestCompactAcquireRemediationIntentStillIssuesTokenForDirectCorrection holds
+// the direct path end to end, then proves the anti-laundering fail-fast: once
+// the failure's one correction settled, a later acquire declaring the same
+// evidence is refused before issuing a token.
+func TestCompactAcquireRemediationIntentStillIssuesTokenForDirectCorrection(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, failedEvidence, _ := seedFailedVerificationLedger(t, repo, "intent-direct-correction", 2)
+
+	correction, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "direct-acquire-correction", WorkUnit: "verify",
+			EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if correction.State != CompactStateProceed || correction.Token == "" {
+		t.Fatalf("direct correction acquire with intent = %#v, want proceed", correction)
+	}
+
+	appendRuntimeLedgerFile(t, repo, "bounded unmanaged correction\n")
+	settled, err := store.Settle(context.Background(), CompactSettleRequest{
+		Token: correction.Token, RequestID: "direct-settle-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "bounded correction passed focused checks",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settled.State != CompactStateComplete {
+		t.Fatalf("direct correction settle = %#v, want complete", settled)
+	}
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	last := status.Attempts[len(status.Attempts)-1]
+	if !status.Complete || last.RemediatesEvidenceRevision != failedEvidence {
+		t.Fatalf("direct correction did not bind the failed evidence: %#v", status)
+	}
+
+	// Anti-laundering fail-fast: the passed settlement severed the chain
+	// binding, so a fresh scope declaring the same evidence refuses at
+	// acquire, with zero mutation.
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: status.Revision, RequestID: "direct-reset-after-completion",
+		Reason: "attempt to reopen the settled correction", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := countRuntimeRecords(t, store.Dir)
+	laundered, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "direct-acquire-laundered", WorkUnit: "remediation",
+			EvidenceGoal: "bounded correction", MaxAttempts: 1, MaxChangedLines: 200,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if laundered.State != CompactStateBlocked || laundered.Reason != CompactBlockRemediationUnsatisfiable ||
+		laundered.Exit == "" || countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("second correction acquire against settled evidence = %#v records=%d, want blocked without mutation (reset revision %s)", laundered, countRuntimeRecords(t, store.Dir), reset.Revision)
+	}
+}
+
+// TestCompactAcquireRemediationIntentFailsFastWithNothingToRemediate refuses a
+// declared correction when the chain holds no failed evidence at all.
+func TestCompactAcquireRemediationIntentFailsFastWithNothingToRemediate(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "intent-nothing-failed")
+	store.ReviewDisabled = true
+	if err := store.ensureDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "nothing-acquire", WorkUnit: "remediation",
+			EvidenceGoal: "bounded correction", MaxAttempts: 1, MaxChangedLines: 200,
+		},
+		RemediatesEvidenceRevision: runtimeTestHash('a'),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != CompactStateBlocked || result.Reason != CompactBlockRemediationUnsatisfiable || result.Token != "" {
+		t.Fatalf("nothing-failed remediation-intent acquire = %#v, want blocked/%s", result, CompactBlockRemediationUnsatisfiable)
+	}
+	if countRuntimeRecords(t, store.Dir) != 0 {
+		t.Fatal("refused remediation-intent acquire mutated an empty ledger")
+	}
+}
+
+// TestCompactAcquireRemediationIntentValidatesRevisionShape mirrors settle's
+// shape validation at the new acquire boundary.
+func TestCompactAcquireRemediationIntentValidatesRevisionShape(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "intent-shape")
+	store.ReviewDisabled = true
+	_, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "shape-acquire", WorkUnit: "verify",
+			EvidenceGoal: "independent verification", MaxAttempts: 1, MaxChangedLines: 20,
+		},
+		RemediatesEvidenceRevision: "not-a-revision",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--remediates-evidence-revision") {
+		t.Fatalf("malformed remediation intent = %v, want a shape refusal naming the flag", err)
+	}
+	if countRuntimeRecords(t, store.Dir) != 0 {
+		t.Fatalf("malformed remediation intent mutated the ledger")
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1898,12 +1898,46 @@ func nativeRuntimeInstructions(status Status, change string) []string {
 		fmt.Sprintf("After the external run, call `gentle-ai sdd-attempt settle --cwd %s --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome <passed|failed|interrupted> --evidence-revision <sha256> --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`; add --successor-lineage only for a distinct approved remediation successor.", pathquote.Quote(workspace), change),
 		"Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic.",
 	}
-	if status.RemediationState.Required && status.RemediationState.LineageID == "" && status.RuntimeStatus != nil && status.RuntimeStatus.Objective != nil {
-		objective := status.RuntimeStatus.Objective
-		instructions = append(instructions,
-			fmt.Sprintf("Disabled/unmanaged remediation has one bounded correction attempt: run `gentle-ai sdd-attempt acquire --cwd %s --change %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d`.", pathquote.Quote(workspace), change, objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines),
-			fmt.Sprintf("After the candidate changes, settle that token with `--remediates-evidence-revision %s`; a fresh independent verification is required before archive.", status.RemediationState.FailedEvidenceRevision),
-		)
+	// #2564 status truthfulness: the bounded correction prescription renders
+	// only while its settlement can structurally succeed. Satisfiability
+	// follows the chain-derived binding (#2565): the immutable attempt chain
+	// must hold unremediated failed evidence, and the prescription names the
+	// chain's own evidence. An audited reset does not sever that binding, so
+	// post-reset states keep the truthful correction route (through the
+	// maintainer's reset when the ledger holds a terminal decision); only a
+	// chain with nothing left to remediate renders the fresh-verification
+	// route instead. Readiness stays runtimeReadiness's answer; only the
+	// chain's immutable facts are derived here.
+	if status.RemediationState.Required && status.RemediationState.LineageID == "" && status.RuntimeStatus != nil {
+		runtime := status.RuntimeStatus
+		readiness, terminal := runtimeReadiness(runtimeReadinessInput{
+			Status: *runtime, AttemptTokens: status.runtimeAttemptTokens,
+		})
+		launchable := !terminal || readiness.Reason == CompactBlockActiveAttempt
+		chainEvidence, chainHasFailedEvidence := runtimeChainFailedEvidence(runtime.Attempts)
+		switch {
+		case chainHasFailedEvidence && runtime.Objective != nil && launchable:
+			objective := runtime.Objective
+			instructions = append(instructions,
+				fmt.Sprintf("Disabled/unmanaged remediation has one bounded correction attempt: run `gentle-ai sdd-attempt acquire --cwd %s --change %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d --remediates-evidence-revision %s`.", pathquote.Quote(workspace), change, objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines, chainEvidence),
+				fmt.Sprintf("After the candidate changes, settle that token with `--remediates-evidence-revision %s`; a fresh independent verification is required before archive.", chainEvidence),
+			)
+		case chainHasFailedEvidence && terminal && readiness.Reason == CompactBlockMaintainerDecision:
+			instructions = append(instructions,
+				fmt.Sprintf("Disabled/unmanaged remediation for failed evidence %s needs a maintainer scope decision before its one bounded correction can launch.", chainEvidence),
+				fmt.Sprintf("Record the maintainer decision with `gentle-ai sdd-attempt reset --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --actor \"<maintainer>\" --reason \"<decision>\"`, then acquire the bounded correction declaring `--remediates-evidence-revision %s`; the failed-evidence binding derives from the immutable attempt chain and survives the audited reset.", pathquote.Quote(workspace), change, runtime.Revision, chainEvidence),
+			)
+		case chainHasFailedEvidence:
+			instructions = append(instructions,
+				fmt.Sprintf("Disabled/unmanaged remediation has one bounded correction attempt: declare `--remediates-evidence-revision %s` on the `gentle-ai sdd-attempt acquire` call above; the failed-evidence binding derives from the immutable attempt chain and survives an audited reset.", chainEvidence),
+				fmt.Sprintf("After the candidate changes, settle that token with `--remediates-evidence-revision %s`; a fresh independent verification is required before archive.", chainEvidence),
+			)
+		default:
+			instructions = append(instructions,
+				fmt.Sprintf("Unmanaged remediation for failed evidence %s cannot settle against the current runtime ledger: the attempt chain holds no unremediated failed evidence (nothing failed, or the failure was already corrected by a passed settlement), so do not acquire with `--remediates-evidence-revision`.", status.RemediationState.FailedEvidenceRevision),
+				fmt.Sprintf("Run `gentle-ai sdd-attempt status --cwd %s --change %q` to read the attempt chain, then continue through a fresh verification objective without `--remediates-evidence-revision`; its own failed settlement records the evidence a bounded correction can name.", pathquote.Quote(workspace), change),
+			)
+		}
 	}
 	return append(instructions, liveRuntimeAttemptInstructions(status)...)
 }

--- a/internal/sddstatus/status_remediation_instructions_test.go
+++ b/internal/sddstatus/status_remediation_instructions_test.go
@@ -1,0 +1,167 @@
+package sddstatus
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #2564 status truthfulness, reconciled with #2565's chain-derived binding:
+// the bounded correction prescription renders whenever the immutable attempt
+// chain holds unremediated failed evidence (naming the chain's evidence, and
+// surviving an audited reset), the decision-required state renders the
+// audited reset route, and only a chain with nothing left to remediate
+// renders the fresh-verification route.
+
+// seedUnmanagedFailedVerification drives the shared fixture: the disabled
+// failed-verification ledger plus the admitted failed verify report that
+// makes RemediationState.Required true.
+func seedUnmanagedFailedVerification(t *testing.T, repo, change string, maxAttempts int) (RuntimeStore, string, RuntimeStatus) {
+	t.Helper()
+	changeRoot := seedReadyChange(t, repo, change, "- [x] 1.1 Work\n")
+	store, failedEvidence, failed := seedFailedVerificationLedger(t, repo, change, maxAttempts)
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(failedEvidence, "fail"))
+	return store, failedEvidence, failed
+}
+
+func resolveDisabledRemediationInstructions(t *testing.T, repo, change string) (Status, string) {
+	t.Helper()
+	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: change, ReviewDisabled: true, IncludeInstructions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.RemediationState.Required || status.RemediationState.LineageID != "" {
+		t.Fatalf("fixture did not require unmanaged remediation: %#v", status.RemediationState)
+	}
+	if status.PhaseInstructions == nil {
+		t.Fatal("PhaseInstructions is nil")
+	}
+	return status, strings.Join(status.PhaseInstructions.Remediate, "\n")
+}
+
+// TestStatusKeepsPrescribingChainBoundRemediationAfterReset pins the slice 1 /
+// slice 2 reconciliation on the status side: after an audited reset and a
+// fresh correction objective, the chain still binds the failed evidence, so
+// the bounded correction prescription keeps rendering with the chain's own
+// revision instead of degrading to a decision route.
+func TestStatusKeepsPrescribingChainBoundRemediationAfterReset(t *testing.T) {
+	const change = "post-reset-advice"
+	repo := initRuntimeLedgerRepo(t)
+	store, failedEvidence, failed := seedUnmanagedFailedVerification(t, repo, change, 1)
+	if !failed.DecisionRequired {
+		t.Fatalf("exhausted failed verification did not require a decision: %#v", failed)
+	}
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: change + "-reset",
+		Reason: "maintainer authorized bounded remediation", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: reset.Revision, RequestID: change + "-begin-correction", WorkUnit: "remediation",
+		EvidenceGoal: "bounded correction", MaxAttempts: 1, MaxChangedLines: 200,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, joined := resolveDisabledRemediationInstructions(t, repo, change)
+	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
+		t.Fatalf("post-reset status lost the chain-bound correction prescription:\n%s", joined)
+	}
+	if !strings.Contains(joined, "Disabled/unmanaged remediation has one bounded correction attempt") {
+		t.Fatalf("post-reset status lost the bounded correction framing:\n%s", joined)
+	}
+	if strings.Contains(joined, "cannot settle") {
+		t.Fatalf("post-reset status degraded a satisfiable correction to the decision route:\n%s", joined)
+	}
+}
+
+// TestStatusRendersResetRouteWhileRemediationNeedsADecision covers the wedge
+// every #1974 occurrence reported: failed evidence with an exhausted budget is
+// decision-required, so an immediate correction acquire would return
+// blocked/maintainer_decision. Status renders the audited reset route with
+// the exact current revision, and names the chain binding the post-reset
+// acquire must declare.
+func TestStatusRendersResetRouteWhileRemediationNeedsADecision(t *testing.T) {
+	const change = "decision-required-advice"
+	repo := initRuntimeLedgerRepo(t)
+	_, failedEvidence, failed := seedUnmanagedFailedVerification(t, repo, change, 1)
+	if !failed.DecisionRequired {
+		t.Fatalf("exhausted failed verification did not require a decision: %#v", failed)
+	}
+
+	_, joined := resolveDisabledRemediationInstructions(t, repo, change)
+	if strings.Contains(joined, "bounded correction attempt: run") {
+		t.Fatalf("decision-required status still prescribes the blocked correction acquire:\n%s", joined)
+	}
+	if !strings.Contains(joined, "sdd-attempt reset") || !strings.Contains(joined, failed.Revision) {
+		t.Fatalf("decision-required status does not render the audited reset route:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
+		t.Fatalf("decision-required status does not name the chain binding for the post-reset acquire:\n%s", joined)
+	}
+}
+
+// TestStatusStillPrescribesSatisfiableUnmanagedRemediation is the regression
+// guard for the direct case: budget remains and the chain binds the failure,
+// so the bounded correction prescription renders exactly as before, now
+// declaring the remediation intent at acquire too.
+func TestStatusStillPrescribesSatisfiableUnmanagedRemediation(t *testing.T) {
+	const change = "satisfiable-advice"
+	repo := initRuntimeLedgerRepo(t)
+	_, failedEvidence, failed := seedUnmanagedFailedVerification(t, repo, change, 2)
+	if failed.DecisionRequired || failed.EvidenceRevision != failedEvidence {
+		t.Fatalf("fixture lost the live failed-evidence binding: %#v", failed)
+	}
+
+	_, joined := resolveDisabledRemediationInstructions(t, repo, change)
+	if !strings.Contains(joined, "Disabled/unmanaged remediation has one bounded correction attempt") {
+		t.Fatalf("satisfiable status lost the bounded correction prescription:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
+		t.Fatalf("satisfiable status does not bind the settle to the failed evidence:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--max-changed-lines 20 --remediates-evidence-revision "+failedEvidence) {
+		t.Fatalf("satisfiable acquire prescription does not declare the remediation intent:\n%s", joined)
+	}
+}
+
+// TestStatusRendersFreshVerificationRouteWhenNothingRemediable is the one
+// state that truly cannot settle: the chain holds no failed evidence (here an
+// interrupted-only chain), so prescribing `--remediates-evidence-revision`
+// would demand a settlement Finish can never admit. Status renders the
+// fresh-verification route instead.
+func TestStatusRendersFreshVerificationRouteWhenNothingRemediable(t *testing.T) {
+	const change = "nothing-remediable-advice"
+	repo := initRuntimeLedgerRepo(t)
+	changeRoot := seedReadyChange(t, repo, change, "- [x] 1.1 Work\n")
+	store := mustRuntimeStore(t, repo, change)
+	store.ReviewDisabled = true
+	begun, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: change + "-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	if _, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: begun.Revision, RequestID: change + "-finish-interrupted", Outcome: AttemptInterrupted,
+		EvidenceRevision: failedEvidence, Diagnosis: "transport ended before verification settled",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "stalled process group cleanup completed",
+		ProcessEvidence: "stalled process scan found no surviving descendants",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(failedEvidence, "fail"))
+
+	_, joined := resolveDisabledRemediationInstructions(t, repo, change)
+	if strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
+		t.Fatalf("nothing-remediable status still prescribes an unsatisfiable binding:\n%s", joined)
+	}
+	if !strings.Contains(joined, "cannot settle") || !strings.Contains(joined, "fresh verification objective") {
+		t.Fatalf("nothing-remediable status does not render the fresh-verification route:\n%s", joined)
+	}
+}


### PR DESCRIPTION
Slice 1 of the #1974 fix, per the design comment recorded there. Remediation intent fails fast at acquire instead of after the correction work, and status stops prescribing unmanaged-remediation instructions that cannot settle.

Closes #2564
Refs #1974

## What changed

- **Acquire-time typed refusal**: `sdd-attempt acquire` accepts `--remediates-evidence-revision`, mirroring settle. A declared unmanaged correction whose settlement is structurally unsatisfiable returns `blocked/remediation_unsatisfiable` with the compactBlocked Exit/Detail discipline, before any token is issued and any correction work runs. Zero mutation on refusal.
- **Status truthfulness**: the bounded correction prescription renders only while it can settle, naming the chain's own failed evidence and now declaring the intent on the prescribed acquire; the decision-required state renders the audited reset route with the exact current revision; a chain with nothing left to remediate renders the fresh-verification route.
- The Finish guard does not change in this slice: `runtime_ledger.go` is untouched (#2565 / PR #2567 owns it).

## Intent-visibility choice

A declared flag on acquire (mirroring settle), not derivation from `RemediationState.Required`: `RemediationState` is a status-layer aggregate (verify report plus review transaction) invisible to `RuntimeStore.Acquire`, and only the caller knows whether a new work unit is meant to bind failed evidence. Deriving intent implicitly would have refused legitimate fresh objectives on the same ledger states.

## Reconciliation with #2565 (PR #2567)

Built before #2567 existed in any base, then reconciled on its chain-derived semantics mid-flight: satisfiability is decided by a mirror of `runtimeChainFailedEvidence` (walk the immutable attempt chain backward, skip running/interrupted audit records, sever at the first passed settlement, bind the most recent settled failure). Consequences:

- an acquire after an audited reset is **satisfiable** while the chain still holds unbound failed evidence (pinned by `TestCompactAcquireRemediationIntentSurvivesAuditedReset`);
- the refusal fires only when the chain holds no bindable failed evidence: nothing failed, the failure already has a passed correction (anti-laundering fail-fast), or a different revision was declared;
- with #2567 now merged, the promised reconciliation is done in this PR: the temporary mirror was deleted and `unmanagedRemediationSettleable` plus the status rendering call the merged `runtimeChainFailedEvidence` directly, so the binding rule has exactly one implementation. `runtime_ledger.go` remains untouched by this slice.

## Base

Rebased onto current `main` (2e5af7a3, which contains both PR #2185 and PR #2567); the PR is a single commit. It was originally built on PR #2185's head because both slices rework the same `status.go` surface.

## RED (verbatim)

On base, the intent is not expressible at acquire:

```
RunSDDAttempt([acquire ... --remediates-evidence-revision sha256:aaaa...]):
  flag provided but not defined: -remediates-evidence-revision
internal/sddstatus/runtime_compact_remediation_intent_test.go:123:3:
  unknown field RemediatesEvidenceRevision in struct literal of type CompactAcquireRequest
```

With only the inert plumbing added (field plus CLI passthrough, zero enforcement), the behavioral RED is the design comment's exact shape:

```
--- FAIL: TestCompactAcquireRemediationIntentFailsFastAfterAuditedReset (0.09s)
    post-reset remediation-intent acquire = sddstatus.CompactAttemptResult{State:"proceed", Reason:"",
    Token:"sha256:f47591eb..."}, want blocked/remediation_unsatisfiable
--- FAIL: TestRunSDDAttemptAcquireRemediationIntentFailsFastAfterReset (0.11s)
    post-reset remediation-intent acquire = cli.compactAttemptOutput{State:"proceed", ...}, want blocked/remediation_unsatisfiable
--- FAIL: TestStatusStopsPrescribingUnsatisfiableRemediationAfterReset
    post-reset status still prescribes the unsatisfiable settle:
    ... settle that token with `--remediates-evidence-revision sha256:aaaa...` ...
--- FAIL: TestStatusRendersResetRouteWhileRemediationNeedsADecision
    decision-required status still prescribes the blocked correction: ...
```

(The post-reset acquire expectation then flipped from blocked to proceed during the #2567 reconciliation; the refusal RED survives as the stale-evidence, settled-evidence, and nothing-failed cases.)

## Verification

- `go test ./... -count=1` at root: all packages ok (includes the refusal-resolution ratchet, the one-readiness-predicate guard, and the legacy compact JSON size bounds)
- `go test ./...` in `bench/`: ok
- `gofmt -l`: clean; `go vet ./...`: clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions
- New refusal string names its runnable continuation (`gentle-ai sdd-attempt acquire`), so the refusal ratchet is satisfied without a baseline entry

## Size

102 changed lines of production code after the mirror collapse (within the design comment's 150-200 estimate); 574 total changed lines. The total exceeds 400 because the tests pin both directions of the slice 1 / slice 2 reconciliation (fail-fast refusals, reset-surviving acquire, anti-laundering, and four status rendering states); trimming them would leave the reconciled contract unpinned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remediation evidence revision support to acquisition workflows.
  * Prevented remediation attempts when matching failed evidence is unavailable, stale, or already settled.
  * Preserved valid remediation paths across audited resets and direct corrections.
  * Improved remediation guidance with clearer routes for acquisition, reset, and fresh verification.
  * Added validation for malformed evidence revisions.

* **Bug Fixes**
  * Verification and remediation decisions now require a current verification report.
  * Improved handling of stale verification evidence and review-authority failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->