### PR TITLE
fix(review): salvage frozen correction binding

### DIFF
--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -386,7 +386,7 @@ func (result ReviewTargetStatusResult) Validate() error {
 		if request := result.NextTransition.CorrectionRequest; request != nil {
 			if result.Authority == nil || result.Frozen == nil || result.Authority.Version != reviewtransaction.AuthorityVersionCompact ||
 				result.Authority.State != reviewtransaction.StateCorrectionRequired || request.LineageID != result.Authority.LineageID ||
-				request.ExpectedRevision != result.Authority.Revision || request.TargetIdentity != result.TargetIdentity ||
+				request.ExpectedRevision != result.Authority.Revision || request.TargetIdentity != reviewAuthorityTargetIdentity(result) ||
 				request.CorrectionBudget != result.Frozen.CorrectionBudget {
 				return errors.New("negotiated status correction request binding is invalid") // refusal:by-design world-action: provider-generated status and request bindings require a code fix when they disagree
 			}

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -1123,3 +1123,93 @@ func writeNegotiatedStatusHistory(t *testing.T, repo string, count int) {
 		}
 	}
 }
+
+// TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix is the regression
+// guard for issue #2132: after a bounded correction the plan request binds to
+// the FROZEN reviewed candidate, so read-only review status must accept it even
+// when the live workspace identity diverges (the fix applied, uncommitted).
+// Before the fix, Validate() compared the plan request's TargetIdentity against
+// the LIVE identity and failed the whole status operation with
+// "negotiated status correction request binding is invalid".
+func TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix(t *testing.T) {
+	for _, tt := range []struct {
+		name, reason string
+		forecast     bool
+		change       bool
+	}{
+		{name: "no forecast, changed workspace", reason: "correction_plan_required", change: true},
+		{name: "forecast, request-build error", reason: "corrected_candidate_unavailable", forecast: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			candidatePath := filepath.Join(repo, "candidate.go")
+			if err := os.WriteFile(candidatePath, []byte("package candidate\n\nfunc value() int { return 1 }\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			lineage := "correction-status-frozen-" + strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(tt.name), ",", ""), " ", "-")
+			started := runNegotiatedReviewStart(t, repo, lineage)
+			resultPath := filepath.Join(t.TempDir(), "blocking-result.json")
+			writeReviewCLIJSON(t, resultPath, facadeReviewerResult{
+				Lens: started.SelectedLenses[0], Findings: []facadeFinding{{
+					Location: "candidate.go:3", Severity: "CRITICAL", Claim: "candidate value is wrong",
+					ProofRefs: []string{"candidate.go:3 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+					CausalDisposition: reviewtransaction.CausalIntroduced,
+				}}, Evidence: []string{"inspected exact candidate"},
+			})
+			if err := finalizeReviewCLIArgs(t, repo, []string{"--cwd", repo, "--lineage", started.LineageID, "--result", resultPath}, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			if tt.forecast {
+				if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--correction-lines", "1"}, &bytes.Buffer{}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.change {
+				// The bounded fix lands in the workspace but stays uncommitted,
+				// so the live identity diverges from the reviewed candidate.
+				if err := os.WriteFile(candidatePath, []byte("package candidate\n\nfunc value() int { return 2 }\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(store.StatePath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var statusOutput bytes.Buffer
+			if err := RunReview([]string{
+				"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition", "--lineage", started.LineageID,
+			}, &statusOutput); err != nil {
+				t.Fatalf("status after applied fix: %v\n%s", err, statusOutput.String())
+			}
+			var status ReviewTargetStatusResult
+			decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+			if err := status.Validate(); err != nil {
+				t.Fatalf("status contract validation: %v\n%s", err, statusOutput.String())
+			}
+			transition, request := status.NextTransition, status.NextTransition.CorrectionRequest
+			if transition == nil || request == nil || transition.ReasonCode != tt.reason {
+				t.Fatalf("status transition = %#v\n%s", transition, statusOutput.String())
+			}
+			if request.LineageID != status.Authority.LineageID || request.ExpectedRevision != status.Authority.Revision ||
+				request.TargetIdentity != reviewAuthorityTargetIdentity(status) {
+				t.Fatalf("correction plan request does not bind to the frozen reviewed candidate: request=%#v status=%#v", request, status)
+			}
+			if tt.change {
+				if status.AuthorityTargetIdentity == "" || request.TargetIdentity != status.AuthorityTargetIdentity ||
+					request.TargetIdentity == status.TargetIdentity {
+					t.Fatalf("changed workspace status did not bind to the frozen authority identity: request=%#v status=%#v", request, status)
+				}
+			} else if status.AuthorityTargetIdentity != "" {
+				t.Fatalf("unchanged workspace status invented an authority identity: %#v", status)
+			}
+			after, err := os.ReadFile(store.StatePath())
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("read-only status after applied fix mutated authority: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -1190,10 +1190,11 @@ func TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix(t *testing.T) {
 			if err := status.Validate(); err != nil {
 				t.Fatalf("status contract validation: %v\n%s", err, statusOutput.String())
 			}
-			transition, request := status.NextTransition, status.NextTransition.CorrectionRequest
-			if transition == nil || request == nil || transition.ReasonCode != tt.reason {
+			transition := status.NextTransition
+			if transition == nil || transition.CorrectionRequest == nil || transition.ReasonCode != tt.reason {
 				t.Fatalf("status transition = %#v\n%s", transition, statusOutput.String())
 			}
+			request := transition.CorrectionRequest
 			if request.LineageID != status.Authority.LineageID || request.ExpectedRevision != status.Authority.Revision ||
 				request.TargetIdentity != reviewAuthorityTargetIdentity(status) {
 				t.Fatalf("correction plan request does not bind to the frozen reviewed candidate: request=%#v status=%#v", request, status)

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -1125,9 +1125,11 @@ func writeNegotiatedStatusHistory(t *testing.T, repo string, count int) {
 }
 
 // TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix is the regression
-// guard for issue #2132: after a bounded correction the plan request binds to
-// the FROZEN reviewed candidate, so read-only review status must accept it even
-// when the live workspace identity diverges (the fix applied, uncommitted).
+// guard for issue #2132's unforecast branch: the plan request binds to the
+// FROZEN reviewed candidate, so read-only review status must accept it even when
+// the live workspace identity diverges (the fix applied, uncommitted). It does
+// not prove the correctly ordered forecasted bounded-correction flow, which
+// routes to correction_repository_verification_required with targeted validation.
 // Before the fix, Validate() compared the plan request's TargetIdentity against
 // the LIVE identity and failed the whole status operation with
 // "negotiated status correction request binding is invalid".
@@ -1142,10 +1144,8 @@ func TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := initReviewCLIRepo(t)
-			candidatePath := filepath.Join(repo, "candidate.go")
-			if err := os.WriteFile(candidatePath, []byte("package candidate\n\nfunc value() int { return 1 }\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
+			const candidatePath = "candidate.go"
+			writeReviewStartCandidate(t, repo, candidatePath, "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
 			lineage := "correction-status-frozen-" + strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(tt.name), ",", ""), " ", "-")
 			started := runNegotiatedReviewStart(t, repo, lineage)
 			resultPath := filepath.Join(t.TempDir(), "blocking-result.json")
@@ -1167,9 +1167,7 @@ func TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix(t *testing.T) {
 			if tt.change {
 				// The bounded fix lands in the workspace but stays uncommitted,
 				// so the live identity diverges from the reviewed candidate.
-				if err := os.WriteFile(candidatePath, []byte("package candidate\n\nfunc value() int { return 2 }\n"), 0o644); err != nil {
-					t.Fatal(err)
-				}
+				writeReviewStartCandidate(t, repo, candidatePath, "package candidate\n\nfunc value() int { return 2 }\n", 0o644)
 			}
 			store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
 			if err != nil {
@@ -1180,9 +1178,8 @@ func TestCorrectionPlanStatusAcceptsFrozenBindingAfterAppliedFix(t *testing.T) {
 				t.Fatal(err)
 			}
 			var statusOutput bytes.Buffer
-			if err := RunReview([]string{
-				"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition", "--lineage", started.LineageID,
-			}, &statusOutput); err != nil {
+			if err := RunReview(negotiatedStatusArgs(repo, ReviewIntegrationContractV2,
+				"--lineage", started.LineageID), &statusOutput); err != nil {
 				t.Fatalf("status after applied fix: %v\n%s", err, statusOutput.String())
 			}
 			var status ReviewTargetStatusResult


### PR DESCRIPTION
## Linked Issue

Fixes #2132

---

## PR Type

- [x] `type:bug` - Bug fix

---

## Summary

- Salvages Jalmar Villarreal's approved frozen-authority binding fix from #2240 onto current `main`.
- Preserves contributor provenance with `-x` cherry-picks of only `ffff87dfcb834435c719925a8af7f920e7a32a79` and `7dbd6da54831340a0028805b97bfea1ba5787e00`.
- Uses the current v2 status boundary with its required runtime identity and declares the fixture candidate under current scope rules.

---

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/cli/review_status_contract.go` | Bind `CorrectionRequest.TargetIdentity` to `reviewAuthorityTargetIdentity(result)`, not the live workspace identity. |
| `internal/cli/review_status_contract_test.go` | Exercise the regression through negotiated v2 status and state its intentionally narrow scope. |

---

## Test Plan

- [x] Genuine RED: final v2 regression failed on the parent production comparison with `operation_failed` in the unforecast, live-diverged branch.
- [x] GREEN: the same regression passes after the one-line frozen-authority correction.
- [x] Focused correction/status tests, including `TestCorrectionNextTransitionAgreesBetweenFinalizeAndRestartStatus` and `TestNegotiatedStatusUnderUnavailableProcessTempContinuesCompactCorrection`.
- [x] `go test ./... -count=1`
- [x] Focused `go test -race ./internal/cli ... -count=1`
- [x] `go run ./internal/gofmtcheck`, `go vet ./...`, and `go build ./...`
- [x] Refusal ratchets, byte-equivalence golden tests, and `./scripts/deadcode-ratchet.sh`
- [x] `GOOS=windows GOARCH=amd64 go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] Bench declaration test plus driven `j51-negotiated-status-correction-continuation`: 1 completed, 0 failed.
- [ ] Docker E2E was not run locally; CI will execute its required lane.

---

## Contributor Checklist

- [x] PR is linked to an approved issue.
- [x] PR stays below 400 changed lines (`+89/-1`).
- [x] Exactly one `type:bug` label is applied.
- [x] Unit tests and Go format pass.
- [x] Benchmark validation completed.
- [x] Documentation is not required for this internal contract correction.
- [x] Commits use Conventional Commit messages and contain no `Co-Authored-By` trailers.

---

## Notes for Reviewers

This is a maintainer salvage of #2240, not a merge or closure of #2240. The two contributor commits above retain Jalmar Villarreal as author and record their original SHA through `-x`; the third, conventional maintainer commit only updates the test fixture and invocation for current v2 requirements.

The regression proves producer/validator consistency only for the unforecast branch where the live workspace diverges after an uncommitted correction. It does **not** claim to prove the correctly ordered forecasted bounded-correction flow. That flow already routes to `correction_repository_verification_required` with targeted validation and is exercised by `TestCorrectionNextTransitionAgreesBetweenFinalizeAndRestartStatus` and driven bench journey `j51`.

No qualifying security, integrity, admission, repair, or governance guard was added or changed; `.guard-population-baseline.txt` is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected correction-request validation to use the appropriate authority identity.
  * Improved status handling after an applied but uncommitted fix, including changed-workspace and request-build-error scenarios.
  * Preserved authority state during status evaluation and clarified returned correction reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->