### PR TITLE
fix(persona): sync selected persona with Pi

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -165,7 +165,7 @@ func TestNormalizeInstallFlagsCustomAcceptsOptionalGentlemanInstallables(t *test
 	}
 }
 
-func TestNormalizeInstallFlagsPiOnlyDefaultsToEngramOnly(t *testing.T) {
+func TestNormalizeInstallFlagsPiOnlyDefaultsToEngramAndPersona(t *testing.T) {
 	input, err := NormalizeInstallFlags(InstallFlags{
 		Agents: []string{string(model.AgentPi)},
 	}, system.DetectionResult{})
@@ -177,7 +177,7 @@ func TestNormalizeInstallFlagsPiOnlyDefaultsToEngramOnly(t *testing.T) {
 	if !reflect.DeepEqual(input.Selection.Agents, wantAgents) {
 		t.Fatalf("agents = %#v, want %#v", input.Selection.Agents, wantAgents)
 	}
-	wantComponents := []model.ComponentID{model.ComponentEngram}
+	wantComponents := []model.ComponentID{model.ComponentEngram, model.ComponentPersona}
 	if !reflect.DeepEqual(input.Selection.Components, wantComponents) {
 		t.Fatalf("components = %#v, want %#v", input.Selection.Components, wantComponents)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1526,6 +1526,14 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentPersona:
 		for _, adapter := range adapters {
+			if adapter.Agent() == model.AgentPi {
+				for _, rootDir := range piPersonaConfigRoots(s.homeDir, s.workspaceDir, s.scope) {
+					if _, err := persona.InjectPiPersona(rootDir, s.selection.Persona); err != nil {
+						return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
+					}
+				}
+				continue
+			}
 			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 			if _, err := persona.Inject(targetDir, adapter, s.selection.Persona); err != nil {
 				return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
@@ -2100,6 +2108,10 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if selection.Persona == model.PersonaCustom {
 				break
 			}
+			if adapter.Agent() == model.AgentPi {
+				paths = append(paths, piPersonaConfigPaths(homeDir, workspaceDir, scope)...)
+				break
+			}
 			if adapter.Agent() == model.AgentOpenClaw {
 				paths = append(paths, filepath.Join(targetDir, "SOUL.md"))
 				break
@@ -2179,6 +2191,27 @@ func componentInjectionDirScoped(homeDir, workspaceDir string, scope InstallScop
 		return workspaceDir
 	}
 	return ResolveAgentConfigDir(scope, homeDir, workspaceDir)
+}
+
+// piPersonaConfigRoots returns the roots whose Pi persona state is managed by
+// install. Global install keeps its global fallback and seeds the active
+// workspace so Pi sees the selected persona immediately; workspace install is
+// limited to the workspace root like every other scoped component.
+func piPersonaConfigRoots(homeDir, workspaceDir string, scope InstallScope) []string {
+	roots := []string{ResolveAgentConfigDir(scope, homeDir, workspaceDir)}
+	if scope == ScopeGlobal && strings.TrimSpace(workspaceDir) != "" && filepath.Clean(workspaceDir) != filepath.Clean(homeDir) {
+		roots = append(roots, workspaceDir)
+	}
+	return roots
+}
+
+func piPersonaConfigPaths(homeDir, workspaceDir string, scope InstallScope) []string {
+	roots := piPersonaConfigRoots(homeDir, workspaceDir, scope)
+	paths := make([]string, 0, len(roots))
+	for _, root := range roots {
+		paths = append(paths, persona.PiPersonaConfigPath(root))
+	}
+	return paths
 }
 
 func codeGraphGuidanceMarkdownForSDD(homeDir string, selected []model.CommunityToolID) string {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -130,6 +130,81 @@ func TestComponentPathsWorkspaceScopedOpenCodeSDDUsesWorkspaceManagedPaths(t *te
 	}
 }
 
+func TestComponentPersonaPiUsesResolvedScopePath(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPi})
+	selection := model.Selection{Persona: model.PersonaNeutral}
+
+	global := componentPathsWithWorkspaceScoped(home, workspace, ScopeGlobal, selection, adapters, model.ComponentPersona)
+	if !containsPath(global, filepath.Join(home, ".pi", "gentle-ai", "persona.json")) {
+		t.Fatalf("global Pi persona paths = %v, missing home-scoped config", global)
+	}
+	if !containsPath(global, filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")) {
+		t.Fatalf("global Pi persona paths = %v, missing active workspace config", global)
+	}
+
+	workspacePaths := componentPathsWithWorkspaceScoped(home, workspace, ScopeWorkspace, selection, adapters, model.ComponentPersona)
+	if !containsPath(workspacePaths, filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")) {
+		t.Fatalf("workspace Pi persona paths = %v, missing workspace-scoped config", workspacePaths)
+	}
+	if containsPath(workspacePaths, filepath.Join(home, ".pi", "gentle-ai", "persona.json")) {
+		t.Fatalf("workspace Pi persona paths = %v, unexpectedly contains home config", workspacePaths)
+	}
+
+	custom := componentPathsWithWorkspaceScoped(home, workspace, ScopeWorkspace, model.Selection{Persona: model.PersonaCustom}, adapters, model.ComponentPersona)
+	if len(custom) != 0 {
+		t.Fatalf("custom Pi persona paths = %v, want none", custom)
+	}
+}
+
+func TestInstallPiPersonaWritesManagedScopePaths(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		scope InstallScope
+	}{
+		{name: "global", scope: ScopeGlobal},
+		{name: "workspace", scope: ScopeWorkspace},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			root, other := home, workspace
+			if tt.scope == ScopeWorkspace {
+				root, other = workspace, home
+			}
+
+			step := componentApplyStep{
+				component:    model.ComponentPersona,
+				homeDir:      home,
+				workspaceDir: workspace,
+				scope:        tt.scope,
+				agents:       []model.AgentID{model.AgentPi},
+				selection:    model.Selection{Persona: model.PersonaNeutral},
+			}
+			if err := step.Run(); err != nil {
+				t.Fatalf("componentApplyStep.Run() error = %v", err)
+			}
+
+			want := filepath.Join(root, ".pi", "gentle-ai", "persona.json")
+			if _, err := os.Stat(want); err != nil {
+				t.Fatalf("Pi persona config %q was not written: %v", want, err)
+			}
+			if tt.scope == ScopeGlobal {
+				workspacePath := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+				if _, err := os.Stat(workspacePath); err != nil {
+					t.Fatalf("global Pi persona config %q was not seeded: %v", workspacePath, err)
+				}
+				return
+			}
+			unwanted := filepath.Join(other, ".pi", "gentle-ai", "persona.json")
+			if _, err := os.Stat(unwanted); !os.IsNotExist(err) {
+				t.Fatalf("workspace-scoped Pi persona config %q was written outside scope; stat err = %v", unwanted, err)
+			}
+		})
+	}
+}
+
 func TestLegacyOpenCodeBackgroundAgentsPluginRequiresConfigOpenCodePluginsPath(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -358,8 +358,8 @@ func BuildSyncSelection(flags SyncFlags, agentIDs []model.AgentID) model.Selecti
 		// correct default skill set when no explicit skills are provided.
 		Preset: model.PresetFullGentleman,
 		// Persona is left as zero-value here. RunSync resolves it from state.json
-		// when present. Missing or invalid persisted persona resolves to neutral
-		// so sync does not silently reactivate regional persona behavior.
+		// when present. A missing persona field resolves to neutral; invalid state
+		// is rejected so sync cannot silently reactivate regional persona behavior.
 	}
 }
 
