### PR TITLE
fix(filemerge): support Windows junction parent directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,23 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      - name: Run native Windows junction parent tests
+        shell: pwsh
+        timeout-minutes: 5
+        run: |
+          $selector = '^(TestWriteFileAtomicFollowsDirectoryJunction|TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets|TestWriteFileAtomicRejectsJunctionLoop)$'
+          $expected = @(
+            'TestWriteFileAtomicFollowsDirectoryJunction'
+            'TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets'
+            'TestWriteFileAtomicRejectsJunctionLoop'
+          )
+          $selected = @(go test ./internal/components/filemerge -list $selector | Where-Object { $_ -match '^Test' })
+          if ($LASTEXITCODE -ne 0) { throw 'Could not list native Windows junction parent tests' }
+          $missing = @($expected | Where-Object { $_ -notin $selected })
+          if ($missing.Count -gt 0) { throw "Missing native Windows junction parent tests: $($missing -join ', ')" }
+          go test -v ./internal/components/filemerge -count=1 -run $selector
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Build native test binary
         shell: pwsh
         run: go build -trimpath -ldflags="-s -w -X main.version=ci" -o "$env:RUNNER_TEMP\gentle-ai.exe" ./cmd/gentle-ai

--- a/internal/components/filemerge/atomic_parent_other.go
+++ b/internal/components/filemerge/atomic_parent_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package filemerge
+
+import "os"
+
+func resolveAtomicParentJunction(string, os.FileInfo) (string, os.FileInfo, bool, error) {
+	return "", nil, false, nil
+}

--- a/internal/components/filemerge/atomic_parent_windows.go
+++ b/internal/components/filemerge/atomic_parent_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package filemerge
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func resolveAtomicParentJunction(dir string, info os.FileInfo) (string, os.FileInfo, bool, error) {
+	if info.Mode()&os.ModeIrregular == 0 {
+		return "", nil, false, nil
+	}
+
+	// os.Readlink supports Windows symlinks and mount-point junctions. Other
+	// reparse-point tags return an error and remain rejected.
+	target, err := os.Readlink(dir)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("resolving directory junction parent %q: %w", dir, err)
+	}
+	resolved, err := filepath.Abs(target)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("resolve directory junction target %q: %w", target, err)
+	}
+	targetInfo, err := os.Stat(dir)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("stat directory junction target %q: %w", resolved, err)
+	}
+	return resolved, targetInfo, true, nil
+}

