### PR TITLE
fix(review): per-gate base-advance attestation policy at delivery gates

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -521,7 +521,8 @@ func Journeys() []Journey {
 	journeys = append(journeys, waveThreeJourneys()...)
 	journeys = append(journeys, waveFiveJourneys()...)
 	journeys = append(journeys, advisoryJourneys()...)
-	return append(journeys, zeroDeltaJourneys()...)
+	journeys = append(journeys, zeroDeltaJourneys()...)
+	return append(journeys, localGateBaseAdvanceJourneys()...)
 }
 
 func coreJourneys() []Journey {

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -32,6 +32,7 @@ func journeySources() []journeySource {
 		{"journeys_wave5.go", waveFiveJourneys()},
 		{"journeys_advisory.go", advisoryJourneys()},
 		{"journeys_zero_delta.go", zeroDeltaJourneys()},
+		{"journeys_local_gate_advance.go", localGateBaseAdvanceJourneys()},
 	}
 }
 

--- a/bench/journeys_local_gate_advance.go
+++ b/bench/journeys_local_gate_advance.go
@@ -1,0 +1,76 @@
+package main
+
+import "path/filepath"
+
+// journeys_local_gate_advance.go covers issue #2388 / D2 (#2471 option a) at
+// the product boundary: an approved, committed base-diff receipt followed by
+// a disjoint parent advance that the child locally merges in (staged, not yet
+// committed -- the literal #2388 reproduction). D2 decided to extend
+// compatible base advance to pre-commit/pre-push by reusing pre-PR's existing
+// content checks without its CI attestation. internal/reviewtransaction's
+// deriveBaseAdvanceCompatibility now supports that (requireAttestation
+// parameter, see prepr.go), and receipt.go's baseAdvanceStatusAllowedForGate
+// generalizes the per-gate policy -- but wiring it into GatePreCommit's own
+// target derivation is a STOPPED sub-path (see
+// internal/reviewtransaction/compact_gate_local_advance_test.go): a staged
+// merge always changes CandidateTree, never just BaseTree, so the shared,
+// unchanged content checks can never certify it compatible. This journey
+// pins the honest, still-refused CLI-visible outcome so a future change that
+// resolves the stop (or accidentally regresses today's refusal into a false
+// allow) has a driven signal either way.
+func localGateBaseAdvanceJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j73-pre-commit-still-refuses-staged-merge-of-an-advanced-parent",
+			Title:  "An approved base-diff receipt's pre-commit gate still refuses a staged merge of a disjointly-advanced parent",
+			Source: "issue #2388 / D2 (#2471 option a): compatible base advance without CI attestation is scoped to content checks pre-commit's own target derivation cannot satisfy (base and candidate cannot move independently for a staged merge), so this remains a refusal by design, not a regression",
+			Steps: []Step{
+				{Name: "fixture: repo with remote", Fixture: baseRepoWithRemote},
+				{Name: "fixture: stage reviewed docs", Fixture: stageDocs("reviewed")},
+				{Name: "review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
+				{Name: "review finalize", Requires: finalizeCapability, Args: productArgs("review", "finalize"), After: rememberLineage},
+				{Name: "fixture: commit the approved delivery", Fixture: commitStaged("reviewed delivery")},
+				{Name: "fixture: advance the parent on a disjoint path, then stage a merge of it (no commit)", Fixture: advanceParentDisjointlyAndStageMerge},
+				{Name: "gate pre-commit still refuses the staged merge", Requires: validateCapability,
+					Args: func(sandbox *Sandbox) ([]string, error) {
+						return []string{"review", "validate", "--gate", "pre-commit", "--lineage", sandbox.Lineage, "--cwd", sandbox.Repo}, nil
+					},
+					After: assertStderrContains("scope-changed"), AbortOnBlock: true},
+			},
+		},
+	}
+}
+
+// advanceParentDisjointlyAndStageMerge reproduces #2388's exact repro shape:
+// branch off the pre-delivery parent commit, add content on a path disjoint
+// from the reviewed delivery, then stage (never commit) a merge of that
+// advance back into the branch carrying the approved delivery. HEAD stays at
+// the approved candidate; only the index/working tree changes.
+func advanceParentDisjointlyAndStageMerge(sandbox *Sandbox) error {
+	parent, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD~1")
+	if err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "branch", "advance-source", parent); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "advance-source"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "docs", "unrelated.md"), "# unrelated\n\nparent advance, disjoint from the reviewed delivery.\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "-A"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "advance the parent"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "main"); err != nil {
+		return err
+	}
+	// The merge is expected to succeed cleanly (disjoint paths); --no-commit
+	// leaves it staged, matching #2388's reproduction exactly.
+	_ = sandbox.git(sandbox.Repo, "merge", "-q", "--no-commit", "--no-ff", "advance-source")
+	return nil
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 72 {
-		t.Errorf("core journey count = %d, want 72", got)
+	if got := len(seen); got != 73 {
+		t.Errorf("core journey count = %d, want 73", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/review_local_gate_base_advance_test.go
+++ b/internal/cli/review_local_gate_base_advance_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// This file is the internal/cli half of D2's (#2471 option a, filed against
+// #2388) evidence trail. internal/reviewtransaction's
+// compact_gate_local_advance_test.go carries the full explanation of why
+// wiring deriveBaseAdvanceCompatibility into GatePreCommit/GatePrePush is
+// stopped rather than attempted with a weaker check: neither local gate's own
+// target derivation can ever produce the "base moved, candidate untouched"
+// precondition the shared, unchanged content checks require. These CLI-level
+// tests reproduce the exact end-user commands #2388 ran (`gentle-ai review
+// validate --gate pre-commit/pre-push`) against a real approved, published
+// receipt, proving the negotiated failure envelope an operator actually sees
+// is unchanged by this work unit -- no regression, and no CLI-visible
+// lookalike allow.
+
+// TestValidatePrePushStillRefusesAfterLocalMergeOfAnAdvancedParent reproduces
+// #2388's pre-push shape end to end through the real CLI surface: an approved,
+// published receipt; the parent (origin/<branch>) advances on a disjoint
+// path; the local branch merges that advance in (a real merge commit, so HEAD
+// itself changes); `review validate --gate pre-push` still denies with
+// candidate-or-paths-mismatch, exactly as it did before this change --
+// deriveBaseAdvanceCompatibility's requireAttestation parameter exists and is
+// unit-tested (internal/reviewtransaction), but nothing in this CLI path
+// invokes it for a local gate, so the CLI-visible outcome for this shape is
+// byte-identical to main.
+func TestValidatePrePushStillRefusesAfterLocalMergeOfAnAdvancedParent(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "--git-dir", remote, "symbolic-ref", "HEAD", "refs/heads/"+branch)
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".remote", "origin")
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+
+	approveDiscoveryMarkdown(t, repo, "local-gate-root", "docs/reviewed.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed delivery")
+	runReviewCLIGit(t, repo, "push", "-q", "origin", branch)
+
+	// Advance the parent on a remote client, on a path disjoint from the
+	// delivered one, then merge that advance in locally.
+	client := filepath.Join(t.TempDir(), "advance-client")
+	runReviewCLIGit(t, repo, "clone", "-q", remote, client)
+	runReviewCLIGit(t, client, "config", "user.email", "advance@example.com")
+	runReviewCLIGit(t, client, "config", "user.name", "advance")
+	writeReviewCLIFile(t, client, "docs/unrelated.md", "parent advance\n")
+	runReviewCLIGit(t, client, "add", "-A")
+	runReviewCLIGit(t, client, "commit", "-qm", "advance the parent")
+	runReviewCLIGit(t, client, "push", "-q", "origin", "HEAD:"+branch)
+	runReviewCLIGit(t, repo, "fetch", "-q", "origin")
+	runReviewCLIGit(t, repo, "merge", "-q", "--no-ff", "--no-edit", "origin/"+branch)
+
+	var output bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePush), "--base-ref", "origin/" + branch,
+	}, &output)
+	if err == nil {
+		t.Fatalf("pre-push validation after a local merge of an advanced parent was allowed:\n%s", output.String())
+	}
+	var failure *ReviewIntegrationFailureError
+	if !errors.As(err, &failure) {
+		t.Fatalf("pre-push denial is not a negotiated failure: %v\n%s", err, output.String())
+	}
+	// The disjoint parent advance plus the local merge changed both base and
+	// candidate away from the receipt, so this is refused at discovery
+	// (receipt_scope_changed) rather than reaching native gate evaluation with
+	// full ScopeChange diagnostics -- either shape proves the same thing: no
+	// compatible-base-advance allow leaked through for this shape.
+	if failure.Failure.Code != "receipt_scope_changed" {
+		t.Fatalf("pre-push denial code = %q, want receipt_scope_changed: %#v\n%s", failure.Failure.Code, failure.Failure, output.String())
+	}
+}
+
+// TestValidatePreCommitStillRefusesStagedMergeOfAnAdvancedParent is
+// pre-commit's counterpart, staging (not committing) the parent's advance --
+// the literal #2388 reproduction shape -- and confirming the CLI's negotiated
+// pre-commit validation still denies with the same diagnostics it always has.
+func TestValidatePreCommitStillRefusesStagedMergeOfAnAdvancedParent(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "--git-dir", remote, "symbolic-ref", "HEAD", "refs/heads/"+branch)
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".remote", "origin")
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+
+	approveDiscoveryMarkdown(t, repo, "local-gate-precommit-root", "docs/reviewed.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed delivery")
+	runReviewCLIGit(t, repo, "push", "-q", "origin", branch)
+
+	client := filepath.Join(t.TempDir(), "advance-client-precommit")
+	runReviewCLIGit(t, repo, "clone", "-q", remote, client)
+	runReviewCLIGit(t, client, "config", "user.email", "advance@example.com")
+	runReviewCLIGit(t, client, "config", "user.name", "advance")
+	writeReviewCLIFile(t, client, "docs/unrelated.md", "parent advance\n")
+	runReviewCLIGit(t, client, "add", "-A")
+	runReviewCLIGit(t, client, "commit", "-qm", "advance the parent")
+	runReviewCLIGit(t, client, "push", "-q", "origin", "HEAD:"+branch)
+	runReviewCLIGit(t, repo, "fetch", "-q", "origin")
+	runReviewCLIGit(t, repo, "merge", "-q", "--no-commit", "--no-ff", "origin/"+branch)
+
+	var output bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--lineage", "local-gate-precommit-root", "--gate", string(reviewtransaction.GatePreCommit),
+	}, &output)
+	if err == nil {
+		t.Fatalf("pre-commit validation of a staged merge of an advanced parent was allowed:\n%s", output.String())
+	}
+	var failure *ReviewIntegrationFailureError
+	if !errors.As(err, &failure) {
+		t.Fatalf("pre-commit denial is not a negotiated failure: %v\n%s", err, output.String())
+	}
+	if failure.Failure.Context == nil || failure.Failure.Context.ScopeChange == nil {
+		t.Fatalf("pre-commit denial carries no scope-change diagnostics: %#v\n%s", failure.Failure, output.String())
+	}
+}
+
+func writeReviewCLIFile(t *testing.T, repo, logicalPath, content string) {
+	t.Helper()
+	path := filepath.Join(repo, filepath.FromSlash(logicalPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -343,7 +343,7 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		}
 	} else if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
 		legacyShape := Receipt{BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest}
-		if proof, proofErr := deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, snapshot, resolvedPrePR, preimages); proofErr == nil {
+		if proof, proofErr := deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, snapshot, resolvedPrePR, preimages, true); proofErr == nil {
 			compatibility = &proof
 			compatibleAdvance = proof.Compatible
 		} else if proof, boundaryErr := deriveCurrentChangesBoundaryCompatibility(ctx, repo, record.State, request, snapshot, resolvedPrePR); boundaryErr == nil {
@@ -505,7 +505,7 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 				finalCompatibility, compatibilityErr = deriveCompactRecoveryAdvanceCompatibility(ctx, repo, finalRecoveryBinding, request, finalSnapshot, finalRefs, finalPreimages)
 			} else {
 				legacyShape := Receipt{BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest}
-				finalCompatibility, compatibilityErr = deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, finalSnapshot, finalRefs, finalPreimages)
+				finalCompatibility, compatibilityErr = deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, finalSnapshot, finalRefs, finalPreimages, true)
 			}
 		}
 		if compatibilityErr != nil || finalCompatibility != *compatibility {

--- a/internal/reviewtransaction/compact_gate_local_advance_test.go
+++ b/internal/reviewtransaction/compact_gate_local_advance_test.go
@@ -1,0 +1,118 @@
+package reviewtransaction
+
+import (
+	"context"
+	"testing"
+)
+
+// This file documents the STOPPED sub-path of D2 (#2471 option a, filed
+// against #2388): "extend compatible base advance to pre-commit and pre-push
+// by reusing the existing content checks without the CI attestation."
+// Goal 1 (deriveBaseAdvanceCompatibility's requireAttestation parameter and
+// receipt.go's gate-agnostic baseAdvanceStatusAllowedForGate policy) is
+// implemented and covered by prepr_base_advance_characterization_test.go and
+// receipt_test.go. Goal 2 -- wiring compact_gate.go's evaluateCompactGate (the
+// gate evaluator the CLI actually calls for compact/modern receipts) to
+// populate GateContext.BaseAdvance for GatePreCommit/GatePrePush -- is
+// deliberately NOT done, because neither local gate's own target derivation
+// can ever produce deriveBaseAdvanceCompatibility's required precondition
+// (BaseTree diverged from the receipt while CandidateTree stayed byte-
+// identical to it) without changing how that derivation works, which is out
+// of scope for a change that must reuse the existing content checks
+// unchanged.
+//
+// The two tests below are the empirical evidence for that conclusion, kept as
+// permanent regression tests (not deleted after investigation) so a future
+// change that touches buildPushTarget or the pre-commit target builder has a
+// failing signal if it silently reintroduces or resolves this gap.
+//
+//   - TestCompactPrePushDisjointParentAdvanceWithoutLocalMergeAlreadyAllows:
+//     buildPushTarget (gate.go:907-950) resolves TargetBaseDiff's BaseRef via
+//     `git merge-base --all HEAD <boundary>` (gate.go:919), which self-heals
+//     back to the true historical divergence point whenever HEAD has not
+//     incorporated the advanced boundary. A pure "parent advanced on disjoint
+//     paths, child untouched" #2388 scenario therefore already resolves
+//     snapshot.BaseTree == receipt.BaseTree at pre-push today, with nothing to
+//     fix: GateAllow, zero mismatch, zero BaseAdvance evidence needed.
+//
+//   - TestCompactPrePushDisjointParentAdvanceWithLocalMergeStillRefuses: the
+//     only way to make snapshot.BaseTree diverge from receipt.BaseTree at
+//     pre-push is for HEAD to also advance (a real local merge commit), but
+//     that necessarily changes snapshot.CandidateTree away from
+//     receipt.FinalCandidateTree too (compact_gate.go:422's
+//     `snapshot.CandidateTree != receipt.FinalCandidateTree` check fires
+//     unconditionally, with no compatibleAdvance override, exactly like it
+//     does today for pre-PR -- see receipt.go's carve-out, which never
+//     overrides a literal candidate-tree mismatch either). Even if this test
+//     wired deriveBaseAdvanceCompatibility in on this path, the derivation's
+//     own condition 3 (prepr.go's patchIdentity calls, both anchored at
+//     receipt.BaseTree) would refuse it: the merged tree's diff against the
+//     OLD base includes both the reviewed content and the parent's advance,
+//     which is not patch-identical to the original reviewed diff. Reusing
+//     that check unchanged -- the explicit instruction -- means this shape
+//     can never be certified compatible without redefining patch identity to
+//     be base-relative, a semantic change to a shared, separately-pinned
+//     characterization (prepr_base_advance_characterization_test.go) that is
+//     out of scope here.
+//
+// Pre-commit has the identical structural gap from the other direction:
+// resolveCurrentChangesBase (snapshot.go:1110-1136) always returns HEAD's own
+// tree, so TargetCurrentChanges's BaseTree can never move independently of
+// CandidateTree either; see TestCompactPreCommitStagedMergeStillRefuses below
+// for its own empirical proof.
+
+// TestCompactPrePushDisjointParentAdvanceWithoutLocalMergeAlreadyAllows is the
+// pre-existing-behavior half of the stop evidence: no BaseAdvance wiring is
+// needed for the "child untouched" shape because pre-push already allows it.
+func TestCompactPrePushDisjointParentAdvanceWithoutLocalMergeAlreadyAllows(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	state, receipt := approvedCompactPrePRFixture(t, fixture)
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: state.LineageID,
+	})
+	if got.Result != GateAllow {
+		t.Fatalf("pre-push disjoint parent advance without a local merge = %#v, want allow (merge-base already self-heals)", got)
+	}
+	if got.Context.BaseTree != receipt.BaseTree || got.Context.CandidateTree != receipt.FinalCandidateTree {
+		t.Fatalf("pre-push context = %#v, want base/candidate unchanged from the receipt", got.Context)
+	}
+	if got.Context.BaseAdvance != nil {
+		t.Fatalf("pre-push context carries BaseAdvance evidence = %#v, want nil: no advance was needed", got.Context.BaseAdvance)
+	}
+}
+
+// TestCompactPrePushDisjointParentAdvanceWithLocalMergeStillRefuses is the
+// still-refused half: once HEAD actually merges the advanced parent in,
+// candidate and base move together, which the shared, unchanged content
+// checks cannot certify as compatible (see file doc comment above).
+func TestCompactPrePushDisjointParentAdvanceWithLocalMergeStillRefuses(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	state, receipt := approvedCompactPrePRFixture(t, fixture)
+	gitSnapshot(t, fixture.repo, "merge", "main", "--no-edit")
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: state.LineageID,
+	})
+	if got.Result != GateScopeChanged || got.Context.Denial == nil || got.Context.Denial.Code != "candidate-or-paths-mismatch" {
+		t.Fatalf("pre-push disjoint parent advance with a local merge = %#v, want scope-changed/candidate-or-paths-mismatch", got)
+	}
+}
+
+// TestCompactPreCommitStagedMergeStillRefuses is pre-commit's own stop
+// evidence: TargetCurrentChanges pins BaseTree to HEAD's own tree
+// (snapshot.go's resolveCurrentChangesBase), so a staged merge of the advanced
+// parent shows up entirely as a CandidateTree delta, never as a BaseTree
+// movement deriveBaseAdvanceCompatibility could certify.
+func TestCompactPreCommitStagedMergeStillRefuses(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	state, receipt := approvedCompactPrePRFixture(t, fixture)
+	gitSnapshot(t, fixture.repo, "merge", "main", "--no-commit", "--no-ff")
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePreCommit, LineageID: state.LineageID,
+	})
+	if got.Result != GateScopeChanged || got.Context.Denial == nil || got.Context.Denial.Code != "candidate-or-paths-mismatch" {
+		t.Fatalf("pre-commit staged merge of the advanced parent = %#v, want scope-changed/candidate-or-paths-mismatch", got)
+	}
+	if got.Context.BaseTree != receipt.FinalCandidateTree {
+		t.Fatalf("pre-commit base_tree = %q, want it pinned to HEAD (== the reviewed candidate %q), proving base never moved", got.Context.BaseTree, receipt.FinalCandidateTree)
+	}
+}

