### PR TITLE
fix(upgrade): preserve Windows self-upgrade provenance

### DIFF
--- a/internal/update/upgrade/effective_method_routing_test.go
+++ b/internal/update/upgrade/effective_method_routing_test.go
@@ -183,7 +183,8 @@ func TestGentleAILegacyScriptDeclarationNeverReachesScriptUpgradeOnWindows(t *te
 }
 
 // TestGentleAIUpgradeWindowsPreservesResolvedAppDataDestination proves the
-// public upgrade boundary refuses before go install can create a second binary.
+// public upgrade boundary refuses before a backup or go install can create a
+// filesystem mutation.
 // No real Windows execution happens here: the platform profile and detectOS are
 // synthetic, which is the only way to exercise Windows ".exe" behavior from a
 // Linux host.
@@ -232,8 +233,9 @@ func TestGentleAIUpgradeWindowsPreservesResolvedAppDataDestination(t *testing.T)
 		Status:        update.UpdateAvailable,
 	}
 	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}
+	homeDir := t.TempDir()
 
-	report := ExecuteWithOptions(context.Background(), []update.UpdateResult{r}, profile, t.TempDir(), false, ExecuteOptions{SkipBackup: true})
+	report := ExecuteWithOptions(context.Background(), []update.UpdateResult{r}, profile, homeDir, false, ExecuteOptions{})
 	if len(report.Results) != 1 {
 		t.Fatalf("upgrade results = %#v, want one result", report.Results)
 	}
@@ -249,6 +251,13 @@ func TestGentleAIUpgradeWindowsPreservesResolvedAppDataDestination(t *testing.T)
 	}
 	if _, err := os.Stat(destination); !os.IsNotExist(err) {
 		t.Errorf("go install destination %s exists after refusal: %v", destination, err)
+	}
+	if report.BackupID != "" || report.BackupWarning != "" {
+		t.Errorf("manual fallback created a backup result: %#v", report)
+	}
+	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
+	if _, err := os.Stat(backupRoot); !os.IsNotExist(err) {
+		t.Errorf("manual fallback created or pruned backup tree %s: %v", backupRoot, err)
 	}
 	for _, want := range []string{active, destination, "go install ", "No files were changed"} {
 		if !strings.Contains(result.ManualHint, want) {
@@ -292,16 +301,20 @@ func TestGentleAIUpgradeWindowsAllowsResolvedGoDestination(t *testing.T) {
 	t.Cleanup(func() { lookPathFn = origLookPath })
 	lookPathFn = func(string) (string, error) { return destination, nil }
 
+	homeDir := t.TempDir()
 	report := ExecuteWithOptions(context.Background(), []update.UpdateResult{{
 		Tool:          registryGentleAI(t),
 		LatestVersion: "2.2.0",
 		Status:        update.UpdateAvailable,
-	}}, system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}, t.TempDir(), false, ExecuteOptions{SkipBackup: true})
+	}}, system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}, homeDir, false, ExecuteOptions{})
 	if len(report.Results) != 1 || report.Results[0].Status != UpgradeSucceeded || report.Results[0].ExitRequested || report.ExitRequested {
 		t.Fatalf("upgrade results = %#v, want a successful Go-owned upgrade", report.Results)
 	}
 	if goInstallCalls != 1 {
 		t.Errorf("go install calls = %d, want 1 for the resolved Go-owned binary", goInstallCalls)
+	}
+	if report.BackupID == "" {
+		t.Errorf("successful Go-owned upgrade did not create a backup: %#v", report)
 	}
 }
 
@@ -358,11 +371,12 @@ func TestGentleAIUpgradeWindowsRefusesUnresolvedGoProvenance(t *testing.T) {
 				return filepath.Join(t.TempDir(), "gentle-ai.exe"), nil
 			}
 
+			homeDir := t.TempDir()
 			report := ExecuteWithOptions(context.Background(), []update.UpdateResult{{
 				Tool:          registryGentleAI(t),
 				LatestVersion: "2.2.0",
 				Status:        update.UpdateAvailable,
-			}}, system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}, t.TempDir(), false, ExecuteOptions{SkipBackup: true})
+			}}, system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}, homeDir, false, ExecuteOptions{})
 			if len(report.Results) != 1 {
 				t.Fatalf("upgrade results = %#v, want one result", report.Results)
 			}
