### PR TITLE
fix(cli): restore Windows compatibility sync

### DIFF
--- a/internal/cli/compatibility_rollback_nonwindows.go
+++ b/internal/cli/compatibility_rollback_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cli
+
+import "github.com/gentleman-programming/gentle-ai/v2/internal/backup"
+
+func restoreCompatibilityEntries(manifest backup.Manifest, _ string) (backup.Manifest, error) {
+	return manifest, nil
+}

--- a/internal/cli/compatibility_rollback_windows.go
+++ b/internal/cli/compatibility_rollback_windows.go
@@ -1,0 +1,99 @@
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
+)
+
+// restoreCompatibilityEntries restores compatibility paths through the
+// descriptor-anchored writer and returns the entries safe for generic restore.
+func restoreCompatibilityEntries(manifest backup.Manifest, homeDir string) (backup.Manifest, error) {
+	skillDir := filepath.Join(homeDir, ".agents", "skills")
+	compatibility, remaining := splitCompatibilityEntries(manifest, skillDir)
+	if len(compatibility.Entries) == 0 {
+		return manifest, nil
+	}
+
+	writer, err := newCompatibilityDirectoryWriter(homeDir, skillDir)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("open compatibility rollback root: %w", err)
+	}
+	defer writer.Close()
+
+	snapshots, cleanupSnapshots, err := compatibilityRollbackSnapshots(compatibility)
+	if err != nil {
+		return backup.Manifest{}, err
+	}
+	defer cleanupSnapshots()
+
+	for _, entry := range compatibility.Entries {
+		if !entry.Existed {
+			if err := writer.Remove(entry.OriginalPath); err != nil {
+				return backup.Manifest{}, fmt.Errorf("remove compatibility rollback destination %q: %w", entry.OriginalPath, err)
+			}
+			continue
+		}
+
+		snapshotPath, ok := snapshots[filepath.ToSlash(entry.SnapshotPath)]
+		if !ok {
+			// refusal:by-design operator-knowledge: a transaction snapshot missing its declared entry cannot be safely reconstructed during rollback.
+			return backup.Manifest{}, fmt.Errorf("compatibility rollback snapshot for %q is missing", entry.OriginalPath)
+		}
+		content, err := os.ReadFile(snapshotPath)
+		if err != nil {
+			return backup.Manifest{}, fmt.Errorf("read compatibility rollback snapshot %q: %w", snapshotPath, err)
+		}
+		if _, err := writer.Write(entry.OriginalPath, content, os.FileMode(entry.Mode)); err != nil {
+			return backup.Manifest{}, fmt.Errorf("restore compatibility rollback destination %q: %w", entry.OriginalPath, err)
+		}
+	}
+
+	return remaining, nil
+}
+
+func splitCompatibilityEntries(manifest backup.Manifest, skillDir string) (backup.Manifest, backup.Manifest) {
+	compatibility := manifest
+	compatibility.Entries = nil
+	remaining := manifest
+	remaining.Entries = nil
+	for _, entry := range manifest.Entries {
+		if _, err := compatibilityPathParts(skillDir, entry.OriginalPath); err == nil {
+			compatibility.Entries = append(compatibility.Entries, entry)
+			continue
+		}
+		remaining.Entries = append(remaining.Entries, entry)
+	}
+	return compatibility, remaining
+}
+
+func compatibilityRollbackSnapshots(manifest backup.Manifest) (map[string]string, func(), error) {
+	snapshots := make(map[string]string)
+	for _, entry := range manifest.Entries {
+		if entry.Existed && !manifest.Compressed {
+			// refusal:by-design operator-knowledge: compatibility rollback only accepts current transaction archives, not legacy plain snapshot layouts.
+			return nil, nil, fmt.Errorf("compatibility rollback for %q has an unsupported uncompressed snapshot", entry.OriginalPath)
+		}
+	}
+	if !manifest.Compressed {
+		return snapshots, func() {}, nil
+	}
+
+	tempDir, err := os.MkdirTemp("", "gentle-ai-compatibility-rollback-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create compatibility rollback snapshot directory: %w", err)
+	}
+	entries, err := backup.ExtractArchive(filepath.Join(manifest.RootDir, backup.ArchiveFilename), tempDir)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return nil, nil, fmt.Errorf("extract compatibility rollback snapshot: %w", err)
+	}
+	for _, entry := range entries {
+		snapshots[entry.RelPath] = entry.SourcePath
+	}
+	return snapshots, func() { _ = os.RemoveAll(tempDir) }, nil
+}

