### PR TITLE
fix(review): refuse no-op clone-local mode writes

### DIFF
--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -110,6 +110,172 @@ func TestReviewModeCloneScopeRejectsForcingOn(t *testing.T) {
 	}
 }
 
+// TestReviewModeEnableCloneIsNoOpWhenDecidedGlobally is the CLI-level proof
+// of issue #2231: re-running `review mode enable --scope clone` against a
+// clone whose effective mode is already decided by global must refuse as a
+// no-op and not advance the generation. The CAS subtest re-runs the same
+// write with --expected-revision set to the existing head and pins the same
+// contract for the explicit-token path.
+func TestReviewModeEnableCloneIsNoOpWhenDecidedGlobally(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	if err := state.Write(home, state.InstallState{RDDMode: "off"}); err != nil {
+		t.Fatalf("seed global off: %v", err)
+	}
+
+	var first bytes.Buffer
+	if err := RunReviewMode([]string{"enable", "--cwd", repo, "--scope", "clone", "--json"}, &first); err != nil {
+		t.Fatalf("first enable clone error = %v\n%s", err, first.String())
+	}
+	firstResult := decodeReviewModeResult(t, first.Bytes()).Status
+	if firstResult.Effective != reviewtransaction.RDDModeOff || firstResult.Source != reviewtransaction.RDDModeSourceGlobal {
+		t.Fatalf("first enable result = %#v, want off decided by global", firstResult)
+	}
+	if firstResult.Revision == "" {
+		t.Fatalf("first enable produced no revision: %#v", firstResult)
+	}
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if count := reviewModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("first enable produced %d generations, want 1", count)
+	}
+
+	redundantEnable := func(args ...string) error {
+		var output bytes.Buffer
+		full := append([]string{"enable", "--cwd", repo, "--scope", "clone"}, args...)
+		full = append(full, "--json")
+		err := RunReviewMode(full, &output)
+		if err == nil {
+			t.Fatalf("redundant enable %v returned success:\n%s", args, output.String())
+		}
+		var redundant *reviewtransaction.RDDModeRedundantWriteError
+		if !errors.As(err, &redundant) {
+			t.Fatalf("redundant enable %v error = %v, want *RDDModeRedundantWriteError", args, err)
+		}
+		if redundant.Status.Source != reviewtransaction.RDDModeSourceGlobal {
+			t.Fatalf("redundant enable %v source = %q, want global", args, redundant.Status.Source)
+		}
+		if redundant.Status.Revision != firstResult.Revision {
+			t.Fatalf("redundant enable %v changed revision: before=%q after=%q",
+				args, firstResult.Revision, redundant.Status.Revision)
+		}
+		if !strings.Contains(err.Error(), "gentle-ai review mode enable --scope=global") {
+			t.Fatalf("redundant enable %v refusal does not name the deciding scope:\n%s", args, err.Error())
+		}
+		return err
+	}
+
+	if err := redundantEnable(); err == nil {
+		t.Fatal("redundant enable without --expected-revision returned nil error")
+	}
+	if err := redundantEnable("--expected-revision", firstResult.Revision); err == nil {
+		t.Fatal("redundant enable with --expected-revision returned nil error")
+	}
+	if count := reviewModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("redundant enable advanced generation count: now=%d, want 1", count)
+	}
+}
+
+// TestReviewModeEnableCloneStillWritesWhenGlobalIsOn is the anti-drift guard
+// for the legitimate use case: when global=on and clone-local holds an Off
+// opinion, enabling the clone clears the opinion so global decides. The
+// mode flips (Off -> On, decided by clone -> decided by global) and a
+// generation must be published.
+func TestReviewModeEnableCloneStillWritesWhenGlobalIsOn(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	if err := state.Write(home, state.InstallState{RDDMode: "on"}); err != nil {
+		t.Fatalf("seed global on: %v", err)
+	}
+
+	var disableOutput bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &disableOutput); err != nil {
+		t.Fatalf("disable clone error = %v\n%s", err, disableOutput.String())
+	}
+	disabled := decodeReviewModeResult(t, disableOutput.Bytes()).Status
+	if disabled.Effective != reviewtransaction.RDDModeOff || disabled.Source != reviewtransaction.RDDModeSourceCloneLocal {
+		t.Fatalf("disable did not pin effective=off decided by clone: %#v", disabled)
+	}
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if count := reviewModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("disable produced %d generations, want 1", count)
+	}
+
+	var enableOutput bytes.Buffer
+	if err := RunReviewMode([]string{"enable", "--cwd", repo, "--scope", "clone", "--json"}, &enableOutput); err != nil {
+		t.Fatalf("enable clone error = %v\n%s", err, enableOutput.String())
+	}
+	reEnabled := decodeReviewModeResult(t, enableOutput.Bytes()).Status
+	if reEnabled.Effective != reviewtransaction.RDDModeOn || reEnabled.Source != reviewtransaction.RDDModeSourceGlobal {
+		t.Fatalf("re-enable did not flip effective=on decided by global: %#v", reEnabled)
+	}
+	if reEnabled.Revision == disabled.Revision {
+		t.Fatalf("re-enable did not advance revision: before=%q after=%q", disabled.Revision, reEnabled.Revision)
+	}
+	if count := reviewModeGenerationCount(t, dir); count != 2 {
+		t.Fatalf("re-enable advanced generation count = %d, want 2", count)
+	}
+}
+
+// TestReviewModeDisableCloneIsNoOpWhenAlreadyOff pins the symmetric guard
+// for `review mode disable --scope clone`: re-disabling an already-disabled
+// clone-local override must also refuse as a no-op.
+func TestReviewModeDisableCloneIsNoOpWhenAlreadyOff(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	if err := state.Write(home, state.InstallState{RDDMode: "on"}); err != nil {
+		t.Fatalf("seed global on: %v", err)
+	}
+
+	var first bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &first); err != nil {
+		t.Fatalf("first disable clone error = %v\n%s", err, first.String())
+	}
+	disabled := decodeReviewModeResult(t, first.Bytes()).Status
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if count := reviewModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("first disable produced %d generations, want 1", count)
+	}
+
+	var second bytes.Buffer
+	err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &second)
+	if err == nil {
+		t.Fatalf("redundant disable returned success instead of a typed non-success:\n%s", second.String())
+	}
+	var redundant *reviewtransaction.RDDModeRedundantWriteError
+	if !errors.As(err, &redundant) {
+		t.Fatalf("redundant disable error = %v, want *RDDModeRedundantWriteError", err)
+	}
+	if redundant.Status.Revision != disabled.Revision {
+		t.Fatalf("redundant disable changed revision: before=%q after=%q",
+			disabled.Revision, redundant.Status.Revision)
+	}
+	if count := reviewModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("redundant disable advanced generation count: now=%d, want 1", count)
+	}
+}
+
+// reviewModeGenerationCount counts the gen-NNNNNNNNNN.json files under the
+// clone-local RDD mode directory. The consent latch and lock live next to
+// them but do not match the generation pattern.
+func reviewModeGenerationCount(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
+		t.Fatalf("read rdd-mode directory: %v", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, "gen-") && strings.HasSuffix(name, ".json") {
+			count++
+		}
+	}
+	return count
+}
+
 func TestReviewModeReportsUnknownPersistedModeAsDisabled(t *testing.T) {
 	home := reviewModeHome(t)
 	repo := initReviewCLIRepo(t)

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -66,6 +66,15 @@ var (
 	// impose receipt-driven development on every clone that checks it out.
 	ErrRDDModeRepositoryForcedOn = errors.New("clone-local review mode override may only disable")
 
+	// ErrRDDModeRedundantWrite reports that a clone-local write would resolve
+	// to the mode already in force, so the transaction layer refused to
+	// advance revision (issue #2231). The persisted record would be
+	// byte-identical except for its timestamp -- the exact shape of "the
+	// write cannot take effect but the tool reports success".
+	//
+	// refusal:by-design human-authority: a sentinel, not a user-facing message. Callers wrap it with the deciding scope and the exact `gentle-ai review mode enable` invocation; the override is off-only, so the only scope that can move the decision is the one that already decided it.
+	ErrRDDModeRedundantWrite = errors.New("clone-local review mode write would not change the effective mode")
+
 	// ErrRDDConsentCorrupt reports an unreadable one-shot consent latch.
 	ErrRDDConsentCorrupt = errors.New("clone-local review consent latch is corrupt")
 
@@ -222,6 +231,41 @@ func reviewModeScopeForSource(source RDDModeSource) string {
 
 func (err *RDDDisabledError) Unwrap() error { return ErrRDDDisabled }
 
+// RDDModeRedundantWriteError is the typed non-success returned when a
+// clone-local write would resolve to the mode already in force. The
+// transaction layer refuses to publish a new generation and refuses to
+// advance revision (issue #2231). The override is off-only: when the
+// deciding source already says what the override would say, the write is
+// a no-op, and the operator has reached the only runnable way forward:
+// change the deciding source itself, not the override that already mirrors it.
+type RDDModeRedundantWriteError struct {
+	Status RDDModeStatus
+	Source RDDModeSource
+}
+
+func (err *RDDModeRedundantWriteError) Unwrap() error { return ErrRDDModeRedundantWrite }
+
+// Error names the runnable continuation: the deciding scope and the exact
+// `gentle-ai review mode enable --scope=<scope>` invocation that could move
+// the decision. When the deciding source is the default, naming a scope
+// would invent a continuation for a state that cannot occur -- mirroring
+// the same guard RDDDisabledError.Error() uses, so the two refusal
+// envelopes cannot drift.
+func (err *RDDModeRedundantWriteError) Error() string {
+	message := fmt.Sprintf(
+		"%v: the %s mode source already says %s, so re-recording the clone-local override changes nothing",
+		ErrRDDModeRedundantWrite, err.Source, err.Status.Effective,
+	)
+	scope := reviewModeScopeForSource(err.Source)
+	if scope == "" {
+		return message + "; no command can change what the default already decided"
+	}
+	return fmt.Sprintf(
+		"%s; change the deciding source with `gentle-ai review mode enable --scope=%s`",
+		message, scope,
+	)
+}
+
 // ResolveRDDMode combines the global user mode with this clone's off-only
 // override. Any off wins, a repository can never force on, and every failure
 // projects a disabled status so a caller that drops the error still fails safe.
@@ -299,6 +343,23 @@ func SetCloneLocalRDDMode(
 	}
 	if head.Generation >= rddModeMaxGeneration {
 		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), errors.New("clone-local review mode generation space is exhausted")
+	}
+	// Issue #2231: a clone-local write whose persisted mode equals the
+	// current head mode would resolve to state already in force. Every
+	// record carries a fresh timestamp, so its SHA differs from the head
+	// and the no-replace publish would not refuse it -- the caller would
+	// receive a success-shaped envelope for a write that cannot take
+	// effect. The override is off-only, so same persisted value, same
+	// effective mode, same deciding source is the only shape that cannot
+	// be a legitimate change. Any other shape (clearing, force-on, CAS
+	// mismatch, corrupt-head repair) falls through to the ordinary record.
+	if present && head.Mode == persisted {
+		globalMode, globalErr := normalizeRDDMode(global.Value)
+		if globalErr != nil {
+			return failedClosedRDDModeStatus(RDDModeSourceGlobal), globalErr
+		}
+		status := rddModeStatus(globalMode, head, true)
+		return status, &RDDModeRedundantWriteError{Status: status, Source: status.Source}
 	}
 
 	record := rddModeOverrideRecord{

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -385,6 +385,118 @@ func TestUnknownRDDModeFailsClosedAsDisabled(t *testing.T) {
 	}
 }
 
+// TestSetCloneLocalRDDModeRedundantEnableWriteDoesNotAdvanceGeneration is
+// the transaction-level proof of issue #2231: with global=off and no
+// clone-local opinion, re-recording "inherit" must refuse as a no-op and
+// must not advance revision or append a generation. The no-op guard lives
+// here so every caller of SetCloneLocalRDDMode inherits the property.
+func TestSetCloneLocalRDDModeRedundantEnableWriteDoesNotAdvanceGeneration(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "off"}
+
+	first, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, "", global)
+	if err != nil {
+		t.Fatalf("first SetCloneLocalRDDMode(enable -> inherit) error = %v", err)
+	}
+	if first.Revision == "" {
+		t.Fatalf("first enable produced no revision: %#v", first)
+	}
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	beforeCount := rddModeGenerationCount(t, dir)
+	if beforeCount != 1 {
+		t.Fatalf("first enable produced %d generations, want 1", beforeCount)
+	}
+
+	second, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, first.Revision, global)
+	if err == nil {
+		t.Fatalf("redundant enable returned success instead of a typed non-success: %#v", second)
+	}
+	var redundant *RDDModeRedundantWriteError
+	if !errors.As(err, &redundant) {
+		t.Fatalf("redundant enable error = %v, want *RDDModeRedundantWriteError", err)
+	}
+	if redundant.Status.Effective != first.Effective || redundant.Status.Source != RDDModeSourceGlobal {
+		t.Fatalf("redundant write status = %#v, want %q decided by global",
+			redundant.Status, first.Effective)
+	}
+	if redundant.Status.Revision != first.Revision {
+		t.Fatalf("redundant write changed revision: before=%q after=%q",
+			first.Revision, redundant.Status.Revision)
+	}
+	if afterCount := rddModeGenerationCount(t, dir); afterCount != beforeCount {
+		t.Fatalf("redundant write advanced generation count: before=%d after=%d", beforeCount, afterCount)
+	}
+}
+
+// TestSetCloneLocalRDDModeRedundantDisableWriteDoesNotAdvanceGeneration pins
+// the symmetric property: disabling an already-disabled clone-local override
+// must also refuse as a no-op, and the fix must not regress the legitimate
+// disable path -- a fresh disable, or a clearing from inherit to off, still
+// publishes a generation.
+func TestSetCloneLocalRDDModeRedundantDisableWriteDoesNotAdvanceGeneration(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	ctx := context.Background()
+	global := RDDGlobalMode{Value: "on"}
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("first SetCloneLocalRDDMode(disable) error = %v", err)
+	}
+	if disabled.Effective != RDDModeOff || disabled.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("first disable did not take effect: %#v", disabled)
+	}
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if count := rddModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("first disable produced %d generations, want 1", count)
+	}
+
+	second, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, disabled.Revision, global)
+	if err == nil {
+		t.Fatalf("redundant disable returned success instead of a typed non-success: %#v", second)
+	}
+	var redundant *RDDModeRedundantWriteError
+	if !errors.As(err, &redundant) {
+		t.Fatalf("redundant disable error = %v, want *RDDModeRedundantWriteError", err)
+	}
+	if redundant.Status.Revision != disabled.Revision {
+		t.Fatalf("redundant disable changed revision: before=%q after=%q",
+			disabled.Revision, redundant.Status.Revision)
+	}
+	if count := rddModeGenerationCount(t, dir); count != 1 {
+		t.Fatalf("redundant disable advanced generation count: now=%d, want 1", count)
+	}
+
+	cleared, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, disabled.Revision, global)
+	if err != nil {
+		t.Fatalf("cleared override error = %v", err)
+	}
+	if cleared.Revision == disabled.Revision || cleared.Effective != RDDModeOn {
+		t.Fatalf("clearing the override did not advance revision or re-enable: %#v", cleared)
+	}
+	if count := rddModeGenerationCount(t, dir); count != 2 {
+		t.Fatalf("clearing advanced generation count = %d, want 2", count)
+	}
+}
+
+// rddModeGenerationCount counts the gen-NNNNNNNNNN.json files under the
+// clone-local RDD mode directory. The consent latch (asked.json) and lock
+// (LOCK) are excluded by the same generation name pattern the read head uses.
+func rddModeGenerationCount(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read rdd-mode directory: %v", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if _, ok := rddModeGenerationOf(entry.Name()); ok {
+			count++
+		}
+	}
+	return count
+}
+
 func TestRDDDeliveryDispositionNeverFabricatesApproval(t *testing.T) {
 	disabled := RDDModeStatus{Effective: RDDModeOff}
 	if got := RDDDeliveryDisposition(disabled, false); got != RDDDeliveryDisabledUnmanaged {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2231

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

> Contributors cannot apply labels (`gh pr edit --add-label` returns 403 `AddLabelsToLabelable`). Maintainer please apply `type:bug` after opening this PR.

---

## 📝 Summary

`gentle-ai review mode enable --scope clone` previously reported success for a write that could never change the effective mode (when global is `off` and `clone_local` is unset), advanced `revision`, and appended a fresh `gen-NNNNNNNNNN.json` to the clone authority store on every invocation. The status body and the response envelope were indistinguishable from a write that actually landed, so an operator had no way to tell that the request was a no-op.

This PR adds a typed-non-success guard inside `SetCloneLocalRDDMode` (transaction layer, so every caller inherits the property). When the persisted head is present AND already carries the same mode as the request, the write is refused with exit code 1, a refusal message naming the deciding source, and `revision` is NOT advanced. The first invocation (no head, or head with a different mode) still falls through to the ordinary generation record path — `enable --scope clone` continues to clear the clone-local override when global permits. The symmetric `disable --scope clone` case is covered by the same guard.

Three cross-platform reproductions (gtrafael, NicolasIppoliti, jemanuelpo on the issue thread) confirm the bug independently of the reporter; the fix covers all three because they all hit the same code path.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/rdd_mode.go` | +61 / -0 — Added `ErrRDDModeNoOpWrite` typed sentinel with `Error()` method, and the `present && head.Mode == persisted` guard inside `SetCloneLocalRDDMode`. Doc comments on every new exported symbol. |
| `internal/reviewtransaction/rdd_mode_test.go` | +112 / -0 — Two transaction-layer tests: redundant `enable` and redundant `disable` clone-local writes do not advance generation; temp Git repo + real `Store`. |
| `internal/cli/review_mode_test.go` | +166 / -0 — Three CLI-level tests: no-op when decided globally (with and without `--expected-revision`), still writes when global is `on` (anti-drift for legitimate clearing), symmetric disable no-op. |

**Total: +339 / -0 across 3 files** (under the 400-line review budget).

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -timeout 60s ./internal/reviewtransaction/... ./internal/cli/...
```
Result on this branch: all new tests pass; all prior `TestRDD*` tests in `reviewtransaction` and prior `TestReviewMode*` / `TestUnreadable*` / `TestDisabledReview*` in CLI still pass.

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Result: silent (clean).

**Build**
```bash
go build -o gga.exe ./cmd/gentle-ai
```
Result: clean.

**Go Vet**
```bash
go vet ./internal/cli/... ./internal/reviewtransaction/...
```
Result: clean.

**Manual Real-Binary E2E** — pre-seeded `~/.gentle-ai/state.json` with global `off`, against a temp Git repo:
- 1st `gga.exe review mode enable --cwd <repo> --scope clone --json` → exit 0, writes `gen-0000000001.json` (legitimate clearing of clone-local opinion).
- 2nd `gga.exe review mode enable --cwd <repo> --scope clone --json` → exit 1, refusal message naming `--scope=global`, gen count stays at 1.
- 3rd `gga.exe review mode enable --cwd <repo> --scope clone --expected-revision <rev> --json` → exit 1, same refusal, gen count stays at 1.
- 4th `gga.exe review mode disable --cwd <repo> --scope clone --json` → exit 0 (legitimate `inherit → off` change), writes `gen-0000000002.json`.
- 5th `gga.exe review mode disable --cwd <repo> --scope clone --json` → exit 1, refusal message naming `--scope=clone`, gen count stays at 2.

(Reproduction is included here rather than as a unit test because the `go build` inside `t.TempDir()` invokes the Go module cache, which creates read-only files under shared `/tmp` on Linux CI runners and breaks `t.TempDir()` cleanup with `permission denied` errors unrelated to the fix. The handler-level tests in `TestReviewModeEnableCloneIsNoOpWhenDecidedGlobally` etc. exercise the same code paths in-process and run deterministically in CI.)

**Docker E2E (`e2e/organicruntime/`)** — NOT run. Docker is unavailable on this Windows runner. The two existing `enableReview()` callers in `e2e/organicruntime/organic_runtime_test.go` (lines 928, 1090) hit the legitimate-clearing path (`global=on`, `clone_local=off → writes inherit`), which is unaffected by this fix and is verified at the CLI layer by `TestReviewModeEnableCloneStillWritesWhenGlobalIsOn`. Maintainer can re-run with Docker before merge.

**Benchmark validation** — N/A. This change does not touch `bench/` and does not affect bench journeys that exercise the `enable --scope clone` path (the legitimate-clearing journey still produces one record per call, which is correct).

**Pre-existing Windows test flakiness (NOT introduced by this PR)** — two tests are flaky on the Windows CI lane:
- `TestStartOverInvalidGraphRefusalNamesSanctionedExit`
- `TestReviewStartIsRejectedWhileTheKillSwitchIsOff`

Both fail with `EvalSymlinks` subprocess hangs to git. Verified pre-existing by `git stash`-ing this branch and re-running on `origin/main` at `14d8e258` — same hang. The fix touches neither their setup nor their assertions. This PR's own tests do not exercise `EvalSymlinks` and run deterministically on Windows.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ pending | `+339 -0` across 3 files, under the 400-line budget. |
| Check Issue Reference | ⏳ pending | Body contains `Closes #2231`. |
| Check Issue Has `status:approved` | ⏳ pending | Issue #2231 was `status:approved` at branch time. |
| Check PR Has `type:*` Label | ⏳ pending | Contributors cannot apply labels — see Pending maintainer actions. |
| Unit Tests | ⏳ pending | `go test ./...` must pass. |
| Go Format | ⏳ pending | `go run ./internal/gofmtcheck` silent on this branch. |
| E2E Tests | ⏳ pending | Docker-based; see Test Plan for status. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#2231)
- [x] PR stays within 400 changed lines (+339 / -0 across 3 files)
- [ ] I have added the appropriate `type:*` label to this PR *(contributor cannot apply labels — see Pending maintainer actions)*
- [x] Unit tests pass on this branch (`go test ./internal/cli/... ./internal/reviewtransaction/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) *(Docker unavailable on this runner — see Test Plan)*
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (`N/A` — see Test Plan)
- [x] I have updated documentation if necessary *(doc comments added on all new exported symbols; no public docs to update)*
- [x] My commits follow Conventional Commits format (`fix(review): refuse no-op clone-local mode writes`)
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This PR modifies `internal/reviewtransaction` (`SetCloneLocalRDDMode`), so the maintainer-side guard checklist applies:

- **Qualifying guard identified**: yes — the new `present && head.Mode == persisted` guard inside `SetCloneLocalRDDMode` is an admission guard for the receipt authority write path. The guard's legitimate input population is the request's intent (the requested `mode` arg) plus the persisted clone-local head's current `mode` (read from the clone authority store under `<git-common-dir>/gentle-ai/review-transactions/rar-authorities/v1/rdd-mode/`). The check is sound because the persisted head is content-addressed and the request's `mode` is the only mutable input the guard depends on — there is no third source.
- **Population direction confirmed**: the guard refuses ONLY when the request's mode equals the head's mode AND a head exists; any other condition (no head, corrupt head, CAS mismatch, head with a different mode, force-on attempt) falls through to the existing `Store.append()` validation and successor logic, which is unchanged. The anti-drift test `TestReviewModeEnableCloneStillWritesWhenGlobalIsOn` proves the legitimate-clearing path is preserved.
- **Real-world evidence**: the reproduction in the issue body was observed on macOS arm64 (Gentle AI 2.2.4, Claude Code), Linux/WSL2 x86_64 (Gentle AI 2.2.4, OpenCode), macOS 25.4.0 (Gentle AI 2.2.4, Claude Code), and Linux x86_64 (Gentle AI 2.3.0-rc.1, OpenCode). The manual real-binary E2E on this branch (`gga.exe` against a temp Git repo with pre-seeded global `off`) reproduces and proves the fix in the same shape: 1st call writes one record, 2nd refuses with exit 1, gen count does not advance.
- **`.guard-population-baseline.txt`**: this PR INTENTIONALLY changes the guard contract — previously any `enable --scope clone` would always write a generation record; now it refuses when the head already carries the requested mode. The baseline for this guard SHOULD change as part of this PR; if it does not, that is itself a regression signal.

---

## Pending maintainer actions

- Apply `type:bug` label (contributor cannot apply labels — `gh pr edit --add-label` returns 403 `AddLabelsToLabelable`).
- Optionally update `.guard-population-baseline.txt` to reflect the new admission guard contract.
- Optionally re-run `cd e2e && ./docker-test.sh` on a Linux/macOS runner before merge to confirm the no-op behavior in the Docker E2E suite.
- Optionally re-run the manual real-binary E2E (steps in Test Plan) on a Linux/macOS runner to confirm the cross-platform behavior described above.