@@ -375,6 +389,13 @@ func TestGentleAIUpgradeWindowsRefusesUnresolvedGoProvenance(t *testing.T) {
 			}
 			if goInstallCalls != 0 {
 				t.Errorf("go install calls = %d, want 0 without resolved provenance", goInstallCalls)
+			}
+			if report.BackupID != "" || report.BackupWarning != "" {
+				t.Errorf("manual fallback created a backup result: %#v", report)
+			}
+			backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
+			if _, err := os.Stat(backupRoot); !os.IsNotExist(err) {
+				t.Errorf("manual fallback created or pruned backup tree %s: %v", backupRoot, err)
 			}
 			for _, want := range []string{tt.wantHint, "go install ", "No files were changed"} {
 				if !strings.Contains(result.ManualHint, want) {

--- a/internal/update/upgrade/effective_method_routing_test.go
+++ b/internal/update/upgrade/effective_method_routing_test.go
@@ -278,10 +278,12 @@ func TestGentleAIUpgradeWindowsAllowsResolvedGoDestination(t *testing.T) {
 	goPath := t.TempDir()
 	destination := writeFakeBinary(t, filepath.Join(goPath, "bin"), "gentle-ai.exe")
 	var goInstallCalls int
+	goEnvCalls := map[string]int{}
 	origExecCommand := execCommand
 	t.Cleanup(func() { execCommand = origExecCommand })
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		if name == "go" && len(args) == 2 && args[0] == "env" {
+			goEnvCalls[args[1]]++
 			switch args[1] {
 			case "GOBIN":
 				return mockCmd("echo", "")
@@ -312,6 +314,11 @@ func TestGentleAIUpgradeWindowsAllowsResolvedGoDestination(t *testing.T) {
 	}
 	if goInstallCalls != 1 {
 		t.Errorf("go install calls = %d, want 1 for the resolved Go-owned binary", goInstallCalls)
+	}
+	for _, key := range []string{"GOBIN", "GOPATH"} {
+		if got := goEnvCalls[key]; got != 1 {
+			t.Errorf("go env %s calls = %d, want 1 after preflight", key, got)
+		}
 	}
 	if report.BackupID == "" {
 		t.Errorf("successful Go-owned upgrade did not create a backup: %#v", report)

--- a/internal/update/upgrade/effective_method_routing_test.go
+++ b/internal/update/upgrade/effective_method_routing_test.go
@@ -2,7 +2,9 @@ package upgrade
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -180,12 +182,12 @@ func TestGentleAILegacyScriptDeclarationNeverReachesScriptUpgradeOnWindows(t *te
 	}
 }
 
-// TestGentleAIWindowsGoInstallVerifiesDestination proves the destination check
-// is reached on the new Windows go-install path and that a mismatch names both
-// absolute paths. No real Windows execution happens here: the platform profile
-// and detectOS are synthetic, which is the only way to exercise the Windows
-// ".exe" naming and case-insensitive comparison from a Linux host.
-func TestGentleAIWindowsGoInstallVerifiesDestination(t *testing.T) {
+// TestGentleAIUpgradeWindowsPreservesResolvedAppDataDestination proves the
+// public upgrade boundary refuses before go install can create a second binary.
+// No real Windows execution happens here: the platform profile and detectOS are
+// synthetic, which is the only way to exercise Windows ".exe" behavior from a
+// Linux host.
+func TestGentleAIUpgradeWindowsPreservesResolvedAppDataDestination(t *testing.T) {
 	origHomebrewPackageInstalled := homebrewPackageInstalled
 	t.Cleanup(func() { homebrewPackageInstalled = origHomebrewPackageInstalled })
 	homebrewPackageInstalled = func(string) bool { return false }
@@ -194,23 +196,26 @@ func TestGentleAIWindowsGoInstallVerifiesDestination(t *testing.T) {
 	t.Cleanup(func() { detectOS = origDetectOS })
 	detectOS = func() string { return "windows" }
 
-	gobin := t.TempDir()
-	stale := t.TempDir()
-	installed := writeFakeBinary(t, gobin, "gentle-ai.exe")
-	shadowing := writeFakeBinary(t, stale, "gentle-ai.exe")
+	appDataBin := filepath.Join(t.TempDir(), "AppData", "Local", "gentle-ai", "bin")
+	active := writeFakeBinary(t, appDataBin, "gentle-ai.exe")
+	goPath := t.TempDir()
+	destination := filepath.Join(goPath, "bin", "gentle-ai.exe")
 
-	var installTarget string
+	var goInstallCalls int
 	origExecCommand := execCommand
 	t.Cleanup(func() { execCommand = origExecCommand })
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		if name == "go" && len(args) == 2 && args[0] == "env" {
-			if args[1] == "GOBIN" {
-				return mockCmd("echo", gobin)
+			switch args[1] {
+			case "GOBIN":
+				return mockCmd("echo", "")
+			case "GOPATH":
+				return mockCmd("echo", goPath)
 			}
-			return mockCmd("echo", "")
 		}
 		if name == "go" && len(args) == 2 && args[0] == "install" {
-			installTarget = args[1]
+			goInstallCalls++
+			writeFakeBinary(t, filepath.Dir(destination), filepath.Base(destination))
 			return mockCmd("true")
 		}
 		t.Fatalf("Windows go-install path executed unexpected command %s %v", name, args)
@@ -219,7 +224,7 @@ func TestGentleAIWindowsGoInstallVerifiesDestination(t *testing.T) {
 
 	origLookPath := lookPathFn
 	t.Cleanup(func() { lookPathFn = origLookPath })
-	lookPathFn = func(string) (string, error) { return shadowing, nil }
+	lookPathFn = func(string) (string, error) { return active, nil }
 
 	r := update.UpdateResult{
 		Tool:          registryGentleAI(t),
@@ -228,24 +233,155 @@ func TestGentleAIWindowsGoInstallVerifiesDestination(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}
 
-	var upgradeErr error
-	stderr := captureStderr(t, func() {
-		_, upgradeErr = runStrategy(context.Background(), r, profile)
-	})
-
-	if upgradeErr != nil {
-		t.Fatalf("Windows go-install upgrade returned error: %v", upgradeErr)
+	report := ExecuteWithOptions(context.Background(), []update.UpdateResult{r}, profile, t.TempDir(), false, ExecuteOptions{SkipBackup: true})
+	if len(report.Results) != 1 {
+		t.Fatalf("upgrade results = %#v, want one result", report.Results)
 	}
-	if want := gentleAIImportPath + "@v2.2.0"; installTarget != want {
-		t.Errorf("go install target = %q, want the pinned release %q", installTarget, want)
+	result := report.Results[0]
+	if result.Status != UpgradeSkipped || result.Err != nil {
+		t.Fatalf("upgrade result = %#v, want manual-fallback skip", result)
 	}
-	if !strings.Contains(stderr, "WARNING") {
-		t.Fatalf("a destination mismatch on Windows must warn; stderr = %q", stderr)
+	if result.ExitRequested || report.ExitRequested {
+		t.Fatalf("manual fallback requested exit: result = %#v, report = %#v", result, report)
 	}
-	for _, want := range []string{installed, shadowing} {
-		if !strings.Contains(stderr, want) {
-			t.Errorf("warning must name %q; stderr = %q", want, stderr)
+	if goInstallCalls != 0 {
+		t.Errorf("go install calls = %d, want 0 before provenance is resolved", goInstallCalls)
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Errorf("go install destination %s exists after refusal: %v", destination, err)
+	}
+	for _, want := range []string{active, destination, "go install ", "No files were changed"} {
+		if !strings.Contains(result.ManualHint, want) {
+			t.Errorf("manual fallback must contain %q: %s", want, result.ManualHint)
 		}
+	}
+}
+
+func TestGentleAIUpgradeWindowsAllowsResolvedGoDestination(t *testing.T) {
+	origHomebrewPackageInstalled := homebrewPackageInstalled
+	t.Cleanup(func() { homebrewPackageInstalled = origHomebrewPackageInstalled })
+	homebrewPackageInstalled = func(string) bool { return false }
+
+	origDetectOS := detectOS
+	t.Cleanup(func() { detectOS = origDetectOS })
+	detectOS = func() string { return "windows" }
+
+	goPath := t.TempDir()
+	destination := writeFakeBinary(t, filepath.Join(goPath, "bin"), "gentle-ai.exe")
+	var goInstallCalls int
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "go" && len(args) == 2 && args[0] == "env" {
+			switch args[1] {
+			case "GOBIN":
+				return mockCmd("echo", "")
+			case "GOPATH":
+				return mockCmd("echo", goPath)
+			}
+		}
+		if name == "go" && len(args) == 2 && args[0] == "install" {
+			goInstallCalls++
+			return mockCmd("true")
+		}
+		t.Fatalf("Windows go-owned upgrade executed unexpected command %s %v", name, args)
+		return nil
+	}
+
+	origLookPath := lookPathFn
+	t.Cleanup(func() { lookPathFn = origLookPath })
+	lookPathFn = func(string) (string, error) { return destination, nil }
+
+	report := ExecuteWithOptions(context.Background(), []update.UpdateResult{{
+		Tool:          registryGentleAI(t),
+		LatestVersion: "2.2.0",
+		Status:        update.UpdateAvailable,
+	}}, system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}, t.TempDir(), false, ExecuteOptions{SkipBackup: true})
+	if len(report.Results) != 1 || report.Results[0].Status != UpgradeSucceeded || report.Results[0].ExitRequested || report.ExitRequested {
+		t.Fatalf("upgrade results = %#v, want a successful Go-owned upgrade", report.Results)
+	}
+	if goInstallCalls != 1 {
+		t.Errorf("go install calls = %d, want 1 for the resolved Go-owned binary", goInstallCalls)
+	}
+}
+
+func TestGentleAIUpgradeWindowsRefusesUnresolvedGoProvenance(t *testing.T) {
+	tests := []struct {
+		name          string
+		goEnvFails    bool
+		lookPathFails bool
+		wantHint      string
+	}{
+		{name: "Go destination", goEnvFails: true, wantHint: "could not determine the Go installation destination"},
+		{name: "active executable", lookPathFails: true, wantHint: "could not resolve the active gentle-ai executable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origHomebrewPackageInstalled := homebrewPackageInstalled
+			t.Cleanup(func() { homebrewPackageInstalled = origHomebrewPackageInstalled })
+			homebrewPackageInstalled = func(string) bool { return false }
+
+			origDetectOS := detectOS
+			t.Cleanup(func() { detectOS = origDetectOS })
+			detectOS = func() string { return "windows" }
+
+			var goInstallCalls int
+			origExecCommand := execCommand
+			t.Cleanup(func() { execCommand = origExecCommand })
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				if name == "go" && len(args) == 2 && args[0] == "env" {
+					if tt.goEnvFails {
+						return mockCmd("false")
+					}
+					switch args[1] {
+					case "GOBIN":
+						return mockCmd("echo", "")
+					case "GOPATH":
+						return mockCmd("echo", t.TempDir())
+					}
+				}
+				if name == "go" && len(args) == 2 && args[0] == "install" {
+					goInstallCalls++
+					return mockCmd("true")
+				}
+				t.Fatalf("Windows unresolved provenance executed unexpected command %s %v", name, args)
+				return nil
+			}
+
+			origLookPath := lookPathFn
+			t.Cleanup(func() { lookPathFn = origLookPath })
+			lookPathFn = func(string) (string, error) {
+				if tt.lookPathFails {
+					return "", exec.ErrNotFound
+				}
+				return filepath.Join(t.TempDir(), "gentle-ai.exe"), nil
+			}
+
+			report := ExecuteWithOptions(context.Background(), []update.UpdateResult{{
+				Tool:          registryGentleAI(t),
+				LatestVersion: "2.2.0",
+				Status:        update.UpdateAvailable,
+			}}, system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}, t.TempDir(), false, ExecuteOptions{SkipBackup: true})
+			if len(report.Results) != 1 {
+				t.Fatalf("upgrade results = %#v, want one result", report.Results)
+			}
+			result := report.Results[0]
+			if result.Status != UpgradeSkipped || result.Err != nil {
+				t.Fatalf("upgrade result = %#v, want manual-fallback skip", result)
+			}
+			if result.ExitRequested || report.ExitRequested {
+				t.Fatalf("manual fallback requested exit: result = %#v, report = %#v", result, report)
+			}
+			if goInstallCalls != 0 {
+				t.Errorf("go install calls = %d, want 0 without resolved provenance", goInstallCalls)
+			}
+			for _, want := range []string{tt.wantHint, "go install ", "No files were changed"} {
+				if !strings.Contains(result.ManualHint, want) {
+					t.Errorf("manual fallback must contain %q: %s", want, result.ManualHint)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -412,8 +412,10 @@ func writeBackupDiagnostic(w io.Writer, format string, args ...any) {
 //   - Status UpToDate, NotInstalled, CheckFailed → omitted from report
 //   - dryRun=true → no exec; eligible tools reported as UpgradeSkipped
 //
-// The backup snapshot is created before any exec call — this is the architectural
-// guarantee that config is safe even if an upgrade fails mid-way.
+// The backup snapshot is created before any executable upgrade — this is the
+// architectural guarantee that config is safe even if an upgrade fails mid-way.
+// Windows gentle-ai provenance is preflighted first because its manual fallback
+// must remain a true zero-mutation outcome.
 func Execute(ctx context.Context, results []update.UpdateResult, profile system.PlatformProfile, homeDir string, dryRun bool, progress ...io.Writer) UpgradeReport {
 	options := ExecuteOptions{}
 	if len(progress) > 0 && progress[0] != nil {
@@ -447,6 +449,11 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 	// If nothing is executable, dev-built, or version-unknown, return empty report.
 	if len(executable) == 0 && len(devBuilds) == 0 && len(versionUnknowns) == 0 {
 		return UpgradeReport{DryRun: dryRun}
+	}
+
+	var preflightSkips []ToolUpgradeResult
+	if !dryRun {
+		executable, preflightSkips = preflightWindowsGentleAIUpgrades(executable, profile)
 	}
 
 	// Create backup snapshot BEFORE any execution (only when there are executables).
@@ -489,7 +496,7 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 	}
 
 	// Build results slice: dev-build skips first (no exec), then executable tools.
-	toolResults := make([]ToolUpgradeResult, 0, len(executable)+len(devBuilds)+len(versionUnknowns))
+	toolResults := make([]ToolUpgradeResult, 0, len(executable)+len(devBuilds)+len(versionUnknowns)+len(preflightSkips))
 
 	// Dev-build tools: always UpgradeSkipped with a source-build hint.
 	for _, r := range devBuilds {
@@ -515,6 +522,8 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 			ManualHint: fmt.Sprintf("installed binary was found but its version could not be determined — check `%s` and reinstall if it is a stale source/dev build", detectCommandHint(r.Tool)),
 		})
 	}
+
+	toolResults = append(toolResults, preflightSkips...)
 
 	// Executable tools: run upgrade strategy.
 	for _, r := range executable {
@@ -557,6 +566,37 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 		Results:       toolResults,
 		DryRun:        dryRun,
 	}
+}
+
+// preflightWindowsGentleAIUpgrades removes unsafe Windows self-upgrades before
+// the backup phase. A manual fallback must not create or prune a backup because
+// no upgrade will be attempted.
+func preflightWindowsGentleAIUpgrades(executable []update.UpdateResult, profile system.PlatformProfile) ([]update.UpdateResult, []ToolUpgradeResult) {
+	remaining := make([]update.UpdateResult, 0, len(executable))
+	skipped := make([]ToolUpgradeResult, 0)
+	for _, r := range executable {
+		if profile.OS != "windows" || r.Tool.Name != "gentle-ai" || effectiveMethod(r.Tool, profile) != update.InstallGoInstall {
+			remaining = append(remaining, r)
+			continue
+		}
+
+		if err := preflightWindowsGentleAIGoInstall(r, profile); err != nil {
+			if hint, ok := AsManualFallback(err); ok {
+				skipped = append(skipped, ToolUpgradeResult{
+					ToolName:   r.Tool.Name,
+					OldVersion: r.InstalledVersion,
+					NewVersion: r.LatestVersion,
+					Method:     effectiveMethod(r.Tool, profile),
+					Status:     UpgradeSkipped,
+					ManualHint: hint,
+				})
+				continue
+			}
+		}
+
+		remaining = append(remaining, r)
+	}
+	return remaining, skipped
 }
 
 func detectCommandHint(tool update.ToolInfo) string {

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -67,6 +67,11 @@ type ExecuteOptions struct {
 	SkipBackup        bool
 }
 
+type executableUpdate struct {
+	result               update.UpdateResult
+	goInstallDestination string
+}
+
 // backupExcludeSubdirs lists subdirectory base names that should be skipped
 // when walking agent config root directories for backup. These directories
 // contain runtime state, caches, or session data that is not configuration
@@ -431,13 +436,13 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 	// dev-build (DevBuild), and version-unknown tools. Non-actionable but user-visible
 	// states are included in the report as UpgradeSkipped so the upgrade flow never
 	// fails silently.
-	var executable []update.UpdateResult
+	var executable []executableUpdate
 	var devBuilds []update.UpdateResult
 	var versionUnknowns []update.UpdateResult
 	for _, r := range results {
 		switch r.Status {
 		case update.UpdateAvailable, update.RegisteredNotMaterialized:
-			executable = append(executable, r)
+			executable = append(executable, executableUpdate{result: r})
 		case update.DevBuild:
 			devBuilds = append(devBuilds, r)
 		case update.VersionUnknown:
@@ -526,11 +531,12 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 	toolResults = append(toolResults, preflightSkips...)
 
 	// Executable tools: run upgrade strategy.
-	for _, r := range executable {
+	for _, candidate := range executable {
+		r := candidate.result
 		method := effectiveMethod(r.Tool, profile)
 		msg := fmt.Sprintf("Upgrading %s via %s (%s → %s)", r.Tool.Name, method, r.InstalledVersion, r.LatestVersion)
 		sp := NewSpinner(pw, msg)
-		toolResult := executeOne(ctx, r, profile, dryRun)
+		toolResult := executeOne(ctx, r, profile, dryRun, candidate.goInstallDestination)
 
 		// Check if the upgrade succeeded but requires immediate exit.
 		// This must be handled BEFORE calling sp.Finish() so the spinner can terminate properly.
@@ -571,16 +577,18 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 // preflightWindowsGentleAIUpgrades removes unsafe Windows self-upgrades before
 // the backup phase. A manual fallback must not create or prune a backup because
 // no upgrade will be attempted.
-func preflightWindowsGentleAIUpgrades(executable []update.UpdateResult, profile system.PlatformProfile) ([]update.UpdateResult, []ToolUpgradeResult) {
-	remaining := make([]update.UpdateResult, 0, len(executable))
+func preflightWindowsGentleAIUpgrades(executable []executableUpdate, profile system.PlatformProfile) ([]executableUpdate, []ToolUpgradeResult) {
+	remaining := make([]executableUpdate, 0, len(executable))
 	skipped := make([]ToolUpgradeResult, 0)
-	for _, r := range executable {
+	for _, candidate := range executable {
+		r := candidate.result
 		if profile.OS != "windows" || r.Tool.Name != "gentle-ai" || effectiveMethod(r.Tool, profile) != update.InstallGoInstall {
-			remaining = append(remaining, r)
+			remaining = append(remaining, candidate)
 			continue
 		}
 
-		if err := preflightWindowsGentleAIGoInstall(r, profile); err != nil {
+		destination, err := preflightWindowsGentleAIGoInstall(r, profile)
+		if err != nil {
 			if hint, ok := AsManualFallback(err); ok {
 				skipped = append(skipped, ToolUpgradeResult{
 					ToolName:   r.Tool.Name,
@@ -594,7 +602,8 @@ func preflightWindowsGentleAIUpgrades(executable []update.UpdateResult, profile 
 			}
 		}
 
-		remaining = append(remaining, r)
+		candidate.goInstallDestination = destination
+		remaining = append(remaining, candidate)
 	}
 	return remaining, skipped
 }
@@ -608,7 +617,7 @@ func detectCommandHint(tool update.ToolInfo) string {
 }
 
 // executeOne runs the upgrade for a single tool.
-func executeOne(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, dryRun bool) ToolUpgradeResult {
+func executeOne(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, dryRun bool, preflightDestination ...string) ToolUpgradeResult {
 	base := ToolUpgradeResult{
 		ToolName:   r.Tool.Name,
 		OldVersion: r.InstalledVersion,
@@ -621,7 +630,7 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 		return base
 	}
 
-	exitReq, err := runStrategy(ctx, r, profile)
+	exitReq, err := runStrategy(ctx, r, profile, preflightDestination...)
 	if err != nil {
 		// Distinguish manual fallback (informational skip) from real failures.
 		if hint, ok := AsManualFallback(err); ok {

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -87,7 +87,7 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 	case update.InstallBrew:
 		return false, brewUpgrade(ctx, r, ownership)
 	case update.InstallGoInstall:
-		return false, goInstallUpgrade(ctx, r.Tool, r.LatestVersion)
+		return false, goInstallUpgrade(ctx, r, profile)
 	case update.InstallBinary:
 		return false, binaryUpgrade(ctx, r, profile)
 	case update.InstallScript:
@@ -460,13 +460,13 @@ func homebrewFailureAdvice(toolName string, output string, detected ...update.Ho
 
 // goInstallUpgrade runs `go install <importPath>@v<version>`.
 //
-// `go install` writes to GOBIN (or GOPATH/bin), which is not necessarily the
-// directory the user's shell resolves for the tool. After a successful install
-// the destination is compared against the effective binary so a silent no-op
-// upgrade cannot pass as a clean success. A mismatch, or a destination that
-// cannot be resolved, is reported as a warning — never as a failure, because
-// the new binary genuinely was written.
-func goInstallUpgrade(ctx context.Context, tool update.ToolInfo, latestVersion string) error {
+// Generic Go-managed tools retain the post-install warning because the new
+// binary was genuinely written. Windows gentle-ai self-upgrades are different:
+// they must prove that Go owns the active executable before writing, or skip to
+// a manual recovery instead of creating a second PATH-visible binary.
+func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
+	tool := r.Tool
+	latestVersion := r.LatestVersion
 	if tool.GoImportPath == "" {
 		return fmt.Errorf("upgrade %q: GoImportPath is empty — cannot run go install", tool.Name)
 	}
@@ -475,6 +475,21 @@ func goInstallUpgrade(ctx context.Context, tool update.ToolInfo, latestVersion s
 	// change, so they are read up front; the PATH lookup happens afterwards so
 	// a first-time install resolves correctly.
 	destDir, destErr := goInstallDestinationDir()
+	if profile.OS == "windows" && tool.Name == "gentle-ai" {
+		if destErr != nil {
+			return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, "", "")}
+		}
+
+		destination := absoluteBinaryPath(filepath.Join(destDir, goInstallBinaryName(tool.Name, profile.OS)))
+		active, err := lookPathFn(tool.Name)
+		if err != nil {
+			return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, destination, "")}
+		}
+		active = absoluteBinaryPath(active)
+		if !sameBinaryPathForOS(destination, active, profile.OS) {
+			return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, destination, active)}
+		}
+	}
 
 	// Pin to the exact release version.
 	target := fmt.Sprintf("%s@v%s", tool.GoImportPath, latestVersion)
@@ -486,6 +501,28 @@ func goInstallUpgrade(ctx context.Context, tool update.ToolInfo, latestVersion s
 
 	warnGoInstallDestination(tool.Name, detectOS(), destDir, destErr)
 	return nil
+}
+
+func gentleAIWindowsGoInstallProvenanceHint(r update.UpdateResult, destination, active string) string {
+	details := "could not determine the Go installation destination"
+	switch {
+	case destination != "" && active == "":
+		details = fmt.Sprintf("could not resolve the active gentle-ai executable before Go would write to %s", destination)
+	case destination != "" && active != "":
+		details = fmt.Sprintf("resolves gentle-ai to %s, but Go would write to %s", active, destination)
+	}
+
+	hint := fmt.Sprintf("Windows self-upgrade %s. No files were changed. ", details)
+	if active != "" {
+		hint += fmt.Sprintf("Keep %s as the active installation, or intentionally migrate to %s with:\n  ", active, destination)
+	} else {
+		hint += "Confirm the active installation, then intentionally migrate with:\n  "
+	}
+	hint += update.GentleAISourceInstallCommand(r.LatestVersion)
+	if destination != "" {
+		hint += fmt.Sprintf("\nAfter a successful migration, ensure only %s resolves for gentle-ai on PATH.", destination)
+	}
+	return hint
 }
 
 func isBetaGentleAIUpgrade(r update.UpdateResult) bool {

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -475,20 +475,8 @@ func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system
 	// change, so they are read up front; the PATH lookup happens afterwards so
 	// a first-time install resolves correctly.
 	destDir, destErr := goInstallDestinationDir()
-	if profile.OS == "windows" && tool.Name == "gentle-ai" {
-		if destErr != nil {
-			return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, "", "")}
-		}
-
-		destination := absoluteBinaryPath(filepath.Join(destDir, goInstallBinaryName(tool.Name, profile.OS)))
-		active, err := lookPathFn(tool.Name)
-		if err != nil {
-			return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, destination, "")}
-		}
-		active = absoluteBinaryPath(active)
-		if !sameBinaryPathForOS(destination, active, profile.OS) {
-			return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, destination, active)}
-		}
+	if err := preflightWindowsGentleAIGoInstallWithDestination(r, profile, destDir, destErr); err != nil {
+		return err
 	}
 
 	// Pin to the exact release version.
@@ -500,6 +488,31 @@ func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system
 	}
 
 	warnGoInstallDestination(tool.Name, detectOS(), destDir, destErr)
+	return nil
+}
+
+func preflightWindowsGentleAIGoInstall(r update.UpdateResult, profile system.PlatformProfile) error {
+	destDir, destErr := goInstallDestinationDir()
+	return preflightWindowsGentleAIGoInstallWithDestination(r, profile, destDir, destErr)
+}
+
+func preflightWindowsGentleAIGoInstallWithDestination(r update.UpdateResult, profile system.PlatformProfile, destDir string, destErr error) error {
+	if profile.OS != "windows" || r.Tool.Name != "gentle-ai" {
+		return nil
+	}
+	if destErr != nil {
+		return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, "", "")}
+	}
+
+	destination := absoluteBinaryPath(filepath.Join(destDir, goInstallBinaryName(r.Tool.Name, profile.OS)))
+	active, err := lookPathFn(r.Tool.Name)
+	if err != nil {
+		return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, destination, "")}
+	}
+	active = absoluteBinaryPath(active)
+	if !sameBinaryPathForOS(destination, active, profile.OS) {
+		return &ManualFallbackError{Hint: gentleAIWindowsGoInstallProvenanceHint(r, destination, active)}
+	}
 	return nil
 }
 

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -65,7 +65,7 @@ const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 //   - script method + windows → manualFallback
 //   - OpenCode plugin method → update materialized package in ~/.config/opencode when possible
 //   - unknown method → manualFallback with explicit message
-func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) (bool, error) {
+func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
 	ownership := update.HomebrewNone
 	if profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
 		var err error
@@ -87,7 +87,7 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 	case update.InstallBrew:
 		return false, brewUpgrade(ctx, r, ownership)
 	case update.InstallGoInstall:
-		return false, goInstallUpgrade(ctx, r, profile)
+		return false, goInstallUpgrade(ctx, r, profile, firstString(preflightDestination))
 	case update.InstallBinary:
 		return false, binaryUpgrade(ctx, r, profile)
 	case update.InstallScript:
@@ -464,7 +464,7 @@ func homebrewFailureAdvice(toolName string, output string, detected ...update.Ho
 // binary was genuinely written. Windows gentle-ai self-upgrades are different:
 // they must prove that Go owns the active executable before writing, or skip to
 // a manual recovery instead of creating a second PATH-visible binary.
-func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
+func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination string) error {
 	tool := r.Tool
 	latestVersion := r.LatestVersion
 	if tool.GoImportPath == "" {
@@ -474,9 +474,13 @@ func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system
 	// GOBIN/GOPATH are static Go configuration that `go install` does not
 	// change, so they are read up front; the PATH lookup happens afterwards so
 	// a first-time install resolves correctly.
-	destDir, destErr := goInstallDestinationDir()
-	if err := preflightWindowsGentleAIGoInstallWithDestination(r, profile, destDir, destErr); err != nil {
-		return err
+	destDir := preflightDestination
+	var destErr error
+	if destDir == "" {
+		destDir, destErr = goInstallDestinationDir()
+		if err := preflightWindowsGentleAIGoInstallWithDestination(r, profile, destDir, destErr); err != nil {
+			return err
+		}
 	}
 
 	// Pin to the exact release version.
@@ -491,9 +495,22 @@ func goInstallUpgrade(ctx context.Context, r update.UpdateResult, profile system
 	return nil
 }
 
-func preflightWindowsGentleAIGoInstall(r update.UpdateResult, profile system.PlatformProfile) error {
+func preflightWindowsGentleAIGoInstall(r update.UpdateResult, profile system.PlatformProfile) (string, error) {
+	if profile.OS != "windows" || r.Tool.Name != "gentle-ai" {
+		return "", nil
+	}
 	destDir, destErr := goInstallDestinationDir()
-	return preflightWindowsGentleAIGoInstallWithDestination(r, profile, destDir, destErr)
+	if err := preflightWindowsGentleAIGoInstallWithDestination(r, profile, destDir, destErr); err != nil {
+		return "", err
+	}
+	return destDir, nil
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }
 
 func preflightWindowsGentleAIGoInstallWithDestination(r update.UpdateResult, profile system.PlatformProfile, destDir string, destErr error) error {


### PR DESCRIPTION
## Linked Issue

Fixes #2359

---

## PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## Summary

- Preflight the Windows `gentle-ai` Go destination and active resolved executable before `go install`.
- Skip through the existing manual-fallback result when provenance is unresolved or differs, with both paths and the version-pinned migration command.
- Keep matching Go-owned Windows upgrades and all non-Windows Go-install behavior unchanged.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/strategy.go` | Fail closed before a Windows self-upgrade can create a duplicate Go binary. |
| `internal/update/upgrade/effective_method_routing_test.go` | Replace the post-write warning test with public-boundary provenance, matching-destination, and unresolved-provenance coverage. |

---

## Evidence

Base: `origin/main` at `bb43f572f18bdaaaa557b02ce2a52f4c1a4969ae`

Head: `b9604fcb5892918177ec74ec04847116516629fb`

Review load: 211 additions + 38 deletions = 249 changed lines (within the 400-line limit).

Genuine RED on the exact parent before the production change:

```text
go test ./internal/update/upgrade -run TestGentleAIUpgradeWindows... -count=1
FAIL: TestGentleAIUpgradeWindowsPreservesResolvedAppDataDestination
WARNING: `go install` wrote the new gentle-ai to .../GOPATH/bin/gentle-ai.exe, but the shell resolved .../AppData/Local/gentle-ai/bin/gentle-ai.exe
```

The failing test intercepted `go install`, materialized the GOPATH destination, and observed the old success result, proving the pre-fix mutation path.

---

## Test Plan

- [x] Focused regression and package suite: `go test ./internal/update/upgrade -count=1`
- [x] Root suite, including golden coverage: `go test ./... -count=1`
- [x] Explicit golden gate: `go test ./internal/reviewtransaction -run ^TestGateBoundaryMatrix_35Cells$ -count=1`
- [x] Refusal gate: `go test ./internal/cli -run TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign\|TestEveryNamedReviewContinuationIsStructurallyReal -count=1`
- [x] Dead-code ratchet: `./scripts/deadcode-ratchet.sh`
- [x] Go format: `go run ./internal/gofmtcheck`
- [x] Vet: `go vet ./...`
- [x] Build: `go build ./...`
- [x] Windows cross-build and upgrade test compilation: `GOOS=windows GOARCH=amd64 go build ./...` and `GOOS=windows GOARCH=amd64 go test -c ./internal/update/upgrade`
- [x] Darwin cross-build and upgrade test compilation: `GOOS=darwin GOARCH=arm64 go build ./...` and `GOOS=darwin GOARCH=arm64 go test -c ./internal/update/upgrade`
- [x] Benchmark validation: N/A; this changes no benchmark corpus, axis, classifier, review-lifecycle, recovery, or delivery semantics.
- [ ] Docker E2E was not rerun locally; CI remains the required cross-platform runtime proof.

---

## Contributor Checklist

- [x] PR is linked to approved issue #2359
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied: `type:bug`
- [x] Unit tests, format, vet, build, golden, refusal, and dead-code gates passed
- [ ] Docker E2E was not run locally (not required by this scoped upgrade-strategy change; CI will run it)
- [x] Documentation is unchanged because behavior is self-diagnosing at the existing upgrade boundary
- [x] Commit follows Conventional Commits
- [x] No `Co-Authored-By` trailer

---

## Notes for Reviewers

This closes only #2359. It does not claim to close #2590 or #1983.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows upgrades now verify that the active application and installation destination match before proceeding.
  * Unsafe upgrades stop before changing files or running installation commands.
  * When the installation source cannot be verified, users receive manual recovery guidance with relevant paths and migration commands.
  * Upgrades continue automatically when destinations are confirmed to match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Correction Evidence

- Corrected the pre-backup ordering at head `a1cc23b5cd2036a5dc8514b1defe2887cd3a5484` on base `9e727d183e9d6ab0548e9a169e457ae0a3dae986`.
- Default-options public regressions now prove mismatch and unresolved provenance create no backup result or backup tree, invoke no `go install`, and leave no GOPATH destination binary.
- Matching Go-owned Windows upgrades still back up and proceed.
- Genuine RED on prior head `cf66f576` showed `BackupID` and `~/.gentle-ai/backups` were created before the manual skip; focused GREEN, root, race, format/vet/build, golden/refusal/deadcode, and Windows/Darwin compilation now pass.
- Final scope is the three #2359 upgrade files; 288 additions + 41 deletions = 329 changed lines.

## Final Correction Evidence

Maintainer explicitly authorized this second and final correction; no third correction is permitted.

- Head: `3bcdaf6ea14114062fabbdd01d9a58ebeca6a187`; base: `9e727d183e9d6ab0548e9a169e457ae0a3dae986`.
- Matching Windows Go-owned upgrade now makes exactly one `go env GOBIN` and one `go env GOPATH` query, while preserving the default backup and `go install` execution.
- Genuine RED on prior head `a1cc23b5` observed two queries of each variable; focused GREEN, `go test ./... -count=1`, `go test -race ./... -count=1`, format/vet/build, golden/refusal/deadcode, and Windows/Darwin compilation pass.
- Default-options zero-mutation mismatch and unresolved-provenance regressions remain unchanged.
- Final scope remains the three #2359 upgrade files: 328 additions + 48 deletions = 376 changed lines.
