### PR TITLE
fix(review): publish immutable artifacts across Linux EXDEV

### DIFF
--- a/internal/reviewtransaction/publish_immutable_linux.go
+++ b/internal/reviewtransaction/publish_immutable_linux.go
@@ -54,23 +54,16 @@ func publishNoReplaceByCopy(source, destination string) error {
 		return err
 	}
 	if err := out.Chmod(info.Mode().Perm()); err != nil {
-		_ = out.Close()
-		_ = removeImmutablePublication(destination)
-		return err
+		return errors.Join(err, out.Close(), removeImmutablePublication(destination))
 	}
 	if _, err := copyImmutablePublication(out, in); err != nil {
-		_ = out.Close()
-		_ = removeImmutablePublication(destination)
-		return err
+		return errors.Join(err, out.Close(), removeImmutablePublication(destination))
 	}
 	if err := out.Sync(); err != nil {
-		_ = out.Close()
-		_ = removeImmutablePublication(destination)
-		return err
+		return errors.Join(err, out.Close(), removeImmutablePublication(destination))
 	}
 	if err := out.Close(); err != nil {
-		_ = removeImmutablePublication(destination)
-		return err
+		return errors.Join(err, removeImmutablePublication(destination))
 	}
 	return removeImmutablePublication(source)
 }

--- a/internal/reviewtransaction/publish_immutable_linux.go
+++ b/internal/reviewtransaction/publish_immutable_linux.go
@@ -4,17 +4,75 @@ package reviewtransaction
 
 import (
 	"errors"
+	"io"
 	"os"
 
 	"golang.org/x/sys/unix"
 )
 
+type immutablePublicationDestination interface {
+	io.Writer
+	Chmod(os.FileMode) error
+	Sync() error
+	Close() error
+}
+
+// These seams exercise filesystem failures that require a mounted filesystem
+// or a full disk in production, including the DrvFS/9p EXDEV case (#2583).
+var (
+	renameNoReplace                       = unix.Renameat2
+	createImmutablePublicationDestination = func(path string, flag int, mode os.FileMode) (immutablePublicationDestination, error) {
+		return os.OpenFile(path, flag, mode)
+	}
+	copyImmutablePublication   = io.Copy
+	removeImmutablePublication = os.Remove
+)
+
 func publishNoReplace(source, destination string) error {
-	err := unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE)
-	if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EOPNOTSUPP) {
-		return os.Link(source, destination)
+	err := renameNoReplace(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE)
+	if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.EXDEV) {
+		return publishNoReplaceByCopy(source, destination)
 	}
 	return err
