### PR TITLE
fix(update): route Windows beta upgrades to the go install @main target

### DIFF
--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -65,6 +65,9 @@ const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 //   - script method + windows → manualFallback
 //   - OpenCode plugin method → update materialized package in ~/.config/opencode when possible
 //   - unknown method → manualFallback with explicit message
+//
+// The beta channel is checked before that routing: its LatestVersion is a
+// `main@<commit>` ref, which no version-pinning strategy can install.
 func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, preflightDestination ...string) (bool, error) {
 	ownership := update.HomebrewNone
 	if profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
@@ -74,7 +77,7 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 			return false, fmt.Errorf("detect Homebrew ownership for %s: %w", r.Tool.Name, err)
 		}
 	}
-	if isBetaGentleAIUpgrade(r) && profile.OS != "windows" && ownership == update.HomebrewNone {
+	if isBetaGentleAIUpgrade(r) && ownership == update.HomebrewNone && betaGoInstallMainAvailable(r.Tool, profile) {
 		return false, goInstallMainUpgrade(r.Tool)
 	}
 
@@ -560,6 +563,27 @@ func isBetaGentleAIUpgrade(r update.UpdateResult) bool {
 		strings.EqualFold(r.Tool.Owner, "Gentleman-Programming") &&
 		r.Tool.Repo == "gentle-ai" &&
 		strings.HasPrefix(strings.TrimSpace(r.LatestVersion), "main@")
+}
+
+// betaGoInstallMainAvailable reports whether the beta `@main` path can actually
+// run on this platform.
+//
+// Linux and macOS always reach it. Windows reaches it only when the resolved
+// self-upgrade method is already go-install — that is, Go on PATH plus a
+// declared GoImportPath, which is also the condition
+// preflightWindowsGentleAIUpgrades uses to run the provenance check before this
+// point. Without Go there is no toolchain to install with, so the request keeps
+// falling through to binaryUpgrade's signed-distribution refusal, which already
+// names `@main` as the runnable source command for this channel.
+//
+// Windows used to be excluded from the beta path outright, which routed it into
+// goInstallUpgrade's `@v` + LatestVersion pin and produced `@vmain@<commit>` —
+// a target `go install` always rejects as an unknown revision.
+func betaGoInstallMainAvailable(tool update.ToolInfo, profile system.PlatformProfile) bool {
+	if profile.OS != "windows" {
+		return true
+	}
+	return effectiveMethod(tool, profile) == update.InstallGoInstall
 }
 
 // goInstallMainUpgrade installs gentle-ai from HEAD on the beta channel. It runs

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -150,6 +150,98 @@ func TestRunStrategy_BetaGentleAISelfUpgradeUsesGoInstallMain(t *testing.T) {
 	}
 }
 
