### PR TITLE
fix(review): collect intended untracked paths

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -782,6 +782,12 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 	repairActor := flags.String("repair-actor", "", "authorized classified repair actor")
 	repairReason := flags.String("repair-reason", "", "authorized classified repair reason")
 	repairAuthorization := flags.String("repair-authorization", "", "exact classified repair authorization binding")
+	untrackedScope := reviewSingleValueFlag{}
+	intendedUntracked := reviewRepeatedPathFlag{}
+	expectedUntrackedInventory := reviewSingleValueFlag{}
+	flags.Var(&untrackedScope, "untracked-scope", "explicit untracked scope: exclude or select")
+	flags.Var(&intendedUntracked, "intended-untracked", "repo-relative untracked path to include; repeat for each path")
+	flags.Var(&expectedUntrackedInventory, "expected-untracked-inventory", "sha256 inventory digest from review status")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -854,6 +860,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 				target.BaseRef = selectedBaseTree
 			}
 		}
+		intendedScope := reviewIntendedUntrackedScope{}
+		if selectedProjection != reviewtransaction.ProjectionStaged {
+			intendedScope, err = reviewIntendedUntrackedScopeForTarget(ctx, reviewtransaction.SnapshotBuilder{Repo: root}, untrackedScope.value,
+				untrackedScope.set, intendedUntracked, expectedUntrackedInventory.value, expectedUntrackedInventory.set)
+			if err != nil {
+				return reviewPreflightError(err)
+			}
+			target.IntendedUntracked = intendedScope.Intended
+		}
 		selector := &reviewTransitionSelector{
 			Kind: target.Kind, Projection: selectedProjection, BaseRef: selectedBaseRef,
 			BaseTree: selectedBaseTree, WorkspaceOverlay: *workspaceOverlay, PrePRRepresentable: true,
@@ -871,6 +886,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			return errors.New("--base-tree does not identify an exact Git tree object")
 		}
 		result := newReviewTargetStatusResultForContract(native, *contract)
+		result.intendedUntracked = intendedScope
 		if native.Applicability == reviewtransaction.TargetApplicabilityCorrupted &&
 			native.Action == reviewtransaction.TargetStatusActionRepairAuthority {
 			repair, repairErr := reviewtransaction.AssessAuthorityRepairAtRepositoryRoot(ctx, root)
@@ -1007,7 +1023,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			if startLineage == "" && native.Applicability == reviewtransaction.TargetApplicabilityUnrelated {
 				startLineage = reviewAvailableStartLineage(ctx, root, native.TargetIdentity)
 			}
-			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, capturedEvidence, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector})
+			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, capturedEvidence, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector, IntendedUntracked: intendedScope})
 			result.NextTransition = &transition
 			if reviewTransitionValidationRequest(&transition) == nil && transition.ReasonCode != "correction_repository_verification_required" &&
 				transition.ReasonCode != "correction_repository_tooling_failed" {
@@ -1020,6 +1036,10 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			if transition.Kind == reviewNextTransitionStop {
 				reviewNarrateStopReason(transition.ReasonCode, runtime)
 			}
+		}
+		if intendedScope.NeedsSelection {
+			transition := reviewIntendedUntrackedCollection(result, intendedScope)
+			result.NextTransition = &transition
 		}
 		if err := result.Validate(); err != nil {
 			return fmt.Errorf("validate negotiated review status: %w", err)
@@ -1463,6 +1483,12 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	tracePath := flags.String("trace", "", "optional diagnostic operation metadata trace path")
 	consent := flags.String("consent", "", "negotiated consent declaration: relay to receive the typed blocking consent question, granted or declined to answer it for the exact frozen candidate")
 	locale := flags.String("locale", "", "optional consent-envelope locale: en or es")
+	untrackedScope := reviewSingleValueFlag{}
+	intendedUntracked := reviewRepeatedPathFlag{}
+	expectedUntrackedInventory := reviewSingleValueFlag{}
+	flags.Var(&untrackedScope, "untracked-scope", "explicit untracked scope: exclude or select")
+	flags.Var(&intendedUntracked, "intended-untracked", "repo-relative untracked path to include; repeat for each path")
+	flags.Var(&expectedUntrackedInventory, "expected-untracked-inventory", "sha256 inventory digest from review status")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -1540,23 +1566,24 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			return errors.New("review start with --base-ref omits dirty tracked changes; rerun with --committed-only to acknowledge committed-only review scope")
 		}
 	}