+}
+
+// publishNoReplaceByCopy preserves immutability where Linux cannot rename or
+// hard-link across the publication boundary. O_EXCL is the no-replace primitive.
+func publishNoReplaceByCopy(source, destination string) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := createImmutablePublicationDestination(destination, os.O_RDWR|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if err := out.Chmod(info.Mode().Perm()); err != nil {
+		_ = out.Close()
+		_ = removeImmutablePublication(destination)
+		return err
+	}
+	if _, err := copyImmutablePublication(out, in); err != nil {
+		_ = out.Close()
+		_ = removeImmutablePublication(destination)
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = removeImmutablePublication(destination)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = removeImmutablePublication(destination)
+		return err
+	}
+	return removeImmutablePublication(source)
 }
 
 func replaceFileAtomic(source, destination string) error {

--- a/internal/reviewtransaction/publish_immutable_linux_test.go
+++ b/internal/reviewtransaction/publish_immutable_linux_test.go
@@ -14,10 +14,18 @@ import (
 
 type testImmutablePublicationDestination struct {
 	*os.File
+	chmodErr error
 	syncErr  error
 	closeErr error
 	synced   bool
 	closed   bool
+}
+
+func (file *testImmutablePublicationDestination) Chmod(mode os.FileMode) error {
+	if file.chmodErr != nil {
+		return file.chmodErr
+	}
+	return file.File.Chmod(mode)
 }
 
 func (file *testImmutablePublicationDestination) Sync() error {
@@ -196,6 +204,67 @@ func TestPublishNoReplaceLinuxCopyFallbackCleansUpSyncAndCloseFailures(t *testin
 			}
 			if _, err := os.Stat(source); err != nil {
 				t.Fatalf("source was removed after %s failure: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestPublishNoReplaceLinuxCopyFallbackJoinsDestinationCleanupFailure(t *testing.T) {
+	for _, stage := range []string{"chmod", "copy", "sync", "close"} {
+		t.Run(stage, func(t *testing.T) {
+			forceLinuxCopyFallback(t, unix.EXDEV)
+			primary := errors.New(stage + " failed")
+			cleanup := errors.New("destination cleanup failed")
+			originalCreate, originalCopy, originalRemove := createImmutablePublicationDestination, copyImmutablePublication, removeImmutablePublication
+			t.Cleanup(func() {
+				createImmutablePublicationDestination, copyImmutablePublication, removeImmutablePublication = originalCreate, originalCopy, originalRemove
+			})
+			createImmutablePublicationDestination = func(path string, flag int, mode os.FileMode) (immutablePublicationDestination, error) {
+				file, err := os.OpenFile(path, flag, mode)
+				if err != nil {
+					return nil, err
+				}
+				destination := &testImmutablePublicationDestination{File: file}
+				switch stage {
+				case "chmod":
+					destination.chmodErr = primary
+				case "sync":
+					destination.syncErr = primary
+				case "close":
+					destination.closeErr = primary
+				}
+				return destination, nil
+			}
+			if stage == "copy" {
+				copyImmutablePublication = func(io.Writer, io.Reader) (int64, error) { return 0, primary }
+			}
+
+			dir := t.TempDir()
+			source := writeImmutablePublicationSource(t, dir)
+			destination := filepath.Join(dir, "receipt.json")
+			sourceRemoved := false
+			removeImmutablePublication = func(path string) error {
+				if path == destination {
+					return cleanup
+				}
+				if path == source {
+					sourceRemoved = true
+				}
+				return os.Remove(path)
+			}
+
+			err := publishNoReplace(source, destination)
+			if !errors.Is(err, primary) || !errors.Is(err, cleanup) {
+				t.Fatalf("publishNoReplace(%s) error = %v, want both primary and cleanup causes", stage, err)
+			}
+			if sourceRemoved {
+				t.Fatal("source was removed after failed destination cleanup")
+			}
+			if _, err := os.Stat(source); err != nil {
+				t.Fatalf("source is missing after failed destination cleanup: %v", err)
+			}
+			if _, err := os.Stat(destination); err != nil {
+				t.Fatalf("partial destination was not exposed after failed cleanup: %v", err)
 			}
 		})
 	}

--- a/internal/reviewtransaction/publish_immutable_linux_test.go
+++ b/internal/reviewtransaction/publish_immutable_linux_test.go
@@ -1,0 +1,242 @@
+//go:build linux
+
+package reviewtransaction
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+type testImmutablePublicationDestination struct {
+	*os.File
+	syncErr  error
+	closeErr error
+	synced   bool
+	closed   bool
+}
+
+func (file *testImmutablePublicationDestination) Sync() error {
+	file.synced = true
+	if file.syncErr != nil {
+		return file.syncErr
+	}
+	return file.File.Sync()
+}
+
+func (file *testImmutablePublicationDestination) Close() error {
+	file.closed = true
+	err := file.File.Close()
+	if file.closeErr != nil {
+		return file.closeErr
+	}
+	return err
+}
+
+func forceLinuxCopyFallback(t *testing.T, renameErr error) {
+	t.Helper()
+	original := renameNoReplace
+	renameNoReplace = func(int, string, int, string, uint) error { return renameErr }
+	t.Cleanup(func() { renameNoReplace = original })
+}
+
+func writeImmutablePublicationSource(t *testing.T, dir string) string {
+	t.Helper()
+	source := filepath.Join(dir, "source.tmp")
+	if err := os.WriteFile(source, []byte("receipt\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	return source
+}
+
+func TestPublishNoReplaceLinuxFallsBackToExclusiveCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		renameErr error
+	}{
+		{name: "EXDEV", renameErr: unix.EXDEV},
+		{name: "ENOSYS", renameErr: unix.ENOSYS},
+		{name: "EINVAL", renameErr: unix.EINVAL},
+		{name: "EOPNOTSUPP", renameErr: unix.EOPNOTSUPP},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			forceLinuxCopyFallback(t, tt.renameErr)
+
+			dir := t.TempDir()
+			source := writeImmutablePublicationSource(t, dir)
+			destination := filepath.Join(dir, "receipt.json")
+			if err := publishNoReplace(source, destination); err != nil {
+				t.Fatalf("publishNoReplace(%s fallback) error = %v", tt.name, err)
+			}
+			payload, err := os.ReadFile(destination)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(payload) != "receipt\n" {
+				t.Fatalf("destination payload = %q, want copied source content", payload)
+			}
+			info, err := os.Stat(destination)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm() != 0o640 {
+				t.Fatalf("destination mode = %v, want 0640", info.Mode().Perm())
+			}
+			if _, err := os.Stat(source); !os.IsNotExist(err) {
+				t.Fatalf("source still exists after durable copy: %v", err)
+			}
+		})
+	}
+}
+
+func TestPublishNoReplaceLinuxCopyFallbackNeverReplacesDestination(t *testing.T) {
+	forceLinuxCopyFallback(t, unix.EXDEV)
+
+	dir := t.TempDir()
+	source := writeImmutablePublicationSource(t, dir)
+	destination := filepath.Join(dir, "receipt.json")
+	if err := os.WriteFile(destination, []byte("existing\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publishNoReplace(source, destination); !os.IsExist(err) {
+		t.Fatalf("publishNoReplace(existing destination) error = %v, want exists", err)
+	}
+	payload, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(payload) != "existing\n" {
+		t.Fatalf("existing destination was replaced: %q", payload)
+	}
+	if _, err := os.Stat(source); err != nil {
+		t.Fatalf("source was removed after destination conflict: %v", err)
+	}
+}
+
+func TestPublishImmutableLinuxCopyFallbackReplaysExactDestination(t *testing.T) {
+	forceLinuxCopyFallback(t, unix.EXDEV)
+
+	destination := filepath.Join(t.TempDir(), "receipt.json")
+	payload := []byte("receipt\n")
+	if err := publishImmutable(destination, payload, 0o640); err != nil {
+		t.Fatalf("publishImmutable(first publish) error = %v", err)
+	}
+	if err := publishImmutable(destination, payload, 0o640); err != nil {
+		t.Fatalf("publishImmutable(exact replay) error = %v", err)
+	}
+	stored, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stored) != string(payload) {
+		t.Fatalf("replayed destination = %q, want %q", stored, payload)
+	}
+}
+
+func TestPublishNoReplaceLinuxCopyFallbackCleansUpCopyFailure(t *testing.T) {
+	forceLinuxCopyFallback(t, unix.EXDEV)
+	original := copyImmutablePublication
+	want := errors.New("copy failed")
+	copyImmutablePublication = func(io.Writer, io.Reader) (int64, error) { return 0, want }
+	t.Cleanup(func() { copyImmutablePublication = original })
+
+	dir := t.TempDir()
+	source := writeImmutablePublicationSource(t, dir)
+	destination := filepath.Join(dir, "receipt.json")
+	if err := publishNoReplace(source, destination); !errors.Is(err, want) {
+		t.Fatalf("publishNoReplace(copy failure) error = %v, want %v", err, want)
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatalf("partial destination remains after copy failure: %v", err)
+	}
+	if _, err := os.Stat(source); err != nil {
+		t.Fatalf("source was removed after copy failure: %v", err)
+	}
+}
+
+func TestPublishNoReplaceLinuxCopyFallbackCleansUpSyncAndCloseFailures(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		syncErr  error
+		closeErr error
+	}{
+		{name: "sync", syncErr: errors.New("sync failed")},
+		{name: "close", closeErr: errors.New("close failed")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			forceLinuxCopyFallback(t, unix.EXDEV)
+			original := createImmutablePublicationDestination
+			var destinationFile *testImmutablePublicationDestination
+			createImmutablePublicationDestination = func(path string, flag int, mode os.FileMode) (immutablePublicationDestination, error) {
+				file, err := os.OpenFile(path, flag, mode)
+				if err != nil {
+					return nil, err
+				}
+				destinationFile = &testImmutablePublicationDestination{File: file, syncErr: tt.syncErr, closeErr: tt.closeErr}
+				return destinationFile, nil
+			}
+			t.Cleanup(func() { createImmutablePublicationDestination = original })
+
+			dir := t.TempDir()
+			source := writeImmutablePublicationSource(t, dir)
+			destination := filepath.Join(dir, "receipt.json")
+			if err := publishNoReplace(source, destination); !errors.Is(err, tt.syncErr) && !errors.Is(err, tt.closeErr) {
+				t.Fatalf("publishNoReplace(%s failure) error = %v", tt.name, err)
+			}
+			if destinationFile == nil || !destinationFile.closed {
+				t.Fatal("destination file was not closed on publication failure")
+			}
+			if _, err := os.Stat(destination); !os.IsNotExist(err) {
+				t.Fatalf("partial destination remains after %s failure: %v", tt.name, err)
+			}
+			if _, err := os.Stat(source); err != nil {
+				t.Fatalf("source was removed after %s failure: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestPublishNoReplaceLinuxCopyFallbackRemovesSourceOnlyAfterDurableDestination(t *testing.T) {
+	forceLinuxCopyFallback(t, unix.EXDEV)
+	originalCreate := createImmutablePublicationDestination
+	originalRemove := removeImmutablePublication
+	var destinationFile *testImmutablePublicationDestination
+	createImmutablePublicationDestination = func(path string, flag int, mode os.FileMode) (immutablePublicationDestination, error) {
+		file, err := os.OpenFile(path, flag, mode)
+		if err != nil {
+			return nil, err
+		}
+		destinationFile = &testImmutablePublicationDestination{File: file}
+		return destinationFile, nil
+	}
+	t.Cleanup(func() { createImmutablePublicationDestination = originalCreate })
+
+	dir := t.TempDir()
+	source := writeImmutablePublicationSource(t, dir)
+	destination := filepath.Join(dir, "receipt.json")
+	removeImmutablePublication = func(path string) error {
+		if path == source {
+			if destinationFile == nil || !destinationFile.synced || !destinationFile.closed {
+				t.Fatal("source removal preceded destination sync and close")
+			}
+			payload, err := os.ReadFile(destination)
+			if err != nil || string(payload) != "receipt\n" {
+				t.Fatalf("destination was not durable before source removal: %q, %v", payload, err)
+			}
+		}
+		return os.Remove(path)
+	}
+	t.Cleanup(func() { removeImmutablePublication = originalRemove })
+
+	if err := publishNoReplace(source, destination); err != nil {
+		t.Fatalf("publishNoReplace(copy fallback) error = %v", err)
+	}
+	if _, err := os.Stat(source); !os.IsNotExist(err) {
+		t.Fatalf("source remains after durable publication: %v", err)
+	}
+}


### PR DESCRIPTION
## Linked Issue

Closes #2583

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Fall back from Linux exclusive rename EXDEV and unsupported errors to an O_EXCL copy, without hard-linking across filesystems.
- Sync and close copied artifacts before source removal; clean partial destinations after copy, sync, or close failure.
- Keep the existing publishImmutable directory fsync and exact-replay path unchanged.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/publish_immutable_linux.go` | Add no-replace copy fallback and injectable filesystem seams. |
| `internal/reviewtransaction/publish_immutable_linux_test.go` | Cover EXDEV/unsupported rename, conflicts, replay, mode, cleanup, and durability ordering. |

---

## Test Plan

- [x] Focused RED: Linux tests did not compile on pre-fix source because the required seam and copy fallback were absent.
- [x] Focused: Linux publish-no-replace tests, uncached
- [x] Unit: `go test ./... -count=1`
- [x] Go format: `go run ./internal/gofmtcheck`
- [x] Vet and build: `go vet ./... && go build ./...`
- [x] Cross-build: Windows amd64, Darwin arm64, Linux amd64
- [x] Ratchets: `./scripts/deadcode-ratchet.sh` and `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`
- [x] Goldens: `go test ./internal/components -run TestGolden -count=1`
- [x] Bench module and CI-equivalent driven corpus: 64 core completed; untagged j57 unsupported; tagged j57 completed.
- [ ] Docker E2E: blocked locally because the Docker socket denies access; CI will execute Ubuntu, Arch, and Fedora.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 365 additions and 3 deletions
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass locally: Docker socket unavailable in this environment
- [x] Benchmark validation completed
- [x] Documentation is not required for an internal filesystem fallback
- [x] Commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

- Integrity guard: O_EXCL retains no-replace publication when renameat2 is unavailable or crosses devices.
- Guard population: only Linux ENOSYS, EINVAL, EOPNOTSUPP, and EXDEV publication failures enter the fallback; all other rename failures still propagate.
- The existing directory fsync and replay checks remain in publishImmutable; no capability, contract, or golden file changed.
- Rollback boundary: revert `049abc42` to remove only Linux fallback behavior and its tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved immutable transaction publication on Linux when direct renaming is unsupported or files span different filesystems.
  - Publication now safely falls back to copying while preserving file permissions and preventing replacement of an existing destination.
  - Improved failure handling to clean up incomplete copies and remove the source only after the destination is fully synchronized and closed.
  - Ensures exact destination contents are retained during fallback publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->