--- a/internal/cli/compatibility_skills.go
+++ b/internal/cli/compatibility_skills.go
@@ -48,18 +48,30 @@ func compatibilitySkillsDir(homeDir string) (string, bool, error) {
 	agentsDir := filepath.Join(homeDir, ".agents")
 	skillDir := filepath.Join(agentsDir, "skills")
 	parent, err := lstatCompatibilityDestination(agentsDir)
-	if os.IsNotExist(err) || err == nil && !parent.IsDir() {
+	if os.IsNotExist(err) {
 		return skillDir, false, nil
 	}
 	if err != nil {
 		return skillDir, false, fmt.Errorf("stat compatibility skills parent directory %q: %w", agentsDir, err)
 	}
+	if compatibilityDirectoryUnsafe(agentsDir, parent) {
+		return skillDir, false, fmt.Errorf("compatibility skills parent directory %q must be a physical directory; replace it with a physical directory, then rerun gentle-ai install or gentle-ai sync", agentsDir)
+	}
+	if !parent.IsDir() {
+		return skillDir, false, nil
+	}
 	info, err := lstatCompatibilityDestination(skillDir)
-	if os.IsNotExist(err) || err == nil && !info.IsDir() {
+	if os.IsNotExist(err) {
 		return skillDir, false, nil
 	}
 	if err != nil {
 		return skillDir, false, fmt.Errorf("stat compatibility skills directory %q: %w", skillDir, err)
+	}
+	if compatibilityDirectoryUnsafe(skillDir, info) {
+		return skillDir, false, fmt.Errorf("compatibility skills directory %q must be a physical directory; replace it with a physical directory, then rerun gentle-ai install or gentle-ai sync", skillDir)
+	}
+	if !info.IsDir() {
+		return skillDir, false, nil
 	}
 	return skillDir, true, nil
 }

--- a/internal/cli/compatibility_skills.go
+++ b/internal/cli/compatibility_skills.go
@@ -123,12 +123,12 @@ func validateCompatibilityDestinations(root string, destinations []string) error
 			if err != nil {
 				return fmt.Errorf("stat compatibility destination ancestor %q: %w", current, err)
 			}
-			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			if compatibilityDestinationUnsafe(current, info) || !info.IsDir() {
 				return fmt.Errorf("compatibility destination ancestor %q must be a physical directory; replace it with a physical directory, then rerun gentle-ai install or gentle-ai sync", current)
 			}
 		}
 		info, err := lstatCompatibilityDestination(destination)
-		if err == nil && (info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular()) {
+		if err == nil && (compatibilityDestinationUnsafe(destination, info) || !info.Mode().IsRegular()) {
 			return fmt.Errorf("compatibility destination %q must be a regular file; replace it with a regular file or remove it, then rerun gentle-ai install or gentle-ai sync", destination)
 		}
 		if err != nil && !os.IsNotExist(err) {
@@ -136,6 +136,15 @@ func validateCompatibilityDestinations(root string, destinations []string) error
 		}
 	}
 	return nil
+}
+
+func compatibilityPathParts(root, path string) ([]string, error) {
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == "." || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		// refusal:by-design operator-knowledge: embedded compatibility destinations must stay below the anchored skills root.
+		return nil, fmt.Errorf("compatibility destination %q escapes %q", path, root)
+	}
+	return strings.Split(relative, string(filepath.Separator)), nil
 }
 
 func (s compatibilitySkillsRefreshStep) Run() error {

--- a/internal/cli/compatibility_skills_test.go
+++ b/internal/cli/compatibility_skills_test.go
@@ -63,6 +63,38 @@ func TestCompatibilitySkillsRefreshStepRefreshesExistingOrdinaryAndSDDAssets(t *
 	}
 }
 
