### PR TITLE
fix(review): refuse zero-delta candidates on every start route

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -520,7 +520,8 @@ func Journeys() []Journey {
 	journeys = append(journeys, waveOneJourneys()...)
 	journeys = append(journeys, waveThreeJourneys()...)
 	journeys = append(journeys, waveFiveJourneys()...)
-	return append(journeys, advisoryJourneys()...)
+	journeys = append(journeys, advisoryJourneys()...)
+	return append(journeys, zeroDeltaJourneys()...)
 }
 
 func coreJourneys() []Journey {

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -31,6 +31,7 @@ func journeySources() []journeySource {
 		{"journeys_wave3.go", waveThreeJourneys()},
 		{"journeys_wave5.go", waveFiveJourneys()},
 		{"journeys_advisory.go", advisoryJourneys()},
+		{"journeys_zero_delta.go", zeroDeltaJourneys()},
 	}
 }
 

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 71 {
-		t.Errorf("core journey count = %d, want 71", got)
+	if got := len(seen); got != 72 {
+		t.Errorf("core journey count = %d, want 72", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/journeys_zero_delta.go
+++ b/bench/journeys_zero_delta.go
@@ -1,0 +1,29 @@
+package main
+
+// journeys_zero_delta.go covers issue #2586's fix: `review start` used to
+// refuse an empty (zero-delta) candidate only on the negotiated route. A
+// plain, non-negotiated `review start` (no --contract) on a clean,
+// fully-committed worktree created a lineage and finalized it to an
+// approved receipt that inspected nothing (base_tree == candidate_tree ==
+// HEAD, paths: []) -- exactly the receipt the issue reports being
+// discoverable afterward as "governing" a later, genuinely unreviewed
+// candidate that happens to share its final tree. The fix moved the
+// refusal into the one shared preflight path both routes go through, so
+// this journey drives the DIRECT route specifically: the one this defect
+// actually reached in practice (the negotiated route's own regression
+// coverage already lives in internal/cli/review_start_empty_candidate_test.go).
+
+func zeroDeltaJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j72-direct-review-start-refuses-empty-candidate",
+			Title:  "Direct (non-negotiated) `review start` on a clean, fully-committed worktree refuses instead of minting a zero-delta receipt",
+			Source: "issue #2586: a plain `review start` (no --contract) on a clean worktree used to create a lineage and finalize an approved receipt that inspected nothing; the empty-candidate refusal was previously negotiated-route-only",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "direct review start on a clean worktree refuses, naming --base-ref", Requires: startCapability,
+					Args: productArgs("review", "start"), After: assertStderrContains("--base-ref"), AbortOnBlock: true},
+			},
+		},
+	}
+}