--- a/internal/components/filemerge/atomic_parent_windows.go
+++ b/internal/components/filemerge/atomic_parent_windows.go
@@ -15,15 +15,14 @@ func resolveAtomicParentJunction(dir string, info os.FileInfo) (string, os.FileI
 
 	// os.Readlink supports Windows symlinks and mount-point junctions. Other
 	// reparse-point tags return an error and remain rejected.
-	target, err := os.Readlink(dir)
+	if _, err := os.Readlink(dir); err != nil {
+		return "", nil, false, fmt.Errorf("resolving directory junction parent %q: %w", dir, err)
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
 	if err != nil {
 		return "", nil, false, fmt.Errorf("resolving directory junction parent %q: %w", dir, err)
 	}
-	resolved, err := filepath.Abs(target)
-	if err != nil {
-		return "", nil, false, fmt.Errorf("resolve directory junction target %q: %w", target, err)
-	}
-	targetInfo, err := os.Stat(dir)
+	targetInfo, err := os.Stat(resolved)
 	if err != nil {
 		return "", nil, false, fmt.Errorf("stat directory junction target %q: %w", resolved, err)
 	}

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -320,6 +320,15 @@ func ensureAtomicParentDir(dir, path string) error {
 			return fmt.Errorf("stat symlink target %q for %q: %w", resolved, path, err)
 		}
 		dir = resolved
+	} else {
+		resolved, resolvedInfo, handled, err := resolveAtomicParentJunction(dir, info)
+		if err != nil {
+			return fmt.Errorf("resolve parent directory for %q: %w", path, err)
+		}
+		if handled {
+			dir = resolved
+			info = resolvedInfo
+		}
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("parent path %q for %q is not a directory", dir, path)

--- a/internal/components/filemerge/writer_junction_windows_test.go
+++ b/internal/components/filemerge/writer_junction_windows_test.go
@@ -1,0 +1,118 @@
+//go:build windows
+
+package filemerge
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomicFollowsDirectoryJunction(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	junction := filepath.Join(root, "junction")
+	createDirectoryJunction(t, junction, target)
+
+	content := []byte("junction payload\n")
+	path := filepath.Join(junction, "config.txt")
+	if _, err := WriteFileAtomic(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic() through directory junction error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(target, "config.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile(target/config.txt) error = %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("target content = %q, want %q", got, content)
+	}
+}
+
+func TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets(t *testing.T) {
+	tests := []struct {
+		name          string
+		replaceTarget func(t *testing.T, target string)
+	}{
+		{
+			name: "broken target",
+			replaceTarget: func(t *testing.T, target string) {
+				if err := os.RemoveAll(target); err != nil {
+					t.Fatalf("RemoveAll(target) error = %v", err)
+				}
+			},
+		},
+		{
+			name: "target is not a directory",
+			replaceTarget: func(t *testing.T, target string) {
+				if err := os.RemoveAll(target); err != nil {
+					t.Fatalf("RemoveAll(target) error = %v", err)
+				}
+				if err := os.WriteFile(target, []byte("not a directory"), 0o644); err != nil {
+					t.Fatalf("WriteFile(target) error = %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			target := filepath.Join(root, "target")
+			if err := os.Mkdir(target, 0o755); err != nil {
+				t.Fatalf("Mkdir(target) error = %v", err)
+			}
+			junction := filepath.Join(root, "junction")
+			createDirectoryJunction(t, junction, target)
+			tt.replaceTarget(t, target)
+
+			err := ensureAtomicParentDir(junction, filepath.Join(junction, "config.txt"))
+			if err == nil {
+				t.Fatal("ensureAtomicParentDir() error = nil, want unsafe junction target rejection")
+			}
+		})
+	}
+}
+
+func TestWriteFileAtomicRejectsLinkLoop(t *testing.T) {
+	root := t.TempDir()
+	first := filepath.Join(root, "first")
+	second := filepath.Join(root, "second")
+	if err := os.Symlink(second, first); err != nil {
+		if isSymlinkPrivilegeError(err) {
+			t.Skipf("skipping: SeCreateSymbolicLinkPrivilege not held on this Windows build: %v", err)
+		}
+		t.Fatalf("Symlink(first) error = %v", err)
+	}
+	if err := os.Symlink(first, second); err != nil {
+		if isSymlinkPrivilegeError(err) {
+			t.Skipf("skipping: SeCreateSymbolicLinkPrivilege not held on this Windows build: %v", err)
+		}
+		t.Fatalf("Symlink(second) error = %v", err)
+	}
+
+	_, err := WriteFileAtomic(filepath.Join(first, "config.txt"), []byte("new\n"), 0o644)
+	if err == nil {
+		t.Fatal("WriteFileAtomic() error = nil, want link-loop rejection")
+	}
+}
+
+func createDirectoryJunction(t *testing.T, link, target string) {
+	t.Helper()
+	output, err := exec.Command("cmd.exe", "/d", "/c", "mklink", "/J", link, target).CombinedOutput()
+	if err != nil {
+		t.Fatalf("mklink /J %q %q error = %v: %s", link, target, err, output)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(link); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("Remove(junction) error = %v", err)
+		}
+	})
+}

--- a/internal/components/filemerge/writer_junction_windows_test.go
+++ b/internal/components/filemerge/writer_junction_windows_test.go
@@ -36,6 +36,32 @@ func TestWriteFileAtomicFollowsDirectoryJunction(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomicFollowsRelativeDirectoryJunction(t *testing.T) {
+	root := t.TempDir()
+	targetName := "relative-target-" + filepath.Base(root)
+	target := filepath.Join(root, targetName)
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	junction := filepath.Join(root, "junction")
+	createDirectoryJunction(t, junction, targetName)
+
+	content := []byte("relative junction payload\n")
+	path := filepath.Join(junction, "config.txt")
+	if _, err := WriteFileAtomic(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic() through relative directory junction error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(target, "config.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile(target/config.txt) error = %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("target content = %q, want %q", got, content)
+	}
+}
+
 func TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -108,7 +134,9 @@ func TestWriteFileAtomicRejectsJunctionLoop(t *testing.T) {
 
 func createDirectoryJunction(t *testing.T, link, target string) {
 	t.Helper()
-	output, err := exec.Command("cmd.exe", "/d", "/c", "mklink", "/J", link, target).CombinedOutput()
+	command := exec.Command("cmd.exe", "/d", "/c", "mklink", "/J", link, target)
+	command.Dir = filepath.Dir(link)
+	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("mklink /J %q %q error = %v: %s", link, target, err, output)
 	}

--- a/internal/components/filemerge/writer_junction_windows_test.go
+++ b/internal/components/filemerge/writer_junction_windows_test.go
@@ -81,26 +81,28 @@ func TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets(t *testing.T
 	}
 }
 
-func TestWriteFileAtomicRejectsLinkLoop(t *testing.T) {
+func TestWriteFileAtomicRejectsJunctionLoop(t *testing.T) {
 	root := t.TempDir()
 	first := filepath.Join(root, "first")
 	second := filepath.Join(root, "second")
-	if err := os.Symlink(second, first); err != nil {
-		if isSymlinkPrivilegeError(err) {
-			t.Skipf("skipping: SeCreateSymbolicLinkPrivilege not held on this Windows build: %v", err)
-		}
-		t.Fatalf("Symlink(first) error = %v", err)
+	if err := os.Mkdir(first, 0o755); err != nil {
+		t.Fatalf("Mkdir(first) error = %v", err)
 	}
-	if err := os.Symlink(first, second); err != nil {
-		if isSymlinkPrivilegeError(err) {
-			t.Skipf("skipping: SeCreateSymbolicLinkPrivilege not held on this Windows build: %v", err)
-		}
-		t.Fatalf("Symlink(second) error = %v", err)
+	if err := os.Mkdir(second, 0o755); err != nil {
+		t.Fatalf("Mkdir(second) error = %v", err)
 	}
+	if err := os.Remove(first); err != nil {
+		t.Fatalf("Remove(first) error = %v", err)
+	}
+	createDirectoryJunction(t, first, second)
+	if err := os.Remove(second); err != nil {
+		t.Fatalf("Remove(second) error = %v", err)
+	}
+	createDirectoryJunction(t, second, first)
 
 	_, err := WriteFileAtomic(filepath.Join(first, "config.txt"), []byte("new\n"), 0o644)
 	if err == nil {
-		t.Fatal("WriteFileAtomic() error = nil, want link-loop rejection")
+		t.Fatal("WriteFileAtomic() error = nil, want junction-loop rejection")
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2164

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Accept Windows directory junctions when their resolved target is an existing directory.
- Preserve rejection for broken junctions, loops, unsupported reparse points, and non-directory targets.
- Add Windows-specific regression coverage without changing non-Windows behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/filemerge/writer.go` | Delegates irregular parent classification to a platform-specific resolver. |
| `internal/components/filemerge/atomic_parent_windows.go` | Resolves valid Windows directory junction parents. |
| `internal/components/filemerge/atomic_parent_other.go` | Keeps non-Windows behavior unchanged. |
| `internal/components/filemerge/writer_junction_windows_test.go` | Covers valid, broken, looping, and non-directory junction targets. |

---

## 🧪 Test Plan

- [x] `go test ./internal/components/filemerge -count=1`
- [x] `go test ./internal/components/... -count=1`
- [x] `GOOS=windows GOARCH=amd64 go test -c ./internal/components/filemerge`
- [x] `go run ./internal/gofmtcheck`
- [ ] Runtime execution on Windows/NTFS. The Windows suite cross-compiles successfully, but a real junction runtime was unavailable from macOS.
- E2E: N/A, this is a focused filesystem boundary covered by package tests.
- Benchmark validation: N/A, this does not change review lifecycle or benchmark behavior.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Appropriate `type:*` label requested
- [x] Relevant unit tests pass
- [x] Go format passes
- [x] E2E applicability explained
- [x] Benchmark applicability explained
- [x] Documentation is not required for this internal compatibility fix
- [x] Commits follow Conventional Commits
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please pay particular attention to the Windows reparse-point boundary. The resolver only accepts a junction when `os.Readlink` and `os.Stat` prove that its target exists and is a directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved atomic file writing on Windows when files are stored inside directory junctions.
  - Added validation to reject broken junctions, junctions targeting non-directories, and junction loops.
  - Preserved consistent behavior on non-Windows platforms.

- **Tests**
  - Added Windows coverage for valid directory junctions and unsafe junction targets.
  - Added automated verification that all junction-related tests are discovered and executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->