### PR TITLE
fix(upgrade): verify OpenCode plugin materialization

### DIFF
--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -629,8 +629,11 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 		base.Status = UpgradeSkipped
 		return base
 	}
+	if base.Method == update.InstallOpenCodePlugin {
+		base.NewVersion = ""
+	}
 
-	exitReq, err := runStrategy(ctx, r, profile, preflightDestination...)
+	outcome, err := runStrategyWithOutcome(ctx, r, profile, preflightDestination...)
 	if err != nil {
 		// Distinguish manual fallback (informational skip) from real failures.
 		if hint, ok := AsManualFallback(err); ok {
@@ -642,8 +645,12 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 			base.Err = err
 		}
 	} else {
+		base.NewVersion = r.LatestVersion
+		if outcome.observedVersion != "" {
+			base.NewVersion = outcome.observedVersion
+		}
 		base.Status = UpgradeSucceeded
-		base.ExitRequested = exitReq
+		base.ExitRequested = outcome.exitRequested
 	}
 
 	return base

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -169,6 +169,13 @@ func TestExecute_RegisteredNotMaterializedIsExecutable(t *testing.T) {
 	execCalled := false
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		execCalled = true
+		pkgDir := filepath.Join(opencodeDir, "node_modules", "opencode-sdd-engram-manage")
+		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"version":"1.2.0"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
 		return mockCmd("true")
 	}
 
@@ -187,8 +194,58 @@ func TestExecute_RegisteredNotMaterializedIsExecutable(t *testing.T) {
 	if report.Results[0].Status != UpgradeSucceeded {
 		t.Fatalf("status = %q, want %q", report.Results[0].Status, UpgradeSucceeded)
 	}
+	if report.Results[0].NewVersion != "1.2.0" {
+		t.Fatalf("new version = %q, want observed materialized version 1.2.0", report.Results[0].NewVersion)
+	}
 	if report.BackupID == "" {
 		t.Fatal("BackupID should be populated before executing registered-pending plugin upgrade")
+	}
+}
+
+func TestExecute_OpenCodePluginNoMaterializationIsSkipped(t *testing.T) {
+	origExecCommand := execCommand
+	origHomeDir := openCodeHomeDir
+	origLookPath := lookPathCommand
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		openCodeHomeDir = origHomeDir
+		lookPathCommand = origLookPath
+	})
+
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(opencodeDir, "tui.json"), []byte(`{"plugin":["opencode-subagent-statusline"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openCodeHomeDir = func() (string, error) { return home, nil }
+	lookPathCommand = func(file string) (string, error) {
+		if file == "npm" {
+			return "/usr/bin/npm", nil
+		}
+		return "", errors.New("not found")
+	}
+	execCommand = func(name string, args ...string) *exec.Cmd { return mockCmd("true") }
+
+	result := makeResult("opencode-subagent-statusline", update.RegisteredNotMaterialized, "0.7.1", "0.8.0", update.InstallOpenCodePlugin)
+	result.Tool.NpmPackage = "opencode-subagent-statusline"
+	toolResult := executeOne(context.Background(), result, linuxProfile(), false)
+
+	if toolResult.Status != UpgradeSkipped {
+		t.Fatalf("status = %q, want %q", toolResult.Status, UpgradeSkipped)
+	}
+	if toolResult.Err != nil {
+		t.Fatalf("Err = %v, want nil for actionable manual fallback", toolResult.Err)
+	}
+	if toolResult.NewVersion != "" {
+		t.Fatalf("new version = %q, want empty when materialization is unverified", toolResult.NewVersion)
+	}
+	for _, want := range []string{"expected version \"0.8.0\"", "absent", opencodeDir} {
+		if !strings.Contains(toolResult.ManualHint, want) {
+			t.Errorf("manual hint %q does not contain %q", toolResult.ManualHint, want)
+		}
 	}
 }
 

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -202,7 +202,7 @@ func TestExecute_RegisteredNotMaterializedIsExecutable(t *testing.T) {
 	}
 }
 
-func TestExecute_OpenCodePluginNoMaterializationIsSkipped(t *testing.T) {
+func TestExecute_OpenCodePluginPostMutationVerificationFailureIsFailed(t *testing.T) {
 	origExecCommand := execCommand
 	origHomeDir := openCodeHomeDir
 	origLookPath := lookPathCommand
@@ -227,9 +227,72 @@ func TestExecute_OpenCodePluginNoMaterializationIsSkipped(t *testing.T) {
 		}
 		return "", errors.New("not found")
 	}
-	execCommand = func(name string, args ...string) *exec.Cmd { return mockCmd("true") }
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		// Model a successful npm mutation that leaves the plugin manifest absent.
+		if err := os.WriteFile(filepath.Join(opencodeDir, "package-lock.json"), []byte(`{"packages":{}}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return mockCmd("true")
+	}
 
 	result := makeResult("opencode-subagent-statusline", update.RegisteredNotMaterialized, "0.7.1", "0.8.0", update.InstallOpenCodePlugin)