@@ -1425,10 +1425,10 @@ func boolToInt(b bool) int {
 //
 // Resolution order:
 //  1. Explicit: if selection.Persona is non-empty, it is left untouched.
-//  2. Persisted: the persisted string is normalized via normalizePersona;
-//     on error (unknown/misspelled value) the fallback is used instead.
-//  3. Fallback: PersonaNeutral for default-safe behavior when persisted state is
-//     missing, empty, unreadable, or invalid.
+//  2. Persisted: the persisted string is normalized via normalizePersona.
+//  3. Fallback: PersonaNeutral for default-safe behavior when the persona field
+//     is empty or the state file is absent. Other read/validation errors are
+//     rejected by validatePersistedSyncState before this function is called.
 func applyResolvedPersona(selection *model.Selection, persisted string) {
 	if selection.Persona != "" {
 		return
@@ -1438,11 +1438,9 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 			selection.Persona = id
 			return
 		}
-		// Unknown/misspelled persisted value — fall through to neutral.
+		// Sync entry points reject unknown persisted values before resolution.
 	}
-	// Default-safe fallback: state files written before persona persistence have
-	// no Persona field, and unreadable/invalid state must not implicitly restore
-	// regional persona behavior.
+	// Default-safe fallback for state files written before persona persistence.
 	selection.Persona = model.PersonaNeutral
 }
 