+// TestRunStrategy_BetaGentleAISelfUpgradeOnWindowsUsesGoInstallMain covers the
+// beta channel on Windows, where the resolved self-upgrade method is already
+// go-install (Go on PATH plus a declared GoImportPath).
+//
+// Excluding Windows from the beta path routed the request into goInstallUpgrade,
+// which pins `@v` + LatestVersion. On this channel LatestVersion is a
+// `main@<commit>` ref, so the pin produced `@vmain@<commit>` — never a valid
+// `go install` version, and the upgrade failed with "unknown revision".
+func TestRunStrategy_BetaGentleAISelfUpgradeOnWindowsUsesGoInstallMain(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+
+	goPath := t.TempDir()
+	destination := filepath.Join(goPath, "bin", "gentle-ai.exe")
+
+	var gotInstallArgs []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "go" && len(args) == 2 && args[0] == "env" {
+			switch args[1] {
+			case "GOBIN":
+				return mockCmd("echo", "")
+			case "GOPATH":
+				return mockCmd("echo", goPath)
+			}
+		}
+		if name == "go" && len(args) == 2 && args[0] == "install" {
+			gotInstallArgs = args
+			return mockCmd("true")
+		}
+		t.Fatalf("Windows beta upgrade executed unexpected command %s %v", name, args)
+		return nil
+	}
+
+	origLookPath := lookPathFn
+	t.Cleanup(func() { lookPathFn = origLookPath })
+	lookPathFn = func(string) (string, error) { return destination, nil }
+
+	r := update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          "gentle-ai",
+			Owner:         "Gentleman-Programming",
+			Repo:          "gentle-ai",
+			InstallMethod: update.InstallBinary,
+			GoImportPath:  "github.com/Gentleman-Programming/gentle-ai/v2/cmd/gentle-ai",
+		},
+		LatestVersion: "main@919ea3daf2af",
+		Status:        update.UpdateAvailable,
+	}
+	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: true}
+
+	_, err := runStrategy(context.Background(), r, profile)
+	if err != nil {
+		t.Fatalf("runStrategy beta gentle-ai on Windows: unexpected error: %v", err)
+	}
+
+	wantArgs := []string{"install", "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main"}
+	if len(gotInstallArgs) != len(wantArgs) || gotInstallArgs[0] != wantArgs[0] || gotInstallArgs[1] != wantArgs[1] {
+		t.Fatalf("go install args = %v, want %v", gotInstallArgs, wantArgs)
+	}
+}
+
+// TestRunStrategy_BetaGentleAIOnWindowsWithoutGoStaysManual guards the other
+// half of the Windows beta routing: without Go on PATH there is no go-install
+// method to resolve, so the request must keep falling through to the existing
+// signed-distribution refusal instead of shelling out to a `go` that is absent.
+func TestRunStrategy_BetaGentleAIOnWindowsWithoutGoStaysManual(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		t.Fatalf("unexpected command %q %v: Windows without Go must not run go install", name, args)
+		return nil
+	}
+
+	r := update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          "gentle-ai",
+			Owner:         "Gentleman-Programming",
+			Repo:          "gentle-ai",
+			InstallMethod: update.InstallBinary,
+		},
+		LatestVersion: "main@919ea3daf2af",
+		Status:        update.UpdateAvailable,
+	}
+	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget", Supported: true, GoAvailable: false}
+
+	_, err := runStrategy(context.Background(), r, profile)
+	if _, ok := AsManualFallback(err); !ok {
+		t.Fatalf("runStrategy beta gentle-ai on Windows without Go: err = %v, want ManualFallbackError", err)
+	}
+}
+
 func envContains(env []string, want string) bool {
 	for _, entry := range env {
 		if entry == want {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2087

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

> ⚠️ I am an external contributor and cannot apply labels. **Requesting a maintainer to apply `type:bug`** so the "Check PR Has `type:*` Label" gate can pass.

---

## 📝 Summary

On the beta channel (`GENTLE_AI_CHANNEL=beta`), `LatestVersion` is a `main@<commit>` ref rather than a semantic version. `runStrategy` excluded Windows from the beta path, so the request fell through to `goInstallUpgrade`, which pins `@v` + `LatestVersion` and produced:

```
go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@vmain@919ea3daf2af
  → invalid version: unknown revision vmain@919ea3daf2af
```

`"v"` prefixed to a `branch@commit` ref is never a valid `go install` version, so beta upgrades on Windows always failed once `main` advanced.

Windows now reaches `goInstallMainUpgrade` (the same `@main` target Linux and macOS already use) — but only when its resolved self-upgrade method is already go-install.

### Why the guard was narrowed instead of removed

The issue proposes dropping the `profile.OS != "windows"` condition outright. That would regress the *other* Windows path: without Go on PATH, `effectiveMethod` resolves to `InstallBinary` and `binaryUpgrade` returns a `ManualFallbackError` that already names `go install ...@main` as the runnable source command for this channel. Removing the guard would instead shell out to a `go` binary that is not there.

The new helper `betaGoInstallMainAvailable` therefore returns true off-Windows, and on Windows only when `effectiveMethod(tool, profile) == update.InstallGoInstall`.

### On the Windows provenance preflight

The issue asks whether the exclusion exists to protect something. It does not cost anything here: `preflightWindowsGentleAIUpgrades` (`executor.go`) runs **before** `runStrategy` and gates on `effectiveMethod(...) == InstallGoInstall`, not on the beta branch. Beta candidates on Windows already pass through that provenance check, and they still do after this change — the new condition is deliberately the same one.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/strategy.go` | Beta routing no longer excludes Windows outright. New `betaGoInstallMainAvailable(tool, profile)` allows the `@main` path on Windows only when the resolved method is go-install, with the rationale documented adjacent to the helper. |
| `internal/update/upgrade/strategy_test.go` | `TestRunStrategy_BetaGentleAISelfUpgradeOnWindowsUsesGoInstallMain` (regression: asserts the `@main` target, previously `@vmain@<commit>`) and `TestRunStrategy_BetaGentleAIOnWindowsWithoutGoStaysManual` (guards that Windows without Go keeps the manual fallback and runs no `go install`). |

118 changed lines.

---

## 🧪 Test Plan

**Failing test first (RED, before the fix):**

```
--- FAIL: TestRunStrategy_BetaGentleAISelfUpgradeOnWindowsUsesGoInstallMain
    strategy_test.go:210: go install args = [install github.com/Gentleman-Programming/gentle-ai/v2/cmd/gentle-ai@vmain@919ea3daf2af],
                          want              [install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main]
```

That is the exact target from the issue report, reproduced from a unit test.

**After the fix:**

```
$ go test ./internal/update/upgrade/ -run 'TestRunStrategy_BetaGentleAI' -v
--- PASS: TestRunStrategy_BetaGentleAISelfUpgradeUsesGoInstallMain
--- PASS: TestRunStrategy_BetaGentleAISelfUpgradeOnWindowsUsesGoInstallMain
--- PASS: TestRunStrategy_BetaGentleAIOnWindowsWithoutGoStaysManual
ok      github.com/gentleman-programming/gentle-ai/v2/internal/update/upgrade
```

`./internal/update/upgrade` passes in full.

**Full suite — A/B comparison, not a bare claim.** This macOS host carries pre-existing environmental failures, so I ran `go test ./...` with the change, stashed it, ran the baseline, and diffed the failing-test-name sets in both directions:

| Run | Failing tests |
|-----|---------------|
| Baseline (`main`, change stashed) | 22 |
| With this change | 22 |

`comm -13` and `comm -23` over the two sorted sets are both **empty** — no regressions, and nothing incidentally fixed.

All 22 are environmental and unrelated to this change:
- `internal/reviewtransaction` — ~20 failures from `review store lock could not be acquired: not a directory` on macOS.
- `internal/update` — `TestCanonicalReleasePublicKeysControlRealLinkerBuild`, because `scripts/canonicalize-release-public-keys.sh` uses `declare -A`, unsupported by the bash 3.2 macOS ships.

**Go Format**

```bash
$ go run ./internal/gofmtcheck   # clean
$ go vet ./internal/update/...   # clean
```

**E2E Tests** — **not run.** Docker is not available in this environment. Declaring this honestly rather than ticking the box; CI will run it.

**Benchmark Validation** — **N/A.** This change is upgrade-strategy routing only. It does not touch the review lifecycle, gates, recovery, delivery, or the benchmark implementation/corpus/classifier, and makes no benchmark claim.

**Manual testing** — not performed on a real Windows host; I do not have one. The behaviour is covered by the unit tests above, which drive the Windows platform profile explicitly (`system.PlatformProfile{OS: "windows", ...}`) so the routing is testable from any host — the same approach the existing Windows routing tests in this package already use.

- [x] Unit tests pass — see the A/B table above: identical failing sets before and after, all pre-existing and macOS-environmental
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — **not run, no Docker available**
- [x] Manually tested locally — via the unit tests driving the Windows profile; **not** on a physical Windows machine

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#2087)
- [x] PR stays within 400 changed lines (118)
- [ ] I have added the appropriate `type:*` label — **I cannot; requesting `type:bug` from a maintainer**
- [x] Unit tests pass (with the environmental caveat documented above)
- [x] Go format passes
- [ ] E2E tests pass — not run, no Docker
- [x] Benchmark validation N/A, reason explained in the Test Plan
- [x] Documentation updated if necessary — the rationale lives in the adjacent code comments; no user-facing docs describe this routing
- [x] Commits follow Conventional Commits
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Two things worth your attention:

1. **The scope decision.** I deliberately did not implement the issue's literal proposal. Dropping the Windows exclusion entirely would make beta upgrades attempt `go install` on Windows hosts without Go, replacing a clear manual-fallback message with an exec failure. If you would rather have the literal removal, say so and I will change it — but the narrowed condition is what the tests encode.

2. **`docs/architecture/guard-population.md` does not apply here.** This change touches none of `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`, and introduces no security, integrity, admission, repair, or governance guard. `betaGoInstallMainAvailable` is platform-capability routing, not an admission boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beta self-upgrades on Windows by using the supported Go installation method when available.
  * Added a safe manual fallback when Go is unavailable, preventing invalid upgrade attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->