--- a/internal/reviewtransaction/compact_recovery_binding.go
+++ b/internal/reviewtransaction/compact_recovery_binding.go
@@ -283,7 +283,7 @@ func deriveCompactRecoveryAdvanceCompatibility(ctx context.Context, repo string,
 		BaseTree: binding.BaseTree, FinalCandidateTree: snapshot.CandidateTree,
 		PathsDigest: frozen.PathsDigest,
 	}
-	proof, err := deriveBaseAdvanceCompatibility(ctx, repo, synthetic, request, snapshot, refs, preimages)
+	proof, err := deriveBaseAdvanceCompatibility(ctx, repo, synthetic, request, snapshot, refs, preimages, true)
 	if err != nil {
 		return BaseAdvanceCompatibility{}, err
 	}

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -331,7 +331,7 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 		gateContext.PrePRBoundary = &boundary
 	}
 	if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
-		if compatibility, compatibilityErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, resolvedPrePR, preimages); compatibilityErr == nil {
+		if compatibility, compatibilityErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, resolvedPrePR, preimages, true); compatibilityErr == nil {
 			gateContext.BaseAdvance = &compatibility
 		}
 	}

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -48,7 +48,17 @@ type prePRCITrust struct {
 }
 
 const (
-	baseAdvanceCompatibleStatus            = "base-advanced-compatible"
+	baseAdvanceCompatibleStatus = "base-advanced-compatible"
+	// baseAdvanceCompatibleLocalStatus is the D2 (#2471 option a) local-gate
+	// counterpart of baseAdvanceCompatibleStatus (#2388): the exact same five
+	// content checks deriveBaseAdvanceCompatibility already enforces for
+	// pre-PR, reused verbatim at pre-commit/pre-push, minus the trusted CI
+	// attestation pre-PR alone can obtain. It is issued only by
+	// deriveBaseAdvanceCompatibility(requireAttestation=false) and is never
+	// accepted at GatePrePR (receipt.go's baseAdvanceStatusAllowedForGate) --
+	// that byte-strict split is the whole point of a second status constant
+	// instead of relaxing baseAdvanceCompatibleStatus's own validity rule.
+	baseAdvanceCompatibleLocalStatus       = "base-advanced-compatible-local"
 	currentChangesBoundaryCompatibleStatus = "current-changes-boundary-compatible"
 	currentChangesBoundaryCIStatus         = "not-required"
 )