@@ -1464,6 +1462,32 @@ func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState,
 	return nil
 }
 
+// validatePersistedSyncState rejects state that cannot safely drive sync.
+// A missing state file is allowed for fresh homes; a decoded state without a
+// persona remains compatible with legacy installations.
+func validatePersistedSyncState(persisted state.InstallState, readErr error) error {
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return nil
+		}
+		return fmt.Errorf("read persisted installation state: %w", readErr)
+	}
+
+	if persisted.Persona == "" {
+		if persisted.PersonaPresent {
+			return fmt.Errorf("validate persisted persona: explicitly empty persona is not valid") // refusal:by-design operator-knowledge: only the operator can choose the intended persona to replace malformed persisted state
+		}
+		return nil
+	}
+	if strings.TrimSpace(persisted.Persona) == "" {
+		return fmt.Errorf("validate persisted persona: whitespace-only persona is not valid") // refusal:by-design operator-knowledge: only the operator can choose the intended persona to replace malformed persisted state
+	}
+	if _, _, err := normalizePersona(persisted.Persona); err != nil {
+		return fmt.Errorf("validate persisted persona: %w", err)
+	}
+	return nil
+}
+
 // RunSyncWithSelection is the programmatic entry point for sync.
 // It skips flag parsing and agent discovery — the caller provides the homeDir
 // and a fully-built Selection (agents + components + options).
@@ -1474,6 +1498,9 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	// below must not rewrite state it could not read. Managed-asset provenance
 	// re-reads under its own lock later (#2685), so this read stays advisory.
 	persistedState, persistedStateErr := state.Read(homeDir)
+	if err := validatePersistedSyncState(persistedState, persistedStateErr); err != nil {
+		return SyncResult{Agents: agentIDs, Selection: selection}, err
+	}
 	restorePersistedCommunityTools(homeDir, &selection, persistedState)
 
 	// Resolve persona from persisted state when the caller has not provided one.
