### PR TITLE
fix(sdd): parse cumulative remediation evidence

### DIFF
--- a/internal/sddstatus/remediation_test.go
+++ b/internal/sddstatus/remediation_test.go
@@ -35,6 +35,94 @@ func TestParseRemediationResultRequiresExactTransactionBinding(t *testing.T) {
 	}
 }
 
+func TestParseRemediationResultCumulativeProgress(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+
+	otherRevision := "sha256:" + strings.Repeat("e", 64)
+	type parseCase struct {
+		name, text string
+		want       bool
+	}
+	cases := []parseCase{
+		{
+			name: "accepts earlier history with different revision",
+			text: remediationResultEvidenceWithBinding(otherRevision, binding) + "\n\n" + remediationResultEvidenceWithBinding(revision, binding),
+			want: true,
+		},
+		{
+			name: "rejects non-adjacent evidence",
+			text: strings.Replace(remediationResultEvidenceWithBinding(revision, binding), "\n```json\n", "\nprogress prose\n```json\n", 1),
+		},
+		{
+			name: "rejects invalid trailing content",
+			text: remediationResultEvidenceWithBinding(revision, binding) + "\ntrailing prose",
+		},
+		{
+			name: "rejects trailing prose with an inline fence marker",
+			text: strings.Join([]string{
+				remediationResultEvidenceWithBinding(revision, binding),
+				"trailing prose with a ```yaml marker",
+			}, "\n"),
+			want: false,
+		},
+		{
+			name: "allows a closed bare fence after the valid pair",
+			text: remediationResultEvidenceWithBinding(revision, binding) + "\n```\nunrelated content\n```",
+			want: true,
+		},
+		{
+			name: "rejects a pair inside an unclosed bare fence",
+			text: "```\n" + remediationResultEvidenceWithBinding(revision, binding),
+		},
+	}
+	for _, tc := range []struct {
+		name     string
+		revision string
+		binding  RemediationBinding
+	}{
+		{"different lineage", revision, RemediationBinding{LineageID: "lineage-2", Generation: binding.Generation, FixBatch: binding.FixBatch}},
+		{"different generation", revision, RemediationBinding{LineageID: binding.LineageID, Generation: binding.Generation + 1, FixBatch: binding.FixBatch}},
+		{"different fix batch", revision, RemediationBinding{LineageID: binding.LineageID, Generation: binding.Generation, FixBatch: binding.FixBatch + 1}},
+	} {
+		cases = append(cases, parseCase{"accepts earlier history with " + tc.name, remediationResultEvidenceWithBinding(tc.revision, tc.binding) + "\n\n" + remediationResultEvidenceWithBinding(revision, binding), true})
+	}
+	for _, tc := range []struct {
+		name, text string
+	}{
+		{"strict pair", remediationResultEvidenceWithBinding(revision, binding)},
+		{"legacy json result", legacyRemediationResult(revision, binding)},
+		{"blockquoted result", quoteRemediationEnvelope(remediationEnvelopeWithBinding(revision, binding), "> ")},
+		{"nested blockquoted result", quoteRemediationEnvelope(remediationEnvelopeWithBinding(revision, binding), "> > ")},
+	} {
+		cases = append(cases, parseCase{"rejects duplicate " + tc.name, tc.text + "\n\n" + remediationResultEvidenceWithBinding(revision, binding), false})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRemediationResult(tc.text, revision, binding).Complete
+			if got != tc.want {
+				t.Fatalf("parseRemediationResult(...).Complete = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseRemediationResultRejectsManyUnclosedFences(t *testing.T) {
+	if got := parseRemediationResult(strings.Repeat("```yaml\n", 4096), "sha256:"+strings.Repeat("d", 64)); got.Complete {
+		t.Fatal("many unclosed fences passed remediation parsing")
+	}
+}
+
+func TestParseRemediationResultMultipleBindingsPreserveEvidenceRevision(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	got := parseRemediationResult(remediationResultEvidenceWithBinding(revision, binding), revision, binding, binding)
+	if got.Complete || got.EvidenceRevision != revision {
+		t.Fatalf("multiple-binding result = %#v, want incomplete result retaining %q", got, revision)
+	}
+}
+
 func remediationEnvelope(revision string) string {
 	return strings.Join([]string{
 		"```yaml",
@@ -67,12 +155,7 @@ func remediationResultEvidence(revision string) string {
 }
 
 func remediationResultEvidenceWithBinding(revision string, binding RemediationBinding) string {
-	envelope := strings.Replace(remediationEnvelope(revision), "focused_tests: passed", strings.Join([]string{
-		"lineage_id: " + binding.LineageID,
-		"generation: " + strconv.Itoa(binding.Generation),
-		"fix_batch: " + strconv.Itoa(binding.FixBatch),
-		"focused_tests: passed",
-	}, "\n"), 1)
+	envelope := remediationEnvelopeWithBinding(revision, binding)
 	payload := map[string]any{
 		"schema":                   "gentle-ai.remediation-evidence/v1",
 		"failed_evidence_revision": revision,
@@ -91,4 +174,16 @@ func remediationResultEvidenceWithBinding(revision string, binding RemediationBi
 	}
 	raw, _ := json.Marshal(payload)
 	return envelope + "\n```json\n" + string(raw) + "\n```"
+}
+
+func remediationEnvelopeWithBinding(revision string, binding RemediationBinding) string {
+	return strings.Replace(remediationEnvelope(revision), "focused_tests: passed", "lineage_id: "+binding.LineageID+"\ngeneration: "+strconv.Itoa(binding.Generation)+"\nfix_batch: "+strconv.Itoa(binding.FixBatch)+"\nfocused_tests: passed", 1)
+}
+
+func legacyRemediationResult(revision string, binding RemediationBinding) string {
+	return "```json\n{\"schema\":\"gentle-ai.remediation-result/v1\",\"failedVerifyRevision\":\"" + revision + "\",\"lineageId\":\"" + binding.LineageID + "\",\"generation\":" + strconv.Itoa(binding.Generation) + ",\"fixBatch\":" + strconv.Itoa(binding.FixBatch) + "}\n```"
+}
+
+func quoteRemediationEnvelope(envelope, prefix string) string {
+	return prefix + strings.ReplaceAll(envelope, "\n", "\n"+prefix)
 }

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -362,6 +362,19 @@ type RemediationBinding struct {
 	FixBatch   int
 }
 
+type remediationIdentity struct {
+	Revision   string
+	LineageID  string
+	Generation int
+	FixBatch   int
+}
+
+type remediationFenceBlock struct {
+	start, end int
+	depth      int
+	token      string
+}
+
 type remediationCommandEvidence struct {
 	Command  string `json:"command"`
 	ExitCode int    `json:"exit_code"`
@@ -381,6 +394,283 @@ type remediationRollbackEvidence struct {
 }
 
 func parseRemediationResult(text, expectedRevision string, bindings ...RemediationBinding) remediationResultEvaluation {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	blocks, invalid := scanRemediationFences(lines)
+	blocksByStart := make(map[int]remediationFenceBlock, len(blocks))
+	for _, block := range blocks {
+		blocksByStart[block.start] = block
+	}
+	claims := 0
+	var candidate remediationResultEvaluation
+	candidateEnd := -1
+	var fallback remediationResultEvaluation
+
+	for _, block := range blocks {
+		if block.end < 0 {
+			continue
+		}
+		if block.token == "json" {
+			if identity, ok := remediationJSONIdentity(lines[block.start+1 : block.end]); ok && remediationIdentityMatches(identity, expectedRevision, bindings) {
+				claims++
+			}
+			continue
+		}
+		if block.token != "yaml" {
+			continue
+		}
+
+		if identity, ok := remediationYAMLIdentity(lines[block.start+1 : block.end]); ok && remediationIdentityMatches(identity, expectedRevision, bindings) {
+			claims++
+		}
+		envelope := parseRemediationResultEnvelope(strings.Join(lines[block.start:block.end+1], "\n"), expectedRevision, bindings...)
+		if fallback.EvidenceRevision == "" && envelope.EvidenceRevision != "" {
+			fallback = envelope
+		}
+
+		if block.depth != 0 {
+			continue
+		}
+
+		evidenceStart := nextNonemptyLine(lines, block.end+1)
+		if evidenceStart < 0 {
+			continue
+		}
+		evidenceBlock, evidenceOK := blocksByStart[evidenceStart]
+		if !evidenceOK || evidenceBlock.depth != 0 || evidenceBlock.token != "json" {
+			continue
+		}
+
+		pair := strings.Join(lines[block.start:evidenceBlock.end+1], "\n")
+		evaluation := parseRemediationResultEnvelope(pair, expectedRevision, bindings...)
+		if fallback.EvidenceRevision == "" && evaluation.EvidenceRevision != "" {
+			fallback = evaluation
+		}
+		if evaluation.Complete && len(bindings) <= 1 {
+			candidate = evaluation
+			candidateEnd = evidenceBlock.end
+		}
+	}
+
+	if invalid || candidateEnd < 0 || claims != 1 || !remediationTrailingContentValid(lines, candidateEnd, blocksByStart) {
+		fallback.Complete = false
+		return fallback
+	}
+	return candidate
+}
+
+func scanRemediationFences(lines []string) ([]remediationFenceBlock, bool) {
+	blocks := make([]remediationFenceBlock, 0)
+	var active remediationFenceBlock
+	open := false
+	for index, line := range lines {
+		depth, token, ok := remediationFence(line)
+		if !ok {
+			continue
+		}
+		if open {
+			if depth != active.depth || token != "bare" {
+				continue
+			}
+			active.end = index
+			blocks = append(blocks, active)
+			open = false
+			continue
+		}
+		active = remediationFenceBlock{start: index, end: -1, depth: depth, token: token}
+		open = true
+	}
+	if open {
+		blocks = append(blocks, active)
+	}
+	return blocks, open
+}
+
+func remediationFence(line string) (int, string, bool) {
+	depth := 0
+	for {
+		trimmed := strings.TrimLeft(line, " \t")
+		if !strings.HasPrefix(trimmed, ">") {
+			line = trimmed
+			break
+		}
+		depth++
+		line = strings.TrimLeft(trimmed[1:], " \t")
+	}
+
+	line = strings.TrimSpace(line)
+	switch line {
+	case "```":
+		return depth, "bare", true
+	case "```yaml":
+		return depth, "yaml", true
+	case "```json":
+		return depth, "json", true
+	}
+	if strings.HasPrefix(line, "```") && strings.TrimSpace(strings.TrimPrefix(line, "```")) != "" {
+		return depth, "other", true
+	}
+	return 0, "", false
+}
+
+func nextNonemptyLine(lines []string, start int) int {
+	for index := start; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) != "" {
+			return index
+		}
+	}
+	return -1
+}
+
+func remediationYAMLIdentity(lines []string) (remediationIdentity, bool) {
+	fields := make(map[string]string)
+	for _, line := range lines {
+		if key, value, ok := strings.Cut(remediationFenceContent(line), ":"); ok {
+			fields[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	return remediationIdentityFromFields(fields)
+}
+
+func remediationJSONIdentity(lines []string) (remediationIdentity, bool) {
+	var fields map[string]any
+	decoder := json.NewDecoder(strings.NewReader(strings.Join(remediationFenceContents(lines), "\n")))
+	if err := decoder.Decode(&fields); err != nil {
+		return remediationIdentity{}, false
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF || fields["schema"] != RemediationResultSchema {
+		return remediationIdentity{}, false
+	}
+
+	identity := remediationIdentity{
+		Revision:  firstStringFieldAny(fields, "failed_evidence_revision", "failed_verify_revision", "failedEvidenceRevision", "failedVerifyRevision"),
+		LineageID: firstStringFieldAny(fields, "lineage_id", "lineageId", "lineageID"),
+	}
+	identity.Generation, _ = firstIntField(fields, "generation")
+	identity.FixBatch, _ = firstIntField(fields, "fix_batch", "fixBatch")
+	return identity, identity.Revision != ""
+}
+
+func remediationIdentityFromFields(fields map[string]string) (remediationIdentity, bool) {
+	if fields["schema"] != RemediationResultSchema {
+		return remediationIdentity{}, false
+	}
+	identity := remediationIdentity{
+		Revision:  firstStringField(fields, "failed_evidence_revision", "failed_verify_revision", "failedEvidenceRevision", "failedVerifyRevision"),
+		LineageID: firstStringField(fields, "lineage_id", "lineageId", "lineageID"),
+	}
+	identity.Generation, _ = parseFirstIntField(fields, "generation")
+	identity.FixBatch, _ = parseFirstIntField(fields, "fix_batch", "fixBatch")
+	return identity, identity.Revision != ""
+}
+
+func firstStringField(fields map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := fields[key]; value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstStringFieldAny(fields map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := fields[key].(string); ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstIntField(fields map[string]any, keys ...string) (int, bool) {
+	for _, key := range keys {
+		switch value := fields[key].(type) {
+		case float64:
+			if value >= 0 && value == float64(int(value)) {
+				return int(value), true
+			}
+		case string:
+			if parsed, ok := parseNonnegativeInt(value); ok {
+				return parsed, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func parseFirstIntField(fields map[string]string, keys ...string) (int, bool) {
+	for _, key := range keys {
+		if parsed, ok := parseNonnegativeInt(fields[key]); ok {
+			return parsed, true
+		}
+	}
+	return 0, false
+}
+
+func remediationIdentityMatches(identity remediationIdentity, expectedRevision string, bindings []RemediationBinding) bool {
+	if identity.Revision != expectedRevision || len(bindings) > 1 {
+		return false
+	}
+	if len(bindings) == 0 {
+		return true
+	}
+	binding := bindings[0]
+	return identity.LineageID == binding.LineageID && identity.Generation == binding.Generation && identity.FixBatch == binding.FixBatch
+}
+
+func remediationTrailingContentValid(lines []string, start int, blocksByStart map[int]remediationFenceBlock) bool {
+	for index := start + 1; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) == "" {
+			continue
+		}
+		if block, ok := blocksByStart[index]; ok {
+			if block.end < 0 || remediationFenceContainsResult(lines[block.start+1:block.end]) {
+				return false
+			}
+			index = block.end
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func remediationFenceContainsResult(lines []string) bool {
+	for _, line := range lines {
+		line = remediationFenceContent(line)
+		if strings.HasPrefix(line, "schema:") {
+			schema := strings.TrimSpace(strings.TrimPrefix(line, "schema:"))
+			if schema == RemediationResultSchema || schema == "gentle-ai.remediation-evidence/v1" {
+				return true
+			}
+		}
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(strings.Join(remediationFenceContents(lines), "\n")), &fields); err == nil {
+		schema, _ := fields["schema"].(string)
+		return schema == RemediationResultSchema || schema == "gentle-ai.remediation-evidence/v1"
+	}
+	return false
+}
+
+func remediationFenceContent(line string) string {
+	for strings.HasPrefix(strings.TrimLeft(line, " \t"), ">") {
+		trimmed := strings.TrimLeft(line, " \t")
+		line = strings.TrimLeft(trimmed[1:], " \t")
+	}
+	return strings.TrimSpace(line)
+}
+
+func remediationFenceContents(lines []string) []string {
+	contents := make([]string, len(lines))
+	for index, line := range lines {
+		contents[index] = remediationFenceContent(line)
+	}
+	return contents
+}
+
+func parseRemediationResultEnvelope(text, expectedRevision string, bindings ...RemediationBinding) remediationResultEvaluation {
 	lines, end, reason := parseLeadingEnvelope(text)
 	if reason != "" {
 		return remediationResultEvaluation{}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1767

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Parse the terminal remediation result from cumulative `apply-progress.md` history.
- Match evidence by revision, lineage, generation, and fix batch while rejecting duplicates and ambiguous pairs.
- Track Markdown fences in one pass so unrelated history is tolerated without accepting fenced or trailing evidence.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/verification.go` | Locate and validate the strict terminal remediation YAML/JSON pair in cumulative history. |
| `internal/sddstatus/remediation_test.go` | Cover valid history, identity mismatches, duplicates, fences, trailing content, and multiple bindings. |

---

## 🧪 Test Plan

- [x] `go test ./internal/sddstatus -count=1`
- [x] Focused remediation parser and routing tests
- [x] `go vet ./internal/sddstatus`
- [x] `git diff --check origin/main`
- [x] `gofmt -l` produces no output
- [ ] `go test ./... -count=1` — package under change passes; the repository-wide run is blocked by pre-existing `reviewtransaction` lock failures and the macOS Bash 3.2 `declare -A` incompatibility in update tests.
- [x] Benchmark validation: N/A; this parser fix does not alter benchmark implementation, corpus, classifiers, or benchmark claims.
- [x] E2E: N/A; parser behavior is covered directly with cumulative artifact fixtures.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer `size:exception` requested below with rationale
- [x] Requested the appropriate `type:bug` label
- [x] Focused unit tests pass
- [x] Go formatting, vet, and diff checks pass
- [x] Documentation is not required for this parser correctness fix
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

### `size:exception` rationale

This PR contains 452 changed lines. The production change and its regression matrix form one integrity boundary: terminal-pair selection, complete binding identity, duplicate rejection, Markdown fence handling, and trailing-content rejection must be reviewed together because separating them would temporarily accept incomplete or ambiguous remediation evidence. Of the total, 149 additions are focused regression tests.

Please challenge the accepted input population around cumulative histories, especially bare fences, quoted legacy markers, duplicate candidates, and multiple bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of remediation results in YAML and JSON formats.
  * Added support for nested quoted content and recognized schema variations.
  * Rejects malformed, ambiguous, stale, duplicate, or incomplete remediation claims.
  * Preserves evidence revisions when multiple valid bindings are provided.
  * Validates trailing content and safely handles excessive unclosed code fences.

* **Tests**
  * Added coverage for cumulative remediation progress, fence handling, transaction-binding validation, duplicate evidence, and evidence revision preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->