### PR TITLE
refactor(review): purify snapshot identity to content-addressed form

### DIFF
--- a/contracts/review-integration/v1/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v1/fixtures/consent.fixture.json
@@ -4,7 +4,7 @@
   "operation": "review.start",
   "action": "consent_required",
   "blocking": true,
-  "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b",
+  "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04",
   "projection": "workspace",
   "risk_level": "high",
   "changed_files": 1,
@@ -20,13 +20,13 @@
       "answer": "granted",
       "label": "Run the review now",
       "effect": "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again.",
-      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v1 --cwd /repo --target sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b --projection workspace --lineage review-consent-fixture --consent granted"
+      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v1 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent granted"
     },
     {
       "answer": "declined",
       "label": "Not now, just this once",
       "effect": "Skips the review for this candidate only; nothing is persisted and the next candidate is asked again. This is not the kill switch.",
-      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v1 --cwd /repo --target sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b --projection workspace --lineage review-consent-fixture --consent declined"
+      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v1 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent declined"
     }
   ],
   "off_path": {

--- a/contracts/review-integration/v1/fixtures/start-v2.fixture.json
+++ b/contracts/review-integration/v1/fixtures/start-v2.fixture.json
@@ -27,10 +27,10 @@
   "artifact_subjects": [
     {
       "schema": "gentle-ai.review-artifact-subject/v1",
-      "subject_hash": "sha256:ac757ec4df5376b6d5b28a15672e6b98e44c22699b8804a29840293dc6a5e447",
+      "subject_hash": "sha256:462591bc0cfab672cdf741536c5f1d8122a1f31b1773b9f1d12c5f2b72c76d23",
       "lineage_id": "review-start-fixture",
-      "authority_revision": "sha256:6a7b523b3aa544078586ec8a249dcde4d0c7a7eca1e025e4f25268abeb6d19e9",
-      "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b",
+      "authority_revision": "sha256:e10bced7198e3c817c5ff6d1172d6aa8ce3321d45ec4d68834e0b5f03a4246d9",
+      "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04",
       "candidate_diff_sha256": "sha256:c18ffcaf6f41a8cd5f3399a10355eb8de3e5eb561cb65cb551ea93bdf4df921b",
       "changed_path_manifest_sha256": "sha256:dc754e73f2d661e2f914fdc5dd8d2a399be18567481137f43ae9d8d45aae3397",
       "lens": "review-risk",
@@ -38,10 +38,10 @@
     },
     {
       "schema": "gentle-ai.review-artifact-subject/v1",
-      "subject_hash": "sha256:8f414f2d456c8fd53f442b759426143dca04f4d45c26deeb3223b67e5fa56df0",
+      "subject_hash": "sha256:6374e313d6524b832afa399bdd205d4e852e1a19ea8d87000804789df6117e3b",
       "lineage_id": "review-start-fixture",
-      "authority_revision": "sha256:6a7b523b3aa544078586ec8a249dcde4d0c7a7eca1e025e4f25268abeb6d19e9",
-      "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b",
+      "authority_revision": "sha256:e10bced7198e3c817c5ff6d1172d6aa8ce3321d45ec4d68834e0b5f03a4246d9",
+      "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04",
       "candidate_diff_sha256": "sha256:c18ffcaf6f41a8cd5f3399a10355eb8de3e5eb561cb65cb551ea93bdf4df921b",
       "changed_path_manifest_sha256": "sha256:dc754e73f2d661e2f914fdc5dd8d2a399be18567481137f43ae9d8d45aae3397",
       "lens": "review-resilience",
@@ -49,10 +49,10 @@
     },
     {
       "schema": "gentle-ai.review-artifact-subject/v1",
-      "subject_hash": "sha256:33b45eec49608043e6d1135fbbc57f602646ee22379fd6cc340d9323d4294f53",
+      "subject_hash": "sha256:56924c7ad539c596fd584905c9be7a82765e551154375a8022fb1e820bc2f61a",
       "lineage_id": "review-start-fixture",
-      "authority_revision": "sha256:6a7b523b3aa544078586ec8a249dcde4d0c7a7eca1e025e4f25268abeb6d19e9",
-      "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b",
+      "authority_revision": "sha256:e10bced7198e3c817c5ff6d1172d6aa8ce3321d45ec4d68834e0b5f03a4246d9",
+      "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04",
       "candidate_diff_sha256": "sha256:c18ffcaf6f41a8cd5f3399a10355eb8de3e5eb561cb65cb551ea93bdf4df921b",
       "changed_path_manifest_sha256": "sha256:dc754e73f2d661e2f914fdc5dd8d2a399be18567481137f43ae9d8d45aae3397",
       "lens": "review-readability",
@@ -60,10 +60,10 @@
     },
     {
       "schema": "gentle-ai.review-artifact-subject/v1",
-      "subject_hash": "sha256:5a1c35c5ca9bec1aa6802bcbd0e48039ce1daf25dde665a0b96e4c8dcf166513",
+      "subject_hash": "sha256:0e15bc61702fd815c7140592e02d752143a0ac10a5fd59b4f8e8a8c0e8ea103b",
       "lineage_id": "review-start-fixture",
-      "authority_revision": "sha256:6a7b523b3aa544078586ec8a249dcde4d0c7a7eca1e025e4f25268abeb6d19e9",
-      "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b",
+      "authority_revision": "sha256:e10bced7198e3c817c5ff6d1172d6aa8ce3321d45ec4d68834e0b5f03a4246d9",
+      "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04",
       "candidate_diff_sha256": "sha256:c18ffcaf6f41a8cd5f3399a10355eb8de3e5eb561cb65cb551ea93bdf4df921b",
       "changed_path_manifest_sha256": "sha256:dc754e73f2d661e2f914fdc5dd8d2a399be18567481137f43ae9d8d45aae3397",
       "lens": "review-reliability",
@@ -91,7 +91,7 @@
   "repository_context": {
     "capability": "review.opaque_repository_context",
     "handle": "rctx1_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "revision": "sha256:6a7b523b3aa544078586ec8a249dcde4d0c7a7eca1e025e4f25268abeb6d19e9",
-    "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b"
+    "revision": "sha256:e10bced7198e3c817c5ff6d1172d6aa8ce3321d45ec4d68834e0b5f03a4246d9",
+    "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04"
   }
 }

--- a/contracts/review-integration/v1/fixtures/status-v2.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status-v2.fixture.json
@@ -8,7 +8,7 @@
     "lineage_id": "review-status-fixture",
     "state": "reviewing",
     "generation": 1,
-    "revision": "sha256:81cdad8f3182d4919147d3c4fe8f614814068e5ef68417e3dcbd5e326dd3e390"
+    "revision": "sha256:c978e5383ae788a963c5e80c4f887d3b65ca415767398d57de827a9f0905f423"
   },
   "receipt": {
     "status": "expected_missing"
@@ -20,7 +20,7 @@
     "original_changed_lines": 2,
     "correction_budget": 1
   },
-  "target_identity": "sha256:e6faad1cb9ceb2db170e0ec9ea5394b44c3991dff6cbd02fb6787539715968f6",
+  "target_identity": "sha256:00c0d796b4136e365d0130886f300c954ecf9431c45d96d8031155c415507d49",
   "projection": {
     "schema": "gentle-ai.review-integration.projection/v1",
     "kind": "current-changes",
@@ -34,8 +34,8 @@
     ],
     "intended_untracked": [],
     "intended_untracked_proof": "sha256:b97229718d4c7fe50a8892eb474ae5aa6491697bccb400e3e31dbaca4894d2f3",
-    "initial_snapshot_identity": "sha256:e6faad1cb9ceb2db170e0ec9ea5394b44c3991dff6cbd02fb6787539715968f6",
-    "current_snapshot_identity": "sha256:e6faad1cb9ceb2db170e0ec9ea5394b44c3991dff6cbd02fb6787539715968f6"
+    "initial_snapshot_identity": "sha256:00c0d796b4136e365d0130886f300c954ecf9431c45d96d8031155c415507d49",
+    "current_snapshot_identity": "sha256:00c0d796b4136e365d0130886f300c954ecf9431c45d96d8031155c415507d49"
   },
   "repair": {
     "schema": "gentle-ai.review-authority-repair-assessment/v1",
@@ -133,13 +133,13 @@
             },
             {
               "name": "expected-revision",
-              "value": "sha256:81cdad8f3182d4919147d3c4fe8f614814068e5ef68417e3dcbd5e326dd3e390",
-              "token": "--expected-revision=sha256:81cdad8f3182d4919147d3c4fe8f614814068e5ef68417e3dcbd5e326dd3e390"
+              "value": "sha256:c978e5383ae788a963c5e80c4f887d3b65ca415767398d57de827a9f0905f423",
+              "token": "--expected-revision=sha256:c978e5383ae788a963c5e80c4f887d3b65ca415767398d57de827a9f0905f423"
             },
             {
               "name": "target",
-              "value": "sha256:e6faad1cb9ceb2db170e0ec9ea5394b44c3991dff6cbd02fb6787539715968f6",
-              "token": "--target=sha256:e6faad1cb9ceb2db170e0ec9ea5394b44c3991dff6cbd02fb6787539715968f6"
+              "value": "sha256:00c0d796b4136e365d0130886f300c954ecf9431c45d96d8031155c415507d49",
+              "token": "--target=sha256:00c0d796b4136e365d0130886f300c954ecf9431c45d96d8031155c415507d49"
             },
             {
               "name": "repository-context",
@@ -159,10 +159,10 @@
           ],
           "artifact_subject": {
             "schema": "gentle-ai.review-artifact-subject/v1",
-            "subject_hash": "sha256:fe57db2ea45a33c7e852d039e8af3291c3bc31911f0c92a710b5fef547b1999d",
+            "subject_hash": "sha256:d8f46ff5cdcd86385033ce73f18cbfd61651c81deba1340b743e034cdf9dce48",
             "lineage_id": "review-status-fixture",
-            "authority_revision": "sha256:81cdad8f3182d4919147d3c4fe8f614814068e5ef68417e3dcbd5e326dd3e390",
-            "target_identity": "sha256:e6faad1cb9ceb2db170e0ec9ea5394b44c3991dff6cbd02fb6787539715968f6",
+            "authority_revision": "sha256:c978e5383ae788a963c5e80c4f887d3b65ca415767398d57de827a9f0905f423",
+            "target_identity": "sha256:00c0d796b4136e365d0130886f300c954ecf9431c45d96d8031155c415507d49",
             "candidate_diff_sha256": "sha256:8ed4bd24d5beb3f73f6026355f6755f5aef7feebcd76447be820860c22bc47c6",
             "changed_path_manifest_sha256": "sha256:64d028ff676fb4ef10f2d4a3488d568854b364b4cc4399578b5932d144d2347b",
             "lens": "review-reliability",

--- a/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
@@ -5,7 +5,7 @@
   "action": "consent_required",
   "agent": "claude-code",
   "blocking": true,
-  "target_identity": "sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b",
+  "target_identity": "sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04",
   "projection": "workspace",
   "risk_level": "high",
   "changed_files": 1,
@@ -21,13 +21,13 @@
       "answer": "granted",
       "label": "Run the review now",
       "effect": "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again.",
-      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b --projection workspace --lineage review-consent-fixture --consent granted"
+      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent granted"
     },
     {
       "answer": "declined",
       "label": "Not now, just this once",
       "effect": "Skips the review for this exact candidate only; no review lineage or receipt is created, and ordinary delivery is unmanaged by candidate choice. The next candidate is asked again. This is not the kill switch.",
-      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:ddc783ecb013d1610c3f35fb7f8655051669a762ea9fd04af55999763a57496b --projection workspace --lineage review-consent-fixture --consent declined"
+      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent declined"
     }
   ],
   "off_path": {

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -17,21 +17,24 @@ func TestReviewProviderArtifactV1ContractsArePinned(t *testing.T) {
 	want := map[string]string{
 		"fixtures/capabilities-v1.4.fixture.json": "84e0db457b76b97b35c2be772dfc647f9eab66810ea98f64fed85645c3c266ba",
 		"fixtures/start.fixture.json":             "f369160ac26eb3427b57de2dd01c9d8c81e51c8a2bd546446780129d31b1945b",
-		"fixtures/start-v2.fixture.json":          "688614bccff748975d5d9b3cce3c7f771cf3920e3cfd2d37fff61a5240f0364a",
-		"fixtures/status.fixture.json":            "555054d8046a896162995dcb117752f9cd1ef903fb9ebaad29af1b7e7f319bb3",
-		"fixtures/status-v2.fixture.json":         "5410d8bbae1b7152a43b3a5c4c880e9e98a5e47b76d910456f5ef13f19836f3a",
-		"fixtures/status-ambiguous.fixture.json":  "ee695fd58ba72adfb3b51dfd16432a177498173a45bfcb594d6bdc53bfa32e6e",
-		"fixtures/status-corrupted.fixture.json":  "4cfc0048c28a39cec8a32fecfaad66e56e5c1248263ceb4ce66b6717981880b2",
-		"fixtures/status-recover.fixture.json":    "714f762f72380ce93d567626cafbaa536ab3aae02af73d3d40ca123f1f30d8b0",
-		"fixtures/status-unrelated.fixture.json":  "deab36c877ced3c9b480ca33724c10d88f75c761d6426fa14be850345122891d",
-		"schemas/admitted-result.schema.json":     "7796e8dbba331434594108c902dfab7ec46f691fa447a9259a78f2448111b0de",
-		"schemas/artifact-subject.schema.json":    "f7dcd934e27e8f3735a37f3d0ec8048dd8ccc1811b9df61124a1dcbf8a03f40e",
-		"schemas/capabilities-v1.4.schema.json":   "926b61c8ac0f870f09214f6bd8af1b035c5b72f14f0b83c0d4a7bdbb277f5447",
-		"schemas/result-artifact.schema.json":     "91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6",
-		"schemas/start.schema.json":               "4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229",
-		"schemas/start-v2.schema.json":            "ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c",
-		"schemas/status.schema.json":              "250d2c646b8822b38eaefafd2bfdefa1134cc23a00e553a7201f33257573149a",
-		"schemas/status-v2.schema.json":           "dd9914b647a1d9edc4ecdcbed4f0c800b39ec290912d5c2a4cc6ba3098d5f21e",
+		// issue #2659: start-v2/status-v2 embed a freshly minted target_identity,
+		// and the purified identity domain legitimately changed that hash for
+		// every new snapshot. Deliberate, not drift.
+		"fixtures/start-v2.fixture.json":         "cc229f42781add54a86d904e913bb72e1373f04e7520a28fb3d245674bf703b5",
+		"fixtures/status.fixture.json":           "555054d8046a896162995dcb117752f9cd1ef903fb9ebaad29af1b7e7f319bb3",
+		"fixtures/status-v2.fixture.json":        "d0dbcddc5bf8947de314f3a9e938b094627b0f01ab3bfaa10a79b3b27fda7a76",
+		"fixtures/status-ambiguous.fixture.json": "ee695fd58ba72adfb3b51dfd16432a177498173a45bfcb594d6bdc53bfa32e6e",
+		"fixtures/status-corrupted.fixture.json": "4cfc0048c28a39cec8a32fecfaad66e56e5c1248263ceb4ce66b6717981880b2",
+		"fixtures/status-recover.fixture.json":   "714f762f72380ce93d567626cafbaa536ab3aae02af73d3d40ca123f1f30d8b0",
+		"fixtures/status-unrelated.fixture.json": "deab36c877ced3c9b480ca33724c10d88f75c761d6426fa14be850345122891d",
+		"schemas/admitted-result.schema.json":    "7796e8dbba331434594108c902dfab7ec46f691fa447a9259a78f2448111b0de",
+		"schemas/artifact-subject.schema.json":   "f7dcd934e27e8f3735a37f3d0ec8048dd8ccc1811b9df61124a1dcbf8a03f40e",
+		"schemas/capabilities-v1.4.schema.json":  "926b61c8ac0f870f09214f6bd8af1b035c5b72f14f0b83c0d4a7bdbb277f5447",
+		"schemas/result-artifact.schema.json":    "91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6",
+		"schemas/start.schema.json":              "4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229",
+		"schemas/start-v2.schema.json":           "ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c",
+		"schemas/status.schema.json":             "250d2c646b8822b38eaefafd2bfdefa1134cc23a00e553a7201f33257573149a",
+		"schemas/status-v2.schema.json":          "dd9914b647a1d9edc4ecdcbed4f0c800b39ec290912d5c2a4cc6ba3098d5f21e",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -71,10 +74,13 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/capabilities-v2.1.fixture.json": "4bbcbaed1b20e6ea8f9c615f35ff17b13ee69b4648784a4906191880751c668d",
-		"fixtures/consent-v3.fixture.json":        "aeac956b9800023449e0a9f78457425429c61813205f05501ef091638441d660",
-		"schemas/capabilities-v2.1.schema.json":   "9ede8ebbe3e169cf6ca4f4a6882c9c4e588a6d1073d8e22a155649cd41d38cd0",
-		"schemas/consent-v3.schema.json":          "80915f5f4f43a494826253d1e7251fc463989f41d2cf163a6a52a8b4328c023c",
-		"schemas/status.schema.json":              "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+		// issue #2659: consent-v3 embeds a freshly minted target_identity;
+		// the purified identity domain legitimately changed that hash.
+		// Deliberate, not drift.
+		"fixtures/consent-v3.fixture.json":      "feb1dc7705f7da6490698ef48021bb7730de154ae23ec73d033d8d96fa996a21",
+		"schemas/capabilities-v2.1.schema.json": "9ede8ebbe3e169cf6ca4f4a6882c9c4e588a6d1073d8e22a155649cd41d38cd0",
+		"schemas/consent-v3.schema.json":        "80915f5f4f43a494826253d1e7251fc463989f41d2cf163a6a52a8b4328c023c",
+		"schemas/status.schema.json":            "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))

--- a/internal/cli/testdata/byte_equivalence_commit_a/start.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/start.golden.json
@@ -6,7 +6,7 @@
   "selected_lenses": [],
   "correction_budget": 1,
   "changed_lines": 1,
-  "target_identity": "sha256:e3db7d34191519edd300559da8fb0bdb96f820aa6788f1b60589c690d3f95d7c",
+  "target_identity": "sha256:a6fa193a8ffe0c3a805dc689508d4afc211f9765b172bd92ab5c24d4049c1c5d",
   "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
   "candidate_tree": "dda629df9960312d5fa455c0757f92502d06fcbc"
 }

--- a/internal/cli/testdata/byte_equivalence_commit_a/status.golden.json
+++ b/internal/cli/testdata/byte_equivalence_commit_a/status.golden.json
@@ -8,7 +8,7 @@
   },
   "action": "start",
   "replayability": "not_replayable",
-  "target_identity": "sha256:e3db7d34191519edd300559da8fb0bdb96f820aa6788f1b60589c690d3f95d7c",
+  "target_identity": "sha256:a6fa193a8ffe0c3a805dc689508d4afc211f9765b172bd92ab5c24d4049c1c5d",
   "projection": {
     "schema": "gentle-ai.review-integration.projection/v1",
     "kind": "current-changes",
@@ -22,8 +22,8 @@
     ],
     "intended_untracked": [],
     "intended_untracked_proof": "sha256:b97229718d4c7fe50a8892eb474ae5aa6491697bccb400e3e31dbaca4894d2f3",
-    "initial_snapshot_identity": "sha256:e3db7d34191519edd300559da8fb0bdb96f820aa6788f1b60589c690d3f95d7c",
-    "current_snapshot_identity": "sha256:e3db7d34191519edd300559da8fb0bdb96f820aa6788f1b60589c690d3f95d7c"
+    "initial_snapshot_identity": "sha256:a6fa193a8ffe0c3a805dc689508d4afc211f9765b172bd92ab5c24d4049c1c5d",
+    "current_snapshot_identity": "sha256:a6fa193a8ffe0c3a805dc689508d4afc211f9765b172bd92ab5c24d4049c1c5d"
   },
   "repair": {
     "schema": "gentle-ai.review-authority-repair-assessment/v1",

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1431,23 +1431,36 @@ func snapshotIdentity(kind TargetKind, baseTree, candidateTree, pathsDigest, pro
 	return snapshotIdentityForProjection(kind, "", baseTree, candidateTree, pathsDigest, proof, intended, ledgerIDs)
 }
 
+// snapshotIdentityForProjection mints the purified, content-addressed
+// identity domain (issue #2659, root 21 of #2471): a domain-separation tag
+// for kind/projection, then baseTree, candidateTree, pathsDigest, and
+// ledgerIDs. proof and intended are deliberately NOT part of this hash: they
+// describe HOW the candidate bytes were declared (a staged path vs. a
+// declared intended-untracked path), not WHAT those bytes are, so folding
+// them into identity let two byte-identical candidates carry different
+// identities. Maintainer decision D1 (recorded in #2471) keeps the
+// untracked-replay proof alive as SIDE-BAND evidence only -- still consumed
+// by BuildStagedWorkspaceOverlayRecovery and BuildCorrectedCandidate for
+// replay validation -- so the parameters stay for call-site compatibility
+// but are intentionally unused here.
+//
+// kind and projection stay in the hash domain on purpose: they are the
+// load-bearing separation that keeps a current-changes receipt from being
+// recognized as a base-workspace-overlay review of identical bytes.
 func snapshotIdentityForProjection(kind TargetKind, projection Projection, baseTree, candidateTree, pathsDigest, proof string, intended, ledgerIDs []string) string {
 	hash := sha256.New()
 	if kind == TargetBaseWorkspaceOverlay {
-		hash.Write([]byte("gentle-ai.review-snapshot/base-workspace-overlay/v1\x00"))
+		hash.Write([]byte("gentle-ai.review-snapshot/base-workspace-overlay/v2\x00"))
 	} else if projection == ProjectionStaged {
-		hash.Write([]byte("gentle-ai.review-snapshot/v2\x00"))
+		hash.Write([]byte("gentle-ai.review-snapshot/v4\x00"))
 	} else {
-		hash.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
+		hash.Write([]byte("gentle-ai.review-snapshot/v3\x00"))
 	}
-	values := []string{string(kind), baseTree, candidateTree, pathsDigest, proof}
+	values := []string{string(kind), baseTree, candidateTree, pathsDigest}
 	if projection == ProjectionStaged {
-		values = []string{string(kind), string(projection), baseTree, candidateTree, pathsDigest, proof}
+		values = []string{string(kind), string(projection), baseTree, candidateTree, pathsDigest}
 	}
 	for _, value := range values {
-		writeLengthPrefixed(hash, []byte(value))
-	}
-	for _, value := range intended {
 		writeLengthPrefixed(hash, []byte(value))
 	}
 	for _, value := range ledgerIDs {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -319,6 +319,150 @@ func TestSnapshotProjectionValidationAndIdentity(t *testing.T) {
 	}
 }
 
+// TestSnapshotIdentityIsRepresentationInvariant is the headline proof for
+// issue #2659 (root 21 of #2471): a declared intended-untracked path and the
+// exact same path staged into the index instead are two REPRESENTATIONS of
+// byte-identical candidate content, and the purified identity domain must not
+// distinguish them. Before the purification, snapshotIdentityForProjection
+// folded IntendedUntracked and its untracked-replay proof into the hash, so
+// these two snapshots carried different Identity values despite an identical
+// CandidateTree -- the bug this change fixes.
+func TestSnapshotIdentityIsRepresentationInvariant(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "declared.txt", "same bytes\n")
+	builder := SnapshotBuilder{Repo: repo}
+
+	declared, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"declared.txt"}})
+	if err != nil {
+		t.Fatalf("Build(declared untracked) error = %v", err)
+	}
+
+	gitSnapshot(t, repo, "add", "--", "declared.txt")
+	staged, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatalf("Build(staged instead) error = %v", err)
+	}
+
+	if declared.CandidateTree != staged.CandidateTree {
+		t.Fatalf("fixture is not content-identical: declared candidate=%s staged candidate=%s", declared.CandidateTree, staged.CandidateTree)
+	}
+	if declared.IntendedUntrackedProof == staged.IntendedUntrackedProof && !equalStrings(declared.IntendedUntracked, staged.IntendedUntracked) {
+		t.Fatalf("fixture did not actually change representation: declared=%#v staged=%#v", declared.IntendedUntracked, staged.IntendedUntracked)
+	}
+	if declared.Identity != staged.Identity {
+		t.Fatalf("purified identity is not representation-invariant: declared=%#v staged=%#v", declared, staged)
+	}
+}
+
+// TestLegacyFrozenSnapshotIdentityFailsValidationClosed is the maintainer-
+// directed inverse of the migration question for #2659: there is no dual
+// recognition of the retired pre-purification identity domain. A snapshot
+// whose Identity was minted under the OLD hash (kind/projection tag folding
+// IntendedUntracked and its proof into the hash) fails ValidateEvidence and
+// ValidateLiveSnapshot closed against the purified recomputation -- it does
+// not silently validate, and it does not panic or surface a cryptic
+// corruption/store error. It fails with the exact same "does not match Git
+// tree evidence" / "no longer matches" shape any other stale target produces,
+// which is the shape internal/cli already classifies as the actionable
+// reviewPreflightStaleTargetReason refusal (see
+// internal/cli/review_start_evidence_test.go, which proves that refusal shape
+// is reachable and actionable) -- so an operator who replays an old hint
+// lands on "re-derive the exact next transition", i.e. run review again, not
+// on a raw internal error.
+func TestLegacyFrozenSnapshotIdentityFailsValidationClosed(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "changed\n")
+	builder := SnapshotBuilder{Repo: repo}
+
+	snapshot, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if err := builder.ValidateEvidence(context.Background(), snapshot); err != nil {
+		t.Fatalf("freshly minted snapshot must validate: %v", err)
+	}
+
+	legacy := snapshot
+	legacy.Identity = legacyPreCutSnapshotIdentityForTest(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree,
+		snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+	if legacy.Identity == snapshot.Identity {
+		t.Fatal("legacy identity fixture did not actually differ from the purified identity")
+	}
+
+	err = builder.ValidateEvidence(context.Background(), legacy)
+	if err == nil {
+		t.Fatal("legacy-frozen identity validated against the purified recomputation")
+	}
+	if !strings.Contains(err.Error(), "match Git tree evidence") {
+		t.Fatalf("legacy-frozen identity failure is not the actionable stale-target shape: %v", err)
+	}
+
+	if err := builder.ValidateLiveSnapshot(context.Background(), legacy); err == nil {
+		t.Fatal("ValidateLiveSnapshot accepted a legacy-frozen identity")
+	} else if !strings.Contains(err.Error(), "match Git tree evidence") {
+		t.Fatalf("ValidateLiveSnapshot legacy-frozen failure is not the actionable stale-target shape: %v", err)
+	}
+}
+
+// legacyPreCutSnapshotIdentityForTest reconstructs, byte for byte, the
+// identity domain snapshotIdentityForProjection used before the #2659
+// purification: it folds proof and intended into the hash under the original
+// v1/v2/base-workspace-overlay-v1 tags. Production code deletes this domain
+// outright (maintainer decision: outdated identities are unusable, not
+// dual-recognized) so this exists ONLY here, as a fixture generator for
+// TestLegacyFrozenSnapshotIdentityFailsValidationClosed. It must stay a
+// byte-for-byte match of the retired formula or the test proves nothing.
+func legacyPreCutSnapshotIdentityForTest(kind TargetKind, projection Projection, baseTree, candidateTree, pathsDigest, proof string, intended, ledgerIDs []string) string {
+	hash := sha256.New()
+	if kind == TargetBaseWorkspaceOverlay {
+		hash.Write([]byte("gentle-ai.review-snapshot/base-workspace-overlay/v1\x00"))
+	} else if projection == ProjectionStaged {
+		hash.Write([]byte("gentle-ai.review-snapshot/v2\x00"))
+	} else {
+		hash.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
+	}
+	values := []string{string(kind), baseTree, candidateTree, pathsDigest, proof}
+	if projection == ProjectionStaged {
+		values = []string{string(kind), string(projection), baseTree, candidateTree, pathsDigest, proof}
+	}
+	for _, value := range values {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	for _, value := range intended {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	for _, value := range ledgerIDs {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+// TestSnapshotIdentityKindDomainSeparationRegression guards the one invariant
+// the #2659 purification explicitly keeps: kind and projection stay in the
+// identity hash domain. Identical baseTree/candidateTree/pathsDigest/ledgerIDs
+// under TargetCurrentChanges vs TargetBaseWorkspaceOverlay must still mint
+// different identities, or a current-changes receipt could be recognized as a
+// base-workspace-overlay review of identical bytes.
+func TestSnapshotIdentityKindDomainSeparationRegression(t *testing.T) {
+	baseTree := strings.Repeat("a", 40)
+	candidateTree := strings.Repeat("b", 40)
+	pathsDigest := digestPaths([]string{"shared.txt"})
+
+	currentChanges := snapshotIdentityForProjection(TargetCurrentChanges, "", baseTree, candidateTree, pathsDigest, "", nil, nil)
+	overlay := snapshotIdentityForProjection(TargetBaseWorkspaceOverlay, "", baseTree, candidateTree, pathsDigest, "", nil, nil)
+	if currentChanges == overlay {
+		t.Fatalf("current-changes and base-workspace-overlay identities collided for identical content: %s", currentChanges)
+	}
+
+	workspace := snapshotIdentityForProjection(TargetCurrentChanges, ProjectionWorkspace, baseTree, candidateTree, pathsDigest, "", nil, nil)
+	staged := snapshotIdentityForProjection(TargetCurrentChanges, ProjectionStaged, baseTree, candidateTree, pathsDigest, "", nil, nil)
+	if workspace == staged {
+		t.Fatalf("workspace and staged projection identities collided for identical content: %s", workspace)
+	}
+}
+
 func TestBuildStagedWorkspaceOverlayRecoveryUsesOnlyTheRealIndex(t *testing.T) {
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2659

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [x] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 🔗 Chain Context

Stacked PR 1 of 3 for root 21 of #2471 (representation treated as identity). Native stack: each PR bases on its parent branch; GitHub retargets automatically as parents merge.

```
main
 └─ #2657 feat/2624-transparent-opencode-reviewer (shared advisory transport) ← base
     └─ 📍 refactor/2659-content-identity (W1: purify snapshot identity — THIS PR)
         └─ fix/2586-zero-delta-refusal (W2: uniform zero-delta refusal — next)
             └─ fix/2388-local-gate-base-advance (W3: compatible base advance at local gates — planned)
```

- **Starts**: after #2657's slices; depends on nothing in W2/W3.
- **Ends**: identity hash purified; clean-break for pre-cut lineages.
- **Out of scope**: zero-delta guards (W2), base-advance recovery (W3), any legacy recognition (maintainer clean-break decision, recorded on #2659).

---

## 📝 Summary

`Snapshot.Identity` was content-plus-representation: `snapshotIdentityForProjection` folded the intended-untracked declaration list and its proof into the hash, so byte-identical candidates could carry different identities when only their Git representation differed (the root behind #2091/#1951-class failures). This PR makes identity content-addressed.

- Preimage after: domain tag + kind [+ projection] + baseTree + candidateTree + pathsDigest + ledgerIDs. No `intended[]`, no `untrackedProof`.
- Domain tags bumped as replacements (v3 workspace, v4 staged, v2 overlay); retired tags are never recomputed in production. Per the maintainer clean-break decision on #2659: lineages frozen under the old formula become outdated and fail validation closed with the existing actionable stale-target refusal; a fresh review mints new authority. No dual recognition, no compatibility shim.
- The untracked replay proof survives as side-band evidence for recovery/replay flows only (D1).
- Kind/projection domain separation is regression-tested: identical content under different target kinds still mints distinct identities.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | Purified preimage, replacement domain tags (+29/-) |
| `internal/reviewtransaction/snapshot_test.go` | 3 new tests: representation invariance, legacy fails closed, domain-separation regression (+144) |
| `contracts/review-integration/*/fixtures/*.json`, `internal/cli/testdata/byte_equivalence_commit_a/*` | Identity-bearing fixture fields regenerated via sanctioned update paths |
| `internal/cli/review_provider_artifact_contract_test.go` | Pinned fixture digests updated with dated issue-#2659 justification comments |

## 🧪 Test Plan

```bash
go test ./internal/reviewtransaction/ -count=1   # ok (129.7s)
go test ./internal/cli/ -count=1                 # ok (190.2s)
cd bench && go test ./... -count=1               # ok
gofmt -l . && go vet ./... && go build ./...     # clean
scripts/deadcode-ratchet.sh                      # no new unreachable functions
```

Review budget: 225 additions + 62 deletions = 287 changed lines.

## ✅ Contributor Checklist

- [x] Linked an approved issue (`status:approved` on #2659)
- [x] Added exactly one `type:*` label
- [x] Shellcheck: no shell scripts modified
- [x] Conventional commit format, no `Co-Authored-By` trailers
- [x] Docs updated where behavior changed (issue records the clean-break contract)