@@ -1622,9 +1649,12 @@ func RunSync(args []string) (SyncResult, error) {
 	selection := BuildSyncSelection(flags, agentIDs)
 
 	// Read state once for both model-assignment restoration and persona resolution.
-	// On error (e.g. state.json absent), treat persisted values as empty — model
-	// maps stay as-is and persona falls back to neutral.
-	persistedState, _ := state.Read(homeDir)
+	// A missing state file is treated as a fresh home; other read/validation
+	// errors stop sync before any persona mutation or asset write.
+	persistedState, persistedStateErr := state.Read(homeDir)
+	if err := validatePersistedSyncState(persistedState, persistedStateErr); err != nil {
+		return SyncResult{Agents: agentIDs, Selection: selection}, err
+	}
 	RestorePersistedSelection(&selection, persistedState, flags)
 	restorePersistedCommunityTools(homeDir, &selection, persistedState)
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -705,10 +705,11 @@ func syncComponentPathsWithWorkspace(homeDir, workspaceDir string, selection mod
 }
 
 // syncPersonaPaths returns the file paths that ComponentPersona writes during
-// sync. Mirrors persona.InjectForSync:
+// sync. Mirrors persona.InjectForSync and the Pi runtime config writer:
 //   - Step 1: SystemPromptFile (the marker-bound markdown block — CLAUDE.md /
 //     AGENTS.md / equivalent).
 //   - Step 3: managed output-style overlay (only when the agent supports it).
+//   - Pi: the project-local gentle-pi persona state file.
 //
 // Step 2 (OpenCode/Kilocode agent definition in opencode.json) is install-only
 // and intentionally NOT declared here.
@@ -722,6 +723,14 @@ func syncPersonaPathsWithWorkspace(homeDir, workspaceDir string, selection model
 	}
 	paths := []string{}
 	for _, adapter := range adapters {
+		if adapter.Agent() == model.AgentPi {
+			rootDir := workspaceDir
+			if strings.TrimSpace(rootDir) == "" {
+				rootDir = homeDir
+			}
+			paths = append(paths, persona.PiPersonaConfigPath(rootDir))
+			continue
+		}
 		targetDir := componentInjectionDir(homeDir, workspaceDir, adapter)
 		if adapter.Agent() == model.AgentOpenClaw {
 			paths = append(paths, filepath.Join(targetDir, "SOUL.md"))
@@ -1149,6 +1158,18 @@ func (s componentSyncStep) Run() error {
 		// merge conflicts with SDD's writes to the same settings file and
 		// remains an install-only concern.
 		for _, adapter := range adapters {
+			if adapter.Agent() == model.AgentPi {
+				rootDir := s.workspaceDir
+				if strings.TrimSpace(rootDir) == "" {
+					rootDir = s.homeDir
+				}
+				res, err := persona.InjectPiPersona(rootDir, s.selection.Persona)
+				if err != nil {
+					return fmt.Errorf("sync persona for %q: %w", adapter.Agent(), err)
+				}
+				s.countChanged(boolToInt(res.Changed), res.Files...)
+				continue
+			}
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 			res, err := persona.InjectForSync(targetDir, adapter, s.selection.Persona)
 			if err != nil {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4053,6 +4053,129 @@ func TestRunSyncFallsBackToNeutralWhenStateLacksPersona(t *testing.T) {
 	}
 }
 
+func TestRunSyncWithSelectionPiUsesNeutralForMissingPersonaField(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	piPath := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+	mustWriteFile(t, piPath, []byte("{\n  \"mode\": \"gentleman\"\n}\n"))
+	mustWriteFile(t, state.Path(home), []byte(`{"installed_agents":["pi"]}`))
+
+	result, err := RunSyncWithSelection(home, model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Components: []model.ComponentID{model.ComponentPersona},
+	})
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	if got, want := result.Selection.Persona, model.PersonaNeutral; got != want {
+		t.Fatalf("Selection.Persona = %q, want %q", got, want)
+	}
+	if got, want := readTextFile(t, piPath), "{\n  \"mode\": \"neutral\"\n}\n"; got != want {
+		t.Fatalf("Pi persona config = %q, want %q", got, want)
+	}
+}
+
+func TestRunSyncWithSelectionPiRejectsInvalidPersistedPersonaWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name       string
+		stateJSON  string
+		stateAsDir bool
+		wantErr    string
+	}{
+		{name: "malformed JSON", stateJSON: `{"installed_agents":["pi"],"persona":`, wantErr: "read persisted installation state"},
+		{name: "unreadable state", stateAsDir: true, wantErr: "read persisted installation state"},
+		{name: "unsupported persona", stateJSON: `{"installed_agents":["pi"],"persona":"unknown"}`, wantErr: `unsupported persona "unknown"`},
+		{name: "explicit empty persona", stateJSON: `{"installed_agents":["pi"],"persona":""}`, wantErr: "explicitly empty persona"},
+		{name: "whitespace-only persona", stateJSON: `{"installed_agents":["pi"],"persona":" \t "}`, wantErr: "whitespace-only persona"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			t.Chdir(workspace)
+			piPath := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+			originalPi := []byte("{\n  \"mode\": \"gentleman\"\n}\n")
+			mustWriteFile(t, piPath, originalPi)
+
+			if tt.stateAsDir {
+				if err := os.MkdirAll(state.Path(home), 0o755); err != nil {
+					t.Fatalf("MkdirAll(state path) error = %v", err)
+				}
+			} else {
+				mustWriteFile(t, state.Path(home), []byte(tt.stateJSON))
+			}
+
+			result, err := RunSyncWithSelection(home, model.Selection{
+				Agents:     []model.AgentID{model.AgentPi},
+				Components: []model.ComponentID{model.ComponentPersona},
+			})
+			if err == nil {
+				t.Fatal("RunSyncWithSelection() error = nil, want persisted persona validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("RunSyncWithSelection() error = %q, want %q", err, tt.wantErr)
+			}
+			if result.Selection.Persona != "" {
+				t.Fatalf("Selection.Persona = %q, want unchanged empty persona", result.Selection.Persona)
+			}
+			if got := readTextFile(t, piPath); got != string(originalPi) {
+				t.Fatalf("Pi persona config mutated after rejected sync: got %q, want %q", got, originalPi)
+			}
+		})
+	}
+}
+
+func TestRunSyncPiRejectsUnsupportedPersistedPersonaBeforeMutation(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	piPath := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+	originalPi := []byte("{\n  \"mode\": \"gentleman\"\n}\n")
+	mustWriteFile(t, piPath, originalPi)
+	mustWriteFile(t, state.Path(home), []byte(`{"installed_agents":["pi"],"persona":"unknown"}`))
+
+	result, err := RunSync([]string{"--agents", "pi"})
+	if err == nil {
+		t.Fatal("RunSync() error = nil, want unsupported persisted persona error")
+	}
+	if !strings.Contains(err.Error(), `unsupported persona "unknown"`) {
+		t.Fatalf("RunSync() error = %q, want unsupported persona", err)
+	}
+	if result.Selection.Persona != "" {
+		t.Fatalf("Selection.Persona = %q, want unchanged empty persona", result.Selection.Persona)
+	}
+	if got := readTextFile(t, piPath); got != string(originalPi) {
+		t.Fatalf("Pi persona config mutated after rejected sync: got %q, want %q", got, originalPi)
+	}
+}
+
+func TestRunSyncWithSelectionPiCustomPersistedPersonaIsByteStable(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	piPath := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+	originalPi := []byte("user-owned Pi persona bytes\n")
+	mustWriteFile(t, piPath, originalPi)
+	mustWriteFile(t, state.Path(home), []byte(`{"installed_agents":["pi"],"persona":"custom"}`))
+
+	result, err := RunSyncWithSelection(home, model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Components: []model.ComponentID{model.ComponentPersona},
+	})
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	if got, want := result.Selection.Persona, model.PersonaCustom; got != want {
+		t.Fatalf("Selection.Persona = %q, want %q", got, want)
+	}
+	if got := readTextFile(t, piPath); got != string(originalPi) {
+		t.Fatalf("custom Pi persona config changed: got %q, want %q", got, originalPi)
+	}
+}
+
 // ─── TUI path: RunSyncWithSelection persona resolution from state ───────────
 
 // TestRunSyncWithSelection_PersonaResolvesFromStateNeutral verifies that when
@@ -4188,19 +4311,19 @@ func TestRunSyncWithSelection_ExplicitPersonaWinsOverState(t *testing.T) {
 	}
 }
 
