### PR TITLE
fix(sync): anchor Windows compatibility transaction

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -22,7 +22,6 @@ internal/cli/review_narration.go	reviewNarrationStripCodeSpans
 internal/cli/review_operation_contract.go	reviewNamedArgument
 internal/cli/review_printed_command.go	ReviewOperationFlagSurface
 internal/cli/review_printed_command.go	SplitPrintedCommandWords
-internal/cli/run.go	BuildRealStagePlan
 internal/cli/run.go	componentPathDir
 internal/cli/run.go	componentPaths
 internal/cli/run.go	ensureGoAvailableAfterInstall

--- a/internal/cli/compatibility_skills.go
+++ b/internal/cli/compatibility_skills.go
@@ -24,12 +24,23 @@ type compatibilitySkillsRefreshStep struct {
 	components   []model.ComponentID
 	selection    model.Selection
 	changedFiles *[]string
+	transaction  compatibilityRefreshTransaction
+	anchored     bool
 }
 
 var lstatCompatibilityDestination = os.Lstat
 
 type compatibilityDirectoryWriter interface {
 	Write(string, []byte, fs.FileMode) (filemerge.WriteResult, error)
+	Close() error
+}
+
+// compatibilityRefreshTransaction owns the Windows compatibility tree for an
+// entire pipeline run. The generic snapshotter must never inspect these paths.
+type compatibilityRefreshTransaction interface {
+	Run() error
+	Rollback() error
+	ChangedFiles() []string
 	Close() error
 }
 