+func TestRunSyncWithSelectionRefreshesCompatibilityAndOpenCodeAssetsOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only sync regression")
+	}
+	home := t.TempDir()
+	compatibilityFiles := []string{
+		filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md"),
+		filepath.Join(home, ".agents", "skills", "go-testing", "references", "examples.md"),
+	}
+	for _, path := range compatibilityFiles {
+		writeStale(t, path)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
+	writeStale(t, pluginPath)
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentOpenCode},
+		Components: []model.ComponentID{model.ComponentSkills},
+		Skills:     []model.SkillID{model.SkillGoTesting},
+		Persona:    model.PersonaNeutral,
+	}
+	if _, err := RunSyncWithSelection(home, selection); err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	for _, path := range append(compatibilityFiles, pluginPath) {
+		content, err := os.ReadFile(path)
+		if err != nil || string(content) == "stale" {
+			t.Fatalf("managed asset %q was not refreshed: content=%q error=%v", path, content, err)
+		}
+	}
+}
+
 func TestRunSyncDryRunMatchesZeroAgentCompatibilityRefresh(t *testing.T) {
 	home := t.TempDir()
 	setSyncTestHome(t, home)

--- a/internal/cli/compatibility_skills_windows_test.go
+++ b/internal/cli/compatibility_skills_windows_test.go
@@ -1,0 +1,126 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func createWindowsJunction(t *testing.T, link, target string) {
+	t.Helper()
+	output, err := exec.Command("cmd", "/c", "mklink", "/J", link, target).CombinedOutput()
+	if err != nil {
+		t.Fatalf("create junction %q -> %q: %v: %s", link, target, err, output)
+	}
+}
+
+func TestRunSyncWithSelectionRefusesWindowsCompatibilityRootAndParentJunctions(t *testing.T) {
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentOpenCode},
+		Components: []model.ComponentID{model.ComponentSkills},
+		Skills:     []model.SkillID{model.SkillGoTesting},
+		Persona:    model.PersonaNeutral,
+	}
+	for _, tc := range []struct {
+		name       string
+		linkParent bool
+	}{
+		{name: "compatibility root"},
+		{name: "compatibility parent", linkParent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, outside := t.TempDir(), t.TempDir()
+			targetSkills := outside
+			link := filepath.Join(home, ".agents", "skills")
+			if tc.linkParent {
+				targetSkills = filepath.Join(outside, "skills")
+				link = filepath.Join(home, ".agents")
+			}
+			if err := os.MkdirAll(targetSkills, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			createWindowsJunction(t, link, outside)
+			writeStale(t, filepath.Join(targetSkills, "go-testing", "SKILL.md"))
+
+			pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
+			writeStale(t, pluginPath)
+			_, err := RunSyncWithSelection(home, selection)
+			if err == nil || !strings.Contains(err.Error(), "must be a physical directory") {
+				t.Fatalf("RunSyncWithSelection() error = %v, want compatibility reparse refusal", err)
+			}
+			for _, path := range []string{
+				filepath.Join(targetSkills, "go-testing", "SKILL.md"),
+				pluginPath,
+			} {
+				content, readErr := os.ReadFile(path)
+				if readErr != nil || string(content) != "stale" {
+					t.Fatalf("refusal mutated %q: content=%q error=%v", path, content, readErr)
+				}
+			}
+		})
+	}
+}
+
+func TestCompatibilityRefreshRefusesWindowsNestedJunction(t *testing.T) {
+	home, outside := t.TempDir(), t.TempDir()
+	skillsDir := filepath.Join(home, ".agents", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createWindowsJunction(t, filepath.Join(skillsDir, "go-testing"), outside)
+	path := filepath.Join(outside, "SKILL.md")
+	writeStale(t, path)
+
+	err := (compatibilitySkillsRefreshStep{
+		homeDir:    home,
+		components: []model.ComponentID{model.ComponentSkills},
+		selection:  model.Selection{Skills: []model.SkillID{model.SkillGoTesting}},
+	}).Run()
+	if err == nil || !strings.Contains(err.Error(), "must be a physical directory") {
+		t.Fatalf("Run() error = %v, want nested compatibility reparse refusal", err)
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil || string(content) != "stale" {
+		t.Fatalf("nested junction target was mutated: content=%q error=%v", content, readErr)
+	}
+}
+
+func TestRollbackRefusesWindowsCompatibilityJunctionSwap(t *testing.T) {
+	home, outside := t.TempDir(), t.TempDir()
+	skillsDir := filepath.Join(home, ".agents", "skills")
+	created := filepath.Join(skillsDir, "go-testing", "references", "examples.md")
+
+	manifest, err := backup.NewSnapshotter().Create(filepath.Join(home, "snapshot"), []string{created})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeStale(t, created)
+	if err := os.Rename(filepath.Join(skillsDir, "go-testing"), filepath.Join(skillsDir, "go-testing-original")); err != nil {
+		t.Fatal(err)
+	}
+	outsideFile := filepath.Join(outside, "references", "examples.md")
+	writeStale(t, outsideFile)
+	createWindowsJunction(t, filepath.Join(skillsDir, "go-testing"), outside)
+
+	err = (rollbackRestoreStep{
+		state:   &runtimeState{manifest: manifest},
+		homeDir: home,
+	}).Rollback()
+	if err == nil {
+		t.Fatal("Rollback() succeeded after a compatibility subtree junction swap")
+	}
+	content, readErr := os.ReadFile(outsideFile)
+	if readErr != nil || string(content) != "stale" {
+		t.Fatalf("rollback mutated junction target: content=%q error=%v", content, readErr)
+	}
+}

--- a/internal/cli/compatibility_writer_unix.go
+++ b/internal/cli/compatibility_writer_unix.go
@@ -213,3 +213,7 @@ func createCompatibilityTempFile(dirFD int, perm fs.FileMode) (string, *os.File,
 func compatibilityDestinationUnsafe(_ string, info os.FileInfo) bool {
 	return info.Mode()&os.ModeSymlink != 0
 }
+
+func compatibilityDirectoryUnsafe(_ string, _ os.FileInfo) bool {
+	return false
+}

--- a/internal/cli/compatibility_writer_unix.go
+++ b/internal/cli/compatibility_writer_unix.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"golang.org/x/sys/unix"
@@ -126,15 +124,6 @@ func (w *unixCompatibilityDirectoryWriter) Write(path string, content []byte, pe
 	return result, nil
 }
 
-func compatibilityPathParts(root, path string) ([]string, error) {
-	relative, err := filepath.Rel(root, path)
-	if err != nil || relative == "." || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		// refusal:by-design operator-knowledge: embedded compatibility destinations must stay below the anchored skills root.
-		return nil, fmt.Errorf("compatibility destination %q escapes %q", path, root)
-	}
-	return strings.Split(relative, string(filepath.Separator)), nil
-}
-
 func (w *unixCompatibilityDirectoryWriter) openParent(parts []string) (int, error) {
 	currentFD := w.rootFD
 	for _, part := range parts {
@@ -219,4 +208,8 @@ func createCompatibilityTempFile(dirFD int, perm fs.FileMode) (string, *os.File,
 	}
 	// refusal:by-design world-action: repeated random-name collisions prevent a safe temporary file publication.
 	return "", nil, fmt.Errorf("create compatibility temp file: exhausted unique names")
+}
+
+func compatibilityDestinationUnsafe(_ string, info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
 }

--- a/internal/cli/compatibility_writer_unsupported.go
+++ b/internal/cli/compatibility_writer_unsupported.go
@@ -1,9 +1,10 @@
-//go:build !(aix || android || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+//go:build !(aix || android || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || windows)
 
 package cli
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 )
 
@@ -13,4 +14,8 @@ import (
 func newCompatibilityDirectoryWriter(homeDir, skillDir string) (compatibilityDirectoryWriter, error) {
 	// refusal:by-design world-action: this platform cannot enforce the compatibility route's physical-directory contract.
 	return nil, fmt.Errorf("compatibility skills refresh is disabled on %s: physical-directory containment is unavailable", runtime.GOOS)
+}
+
+func compatibilityDestinationUnsafe(_ string, info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
 }

--- a/internal/cli/compatibility_writer_unsupported.go
+++ b/internal/cli/compatibility_writer_unsupported.go
@@ -19,3 +19,7 @@ func newCompatibilityDirectoryWriter(homeDir, skillDir string) (compatibilityDir
 func compatibilityDestinationUnsafe(_ string, info os.FileInfo) bool {
 	return info.Mode()&os.ModeSymlink != 0
 }
+
+func compatibilityDirectoryUnsafe(_ string, _ os.FileInfo) bool {
+	return false
+}

--- a/internal/cli/compatibility_writer_windows.go
+++ b/internal/cli/compatibility_writer_windows.go
@@ -1,0 +1,321 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"unsafe"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+	"golang.org/x/sys/windows"
+)
+
+const maxCompatibilityAtomicFileSize = 16 << 20
+
+type windowsCompatibilityDirectoryWriter struct {
+	root   string
+	rootFD windows.Handle
+}
+
+func newCompatibilityDirectoryWriter(homeDir, skillDir string) (compatibilityDirectoryWriter, error) {
+	home, err := reviewtransaction.OpenPhysicalPath(homeDir, true)
+	if err != nil {
+		return nil, fmt.Errorf("open compatibility home directory %q: %w", homeDir, err)
+	}
+	defer home.Close()
+
+	agentsFD, err := openWindowsCompatibilityDirectoryAt(windows.Handle(home.Fd()), ".agents", windows.FILE_OPEN)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(agentsFD)
+
+	skillsFD, err := openWindowsCompatibilityDirectoryAt(agentsFD, "skills", windows.FILE_OPEN)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsCompatibilityDirectoryWriter{root: skillDir, rootFD: skillsFD}, nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) Close() error {
+	return windows.CloseHandle(w.rootFD)
+}
+
+func (w *windowsCompatibilityDirectoryWriter) Write(path string, content []byte, perm fs.FileMode) (filemerge.WriteResult, error) {
+	parts, err := compatibilityPathParts(w.root, path)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+
+	parentFD, err := w.openParent(parts[:len(parts)-1])
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	if parentFD != w.rootFD {
+		defer windows.CloseHandle(parentFD)
+	}
+
+	name := parts[len(parts)-1]
+	existing, exists, err := readWindowsCompatibilityFile(parentFD, name)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	if exists && bytes.Equal(existing, content) {
+		return filemerge.WriteResult{}, nil
+	}
+
+	_, tmp, err := createWindowsCompatibilityTempFile(parentFD, perm)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			removeWindowsCompatibilityTemp(tmp)
+		}
+		_ = tmp.Close()
+	}()
+
+	if _, err := tmp.Write(content); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("write compatibility temp file %q: %w", path, err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("set compatibility temp file permissions for %q: %w", path, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("sync compatibility temp file %q: %w", path, err)
+	}
+	if err := renameWindowsCompatibilityFile(windows.Handle(tmp.Fd()), parentFD, name); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("replace compatibility destination %q: %w", path, err)
+	}
+	cleanup = false
+	result := filemerge.WriteResult{Changed: true, Created: !exists}
+	if err := tmp.Close(); err != nil {
+		return result, fmt.Errorf("close compatibility temp file %q: %w", path, err)
+	}
+
+	readBack, readBackExists, err := readWindowsCompatibilityFile(parentFD, name)
+	if err != nil {
+		return result, err
+	}
+	if !readBackExists || !bytes.Equal(readBack, content) {
+		// refusal:by-design world-action: publication did not produce the staged bytes at the anchored destination.
+		return result, fmt.Errorf("replace compatibility destination %q: the replacement did not land", path)
+	}
+	return result, nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) openParent(parts []string) (windows.Handle, error) {
+	currentFD := w.rootFD
+	for _, part := range parts {
+		nextFD, err := openWindowsCompatibilityDirectoryAt(currentFD, part, windows.FILE_OPEN)
+		if windowsCompatibilityNotExist(err) {
+			nextFD, err = openWindowsCompatibilityDirectoryAt(currentFD, part, windows.FILE_OPEN_IF)
+		}
+		if err != nil {
+			if currentFD != w.rootFD {
+				_ = windows.CloseHandle(currentFD)
+			}
+			return 0, fmt.Errorf("open physical compatibility directory %q: %w", part, err)
+		}
+		if currentFD != w.rootFD {
+			_ = windows.CloseHandle(currentFD)
+		}
+		currentFD = nextFD
+	}
+	return currentFD, nil
+}
+
+func openWindowsCompatibilityDirectoryAt(parent windows.Handle, name string, disposition uint32) (windows.Handle, error) {
+	return openWindowsCompatibilityObject(parent, name, true, windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE, disposition)
+}
+
+func openWindowsCompatibilityFileAt(parent windows.Handle, name string, access uint32, disposition uint32) (windows.Handle, error) {
+	return openWindowsCompatibilityObject(parent, name, false, access, disposition)
+}
+
+func openWindowsCompatibilityObject(parent windows.Handle, name string, directory bool, access uint32, disposition uint32) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: parent,
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+	}
+	options := uint32(windows.FILE_SYNCHRONOUS_IO_NONALERT | windows.FILE_OPEN_REPARSE_POINT)
+	fileAttributes := uint32(windows.FILE_ATTRIBUTE_NORMAL)
+	if directory {
+		options |= windows.FILE_DIRECTORY_FILE
+		fileAttributes = windows.FILE_ATTRIBUTE_DIRECTORY
+	} else {
+		options |= windows.FILE_NON_DIRECTORY_FILE
+	}
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&handle,
+		access,
+		attributes,
+		&status,
+		nil,
+		fileAttributes,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		disposition,
+		options,
+		0,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if err := validateWindowsCompatibilityHandle(handle, directory); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+func validateWindowsCompatibilityHandle(handle windows.Handle, directory bool) error {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return err
+	}
+	fileType, err := windows.GetFileType(handle)
+	if err != nil {
+		return err
+	}
+	if fileType != windows.FILE_TYPE_DISK || info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 ||
+		directory != (info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0) {
+		// refusal:by-design world-action: physical-directory containment requires the opened handle not target a reparse point.
+		return fmt.Errorf("compatibility target is not a physical %s", map[bool]string{true: "directory", false: "file"}[directory])
+	}
+	return nil
+}
+
+func readWindowsCompatibilityFile(parent windows.Handle, name string) ([]byte, bool, error) {
+	handle, err := openWindowsCompatibilityFileAt(parent, name, windows.FILE_GENERIC_READ, windows.FILE_OPEN)
+	if windowsCompatibilityNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("open physical compatibility destination %q: %w", name, err)
+	}
+	file := os.NewFile(uintptr(handle), name)
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("stat compatibility destination %q: %w", name, err)
+	}
+	if !info.Mode().IsRegular() {
+		// refusal:by-design world-action: a non-regular destination must be replaced before a safe atomic refresh can continue.
+		return nil, false, fmt.Errorf("compatibility destination %q must be a regular file", name)
+	}
+	if info.Size() > maxCompatibilityAtomicFileSize {
+		// refusal:by-design world-action: an oversized destination cannot be safely compared before replacement.
+		return nil, false, fmt.Errorf("compatibility destination %q exceeds max atomic compare size %d bytes", name, maxCompatibilityAtomicFileSize)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxCompatibilityAtomicFileSize+1))
+	if err != nil {
+		return nil, false, fmt.Errorf("read compatibility destination %q: %w", name, err)
+	}
+	if len(data) > maxCompatibilityAtomicFileSize {
+		// refusal:by-design world-action: an oversized destination cannot be safely compared before replacement.
+		return nil, false, fmt.Errorf("compatibility destination %q exceeds max atomic compare size %d bytes", name, maxCompatibilityAtomicFileSize)
+	}
+	return data, true, nil
+}
+
+func createWindowsCompatibilityTempFile(parent windows.Handle, perm fs.FileMode) (string, *os.File, error) {
+	for range 10 {
+		var token [12]byte
+		if _, err := rand.Read(token[:]); err != nil {
+			return "", nil, fmt.Errorf("generate compatibility temp file name: %w", err)
+		}
+		name := ".gentle-ai-" + hex.EncodeToString(token[:]) + ".tmp"
+		handle, err := openWindowsCompatibilityFileAt(parent, name, windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE|windows.DELETE, windows.FILE_CREATE)
+		if windowsCompatibilityAlreadyExists(err) {
+			continue
+		}
+		if err != nil {
+			return "", nil, fmt.Errorf("create compatibility temp file: %w", err)
+		}
+		file := os.NewFile(uintptr(handle), name)
+		if err := file.Chmod(perm); err != nil {
+			_ = file.Close()
+			return "", nil, fmt.Errorf("set compatibility temp file permissions: %w", err)
+		}
+		return name, file, nil
+	}
+	// refusal:by-design world-action: repeated random-name collisions prevent a safe temporary file publication.
+	return "", nil, fmt.Errorf("create compatibility temp file: exhausted unique names")
+}
+
+type windowsCompatibilityRenameInformation struct {
+	ReplaceIfExists uint32
+	RootDirectory   windows.Handle
+	FileNameLength  uint32
+	FileName        [1]uint16
+}
+
+func renameWindowsCompatibilityFile(file, parent windows.Handle, name string) error {
+	utf16Name, err := windows.UTF16FromString(name)
+	if err != nil {
+		return err
+	}
+	nameLength := (len(utf16Name) - 1) * 2
+	var rename windowsCompatibilityRenameInformation
+	bufferSize := int(unsafe.Offsetof(rename.FileName)) + nameLength
+	buffer := make([]byte, bufferSize)
+	info := (*windowsCompatibilityRenameInformation)(unsafe.Pointer(&buffer[0]))
+	info.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS | windows.FILE_RENAME_POSIX_SEMANTICS
+	info.RootDirectory = parent
+	info.FileNameLength = uint32(nameLength)
+	copy(unsafe.Slice(&info.FileName[0], len(utf16Name)-1), utf16Name)
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(file, &status, &buffer[0], uint32(bufferSize), windows.FileRenameInformation)
+}
+
+func removeWindowsCompatibilityTemp(file *os.File) {
+	if file == nil {
+		return
+	}
+	deleteFile := byte(1)
+	var status windows.IO_STATUS_BLOCK
+	_ = windows.NtSetInformationFile(windows.Handle(file.Fd()), &status, &deleteFile, 1, windows.FileDispositionInformation)
+}
+
+func windowsCompatibilityNotExist(err error) bool {
+	return errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_FILE_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_PATH_NOT_FOUND)
+}
+
+func windowsCompatibilityAlreadyExists(err error) bool {
+	return errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) ||
+		errors.Is(err, windows.ERROR_FILE_EXISTS) ||
+		errors.Is(err, windows.ERROR_ALREADY_EXISTS)
+}
+
+func compatibilityDestinationUnsafe(path string, info os.FileInfo) bool {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return true
+	}
+	attributes, err := windows.GetFileAttributes(name)
+	return err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0
+}