-// TestRunSyncWithSelection_UnknownPersistedPersonaFallsBackToNeutral documents
-// the normalizePersona contract for unrecognized persisted values: an unknown or
-// misspelled persona string must NOT silently propagate or reactivate Gentleman.
-func TestRunSyncWithSelection_UnknownPersistedPersonaFallsBackToNeutral(t *testing.T) {
+// TestRunSyncWithSelection_UnknownPersistedPersonaFailsClosed verifies that an
+// unsupported persisted persona is rejected before sync can rewrite assets.
+func TestRunSyncWithSelection_UnknownPersistedPersonaFailsClosed(t *testing.T) {
 	home := t.TempDir()
 	setSyncTestHome(t, home)
 
 	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
+	personaPath := filepath.Join(home, ".claude", "CLAUDE.md")
+	originalPersona := "<!-- gentle-ai:persona -->\nexisting valid persona\n<!-- /gentle-ai:persona -->\n"
+	mustWriteFile(t, personaPath, []byte(originalPersona))
 	// Write a state with an unrecognized persona value (wrong capitalization).
-	// normalizePersona does a case-sensitive switch, so "Gentleman" != "gentleman"
-	// and must return an error, triggering the neutral fallback.
 	if err := state.Write(home, state.InstallState{
 		InstalledAgents: []string{"claude-code"},
 		Persona:         "Gentleman", // capitalized — not a valid PersonaID
@@ -4215,12 +4338,17 @@ func TestRunSyncWithSelection_UnknownPersistedPersonaFallsBackToNeutral(t *testi
 	}
 
 	result, err := RunSyncWithSelection(home, sel)
-	if err != nil {
-		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	if err == nil {
+		t.Fatal("RunSyncWithSelection() error = nil, want unsupported persisted persona error")
 	}
-
-	if got, want := result.Selection.Persona, model.PersonaNeutral; got != want {
-		t.Errorf("result.Selection.Persona = %q, want %q (unknown persisted value must fall back to neutral)", got, want)
+	if !strings.Contains(err.Error(), `unsupported persona "Gentleman"`) {
+		t.Fatalf("RunSyncWithSelection() error = %q, want unsupported persona", err)
+	}
+	if result.Selection.Persona != "" {
+		t.Fatalf("Selection.Persona = %q, want unchanged empty persona", result.Selection.Persona)
+	}
+	if got := readTextFile(t, personaPath); got != originalPersona {
+		t.Fatalf("persona config mutated after rejected sync: got %q, want %q", got, originalPersona)
 	}
 }
 
@@ -4549,6 +4677,7 @@ func TestRunSyncPreservesCompletePersistedState(t *testing.T) {
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4", Effort: "medium"},
 		},
 		Persona:         "neutral",
+		PersonaPresent:  true,
 		LastUpdateCheck: &lastUpdate,
 		PendingSync:     true,
 	}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -749,6 +749,113 @@ func TestComponentSyncStepRunsPersonaInjectForSync(t *testing.T) {
 	}
 }
 
+func TestComponentSyncStepWritesPiPersonaToWorkspaceAndReportsChangedFile(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+	var changed []string
+	step := componentSyncStep{
+		id:           "sync:persona",
+		component:    model.ComponentPersona,
+		homeDir:      home,
+		workspaceDir: workspace,
+		agents:       []model.AgentID{model.AgentPi},
+		selection:    model.Selection{Persona: model.PersonaNeutral},
+		changedFiles: &changed,
+	}
+
+	if err := step.Run(); err != nil {
+		t.Fatalf("first Pi persona sync error = %v", err)
+	}
+	if !containsPath(changed, path) {
+		t.Fatalf("first Pi persona sync changed files = %v, missing %q", changed, path)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".pi", "gentle-ai", "persona.json")); !os.IsNotExist(err) {
+		t.Fatalf("Pi sync wrote a home-scoped persona config; stat err = %v", err)
+	}
+	if got := readTextFile(t, path); got != "{\n  \"mode\": \"neutral\"\n}\n" {
+		t.Fatalf("Pi persona config = %q, want neutral mode", got)
+	}
+
+	changed = nil
+	if err := step.Run(); err != nil {
+		t.Fatalf("second Pi persona sync error = %v", err)
+	}
+	if len(changed) != 0 {
+		t.Fatalf("second Pi persona sync changed files = %v, want none", changed)
+	}
+}
+
+func TestSyncPersonaPathsAndBackupTargetsTrackOnlyPiWorkspaceConfig(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    model.PersonaNeutral,
+	}
+	adapters := resolveAdapters(selection.Agents)
+	want := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+	unwanted := filepath.Join(home, ".pi", "gentle-ai", "persona.json")
+
+	paths := syncPersonaPathsWithWorkspace(home, workspace, selection, adapters)
+	if !containsPath(paths, want) || containsPath(paths, unwanted) {
+		t.Fatalf("sync persona paths = %v, want only workspace Pi config %q", paths, want)
+	}
+	targets, err := syncBackupTargets(home, workspace, selection, adapters)
+	if err != nil {
+		t.Fatalf("syncBackupTargets() error = %v", err)
+	}
+	if !containsPath(targets, want) || containsPath(targets, unwanted) {
+		t.Fatalf("sync backup targets = %v, want only workspace Pi config %q", targets, want)
+	}
+
+	selection.Persona = model.PersonaCustom
+	if paths := syncPersonaPathsWithWorkspace(home, workspace, selection, adapters); len(paths) != 0 {
+		t.Fatalf("custom sync persona paths = %v, want none", paths)
+	}
+}
+
+func TestPiPersonaSyncSnapshotRestoresWorkspaceConfig(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
+	mustWriteFile(t, path, []byte("{\n  \"mode\": \"gentleman\"\n}\n"))
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    model.PersonaNeutral,
+	}
+	targets, err := syncBackupTargets(home, workspace, selection, resolveAdapters(selection.Agents))
+	if err != nil {
+		t.Fatalf("syncBackupTargets() error = %v", err)
+	}
+	before, err := snapshotSyncFiles(targets)
+	if err != nil {
+		t.Fatalf("snapshotSyncFiles() error = %v", err)
+	}
+	step := componentSyncStep{
+		component:    model.ComponentPersona,
+		homeDir:      home,
+		workspaceDir: workspace,
+		agents:       selection.Agents,
+		selection:    selection,
+	}
+	if err := step.Run(); err != nil {
+		t.Fatalf("Pi persona sync error = %v", err)
+	}
+	if got := readTextFile(t, path); got == "{\n  \"mode\": \"gentleman\"\n}\n" {
+		t.Fatal("Pi persona sync did not change the workspace config before rollback")
+	}
+	if err := restoreSyncFiles(before); err != nil {
+		t.Fatalf("restoreSyncFiles() error = %v", err)
+	}
+	if got, want := readTextFile(t, path), "{\n  \"mode\": \"gentleman\"\n}\n"; got != want {
+		t.Fatalf("restored Pi persona config = %q, want %q", got, want)
+	}
+}
+
 func TestComponentSyncStepRunsSDDInject(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -273,7 +273,7 @@ func isPiOnlyAgents(agents []model.AgentID) bool {
 }
 
 func piOnlyComponents() []model.ComponentID {
-	return []model.ComponentID{model.ComponentEngram}
+	return []model.ComponentID{model.ComponentEngram, model.ComponentPersona}
 }
 
 func unique[T comparable](items []T) []T {

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -18,6 +18,43 @@ type InjectionResult struct {
 	Files   []string
 }
 
+// PiPersonaConfigPath returns the managed Pi persona state path beneath rootDir.
+// Pi resolves this file relative to the active agent configuration root, which
+// is the user's home for global install and the workspace for workspace install.
+func PiPersonaConfigPath(rootDir string) string {
+	return filepath.Join(rootDir, ".pi", "gentle-ai", "persona.json")
+}
+
+// InjectPiPersona writes the small runtime config consumed by gentle-pi.
+// Custom personas remain user-owned and therefore intentionally do nothing.
+func InjectPiPersona(rootDir string, persona model.PersonaID) (InjectionResult, error) {
+	if strings.TrimSpace(rootDir) == "" {
+		return InjectionResult{}, fmt.Errorf("Pi persona root must not be empty")
+	}
+	if persona == model.PersonaCustom {
+		return InjectionResult{}, nil
+	}
+
+	mode := string(persona)
+	if mode == "" {
+		mode = string(model.PersonaGentleman)
+	}
+	content, err := json.MarshalIndent(struct {
+		Mode string `json:"mode"`
+	}{Mode: mode}, "", "  ")
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("encode Pi persona config: %w", err)
+	}
+	content = append(content, '\n')
+
+	path := PiPersonaConfigPath(rootDir)
+	writeResult, err := filemerge.WriteFileAtomic(path, content, 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{path}}, nil
+}
+
 // bootstrapper is an optional adapter capability: if an adapter implements
 // this interface, any injector that writes Jinja modules will first ensure
 // the base template (entry point) exists.

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -434,6 +434,66 @@ func TestInjectCustomOpenCodeDoesNothing(t *testing.T) {
 	}
 }
 