@@ -62,7 +72,7 @@ func (proof BaseAdvanceCompatibility) valid() bool {
 	case baseAdvanceCompatibleStatus:
 		return core && validSHA256(proof.CIAttestationArtifactHash) &&
 			strings.TrimSpace(proof.CIAttestationIssuer) != "" && proof.CIStatus == "success"
-	case currentChangesBoundaryCompatibleStatus:
+	case baseAdvanceCompatibleLocalStatus, currentChangesBoundaryCompatibleStatus:
 		return core && proof.CIAttestationArtifactHash == "" && proof.CIAttestationIssuer == "" &&
 			proof.CIStatus == currentChangesBoundaryCIStatus
 	default:
@@ -70,14 +80,28 @@ func (proof BaseAdvanceCompatibility) valid() bool {
 	}
 }
 
-func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs, preimages gateArtifactPreimages) (BaseAdvanceCompatibility, error) {
+// deriveBaseAdvanceCompatibility runs the five content checks D2 (#2471
+// option a, filed against #2388) designates as the complete, gate-agnostic
+// compatible-base-advance contract: merge-base tree preservation, delivered
+// path identity, delivered patch identity, base-advance/delivered path
+// disjointness, and a conflict-free `merge-tree --write-tree`. requireAttestation
+// is the ONLY axis that varies by gate: true reproduces the exact pre-PR
+// behavior this function always had (a trusted CI attestation over the merged
+// result is mandatory, and the returned proof carries baseAdvanceCompatibleStatus);
+// false skips the attestation lookup/verification entirely and returns
+// baseAdvanceCompatibleLocalStatus instead, so a caller can never launder a
+// locally-derived proof into the CI-attested shape pre-PR's byte-strict
+// validation (receipt.go's baseAdvanceStatusAllowedForGate) requires. The five
+// content checks themselves are not duplicated, weakened, or parameterized --
+// same code, same order, same failure strings, for every caller.
+func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs, preimages gateArtifactPreimages, requireAttestation bool) (BaseAdvanceCompatibility, error) {
 	if refs == nil {
 		return BaseAdvanceCompatibility{}, errors.New("resolved pre-PR refs are missing")
 	}
 	if request.ExternalEvidence != ExternalEvidenceNone {
 		return BaseAdvanceCompatibility{}, errors.New("external evidence invalidates or escalates compatibility")
 	}
-	if request.PrePR == nil || strings.TrimSpace(request.PrePR.CIAttestationArtifact) == "" {
+	if requireAttestation && (request.PrePR == nil || strings.TrimSpace(request.PrePR.CIAttestationArtifact) == "") {
 		return BaseAdvanceCompatibility{}, errors.New("trusted CI attestation is required")
 	}
 	mergeBase, err := runGit(ctx, repo, nil, nil, "merge-base", refs.Selection.Commit, refs.HeadCommit)
@@ -124,15 +148,18 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {
 		return BaseAdvanceCompatibility{}, errors.New("merged result tree cannot be derived")
 	}
-	attestationHash, issuer, err := verifyPrePRCIAttestation(preimages.policy, preimages.ciAttestation, mergedFields[0])
-	if err != nil {
-		return BaseAdvanceCompatibility{}, err
+	var attestationHash, issuer string
+	if requireAttestation {
+		attestationHash, issuer, err = verifyPrePRCIAttestation(preimages.policy, preimages.ciAttestation, mergedFields[0])
+		if err != nil {
+			return BaseAdvanceCompatibility{}, err
+		}
 	}
 	selector := ""
 	if refs.Selection.Source == PrePRBoundaryExplicit {
 		selector = refs.Selection.Selector
 	}
-	selectionNow, err := selectPrePRBoundary(ctx, repo, selector)
+	selectionNow, err := reselectBoundaryForGate(ctx, repo, request.Gate, selector)
 	if err != nil || selectionNow != refs.Selection {
 		return BaseAdvanceCompatibility{}, errors.New("pre-PR base ref advanced during validation")
 	}
@@ -140,17 +167,35 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if err != nil || headNow != refs.HeadCommit {
 		return BaseAdvanceCompatibility{}, errors.New("HEAD advanced during validation")
 	}
+	status, ciStatus := baseAdvanceCompatibleLocalStatus, currentChangesBoundaryCIStatus
+	if requireAttestation {
+		status, ciStatus = baseAdvanceCompatibleStatus, "success"
+	}
 	proof := BaseAdvanceCompatibility{
-		Status: baseAdvanceCompatibleStatus, Compatible: true, OriginalMergeBaseTree: receipt.BaseTree, NewBaseTree: snapshot.BaseTree,
+		Status: status, Compatible: true, OriginalMergeBaseTree: receipt.BaseTree, NewBaseTree: snapshot.BaseTree,
 		OriginalPatchIdentity: originalPatch, DeliveredPatchIdentity: currentPatch,
 		DeliveredPathsDigest: receipt.PathsDigest, BaseAdvancePathsDigest: digestPaths(basePaths), PathsDisjoint: true,
 		MergedResultTree: mergedFields[0], CIAttestationArtifactHash: attestationHash,
-		CIAttestationIssuer: issuer, CIStatus: "success",
+		CIAttestationIssuer: issuer, CIStatus: ciStatus,
 	}
 	if !proof.valid() {
 		return BaseAdvanceCompatibility{}, errors.New("compatible base advance proof is incomplete")
 	}
 	return proof, nil
+}
+
+// reselectBoundaryForGate re-derives the boundary selector using exactly the
+// same resolution algorithm the target's own gate used the first time
+// (gate.go's prePRBoundaryForRequest vs. buildPushTarget/selectPrePushBoundary
+// diverge on how an empty/default selector resolves), so the freshness check
+// below compares like with like instead of risking a false "advanced during
+// validation" -- or worse, a false pass -- from mixing the two boundary
+// resolvers.
+func reselectBoundaryForGate(ctx context.Context, repo string, gate GateKind, selector string) (PrePRBoundarySelection, error) {
+	if gate == GatePrePush {
+		return selectPrePushBoundary(ctx, repo, selector)
+	}
+	return selectPrePRBoundary(ctx, repo, selector)
 }
 
 // deriveCurrentChangesBoundaryCompatibility reconciles an approved

--- a/internal/reviewtransaction/prepr_base_advance_characterization_test.go
+++ b/internal/reviewtransaction/prepr_base_advance_characterization_test.go
@@ -68,6 +68,14 @@ type baseAdvanceScenario struct {
 	// deriveBaseAdvanceCompatibility is called, so it can move live Git state
 	// out from under the already-captured refs. Used to isolate condition 7.
 	afterRefsCaptured func(t *testing.T, repo string)
+
+	// localGate runs deriveBaseAdvanceCompatibility with requireAttestation
+	// false -- the D2 (#2471 option a) local-gate policy pre-commit/pre-push
+	// consult instead of pre-PR's CI-backed one -- and skips building the
+	// attestation/policy artifacts a local gate request never carries. The
+	// five content checks (conditions 1-5 and 7) are otherwise identical;
+	// condition 6 (CI attestation) does not apply.
+	localGate bool
 }
 
 type baseAdvanceScenarioResult struct {
@@ -161,25 +169,38 @@ func runBaseAdvanceScenario(t *testing.T, scenario baseAdvanceScenario) baseAdva
 		}
 	}
 
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("ed25519.GenerateKey: %v", err)
+	requireAttestation := !scenario.localGate
+	var preimages gateArtifactPreimages
+	request := GateRequest{Gate: GatePrePR, ExternalEvidence: ExternalEvidenceNone}
+	if scenario.localGate {
+		// A real pre-commit/pre-push GateRequest never carries a PrePR block;
+		// leaving it unset here (instead of a present-but-empty one) proves
+		// requireAttestation=false genuinely never dereferences it. request.Gate
+		// stays GatePrePR so reselectBoundaryForGate below re-derives the
+		// boundary exactly the way it was captured above (selectPrePRBoundary);
+		// the gate-conditional reselect branch (selectPrePushBoundary) is
+		// covered separately and is orthogonal to this file's five-content-
+		// check characterization.
+	} else {
+		publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("ed25519.GenerateKey: %v", err)
+		}
+		attestation := prePRCIAttestation{Schema: prePRCIAttestationSchema, Issuer: "trusted-ci", MergedTree: mergedTree, Status: "success"}
+		if scenario.mutateAttestation != nil {
+			scenario.mutateAttestation(&attestation)
+		}
+		attestation.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, prePRCIAttestationPreimage(attestation)))
+		attestationPayload, err := json.Marshal(attestation)
+		if err != nil {
+			t.Fatalf("marshal attestation: %v", err)
+		}
+		policy := []byte("# Bounded review policy\n\npre_pr_ci_issuer: trusted-ci\npre_pr_ci_ed25519_public_key: " + base64.StdEncoding.EncodeToString(publicKey) + "\n")
+		preimages = gateArtifactPreimages{policy: policy, ciAttestation: attestationPayload}
+		request.PrePR = &PrePRRequest{CIAttestationArtifact: "ci-attestation-present"}
 	}
