### PR TITLE
test(windows): make Full Suite fixtures portable

### DIFF
--- a/internal/assets/review_plugin_typed_cause_test.go
+++ b/internal/assets/review_plugin_typed_cause_test.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -17,6 +18,9 @@ import (
 
 // TestReviewPluginNamesDistinctNativeCauses is the two-distinct-causes proof.
 func TestReviewPluginNamesDistinctNativeCauses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("review plugin scenario harness requires a POSIX shell")
+	}
 	cases := []struct {
 		name   string
 		native string
@@ -86,6 +90,9 @@ func TestReviewPluginScrubsForwardedNativeCause(t *testing.T) {
 // selected lens", which names none of them. #2461 reported all four lenses
 // rejected with exactly that sentence.
 func TestReviewPluginNamesRejectedBindingField(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("review plugin scenario harness requires a POSIX shell")
+	}
 	cases := []struct {
 		name     string
 		scenario string

--- a/internal/cli/review_incident.go
+++ b/internal/cli/review_incident.go
@@ -307,8 +307,7 @@ func RunReviewPreserveResult(args []string, stdout io.Writer) error {
 		}
 		return reviewPreflightError(errors.New("preserve-result binding does not match the current reviewing authority"))
 	}
-	dir, err := reviewtransaction.CompactIncidentsDir(ctx, repo, *lineage)
-	if err != nil {
+	if _, err := reviewtransaction.CompactIncidentsDir(ctx, repo, *lineage); err != nil {
 		if contextHandle != "" {
 			return reviewOpaqueContextCause("repository_context_preserve_unavailable", "retry preserve-result with the same exact binding", err)
 		}
@@ -321,7 +320,7 @@ func RunReviewPreserveResult(args []string, stdout io.Writer) error {
 	if len(payload) == 0 || len(payload) > reviewResultArtifactLimit {
 		return reviewPreflightError(errors.New("raw reviewer result must be non-empty and within the native result size limit"))
 	}
-	artifact, err := preserveIncidentArtifact(dir, *lineage, *target, *lens, *order, payload, reviewtransaction.ResultIncidentClass(*class))
+	artifact, err := preserveIncidentArtifact(ctx, repo, *lineage, *target, *lens, *order, payload, reviewtransaction.ResultIncidentClass(*class))
 	if err != nil {
 		if contextHandle != "" {
 			return reviewOpaqueContextCause("repository_context_preserve_failed", "retry preserve-result with the same exact binding", err)
@@ -348,8 +347,9 @@ func reviewIncidentReference(artifact reviewIncidentArtifact) string {
 	return reviewIncidentReferencePrefix + strings.TrimPrefix(facadePayloadHash(payload), "sha256:")
 }
 
-func preserveIncidentArtifact(dir, lineage, target, lens string, order int, payload []byte, class reviewtransaction.ResultIncidentClass) (reviewIncidentArtifact, error) {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+func preserveIncidentArtifact(ctx context.Context, repo, lineage, target, lens string, order int, payload []byte, class reviewtransaction.ResultIncidentClass) (reviewIncidentArtifact, error) {
+	dir, err := reviewtransaction.EnsureCompactIncidentsDir(ctx, repo, lineage)
+	if err != nil {
 		return reviewIncidentArtifact{}, fmt.Errorf("create incident preservation directory: %w", err)
 	}
 	info, err := os.Lstat(dir)

--- a/internal/cli/review_opaque_typed_cause_nonwindows_test.go
+++ b/internal/cli/review_opaque_typed_cause_nonwindows_test.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func makeOpaqueSharedDirectory(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Chmod(path, 0o777); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestOpaqueRepositoryContextResolutionNamesDistinctCauses(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			want: "no such file or directory",
+			want: opaqueNativeCause("no such file or directory", "The system cannot find the file specified."),
 		},
 		{
 			name: "authority-record-unparsable",
@@ -91,7 +92,13 @@ func TestOpaqueRepositoryContextResolutionNamesDistinctCauses(t *testing.T) {
 			messages[tt.name] = message
 		})
 	}
-	assertPairwiseDistinct(t, messages, len(cases))
+	wantMessages := len(cases)
+	if runtime.GOOS == "windows" {
+		// The Git shim is a POSIX shell script, so Windows exercises the two
+		// native filesystem roots while retaining their distinct-cause proof.
+		wantMessages -= 2
+	}
+	assertPairwiseDistinct(t, messages, wantMessages)
 }
 
 // TestOpaqueRepositoryContextCaptureNamesDistinctCauses covers the collapse
@@ -122,7 +129,7 @@ func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			want: "not a directory",
+			want: opaqueNativeCause("not a directory", "unsafe RAR authority path"),
 		},
 	}
 	messages := make(map[string]string, len(cases))
@@ -166,7 +173,7 @@ func TestOpaqueRepositoryContextCauseIsScrubbed(t *testing.T) {
 	if strings.Contains(message, repo) || strings.Contains(message, lineage+"/review-state.json") {
 		t.Fatalf("forwarded cause leaked an absolute path: %s", message)
 	}
-	if !strings.Contains(message, "no such file or directory") {
+	if !strings.Contains(message, opaqueNativeCause("no such file or directory", "The system cannot find the file specified.")) {
 		t.Fatalf("scrubbing removed the cause along with the path: %s", message)
 	}
 	if scrubbed := reviewScrubDefectReportField(message); scrubbed != message {
@@ -185,6 +192,13 @@ func assertOpaqueFailureNamesCause(t *testing.T, message, code, wantCause, repo 
 	if strings.Contains(message, repo) {
 		t.Fatalf("failure leaked a private path: %s", message)
 	}
+}
+
+func opaqueNativeCause(unix, windows string) string {
+	if runtime.GOOS == "windows" {
+		return windows
+	}
+	return unix
 }
 
 // assertPairwiseDistinct is the whole point of these tests: every root that
@@ -262,7 +276,7 @@ func TestOpaqueRepositoryContextPreserveNamesDistinctCauses(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			want: "not a directory",
+			want: opaqueNativeCause("not a directory", "The system cannot find the path specified."),
 		},
 		{
 			name: "incidents-directory-is-shared",

--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -263,32 +264,35 @@ func admissibleOpaqueReviewerResult(t *testing.T, binding []string, evidence str
 func TestOpaqueRepositoryContextPreserveNamesDistinctCauses(t *testing.T) {
 	cases := []struct {
 		name    string
-		arrange func(t *testing.T, incidents string)
+		arrange func(t *testing.T, repo, lineage string)
 		want    string
 	}{
 		{
 			name: "incidents-path-is-a-file",
-			arrange: func(t *testing.T, incidents string) {
-				if err := os.MkdirAll(filepath.Dir(incidents), 0o700); err != nil {
+			arrange: func(t *testing.T, repo, lineage string) {
+				incidents, err := reviewtransaction.EnsureCompactIncidentsDir(context.Background(), repo, lineage)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(incidents); err != nil {
 					t.Fatal(err)
 				}
 				if err := os.WriteFile(incidents, []byte("not a directory\n"), 0o600); err != nil {
 					t.Fatal(err)
 				}
 			},
-			want: opaqueNativeCause("not a directory", "The system cannot find the path specified."),
+			want: "unsafe RAR authority path",
 		},
 		{
 			name: "incidents-directory-is-shared",
-			arrange: func(t *testing.T, incidents string) {
-				if err := os.MkdirAll(incidents, 0o777); err != nil {
+			arrange: func(t *testing.T, repo, lineage string) {
+				incidents, err := reviewtransaction.EnsureCompactIncidentsDir(context.Background(), repo, lineage)
+				if err != nil {
 					t.Fatal(err)
 				}
-				if err := os.Chmod(incidents, 0o777); err != nil {
-					t.Fatal(err)
-				}
+				makeOpaqueSharedDirectory(t, filepath.Dir(incidents))
 			},
-			want: "not a private native directory",
+			want: "unsafe RAR authority path",
 		},
 	}
 	messages := make(map[string]string, len(cases))
@@ -296,7 +300,7 @@ func TestOpaqueRepositoryContextPreserveNamesDistinctCauses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lineage := "opaque-preserve-" + tt.name
 			args, input, repo := startedOpaqueCaptureBinding(t, lineage)
-			tt.arrange(t, filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "incidents", lineage))
+			tt.arrange(t, repo, lineage)
 
 			err := RunReviewPreserveResult(append(append([]string{}, args...), "--input", input), io.Discard)
 			if err == nil {

--- a/internal/cli/review_opaque_typed_cause_windows_test.go
+++ b/internal/cli/review_opaque_typed_cause_windows_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package cli
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func makeOpaqueSharedDirectory(t *testing.T, path string) {
+	t.Helper()
+	shared, err := windows.CreateWellKnownSid(windows.WinAuthenticatedUserSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.ACCESS_MASK(windows.GENERIC_ALL),
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_GROUP,
+			TrusteeValue: windows.TrusteeValueFromSID(shared),
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, acl, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/components/engram/download_durability_test.go
+++ b/internal/components/engram/download_durability_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -57,7 +58,7 @@ func TestEngramDownloadDigestDescribesTheFileOnDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat parent: %v", err)
 	}
-	if parent.Mode().Perm() != 0o755 {
+	if runtime.GOOS != "windows" && parent.Mode().Perm() != 0o755 {
 		t.Errorf("parent directory mode = %v, want 0755", parent.Mode().Perm())
 	}
 }
@@ -149,7 +150,7 @@ func TestEngramWriteExecutablePublishesAnExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if info.Mode().Perm()&0o111 == 0 {
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 		t.Errorf("mode = %v, want the executable bits set", info.Mode().Perm())
 	}
 	onDisk, err := os.ReadFile(outPath)

--- a/internal/components/filemerge/stream_test.go
+++ b/internal/components/filemerge/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -94,9 +95,6 @@ func TestWriteStreamAtomicReportsTheDigestOfTheFileOnDisk(t *testing.T) {
 // TestWriteStreamAtomicPreservesRequestedMode covers the executable case the
 // binary installers rely on.
 func TestWriteStreamAtomicPreservesRequestedMode(t *testing.T) {
-	if os.Getenv("GOOS") == "windows" {
-		t.Skip("mode bits are not meaningful on Windows")
-	}
 	path := filepath.Join(t.TempDir(), "gentle-ai")
 
 	if _, err := WriteStreamAtomic(path, strings.NewReader("#!/bin/sh\n"), 0o755); err != nil {
@@ -106,7 +104,7 @@ func TestWriteStreamAtomicPreservesRequestedMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o755 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
 		t.Errorf("mode = %v, want 0755", info.Mode().Perm())
 	}
 }

--- a/internal/components/filemerge/writer_landed_test.go
+++ b/internal/components/filemerge/writer_landed_test.go
@@ -2,6 +2,7 @@ package filemerge
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,8 +123,8 @@ func TestWriteFileAtomicFailsWhenReplacementDoesNotLand(t *testing.T) {
 			if err == nil {
 				t.Fatal("WriteFileAtomic reported success for a replacement that never landed on disk")
 			}
-			if !strings.Contains(err.Error(), path) {
-				t.Errorf("error %q does not name the destination %q", err, path)
+			if want := fmt.Sprintf("%q", path); !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not name the destination representation %s", err, want)
 			}
 			if result.Changed {
 				t.Errorf("WriteFileAtomic = %+v, want Changed=false: the destination does not hold the requested bytes", result)

--- a/internal/components/uninstall/batch_boundary_test.go
+++ b/internal/components/uninstall/batch_boundary_test.go
@@ -2,6 +2,7 @@ package uninstall
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -39,8 +40,8 @@ func TestPartialUninstallCommitsSucceededAgentsWhenAnotherAgentFails(t *testing.
 	if err == nil {
 		t.Fatal("PartialUninstall() error = nil, want the hermes cleanup failure surfaced")
 	}
-	if !strings.Contains(err.Error(), hermesConfig) {
-		t.Fatalf("PartialUninstall() error = %v, want it to name %q", err, hermesConfig)
+	if want := fmt.Sprintf("%q", hermesConfig); !strings.Contains(err.Error(), want) {
+		t.Fatalf("PartialUninstall() error = %v, want it to name the representation %s", err, want)
 	}
 
 	if !slices.Equal(result.FailedAgents, []model.AgentID{model.AgentHermes}) {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -1074,6 +1074,16 @@ func compactMaintenanceLockPath(authorityRoot string) string {
 // so incident preservation still works when capture was attempted from a
 // repository that does not own the reviewing lineage.
 func CompactIncidentsDir(ctx context.Context, repo, lineageID string) (string, error) {
+	return compactIncidentsDir(ctx, repo, lineageID, false)
+}
+
+// EnsureCompactIncidentsDir creates the durable raw-result incident directory
+// with the same owner-only safety boundary as compact authority artifacts.
+func EnsureCompactIncidentsDir(ctx context.Context, repo, lineageID string) (string, error) {
+	return compactIncidentsDir(ctx, repo, lineageID, true)
+}
+
+func compactIncidentsDir(ctx context.Context, repo, lineageID string, create bool) (string, error) {
 	if err := validateLineageID(lineageID); err != nil {
 		return "", err
 	}
@@ -1081,7 +1091,23 @@ func CompactIncidentsDir(ctx context.Context, repo, lineageID string) (string, e
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "incidents", lineageID), nil
+	dir := filepath.Join(base, "incidents", lineageID)
+	if create {
+		if err := ensureCompactIncidentsDir(dir); err != nil {
+			return "", fmt.Errorf("ensure private incident preservation directory: %w", err)
+		}
+	}
+	return dir, nil
+}
+
+func ensureCompactIncidentsDir(dir string) error {
+	if _, err := createPrivateRARDirectory(filepath.Dir(dir)); err != nil {
+		return fmt.Errorf("create private incident root: %w", err)
+	}
+	if _, err := createPrivateRARDirectory(dir); err != nil {
+		return fmt.Errorf("create private incident lineage directory: %w", err)
+	}
+	return nil
 }
 
 func DiscoverCompactStores(ctx context.Context, repo string) ([]CompactStore, error) {

--- a/internal/sddstatus/runtime_ledger_worktree_binding_test.go
+++ b/internal/sddstatus/runtime_ledger_worktree_binding_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
 )
 
 // TestRuntimeLedgerRefusesFinishFromADifferentLinkedWorktreeThanBegin is the
@@ -54,11 +56,13 @@ func TestRuntimeLedgerRefusesFinishFromADifferentLinkedWorktreeThanBegin(t *test
 		t.Fatalf("cross-worktree finish error = %v, want ErrRuntimeWorktreeMismatch", finishErr)
 	}
 	message := finishErr.Error()
-	if !strings.Contains(message, repo) {
-		t.Fatalf("refusal %q does not name the begin worktree %q to rerun finish from", message, repo)
+	beginWorktree := canonicalRuntimeLedgerWorktreePath(t, repo)
+	if !strings.Contains(message, beginWorktree) {
+		t.Fatalf("refusal %q does not name the begin worktree %q to rerun finish from", message, beginWorktree)
 	}
-	if !strings.Contains(message, worktree) {
-		t.Fatalf("refusal %q does not name the current mismatched worktree %q", message, worktree)
+	currentWorktree := canonicalRuntimeLedgerWorktreePath(t, worktree)
+	if !strings.Contains(message, currentWorktree) {
+		t.Fatalf("refusal %q does not name the current mismatched worktree %q", message, currentWorktree)
 	}
 
 	// Mutation proof: the refusal fires before any candidate capture/diff, so
@@ -85,6 +89,19 @@ func TestRuntimeLedgerRefusesFinishFromADifferentLinkedWorktreeThanBegin(t *test
 	if len(finished.Attempts) != 1 || finished.Attempts[0].ChangedLines != 1 {
 		t.Fatalf("same-worktree finish attempts = %#v, want exactly one changed line", finished.Attempts)
 	}
+}
+
+func canonicalRuntimeLedgerWorktreePath(t *testing.T, path string) string {
+	t.Helper()
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pathquote.Quote(filepath.Clean(canonical))
 }
 
 // TestRuntimeLedgerBeginRecordsTheCanonicalBeginWorktreeEndToEnd is the

--- a/internal/update/upgrade/download_durability_test.go
+++ b/internal/update/upgrade/download_durability_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -177,7 +178,7 @@ func TestWriteExecutablePublishesAnExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if info.Mode().Perm()&0o111 == 0 {
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 		t.Errorf("mode = %v, want the executable bits set", info.Mode().Perm())
 	}
 	onDisk, err := os.ReadFile(outPath)
@@ -193,7 +194,7 @@ func TestWriteExecutablePublishesAnExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat parent: %v", err)
 	}
-	if parent.Mode().Perm() != 0o755 {
+	if runtime.GOOS != "windows" && parent.Mode().Perm() != 0o755 {
 		t.Errorf("parent directory mode = %v, want 0755", parent.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## Linked Issues

Fixes #2604
Fixes #2537
Fixes #2602
Fixes #2600
Fixes #2605

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Resolves the 13 deterministic Windows Full Suite fixture-portability failures without weakening production contracts.
- Keeps the change as six reviewable root-class commits and 193 changed lines.

## Changes

| Root class | Files / change |
| --- | --- |
| Opaque native error wording (#2604) | `internal/cli/review_opaque_typed_cause_test.go`: accepts native Windows diagnostics while retaining typed-code, redaction, and pairwise-distinctness checks. |
| Opaque shared-directory fixture (#2604) | `internal/reviewtransaction/compact_store.go`, `internal/cli/review_incident.go`, and CLI fixtures: creates owner-only incident directories and uses an Authenticated Users DACL fixture on Windows. |
| Unsupported assets parent (#2537) | `internal/assets/review_plugin_typed_cause_test.go`: parents skip before capture-map assertions when the POSIX-shell harness is unavailable. |
| POSIX mode metadata (#2602) | Enram, filemerge, and upgrade durability tests gate only POSIX mode checks with `runtime.GOOS`; byte, digest, atomic publication, and cleanup checks still run. |
| Rendered paths (#2600) | Filemerge and uninstall tests compare the existing `%q` error representation. |
| SDD worktree spelling (#2605) | `internal/sddstatus/runtime_ledger_worktree_binding_test.go`: canonicalizes and contract-renders paths before containment checks; the cross-worktree refusal remains asserted. |

## Inherited RED Evidence

No Windows Full Suite or shard was dispatched, rerun, waited on, or polled for this change.

- [Run 31029965378](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31029965378) at `b64b7c8f6afdb5e194a8d1e54ba83c8cd8f2c076`: `cli-d-q` and `rest` recorded the fixture failures.
- [Run 31044707845](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31044707845) at `78c2937750f9ca60e831d7bd77abbdab108f3c11`: the same current failure clusters remained in `cli-d-q` and `rest`; the other five shards passed.

## Test Plan

- [x] `go test ./... -count=1`
- [x] `go test -race` across all changed packages and `internal/reviewtransaction`
- [x] `go run ./internal/gofmtcheck`, `go vet ./...`, and `go build ./...`
- [x] Refusal ratchet: `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign`
- [x] Deadcode ratchet: `./scripts/deadcode-ratchet.sh`
- [x] Windows amd64 cross-compilation for every changed test package and the CLI binary
- [x] Golden coverage: no golden files changed; the full root suite passed.
- [x] Benchmark validation: N/A; no bench corpus, classifier, or journey contract changed.

## Closure

One final main Windows Full Suite after merge is the only proof of closure for these inherited Windows failures. This PR does not merge or rerun that suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preservation of review incident artifacts by reliably creating and using the appropriate storage location.
  - Improved handling and reporting of unsafe paths, filesystem permissions, and replacement failures.
  - Error messages now provide clearer, more precise path details.

- **Compatibility**
  - Improved behavior and validation across Windows and POSIX-based systems, including platform-specific filesystem and shell differences.

- **Tests**
  - Expanded coverage for protected directories, worktree paths, incident storage, and platform-specific error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->