+func TestInjectPiPersonaWritesSelectedModeAndIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	path := PiPersonaConfigPath(root)
+
+	result, err := InjectPiPersona(root, model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("InjectPiPersona() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("first Pi persona injection changed = false, want true")
+	}
+	if len(result.Files) != 1 || result.Files[0] != path {
+		t.Fatalf("first Pi persona injection files = %v, want [%q]", result.Files, path)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if got, want := string(content), "{\n  \"mode\": \"neutral\"\n}\n"; got != want {
+		t.Fatalf("Pi persona config = %q, want %q", got, want)
+	}
+
+	second, err := InjectPiPersona(root, model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("second InjectPiPersona() error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("second Pi persona injection changed = true, want false")
+	}
+}
+
+func TestInjectPiPersonaCustomPreservesExistingConfig(t *testing.T) {
+	root := t.TempDir()
+	path := PiPersonaConfigPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	const existing = "{\n  \"mode\": \"user-defined\"\n}\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	result, err := InjectPiPersona(root, model.PersonaCustom)
+	if err != nil {
+		t.Fatalf("InjectPiPersona(custom) error = %v", err)
+	}
+	if result.Changed || len(result.Files) != 0 {
+		t.Fatalf("InjectPiPersona(custom) result = %#v, want no-op", result)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if string(content) != existing {
+		t.Fatalf("custom Pi persona config = %q, want existing content %q", content, existing)
+	}
+}
+
 func TestInjectOpenCodeGentlemanWritesAgentsFile(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -99,6 +99,9 @@ type InstallState struct {
 	// Empty for state files written before persona persistence was added —
 	// callers fall back to PersonaGentleman in that case.
 	Persona string `json:"persona,omitempty"`
+	// PersonaPresent distinguishes an omitted legacy field from an explicit
+	// empty persona, which must fail closed during sync validation.
+	PersonaPresent bool `json:"-"`
 
 	// LastUpdateCheck records the last time a successful remote update check was
 	// performed. Used by the cooldown gate (UpdateCheckTTL = 6h) to avoid
@@ -130,6 +133,25 @@ type InstallState struct {
 	// recorded is authority, not a cosmetic audit field. Nil for state files
 	// written before the switch existed.
 	RDDModeRecordedAt *time.Time `json:"rdd_mode_recorded_at,omitempty"`
+}
+
+// UnmarshalJSON preserves whether the persisted persona field was present.
+// The value itself is still decoded into the public InstallState field.
+func (s *InstallState) UnmarshalJSON(data []byte) error {
+	type plainInstallState InstallState
+	var decoded plainInstallState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	*s = InstallState(decoded)
+	_, s.PersonaPresent = fields["persona"]
+	return nil
 }
 
 // Path returns the absolute path to the state file for the given home directory.
@@ -213,6 +235,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		CodexCarrilModelAssignments: existing.CodexCarrilModelAssignments,
 		CodexPhaseModelAssignments:  existing.CodexPhaseModelAssignments,
 		Persona:                     existing.Persona,
+		PersonaPresent:              existing.PersonaPresent,
 		LastUpdateCheck:             existing.LastUpdateCheck,
 		PendingSync:                 existing.PendingSync,
 		RDDMode:                     existing.RDDMode,

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -194,6 +194,35 @@ func TestPersonaBackwardCompat(t *testing.T) {
 	}
 }
 
+func TestPersonaPresenceDistinguishesOmittedAndExplicitEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		stateJSON   string
+		wantPresent bool
+	}{
+		{name: "omitted", stateJSON: `{"installed_agents":["pi"]}`, wantPresent: false},
+		{name: "explicit empty", stateJSON: `{"installed_agents":["pi"],"persona":""}`, wantPresent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.MkdirAll(filepath.Dir(Path(home)), 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			if err := os.WriteFile(Path(home), []byte(tc.stateJSON), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			got, err := Read(home)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if got.PersonaPresent != tc.wantPresent {
+				t.Fatalf("PersonaPresent = %t, want %t", got.PersonaPresent, tc.wantPresent)
+			}
+		})
+	}
+}
+
 // TestWriteCreatesStateDir verifies that Write creates the .gentle-ai directory
 // when it does not exist yet.
 func TestWriteCreatesStateDir(t *testing.T) {
@@ -276,7 +305,7 @@ func TestWriteOverwrite(t *testing.T) {
 
 func TestWriteFailurePreservesExistingState(t *testing.T) {
 	home := t.TempDir()
-	original := InstallState{InstalledAgents: []string{"opencode"}, Persona: "neutral"}
+	original := InstallState{InstalledAgents: []string{"opencode"}, Persona: "neutral", PersonaPresent: true}
 	if err := Write(home, original); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #610

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Keep `.pi/gentle-ai/persona.json` aligned with the selected built-in persona during install and sync.
- Include the Pi persona file in managed paths, snapshots, backups, changed-files reporting, and rollback.
- Preserve existing Pi configuration for custom personas and cover scope and idempotency behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/persona` | Adds atomic Pi persona injection and behavior tests. |
| `internal/cli/run.go` | Includes Pi persona paths and the persona component in applicable installs. |
| `internal/cli/sync.go` | Synchronizes and backs up the workspace Pi persona file. |
| `internal/cli/validate.go` | Aligns Pi component validation with persona management. |
| CLI tests | Covers paths, scopes, changed files, snapshots, rollback, custom personas, and idempotency. |

---

## 🧪 Test Plan

- [x] Focused persona and Pi CLI tests pass.
- [x] Snapshot, backup, rollback, changed-files, scope, custom-persona, and idempotency scenarios pass.
- [x] `go run ./internal/gofmtcheck`
- [ ] The broad `go test ./internal/components/persona ./internal/cli/... -count=1` run exceeded 300 seconds in the pre-existing `TestReviewArtifactSubstitutionFailsBeforeMutation` reviewtransaction lock/fsync path. This PR does not modify that subsystem. CI should provide the authoritative full-suite result.
- E2E: N/A locally, the behavior is covered through the install/sync filesystem pipeline tests.
- Benchmark validation: N/A, this does not change review lifecycle or benchmark behavior.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (`341`)
- [x] Appropriate `type:*` label requested
- [x] Focused unit tests pass
- [x] Go format passes
- [x] E2E applicability explained
- [x] Benchmark applicability explained
- [x] Documentation is not required for this compatibility fix
- [x] Commits follow Conventional Commits
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

For the `internal/cli` guard review, the managed-path population now intentionally includes the Pi persona file wherever the install or sync flow can mutate it. No guard-population baseline change is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi persona configuration support for global and workspace installations.
  * Global installations now configure both the home directory and active workspace.
  * Workspace synchronization now updates and backs up the local Pi persona configuration.
  * Added built-in persona selection while preserving custom configurations.

* **Bug Fixes**
  * Pi-only installations now include both Engram and Persona components.
  * Improved backup and rollback handling for Pi persona files.
  * Invalid or unsupported saved persona settings now produce an error without modifying configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->