--- a/internal/cli/review_abandon_disabled_test.go
+++ b/internal/cli/review_abandon_disabled_test.go
@@ -186,6 +186,7 @@ func TestReviewStartStaysRefusedWhileKillSwitchDisabled(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "candidate.go"), []byte("package candidate\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "candidate.go")
 	disableReviewForClone(t, repo)
 
 	var output bytes.Buffer

--- a/internal/cli/review_boolean_flag_spacing_test.go
+++ b/internal/cli/review_boolean_flag_spacing_test.go
@@ -22,6 +22,9 @@ import (
 func TestReviewBooleanFlagSpacedValueNamesTheEqualsForm(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/second.md", "# second\n\nplain prose, no executable content.\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "docs/second.md")
+	runReviewCLIGit(t, repo, "commit", "-qm", "second")
 
 	t.Run("review start --committed-only true names the = form", func(t *testing.T) {
 		var output bytes.Buffer
@@ -40,7 +43,7 @@ func TestReviewBooleanFlagSpacedValueNamesTheEqualsForm(t *testing.T) {
 
 	t.Run("review start --committed-only=true still works", func(t *testing.T) {
 		var output bytes.Buffer
-		err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", "HEAD", "--committed-only=true"}, &output)
+		err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", "HEAD~1", "--committed-only=true"}, &output)
 		if err != nil {
 			t.Fatalf("the = form must keep working: %v\n%s", err, output.String())
 		}

--- a/internal/cli/review_disabled_mutation_test.go
+++ b/internal/cli/review_disabled_mutation_test.go
@@ -38,6 +38,7 @@ func disabledReviewRepo(t *testing.T, lineage string) (repo string, started Revi
 	if err := os.WriteFile(filepath.Join(repo, "docs", "frozen.md"), []byte("frozen by the kill switch\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/frozen.md")
 	started = startFacadeReviewResult(t, repo, lineage)
 	disableReviewForClone(t, repo)
 	return repo, started
@@ -258,6 +259,7 @@ func TestDisabledReviewReplaysTerminalAuthorityWhileDisabled(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "docs", "terminal.md"), []byte("approved before the switch went off\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/terminal.md")
 	const lineage = "review-disabled-terminal-replay"
 	startFacadeReviewResult(t, repo, lineage)
 

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1566,13 +1566,25 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		return reviewPreflightRefusal(reviewPreflightStaleTargetReason,
 			errors.New("review start target does not match the freshly built snapshot"))
 	}
-	// A negotiated TargetCurrentChanges candidate with zero changed paths
-	// (a clean, fully-committed worktree) would otherwise freeze as an empty
-	// candidate, pass risk assessment and consent, and only fail late and
-	// misleadingly at pre-push. Refuse it here, before any authority is
-	// created, and name --base-ref as the way to review committed work
-	// instead of silently deriving one.
-	if negotiated && snapshot.Kind == reviewtransaction.TargetCurrentChanges && len(snapshot.Paths) == 0 {
+	// Issue #2586: a TargetCurrentChanges candidate with zero changed paths
+	// (a clean, fully-committed worktree) or a TargetBaseDiff candidate
+	// whose named base nets zero changed paths (a mode-only or truly-empty
+	// diff) would otherwise freeze as an empty candidate, pass risk
+	// assessment, and mint an approved receipt that inspected nothing. Left
+	// alive on ANY route, that receipt's base_tree/final_candidate_tree can
+	// coincide with a genuinely unreviewed candidate's tree and get
+	// discovered ahead of it. This guard used to fire only on the negotiated
+	// route and only for TargetCurrentChanges, so a plain (non-negotiated)
+	// `review start` on a clean worktree minted exactly this receipt
+	// (reported in #2586) and a `--base-ref` netting no manifest entries was
+	// unguarded on either route. Refusing here, before any authority is
+	// created, for both routes and both target kinds, and naming --base-ref
+	// as the way to name a real comparison base instead of silently deriving
+	// one, is cheaper and safer than the two narrower guards it replaces.
+	// This refusal already spells out its own runnable resolution
+	// (reviewStartEmptyCandidateHint), exactly as it did before this change,
+	// so no additional exemption marker is needed here.
+	if len(snapshot.Paths) == 0 && (snapshot.Kind == reviewtransaction.TargetCurrentChanges || snapshot.Kind == reviewtransaction.TargetBaseDiff) {
 		return reviewPreflightRefusal(reviewPreflightEmptyCandidateReason,
 			errors.New(reviewStartEmptyCandidateHint))
 	}

--- a/internal/cli/review_facade_finalize_new_lineage_test.go
+++ b/internal/cli/review_facade_finalize_new_lineage_test.go
@@ -32,6 +32,7 @@ func startNewLineageForFinalizeTest(t *testing.T, repo, lineage string) {
 	if err := os.WriteFile(path, []byte(joinReviewCLILines(lines)), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/"+lineage+".md")
 	var out bytes.Buffer
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, &out); err != nil {
 		t.Fatalf("new-lineage start: %v\n%s", err, out.String())

--- a/internal/cli/review_invalidate_test.go
+++ b/internal/cli/review_invalidate_test.go
@@ -68,6 +68,13 @@ func TestLegacyOrdinaryMutationRoutesShareTypedReadOnlyErrorWithoutMutation(t *t
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := initReviewCLIRepo(t)
+			// The "start collision" case drives a real `review start`, which
+			// issue #2586's unified empty-candidate guard would otherwise
+			// refuse first on a clean worktree, masking the legacy-collision
+			// refusal this test exists to pin. A staged, low-risk change
+			// gives every subtest a non-empty candidate; the other subtests
+			// never build a fresh candidate at all, so it is inert for them.
+			writeReviewStartCandidate(t, repo, "docs/pending.md", "# pending\n\nplain prose, no executable content.\n", 0o644)
 			lineage := "legacy-route-" + strings.ReplaceAll(tt.name, " ", "-")
 			store := addPristineLegacyAuthority(t, repo, lineage)
 			chain, err := store.LoadChain()

--- a/internal/cli/review_low_risk_lifecycle_test.go
+++ b/internal/cli/review_low_risk_lifecycle_test.go
@@ -179,6 +179,7 @@ func TestLowRiskExternalEvidenceRemainsBackwardCompatible(t *testing.T) {
 	if err := os.WriteFile(path, []byte("ordinary documentation\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/guide.md")
 	started := startReviewOperationFixture(t, repo, "review-low-external-evidence")
 	evidence := []byte("external focused tests pass\n")
 	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")

--- a/internal/cli/review_new_lineage_switch_test.go
+++ b/internal/cli/review_new_lineage_switch_test.go
@@ -25,6 +25,7 @@ func TestReviewStartNewLineageSwitchOffCreatesNoV3Entries(t *testing.T) {
 	if err := os.WriteFile(path, []byte("kill-switch-off structural-unfailure fixture\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/kill-switch-off.md")
 
 	var out bytes.Buffer
 	if err := RunReviewFacadeStart([]string{"--cwd", repo}, &out); err != nil {

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -278,14 +278,18 @@ var reviewPreflightDirectRouteUncompletableReason = reviewPreflightReason{
 	NextAction: "review.start",
 }
 
-// reviewPreflightEmptyCandidateReason classifies a negotiated START whose
-// frozen TargetCurrentChanges candidate has zero changed paths (a clean,
-// fully-committed worktree). Left unguarded, this candidate would freeze as
-// base_tree == candidate_tree == HEAD, pass risk assessment and pre-commit,
-// then fail late and misleadingly at pre-push. `base_ref` is already in the
-// published required_inputs enum, and `next_action: correct_request` is
-// honest because the caller genuinely must supply it: the system never
-// auto-derives a base ref (e.g. HEAD~1) on the caller's behalf.
+// reviewPreflightEmptyCandidateReason classifies a START -- negotiated or
+// direct -- whose frozen candidate has zero changed paths: a TargetCurrentChanges
+// candidate on a clean, fully-committed worktree (base_tree == candidate_tree
+// == HEAD), or a TargetBaseDiff candidate whose named base nets no manifest
+// entries (a mode-only or truly-empty diff). Left unguarded, either shape
+// would freeze, pass risk assessment, and mint an approved receipt that
+// inspected nothing -- issue #2586 (a stale zero-delta receipt discovered
+// as "governing" a later, genuinely unreviewed candidate that happens to
+// share its final tree). `base_ref` is already in the published
+// required_inputs enum, and `next_action: correct_request` is honest because
+// the caller genuinely must supply it: the system never auto-derives a base
+// ref (e.g. HEAD~1) on the caller's behalf.
 var reviewPreflightEmptyCandidateReason = reviewPreflightReason{
 	Code:           "empty_candidate_scope",
 	Message:        "The review candidate has no pending changes to freeze; name the base to compare against before retrying.",

--- a/internal/cli/review_reclaim_test.go
+++ b/internal/cli/review_reclaim_test.go
@@ -113,6 +113,7 @@ func TestReviewStartSucceedsDespiteIncompleteStoreResidue(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "docs", "start.md"), []byte("start\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/start.md")
 	var output bytes.Buffer
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output); err != nil {
 		t.Fatalf("review start with incomplete residue present: %v\n%s", err, output.String())
@@ -137,6 +138,7 @@ func TestReviewReclaimClearsEnumeratedResidueThatNeverBlockedStart(t *testing.T)
 	if err := os.WriteFile(filepath.Join(repo, "docs", "start.md"), []byte("start\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "docs/start.md")
 	var output bytes.Buffer
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output); err != nil {
 		t.Fatalf("enumerated residue blocked an unrelated start: %v\n%s", err, output.String())

--- a/internal/cli/review_recover_self_derivation_test.go
+++ b/internal/cli/review_recover_self_derivation_test.go
@@ -18,6 +18,7 @@ import (
 func invalidatedRecoverySelfDerivationPredecessor(t *testing.T, lineage string) (string, reviewtransaction.CompactRecord) {
 	t.Helper()
 	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/predecessor.md", "# predecessor\n\nplain prose, no executable content.\n", 0o644)
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
@@ -180,6 +181,7 @@ func TestReviewRecoverSelfDerivationCorruptedAuthorityStillRefuses(t *testing.T)
 func TestReviewRecoverSelfDerivationActiveAttemptNeverAutoResets(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	lineage := "self-derive-active-attempt"
+	writeReviewStartCandidate(t, repo, "docs/active-attempt.md", "# active attempt\n\nplain prose, no executable content.\n", 0o644)
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, io.Discard); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/review_refusal_wording_test.go
+++ b/internal/cli/review_refusal_wording_test.go
@@ -99,6 +99,7 @@ func TestReviewFinalizeNoDiscoverableLineageNamesStartCommand(t *testing.T) {
 func TestReviewValidateReceiptNotAvailableNamesFinalizeCommandWithLineage(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	lineage := "receipt-not-available-needs-finalize"
+	writeReviewStartCandidate(t, repo, "docs/pending.md", "# pending\n\nplain prose, no executable content.\n", 0o644)
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, io.Discard); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/review_start_empty_candidate_test.go
+++ b/internal/cli/review_start_empty_candidate_test.go
@@ -1,18 +1,19 @@
 package cli
 
-// Issue: negotiated `review.start` with TargetCurrentChanges on a clean,
-// fully-committed worktree freezes an EMPTY candidate (base_tree ==
-// candidate_tree == HEAD, paths: []), passes risk assessment and
-// pre-commit, then fails late and misleadingly at pre-push ("reviewed
-// delivery is not exactly one commit from its reviewed base"). These tests
-// pin a typed preflight refusal that stops this flow before any authority
-// is created, naming --base-ref as the resolution instead of silently
-// deriving one.
+// Issue #2586: `review start` with a TargetCurrentChanges candidate on a
+// clean, fully-committed worktree, or a TargetBaseDiff candidate whose named
+// base nets zero changed paths, freezes an EMPTY candidate (paths: []) that
+// would pass risk assessment and mint an approved receipt inspecting
+// nothing -- discoverable afterward as "governing" a later, genuinely
+// unreviewed candidate sharing its final tree. The guard used to fire only
+// on the negotiated route and only for TargetCurrentChanges; these tests pin
+// the unified refusal that now fires on both routes and both target kinds,
+// before any authority is created, naming --base-ref as the resolution
+// instead of silently deriving one.
 
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -122,25 +123,93 @@ func TestNegotiatedStartWithPendingChangesIsUnaffected(t *testing.T) {
 	}
 }
 
-// TestUnnegotiatedEmptyCandidateStartKeepsItsHint is a regression pin: the
-// plain (non-negotiated) review start path on a clean tree must keep
-// emitting its existing hint unchanged by the negotiated-only guard added
-// by this change.
-func TestUnnegotiatedEmptyCandidateStartKeepsItsHint(t *testing.T) {
+// TestDirectReviewStartRefusesEmptyCandidateWithoutAuthority is the direct-
+// route repro from issue #2586: before this fix, a plain (non-negotiated)
+// `review start` (no --contract) on a clean, fully-committed worktree
+// created a lineage and finalized it to an approved receipt that inspected
+// nothing (base_tree == candidate_tree == HEAD) -- exactly the zero-delta
+// receipt the issue reports being discovered as "governing" a later,
+// genuinely unreviewed candidate that happens to share its final tree. The
+// guard that used to fire only on the negotiated route now fires here too,
+// before any authority is created.
+func TestDirectReviewStartRefusesEmptyCandidateWithoutAuthority(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 
 	var output bytes.Buffer
-	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "unnegotiated-empty"}, &output); err != nil {
-		t.Fatalf("unnegotiated review start on a clean worktree: %v\n%s", err, output.String())
+	err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "unnegotiated-empty"}, &output)
+	if err == nil {
+		t.Fatalf("direct review start admitted an empty candidate:\n%s", output.String())
 	}
-	var started ReviewFacadeStartResult
-	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
-		t.Fatal(err)
+	if !strings.Contains(err.Error(), reviewStartEmptyCandidateHint) {
+		t.Fatalf("direct empty-candidate refusal = %q, want it to contain %q", err.Error(), reviewStartEmptyCandidateHint)
 	}
-	if started.ChangedFiles != 0 {
-		t.Fatalf("unnegotiated clean-worktree start changed_files = %d, want 0", started.ChangedFiles)
+	if !strings.Contains(err.Error(), "--base-ref") {
+		t.Fatalf("direct empty-candidate refusal = %q, want it to name --base-ref", err.Error())
 	}
-	if started.Hint != reviewStartEmptyCandidateHint {
-		t.Fatalf("unnegotiated empty-candidate start hint = %q, want %q", started.Hint, reviewStartEmptyCandidateHint)
+
+	stores, discoverErr := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if discoverErr != nil {
+		t.Fatal(discoverErr)
+	}
+	if len(stores) != 0 {
+		t.Fatalf("refused direct-route empty-candidate START created authority: %#v", stores)
+	}
+}
+
+// TestNegotiatedReviewStartRefusesEmptyBaseDiffCandidate proves the guard's
+// #2586 extension: a TargetBaseDiff candidate whose named base nets zero
+// changed paths (here, the named base IS the current HEAD -- a truly-empty
+// diff) refuses identically to a clean TargetCurrentChanges candidate, on
+// the negotiated route.
+func TestNegotiatedReviewStartRefusesEmptyBaseDiffCandidate(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", "empty-base-diff",
+		"--base-ref", "HEAD",
+	}), &output)
+	if err == nil {
+		t.Fatalf("negotiated review start admitted a zero-delta base-diff candidate:\n%s", output.String())
+	}
+
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Code != "empty_candidate_scope" {
+		t.Fatalf("negotiated base-diff failure code = %q, want empty_candidate_scope\n%s", failure.Code, output.String())
+	}
+	if failure.Phase != "preflight" {
+		t.Fatalf("negotiated base-diff failure phase = %q, want preflight\n%s", failure.Phase, output.String())
+	}
+
+	stores, discoverErr := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if discoverErr != nil {
+		t.Fatal(discoverErr)
+	}
+	if len(stores) != 0 {
+		t.Fatalf("refused zero-delta base-diff START created authority: %#v", stores)
+	}
+}
+
+// TestDirectReviewStartRefusesEmptyBaseDiffCandidate is the same proof on the
+// direct (non-negotiated) route: issue #2586's guard extension applies to
+// both target kinds on both routes, not only the negotiated one.
+func TestDirectReviewStartRefusesEmptyBaseDiffCandidate(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "unnegotiated-empty-base-diff", "--base-ref", "HEAD"}, &output)
+	if err == nil {
+		t.Fatalf("direct review start admitted a zero-delta base-diff candidate:\n%s", output.String())
+	}
+	if !strings.Contains(err.Error(), reviewStartEmptyCandidateHint) {
+		t.Fatalf("direct base-diff refusal = %q, want it to contain %q", err.Error(), reviewStartEmptyCandidateHint)
+	}
+
+	stores, discoverErr := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if discoverErr != nil {
+		t.Fatal(discoverErr)
+	}
+	if len(stores) != 0 {
+		t.Fatalf("refused direct-route zero-delta base-diff START created authority: %#v", stores)
 	}
 }

--- a/internal/cli/review_zero_delta_gate_governance_test.go
+++ b/internal/cli/review_zero_delta_gate_governance_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// Issue #2586, item 2 (the "governing-half" verification): does an EXISTING
+// zero-delta approved receipt -- one an old build minted before this
+// change's START-time guard existed, base_tree == final_candidate_tree,
+// paths: [] -- ever get to GOVERN a delivery gate over later, genuinely
+// unreviewed content that happens to land on top of that same base tree?
+//
+// It does not. Every gate that actually delivers something
+// (post-apply/pre-commit/pre-push/pre-pr/release) builds its OWN live gate
+// target from the real current repository state -- compactPushDeliveryBaseTree
+// + buildPushTarget for pre-push, the live staged/workspace projection for
+// pre-commit/post-apply (buildCompactGateRequestWithPushBase,
+// internal/reviewtransaction/compact_gate.go) -- independent of whatever
+// kind the receipt being checked was originally started against. Once real
+// content exists, that live target's CandidateTree is no longer the
+// receipt's own self-referencing tree, so validateDerivedGate's very first
+// comparison (internal/reviewtransaction/receipt.go: "receipt.FinalCandidateTree
+// != context.CandidateTree" -> GateScopeChanged) already refuses it -- for
+// every gate, not only the ones with their own base-relationship checks.
+//
+// This test constructs exactly such a historical zero-delta receipt (via
+// runLegacyFacadeStartForTest, which bypasses this change's own START guard
+// on purpose -- it exists to build fixtures the guard newly forbids
+// creating going forward) and proves neither pre-commit nor pre-push ever
+// governs real content through it. No production code changes were needed
+// for this half of #2586; this test is the proof.
+func TestZeroDeltaReceiptNeverGovernsANonEmptyDeliveryGate(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
+
+	// Historical bytes: a zero-delta lineage started and finalized on the
+	// clean worktree, exactly as an old build (pre-#2586-fix) would have
+	// produced from a bare `review start`.
+	if err := runLegacyFacadeStartForTest(t, []string{"--cwd", repo, "--lineage", "zero-delta"}, io.Discard); err != nil {
+		t.Fatalf("construct historical zero-delta authority: %v", err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", "zero-delta"}, io.Discard); err != nil {
+		t.Fatalf("finalize historical zero-delta authority: %v", err)
+	}
+
+	// Real, unreviewed content lands on top of that exact base tree.
+	writeScopeRecoveryFile(t, repo, "session.go", "package auth\n")
+	runReviewCLIGit(t, repo, "add", "session.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "feat: auth")
+
+	for _, gate := range []string{"pre-commit", "pre-push"} {
+		var output bytes.Buffer
+		err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", "zero-delta", "--gate", gate}, &output)
+		if err == nil {
+			t.Fatalf("%s gate allowed unreviewed content through a zero-delta receipt: %s", gate, output.String())
+		}
+		var denied ReviewGateDeniedError
+		if !errors.As(err, &denied) {
+			t.Fatalf("%s gate error = %T %v, want ReviewGateDeniedError", gate, err, err)
+		}
+		// GateScopeChanged specifically: validateDerivedGate's very first
+		// comparison (receipt.FinalCandidateTree != context.CandidateTree)
+		// already trips, for both gates, because the live target's tree
+		// moved once real content landed -- confirming the receipt's own
+		// tree/digest comparison, not a new non-governing rule, is what
+		// keeps a zero-delta receipt from ever governing real content.
+		if denied.Result != reviewtransaction.GateScopeChanged {
+			t.Fatalf("%s gate result = %q, want scope-changed", gate, denied.Result)
+		}
+	}
+}

--- a/internal/cli/sdd_status_reenable_fresh_review_test.go
+++ b/internal/cli/sdd_status_reenable_fresh_review_test.go
@@ -14,6 +14,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
@@ -38,6 +39,25 @@ func dispatchNamedReviewStart(t *testing.T, repo string, tokens []string, extra 
 	var started ReviewFacadeStartResult
 	decodeStrictReviewJSON(t, output.Bytes(), &started)
 	return started
+}
+
+// dispatchNamedReviewStartExpectingRefusal is dispatchNamedReviewStart's
+// negative twin: issue #2586's unified empty-candidate guard means a named
+// continuation run over a clean worktree now refuses up front instead of
+// freezing an empty candidate and hinting the rerun only afterward. This
+// requires exactly that refusal and returns its text.
+func dispatchNamedReviewStartExpectingRefusal(t *testing.T, repo string, tokens []string) string {
+	t.Helper()
+	if len(tokens) < 2 || tokens[0] != "review" || tokens[1] != "start" {
+		t.Fatalf("named continuation is %v, want gentle-ai review start", tokens)
+	}
+	args := append(append([]string{}, tokens[1:]...), "--cwd", repo)
+	var output bytes.Buffer
+	err := RunReview(args, &output)
+	if err == nil {
+		t.Fatalf("the named continuation on a clean worktree unexpectedly succeeded: gentle-ai review %v:\n%s", args, output.String())
+	}
+	return err.Error()
 }
 
 func commitAllSDDStatus(t *testing.T, repo, message string) string {
@@ -104,36 +124,31 @@ func TestSDDStatusReEnableSequenceLandsOnTheFreshFullReview(t *testing.T) {
 	}
 	tokens := namedReviewCommandTokens(t, blocked.ReviewGate.Reason)
 
-	// Run exactly what the stop names. The tree is clean, so this start
-	// freezes an empty candidate and its hint names the --base-ref rerun.
-	emptyStart := dispatchNamedReviewStart(t, root, tokens)
-	if emptyStart.ChangedFiles != 0 {
-		t.Fatalf("clean-tree start froze %d files, fixture is wrong", emptyStart.ChangedFiles)
+	// Run exactly what the stop names. The tree is clean, so issue #2586's
+	// unified empty-candidate guard now refuses this up front -- before this
+	// fix, the same command froze an empty candidate and named --base-ref
+	// only in the after-the-fact hint on a SUCCESSFUL response; the guard
+	// this change adds moves that same --base-ref hint into the refusal
+	// itself, before any authority is created.
+	refusal := dispatchNamedReviewStartExpectingRefusal(t, root, tokens)
+	if !strings.Contains(refusal, "--base-ref") {
+		t.Fatalf("empty-candidate refusal does not name the committed-work rerun: %q", refusal)
 	}
-	if !strings.Contains(emptyStart.Hint, "--base-ref") {
-		t.Fatalf("empty start hint does not name the committed-work rerun: %q", emptyStart.Hint)
-	}
-	finalizeFacadeLineage(t, root, emptyStart.LineageID)
 
-	// The approved empty receipt reviewed nothing, so it must not read as
-	// coverage of the unmanaged history: the archive stop stays blocked and
-	// keeps naming the fresh review.
+	// Nothing was created by the refused attempt, so the archive stop is
+	// unchanged: still blocked, still naming the same bare start.
 	stillBlocked := resolveSDDStatusJSON(t, root)
 	if stillBlocked.Dependencies.Archive != sddstatus.DependencyBlocked || stillBlocked.ReviewGate == nil {
-		t.Fatalf("an empty-candidate review unblocked the archive: %#v", stillBlocked.Dependencies)
+		t.Fatalf("a refused empty-candidate start left a trace that unblocked the archive: %#v", stillBlocked.Dependencies)
 	}
 	if stillBlocked.ReviewGate.Result == reviewtransaction.GateAllow {
-		t.Fatalf("an empty-candidate review fabricated coverage of unmanaged history: %#v", stillBlocked.ReviewGate)
+		t.Fatalf("a refused empty-candidate start fabricated coverage of unmanaged history: %#v", stillBlocked.ReviewGate)
 	}
-	tokens = namedReviewCommandTokens(t, stillBlocked.ReviewGate.Reason)
 
-	// Run the base-ref rerun the message names, supplying the one
-	// operator-owned placeholder value: the boundary to re-govern from. The
-	// fresh full review freezes the delivered range.
-	if tokens[len(tokens)-1] != "--base-ref" {
-		t.Fatalf("empty-receipt continuation = %v, want it to end at the operator's --base-ref value", tokens)
-	}
-	freshStart := dispatchNamedReviewStart(t, root, tokens, baselineCommit)
+	// Run the real fresh full review, guided by the refusal's own --base-ref
+	// hint: the operator-owned placeholder value is the boundary to
+	// re-govern from. The fresh full review freezes the delivered range.
+	freshStart := dispatchNamedReviewStart(t, root, tokens, "--base-ref", baselineCommit)
 	if freshStart.ChangedFiles == 0 {
 		t.Fatalf("the fresh full review froze no content: %#v", freshStart)
 	}
@@ -159,6 +174,14 @@ func TestSDDStatusReEnableSequenceLandsOnTheFreshFullReview(t *testing.T) {
 // delivered history, and a single approved empty-candidate receipt. The
 // archive must record that nothing was reviewed and keep naming the fresh
 // review with its base-ref selector.
+//
+// Issue #2586's unified empty-candidate guard refuses to CREATE this receipt
+// through the live CLI (RunReviewFacadeStart / RunReview) on any route --
+// that refusal is this repository's fix. The receipt this test needs, to
+// prove archive-side defense-in-depth never treats it as coverage, can
+// therefore only exist as historical bytes an old build minted before this
+// fix; runLegacyFacadeStartForTest reproduces exactly that pre-guard START
+// pipeline, on purpose, for fixtures like this one.
 func TestSDDStatusArchiveNeverTreatsAnEmptyCandidateReviewAsCoverage(t *testing.T) {
 	reviewModeHome(t)
 	root := t.TempDir()
@@ -169,11 +192,10 @@ func TestSDDStatusArchiveNeverTreatsAnEmptyCandidateReviewAsCoverage(t *testing.
 	commitAllSDDStatus(t, root, "unmanaged delivery")
 	enableReviewForClone(t, root)
 
-	emptyStart := startFacadeReviewResult(t, root, "reenable-empty-only")
-	if emptyStart.ChangedFiles != 0 {
-		t.Fatalf("clean-tree start froze %d files, fixture is wrong", emptyStart.ChangedFiles)
+	if err := runLegacyFacadeStartForTest(t, []string{"--cwd", root, "--lineage", "reenable-empty-only"}, io.Discard); err != nil {
+		t.Fatalf("construct historical empty-candidate authority: %v", err)
 	}
-	finalizeFacadeLineage(t, root, emptyStart.LineageID)
+	finalizeFacadeLineage(t, root, "reenable-empty-only")
 
 	status := resolveSDDStatusJSON(t, root)
 	if status.ReviewGate == nil || status.ReviewGate.Result == reviewtransaction.GateAllow {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2586

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 🔗 Chain Context

Stacked PR 2 of 3 for root 21 of #2471.

```
main
 └─ #2657 feat/2624-transparent-opencode-reviewer (shared advisory transport)
     └─ #2660 refactor/2659-content-identity (W1: purify snapshot identity)
         └─ 📍 fix/2586-zero-delta-refusal (W2: uniform zero-delta refusal — THIS PR)
             └─ fix/2388-local-gate-base-advance (W3: compatible base advance — next)
```

- **Starts**: after W1; shares no surface with it (guard lives in the CLI start path, identity in reviewtransaction).
- **Ends**: zero-delta candidates refused on every route and both target kinds.
- **Out of scope**: base-advance recovery (W3); any recognition logic for historical zero-delta receipts (proven unnecessary, see below).

---

## 📝 Summary

The empty-candidate refusal fired only on the negotiated route and only for `TargetCurrentChanges` (`review_facade.go`), so a plain `review start` on a clean worktree minted an approved receipt that inspected nothing (#2586's exact repro), and a `--base-ref` diff netting zero manifest entries was unguarded on both routes.

- One guard now refuses zero-delta candidates before any authority is created, on both routes and both target kinds, with the existing typed refusal shape (`empty_candidate` reason + `--base-ref` hint). The route-conditional form is deleted.
- The governing-receipt half was **verified unnecessary rather than implemented**: every delivery gate rebuilds its live target from actual repository state, so the first tree comparison (`receipt.go:292`, compact mirror `compact_gate.go:422`) already refuses a historical zero-delta receipt the moment real content exists. `TestZeroDeltaReceiptNeverGovernsANonEmptyDeliveryGate` proves it empirically with a legacy-built fixture receipt. No new machinery.
- The universal guard surfaced 29 latent test bugs (fixtures that unknowingly reviewed empty candidates — content written but never staged, or clean-tree starts as incidental setup). Each fixed by staging the intended content or constructing historical fixtures through the legacy test helper; the two SDD-status defense-in-depth tests now assert the refusal directly.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Unified zero-delta guard; route-conditional deleted; issue-#2586 rationale comment |
| `internal/cli/review_operation_contract.go` | Contract doc updated for the universal refusal |
| `internal/reviewtransaction/*_test.go`, `internal/cli/*_test.go` | New refusal/governing tests; 29 latent fixture bugs fixed |
| `bench/journeys_zero_delta.go` | `j72-direct-review-start-refuses-empty-candidate`; count pin 71→72 |

## 🧪 Test Plan

```bash
go test ./internal/cli/ -count=1              # ok (189s)
go test ./internal/reviewtransaction/ -count=1 # ok (111s)
cd bench && go test ./... -count=1             # ok; j72 driven-mode: 1 completed, 0 failed
gofmt -l . && go vet ./... && go build ./...   # clean
scripts/deadcode-ratchet.sh                    # no new unreachable functions
```

Review budget: 306 additions + 68 deletions = 374 changed lines.

## ✅ Contributor Checklist

- [x] Linked an approved issue (`status:approved` on #2586)
- [x] Added exactly one `type:*` label
- [x] Shellcheck: no shell scripts modified
- [x] Conventional commit format, no `Co-Authored-By` trailers
- [x] Docs updated where behavior changed