@@ -74,6 +85,19 @@ func compatibilitySkillsRefreshable(homeDir string, selection model.Selection) (
 }
 
 func compatibilitySkillFiles(skillDir string, components []model.ComponentID, selection model.Selection) ([]string, error) {
+	files, err := compatibilitySkillPaths(skillDir, components, selection)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateCompatibilityDestinations(skillDir, files); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// compatibilitySkillPaths lists the paths that the embedded asset injectors
+// will target without inspecting the destination filesystem.
+func compatibilitySkillPaths(skillDir string, components []model.ComponentID, selection model.Selection) ([]string, error) {
 	paths := map[string]struct{}{}
 	if slices.Contains(components, model.ComponentSkills) {
 		prospective, err := skills.DirectoryPaths(skillDir, selectedSkillIDs(selection), "")
@@ -98,9 +122,6 @@ func compatibilitySkillFiles(skillDir string, components []model.ComponentID, se
 		files = append(files, path)
 	}
 	sort.Strings(files)
-	if err := validateCompatibilityDestinations(skillDir, files); err != nil {
-		return nil, err
-	}
 	return files, nil
 }
 
@@ -139,6 +160,16 @@ func validateCompatibilityDestinations(root string, destinations []string) error
 }
 
 func (s compatibilitySkillsRefreshStep) Run() error {
+	if s.anchored {
+		if s.transaction == nil {
+			return nil
+		}
+		if err := s.transaction.Run(); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	skillDir, ok, err := compatibilitySkillsDir(s.homeDir)
 	if err != nil {
 		return err
@@ -186,4 +217,11 @@ func (s compatibilitySkillsRefreshStep) Run() error {
 		*s.changedFiles = append(*s.changedFiles, changed...)
 	}
 	return nil
+}
+
+func (s compatibilitySkillsRefreshStep) Rollback() error {
+	if !s.anchored || s.transaction == nil {
+		return nil
+	}
+	return s.transaction.Rollback()
 }

--- a/internal/cli/compatibility_skills_test.go
+++ b/internal/cli/compatibility_skills_test.go
@@ -452,8 +452,11 @@ func TestCompatibilitySkillFilesAreInstallAndSyncBackupTargets(t *testing.T) {
 	}
 	for _, targets := range [][]string{installTargets, syncTargets} {
 		for _, path := range files {
-			if !slices.Contains(targets, path) {
+			if !usesAnchoredCompatibilityTransaction() && !slices.Contains(targets, path) {
 				t.Errorf("backup targets missing prospective %q; targets=%v", path, targets)
+			}
+			if usesAnchoredCompatibilityTransaction() && slices.Contains(targets, path) {
+				t.Errorf("generic backup target includes anchored compatibility path %q; targets=%v", path, targets)
 			}
 		}
 	}

--- a/internal/cli/compatibility_skills_test.go
+++ b/internal/cli/compatibility_skills_test.go
@@ -87,6 +87,9 @@ func TestRunSyncDryRunMatchesZeroAgentCompatibilityRefresh(t *testing.T) {
 }
 
 func TestRunSyncDryRunPropagatesCompatibilityManagedPathError(t *testing.T) {
+	if usesAnchoredCompatibilityTransaction() {
+		t.Skip("Windows compatibility discovery intentionally has no path-based lstat seam")
+	}
 	home := t.TempDir()
 	setSyncTestHome(t, home)
 	managedPath := filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md")
@@ -236,6 +239,9 @@ func TestCompatibilityRefreshDoesNotFollowParentSwappedAfterValidation(t *testin
 }
 
 func TestCompatibilityManagedPathErrorsReachBackupPreparation(t *testing.T) {
+	if usesAnchoredCompatibilityTransaction() {
+		t.Skip("Windows compatibility snapshots are anchored before generic backup")
+	}
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, ".agents", "skills"), 0o755); err != nil {
 		t.Fatal(err)
@@ -294,6 +300,9 @@ func TestCompatibilityManagedPathErrorsReachBackupPreparation(t *testing.T) {
 }
 
 func TestCompatibilityDirectoryStatErrorsReachBackupPreparation(t *testing.T) {
+	if usesAnchoredCompatibilityTransaction() {
+		t.Skip("Windows compatibility discovery intentionally has no path-based lstat seam")
+	}
 	for _, statTarget := range []string{".agents", filepath.Join(".agents", "skills")} {
 		t.Run(statTarget, func(t *testing.T) {
 			home := t.TempDir()
@@ -347,6 +356,9 @@ func TestCompatibilityDirectoryStatErrorsReachBackupPreparation(t *testing.T) {
 }
 
 func TestCompatibilityDirectoryStatErrorsPreventZeroAgentSyncNoOp(t *testing.T) {
+	if usesAnchoredCompatibilityTransaction() {
+		t.Skip("Windows compatibility discovery intentionally has no path-based lstat seam")
+	}
 	for _, statTarget := range []string{".agents", filepath.Join(".agents", "skills")} {
 		t.Run(statTarget, func(t *testing.T) {
 			home := t.TempDir()

--- a/internal/cli/compatibility_transaction_nonwindows.go
+++ b/internal/cli/compatibility_transaction_nonwindows.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package cli
+
+import "github.com/gentleman-programming/gentle-ai/v2/internal/model"
+
+func usesAnchoredCompatibilityTransaction() bool {
+	return false
+}
+
+func newCompatibilityRefreshTransaction(string, []model.ComponentID, model.Selection) (compatibilityRefreshTransaction, error) {
+	return nil, nil
+}

--- a/internal/cli/compatibility_transaction_windows.go
+++ b/internal/cli/compatibility_transaction_windows.go
@@ -36,6 +36,10 @@ const (
 // reparse races. Production leaves it nil.
 var windowsCompatibilityTransactionHook func(string)
 
+// windowsCompatibilityTransactionCloseHook observes completed handle release
+// in native tests. Production leaves it nil.
+var windowsCompatibilityTransactionCloseHook func(error)
+
 type windowsCompatibilitySnapshot struct {
 	data    []byte
 	mode    fs.FileMode
@@ -58,7 +62,7 @@ func usesAnchoredCompatibilityTransaction() bool {
 
 // newCompatibilityRefreshTransaction anchors, classifies, and snapshots every
 // compatibility destination before the generic backup can touch user paths.
-func newCompatibilityRefreshTransaction(homeDir string, components []model.ComponentID, selection model.Selection) (_ compatibilityRefreshTransaction, retErr error) {
+func newCompatibilityRefreshTransaction(homeDir string, components []model.ComponentID, selection model.Selection) (compatibilityRefreshTransaction, error) {
 	if !needsCompatibilitySkillsRefresh(components) {
 		return nil, nil
 	}
@@ -71,8 +75,9 @@ func newCompatibilityRefreshTransaction(homeDir string, components []model.Compo
 	if !exists {
 		return nil, nil
 	}
+	transferred := false
 	defer func() {
-		if retErr != nil {
+		if !transferred {
 			_ = writer.Close()
 		}
 	}()
@@ -97,6 +102,7 @@ func newCompatibilityRefreshTransaction(homeDir string, components []model.Compo
 		}
 		transaction.snapshots[path] = snapshot
 	}
+	transferred = true
 	return transaction, nil
 }
 
@@ -179,6 +185,9 @@ func (t *windowsCompatibilityRefreshTransaction) Close() error {
 	}
 	err := t.writer.Close()
 	t.writer = nil
+	if windowsCompatibilityTransactionCloseHook != nil {
+		windowsCompatibilityTransactionCloseHook(err)
+	}
 	return err
 }
 

--- a/internal/cli/compatibility_transaction_windows.go
+++ b/internal/cli/compatibility_transaction_windows.go
@@ -1,0 +1,588 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unsafe"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/skills"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+	"golang.org/x/sys/windows"
+)
+
+const maxCompatibilityAtomicFileSize = 16 << 20
+
+const (
+	compatibilityBeforeSnapshot = "before-snapshot"
+	compatibilityBeforeWrite    = "after-snapshot-before-write"
+	compatibilityAfterPublish   = "after-publication-before-rollback"
+)
+
+// windowsCompatibilityTransactionHook is test-only synchronization for the
+// reparse races. Production leaves it nil.
+var windowsCompatibilityTransactionHook func(string)
+
+type windowsCompatibilitySnapshot struct {
+	data    []byte
+	mode    fs.FileMode
+	existed bool
+}
+
+type windowsCompatibilityRefreshTransaction struct {
+	writer     *windowsCompatibilityDirectoryWriter
+	components []model.ComponentID
+	selection  model.Selection
+	paths      []string
+	snapshots  map[string]windowsCompatibilitySnapshot
+	changed    []string
+	applied    bool
+}
+
+func usesAnchoredCompatibilityTransaction() bool {
+	return true
+}
+
+// newCompatibilityRefreshTransaction anchors, classifies, and snapshots every
+// compatibility destination before the generic backup can touch user paths.
+func newCompatibilityRefreshTransaction(homeDir string, components []model.ComponentID, selection model.Selection) (_ compatibilityRefreshTransaction, retErr error) {
+	if !needsCompatibilitySkillsRefresh(components) {
+		return nil, nil
+	}
+
+	skillDir := filepath.Join(homeDir, ".agents", "skills")
+	writer, exists, err := openWindowsCompatibilityDirectoryWriter(homeDir, skillDir)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	defer func() {
+		if retErr != nil {
+			_ = writer.Close()
+		}
+	}()
+
+	paths, err := compatibilitySkillPaths(skillDir, components, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	transaction := &windowsCompatibilityRefreshTransaction{
+		writer:     writer,
+		components: components,
+		selection:  selection,
+		paths:      paths,
+		snapshots:  make(map[string]windowsCompatibilitySnapshot, len(paths)),
+	}
+	notifyWindowsCompatibilityTransaction(compatibilityBeforeSnapshot)
+	for _, path := range paths {
+		snapshot, snapshotErr := transaction.snapshot(path)
+		if snapshotErr != nil {
+			return nil, fmt.Errorf("snapshot compatibility destination %q: %w", path, snapshotErr)
+		}
+		transaction.snapshots[path] = snapshot
+	}
+	return transaction, nil
+}
+
+func notifyWindowsCompatibilityTransaction(boundary string) {
+	if windowsCompatibilityTransactionHook != nil {
+		windowsCompatibilityTransactionHook(boundary)
+	}
+}
+
+func (t *windowsCompatibilityRefreshTransaction) Run() (runErr error) {
+	if t.applied {
+		return nil
+	}
+	t.applied = true
+	defer func() {
+		if runErr == nil {
+			return
+		}
+		if rollbackErr := t.Rollback(); rollbackErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("rollback partial compatibility refresh: %w", rollbackErr))
+		}
+	}()
+
+	notifyWindowsCompatibilityTransaction(compatibilityBeforeWrite)
+	if slicesContainsComponent(t.components, model.ComponentSkills) {
+		skillIDs := selectedSkillIDs(t.selection)
+		if len(skillIDs) > 0 {
+			result, err := skills.InjectDirectoryWithWriter(t.writer.root, skillIDs, t.writer.Write)
+			if err != nil {
+				return fmt.Errorf("refresh compatibility skills: %w", err)
+			}
+			if result.Changed {
+				t.changed = append(t.changed, result.Files...)
+			}
+		}
+	}
+
+	if slicesContainsComponent(t.components, model.ComponentSDD) {
+		result, err := sdd.InjectSkillDirectoryWithWriter(t.writer.root, "", t.writer.Write)
+		if err != nil {
+			return fmt.Errorf("refresh compatibility SDD skills: %w", err)
+		}
+		if result.Changed {
+			t.changed = append(t.changed, result.Files...)
+		}
+	}
+	notifyWindowsCompatibilityTransaction(compatibilityAfterPublish)
+	return nil
+}
+
+func (t *windowsCompatibilityRefreshTransaction) Rollback() error {
+	if !t.applied {
+		return nil
+	}
+	var rollbackErr error
+	paths := append([]string(nil), t.paths...)
+	sort.Strings(paths)
+	for _, path := range paths {
+		snapshot := t.snapshots[path]
+		if !snapshot.existed {
+			if err := t.writer.Remove(path); err != nil {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove compatibility rollback destination %q: %w", path, err))
+			}
+			continue
+		}
+		if _, err := t.writer.Write(path, snapshot.data, snapshot.mode); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore compatibility rollback destination %q: %w", path, err))
+		}
+	}
+	return rollbackErr
+}
+
+func (t *windowsCompatibilityRefreshTransaction) ChangedFiles() []string {
+	return append([]string(nil), t.changed...)
+}
+
+func (t *windowsCompatibilityRefreshTransaction) Close() error {
+	if t.writer == nil {
+		return nil
+	}
+	err := t.writer.Close()
+	t.writer = nil
+	return err
+}
+
+func (t *windowsCompatibilityRefreshTransaction) snapshot(path string) (windowsCompatibilitySnapshot, error) {
+	parts, err := windowsCompatibilityPathParts(t.writer.root, path)
+	if err != nil {
+		return windowsCompatibilitySnapshot{}, err
+	}
+	parent, exists, err := t.writer.openExistingParent(parts[:len(parts)-1])
+	if err != nil || !exists {
+		return windowsCompatibilitySnapshot{}, err
+	}
+	if parent != t.writer.rootFD {
+		defer windows.CloseHandle(parent)
+	}
+	return snapshotWindowsCompatibilityFile(parent, parts[len(parts)-1])
+}
+
+type windowsCompatibilityDirectoryWriter struct {
+	root   string
+	rootFD windows.Handle
+}
+
+// openWindowsCompatibilityDirectoryWriter is the only discovery path for the
+// Windows compatibility transaction. Every child open is handle-relative and
+// refuses reparse points before it can resolve through them.
+func openWindowsCompatibilityDirectoryWriter(homeDir, skillDir string) (*windowsCompatibilityDirectoryWriter, bool, error) {
+	home, err := reviewtransaction.OpenPhysicalPath(homeDir, true)
+	if err != nil {
+		return nil, false, fmt.Errorf("open compatibility home directory %q: %w", homeDir, err)
+	}
+	defer home.Close()
+
+	agentsFD, err := openWindowsCompatibilityDirectoryAt(windows.Handle(home.Fd()), ".agents", windows.FILE_OPEN)
+	if windowsCompatibilityNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("open compatibility skills parent directory %q: %w", filepath.Join(homeDir, ".agents"), err)
+	}
+	defer windows.CloseHandle(agentsFD)
+
+	skillsFD, err := openWindowsCompatibilityDirectoryAt(agentsFD, "skills", windows.FILE_OPEN)
+	if windowsCompatibilityNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("open compatibility skills root directory %q: %w", skillDir, err)
+	}
+	return &windowsCompatibilityDirectoryWriter{root: skillDir, rootFD: skillsFD}, true, nil
+}
+
+func newCompatibilityDirectoryWriter(homeDir, skillDir string) (compatibilityDirectoryWriter, error) {
+	writer, exists, err := openWindowsCompatibilityDirectoryWriter(homeDir, skillDir)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		// refusal:by-design operator-knowledge: the compatibility directory is absent and this legacy writer cannot create an opt-in destination.
+		return nil, fmt.Errorf("compatibility skills directory %q is absent", skillDir)
+	}
+	return writer, nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) Close() error {
+	return windows.CloseHandle(w.rootFD)
+}
+
+func (w *windowsCompatibilityDirectoryWriter) Write(path string, content []byte, perm fs.FileMode) (filemerge.WriteResult, error) {
+	parts, err := windowsCompatibilityPathParts(w.root, path)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+
+	parentFD, err := w.openParent(parts[:len(parts)-1])
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	if parentFD != w.rootFD {
+		defer windows.CloseHandle(parentFD)
+	}
+
+	name := parts[len(parts)-1]
+	existing, exists, err := readWindowsCompatibilityFile(parentFD, name)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	if exists && bytes.Equal(existing, content) {
+		return filemerge.WriteResult{}, nil
+	}
+
+	_, tmp, err := createWindowsCompatibilityTempFile(parentFD, perm)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			removeWindowsCompatibilityTemp(tmp)
+		}
+		_ = tmp.Close()
+	}()
+
+	if _, err := tmp.Write(content); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("write compatibility temp file %q: %w", path, err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("set compatibility temp file permissions for %q: %w", path, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("sync compatibility temp file %q: %w", path, err)
+	}
+	if err := renameWindowsCompatibilityFile(windows.Handle(tmp.Fd()), parentFD, name); err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("replace compatibility destination %q: %w", path, err)
+	}
+	cleanup = false
+	result := filemerge.WriteResult{Changed: true, Created: !exists}
+	if err := tmp.Close(); err != nil {
+		return result, fmt.Errorf("close compatibility temp file %q: %w", path, err)
+	}
+
+	readBack, readBackExists, err := readWindowsCompatibilityFile(parentFD, name)
+	if err != nil {
+		return result, err
+	}
+	if !readBackExists || !bytes.Equal(readBack, content) {
+		// refusal:by-design world-action: publication did not produce the staged bytes at the anchored destination.
+		return result, fmt.Errorf("replace compatibility destination %q: the replacement did not land", path)
+	}
+	return result, nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) Remove(path string) error {
+	parts, err := windowsCompatibilityPathParts(w.root, path)
+	if err != nil {
+		return err
+	}
+
+	parentFD, exists, err := w.openExistingParent(parts[:len(parts)-1])
+	if err != nil || !exists {
+		return err
+	}
+	if parentFD != w.rootFD {
+		defer windows.CloseHandle(parentFD)
+	}
+
+	handle, err := openWindowsCompatibilityFileAt(parentFD, parts[len(parts)-1], windows.DELETE, windows.FILE_OPEN)
+	if windowsCompatibilityNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open physical compatibility destination %q for removal: %w", path, err)
+	}
+	defer windows.CloseHandle(handle)
+
+	deleteFile := byte(1)
+	var status windows.IO_STATUS_BLOCK
+	if err := windows.NtSetInformationFile(handle, &status, &deleteFile, 1, windows.FileDispositionInformation); err != nil {
+		return fmt.Errorf("remove compatibility destination %q: %w", path, err)
+	}
+	return nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) openParent(parts []string) (windows.Handle, error) {
+	currentFD := w.rootFD
+	for _, part := range parts {
+		nextFD, err := openWindowsCompatibilityDirectoryAt(currentFD, part, windows.FILE_OPEN)
+		if windowsCompatibilityNotExist(err) {
+			nextFD, err = openWindowsCompatibilityDirectoryAt(currentFD, part, windows.FILE_OPEN_IF)
+		}
+		if err != nil {
+			if currentFD != w.rootFD {
+				_ = windows.CloseHandle(currentFD)
+			}
+			return 0, fmt.Errorf("open physical compatibility directory %q: %w", part, err)
+		}
+		if currentFD != w.rootFD {
+			_ = windows.CloseHandle(currentFD)
+		}
+		currentFD = nextFD
+	}
+	return currentFD, nil
+}
+
+func (w *windowsCompatibilityDirectoryWriter) openExistingParent(parts []string) (windows.Handle, bool, error) {
+	currentFD := w.rootFD
+	for _, part := range parts {
+		nextFD, err := openWindowsCompatibilityDirectoryAt(currentFD, part, windows.FILE_OPEN)
+		if windowsCompatibilityNotExist(err) {
+			if currentFD != w.rootFD {
+				_ = windows.CloseHandle(currentFD)
+			}
+			return 0, false, nil
+		}
+		if err != nil {
+			if currentFD != w.rootFD {
+				_ = windows.CloseHandle(currentFD)
+			}
+			return 0, false, fmt.Errorf("open physical compatibility directory %q: %w", part, err)
+		}
+		if currentFD != w.rootFD {
+			_ = windows.CloseHandle(currentFD)
+		}
+		currentFD = nextFD
+	}
+	return currentFD, true, nil
+}
+
+func openWindowsCompatibilityDirectoryAt(parent windows.Handle, name string, disposition uint32) (windows.Handle, error) {
+	return openWindowsCompatibilityObject(parent, name, true, windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE, disposition)
+}
+
+func openWindowsCompatibilityFileAt(parent windows.Handle, name string, access uint32, disposition uint32) (windows.Handle, error) {
+	return openWindowsCompatibilityObject(parent, name, false, access, disposition)
+}
+
+func openWindowsCompatibilityObject(parent windows.Handle, name string, directory bool, access uint32, disposition uint32) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: parent,
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+	}
+	options := uint32(windows.FILE_SYNCHRONOUS_IO_NONALERT | windows.FILE_OPEN_REPARSE_POINT)
+	fileAttributes := uint32(windows.FILE_ATTRIBUTE_NORMAL)
+	if directory {
+		options |= windows.FILE_DIRECTORY_FILE
+		fileAttributes = windows.FILE_ATTRIBUTE_DIRECTORY
+	} else {
+		options |= windows.FILE_NON_DIRECTORY_FILE
+	}
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&handle,
+		access,
+		attributes,
+		&status,
+		nil,
+		fileAttributes,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		disposition,
+		options,
+		0,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if err := validateWindowsCompatibilityHandle(handle, directory); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+func validateWindowsCompatibilityHandle(handle windows.Handle, directory bool) error {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return err
+	}
+	fileType, err := windows.GetFileType(handle)
+	if err != nil {
+		return err
+	}
+	if fileType != windows.FILE_TYPE_DISK || info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 ||
+		directory != (info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0) {
+		// refusal:by-design world-action: physical-directory containment requires the opened handle not target a reparse point.
+		return fmt.Errorf("compatibility target is not a physical %s", map[bool]string{true: "directory", false: "file"}[directory])
+	}
+	return nil
+}
+
+func snapshotWindowsCompatibilityFile(parent windows.Handle, name string) (windowsCompatibilitySnapshot, error) {
+	handle, err := openWindowsCompatibilityFileAt(parent, name, windows.FILE_GENERIC_READ, windows.FILE_OPEN)
+	if windowsCompatibilityNotExist(err) {
+		return windowsCompatibilitySnapshot{}, nil
+	}
+	if err != nil {
+		return windowsCompatibilitySnapshot{}, fmt.Errorf("open physical compatibility destination %q: %w", name, err)
+	}
+	file := os.NewFile(uintptr(handle), name)
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return windowsCompatibilitySnapshot{}, fmt.Errorf("stat compatibility destination %q: %w", name, err)
+	}
+	if !info.Mode().IsRegular() {
+		// refusal:by-design world-action: a non-regular destination must be replaced before a safe atomic refresh can continue.
+		return windowsCompatibilitySnapshot{}, fmt.Errorf("compatibility destination %q must be a regular file", name)
+	}
+	if info.Size() > maxCompatibilityAtomicFileSize {
+		// refusal:by-design world-action: an oversized destination cannot be safely compared before replacement.
+		return windowsCompatibilitySnapshot{}, fmt.Errorf("compatibility destination %q exceeds max atomic compare size %d bytes", name, maxCompatibilityAtomicFileSize)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxCompatibilityAtomicFileSize+1))
+	if err != nil {
+		return windowsCompatibilitySnapshot{}, fmt.Errorf("read compatibility destination %q: %w", name, err)
+	}
+	if len(data) > maxCompatibilityAtomicFileSize {
+		// refusal:by-design world-action: an oversized destination cannot be safely compared before replacement.
+		return windowsCompatibilitySnapshot{}, fmt.Errorf("compatibility destination %q exceeds max atomic compare size %d bytes", name, maxCompatibilityAtomicFileSize)
+	}
+	return windowsCompatibilitySnapshot{data: data, mode: info.Mode().Perm(), existed: true}, nil
+}
+
+func readWindowsCompatibilityFile(parent windows.Handle, name string) ([]byte, bool, error) {
+	snapshot, err := snapshotWindowsCompatibilityFile(parent, name)
+	if err != nil {
+		return nil, false, err
+	}
+	return snapshot.data, snapshot.existed, nil
+}
+
+func createWindowsCompatibilityTempFile(parent windows.Handle, perm fs.FileMode) (string, *os.File, error) {
+	for range 10 {
+		var token [12]byte
+		if _, err := rand.Read(token[:]); err != nil {
+			return "", nil, fmt.Errorf("generate compatibility temp file name: %w", err)
+		}
+		name := ".gentle-ai-" + hex.EncodeToString(token[:]) + ".tmp"
+		handle, err := openWindowsCompatibilityFileAt(parent, name, windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE|windows.DELETE, windows.FILE_CREATE)
+		if windowsCompatibilityAlreadyExists(err) {
+			continue
+		}
+		if err != nil {
+			return "", nil, fmt.Errorf("create compatibility temp file: %w", err)
+		}
+		file := os.NewFile(uintptr(handle), name)
+		if err := file.Chmod(perm); err != nil {
+			_ = file.Close()
+			return "", nil, fmt.Errorf("set compatibility temp file permissions: %w", err)
+		}
+		return name, file, nil
+	}
+	// refusal:by-design world-action: repeated random-name collisions prevent a safe temporary file publication.
+	return "", nil, fmt.Errorf("create compatibility temp file: exhausted unique names")
+}
+
+type windowsCompatibilityRenameInformation struct {
+	ReplaceIfExists uint32
+	RootDirectory   windows.Handle
+	FileNameLength  uint32
+	FileName        [1]uint16
+}
+
+func renameWindowsCompatibilityFile(file, parent windows.Handle, name string) error {
+	utf16Name, err := windows.UTF16FromString(name)
+	if err != nil {
+		return err
+	}
+	nameLength := (len(utf16Name) - 1) * 2
+	var rename windowsCompatibilityRenameInformation
+	bufferSize := int(unsafe.Offsetof(rename.FileName)) + nameLength
+	buffer := make([]byte, bufferSize)
+	info := (*windowsCompatibilityRenameInformation)(unsafe.Pointer(&buffer[0]))
+	info.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS | windows.FILE_RENAME_POSIX_SEMANTICS
+	info.RootDirectory = parent
+	info.FileNameLength = uint32(nameLength)
+	copy(unsafe.Slice(&info.FileName[0], len(utf16Name)-1), utf16Name)
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(file, &status, &buffer[0], uint32(bufferSize), windows.FileRenameInformation)
+}
+
+func removeWindowsCompatibilityTemp(file *os.File) {
+	if file == nil {
+		return
+	}
+	deleteFile := byte(1)
+	var status windows.IO_STATUS_BLOCK
+	_ = windows.NtSetInformationFile(windows.Handle(file.Fd()), &status, &deleteFile, 1, windows.FileDispositionInformation)
+}
+
+func windowsCompatibilityNotExist(err error) bool {
+	return errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_FILE_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_PATH_NOT_FOUND)
+}
+
+func windowsCompatibilityAlreadyExists(err error) bool {
+	return errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) ||
+		errors.Is(err, windows.ERROR_FILE_EXISTS) ||
+		errors.Is(err, windows.ERROR_ALREADY_EXISTS)
+}
+
+func windowsCompatibilityPathParts(root, path string) ([]string, error) {
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == "." || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		// refusal:by-design operator-knowledge: embedded compatibility destinations must stay below the anchored skills root.
+		return nil, fmt.Errorf("compatibility destination %q escapes %q", path, root)
+	}
+	return strings.Split(relative, string(filepath.Separator)), nil
+}
+
+func slicesContainsComponent(components []model.ComponentID, target model.ComponentID) bool {
+	for _, component := range components {
+		if component == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/compatibility_transaction_windows.go
+++ b/internal/cli/compatibility_transaction_windows.go
@@ -325,7 +325,7 @@ func (w *windowsCompatibilityDirectoryWriter) Remove(path string) error {
 		defer windows.CloseHandle(parentFD)
 	}
 
-	handle, err := openWindowsCompatibilityFileAt(parentFD, parts[len(parts)-1], windows.DELETE, windows.FILE_OPEN)
+	handle, err := openWindowsCompatibilityFileAt(parentFD, parts[len(parts)-1], windows.FILE_GENERIC_READ|windows.DELETE, windows.FILE_OPEN)
 	if windowsCompatibilityNotExist(err) {
 		return nil
 	}

--- a/internal/cli/compatibility_transaction_windows_test.go
+++ b/internal/cli/compatibility_transaction_windows_test.go
@@ -1,0 +1,304 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
+)
+
+func createWindowsCompatibilityJunction(t *testing.T, link, target string) {
+	t.Helper()
+	output, err := exec.Command("cmd", "/c", "mklink", "/J", link, target).CombinedOutput()
+	if err != nil {
+		t.Fatalf("create junction %q -> %q: %v: %s", link, target, err, output)
+	}
+}
+
+func windowsCompatibilitySelection() model.Selection {
+	return model.Selection{
+		Agents:     []model.AgentID{model.AgentOpenCode},
+		Components: []model.ComponentID{model.ComponentSkills},
+		Skills:     []model.SkillID{model.SkillGoTesting},
+		Persona:    model.PersonaNeutral,
+	}
+}
+
+func installWindowsCompatibilityHook(t *testing.T, hook func(string)) {
+	t.Helper()
+	previous := windowsCompatibilityTransactionHook
+	windowsCompatibilityTransactionHook = hook
+	t.Cleanup(func() { windowsCompatibilityTransactionHook = previous })
+}
+
+func TestRunSyncWithSelectionRefreshesCompatibilityAndOpenCodeAssetsOnWindows(t *testing.T) {
+	home := t.TempDir()
+	compatibilityFiles := []string{
+		filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md"),
+		filepath.Join(home, ".agents", "skills", "go-testing", "references", "examples.md"),
+	}
+	for _, path := range compatibilityFiles {
+		writeStale(t, path)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
+	writeStale(t, pluginPath)
+
+	if _, err := RunSyncWithSelection(home, windowsCompatibilitySelection()); err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	for _, path := range append(compatibilityFiles, pluginPath) {
+		content, err := os.ReadFile(path)
+		if err != nil || string(content) == "stale" {
+			t.Fatalf("managed asset %q was not refreshed: content=%q error=%v", path, content, err)
+		}
+	}
+}
+
+func assertWindowsCompatibilitySentinel(t *testing.T, path string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil || string(content) != "outside" {
+		t.Fatalf("outside sentinel %q changed: content=%q error=%v", path, content, err)
+	}
+}
+
+func TestWindowsCompatibilityTransactionAllowsAbsentDirectory(t *testing.T) {
+	home := t.TempDir()
+	transaction, err := newCompatibilityRefreshTransaction(home, []model.ComponentID{model.ComponentSkills}, windowsCompatibilitySelection())
+	if err != nil || transaction != nil {
+		t.Fatalf("newCompatibilityRefreshTransaction() = %v, %v; want nil transaction and nil error", transaction, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".agents", "skills")); !os.IsNotExist(statErr) {
+		t.Fatalf("absent compatibility directory was created: %v", statErr)
+	}
+}
+
+func TestWindowsCompatibilityTransactionRefusesRootParentAndNestedJunctions(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		junctionAt string
+	}{
+		{name: "root", junctionAt: "skills"},
+		{name: "parent", junctionAt: ".agents"},
+		{name: "nested", junctionAt: "go-testing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, outside := t.TempDir(), t.TempDir()
+			skillsDir := filepath.Join(home, ".agents", "skills")
+			outsideSkill := filepath.Join(outside, "go-testing", "SKILL.md")
+			switch tc.junctionAt {
+			case "skills":
+				if err := os.MkdirAll(filepath.Dir(skillsDir), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				createWindowsCompatibilityJunction(t, skillsDir, outside)
+			case ".agents":
+				if err := os.MkdirAll(home, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				createWindowsCompatibilityJunction(t, filepath.Join(home, ".agents"), outside)
+				outsideSkill = filepath.Join(outside, "skills", "go-testing", "SKILL.md")
+			case "go-testing":
+				if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				createWindowsCompatibilityJunction(t, filepath.Join(skillsDir, "go-testing"), outside)
+			}
+			if err := os.MkdirAll(filepath.Dir(outsideSkill), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(outsideSkill, []byte("outside"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
+			writeStale(t, pluginPath)
+
+			_, err := RunSyncWithSelection(home, windowsCompatibilitySelection())
+			if err == nil || !strings.Contains(err.Error(), "physical directory") {
+				t.Fatalf("RunSyncWithSelection() error = %v, want physical-directory refusal", err)
+			}
+			assertWindowsCompatibilitySentinel(t, outsideSkill)
+			if content, readErr := os.ReadFile(pluginPath); readErr != nil || string(content) != "stale" {
+				t.Fatalf("plugin refresh ran after compatibility refusal: content=%q error=%v", content, readErr)
+			}
+			if _, statErr := os.Stat(filepath.Join(home, ".gentle-ai", "backups")); !os.IsNotExist(statErr) {
+				t.Fatalf("backup started after compatibility refusal: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestWindowsCompatibilityTransactionCannotFollowJunctionSwapBeforeSnapshot(t *testing.T) {
+	home, outside := t.TempDir(), t.TempDir()
+	skillsDir := filepath.Join(home, ".agents", "skills")
+	writeStale(t, filepath.Join(skillsDir, "go-testing", "SKILL.md"))
+	sentinel := filepath.Join(outside, "go-testing", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	swapped := false
+	installWindowsCompatibilityHook(t, func(boundary string) {
+		if boundary != compatibilityBeforeSnapshot || swapped {
+			return
+		}
+		swapped = true
+		if err := os.Rename(skillsDir, skillsDir+"-original"); err != nil {
+			t.Fatal(err)
+		}
+		createWindowsCompatibilityJunction(t, skillsDir, outside)
+	})
+	transaction, err := newCompatibilityRefreshTransaction(home, []model.ComponentID{model.ComponentSkills}, windowsCompatibilitySelection())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transaction.Close()
+	if !swapped {
+		t.Fatal("test did not reach the pre-snapshot boundary")
+	}
+	if err := transaction.Run(); err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsCompatibilitySentinel(t, sentinel)
+}
+
+func TestWindowsCompatibilityTransactionCannotFollowJunctionSwapBetweenSnapshotAndWrite(t *testing.T) {
+	home, outside := t.TempDir(), t.TempDir()
+	skillsDir := filepath.Join(home, ".agents", "skills")
+	writeStale(t, filepath.Join(skillsDir, "go-testing", "SKILL.md"))
+	sentinel := filepath.Join(outside, "go-testing", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	transaction, err := newCompatibilityRefreshTransaction(home, []model.ComponentID{model.ComponentSkills}, windowsCompatibilitySelection())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transaction.Close()
+	swapped := false
+	installWindowsCompatibilityHook(t, func(boundary string) {
+		if boundary != compatibilityBeforeWrite || swapped {
+			return
+		}
+		swapped = true
+		if err := os.Rename(skillsDir, skillsDir+"-original"); err != nil {
+			t.Fatal(err)
+		}
+		createWindowsCompatibilityJunction(t, skillsDir, outside)
+	})
+	if err := transaction.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if !swapped {
+		t.Fatal("test did not reach the post-snapshot boundary")
+	}
+	assertWindowsCompatibilitySentinel(t, sentinel)
+}
+
+func TestWindowsCompatibilityTransactionRollbackCannotFollowJunctionSwap(t *testing.T) {
+	home, outside := t.TempDir(), t.TempDir()
+	skillsDir := filepath.Join(home, ".agents", "skills")
+	existing := filepath.Join(skillsDir, "go-testing", "SKILL.md")
+	writeStale(t, existing)
+	if err := os.Chmod(existing, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	beforeInfo, err := os.Stat(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(outside, "go-testing", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	transaction, err := newCompatibilityRefreshTransaction(home, []model.ComponentID{model.ComponentSkills}, windowsCompatibilitySelection())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transaction.Close()
+	swapped := false
+	installWindowsCompatibilityHook(t, func(boundary string) {
+		if boundary != compatibilityAfterPublish || swapped {
+			return
+		}
+		swapped = true
+		if err := os.Rename(skillsDir, skillsDir+"-original"); err != nil {
+			t.Fatal(err)
+		}
+		createWindowsCompatibilityJunction(t, skillsDir, outside)
+	})
+	if err := transaction.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := transaction.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if !swapped {
+		t.Fatal("test did not reach the post-publication boundary")
+	}
+	originalExisting := filepath.Join(skillsDir+"-original", "go-testing", "SKILL.md")
+	originalCreated := filepath.Join(skillsDir+"-original", "go-testing", "references", "examples.md")
+	if content, readErr := os.ReadFile(originalExisting); readErr != nil || string(content) != "stale" {
+		t.Fatalf("rollback did not restore original bytes: content=%q error=%v", content, readErr)
+	}
+	if info, statErr := os.Stat(originalExisting); statErr != nil || info.Mode().Perm() != beforeInfo.Mode().Perm() {
+		t.Fatalf("rollback did not restore original mode: info=%v error=%v", info, statErr)
+	}
+	if _, statErr := os.Stat(originalCreated); !os.IsNotExist(statErr) {
+		t.Fatalf("rollback left a transaction-created compatibility file: %v", statErr)
+	}
+	assertWindowsCompatibilitySentinel(t, sentinel)
+}
+
+func TestWindowsCompatibilityTransactionRollbackRemovesCreatedFilesAfterDuplicateBackup(t *testing.T) {
+	home := temporaryUserHome(t)
+	existing := filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md")
+	created := filepath.Join(home, ".agents", "skills", "go-testing", "references", "examples.md")
+	writeStale(t, existing)
+	selection := model.Selection{Components: []model.ComponentID{model.ComponentSkills}, Skills: []model.SkillID{model.SkillGoTesting}}
+
+	first, err := newSyncRuntime(home, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.stagePlan().Prepare[0].Run(); err != nil {
+		t.Fatal(err)
+	}
+	first.state.cleanupRollbackSnapshot()
+	first.state.cleanupCompatibilityTransaction()
+
+	runtime, err := newSyncRuntime(home, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.state.cleanupCompatibilityTransaction()
+	plan := runtime.stagePlan()
+	plan.Apply = append(plan.Apply, failingCompatibilityStep{})
+	result := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(plan)
+	if result.Err == nil {
+		t.Fatal("pipeline unexpectedly succeeded")
+	}
+	if content, readErr := os.ReadFile(existing); readErr != nil || string(content) != "stale" {
+		t.Fatalf("rollback did not restore existing file: content=%q error=%v", content, readErr)
+	}
+	if _, statErr := os.Stat(created); !os.IsNotExist(statErr) {
+		t.Fatalf("rollback left newly created compatibility file: %v", statErr)
+	}
+}

--- a/internal/cli/compatibility_transaction_windows_test.go
+++ b/internal/cli/compatibility_transaction_windows_test.go
@@ -37,8 +37,22 @@ func installWindowsCompatibilityHook(t *testing.T, hook func(string)) {
 	t.Cleanup(func() { windowsCompatibilityTransactionHook = previous })
 }
 
+func installWindowsCompatibilityCloseHook(t *testing.T, hook func(error)) {
+	t.Helper()
+	previous := windowsCompatibilityTransactionCloseHook
+	windowsCompatibilityTransactionCloseHook = hook
+	t.Cleanup(func() { windowsCompatibilityTransactionCloseHook = previous })
+}
+
 func TestRunSyncWithSelectionRefreshesCompatibilityAndOpenCodeAssetsOnWindows(t *testing.T) {
 	home := t.TempDir()
+	closeCount := 0
+	installWindowsCompatibilityCloseHook(t, func(err error) {
+		if err != nil {
+			t.Errorf("close compatibility transaction: %v", err)
+		}
+		closeCount++
+	})
 	compatibilityFiles := []string{
 		filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md"),
 		filepath.Join(home, ".agents", "skills", "go-testing", "references", "examples.md"),
@@ -57,6 +71,52 @@ func TestRunSyncWithSelectionRefreshesCompatibilityAndOpenCodeAssetsOnWindows(t 
 		if err != nil || string(content) == "stale" {
 			t.Fatalf("managed asset %q was not refreshed: content=%q error=%v", path, content, err)
 		}
+	}
+	if closeCount != 1 {
+		t.Fatalf("compatibility transaction close count = %d, want 1", closeCount)
+	}
+}
+
+func TestRunSyncWithSelectionClosesWindowsCompatibilityTransactionAfterSnapshotFailure(t *testing.T) {
+	home := t.TempDir()
+	writeStale(t, filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md"))
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	closeCount := 0
+	installWindowsCompatibilityCloseHook(t, func(err error) {
+		if err != nil {
+			t.Errorf("close compatibility transaction: %v", err)
+		}
+		closeCount++
+	})
+	if _, err := RunSyncWithSelection(home, windowsCompatibilitySelection()); err == nil || !strings.Contains(err.Error(), "model-variants.ts") {
+		t.Fatalf("RunSyncWithSelection() error = %v, want snapshot failure for model-variants.ts", err)
+	}
+	if closeCount != 1 {
+		t.Fatalf("compatibility transaction close count = %d, want 1", closeCount)
+	}
+}
+
+func TestRunSyncDryRunClosesWindowsCompatibilityTransaction(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+	writeStale(t, filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md"))
+
+	closeCount := 0
+	installWindowsCompatibilityCloseHook(t, func(err error) {
+		if err != nil {
+			t.Errorf("close compatibility transaction: %v", err)
+		}
+		closeCount++
+	})
+	result, err := RunSync([]string{"--dry-run"})
+	if err != nil || result.NoOp {
+		t.Fatalf("RunSync(--dry-run) no-op=%t, error=%v; want compatibility plan", result.NoOp, err)
+	}
+	if closeCount != 1 {
+		t.Fatalf("compatibility transaction close count = %d, want 1", closeCount)
 	}
 }
 

--- a/internal/cli/compatibility_transaction_windows_test.go
+++ b/internal/cli/compatibility_transaction_windows_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
 func createWindowsCompatibilityJunction(t *testing.T, link, target string) {
@@ -117,6 +119,89 @@ func TestRunSyncDryRunClosesWindowsCompatibilityTransaction(t *testing.T) {
 	}
 	if closeCount != 1 {
 		t.Fatalf("compatibility transaction close count = %d, want 1", closeCount)
+	}
+}
+
+func windowsTUICompatibilityPlan() (model.Selection, planner.ResolvedPlan, system.PlatformProfile) {
+	selection := windowsCompatibilitySelection()
+	selection.Agents = nil
+	return selection, planner.ResolvedPlan{OrderedComponents: selection.Components}, system.PlatformProfile{
+		OS:             "windows",
+		PackageManager: "winget",
+		Supported:      true,
+	}
+}
+
+func installTUIInstallStagePlan(t *testing.T, decorate func(pipeline.StagePlan) pipeline.StagePlan) {
+	t.Helper()
+	previous := tuiInstallStagePlan
+	tuiInstallStagePlan = func(runtime *installRuntime) pipeline.StagePlan {
+		return decorate(previous(runtime))
+	}
+	t.Cleanup(func() { tuiInstallStagePlan = previous })
+}
+
+func TestExecuteTUIInstallClosesWindowsCompatibilityTransactionAfterSuccess(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md")
+	writeStale(t, path)
+
+	closeCount := 0
+	closedAfterApply := false
+	installWindowsCompatibilityCloseHook(t, func(err error) {
+		if err != nil {
+			t.Errorf("close compatibility transaction: %v", err)
+		}
+		content, readErr := os.ReadFile(path)
+		closedAfterApply = readErr == nil && string(content) != "stale"
+		closeCount++
+	})
+	selection, resolved, profile := windowsTUICompatibilityPlan()
+	result := ExecuteTUIInstall(home, selection, resolved, profile, nil)
+	if result.Err != nil {
+		t.Fatalf("ExecuteTUIInstall() error = %v", result.Err)
+	}
+	if closeCount != 1 {
+		t.Fatalf("compatibility transaction close count = %d, want 1", closeCount)
+	}
+	if !closedAfterApply {
+		t.Fatal("compatibility transaction closed before its TUI stages published")
+	}
+}
+
+func TestExecuteTUIInstallClosesWindowsCompatibilityTransactionAfterRollback(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".agents", "skills", "go-testing", "SKILL.md")
+	writeStale(t, path)
+
+	closeCount := 0
+	closedAfterRollback := false
+	installWindowsCompatibilityCloseHook(t, func(err error) {
+		if err != nil {
+			t.Errorf("close compatibility transaction: %v", err)
+		}
+		content, readErr := os.ReadFile(path)
+		closedAfterRollback = readErr == nil && string(content) == "stale"
+		closeCount++
+	})
+	installTUIInstallStagePlan(t, func(plan pipeline.StagePlan) pipeline.StagePlan {
+		plan.Apply = append(plan.Apply, failingCompatibilityStep{})
+		return plan
+	})
+
+	selection, resolved, profile := windowsTUICompatibilityPlan()
+	result := ExecuteTUIInstall(home, selection, resolved, profile, nil)
+	if result.Err == nil {
+		t.Fatal("ExecuteTUIInstall() error = nil, want post-publication failure")
+	}
+	if !result.Rollback.Success {
+		t.Fatalf("ExecuteTUIInstall() rollback = %+v, want successful restoration", result.Rollback)
+	}
+	if closeCount != 1 {
+		t.Fatalf("compatibility transaction close count = %d, want 1", closeCount)
+	}
+	if !closedAfterRollback {
+		t.Fatal("compatibility transaction closed before TUI rollback restored the original bytes")
 	}
 }
 

--- a/internal/cli/compatibility_writer_unsupported.go
+++ b/internal/cli/compatibility_writer_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !(aix || android || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+//go:build !(aix || android || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || windows)
 
 package cli
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -167,6 +167,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	if err != nil {
 		return result, err
 	}
+	defer runtime.state.cleanupCompatibilityTransaction()
 
 	// Print dependency warnings before the pipeline starts (CLI only).
 	// The TUI surfaces these on the complete screen instead.
@@ -182,7 +183,6 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	orchestrator := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy())
 	result.Execution = orchestrator.Execute(stagePlan)
 	runtime.state.cleanupRollbackSnapshot()
-	runtime.state.cleanupCompatibilityTransaction()
 	if result.Execution.Err != nil {
 		return result, fmt.Errorf("execute install pipeline: %w", result.Execution.Err)
 	}
@@ -586,10 +586,11 @@ func (s *runtimeState) cleanupCompatibilityTransaction() {
 	if s == nil || s.compatibilityTransaction == nil {
 		return
 	}
-	if err := s.compatibilityTransaction.Close(); err != nil {
+	transaction := s.compatibilityTransaction
+	s.compatibilityTransaction = nil
+	if err := transaction.Close(); err != nil {
 		log.Printf("compatibility: close transaction: %v", err)
 	}
-	s.compatibilityTransaction = nil
 }
 
 func (s *runtimeState) compatibilityChangedFiles() []string {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -182,6 +182,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	orchestrator := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy())
 	result.Execution = orchestrator.Execute(stagePlan)
 	runtime.state.cleanupRollbackSnapshot()
+	runtime.state.cleanupCompatibilityTransaction()
 	if result.Execution.Err != nil {
 		return result, fmt.Errorf("execute install pipeline: %w", result.Execution.Err)
 	}
@@ -555,9 +556,10 @@ type installRuntime struct {
 }
 
 type runtimeState struct {
-	manifest            backup.Manifest
-	rollbackSnapshotDir string
-	piCodeGraph         *communitytool.PiCodeGraphResult
+	manifest                 backup.Manifest
+	rollbackSnapshotDir      string
+	piCodeGraph              *communitytool.PiCodeGraphResult
+	compatibilityTransaction compatibilityRefreshTransaction
 
 	// engramVersionResolved, engramVersion, and engramVersionErr cache the
 	// single `engram version` invocation performed by componentApplyStep.Run
@@ -580,9 +582,32 @@ func (s *runtimeState) cleanupRollbackSnapshot() {
 	s.rollbackSnapshotDir = ""
 }
 
+func (s *runtimeState) cleanupCompatibilityTransaction() {
+	if s == nil || s.compatibilityTransaction == nil {
+		return
+	}
+	if err := s.compatibilityTransaction.Close(); err != nil {
+		log.Printf("compatibility: close transaction: %v", err)
+	}
+	s.compatibilityTransaction = nil
+}
+
+func (s *runtimeState) compatibilityChangedFiles() []string {
+	if s == nil || s.compatibilityTransaction == nil {
+		return nil
+	}
+	return s.compatibilityTransaction.ChangedFiles()
+}
+
 func newInstallRuntime(homeDir string, scope InstallScope, channel InstallChannel, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (*installRuntime, error) {
 	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
+	compatibilityTransaction, err := newCompatibilityRefreshTransaction(homeDir, resolved.OrderedComponents, selection)
+	if err != nil {
+		return nil, err
+	}
+	state := &runtimeState{compatibilityTransaction: compatibilityTransaction}
 	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
+		state.cleanupCompatibilityTransaction()
 		return nil, fmt.Errorf("create backup root directory %q: %w", backupRoot, err)
 	}
 
@@ -598,7 +623,7 @@ func newInstallRuntime(homeDir string, scope InstallScope, channel InstallChanne
 		profile:      profile,
 		channel:      channel,
 		backupRoot:   backupRoot,
-		state:        &runtimeState{},
+		state:        state,
 	}, nil
 }
 
@@ -677,10 +702,12 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 
 	if needsCompatibilitySkillsRefresh(r.resolved.OrderedComponents) {
 		apply = append(apply, compatibilitySkillsRefreshStep{
-			id:         "component:compatibility-skills-refresh",
-			homeDir:    r.homeDir,
-			components: r.resolved.OrderedComponents,
-			selection:  r.selection,
+			id:          "component:compatibility-skills-refresh",
+			homeDir:     r.homeDir,
+			components:  r.resolved.OrderedComponents,
+			selection:   r.selection,
+			transaction: r.state.compatibilityTransaction,
+			anchored:    usesAnchoredCompatibilityTransaction(),
 		})
 	}
 	if containsAgent(r.resolved.Agents, model.AgentPi) {
@@ -1824,7 +1851,7 @@ func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection m
 	for _, path := range adapterSkillPaths {
 		paths[path] = struct{}{}
 	}
-	if needsCompatibilitySkillsRefresh(resolved.OrderedComponents) {
+	if !usesAnchoredCompatibilityTransaction() && needsCompatibilitySkillsRefresh(resolved.OrderedComponents) {
 		skillDir, ok, err := compatibilitySkillsDir(homeDir)
 		if err != nil {
 			return nil, err

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1671,37 +1671,22 @@ func windowsGoCandidates() []string {
 	}
 }
 
-// BuildRealStagePlan creates a StagePlan with real backup, agent install, and component apply steps.
-// It is used by both the CLI and TUI paths.
-// scope controls where agent config files are written (ScopeGlobal writes to homeDir, ScopeWorkspace writes to cwd).
-func BuildRealStagePlan(homeDir string, scope InstallScope, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (pipeline.StagePlan, error) {
-	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
-	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
-		return pipeline.StagePlan{}, fmt.Errorf("create backup root directory %q: %w", backupRoot, err)
-	}
-
-	channel, err := ResolveInstallChannel("")
-	if err != nil {
-		return pipeline.StagePlan{}, err
-	}
-
-	runtime, err := newInstallRuntime(homeDir, scope, channel, selection, resolved, profile)
-	if err != nil {
-		return pipeline.StagePlan{}, err
-	}
-
-	return runtime.stagePlan(), nil
-}
-
 // ExecuteTUIInstall runs the same install runtime as the CLI and carries
 // non-fatal Pi CodeGraph manual actions into the TUI completion result.
+// The seam lets native tests add a post-publication failure while still using
+// the public TUI execution boundary and the real compatibility writer.
+var tuiInstallStagePlan = func(runtime *installRuntime) pipeline.StagePlan {
+	return runtime.stagePlan()
+}
+
 func ExecuteTUIInstall(homeDir string, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile, onProgress pipeline.ProgressFunc) pipeline.ExecutionResult {
 	runtime, err := newInstallRuntime(homeDir, ScopeGlobal, ChannelStable, selection, resolved, profile)
 	if err != nil {
 		return pipeline.ExecutionResult{Err: err}
 	}
+	defer runtime.state.cleanupCompatibilityTransaction()
 	orchestrator := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy(), pipeline.WithFailurePolicy(pipeline.ContinueOnError), pipeline.WithProgressFunc(onProgress))
-	result := orchestrator.Execute(runtime.stagePlan())
+	result := orchestrator.Execute(tuiInstallStagePlan(runtime))
 	runtime.state.cleanupRollbackSnapshot()
 	if runtime.state.piCodeGraph != nil {
 		result.ManualActions = append(result.ManualActions, runtime.state.piCodeGraph.ManualActions...)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1412,6 +1412,7 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	if err != nil {
 		return result, err
 	}
+	defer rt.state.cleanupCompatibilityTransaction()
 
 	stagePlan := rt.stagePlan()
 	result.Plan = stagePlan
@@ -1424,7 +1425,6 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	result.Execution = orchestrator.Execute(stagePlan)
 	compatibilityChanged := rt.state.compatibilityChangedFiles()
 	rt.state.cleanupRollbackSnapshot()
-	rt.state.cleanupCompatibilityTransaction()
 	if result.Execution.Err != nil {
 		return result, fmt.Errorf("execute sync pipeline: %w", result.Execution.Err)
 	}
@@ -1589,6 +1589,7 @@ func RunSync(args []string) (SyncResult, error) {
 		if err != nil {
 			return result, err
 		}
+		defer rt.state.cleanupCompatibilityTransaction()
 		result.Plan = rt.stagePlan()
 		for _, step := range result.Plan.Prepare {
 			if prepare, ok := step.(prepareBackupStep); ok && prepare.targetErr != nil {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -459,6 +459,10 @@ func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, er
 	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
 	workspaceDir, _ := os.Getwd()
 	workspaceDir = resolveOpenClawWorkspaceDir(homeDir, workspaceDir, selection.Agents)
+	compatibilityTransaction, err := newCompatibilityRefreshTransaction(homeDir, selection.Components, selection)
+	if err != nil {
+		return nil, err
+	}
 
 	return &syncRuntime{
 		homeDir:      homeDir,
@@ -466,7 +470,7 @@ func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, er
 		selection:    selection,
 		agentIDs:     selection.Agents,
 		backupRoot:   backupRoot,
-		state:        &runtimeState{},
+		state:        &runtimeState{compatibilityTransaction: compatibilityTransaction},
 	}, nil
 }
 
@@ -512,6 +516,8 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 			components:   r.selection.Components,
 			selection:    r.selection,
 			changedFiles: &r.changedFiles,
+			transaction:  r.state.compatibilityTransaction,
+			anchored:     usesAnchoredCompatibilityTransaction(),
 		})
 	}
 
@@ -605,7 +611,7 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 	for _, path := range adapterSkillPaths {
 		paths[path] = struct{}{}
 	}
-	if needsCompatibilitySkillsRefresh(selection.Components) {
+	if !usesAnchoredCompatibilityTransaction() && needsCompatibilitySkillsRefresh(selection.Components) {
 		skillDir, ok, err := compatibilitySkillsDir(homeDir)
 		if err != nil {
 			return nil, err
@@ -1416,7 +1422,9 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 
 	orchestrator := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy())
 	result.Execution = orchestrator.Execute(stagePlan)
+	compatibilityChanged := rt.state.compatibilityChangedFiles()
 	rt.state.cleanupRollbackSnapshot()
+	rt.state.cleanupCompatibilityTransaction()
 	if result.Execution.Err != nil {
 		return result, fmt.Errorf("execute sync pipeline: %w", result.Execution.Err)
 	}
@@ -1428,6 +1436,7 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	if err != nil {
 		return result, err
 	}
+	result.ChangedFiles = dedupPaths(append(result.ChangedFiles, compatibilityChanged...))
 	result.FilesChanged = len(result.ChangedFiles)
 
 	// True no-op: agents were discovered but all managed assets were already

--- a/internal/reviewtransaction/rar_path_safety_windows.go
+++ b/internal/reviewtransaction/rar_path_safety_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"runtime"
 	"unsafe"
 
@@ -163,6 +164,15 @@ func openRARPathNoFollow(path string, directory bool) (*os.File, error) {
 		return nil, errUnsafeRARAuthorityPath
 	}
 	return file, nil
+}
+
+// OpenPhysicalPath opens a file or directory without traversing reparse points.
+func OpenPhysicalPath(path string, directory bool) (*os.File, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	return openRARPathNoFollow(absPath, directory)
 }
 
 func openWindowsRARObject(objectPath string, directory bool) (windows.Handle, error) {


### PR DESCRIPTION
## Linked Issue

Fixes #2590

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Replaces rejected #2594 with one Windows compatibility transaction rooted at a no-reparse NT handle.
- The transaction owns discovery, snapshots, publication, restoration, created-file removal, and now every live owner path. Generic backup, comparison, and restore do not inspect compatibility paths on Windows.
- Unix behavior is unchanged.

## Exceptional Corrections

This PR has used both maintainer-authorized corrections. No third correction is permitted.

1. `78c29377` repaired sync snapshot-error and dry-run lifetime leaks with one idempotent runtime cleanup owner.
2. `202508ddce6f37d96588a73d0072fbd23fa06ef0` gives real TUI install execution the same deferred owner cleanup and deletes unreachable `BuildRealStagePlan`, which previously created and dropped a transaction owner.

`ExecuteTUIInstall` now retains the transaction through all stages and rollback, then closes exactly once at return. The test seam adds only a post-publication failing stage; the observed close remains the real Windows writer close.

## Focused TUI Evidence

Native-focused tests assert exactly one close through the real `ExecuteTUIInstall` boundary for:

- successful publication, proving close follows completion of the TUI stages;
- a post-publication failure, proving rollback restores original bytes before close.

The existing sync tests continue to prove success, generic snapshot failure, and dry-run closure.

## Size Exception

The maintainer-approved `size:exception` covers the one security transaction and its native boundary proof. Current diff: `+1184/-39`.

## Verification

- [x] `go test ./... -count=1`
- [x] `go test -race ./... -count=1`
- [x] focused CLI test and Windows test compilation
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] production build, focused refusal, deadcode ratchet, golden selection, and Windows/Darwin build/test compilation
- [x] Required CI on `202508dd`: https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31049146838
- [x] PR validation on `202508dd`: https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31049146690

The first full local run hit an unrelated `TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403` request-order failure in `internal/components/engram`; its focused rerun and the full rerun both passed.

## Windows Evidence Policy

No Windows Full Suite or shard was dispatched, rerun, waited for, or polled for this correction. The earlier `78c29377` run is inherited same-lineage evidence only: https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31044707845. It passed all compatibility-containing CLI shards and both reviewtransaction shards; its remaining `cli-d-q` and `rest` failures matched baseline.

## Reviewer Notes

- Every Windows compatibility read or write must start from the saved handle, never a path string.
- Absent legacy `.agents/skills` remains an opt-in no-op; root, parent, and selected nested reparse points refuse before backup, apply, or plugin refresh.
- No merge, release, force push, RDD action, secret mutation, or root-checkout mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer Windows compatibility-skill refreshes during installation, synchronization, and TUI workflows.
  * Refreshes now publish changes atomically and report all modified files.
* **Bug Fixes**
  * Failed refreshes automatically roll back, restoring existing files and permissions.
  * Newly created files are removed when operations fail.
  * Unsafe junctions, reparse points, and path escapes are rejected.
* **Compatibility**
  * Existing behavior remains unchanged on non-Windows platforms.
  * Dry-run operations clean up without applying changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->