+	result.Tool.NpmPackage = "opencode-subagent-statusline"
+	toolResult := executeOne(context.Background(), result, linuxProfile(), false)
+
+	if toolResult.Status != UpgradeFailed {
+		t.Fatalf("status = %q, want %q", toolResult.Status, UpgradeFailed)
+	}
+	if toolResult.Err == nil {
+		t.Fatal("Err = nil, want failed postcondition error")
+	}
+	if toolResult.NewVersion != "" {
+		t.Fatalf("new version = %q, want empty when materialization is unverified", toolResult.NewVersion)
+	}
+	if toolResult.ManualHint != "" {
+		t.Fatalf("ManualHint = %q, want empty for a real failure", toolResult.ManualHint)
+	}
+	for _, want := range []string{"after npm mutation", "expected version \"0.8.0\"", "absent", "No automatic rollback", "restore or correct", opencodeDir} {
+		if !strings.Contains(toolResult.Err.Error(), want) {
+			t.Errorf("error %q does not contain %q", toolResult.Err, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(opencodeDir, "package-lock.json")); err != nil {
+		t.Fatalf("simulated package-manager mutation should remain inspectable: %v", err)
+	}
+}
+
+func TestExecute_OpenCodePluginUnregisteredSkipsWithoutMutation(t *testing.T) {
+	origExecCommand := execCommand
+	origHomeDir := openCodeHomeDir
+	origLookPath := lookPathCommand
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		openCodeHomeDir = origHomeDir
+		lookPathCommand = origLookPath
+	})
+
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(opencodeDir, "tui.json"), []byte(`{"plugin":["other-plugin"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openCodeHomeDir = func() (string, error) { return home, nil }
+	lookPathCommand = func(file string) (string, error) {
+		if file == "npm" {
+			return "/usr/bin/npm", nil
+		}
+		return "", errors.New("not found")
+	}
+	execCalled := false
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		execCalled = true
+		return mockCmd("true")
+	}
+
+	result := makeResult("opencode-subagent-statusline", update.UpdateAvailable, "0.7.1", "0.8.0", update.InstallOpenCodePlugin)
 	result.Tool.NpmPackage = "opencode-subagent-statusline"
 	toolResult := executeOne(context.Background(), result, linuxProfile(), false)
 
@@ -237,15 +300,16 @@ func TestExecute_OpenCodePluginNoMaterializationIsSkipped(t *testing.T) {
 		t.Fatalf("status = %q, want %q", toolResult.Status, UpgradeSkipped)
 	}
 	if toolResult.Err != nil {
-		t.Fatalf("Err = %v, want nil for actionable manual fallback", toolResult.Err)
+		t.Fatalf("Err = %v, want nil for a zero-mutation skip", toolResult.Err)
 	}
-	if toolResult.NewVersion != "" {
-		t.Fatalf("new version = %q, want empty when materialization is unverified", toolResult.NewVersion)
+	if toolResult.ManualHint == "" {
+		t.Fatal("ManualHint = empty, want an actionable pre-mutation hint")
 	}
-	for _, want := range []string{"expected version \"0.8.0\"", "absent", opencodeDir} {
-		if !strings.Contains(toolResult.ManualHint, want) {
-			t.Errorf("manual hint %q does not contain %q", toolResult.ManualHint, want)
-		}
+	if execCalled {
+		t.Fatal("package manager must not run for an unregistered, unmaterialized plugin")
+	}
+	if _, err := os.Stat(filepath.Join(opencodeDir, "package-lock.json")); !os.IsNotExist(err) {
+		t.Fatalf("package manager state exists after zero-mutation skip, stat err: %v", err)
 	}
 }
 

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -60,9 +60,9 @@ type strategyOutcome struct {
 	observedVersion string
 }
 
-// runStrategy executes the upgrade for a single tool using the appropriate strategy
-// for the given platform profile. It preserves the historical return contract
-// for callers that only need the exit-request flag.
+// runStrategyWithOutcome executes the upgrade for a single tool using the
+// appropriate strategy for the given platform profile. It returns both the
+// exit-request flag and any version observed after the strategy completes.
 //
 // Strategy routing:
 //   - brew profile → brewUpgrade (regardless of tool's declared method)
@@ -74,11 +74,6 @@ type strategyOutcome struct {
 //   - script method + windows → manualFallback
 //   - OpenCode plugin method → update materialized package in ~/.config/opencode when possible
 //   - unknown method → manualFallback with explicit message
-func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
-	outcome, err := runStrategyWithOutcome(ctx, r, profile, preflightDestination...)
-	return outcome.exitRequested, err
-}
-
 func runStrategyWithOutcome(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (strategyOutcome, error) {
 	ownership := update.HomebrewNone
 	if profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
@@ -161,7 +156,11 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) (string, 
 	default:
 	}
 
-	targets := []string{pkg + "@latest", "@opencode-ai/plugin@latest"}
+	expectedVersion := strings.TrimSpace(r.LatestVersion)
+	if expectedVersion == "" {
+		return "", &ManualFallbackError{Hint: fmt.Sprintf("OpenCode plugin %s upgrade cannot be pinned because the expected version is empty; rerun the update check and try again.", pkg)}
+	}
+	targets := []string{pkg + "@" + expectedVersion, "@opencode-ai/plugin@latest"}
 	var cmd *exec.Cmd
 	switch pm {
 	case "bun":
@@ -199,7 +198,7 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) (string, 
 	}
 
 	observedVersion, err := inspectOpenCodePluginVersion(opencodeDir, pkg)
-	if err != nil || observedVersion != strings.TrimSpace(r.LatestVersion) {
+	if err != nil || observedVersion != expectedVersion {
 		return "", &ManualFallbackError{Hint: openCodePluginVerificationHint(r, pkg, opencodeDir, observedVersion, err)}
 	}
 	return observedVersion, nil

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -52,8 +52,17 @@ var (
 // server or CDN could still serve a malicious script within this size limit.
 const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 
+// strategyOutcome carries the result data that is only available after a
+// strategy runs. OpenCode plugin upgrades populate observedVersion from the
+// installed package manifest instead of reusing remote metadata.
+type strategyOutcome struct {
+	exitRequested   bool
+	observedVersion string
+}
+
 // runStrategy executes the upgrade for a single tool using the appropriate strategy
-// for the given platform profile.
+// for the given platform profile. It preserves the historical return contract
+// for callers that only need the exit-request flag.
 //
 // Strategy routing:
 //   - brew profile → brewUpgrade (regardless of tool's declared method)
@@ -66,16 +75,21 @@ const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 //   - OpenCode plugin method → update materialized package in ~/.config/opencode when possible
 //   - unknown method → manualFallback with explicit message
 func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
+	outcome, err := runStrategyWithOutcome(ctx, r, profile, preflightDestination...)
+	return outcome.exitRequested, err
+}
+
+func runStrategyWithOutcome(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (strategyOutcome, error) {
 	ownership := update.HomebrewNone
 	if profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
 		var err error
 		ownership, err = homebrewOwnershipDetector(r.Tool.Name)
 		if err != nil {
-			return false, fmt.Errorf("detect Homebrew ownership for %s: %w", r.Tool.Name, err)
+			return strategyOutcome{}, fmt.Errorf("detect Homebrew ownership for %s: %w", r.Tool.Name, err)
 		}
 	}
 	if isBetaGentleAIUpgrade(r) && profile.OS != "windows" && ownership == update.HomebrewNone {
-		return false, goInstallMainUpgrade(r.Tool)
+		return strategyOutcome{}, goInstallMainUpgrade(r.Tool)
 	}
 
 	method := effectiveMethod(r.Tool, profile)
@@ -85,11 +99,11 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 
 	switch method {
 	case update.InstallBrew:
-		return false, brewUpgrade(ctx, r, ownership)
+		return strategyOutcome{}, brewUpgrade(ctx, r, ownership)
 	case update.InstallGoInstall:
-		return false, goInstallUpgrade(ctx, r, profile, firstString(preflightDestination))
+		return strategyOutcome{}, goInstallUpgrade(ctx, r, profile, firstString(preflightDestination))
 	case update.InstallBinary:
-		return false, binaryUpgrade(ctx, r, profile)
+		return strategyOutcome{}, binaryUpgrade(ctx, r, profile)
 	case update.InstallScript:
 		// GGA's install.sh expects to run from within a cloned repo — it references
 		// $SCRIPT_DIR/bin/gga and $SCRIPT_DIR/lib/*.sh. The generic scriptUpgrade
@@ -97,52 +111,53 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 		// breaks because those relative paths don't exist. Use the git clone approach
 		// (same as the initial install resolver) for GGA specifically.
 		if r.Tool.Name == "gga" {
-			return false, ggaScriptUpgrade(ctx, r)
+			return strategyOutcome{}, ggaScriptUpgrade(ctx, r)
 		}
-		return false, scriptUpgrade(ctx, r, profile)
+		return strategyOutcome{}, scriptUpgrade(ctx, r, profile)
 	case update.InstallOpenCodePlugin:
-		return false, opencodePluginUpgrade(ctx, r)
+		observedVersion, err := opencodePluginUpgrade(ctx, r)
+		return strategyOutcome{observedVersion: observedVersion}, err
 	default:
-		return false, &ManualFallbackError{
+		return strategyOutcome{}, &ManualFallbackError{
 			Hint: fmt.Sprintf("upgrade %q: unsupported install method %q — please update manually. See: https://github.com/Gentleman-Programming/%s",
 				r.Tool.Name, method, r.Tool.Repo),
 		}
 	}
 }
 
-func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) error {
+func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) (string, error) {
 	pkg := strings.TrimSpace(r.Tool.NpmPackage)
 	if pkg == "" {
-		return &ManualFallbackError{Hint: openCodePluginManualHint(r)}
+		return "", &ManualFallbackError{Hint: openCodePluginManualHint(r)}
 	}
 
 	homeDir, err := openCodeHomeDir()
 	if err != nil || strings.TrimSpace(homeDir) == "" {
-		return &ManualFallbackError{Hint: fmt.Sprintf("%s Could not resolve the user home directory; update %s manually.", openCodePluginManualHint(r), pkg)}
+		return "", &ManualFallbackError{Hint: fmt.Sprintf("%s Could not resolve the user home directory; update %s manually.", openCodePluginManualHint(r), pkg)}
 	}
 
 	opencodeDir := filepath.Join(homeDir, ".config", "opencode")
 	info, err := os.Stat(opencodeDir)
 	if err != nil || !info.IsDir() {
-		return &ManualFallbackError{Hint: fmt.Sprintf("%s OpenCode config directory was not found at %s; %s is not installed/materialized yet.", openCodePluginManualHint(r), opencodeDir, pkg)}
+		return "", &ManualFallbackError{Hint: fmt.Sprintf("%s OpenCode config directory was not found at %s; %s is not installed/materialized yet.", openCodePluginManualHint(r), opencodeDir, pkg)}
 	}
 
 	materialized, registered, err := openCodePluginRegisteredOrMaterialized(opencodeDir, pkg)
 	if err != nil {
-		return fmt.Errorf("inspect OpenCode plugin %s: %w", pkg, err)
+		return "", fmt.Errorf("inspect OpenCode plugin %s: %w", pkg, err)
 	}
 	if !materialized && !registered && r.Status != update.RegisteredNotMaterialized {
-		return &ManualFallbackError{Hint: fmt.Sprintf("%s %s is not registered in tui.json and is not present in node_modules; start/reload OpenCode first so it materializes the plugin.", openCodePluginManualHint(r), pkg)}
+		return "", &ManualFallbackError{Hint: fmt.Sprintf("%s %s is not registered in tui.json and is not present in node_modules; start/reload OpenCode first so it materializes the plugin.", openCodePluginManualHint(r), pkg)}
 	}
 
 	pm, err := selectOpenCodePackageManager(opencodeDir)
 	if err != nil {
-		return &ManualFallbackError{Hint: fmt.Sprintf("OpenCode plugin %s can be upgraded from %s, but no supported package manager is available in PATH. Install bun or npm, then run update tools again.", pkg, opencodeDir)}
+		return "", &ManualFallbackError{Hint: fmt.Sprintf("OpenCode plugin %s can be upgraded from %s, but no supported package manager is available in PATH. Install bun or npm, then run update tools again.", pkg, opencodeDir)}
 	}
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return "", ctx.Err()
 	default:
 	}
 
@@ -154,7 +169,7 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) error {
 	case "npm":
 		cmd = execCommand("npm", append([]string{"install", "--save", "--no-audit", "--no-fund"}, targets...)...)
 	default:
-		return &ManualFallbackError{Hint: fmt.Sprintf("unsupported OpenCode package manager %q for %s", pm, pkg)}
+		return "", &ManualFallbackError{Hint: fmt.Sprintf("unsupported OpenCode package manager %q for %s", pm, pkg)}
 	}
 	cmd.Dir = opencodeDir
 	cmd.Stdin = nil
@@ -164,7 +179,7 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) error {
 		if pm == "npm" && npmErrorCode(outStr) == "ERESOLVE" {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return "", ctx.Err()
 			default:
 			}
 			fmt.Fprintln(os.Stderr, "WARNING: npm reported an ERESOLVE peer dependency conflict; retrying with --legacy-peer-deps")
@@ -173,16 +188,56 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) error {
 			retryCmd.Stdin = nil
 			retryCmd.Env = openCodePluginUpgradeEnv(retryCmd.Env)
 			if retryOut, retryErr := retryCmd.CombinedOutput(); retryErr != nil {
-				return fmt.Errorf("%s upgrade %s in %s: retry with --legacy-peer-deps failed: %w (retry output: %s); original error: %v (original output: %s)", pm, pkg, opencodeDir, retryErr, string(retryOut), err, outStr)
+				return "", fmt.Errorf("%s upgrade %s in %s: retry with --legacy-peer-deps failed: %w (retry output: %s); original error: %v (original output: %s)", pm, pkg, opencodeDir, retryErr, string(retryOut), err, outStr)
 			}
 		} else {
-			return fmt.Errorf("%s upgrade %s in %s: %w (output: %s)", pm, pkg, opencodeDir, err, outStr)
+			return "", fmt.Errorf("%s upgrade %s in %s: %w (output: %s)", pm, pkg, opencodeDir, err, outStr)
 		}
 	}
 	if err := clearOpenCodePluginPackageCache(homeDir, pkg); err != nil {
-		return fmt.Errorf("clear OpenCode package cache for %s: %w", pkg, err)
+		return "", fmt.Errorf("clear OpenCode package cache for %s: %w", pkg, err)
 	}
-	return nil
+
+	observedVersion, err := inspectOpenCodePluginVersion(opencodeDir, pkg)
+	if err != nil || observedVersion != strings.TrimSpace(r.LatestVersion) {
+		return "", &ManualFallbackError{Hint: openCodePluginVerificationHint(r, pkg, opencodeDir, observedVersion, err)}
+	}
+	return observedVersion, nil
+}
+
+func inspectOpenCodePluginVersion(opencodeDir, pkg string) (string, error) {
+	manifestPath := filepath.Join(opencodeDir, "node_modules", pkg, "package.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("installed manifest is absent at %s", manifestPath)
+		}
+		return "", fmt.Errorf("installed manifest could not be read at %s: %w", manifestPath, err)
+	}
+
+	var manifest struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", fmt.Errorf("installed manifest is invalid at %s: %w", manifestPath, err)
+	}
+	version := strings.TrimSpace(manifest.Version)
+	if version == "" {
+		return "", fmt.Errorf("installed manifest is invalid at %s: version is missing", manifestPath)
+	}
+	return version, nil
+}
+
+func openCodePluginVerificationHint(r update.UpdateResult, pkg, opencodeDir, observedVersion string, verificationErr error) string {
+	observed := strings.TrimSpace(observedVersion)
+	if observed == "" {
+		observed = "absent or invalid"
+	}
+	detail := ""
+	if verificationErr != nil {
+		detail = fmt.Sprintf(" (%s)", verificationErr)
+	}
+	return fmt.Sprintf("OpenCode plugin %s upgrade was not verified: expected version %q but observed %q%s. Inspect %s/node_modules/%s/package.json and rerun the upgrade.", pkg, strings.TrimSpace(r.LatestVersion), observed, detail, opencodeDir, pkg)
 }
 
 func npmErrorCode(output string) string {

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -52,17 +52,13 @@ var (
 // server or CDN could still serve a malicious script within this size limit.
 const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 
-// strategyOutcome carries the result data that is only available after a
-// strategy runs. OpenCode plugin upgrades populate observedVersion from the
-// installed package manifest instead of reusing remote metadata.
 type strategyOutcome struct {
 	exitRequested   bool
 	observedVersion string
 }
 
-// runStrategyWithOutcome executes the upgrade for a single tool using the
-// appropriate strategy for the given platform profile. It returns both the
-// exit-request flag and any version observed after the strategy completes.
+// runStrategy executes the upgrade for a single tool using the appropriate strategy
+// for the given platform profile.
 //
 // Strategy routing:
 //   - brew profile → brewUpgrade (regardless of tool's declared method)
@@ -74,17 +70,17 @@ type strategyOutcome struct {
 //   - script method + windows → manualFallback
 //   - OpenCode plugin method → update materialized package in ~/.config/opencode when possible
 //   - unknown method → manualFallback with explicit message
-func runStrategyWithOutcome(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (strategyOutcome, error) {
+func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
 	ownership := update.HomebrewNone
 	if profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
 		var err error
 		ownership, err = homebrewOwnershipDetector(r.Tool.Name)
 		if err != nil {
-			return strategyOutcome{}, fmt.Errorf("detect Homebrew ownership for %s: %w", r.Tool.Name, err)
+			return false, fmt.Errorf("detect Homebrew ownership for %s: %w", r.Tool.Name, err)
 		}
 	}
 	if isBetaGentleAIUpgrade(r) && profile.OS != "windows" && ownership == update.HomebrewNone {
-		return strategyOutcome{}, goInstallMainUpgrade(r.Tool)
+		return false, goInstallMainUpgrade(r.Tool)
 	}
 
 	method := effectiveMethod(r.Tool, profile)
@@ -94,11 +90,11 @@ func runStrategyWithOutcome(ctx context.Context, r update.UpdateResult, profile 
 
 	switch method {
 	case update.InstallBrew:
-		return strategyOutcome{}, brewUpgrade(ctx, r, ownership)
+		return false, brewUpgrade(ctx, r, ownership)
 	case update.InstallGoInstall:
-		return strategyOutcome{}, goInstallUpgrade(ctx, r, profile, firstString(preflightDestination))
+		return false, goInstallUpgrade(ctx, r, profile, firstString(preflightDestination))
 	case update.InstallBinary:
-		return strategyOutcome{}, binaryUpgrade(ctx, r, profile)
+		return false, binaryUpgrade(ctx, r, profile)
 	case update.InstallScript:
 		// GGA's install.sh expects to run from within a cloned repo — it references
 		// $SCRIPT_DIR/bin/gga and $SCRIPT_DIR/lib/*.sh. The generic scriptUpgrade
@@ -106,18 +102,27 @@ func runStrategyWithOutcome(ctx context.Context, r update.UpdateResult, profile 
 		// breaks because those relative paths don't exist. Use the git clone approach
 		// (same as the initial install resolver) for GGA specifically.
 		if r.Tool.Name == "gga" {
-			return strategyOutcome{}, ggaScriptUpgrade(ctx, r)
+			return false, ggaScriptUpgrade(ctx, r)
 		}
-		return strategyOutcome{}, scriptUpgrade(ctx, r, profile)
+		return false, scriptUpgrade(ctx, r, profile)
 	case update.InstallOpenCodePlugin:
-		observedVersion, err := opencodePluginUpgrade(ctx, r)
-		return strategyOutcome{observedVersion: observedVersion}, err
+		_, err := opencodePluginUpgrade(ctx, r)
+		return false, err
 	default:
-		return strategyOutcome{}, &ManualFallbackError{
+		return false, &ManualFallbackError{
 			Hint: fmt.Sprintf("upgrade %q: unsupported install method %q — please update manually. See: https://github.com/Gentleman-Programming/%s",
 				r.Tool.Name, method, r.Tool.Repo),
 		}
 	}
+}
+
+func runStrategyWithOutcome(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (strategyOutcome, error) {
+	if effectiveMethod(r.Tool, profile) == update.InstallOpenCodePlugin {
+		observedVersion, err := opencodePluginUpgrade(ctx, r)
+		return strategyOutcome{observedVersion: observedVersion}, err
+	}
+	exitRequested, err := runStrategy(ctx, r, profile, preflightDestination...)
+	return strategyOutcome{exitRequested: exitRequested}, err
 }
 
 func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) (string, error) {

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -199,7 +199,10 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) (string, 
 
 	observedVersion, err := inspectOpenCodePluginVersion(opencodeDir, pkg)
 	if err != nil || observedVersion != expectedVersion {
-		return "", &ManualFallbackError{Hint: openCodePluginVerificationHint(r, pkg, opencodeDir, observedVersion, err)}
+		// A successful package-manager command crosses the mutation boundary. A
+		// failed materialization check is therefore a real failed postcondition,
+		// not a no-op manual fallback.
+		return "", fmt.Errorf("OpenCode plugin %s materialization failed after %s mutation: %s", pkg, pm, openCodePluginVerificationHint(r, pkg, opencodeDir, observedVersion, err))
 	}
 	return observedVersion, nil
 }
@@ -236,7 +239,7 @@ func openCodePluginVerificationHint(r update.UpdateResult, pkg, opencodeDir, obs
 	if verificationErr != nil {
 		detail = fmt.Sprintf(" (%s)", verificationErr)
 	}
-	return fmt.Sprintf("OpenCode plugin %s upgrade was not verified: expected version %q but observed %q%s. Inspect %s/node_modules/%s/package.json and rerun the upgrade.", pkg, strings.TrimSpace(r.LatestVersion), observed, detail, opencodeDir, pkg)
+	return fmt.Sprintf("OpenCode plugin %s upgrade was not verified: expected version %q but observed %q%s. No automatic rollback is available for package-manager state; package metadata, lockfiles, or node_modules may have changed. Inspect %s/node_modules/%s/package.json and the package-manager files in %s, restore or correct them, then rerun the upgrade.", pkg, strings.TrimSpace(r.LatestVersion), observed, detail, opencodeDir, pkg, opencodeDir)
 }
 
 func npmErrorCode(output string) string {

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -17,6 +17,13 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/update"
 )
 
+// runStrategy preserves the boolean assertion seam used by legacy strategy
+// tests. Production callers use runStrategyWithOutcome directly.
+func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
+	outcome, err := runStrategyWithOutcome(ctx, r, profile, preflightDestination...)
+	return outcome.exitRequested, err
+}
+
 func TestMain(m *testing.M) {
 	if err := os.Unsetenv("GENTLE_AI_CHANNEL"); err != nil {
 		panic(err)
@@ -600,7 +607,7 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 			NpmPackage:    pkg,
 		},
 		InstalledVersion: "0.1.0",
-		LatestVersion:    "0.2.0",
+		LatestVersion:    " 0.2.0 ",
 	}, system.PlatformProfile{PackageManager: "brew"})
 	if err != nil {
 		t.Fatalf("runStrategy OpenCode plugin: unexpected error: %v", err)
@@ -612,7 +619,7 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 	if gotName != "bun" {
 		t.Fatalf("exec name = %q, want bun", gotName)
 	}
-	wantArgs := []string{"add", pkg + "@latest", "@opencode-ai/plugin@latest"}
+	wantArgs := []string{"add", pkg + "@0.2.0", "@opencode-ai/plugin@latest"}
 	if strings.Join(gotArgs, " ") != strings.Join(wantArgs, " ") {
 		t.Fatalf("exec args = %v, want %v", gotArgs, wantArgs)
 	}
@@ -638,6 +645,56 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 	}
 	if gotCwd != wantCwd {
 		t.Fatalf("command cwd = %q, want %q", gotCwd, wantCwd)
+	}
+}
+
+func TestRunStrategyOpenCodePluginRejectsEmptyExpectedVersion(t *testing.T) {
+	origHomeDir, origLookPath, origExecCommand := openCodeHomeDir, lookPathCommand, execCommand
+	t.Cleanup(func() {
+		openCodeHomeDir, lookPathCommand, execCommand = origHomeDir, origLookPath, origExecCommand
+	})
+
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	pkg := "opencode-subagent-statusline"
+	pkgDir := filepath.Join(opencodeDir, "node_modules", pkg)
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"version":"0.7.1"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openCodeHomeDir = func() (string, error) { return home, nil }
+	lookPathCommand = func(file string) (string, error) {
+		if file == "bun" {
+			return "/usr/bin/bun", nil
+		}
+		return "", errors.New("not found")
+	}
+	execCalled := false
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		execCalled = true
+		return mockCmd("true")
+	}
+
+	_, err := runStrategyWithOutcome(context.Background(), update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          pkg,
+			InstallMethod: update.InstallOpenCodePlugin,
+			NpmPackage:    pkg,
+		},
+		LatestVersion: "  ",
+		Status:        update.UpdateAvailable,
+	}, system.PlatformProfile{})
+	if err == nil {
+		t.Fatal("expected empty expected version to be rejected")
+	}
+	hint, ok := AsManualFallback(err)
+	if !ok || !strings.Contains(hint, "expected version is empty") {
+		t.Fatalf("error = %T %v, want an actionable empty-version fallback", err, err)
+	}
+	if execCalled {
+		t.Fatal("package manager must not run without a pinned expected version")
 	}
 }
 
@@ -787,7 +844,7 @@ func TestRunStrategyOpenCodePluginRegisteredPendingRunsPackageManager(t *testing
 	if gotName != "npm" {
 		t.Fatalf("exec name = %q, want npm", gotName)
 	}
-	wantArgs := []string{"install", "--save", "--no-audit", "--no-fund", pkg + "@latest", "@opencode-ai/plugin@latest"}
+	wantArgs := []string{"install", "--save", "--no-audit", "--no-fund", pkg + "@1.2.0", "@opencode-ai/plugin@latest"}
 	if strings.Join(gotArgs, " ") != strings.Join(wantArgs, " ") {
 		t.Fatalf("exec args = %v, want %v", gotArgs, wantArgs)
 	}
@@ -832,7 +889,7 @@ func TestRunStrategyOpenCodePluginNpmERESOLVERetriesWithLegacyPeerDeps(t *testin
 	if len(callHistory) != 2 {
 		t.Fatalf("expected 2 exec calls (initial + retry), got %d", len(callHistory))
 	}
-	wantRetry := []string{"npm", "install", "--save", "--no-audit", "--no-fund", "--legacy-peer-deps", "opencode-sdd-engram-manage@latest", "@opencode-ai/plugin@latest"}
+	wantRetry := []string{"npm", "install", "--save", "--no-audit", "--no-fund", "--legacy-peer-deps", "opencode-sdd-engram-manage@1.2.0", "@opencode-ai/plugin@latest"}
 	if strings.Join(callHistory[1], " ") != strings.Join(wantRetry, " ") {
 		t.Fatalf("retry command = %v, want %v", callHistory[1], wantRetry)
 	}

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -587,11 +587,13 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GENTLE_AI_UPGRADE_HELPER=1",
 			"GENTLE_AI_UPGRADE_HELPER_CWD_FILE="+cwdFile,
+			"GENTLE_AI_UPGRADE_HELPER_MANIFEST_PATH="+filepath.Join(pkgDir, "package.json"),
+			"GENTLE_AI_UPGRADE_HELPER_MANIFEST_VERSION=0.2.0",
 		)
 		return cmd
 	}
 
-	_, err := runStrategy(context.Background(), update.UpdateResult{
+	outcome, err := runStrategyWithOutcome(context.Background(), update.UpdateResult{
 		Tool: update.ToolInfo{
 			Name:          pkg,
 			InstallMethod: update.InstallOpenCodePlugin,
@@ -602,6 +604,9 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 	}, system.PlatformProfile{PackageManager: "brew"})
 	if err != nil {
 		t.Fatalf("runStrategy OpenCode plugin: unexpected error: %v", err)
+	}
+	if outcome.observedVersion != "0.2.0" {
+		t.Fatalf("observed version = %q, want 0.2.0 from the installed manifest", outcome.observedVersion)
 	}
 
 	if gotName != "bun" {
@@ -633,6 +638,95 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 	}
 	if gotCwd != wantCwd {
 		t.Fatalf("command cwd = %q, want %q", gotCwd, wantCwd)
+	}
+}
+
+func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T) {
+	tests := []struct {
+		name          string
+		manifest      string
+		registerOnly  bool
+		wantHintParts []string
+	}{
+		{
+			name:          "package manager succeeds without materializing the package",
+			registerOnly:  true,
+			wantHintParts: []string{"expected version \"0.8.0\"", "absent"},
+		},
+		{
+			name:          "package manager succeeds but leaves the stale version",
+			manifest:      `{"version":"0.7.1"}`,
+			wantHintParts: []string{"expected version \"0.8.0\"", "0.7.1"},
+		},
+		{
+			name:          "package manager succeeds but leaves an invalid manifest",
+			manifest:      `{not valid json`,
+			wantHintParts: []string{"expected version \"0.8.0\"", "invalid"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origHomeDir, origLookPath, origExecCommand := openCodeHomeDir, lookPathCommand, execCommand
+			t.Cleanup(func() {
+				openCodeHomeDir, lookPathCommand, execCommand = origHomeDir, origLookPath, origExecCommand
+			})
+
+			home := t.TempDir()
+			opencodeDir := filepath.Join(home, ".config", "opencode")
+			if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			pkg := "opencode-subagent-statusline"
+			pkgDir := filepath.Join(opencodeDir, "node_modules", pkg)
+			if tc.manifest != "" {
+				if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(tc.manifest), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.registerOnly {
+				if err := os.WriteFile(filepath.Join(opencodeDir, "tui.json"), []byte(`{"plugin":["`+pkg+`"]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			openCodeHomeDir = func() (string, error) { return home, nil }
+			lookPathCommand = func(file string) (string, error) {
+				if file == "bun" {
+					return "/usr/bin/bun", nil
+				}
+				return "", errors.New("not found")
+			}
+			execCommand = func(name string, args ...string) *exec.Cmd { return mockCmd("true") }
+
+			outcome, err := runStrategyWithOutcome(context.Background(), update.UpdateResult{
+				Tool: update.ToolInfo{
+					Name:          pkg,
+					InstallMethod: update.InstallOpenCodePlugin,
+					NpmPackage:    pkg,
+				},
+				LatestVersion: "0.8.0",
+				Status:        update.UpdateAvailable,
+			}, system.PlatformProfile{})
+			if err == nil {
+				t.Fatal("expected verification failure after a successful package-manager command")
+			}
+			if outcome.observedVersion != "" {
+				t.Fatalf("observed version = %q, want empty on verification failure", outcome.observedVersion)
+			}
+			hint, ok := AsManualFallback(err)
+			if !ok {
+				t.Fatalf("error = %T %v, want ManualFallbackError", err, err)
+			}
+			for _, want := range tc.wantHintParts {
+				if !strings.Contains(hint, want) {
+					t.Errorf("hint %q does not contain %q", hint, want)
+				}
+			}
+		})
 	}
 }
 