-	attestation := prePRCIAttestation{Schema: prePRCIAttestationSchema, Issuer: "trusted-ci", MergedTree: mergedTree, Status: "success"}
-	if scenario.mutateAttestation != nil {
-		scenario.mutateAttestation(&attestation)
-	}
-	attestation.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, prePRCIAttestationPreimage(attestation)))
-	attestationPayload, err := json.Marshal(attestation)
-	if err != nil {
-		t.Fatalf("marshal attestation: %v", err)
-	}
-	policy := []byte("# Bounded review policy\n\npre_pr_ci_issuer: trusted-ci\npre_pr_ci_ed25519_public_key: " + base64.StdEncoding.EncodeToString(publicKey) + "\n")
 
-	preimages := gateArtifactPreimages{policy: policy, ciAttestation: attestationPayload}
-	request := GateRequest{ExternalEvidence: ExternalEvidenceNone, PrePR: &PrePRRequest{CIAttestationArtifact: "ci-attestation-present"}}
-
-	proof, deriveErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, refs, preimages)
+	proof, deriveErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, refs, preimages, requireAttestation)
 	return baseAdvanceScenarioResult{proof: proof, err: deriveErr, repo: repo, receipt: receipt, snapshot: snapshot, refs: refs, mergedTree: mergedTree}
 }
 