--- a/internal/cli/compatibility_writer_windows.go
+++ b/internal/cli/compatibility_writer_windows.go
@@ -25,7 +25,7 @@ type windowsCompatibilityDirectoryWriter struct {
 	rootFD windows.Handle
 }
 
-func newCompatibilityDirectoryWriter(homeDir, skillDir string) (compatibilityDirectoryWriter, error) {
+func newCompatibilityDirectoryWriter(homeDir, skillDir string) (*windowsCompatibilityDirectoryWriter, error) {
 	home, err := reviewtransaction.OpenPhysicalPath(homeDir, true)
 	if err != nil {
 		return nil, fmt.Errorf("open compatibility home directory %q: %w", homeDir, err)
@@ -113,6 +113,37 @@ func (w *windowsCompatibilityDirectoryWriter) Write(path string, content []byte,
 	return result, nil
 }
 
+func (w *windowsCompatibilityDirectoryWriter) Remove(path string) error {
+	parts, err := compatibilityPathParts(w.root, path)
+	if err != nil {
+		return err
+	}
+
+	parentFD, exists, err := w.openExistingParent(parts[:len(parts)-1])
+	if err != nil || !exists {
+		return err
+	}
+	if parentFD != w.rootFD {
+		defer windows.CloseHandle(parentFD)
+	}
+
+	handle, err := openWindowsCompatibilityFileAt(parentFD, parts[len(parts)-1], windows.DELETE, windows.FILE_OPEN)
+	if windowsCompatibilityNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open physical compatibility destination %q for removal: %w", path, err)
+	}
+	defer windows.CloseHandle(handle)
+
+	deleteFile := byte(1)
+	var status windows.IO_STATUS_BLOCK
+	if err := windows.NtSetInformationFile(handle, &status, &deleteFile, 1, windows.FileDispositionInformation); err != nil {
+		return fmt.Errorf("remove compatibility destination %q: %w", path, err)
+	}
+	return nil
+}
+
 func (w *windowsCompatibilityDirectoryWriter) openParent(parts []string) (windows.Handle, error) {
 	currentFD := w.rootFD
 	for _, part := range parts {
@@ -132,6 +163,30 @@ func (w *windowsCompatibilityDirectoryWriter) openParent(parts []string) (window
 		currentFD = nextFD
 	}
 	return currentFD, nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) openExistingParent(parts []string) (windows.Handle, bool, error) {
+	currentFD := w.rootFD
+	for _, part := range parts {
+		nextFD, err := openWindowsCompatibilityDirectoryAt(currentFD, part, windows.FILE_OPEN)
+		if windowsCompatibilityNotExist(err) {
+			if currentFD != w.rootFD {
+				_ = windows.CloseHandle(currentFD)
+			}
+			return 0, false, nil
+		}
+		if err != nil {
+			if currentFD != w.rootFD {
+				_ = windows.CloseHandle(currentFD)
+			}
+			return 0, false, fmt.Errorf("open physical compatibility directory %q: %w", part, err)
+		}
+		if currentFD != w.rootFD {
+			_ = windows.CloseHandle(currentFD)
+		}
+		currentFD = nextFD
+	}
+	return currentFD, true, nil
 }
 
 func openWindowsCompatibilityDirectoryAt(parent windows.Handle, name string, disposition uint32) (windows.Handle, error) {
@@ -318,4 +373,8 @@ func compatibilityDestinationUnsafe(path string, info os.FileInfo) bool {
 	}
 	attributes, err := windows.GetFileAttributes(name)
 	return err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+func compatibilityDirectoryUnsafe(path string, info os.FileInfo) bool {
+	return compatibilityDestinationUnsafe(path, info)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1033,7 +1033,14 @@ func (s rollbackRestoreStep) Rollback() error {
 		return nil
 	}
 
-	return backup.RestoreService{Roots: rollbackRoots(s.homeDir, s.workspaceDir)}.Restore(s.state.manifest)
+	manifest, err := restoreCompatibilityEntries(s.state.manifest, s.homeDir)
+	if err != nil {
+		return err
+	}
+	if len(manifest.Entries) == 0 {
+		return nil
+	}
+	return backup.RestoreService{Roots: rollbackRoots(s.homeDir, s.workspaceDir)}.Restore(manifest)
 }
 
 // rollbackRoots returns the directories this install/sync run could

--- a/internal/reviewtransaction/rar_path_safety_windows.go
+++ b/internal/reviewtransaction/rar_path_safety_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"runtime"
 	"unsafe"
 
@@ -163,6 +164,15 @@ func openRARPathNoFollow(path string, directory bool) (*os.File, error) {
 		return nil, errUnsafeRARAuthorityPath
 	}
 	return file, nil
+}
+
+// OpenPhysicalPath opens a file or directory without traversing reparse points.
+func OpenPhysicalPath(path string, directory bool) (*os.File, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	return openRARPathNoFollow(absPath, directory)
 }
 
 func openWindowsRARObject(objectPath string, directory bool) (windows.Handle, error) {


### PR DESCRIPTION
## Linked Issue

Fixes #2590

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Restores Windows compatibility-skill refresh through no-reparse, handle-relative operations.
- Refuses Windows compatibility root, parent, and nested reparse points before backup or OpenCode plugin refresh.
- Restores compatibility rollback entries through the same anchored writer so a post-publication junction swap cannot redirect writes.

## Size Exception

This is one atomic correction for the two verifier-confirmed P1 defects: silent root/parent reparse skips and unanchored compatibility rollback. The resulting diff is `+707/-17` across 10 focused files. The maintainer-applied `size:exception` label is required because the native Windows junction regressions must ship with the containment fix.

## Exact Scope

| Area | Change |
| --- | --- |
| `internal/cli/compatibility_skills.go` | Refuse Windows compatibility root and parent reparse points before planning backup or plugins. |
| `internal/cli/compatibility_writer_windows.go` | Anchor compatibility writes and removals to physical Windows handles. |
| `internal/cli/compatibility_rollback_windows.go` | Extract transaction snapshots safely and restore/remove compatibility entries through the anchored writer. |
| `internal/cli/compatibility_rollback_nonwindows.go` | Preserve pre-existing non-Windows rollback behavior. |
| `internal/cli/compatibility_skills_windows_test.go` | Add native junction regressions for root, parent, nested, and rollback-swap containment. |
| `internal/cli/compatibility_skills_test.go` | Retain the successful full Windows compatibility and OpenCode refresh regression. |
| `internal/cli/compatibility_writer_unix.go` | Keep Unix no-follow writer behavior while sharing path validation. |
| `internal/cli/compatibility_writer_unsupported.go` | Keep unsupported-platform behavior and satisfy shared validation hooks. |
| `internal/reviewtransaction/rar_path_safety_windows.go` | Expose the existing physical Windows path opener for the compatibility writer. |

No files outside `internal/cli` and `internal/reviewtransaction` changed.

## Verification

- [x] `go test ./... -count=1`
- [x] Focused compatibility, absent-directory, successful refresh, and rollback tests: `go test ./internal/cli -count=1 -run '^(TestCompatibilitySkillsRefreshStepRefreshesExistingOrdinaryAndSDDAssets|TestCompatibilitySkillsRefreshRequiresPhysicalDirectory|TestCompatibilityRefreshDoesNotFollowParentSwappedAfterValidation|TestCompatibilityRefreshRollbackRemovesNewFilesAfterDuplicateBackup|TestRunSyncWithSelectionRefreshesCompatibilityAndOpenCodeAssetsOnWindows|TestRunSyncWithSelectionRefusesWindowsCompatibilityRootAndParentJunctions|TestCompatibilityRefreshRefusesWindowsNestedJunction|TestRollbackRefusesWindowsCompatibilityJunctionSwap)$'`
- [x] `go test -race ./internal/cli -count=1 -run '^TestCompatibility'`
- [x] `go test ./internal/backup ./internal/assets -count=1`
- [x] `go test ./internal/cli -count=1 -run '^TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign$'`
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] `go build -trimpath -o /tmp/opencode/gentle-ai-2594 ./cmd/gentle-ai`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] `GOOS=windows GOARCH=amd64 go build -trimpath -o /tmp/opencode/gentle-ai-2594-windows.exe ./cmd/gentle-ai`
- [x] `GOOS=windows GOARCH=amd64 go test -exec /bin/true ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build -trimpath -o /tmp/opencode/gentle-ai-2594-darwin ./cmd/gentle-ai`
- [x] `GOOS=darwin GOARCH=arm64 go test -exec /bin/true ./...`

Native Windows junction tests require a Windows host and are compiled above; the pushed head must pass the Windows Suite before merge.

## Benchmark Validation

N/A locally. This correction changes no `bench/` code or corpus declaration, and the benchmark corpus has no journey pinning compatibility-skill refresh, reparse refusal, or compatibility rollback behavior. CI still runs its standard benchmark evidence on this head.

## Contributor Checklist

- [x] PR is linked to approved issue #2590
- [x] Exactly one `type:*` label is applied (`type:bug`)
- [x] `size:exception` is applied for the atomic two-P1 correction
- [x] Unit, race, format, vet, build, refusal, deadcode, and cross-platform compilation gates passed
- [x] Conventional commit with no `Co-Authored-By` trailer
