### PR TITLE
docs: clarify issue form auto-label behavior

### DIFF
--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -18,8 +18,8 @@ Load this skill whenever you need to:
 
 ## Critical Rules
 
-1. **Blank issues are DISABLED** — `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`. You MUST use a template.
-2. **Template auto-labels require the web form** — use the web-form URLs below to receive the template's type label and `status:needs-review`. GitHub CLI 2.96.0 supports Markdown issue templates, not YAML issue forms, so CLI-created issues do not inherit these labels. Fork contributors using the CLI must list the missing labels in the issue body for a maintainer.
+1. **Blank issues are DISABLED** — `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`. Web-form submissions MUST use a template; CLI submissions MUST include every required template field in the body.
+2. **Template auto-labels require the web form** — use the web-form URLs below to receive the template's type label and `status:needs-review`. GitHub CLI 2.96.0 supports Markdown issue templates, not YAML issue forms, so CLI-created issues do not inherit these labels. CLI submitters must list the missing labels in the issue body for a maintainer.
 3. **`status:approved` is REQUIRED before ANY work begins** — a maintainer must label the issue before you or anyone opens a PR.
 4. **Questions go to Discussions** — use [GitHub Discussions](https://github.com/Gentleman-Programming/gentle-ai/discussions), NOT issues, for questions and general conversation.
 5. **No Co-Authored-By trailers** — never add AI attribution to commits.
@@ -90,7 +90,7 @@ Intentionally public identifiers are NOT redacted: tool names (`gentle-ai`, `eng
 
 Use the web form when the template's auto-labels matter:
 
-```
+```text
 https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=bug_report.yml
 ```
 
@@ -127,7 +127,7 @@ gh issue create \
 
 Use the web form when the template's auto-labels matter:
 
-```
+```text
 https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=feature_request.yml
 ```
 
@@ -150,7 +150,7 @@ gh issue create \
 
 | Label | Description | Who Applies |
 |-------|-------------|-------------|
-| `status:needs-review` | Newly opened, awaiting maintainer review | **Auto** (template) |
+| `status:needs-review` | Newly opened, awaiting maintainer review | **Auto** (web form only); CLI submitters list it for a maintainer |
 | `status:approved` | Approved — work can begin | Maintainer only |
 | `status:in-progress` | Being actively worked on | Contributor |
 | `status:blocked` | Blocked by another issue or external dependency | Maintainer / Contributor |

--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -19,7 +19,7 @@ Load this skill whenever you need to:
 ## Critical Rules
 
 1. **Blank issues are DISABLED** — `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`. You MUST use a template.
-2. **`status:needs-review` is applied automatically** — every new issue gets this label; you do NOT add it manually.
+2. **Template auto-labels require the web form** — use the web-form URLs below to receive the template's type label and `status:needs-review`. GitHub CLI 2.96.0 supports Markdown issue templates, not YAML issue forms, so CLI-created issues do not inherit these labels. Fork contributors using the CLI must list the missing labels in the issue body for a maintainer.
 3. **`status:approved` is REQUIRED before ANY work begins** — a maintainer must label the issue before you or anyone opens a PR.
 4. **Questions go to Discussions** — use [GitHub Discussions](https://github.com/Gentleman-Programming/gentle-ai/discussions), NOT issues, for questions and general conversation.
 5. **No Co-Authored-By trailers** — never add AI attribution to commits.
@@ -52,7 +52,7 @@ Intentionally public identifiers are NOT redacted: tool names (`gentle-ai`, `eng
    - Bug   → .github/ISSUE_TEMPLATE/bug_report.yml
    - Feat  → .github/ISSUE_TEMPLATE/feature_request.yml
 
-3. Submit the issue → status:needs-review is applied automatically
+3. Submit through the web form → template labels are applied automatically
 
 4. Wait — a maintainer reviews and adds status:approved (or closes)
 
@@ -66,7 +66,7 @@ Intentionally public identifiers are NOT redacted: tool names (`gentle-ai`, `eng
 ## Bug Report
 
 **Template path**: `.github/ISSUE_TEMPLATE/bug_report.yml`
-**Auto-labels**: `bug`, `status:needs-review`
+**Web-form auto-labels**: `bug`, `status:needs-review`
 
 ### Required Fields
 
@@ -86,18 +86,23 @@ Intentionally public identifiers are NOT redacted: tool names (`gentle-ai`, `eng
 
 `CLI (commands, flags)` · `TUI (terminal UI)` · `Installation Pipeline` · `Agent Detection` · `System Detection` · `Catalog/Steps` · `Documentation` · `Other`
 
+### Recommended Web Form
+
+Use the web form when the template's auto-labels matter:
+
+```
+https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=bug_report.yml
+```
+
 ### Example CLI Command
+
+CLI filing does not load the YAML issue form or apply its labels. Prepare a body with every required field and list `bug` and `status:needs-review` as maintainer-owed labels.
 
 ```bash
 gh issue create \
   --repo Gentleman-Programming/gentle-ai \
-  --template bug_report.yml \
+  --body-file bug-report.md \
   --title "fix(agent): Claude Code not detected on Linux Arch"
-```
-
-Or open the web form directly:
-```
-https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=bug_report.yml
 ```
 
 ---
@@ -105,7 +110,7 @@ https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=bug_repor
 ## Feature Request
 
 **Template path**: `.github/ISSUE_TEMPLATE/feature_request.yml`
-**Auto-labels**: `enhancement`, `status:needs-review`
+**Web-form auto-labels**: `enhancement`, `status:needs-review`
 
 ### Required Fields
 
@@ -118,18 +123,23 @@ https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=bug_repor
 | Alternatives Considered | (optional) Other approaches you thought about |
 | Additional Context | (optional) Screenshots, config files, etc. |
 
+### Recommended Web Form
+
+Use the web form when the template's auto-labels matter:
+
+```
+https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=feature_request.yml
+```
+
 ### Example CLI Command
+
+CLI filing does not load the YAML issue form or apply its labels. Prepare a body with every required field and list `enhancement` and `status:needs-review` as maintainer-owed labels.
 
 ```bash
 gh issue create \
   --repo Gentleman-Programming/gentle-ai \
-  --template feature_request.yml \
+  --body-file feature-request.md \
   --title "feat(tui): add keyboard shortcut help overlay"
-```
-
-Or open the web form directly:
-```
-https://github.com/Gentleman-Programming/gentle-ai/issues/new?template=feature_request.yml
 ```
 
 ---
@@ -231,19 +241,23 @@ gh issue list --repo Gentleman-Programming/gentle-ai --state all --search "your 
 
 ### Create a Bug Report
 
+The body must include the required template fields and identify `bug` and `status:needs-review` as maintainer-owed labels.
+
 ```bash
 gh issue create \
   --repo Gentleman-Programming/gentle-ai \
-  --template bug_report.yml \
+  --body-file bug-report.md \
   --title "fix(<scope>): <short description>"
 ```
 
 ### Create a Feature Request
 
+The body must include the required template fields and identify `enhancement` and `status:needs-review` as maintainer-owed labels.
+
 ```bash
 gh issue create \
   --repo Gentleman-Programming/gentle-ai \
-  --template feature_request.yml \
+  --body-file feature-request.md \
   --title "feat(<scope>): <short description>"
 ```
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2631

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

`type:docs` is owed by a maintainer because fork contributors do not have triage rights.

---

## 📝 Summary

Corrects the issue-creation skill's unconditional auto-label claim. The skill now recommends the web form when template labels matter and keeps CLI examples with an explicit warning that YAML issue forms and their labels are not loaded by GitHub CLI 2.96.0.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `skills/issue-creation/SKILL.md` | Made auto-label behavior conditional on web-form submission, recommended the existing web-form URLs, and changed CLI examples to body files with maintainer-owed label guidance |

The tracked diff is 50 changed lines (32 additions and 18 deletions), within the 400-line cognitive budget.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

Not run, documentation-only change with no executable behavior.

**Go Format**
```bash
go run ./internal/gofmtcheck
```

Not run, no Go files changed.

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

Not run, documentation-only change with no product behavior.

**Benchmark Validation**

N/A. This change does not touch review lifecycle, gates, recovery, delivery, benchmark code or corpus, or benchmark claims.

- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual validation:

- `git diff --check`
- Verified the installed GitHub CLI version and `gh issue create --help` output.
- Verified `cli/cli` issues #5865 and #11681 document that `--template` supports Markdown templates, not YAML issue forms.
- Verified `gh issue view 2628 --repo Gentleman-Programming/gentle-ai --json labels` returns an empty label array for a real `--body-file` submission.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR is 50 changed lines, within the 400-line budget |
| Check Issue Reference | ⏳ | PR body contains `Closes #2631` pending issue publication and substitution |
| Check Issue Has `status:approved` | ⏳ | Linked issue must be approved before the PR is opened |
| Check PR Has `type:*` Label | ⏳ | Maintainer must apply exactly `type:docs` |
| Unit Tests | ⏳ | Deferred to CI; documentation-only change |
| Go Format | ⏳ | Deferred to CI; no Go files changed |
| E2E Tests | ⏳ | Deferred to CI; documentation-only change |

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` (pending issue publication and maintainer approval)
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR (maintainer owes `type:docs`)
- [ ] Unit tests pass (`go test ./...`) (not run locally; documentation-only change)
- [ ] Go format passes (`go run ./internal/gofmtcheck`) (not run locally; no Go files changed)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (not run locally; documentation-only change)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (N/A, documentation-only change).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The claim is intentionally bounded to evidence available without creating a test issue. GitHub CLI 2.96.0 documents `--template` as starting body text, its source discovers templates through `Repository.issueTemplates`, and upstream `cli/cli` issues #5865 and #11681 confirm that YAML issue forms are not supported. Separately, Gentle AI issue #2628 proves that a working `--body-file` submission receives none of the YAML form's declared labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified issue creation guidance for both web-form and CLI submissions.
  - Added dedicated links and updated workflows for bug reports and feature requests.
  - Documented automatic template labeling for web forms and required label identification for CLI submissions.
  - Revised CLI examples to use body files, helping ensure issue details are submitted consistently.
  - Updated descriptions of labeling behavior and submission requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->