@@ -323,6 +344,114 @@ func TestDeriveBaseAdvanceCompatibilityFailsClosedOnSingleConditionViolation(t *
 			}
 			if (result.proof != BaseAdvanceCompatibility{}) {
 				t.Fatalf("condition %s: proof = %#v, want zero value on failure", tt.condition, result.proof)
+			}
+		})
+	}
+}
+
+// TestDeriveBaseAdvanceCompatibilityCertifiesLocalGateWithoutAttestation is
+// the #2388 / D2 (#2471 option a) characterization at the derivation layer:
+// requireAttestation=false runs the exact same five content checks (merge-base
+// tree preservation, path digest identity, patch identity, path disjointness,
+// conflict-free merge-tree) without ever requiring or reading a CI
+// attestation, and returns a proof carrying baseAdvanceCompatibleLocalStatus
+// instead of baseAdvanceCompatibleStatus. This is the reusable machinery a
+// pre-commit/pre-push gate would consult for a disjoint, content-identical
+// parent advance; see the compact_gate_local_advance_test.go stop-evidence for
+// why no gate currently reaches this precondition (gate-request derivation,
+// not this function, is the missing piece).
+func TestDeriveBaseAdvanceCompatibilityCertifiesLocalGateWithoutAttestation(t *testing.T) {
+	result := runBaseAdvanceScenario(t, baseAdvanceScenario{localGate: true})
+	if result.err != nil {
+		t.Fatalf("deriveBaseAdvanceCompatibility(requireAttestation=false) error = %v, want nil", result.err)
+	}
+	if !result.proof.valid() {
+		t.Fatalf("proof.valid() = false, proof = %#v", result.proof)
+	}
+	if !result.proof.Compatible || result.proof.Status != baseAdvanceCompatibleLocalStatus {
+		t.Fatalf("proof compatibility/status = %#v, want Compatible=true Status=%q", result.proof, baseAdvanceCompatibleLocalStatus)
+	}
+	if result.proof.CIAttestationArtifactHash != "" || result.proof.CIAttestationIssuer != "" {
+		t.Fatalf("local proof carries CI attestation evidence: %#v", result.proof)
+	}
+	if result.proof.CIStatus != currentChangesBoundaryCIStatus {
+		t.Fatalf("local proof CIStatus = %q, want %q", result.proof.CIStatus, currentChangesBoundaryCIStatus)
+	}
+	// The five content checks are unaffected: same merge-base/patch/paths
+	// evidence as the attested success characterization above.
+	if result.proof.OriginalMergeBaseTree != result.receipt.BaseTree || result.proof.DeliveredPathsDigest != result.receipt.PathsDigest ||
+		result.proof.OriginalPatchIdentity != result.proof.DeliveredPatchIdentity || !result.proof.PathsDisjoint ||
+		!validGitTree(result.proof.MergedResultTree) || result.proof.MergedResultTree != result.mergedTree {
+		t.Fatalf("local proof content evidence diverged from the attested contract: %#v", result.proof)
+	}
+}
+
+// TestDeriveBaseAdvanceCompatibilityFailsClosedAtLocalGate reruns the same
+// fail-closed conditions 1-5 and 7 (condition 6, CI attestation, does not
+// exist at requireAttestation=false) with localGate:true, proving the local
+// policy reuses the identical content checks rather than a parallel, looser
+// implementation -- overlapping paths, a changed patch identity, and an
+// unresolvable merge conflict are refused exactly like the attested path.
+func TestDeriveBaseAdvanceCompatibilityFailsClosedAtLocalGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		scenario   baseAdvanceScenario
+		wantErrSub string
+	}{
+		{
+			name:       "merge-base tree not preserved",
+			scenario:   baseAdvanceScenario{localGate: true, mutateReceipt: func(receipt *Receipt) { receipt.BaseTree = emptyGitTreeSHA1 }},
+			wantErrSub: "original reviewed merge-base tree is not preserved",
+		},
+		{
+			name:       "path digest mismatch",
+			scenario:   baseAdvanceScenario{localGate: true, mutateReceipt: func(receipt *Receipt) { receipt.PathsDigest = digestPaths([]string{"unrelated-path.txt"}) }},
+			wantErrSub: "delivered path identity changed",
+		},
+		{
+			name: "patch identity changed",
+			scenario: baseAdvanceScenario{
+				localGate: true,
+				mutateContent: func(t *testing.T, repo string) {
+					writeSnapshotFile(t, repo, "delivery.txt", "changed after review\n")
+					gitSnapshot(t, repo, "add", "--", "delivery.txt")
+					gitSnapshot(t, repo, "commit", "-m", "unreviewed content change")
+				},
+			},
+			wantErrSub: "delivered patch identity changed",
+		},
+		{
+			name:       "base advance overlaps delivered paths",
+			scenario:   baseAdvanceScenario{localGate: true, deliveryPath: "shared.txt", basePath: "shared.txt"},
+			wantErrSub: "base advance overlaps delivered paths",
+		},
+		{
+			name:       "merge against new base is not conflict-free",
+			scenario:   baseAdvanceScenario{localGate: true, deliveryPath: "conflict/file.txt", basePath: "conflict"},
+			wantErrSub: "merge against new base is not conflict-free",
+		},
+		{
+			name: "HEAD advances after refs are captured",
+			scenario: baseAdvanceScenario{
+				localGate: true,
+				afterRefsCaptured: func(t *testing.T, repo string) {
+					gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "advance head after refs captured")
+				},
+			},
+			wantErrSub: "HEAD advanced during validation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runBaseAdvanceScenario(t, tt.scenario)
+			if result.err == nil {
+				t.Fatalf("deriveBaseAdvanceCompatibility(requireAttestation=false) error = nil, want failure containing %q", tt.wantErrSub)
+			}
+			if !strings.Contains(result.err.Error(), tt.wantErrSub) {
+				t.Fatalf("error = %q, want substring %q", result.err.Error(), tt.wantErrSub)
+			}
+			if (result.proof != BaseAdvanceCompatibility{}) {
+				t.Fatalf("proof = %#v, want zero value on failure", result.proof)
 			}
 		})
 	}

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -275,6 +275,29 @@ func RecoverySelfDerivedInputs(predecessor State) []string {
 	}
 }
 
