### PR TITLE
chore(ci): baseline codexAdvisoryEnvironment beside its e2e-only caller

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -1,5 +1,6 @@
 internal/advisoryreview/codex_adapter.go	CodexAdapter.Review
 internal/advisoryreview/codex_adapter.go	NewCodexAdapter
+internal/advisoryreview/codex_adapter.go	codexAdvisoryEnvironment
 internal/advisoryreview/contract.go	RuntimeNames
 internal/advisoryreview/contract.go	SupportedRuntimes
 internal/agentbuilder/engine.go	MockEngine.Agent


### PR DESCRIPTION
Closes #2673

One-line deadcode baseline entry: codexAdvisoryEnvironment is called only by CodexAdapter.Review, itself already baselined as an e2e-only call-graph blind spot. The organic proof and the env-scrub unit test execute both. Verified locally: scripts/deadcode-ratchet.sh → no new unreachable functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code-quality tracking to account for an existing advisory review component.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->