@@ -668,6 +762,13 @@ func TestRunStrategyOpenCodePluginRegisteredPendingRunsPackageManager(t *testing
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		gotName = name
 		gotArgs = append([]string(nil), args...)
+		pkgDir := filepath.Join(opencodeDir, "node_modules", pkg)
+		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"version":"1.2.0"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
 		return mockCmd("true")
 	}
 
@@ -677,7 +778,8 @@ func TestRunStrategyOpenCodePluginRegisteredPendingRunsPackageManager(t *testing
 			InstallMethod: update.InstallOpenCodePlugin,
 			NpmPackage:    pkg,
 		},
-		Status: update.RegisteredNotMaterialized,
+		LatestVersion: "1.2.0",
+		Status:        update.RegisteredNotMaterialized,
 	}, system.PlatformProfile{})
 	if err != nil {
 		t.Fatalf("registered OpenCode plugin should be npm-managed during upgrade, got: %v", err)
@@ -808,6 +910,13 @@ func configureOpenCodeNpmTest(t *testing.T, command func(string, ...string) *exe
 	if err := os.WriteFile(filepath.Join(opencodeDir, "tui.json"), []byte(`{"plugin":["opencode-sdd-engram-manage"]}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	pkgDir := filepath.Join(opencodeDir, "node_modules", "opencode-sdd-engram-manage")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"version":"1.2.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	openCodeHomeDir = func() (string, error) { return home, nil }
 	lookPathCommand = func(file string) (string, error) {
 		if file == "npm" {
@@ -819,7 +928,7 @@ func configureOpenCodeNpmTest(t *testing.T, command func(string, ...string) *exe
 }
 
 func openCodePluginUpdateResult(pkg string) update.UpdateResult {
-	return update.UpdateResult{Tool: update.ToolInfo{Name: pkg, InstallMethod: update.InstallOpenCodePlugin, NpmPackage: pkg}, Status: update.RegisteredNotMaterialized}
+	return update.UpdateResult{Tool: update.ToolInfo{Name: pkg, InstallMethod: update.InstallOpenCodePlugin, NpmPackage: pkg}, LatestVersion: "1.2.0", Status: update.RegisteredNotMaterialized}
 }
 
 func slicesContain(values []string, want string) bool {
@@ -919,6 +1028,13 @@ func TestOpenCodePluginUpgradeHelperProcess(t *testing.T) {
 	if err := os.WriteFile(os.Getenv("GENTLE_AI_UPGRADE_HELPER_CWD_FILE"), []byte(cwd), 0o644); err != nil {
 		_, _ = os.Stderr.WriteString(err.Error())
 		os.Exit(2)
+	}
+	if manifestPath := os.Getenv("GENTLE_AI_UPGRADE_HELPER_MANIFEST_PATH"); manifestPath != "" {
+		version := os.Getenv("GENTLE_AI_UPGRADE_HELPER_MANIFEST_VERSION")
+		if err := os.WriteFile(manifestPath, []byte(`{"version":"`+version+`"}`), 0o644); err != nil {
+			_, _ = os.Stderr.WriteString(err.Error())
+			os.Exit(2)
+		}
 	}
 	os.Exit(0)
 }

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -700,25 +700,25 @@ func TestRunStrategyOpenCodePluginRejectsEmptyExpectedVersion(t *testing.T) {
 
 func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T) {
 	tests := []struct {
-		name          string
-		manifest      string
-		registerOnly  bool
-		wantHintParts []string
+		name           string
+		manifest       string
+		registerOnly   bool
+		wantErrorParts []string
 	}{
 		{
-			name:          "package manager succeeds without materializing the package",
-			registerOnly:  true,
-			wantHintParts: []string{"expected version \"0.8.0\"", "absent"},
+			name:           "package manager succeeds without materializing the package",
+			registerOnly:   true,
+			wantErrorParts: []string{"after bun mutation", "expected version \"0.8.0\"", "absent", "No automatic rollback", "restore or correct"},
 		},
 		{
-			name:          "package manager succeeds but leaves the stale version",
-			manifest:      `{"version":"0.7.1"}`,
-			wantHintParts: []string{"expected version \"0.8.0\"", "0.7.1"},
+			name:           "package manager succeeds but leaves the stale version",
+			manifest:       `{"version":"0.7.1"}`,
+			wantErrorParts: []string{"after bun mutation", "expected version \"0.8.0\"", "0.7.1", "No automatic rollback", "restore or correct"},
 		},
 		{
-			name:          "package manager succeeds but leaves an invalid manifest",
-			manifest:      `{not valid json`,
-			wantHintParts: []string{"expected version \"0.8.0\"", "invalid"},
+			name:           "package manager succeeds but leaves an invalid manifest",
+			manifest:       `{not valid json`,
+			wantErrorParts: []string{"after bun mutation", "expected version \"0.8.0\"", "invalid", "No automatic rollback", "restore or correct"},
 		},
 	}
 
@@ -774,13 +774,12 @@ func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T)
 			if outcome.observedVersion != "" {
 				t.Fatalf("observed version = %q, want empty on verification failure", outcome.observedVersion)
 			}
-			hint, ok := AsManualFallback(err)
-			if !ok {
-				t.Fatalf("error = %T %v, want ManualFallbackError", err, err)
+			if _, ok := AsManualFallback(err); ok {
+				t.Fatalf("error = %T %v, must not be ManualFallbackError after package-manager mutation", err, err)
 			}
-			for _, want := range tc.wantHintParts {
-				if !strings.Contains(hint, want) {
-					t.Errorf("hint %q does not contain %q", hint, want)
+			for _, want := range tc.wantErrorParts {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
 				}
 			}
 		})

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -17,13 +17,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/update"
 )
 
-// runStrategy preserves the boolean assertion seam used by legacy strategy
-// tests. Production callers use runStrategyWithOutcome directly.
-func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
-	outcome, err := runStrategyWithOutcome(ctx, r, profile, preflightDestination...)
-	return outcome.exitRequested, err
-}
-
 func TestMain(m *testing.M) {
 	if err := os.Unsetenv("GENTLE_AI_CHANNEL"); err != nil {
 		panic(err)
@@ -648,76 +641,38 @@ func TestRunStrategyOpenCodePluginUpgradesMaterializedPackage(t *testing.T) {
 	}
 }
 
-func TestRunStrategyOpenCodePluginRejectsEmptyExpectedVersion(t *testing.T) {
-	origHomeDir, origLookPath, origExecCommand := openCodeHomeDir, lookPathCommand, execCommand
-	t.Cleanup(func() {
-		openCodeHomeDir, lookPathCommand, execCommand = origHomeDir, origLookPath, origExecCommand
-	})
-
-	home := t.TempDir()
-	opencodeDir := filepath.Join(home, ".config", "opencode")
-	pkg := "opencode-subagent-statusline"
-	pkgDir := filepath.Join(opencodeDir, "node_modules", pkg)
-	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"version":"0.7.1"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	openCodeHomeDir = func() (string, error) { return home, nil }
-	lookPathCommand = func(file string) (string, error) {
-		if file == "bun" {
-			return "/usr/bin/bun", nil
-		}
-		return "", errors.New("not found")
-	}
-	execCalled := false
-	execCommand = func(name string, args ...string) *exec.Cmd {
-		execCalled = true
-		return mockCmd("true")
-	}
-
-	_, err := runStrategyWithOutcome(context.Background(), update.UpdateResult{
-		Tool: update.ToolInfo{
-			Name:          pkg,
-			InstallMethod: update.InstallOpenCodePlugin,
-			NpmPackage:    pkg,
-		},
-		LatestVersion: "  ",
-		Status:        update.UpdateAvailable,
-	}, system.PlatformProfile{})
-	if err == nil {
-		t.Fatal("expected empty expected version to be rejected")
-	}
-	hint, ok := AsManualFallback(err)
-	if !ok || !strings.Contains(hint, "expected version is empty") {
-		t.Fatalf("error = %T %v, want an actionable empty-version fallback", err, err)
-	}
-	if execCalled {
-		t.Fatal("package manager must not run without a pinned expected version")
-	}
-}
-
 func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T) {
 	tests := []struct {
 		name           string
 		manifest       string
 		registerOnly   bool
+		latestVersion  string
+		wantFallback   bool
 		wantErrorParts []string
 	}{
 		{
+			name:           "empty expected version skips before package manager mutation",
+			registerOnly:   true,
+			latestVersion:  "  ",
+			wantFallback:   true,
+			wantErrorParts: []string{"expected version is empty"},
+		},
+		{
 			name:           "package manager succeeds without materializing the package",
 			registerOnly:   true,
+			latestVersion:  "0.8.0",
 			wantErrorParts: []string{"after bun mutation", "expected version \"0.8.0\"", "absent", "No automatic rollback", "restore or correct"},
 		},
 		{
 			name:           "package manager succeeds but leaves the stale version",
 			manifest:       `{"version":"0.7.1"}`,
+			latestVersion:  "0.8.0",
 			wantErrorParts: []string{"after bun mutation", "expected version \"0.8.0\"", "0.7.1", "No automatic rollback", "restore or correct"},
 		},
 		{
 			name:           "package manager succeeds but leaves an invalid manifest",
 			manifest:       `{not valid json`,
+			latestVersion:  "0.8.0",
 			wantErrorParts: []string{"after bun mutation", "expected version \"0.8.0\"", "invalid", "No automatic rollback", "restore or correct"},
 		},
 	}
@@ -757,7 +712,11 @@ func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T)
 				}
 				return "", errors.New("not found")
 			}
-			execCommand = func(name string, args ...string) *exec.Cmd { return mockCmd("true") }
+			execCalled := false
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				execCalled = true
+				return mockCmd("true")
+			}
 
 			outcome, err := runStrategyWithOutcome(context.Background(), update.UpdateResult{
 				Tool: update.ToolInfo{
@@ -765,7 +724,7 @@ func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T)
 					InstallMethod: update.InstallOpenCodePlugin,
 					NpmPackage:    pkg,
 				},
-				LatestVersion: "0.8.0",
+				LatestVersion: tc.latestVersion,
 				Status:        update.UpdateAvailable,
 			}, system.PlatformProfile{})
 			if err == nil {
@@ -774,8 +733,16 @@ func TestRunStrategyOpenCodePluginRejectsUnverifiedMaterialization(t *testing.T)
 			if outcome.observedVersion != "" {
 				t.Fatalf("observed version = %q, want empty on verification failure", outcome.observedVersion)
 			}
-			if _, ok := AsManualFallback(err); ok {
-				t.Fatalf("error = %T %v, must not be ManualFallbackError after package-manager mutation", err, err)
+			if hint, ok := AsManualFallback(err); ok != tc.wantFallback {
+				t.Fatalf("error = %T %v, ManualFallbackError = %t, want %t", err, err, ok, tc.wantFallback)
+			} else if ok && !strings.Contains(hint, tc.wantErrorParts[0]) {
+				t.Errorf("fallback hint %q does not contain %q", hint, tc.wantErrorParts[0])
+			}
+			if tc.wantFallback {
+				if execCalled {
+					t.Fatal("package manager must not run without a pinned expected version")
+				}
+				return
 			}
 			for _, want := range tc.wantErrorParts {
 				if !strings.Contains(err.Error(), want) {

--- a/internal/update/upgrade/types.go
+++ b/internal/update/upgrade/types.go
@@ -10,6 +10,10 @@ import (
 type ToolUpgradeStatus string
 
 const (
+	// UpgradeSucceeded means the selected strategy completed successfully. For
+	// OpenCode plugins, this specifically means the expected package manifest
+	// version was observed; it does not assert that a running OpenCode process
+	// has already reloaded the plugin.
 	UpgradeSucceeded ToolUpgradeStatus = "succeeded"
 	UpgradeFailed    ToolUpgradeStatus = "failed"
 	UpgradeSkipped   ToolUpgradeStatus = "skipped" // dry-run, dev build, or unsupported platform


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #744

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Verify the OpenCode plugin version from its installed package manifest after an upgrade command succeeds.
- Report missing, invalid, or stale materialization as skipped instead of assuming the target version was installed.
- Preserve command failure and ERESOLVE retry behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/strategy.go` | Inspect the installed OpenCode plugin manifest and validate its observed version. |
| `internal/update/upgrade/executor.go` | Report the observed installed version rather than the requested version. |
| Upgrade tests | Cover materialized, missing, invalid, stale, and retry outcomes. |

---

## 🧪 Test Plan

- [x] `go test ./internal/update/upgrade -count=1`
- [x] `go test -race ./internal/update/upgrade -count=1`
- [x] `go vet ./internal/update/...`
- [x] `git diff --check origin/main`
- [ ] `go test ./internal/update/... -count=1` — blocked by a pre-existing macOS Bash 3.2 incompatibility with `declare -A` in `release_security_test.go`.
- [x] Benchmark validation: N/A; this change does not affect review lifecycle, gates, recovery, delivery, or benchmark behavior.
- [x] E2E: N/A; the affected behavior is covered at the upgrade strategy/executor boundary.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Requested the appropriate `type:bug` label
- [x] Focused unit and race tests pass
- [x] Go formatting and vet checks pass
- [x] Documentation is not required for this internal correctness fix
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Please focus on the distinction between command success and verified package materialization, including scoped package paths and stale manifests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenCode plugin upgrades now verify the installed package version after installation.
  * Missing, stale, or invalid installations are no longer marked as successful.
  * Successfully verified upgrades report the installed version accurately.

* **Upgrade Experience**
  * Unregistered plugins are skipped without modifying package-manager state.
  * Manual guidance includes the expected version and plugin location when intervention is needed.
  * Cancellation and upgrade completion status are handled more accurately.

* **Documentation**
  * Clarified what constitutes a successful plugin upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->