+// baseAdvanceStatusAllowedForGate is the single source of truth D2 (#2471
+// option a) adds for the per-gate compatible-base-advance attestation policy:
+// GatePrePR alone may carry a CI-attested proof (baseAdvanceCompatibleStatus)
+// or the unrelated, already-existing current-changes boundary reconciliation
+// (currentChangesBoundaryCompatibleStatus, #1376); GatePreCommit and
+// GatePrePush may carry only the unattested local proof
+// (baseAdvanceCompatibleLocalStatus) deriveBaseAdvanceCompatibility issues
+// when its requireAttestation parameter is false. Both validateDerivedGate's
+// carve-out and ParseGateContext's structural validation call this one
+// function, so the attestation policy can never drift between "what a gate
+// accepts at evaluation time" and "what a persisted context is allowed to
+// claim happened."
+func baseAdvanceStatusAllowedForGate(gate GateKind, status string) bool {
+	switch gate {
+	case GatePrePR:
+		return status == baseAdvanceCompatibleStatus || status == currentChangesBoundaryCompatibleStatus
+	case GatePreCommit, GatePrePush:
+		return status == baseAdvanceCompatibleLocalStatus
+	default:
+		return false
+	}
+}
+
 func validateDerivedGate(receipt Receipt, context GateContext) GateResult {
 	if err := validateReceiptStructure(receipt); err != nil {
 		return GateInvalidated
@@ -285,7 +308,7 @@ func validateDerivedGate(receipt Receipt, context GateContext) GateResult {
 	if receipt.TerminalState != TerminalApproved {
 		return GateInvalidated
 	}
-	compatibleAdvance := context.Gate == GatePrePR && context.BaseAdvance != nil && context.BaseAdvance.Compatible
+	compatibleAdvance := context.BaseAdvance != nil && context.BaseAdvance.Compatible && baseAdvanceStatusAllowedForGate(context.Gate, context.BaseAdvance.Status)
 	if receipt.LineageID != context.LineageID || receipt.Generation != context.Generation {
 		return GateScopeChanged
 	}
@@ -344,7 +367,7 @@ func ParseGateContext(payload []byte) (GateContext, error) {
 		}
 	}
 	if context.BaseAdvance != nil {
-		if context.Gate != GatePrePR || !context.BaseAdvance.valid() {
+		if !context.BaseAdvance.valid() || !baseAdvanceStatusAllowedForGate(context.Gate, context.BaseAdvance.Status) {
 			return GateContext{}, errors.New("gate context contains invalid compatible base advance evidence")
 		}
 	}

--- a/internal/reviewtransaction/receipt_test.go
+++ b/internal/reviewtransaction/receipt_test.go
@@ -60,6 +60,171 @@ func TestReceiptDistinguishesReviewedAndFinalTreesAndValidatesExactGateInputs(t 
 	}
 }
 
+// validBaseAdvanceCore builds a syntactically-valid BaseAdvanceCompatibility
+// core (the five content-check fields every status shares) so each test below
+// only has to vary Status/CIStatus/CI fields, the one axis
+// baseAdvanceStatusAllowedForGate (receipt.go) actually polices.
+func validBaseAdvanceCore(originalBase, newBase string) BaseAdvanceCompatibility {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	return BaseAdvanceCompatibility{
+		Compatible: true, OriginalMergeBaseTree: originalBase, NewBaseTree: newBase,
+		OriginalPatchIdentity: digest, DeliveredPatchIdentity: digest,
+		DeliveredPathsDigest: digest, BaseAdvancePathsDigest: digest, PathsDisjoint: true,
+		MergedResultTree: newBase,
+	}
+}
+
+// TestValidateDerivedGateGeneralizesCompatibleBaseAdvanceToLocalGates pins D2
+// (#2471 option a, filed against #2388): the compatibleAdvance carve-out
+// (receipt.go's validateDerivedGate) used to consult context.BaseAdvance only
+// when context.Gate == GatePrePR. It must now consult it at GatePreCommit and
+// GatePrePush too, using the unattested baseAdvanceCompatibleLocalStatus proof
+// deriveBaseAdvanceCompatibility(requireAttestation=false) issues, and still
+// allow despite BaseTree/CandidateTree/PathsDigest diverging from the receipt
+// -- exactly the diagnostic #2388 reported as a hard pre-commit/pre-push
+// refusal with no recovery path.
+func TestValidateDerivedGateGeneralizesCompatibleBaseAdvanceToLocalGates(t *testing.T) {
+	tx := ordinaryAtFixValidation(t)
+	if err := tx.ValidateFixDelta([]string{"R1-DET"}, true); err != nil {
+		t.Fatalf("ValidateFixDelta() error = %v", err)
+	}
+	if err := tx.BeginFinalVerification(); err != nil {
+		t.Fatalf("BeginFinalVerification() error = %v", err)
+	}
+	if err := tx.CompleteFinalVerification(hash("5"), true); err != nil {
+		t.Fatalf("CompleteFinalVerification() error = %v", err)
+	}
+	receipt, err := tx.Receipt()
+	if err != nil {
+		t.Fatalf("Receipt() error = %v", err)
+	}
+	newBase := tree("e")
+	advance := validBaseAdvanceCore(receipt.BaseTree, newBase)
+	advance.Status, advance.CIStatus = baseAdvanceCompatibleLocalStatus, currentChangesBoundaryCIStatus
+	if !advance.valid() {
+		t.Fatalf("local advance proof is not valid: %#v", advance)
+	}
+	for _, gate := range []GateKind{GatePreCommit, GatePrePush} {
+		context := GateContext{
+			Gate: gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
+			BaseTree: newBase, CandidateTree: receipt.FinalCandidateTree,
+			PathsDigest: receipt.PathsDigest, FixDeltaHash: receipt.FixDeltaHash,
+			PolicyHash: receipt.PolicyHash, LedgerHash: receipt.LedgerHash, EvidenceHash: receipt.EvidenceHash,
+			BaseRelationshipValid: false, BaseAdvance: &advance,
+		}
+		if got := validateDerivedGate(receipt, context); got != GateAllow {
+			t.Fatalf("validateDerivedGate(%s, compatible local base advance) = %q, want allow", gate, got)
+		}
+	}
+}
+
+// TestValidateDerivedGateRefusesLocalStatusAtPrePRRegression is the byte-strict
+// regression guard D2 requires: the unattested local proof must never
+// authorize GatePrePR, even when every content-check field matches, because
+// GatePrePR alone can reach real CI and D2 keeps its attestation requirement
+// exactly as strict as before this change.
+func TestValidateDerivedGateRefusesLocalStatusAtPrePRRegression(t *testing.T) {
+	tx := ordinaryAtFixValidation(t)
+	if err := tx.ValidateFixDelta([]string{"R1-DET"}, true); err != nil {
+		t.Fatalf("ValidateFixDelta() error = %v", err)
+	}
+	if err := tx.BeginFinalVerification(); err != nil {
+		t.Fatalf("BeginFinalVerification() error = %v", err)
+	}
+	if err := tx.CompleteFinalVerification(hash("5"), true); err != nil {
+		t.Fatalf("CompleteFinalVerification() error = %v", err)
+	}
+	receipt, err := tx.Receipt()
+	if err != nil {
+		t.Fatalf("Receipt() error = %v", err)
+	}
+	newBase := tree("e")
+	advance := validBaseAdvanceCore(receipt.BaseTree, newBase)
+	advance.Status, advance.CIStatus = baseAdvanceCompatibleLocalStatus, currentChangesBoundaryCIStatus
+	context := GateContext{
+		Gate: GatePrePR, LineageID: receipt.LineageID, Generation: receipt.Generation,
+		BaseTree: newBase, CandidateTree: receipt.FinalCandidateTree,
+		PathsDigest: receipt.PathsDigest, FixDeltaHash: receipt.FixDeltaHash,
+		PolicyHash: receipt.PolicyHash, LedgerHash: receipt.LedgerHash, EvidenceHash: receipt.EvidenceHash,
+		BaseRelationshipValid: false, BaseAdvance: &advance,
+	}
+	if got := validateDerivedGate(receipt, context); got == GateAllow {
+		t.Fatalf("validateDerivedGate(pre-pr, unattested local advance) = %q, want refused", got)
+	}
+	if baseAdvanceStatusAllowedForGate(GatePrePR, baseAdvanceCompatibleLocalStatus) {
+		t.Fatal("baseAdvanceStatusAllowedForGate(pre-pr, local) = true, want false")
+	}
+	for _, gate := range []GateKind{GatePreCommit, GatePrePush} {
+		if baseAdvanceStatusAllowedForGate(gate, baseAdvanceCompatibleStatus) {
+			t.Fatalf("baseAdvanceStatusAllowedForGate(%s, attested) = true, want false", gate)
+		}
+	}
+}
+
+// TestParseGateContextRestrictsBaseAdvanceStatusPerGate proves the same
+// byte-strict split at the persisted-context boundary: ParseGateContext must
+// accept the local status only at GatePreCommit/GatePrePush, accept the
+// attested (or current-changes-boundary) status only at GatePrePR, and a
+// historical context with no base_advanced_compatible field at all -- every
+// context ever persisted before this change -- must still parse unchanged
+// (the additive-only, forensic-invariant requirement).
+func TestParseGateContextRestrictsBaseAdvanceStatusPerGate(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("d", 64)
+	base := strings.Repeat("a", 40)
+	newBase := strings.Repeat("b", 40)
+	candidate := strings.Repeat("c", 40)
+	coreFields := `"compatible":true,"old_base_tree":"` + base +
+		`","new_base_tree":"` + newBase + `","original_patch_identity":"` + digest + `","delivered_patch_identity":"` + digest +
+		`","delivered_paths_digest":"` + digest + `","base_advance_paths_digest":"` + digest + `","paths_disjoint":true,"merged_result_tree":"` + newBase + `"`
+	// localJSON has no CI fields (ci_status is the shared "not-required"
+	// sentinel both baseAdvanceCompatibleLocalStatus and
+	// currentChangesBoundaryCompatibleStatus use). attestedJSON adds the three
+	// CI fields baseAdvanceCompatibleStatus's own valid() requires, so a
+	// "does this status parse at this gate" case is never confused with "is
+	// this proof's own shape valid at all".
+	localJSON := `,"base_advanced_compatible":{"status":"STATUS",` + coreFields + `,"ci_status":"not-required"}`
+	attestedJSON := `,"base_advanced_compatible":{"status":"` + baseAdvanceCompatibleStatus + `",` + coreFields +
+		`,"ci_attestation_artifact_hash":"` + digest + `","ci_attestation_issuer":"trusted-ci","ci_status":"success"}`
+	baseContext := func(gate GateKind) string {
+		return `{"gate":"` + string(gate) + `","lineage_id":"lineage-one","generation":1,"store_revision":"` + digest +
+			`","genesis_revision":"` + digest + `","chain_identity":"` + digest + `","bundle_digest":"` + digest +
+			`","base_tree":"` + newBase + `","candidate_tree":"` + candidate + `","paths_digest":"` + digest +
+			`","fix_delta_hash":"` + digest + `","policy_hash":"` + digest + `","ledger_hash":"` + digest +
+			`","evidence_hash":"` + digest + `","base_relationship_valid":false`
+	}
+	withLocal := func(gate GateKind) string {
+		return baseContext(gate) + strings.Replace(localJSON, "STATUS", baseAdvanceCompatibleLocalStatus, 1) + "}"
+	}
+	withAttested := func(gate GateKind) string { return baseContext(gate) + attestedJSON + "}" }
+	withoutAdvance := func(gate GateKind) string { return baseContext(gate) + "}" }
+
+	for _, tt := range []struct {
+		name    string
+		payload string
+		wantErr bool
+	}{
+		{"local status at pre-commit parses", withLocal(GatePreCommit), false},
+		{"local status at pre-push parses", withLocal(GatePrePush), false},
+		{"attested status at pre-pr parses", withAttested(GatePrePR), false},
+		{"local status at pre-pr is rejected (byte-strict regression)", withLocal(GatePrePR), true},
+		{"attested status at pre-commit is rejected", withAttested(GatePreCommit), true},
+		{"attested status at pre-push is rejected", withAttested(GatePrePush), true},
+		{"historical context without base advance still parses at pre-commit", withoutAdvance(GatePreCommit), false},
+		{"historical context without base advance still parses at pre-push", withoutAdvance(GatePrePush), false},
+		{"historical context without base advance still parses at pre-pr", withoutAdvance(GatePrePR), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseGateContext([]byte(tt.payload))
+			if tt.wantErr && err == nil {
+				t.Fatalf("ParseGateContext(%s) accepted an invalid base-advance/gate pairing", tt.name)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ParseGateContext(%s) error = %v, want nil", tt.name, err)
+			}
+		})
+	}
+}
+
 func TestReceiptParserIsStrictAndTerminalVocabularyIsClosed(t *testing.T) {
 	tx := newTestTransaction(t, ModeOrdinary4R)
 	_ = tx.StartReview()

--- a/internal/reviewtransaction/shadow_relation_test.go
+++ b/internal/reviewtransaction/shadow_relation_test.go
@@ -332,7 +332,7 @@ func buildShadowBaseAdvanceFixture(t *testing.T, breakMergeBasePreservation bool
 // here only for this file's own direct characterization of Amendment A
 // delegation, independent of any observer.
 func deriveBaseAdvanceCompatibilityPtr(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs, preimages gateArtifactPreimages) *BaseAdvanceCompatibility {
-	proof, err := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, refs, preimages)
+	proof, err := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, refs, preimages, true)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2665

Refs #2388 (first slice; remaining shapes need a target-derivation design decision, evidence recorded there).

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 🔗 Chain Context

Stacked PR 3 of 3 for root 21 of #2471.

```
main
 └─ #2657 feat/2624-transparent-opencode-reviewer (shared advisory transport)
     └─ #2660 refactor/2659-content-identity (W1)
         └─ #2663 fix/2586-zero-delta-refusal (W2)
             └─ 📍 fix/2388-local-gate-base-advance (W3 — THIS PR)
```

- **Starts**: after W2; touches prepr.go/receipt.go policy, no W1/W2 surface.
- **Ends**: per-gate attestation policy live (dormant at local gates until target derivation produces the local status), pre-push freshness re-check fixed, behavior characterized permanently.
- **Out of scope**: target-derivation redesign for the locally-merged-advance shapes (#2388 remainder, maintainer design decision).

---

## 📝 Summary

Evidence-first outcome. The task was to extend compatible base advance to local gates (D2, #2471); the mechanism investigation proved half the problem no longer exists and the other half cannot be certified by the existing checks without weakening them:

- `TestCompactPrePushDisjointParentAdvanceWithoutLocalMergeAlreadyAllows` proves pre-push on current main ALREADY allows a disjoint parent advance when the user has not merged it locally: `buildPushTarget` derives the base via `git merge-base --all HEAD`, self-healing to the true divergence point.
- The still-refused shapes (local merge of the advanced parent; pre-commit staged merge) move `CandidateTree` together with the base, which the five content checks structurally cannot certify — the refusal is correct, and inventing a weaker lookalike check was explicitly rejected. Characterized permanently by `TestCompactPrePushDisjointParentAdvanceWithLocalMergeStillRefuses` and `TestCompactPreCommitStagedMergeStillRefuses`.

What lands as production change:
- `deriveBaseAdvanceCompatibility` gains a `requireAttestation` policy parameter: `true` reproduces pre-PR behavior byte-for-byte (regression-tested); `false` yields the new local status without the CI attestation that cannot exist at local gates. Five content checks untouched — same code, order, failure strings.
- `baseAdvanceStatusAllowedForGate` is the single per-gate policy consulted by `validateDerivedGate` (generalized from the pre-PR-only carve-out) and `ParseGateContext`. Additive JSON only; historical gate contexts parse unchanged (tested).
- Latent bug fixed: the final freshness re-check now reselects the boundary with the algorithm the target actually used (`selectPrePushBoundary` vs `selectPrePRBoundary`).

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/prepr.go` | Per-gate attestation policy; freshness boundary re-check fix (+~60 production) |
| `internal/reviewtransaction/receipt.go` | `baseAdvanceStatusAllowedForGate` single policy; carve-out generalized (+~40 production) |
| `internal/reviewtransaction/*_test.go`, `internal/cli/review_local_gate_base_advance_test.go` | Compatibility matrix, byte-strict pre-PR regression, stop-evidence characterization (+675 test) |
| `bench/` | `j73-pre-commit-still-refuses-staged-merge-of-an-advanced-parent`; count pin 72→73 |

## 🧪 Test Plan

```bash
go test ./internal/reviewtransaction/ -count=1  # ok (128s)
go test ./internal/cli/ -count=1                # ok (190s)
cd bench && go test ./... -count=1              # ok; driven run 73/73 completed
gofmt -l . && go vet ./... && go build ./...    # clean
scripts/deadcode-ratchet.sh                     # no new unreachable functions
```

Review budget: 738 additions + 37 deletions = 775 changed lines (100 production, 675 test/journey — characterization-heavy by design; `size:exception` requested on that basis).

## ✅ Contributor Checklist

- [x] Linked an approved issue (`status:approved` on #2665)
- [x] Added exactly one `type:*` label
- [x] Shellcheck: no shell scripts modified
- [x] Conventional commit format, no `Co-Authored-By` trailers
- [x] Docs updated where behavior changed (issue #2388 carries the evidence record)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pre-push and pre-commit validation when a parent branch advances independently.
  - Correctly rejects local merges and staged changes that introduce scope mismatches.
  - Added gate-specific handling for locally verified changes without CI attestation.
  - Preserved compatibility with historical validation records and existing attested workflows.

- **Tests**
  - Added coverage for local merge scenarios, branch advances, proof validation, and scope-change diagnostics across supported validation gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->