-	// Issue #2394: START used to sweep every unignored untracked path in the
-	// worktree into the frozen candidate. Existing on disk is not a
-	// declaration, and the sweep handed a reviewer the exact bytes of files
-	// the user never submitted -- two unrelated credential files, in the
-	// reported occurrence. Review scope is now only what the user declared
-	// through Git's own mechanism: tracked modifications, plus new files put
-	// in the index with `git add`, which the candidate is already built from.
-	// Nothing here has to be configured for that to be safe, because there is
-	// no longer anything to configure: the sweep is gone rather than filtered.
-	intended := []string{}
-	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: selectedProjection, IntendedUntracked: intended}
+	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: selectedProjection, IntendedUntracked: []string{}}
 	if strings.TrimSpace(*baseRef) != "" {
 		target.Kind = reviewtransaction.TargetBaseDiff
 		target.BaseRef = strings.TrimSpace(*baseRef)
 	}
 	if *workspaceOverlay {
 		target.Kind = reviewtransaction.TargetBaseWorkspaceOverlay
+	}
+	if selectedProjection != reviewtransaction.ProjectionStaged {
+		scope, scopeErr := reviewIntendedUntrackedScopeForTarget(ctx, reviewtransaction.SnapshotBuilder{Repo: root}, untrackedScope.value,
+			untrackedScope.set, intendedUntracked, expectedUntrackedInventory.value, expectedUntrackedInventory.set)
+		if scopeErr != nil {
+			return reviewPreflightError(scopeErr)
+		}
+		if scope.NeedsSelection {
+			return reviewPreflightError(reviewIntendedUntrackedSelectionRequired(scope))
+		}
+		target.IntendedUntracked = scope.Intended
 	}
 	snapshot, err := reviewFacadeBuildStartSnapshot(ctx, reviewtransaction.SnapshotBuilder{Repo: root}, target)
 	if err != nil {

--- a/internal/cli/review_intended_untracked.go
+++ b/internal/cli/review_intended_untracked.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+const reviewIntendedUntrackedSelectionSchema = "gentle-ai.review-intended-untracked-selection/v1"
+
+type reviewRepeatedPathFlag []string
+
+func (paths *reviewRepeatedPathFlag) String() string { return strings.Join(*paths, "\n") }
+func (paths *reviewRepeatedPathFlag) Set(value string) error {
+	*paths = append(*paths, value)
+	return nil
+}
+
+type reviewSingleValueFlag struct {
+	value string
+	set   bool
+}
+
+func (flag *reviewSingleValueFlag) String() string { return flag.value }
+func (flag *reviewSingleValueFlag) Set(value string) error {
+	if flag.set {
+		return errors.New("untracked scope flags may only be specified once")
+	}
+	flag.value, flag.set = value, true
+	return nil
+}
+
+type reviewIntendedUntrackedScope struct {
+	Inventory, Intended []string
+	Digest              string
+	NeedsSelection      bool
+	Declared            bool
+}
+
+func reviewIntendedUntrackedScopeForTarget(ctx context.Context, builder reviewtransaction.SnapshotBuilder, mode string, modeProvided bool, selected []string, expectedDigest string, digestProvided bool) (reviewIntendedUntrackedScope, error) {
+	inventory, digest, err := builder.IntendedUntrackedInventory(ctx)
+	if err != nil {
+		return reviewIntendedUntrackedScope{}, err
+	}
+	scope := reviewIntendedUntrackedScope{Inventory: inventory, Intended: []string{}, Digest: digest, Declared: modeProvided || len(selected) != 0 || digestProvided}
+	if len(inventory) == 0 && !scope.Declared {
+		return scope, nil
+	}
+	if !scope.Declared {
+		scope.NeedsSelection = true
+		return scope, nil
+	}
+	if !modeProvided || !digestProvided {
+		return reviewIntendedUntrackedScope{}, errors.New("untracked selection requires --untracked-scope and --expected-untracked-inventory")
+	}
+	switch mode {
+	case "exclude":
+		if len(selected) != 0 {
+			return reviewIntendedUntrackedScope{}, errors.New("--untracked-scope=exclude does not accept --intended-untracked")
+		}
+	case "select":
+		if len(selected) == 0 {
+			return reviewIntendedUntrackedScope{}, errors.New("--untracked-scope=select requires at least one --intended-untracked")
+		}
+	default:
+		return reviewIntendedUntrackedScope{}, fmt.Errorf("--untracked-scope must be exclude or select, got %q", mode)
+	}
+	intended, err := builder.ValidateIntendedUntrackedSelection(ctx, expectedDigest, selected)
+	if err != nil {
+		return reviewIntendedUntrackedScope{}, err
+	}
+	scope.Intended = intended
+	return scope, nil
+}
+
+func reviewIntendedUntrackedSelectionRequired(scope reviewIntendedUntrackedScope) error {
+	return fmt.Errorf("untracked files require an explicit declaration; rerun with --untracked-scope=exclude --expected-untracked-inventory=%s or --untracked-scope=select --intended-untracked=<repo-relative-path> --expected-untracked-inventory=%s", scope.Digest, scope.Digest)
+}
+
+func reviewIntendedUntrackedCollection(status ReviewTargetStatusResult, scope reviewIntendedUntrackedScope) ReviewNextTransition {
+	paths, _ := json.Marshal(scope.Inventory)
+	return reviewCollectTransition("intended_untracked_selection_required", ReviewTransitionInput{
+		Name: "intended_untracked_selection", Schema: reviewIntendedUntrackedSelectionSchema,
+		CaptureOperation: "external.select_intended_untracked",
+		Arguments: append(reviewTargetArguments(status),
+			ReviewTransitionArgument{Name: "eligible_paths_json", Value: string(paths)},
+			ReviewTransitionArgument{Name: "expected_untracked_inventory", Value: scope.Digest}),
+	})
+}
+
+func reviewStartIntendedUntrackedArguments(scope reviewIntendedUntrackedScope) []ReviewTransitionArgument {
+	if !scope.Declared {
+		return nil
+	}
+	arguments := []ReviewTransitionArgument{
+		{Name: "untracked-scope", Value: map[bool]string{true: "select", false: "exclude"}[len(scope.Intended) != 0]},
+		{Name: "expected-untracked-inventory", Value: scope.Digest},
+	}
+	for _, path := range scope.Intended {
+		arguments = append(arguments, ReviewTransitionArgument{Name: "intended-untracked", Value: path})
+	}
+	return arguments
+}

--- a/internal/cli/review_intended_untracked.go
+++ b/internal/cli/review_intended_untracked.go
@@ -28,17 +28,16 @@ type reviewSingleValueFlag struct {
 func (flag *reviewSingleValueFlag) String() string { return flag.value }
 func (flag *reviewSingleValueFlag) Set(value string) error {
 	if flag.set {
-		return errors.New("untracked scope flags may only be specified once")
+		return errors.New("untracked scope flags may only be specified once") // refusal:by-design operator-knowledge: remove the ambiguous duplicate declaration before retrying
 	}
 	flag.value, flag.set = value, true
 	return nil
 }
 
 type reviewIntendedUntrackedScope struct {
-	Inventory, Intended []string
-	Digest              string
-	NeedsSelection      bool
-	Declared            bool
+	Inventory, Intended      []string
+	Digest                   string
+	NeedsSelection, Declared bool
 }
 
 func reviewIntendedUntrackedScopeForTarget(ctx context.Context, builder reviewtransaction.SnapshotBuilder, mode string, modeProvided bool, selected []string, expectedDigest string, digestProvided bool) (reviewIntendedUntrackedScope, error) {
@@ -55,19 +54,19 @@ func reviewIntendedUntrackedScopeForTarget(ctx context.Context, builder reviewtr
 		return scope, nil
 	}
 	if !modeProvided || !digestProvided {
-		return reviewIntendedUntrackedScope{}, errors.New("untracked selection requires --untracked-scope and --expected-untracked-inventory")
+		return reviewIntendedUntrackedScope{}, errors.New("untracked selection requires --untracked-scope and --expected-untracked-inventory; rerun `gentle-ai review status --next-transition`")
 	}
 	switch mode {
 	case "exclude":
 		if len(selected) != 0 {
-			return reviewIntendedUntrackedScope{}, errors.New("--untracked-scope=exclude does not accept --intended-untracked")
+			return reviewIntendedUntrackedScope{}, errors.New("--untracked-scope=exclude does not accept --intended-untracked; rerun `gentle-ai review start --untracked-scope=select`")
 		}
 	case "select":
 		if len(selected) == 0 {
-			return reviewIntendedUntrackedScope{}, errors.New("--untracked-scope=select requires at least one --intended-untracked")
+			return reviewIntendedUntrackedScope{}, errors.New("--untracked-scope=select requires at least one --intended-untracked; rerun `gentle-ai review start --untracked-scope=exclude`")
 		}
 	default:
-		return reviewIntendedUntrackedScope{}, fmt.Errorf("--untracked-scope must be exclude or select, got %q", mode)
+		return reviewIntendedUntrackedScope{}, fmt.Errorf("--untracked-scope must be exclude or select, got %q; rerun `gentle-ai review status --next-transition`", mode)
 	}
 	intended, err := builder.ValidateIntendedUntrackedSelection(ctx, expectedDigest, selected)
 	if err != nil {
@@ -76,11 +75,9 @@ func reviewIntendedUntrackedScopeForTarget(ctx context.Context, builder reviewtr
 	scope.Intended = intended
 	return scope, nil
 }
-
 func reviewIntendedUntrackedSelectionRequired(scope reviewIntendedUntrackedScope) error {
-	return fmt.Errorf("untracked files require an explicit declaration; rerun with --untracked-scope=exclude --expected-untracked-inventory=%s or --untracked-scope=select --intended-untracked=<repo-relative-path> --expected-untracked-inventory=%s", scope.Digest, scope.Digest)
+	return fmt.Errorf("untracked files require an explicit declaration; run `gentle-ai review status --next-transition`, then rerun with --untracked-scope=exclude --expected-untracked-inventory=%s or --untracked-scope=select --intended-untracked=<repo-relative-path> --expected-untracked-inventory=%s", scope.Digest, scope.Digest)
 }
-
 func reviewIntendedUntrackedCollection(status ReviewTargetStatusResult, scope reviewIntendedUntrackedScope) ReviewNextTransition {
 	paths, _ := json.Marshal(scope.Inventory)
 	return reviewCollectTransition("intended_untracked_selection_required", ReviewTransitionInput{
@@ -91,7 +88,6 @@ func reviewIntendedUntrackedCollection(status ReviewTargetStatusResult, scope re
 			ReviewTransitionArgument{Name: "expected_untracked_inventory", Value: scope.Digest}),
 	})
 }
-
 func reviewStartIntendedUntrackedArguments(scope reviewIntendedUntrackedScope) []ReviewTransitionArgument {
 	if !scope.Declared {
 		return nil

--- a/internal/cli/review_intended_untracked_test.go
+++ b/internal/cli/review_intended_untracked_test.go
@@ -36,15 +36,10 @@ func intendedUntrackedSelection(t *testing.T, status ReviewTargetStatusResult) (
 	if err := json.Unmarshal([]byte(arguments["eligible_paths_json"]), &paths); err != nil {
 		t.Fatal(err)
 	}
-	digest := arguments["expected_untracked_inventory"]
-	if digest == "" {
-		t.Fatal("selection input omits the expected inventory digest")
-	}
-	return digest, paths
+	return arguments["expected_untracked_inventory"], paths
 }
 func assertNoUntrackedSelectionAuthority(t *testing.T, repo string) {
-	stores, err := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
-	if err != nil || len(stores) != 0 {
+	if stores, err := reviewtransaction.DiscoverCompactStores(context.Background(), repo); err != nil || len(stores) != 0 {
 		t.Fatalf("incomplete untracked intent created authority: err=%v stores=%#v", err, stores)
 	}
 }
@@ -52,8 +47,7 @@ func TestIntendedUntrackedSelectionRequiresExplicitIntentBeforeAuthority(t *test
 	repo := initReviewCLIRepo(t)
 	writeUndeclaredWorkspaceFile(t, repo, "candidate, with space.txt", "candidate\n", 0o644)
 	writeUndeclaredWorkspaceFile(t, repo, unrelatedCredentialPath, unrelatedCredentialContents, 0o600)
-	status := intendedUntrackedStatus(t, repo)
-	digest, inventory := intendedUntrackedSelection(t, status)
+	digest, inventory := intendedUntrackedSelection(t, intendedUntrackedStatus(t, repo))
 	if !containsString(inventory, "candidate, with space.txt") || !containsString(inventory, unrelatedCredentialPath) || strings.Contains(strings.Join(inventory, "\n"), unrelatedCredentialMarker) {
 		t.Fatalf("selection inventory = %q, want canonical paths but no candidate bytes", inventory)
 	}

--- a/internal/cli/review_intended_untracked_test.go
+++ b/internal/cli/review_intended_untracked_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+func intendedUntrackedStatus(t *testing.T, repo string, args ...string) ReviewTargetStatusResult {
+	var output bytes.Buffer
+	if err := RunReviewStatus(append([]string{"--contract", ReviewIntegrationContractV2, "--next-transition", "--cwd", repo}, args...), &output); err != nil {
+		t.Fatalf("review status %v: %v\n%s", args, err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	return status
+}
+func intendedUntrackedSelection(t *testing.T, status ReviewTargetStatusResult) (string, []string) {
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect || status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("selection transition = %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.Name != "intended_untracked_selection" || input.Schema != reviewIntendedUntrackedSelectionSchema || input.CaptureOperation != "external.select_intended_untracked" {
+		t.Fatalf("selection input = %#v", input)
+	}
+	arguments, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var paths []string
+	if err := json.Unmarshal([]byte(arguments["eligible_paths_json"]), &paths); err != nil {
+		t.Fatal(err)
+	}
+	digest := arguments["expected_untracked_inventory"]
+	if digest == "" {
+		t.Fatal("selection input omits the expected inventory digest")
+	}
+	return digest, paths
+}
+func assertNoUntrackedSelectionAuthority(t *testing.T, repo string) {
+	stores, err := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if err != nil || len(stores) != 0 {
+		t.Fatalf("incomplete untracked intent created authority: err=%v stores=%#v", err, stores)
+	}
+}
+func TestIntendedUntrackedSelectionRequiresExplicitIntentBeforeAuthority(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeUndeclaredWorkspaceFile(t, repo, "candidate, with space.txt", "candidate\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, unrelatedCredentialPath, unrelatedCredentialContents, 0o600)
+	status := intendedUntrackedStatus(t, repo)
+	digest, inventory := intendedUntrackedSelection(t, status)
+	if !containsString(inventory, "candidate, with space.txt") || !containsString(inventory, unrelatedCredentialPath) || strings.Contains(strings.Join(inventory, "\n"), unrelatedCredentialMarker) {
+		t.Fatalf("selection inventory = %q, want canonical paths but no candidate bytes", inventory)
+	}
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "missing-intent"}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "--untracked-scope=exclude") || !strings.Contains(err.Error(), digest) {
+		t.Fatalf("direct missing-intent refusal = %v, want exact continuation flags and digest", err)
+	}
+	assertNoUntrackedSelectionAuthority(t, repo)
+}
+func TestIntendedUntrackedSelectionScopesOnlyExplicitPaths(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeUndeclaredWorkspaceFile(t, repo, "chosen, file.txt", "chosen\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, unrelatedCredentialPath, unrelatedCredentialContents, 0o600)
+	writeUndeclaredWorkspaceFile(t, repo, "ignored.txt", "ignored\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, ".gitignore", "ignored.txt\n", 0o644)
+	writeReviewStartCandidate(t, repo, "tracked.txt", "tracked change\n", 0o644)
+	digest, inventory := intendedUntrackedSelection(t, intendedUntrackedStatus(t, repo))
+	if containsString(inventory, "ignored.txt") {
+		t.Fatalf("ignored path entered selection inventory: %v", inventory)
+	}
+	selected := intendedUntrackedStatus(t, repo, "--untracked-scope=select", "--intended-untracked=chosen, file.txt", "--intended-untracked="+unrelatedCredentialPath, "--expected-untracked-inventory="+digest)
+	if !reflect.DeepEqual(selected.Projection.Paths, []string{"chosen, file.txt", "tracked.txt", unrelatedCredentialPath}) {
+		t.Fatalf("partial selected projection paths = %v", selected.Projection.Paths)
+	}
+	if selected.NextTransition == nil || selected.NextTransition.Kind != reviewNextTransitionExecute || selected.NextTransition.Execute == nil || selected.NextTransition.Execute.Operation != "review.start" || strings.Count(selected.NextTransition.Execute.Command, "--intended-untracked=") != 2 {
+		t.Fatalf("selected transition = %#v, want executable START", selected.NextTransition)
+	}
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "direct-parity", "--untracked-scope=select", "--intended-untracked=chosen, file.txt", "--intended-untracked=" + unrelatedCredentialPath, "--expected-untracked-inventory=" + digest}, &output); err != nil {
+		t.Fatalf("direct selected start: %v\n%s", err, output.String())
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	if started.TargetIdentity != selected.TargetIdentity {
+		t.Fatalf("direct target = %s, negotiated target = %s", started.TargetIdentity, selected.TargetIdentity)
+	}
+}
+func TestIntendedUntrackedSelectionFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		args func(string) []string
+	}{
+		{"missing mode", func(digest string) []string { return []string{"--expected-untracked-inventory=" + digest} }},
+		{"missing digest", func(string) []string { return []string{"--untracked-scope=exclude"} }},
+		{"stale digest", func(string) []string {
+			return []string{"--untracked-scope=exclude", "--expected-untracked-inventory=sha256:" + strings.Repeat("a", 64)}
+		}},
+		{"duplicate path", func(digest string) []string {
+			return []string{"--untracked-scope=select", "--intended-untracked=candidate.txt", "--intended-untracked=candidate.txt", "--expected-untracked-inventory=" + digest}
+		}},
+		{"duplicate mode", func(digest string) []string {
+			return []string{"--untracked-scope=exclude", "--untracked-scope=exclude", "--expected-untracked-inventory=" + digest}
+		}},
+		{"duplicate digest", func(digest string) []string {
+			return []string{"--untracked-scope=exclude", "--expected-untracked-inventory=" + digest, "--expected-untracked-inventory=" + digest}
+		}},
+		{"nonmember path", func(digest string) []string {
+			return []string{"--untracked-scope=select", "--intended-untracked=missing.txt", "--expected-untracked-inventory=" + digest}
+		}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			writeUndeclaredWorkspaceFile(t, repo, "candidate.txt", "candidate\n", 0o644)
+			digest, _ := intendedUntrackedSelection(t, intendedUntrackedStatus(t, repo))
+			err := RunReviewFacadeStart(append([]string{"--cwd", repo, "--lineage", "fail-closed"}, tt.args(digest)...), &bytes.Buffer{})
+			if err == nil {
+				t.Fatal("incomplete untracked intent started review")
+			}
+			if err := RunReview(append([]string{"status", "--contract", ReviewIntegrationContractV2, "--cwd", repo}, tt.args(digest)...), &bytes.Buffer{}); err == nil {
+				t.Fatal("incomplete untracked intent reached negotiated status")
+			}
+			assertNoUntrackedSelectionAuthority(t, repo)
+		})
+	}
+	if _, err := reviewTransitionArgumentMap([]ReviewTransitionArgument{{Name: "lineage", Value: "one"}, {Name: "lineage", Value: "two"}}, "review.finalize"); err == nil {
+		t.Fatal("non-START transition accepted a repeated argument")
+	}
+}

--- a/internal/cli/review_low_risk_lifecycle_test.go
+++ b/internal/cli/review_low_risk_lifecycle_test.go
@@ -257,10 +257,15 @@ func TestLowRiskNativeVerificationSupportsBaseWorkspaceOverlay(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "docs", "overlay.md"), []byte("overlay documentation\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var output bytes.Buffer
 	if err := RunReviewFacadeStart([]string{
 		"--cwd", repo, "--base-ref", base, "--workspace-overlay", "--lineage", "low-risk-overlay",
+		"--untracked-scope=exclude", "--expected-untracked-inventory=" + digest,
 	}, &output); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -144,7 +144,7 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 					Arguments: reviewTargetArguments(status),
 				})
 			}
-			return reviewExecuteTransition("fresh_target_ready", "review.start", reviewStartArguments(status, input.StartLineage, input.RuntimeAgent), []ReviewTransitionArgument{{Name: "target_identity", Value: status.TargetIdentity}}, ReviewTransitionBinding{LineageID: input.StartLineage, TargetIdentity: status.TargetIdentity}, nil)
+			return reviewExecuteTransition("fresh_target_ready", "review.start", reviewStartArguments(status, input.StartLineage, input.RuntimeAgent, input.IntendedUntracked), []ReviewTransitionArgument{{Name: "target_identity", Value: status.TargetIdentity}}, ReviewTransitionBinding{LineageID: input.StartLineage, TargetIdentity: status.TargetIdentity}, nil)
 		case reviewtransaction.TargetApplicabilityAmbiguous:
 			return reviewCollectTransition("lineage_selection_required", ReviewTransitionInput{
 				Name: "lineage_selection", Schema: "gentle-ai.review-lineage-selection/v1", CaptureOperation: "external.select_lineage",
@@ -476,6 +476,7 @@ type reviewNextTransitionInput struct {
 	CorrectionForecasted                           bool
 	CaptureContext                                 *reviewCaptureContext
 	Selector                                       *reviewTransitionSelector
+	IntendedUntracked                              reviewIntendedUntrackedScope
 }
 
 const reviewSubmissionValuePlaceholder = "{{value}}"
@@ -576,7 +577,7 @@ type reviewTransitionSelector struct {
 	PrePRRepresentable    bool
 }
 
-func reviewStartArguments(status ReviewTargetStatusResult, lineage string, runtime model.AgentID) []ReviewTransitionArgument {
+func reviewStartArguments(status ReviewTargetStatusResult, lineage string, runtime model.AgentID, intended reviewIntendedUntrackedScope) []ReviewTransitionArgument {
 	contract := status.Contract
 	if contract == "" {
 		contract = ReviewIntegrationContractV1
@@ -601,6 +602,7 @@ func reviewStartArguments(status ReviewTargetStatusResult, lineage string, runti
 	if contract == ReviewIntegrationContractV2 {
 		arguments = append(arguments, ReviewTransitionArgument{Name: "consent", Value: string(reviewConsentModeRelay)})
 	}
+	arguments = append(arguments, reviewStartIntendedUntrackedArguments(intended)...)
 	return arguments
 }
 

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -715,16 +715,16 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 
 func (result ReviewTargetStatusResult) validateIntendedUntrackedSelectionTransition() error {
 	if result.NextTransition.Collect == nil || len(result.NextTransition.Collect.Inputs) != 1 {
-		return errors.New("fresh target lacks an intended-untracked selection transition")
+		return errors.New("fresh target lacks an intended-untracked selection transition") // refusal:by-design world-action: only provider code can restore the malformed transition binding
 	}
 	input := result.NextTransition.Collect.Inputs[0]
 	if input.Name != "intended_untracked_selection" || input.Schema != reviewIntendedUntrackedSelectionSchema ||
 		input.CaptureOperation != "external.select_intended_untracked" || input.Submission != nil || len(input.Arguments) != 6 {
-		return errors.New("fresh target lacks an intended-untracked selection transition")
+		return errors.New("fresh target lacks an intended-untracked selection transition") // refusal:by-design world-action: only provider code can restore the malformed transition binding
 	}
 	if !reflect.DeepEqual(input.Arguments[:4], reviewTargetArguments(result)) || input.Arguments[4].Name != "eligible_paths_json" ||
 		input.Arguments[5].Name != "expected_untracked_inventory" || input.Arguments[5].Value == "" {
-		return errors.New("fresh target lacks an intended-untracked selection transition")
+		return errors.New("fresh target lacks an intended-untracked selection transition") // refusal:by-design world-action: only provider code can restore the malformed transition binding
 	}
 	return nil
 }

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -69,6 +69,7 @@ type ReviewTargetStatusResult struct {
 	NextTransition         *ReviewNextTransition                                `json:"next_transition,omitempty"`
 	ValidationRequest      *reviewtransaction.TargetedValidationRequest         `json:"validation_request,omitempty"`
 	FinalVerificationRetry *reviewtransaction.FinalVerificationRetryEligibility `json:"final_verification_retry,omitempty"`
+	intendedUntracked      reviewIntendedUntrackedScope
 }
 
 // ReviewActionEligibility remains an additive compatibility detail for older
@@ -637,6 +638,9 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 		// caller must choose instead, so requiring an executable START here
 		// would only relocate the contradiction.
 		if result.Projection.Kind == reviewtransaction.TargetCurrentChanges && len(result.Projection.Paths) == 0 {
+			if result.NextTransition.Kind == reviewNextTransitionCollect && result.NextTransition.ReasonCode == "intended_untracked_selection_required" {
+				return result.validateIntendedUntrackedSelectionTransition()
+			}
 			if result.NextTransition.Kind != reviewNextTransitionCollect || result.NextTransition.ReasonCode != "empty_candidate_base_ref_required" ||
 				result.NextTransition.Collect == nil || len(result.NextTransition.Collect.Inputs) != 1 {
 				return errors.New("fresh empty workspace target lacks a base-ref collection transition") // refusal:by-design world-action: only a provider code fix can emit the base-ref collection this classification requires
@@ -648,6 +652,9 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 				return errors.New("fresh empty workspace target lacks a base-ref collection transition") // refusal:by-design world-action: only a provider code fix can emit the base-ref collection this classification requires
 			}
 			return nil
+		}
+		if result.NextTransition.Kind == reviewNextTransitionCollect && result.NextTransition.ReasonCode == "intended_untracked_selection_required" {
+			return result.validateIntendedUntrackedSelectionTransition()
 		}
 		return result.validateStartNextTransition()
 	}
@@ -702,6 +709,22 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 			result.Contract == ReviewIntegrationContractV2 && (input.CandidateDiff != nil || input.BaseTree != result.Projection.BaseTree || input.CandidateTree != result.Projection.InitialReviewTree) {
 			return errors.New("negotiated status capture transport differs from its contract") // refusal:by-design world-action: provider-built STATUS mixed negotiated transports and requires a code fix
 		}
+	}
+	return nil
+}
+
+func (result ReviewTargetStatusResult) validateIntendedUntrackedSelectionTransition() error {
+	if result.NextTransition.Collect == nil || len(result.NextTransition.Collect.Inputs) != 1 {
+		return errors.New("fresh target lacks an intended-untracked selection transition")
+	}
+	input := result.NextTransition.Collect.Inputs[0]
+	if input.Name != "intended_untracked_selection" || input.Schema != reviewIntendedUntrackedSelectionSchema ||
+		input.CaptureOperation != "external.select_intended_untracked" || input.Submission != nil || len(input.Arguments) != 6 {
+		return errors.New("fresh target lacks an intended-untracked selection transition")
+	}
+	if !reflect.DeepEqual(input.Arguments[:4], reviewTargetArguments(result)) || input.Arguments[4].Name != "eligible_paths_json" ||
+		input.Arguments[5].Name != "expected_untracked_inventory" || input.Arguments[5].Value == "" {
+		return errors.New("fresh target lacks an intended-untracked selection transition")
 	}
 	return nil
 }
@@ -782,7 +805,7 @@ func (result ReviewTargetStatusResult) validateStartNextTransition() error {
 		transition.Execute.Operation != "review.start" || len(transition.Execute.Artifacts) != 0 {
 		return errors.New("fresh target lacks an executable START transition")
 	}
-	arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments)
+	arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments, transition.Execute.Operation)
 	if err != nil {
 		return err
 	}
@@ -797,7 +820,7 @@ func (result ReviewTargetStatusResult) validateStartNextTransition() error {
 			return errors.New("fresh target START runtime lacks immutable review transport")
 		}
 	}
-	wantArguments := reviewStartArguments(result, lineage, runtime)
+	wantArguments := reviewStartArguments(result, lineage, runtime, result.intendedUntracked)
 	for index, argument := range wantArguments {
 		argument.Token = reviewTransitionArgumentToken(argument)
 		wantArguments[index] = argument
@@ -875,7 +898,7 @@ func (result ReviewTargetStatusResult) validateRepairNextTransition() error {
 			transition.Execute.Binding.LineageID != candidate.LineageID || transition.Execute.Binding.Revision != candidate.Revision {
 			return errors.New("classified repair execution transition is incomplete")
 		}
-		arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments)
+		arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments, transition.Execute.Operation)
 		if err != nil || len(arguments) != len(provider)+3 {
 			return errors.New("classified repair execution arguments are incomplete")
 		}
@@ -1048,7 +1071,7 @@ func (transition ReviewNextTransition) Validate() error {
 				return errors.New("execution transition has an incomplete precondition")
 			}
 		}
-		arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments)
+		arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments, transition.Execute.Operation)
 		if err != nil {
 			return err
 		}
@@ -1153,10 +1176,11 @@ func (submission ReviewTransitionSubmission) validateFinalize() error {
 	return nil
 }
 
-func reviewTransitionArgumentMap(arguments []ReviewTransitionArgument) (map[string]string, error) {
+func reviewTransitionArgumentMap(arguments []ReviewTransitionArgument, operation ...string) (map[string]string, error) {
+	allowIntendedUntracked := len(operation) == 1 && operation[0] == "review.start"
 	values := make(map[string]string, len(arguments))
 	for _, argument := range arguments {
-		if _, duplicate := values[argument.Name]; duplicate {
+		if previous, duplicate := values[argument.Name]; duplicate && (!allowIntendedUntracked || argument.Name != "intended-untracked" || previous == argument.Value) {
 			return nil, errors.New("review transition repeats an argument")
 		}
 		values[argument.Name] = argument.Value

--- a/internal/cli/review_untracked_scope_test.go
+++ b/internal/cli/review_untracked_scope_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +33,21 @@ func startedChangedPathManifest(t *testing.T, started ReviewIntegrationStartResu
 	return *started.ChangedPathManifest
 }
 
+func runNegotiatedReviewStartExcludingUntracked(t *testing.T, repo, lineage string) ReviewIntegrationStartResult {
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--lineage", lineage,
+		"--untracked-scope=exclude", "--expected-untracked-inventory=" + digest,
+	}), &output); err != nil {
+		t.Fatal(err)
+	}
+	return decodeNegotiatedReviewStart(t, output.Bytes())
+}
+
 // startWithUnrelatedUntrackedCredential freezes a candidate whose only real
 // change is one tracked file, while an unrelated credential-shaped file sits
 // untracked and undeclared next to it.
@@ -41,7 +58,7 @@ func startWithUnrelatedUntrackedCredential(t *testing.T, lineage string) (string
 	repo := initReviewCLIRepo(t)
 	writeReviewStartCandidate(t, repo, "tracked.txt", "reviewed candidate\n", 0o644)
 	writeUndeclaredWorkspaceFile(t, repo, unrelatedCredentialPath, unrelatedCredentialContents, 0o600)
-	return repo, runNegotiatedReviewStart(t, repo, lineage)
+	return repo, runNegotiatedReviewStartExcludingUntracked(t, repo, lineage)
 }
 
 // TestNegotiatedStartKeepsUndeclaredUntrackedFileOutOfCandidate pins the first
@@ -78,7 +95,7 @@ func TestNegotiatedStartKeepsDeclaredUntrackedFileInCandidate(t *testing.T) {
 	writeUndeclaredWorkspaceFile(t, repo, unrelatedCredentialPath, unrelatedCredentialContents, 0o600)
 	runReviewCLIGit(t, repo, "add", "declared-helper.txt")
 
-	started := runNegotiatedReviewStart(t, repo, "untracked-scope-declared")
+	started := runNegotiatedReviewStartExcludingUntracked(t, repo, "untracked-scope-declared")
 
 	declared := false
 	manifest := startedChangedPathManifest(t, started)

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -614,6 +614,10 @@ func (builder SnapshotBuilder) ResolveRepositoryRoot(ctx context.Context) (strin
 // callers that mean "what did the user submit" must not call this. The
 // remaining callers ask a different question: what is untracked right now.
 func (builder SnapshotBuilder) DiscoverUnignoredUntracked(ctx context.Context) ([]string, error) {
+	return builder.discoverUnignoredUntracked(ctx, true)
+}
+
+func (builder SnapshotBuilder) discoverUnignoredUntracked(ctx context.Context, rejectForeignNestedRepositories bool) ([]string, error) {
 	root, err := builder.ResolveRepositoryRoot(ctx)
 	if err != nil {
 		return nil, err
@@ -642,7 +646,7 @@ func (builder SnapshotBuilder) DiscoverUnignoredUntracked(ctx context.Context) (
 		}
 		paths = append(paths, value)
 	}
-	if len(nestedRepositories) != 0 {
+	if rejectForeignNestedRepositories && len(nestedRepositories) != 0 {
 		if err := excludeRegisteredNestedWorktrees(ctx, root, nestedRepositories); err != nil {
 			return nil, err
 		}
@@ -654,10 +658,9 @@ func (builder SnapshotBuilder) DiscoverUnignoredUntracked(ctx context.Context) (
 	return canonical, nil
 }
 
-// IntendedUntrackedInventory returns the canonical eligible paths and the
-// digest a caller must bind an explicit selection to.
+// IntendedUntrackedInventory returns canonical eligible paths and their digest.
 func (builder SnapshotBuilder) IntendedUntrackedInventory(ctx context.Context) ([]string, string, error) {
-	paths, err := builder.DiscoverUnignoredUntracked(ctx)
+	paths, err := builder.discoverUnignoredUntracked(ctx, false)
 	if err != nil {
 		return nil, "", err
 	}
@@ -672,7 +675,7 @@ func (builder SnapshotBuilder) ValidateIntendedUntrackedSelection(ctx context.Co
 		return nil, err
 	}
 	if expectedDigest != digest {
-		return nil, errors.New("untracked inventory changed; refresh review status before selecting paths")
+		return nil, errors.New("untracked inventory changed; rerun `gentle-ai review status --next-transition` before selecting paths")
 	}
 	selected, err = canonicalPaths(selected)
 	if err != nil {
@@ -684,7 +687,7 @@ func (builder SnapshotBuilder) ValidateIntendedUntrackedSelection(ctx context.Co
 	}
 	for _, path := range selected {
 		if _, ok := eligible[path]; !ok {
-			return nil, fmt.Errorf("intended-untracked path %q is not in the current eligible inventory", path)
+			return nil, fmt.Errorf("intended-untracked path %q is not in the current eligible inventory; rerun `gentle-ai review status --next-transition`", path)
 		}
 	}
 	return selected, nil

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -654,6 +654,51 @@ func (builder SnapshotBuilder) DiscoverUnignoredUntracked(ctx context.Context) (
 	return canonical, nil
 }
 
+// IntendedUntrackedInventory returns the canonical eligible paths and the
+// digest a caller must bind an explicit selection to.
+func (builder SnapshotBuilder) IntendedUntrackedInventory(ctx context.Context) ([]string, string, error) {
+	paths, err := builder.DiscoverUnignoredUntracked(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	return paths, intendedUntrackedInventoryDigest(paths), nil
+}
+
+// ValidateIntendedUntrackedSelection proves a supplied selection still names
+// only paths in the current eligible inventory.
+func (builder SnapshotBuilder) ValidateIntendedUntrackedSelection(ctx context.Context, expectedDigest string, selected []string) ([]string, error) {
+	paths, digest, err := builder.IntendedUntrackedInventory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if expectedDigest != digest {
+		return nil, errors.New("untracked inventory changed; refresh review status before selecting paths")
+	}
+	selected, err = canonicalPaths(selected)
+	if err != nil {
+		return nil, err
+	}
+	eligible := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		eligible[path] = struct{}{}
+	}
+	for _, path := range selected {
+		if _, ok := eligible[path]; !ok {
+			return nil, fmt.Errorf("intended-untracked path %q is not in the current eligible inventory", path)
+		}
+	}
+	return selected, nil
+}
+
+func intendedUntrackedInventoryDigest(paths []string) string {
+	hash := sha256.New()
+	writeLengthPrefixed(hash, []byte("gentle-ai.intended-untracked-inventory/v1"))
+	for _, path := range paths {
+		writeLengthPrefixed(hash, []byte(path))
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
 // UntrackedScopeRefusalError marks a working-tree shape that untracked-scope
 // discovery refuses as a NAMED, anticipated condition: an embedded foreign
 // repository, or an untracked path Git reported that cannot be addressed as


### PR DESCRIPTION
## Linked Issue

Closes #2652

---

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation only
- [ ] Code refactoring (no functional changes)
- [ ] Build, CI, or tooling changes
- [ ] Breaking change (fix or feature that changes existing behavior)

---

## Summary

Makes the provider-owned eligible untracked inventory explicit before review admission: callers must exclude or select paths and bind that choice to an inventory digest. Direct START and negotiated STATUS now have parity, and untracked bytes are never admitted automatically.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| Shared CLI preflight and START transition (`internal/cli/review_facade.go`, `review_intended_untracked.go`, `review_next_transition.go`, `review_status_contract.go`) | Collects eligible inventory, requires explicit exclude/select plus digest, and carries validated intent from negotiated STATUS to executable START. |
| Snapshot inventory validation (`internal/reviewtransaction/snapshot.go`) | Supplies canonical provider-owned eligible paths, a stable digest, and fail-closed selection validation. |
| Regression tests (`internal/cli/review_intended_untracked_test.go`, `review_untracked_scope_test.go`) | Covers explicit intent, direct/negotiated parity, privacy, snapshots, stale or invalid declarations, and repeated distinct selections. |

---

## Test Evidence

Passed locally:

- `go run ./internal/gofmtcheck`
- `go vet ./...`
- `go test ./internal/cli ./internal/reviewtransaction -run '^$' -count=1`
- Focused `TestIntendedUntrackedSelection` coverage and existing privacy/snapshot tests.
- Isolated candidate-binary journey with two distinct paths, including `second file,with comma.txt`: STATUS collected the selection, then emitted an executable START transition; no authority was created before explicit intent.

`go test ./internal/cli ./internal/reviewtransaction -count=1` was attempted once locally but exceeded the 300-second tool bound with no result and was not retried. Hosted PR CI is the broad proof. E2E was not run locally. Shellcheck was not run because no scripts changed.

Benchmark validation: N/A. This changes CLI/snapshot admission behavior, not review-lifecycle, gates, recovery, delivery, benchmark implementation, corpus, or classifier behavior.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: this candidate is exactly 400 changed lines
- [x] The appropriate type label is applied (type:bug)
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Evidence)
- [x] I have updated documentation if necessary (no documentation change is necessary)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Review the shared CLI preflight and its direct/negotiated START parity first, then the snapshot inventory validation and regression tests. RDD review is `disabled/unmanaged` because the global user-owned mode is off; no review lifecycle was enabled or run.

- [x] Identify the explicit intended-untracked admission guard and challenge its eligible input population against the privacy, snapshot, and isolated candidate-binary evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed. No guard-population declaration or baseline change is included here.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added explicit selection of untracked files when starting a review.
- Added options to include selected files or exclude all untracked files.
- Review status now reports when untracked-file selection is required.
- Added inventory validation to prevent reviews from starting with changed, stale, duplicated, or invalid file selections.
- Selected untracked files are preserved through subsequent review transitions.
- Added safeguards to ensure only eligible, declared files can be selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
