### PR TITLE
fix(sdd): resolve Engram project identity from linked worktrees

### DIFF
--- a/internal/sddstatus/engram_project_test.go
+++ b/internal/sddstatus/engram_project_test.go
@@ -1,0 +1,109 @@
+package sddstatus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates path and every missing parent directory.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const originConfig = `[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = https://github.com/<owner>/Example-Repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`
+
+// TestInferEngramProjectOrdinaryCheckout pins the already-working shape: a
+// `.git` directory is read directly and the project comes from the remote.
+func TestInferEngramProjectOrdinaryCheckout(t *testing.T) {
+	t.Setenv("ENGRAM_PROJECT", "")
+
+	root := filepath.Join(t.TempDir(), "some-checkout-dir")
+	writeFile(t, filepath.Join(root, ".git", "config"), originConfig)
+
+	if got, want := inferEngramProject(root), "example-repo"; got != want {
+		t.Fatalf("inferEngramProject(ordinary checkout) = %q, want %q", got, want)
+	}
+}
+
+// TestInferEngramProjectLinkedWorktree is the regression for #2682. In a linked
+// worktree `.git` is a file holding a `gitdir:` pointer, and `config` lives in
+// the common dir — not under the pointed-to worktree gitdir. Inference must
+// resolve the same project as the primary checkout instead of degrading to the
+// worktree's directory basename.
+func TestInferEngramProjectLinkedWorktree(t *testing.T) {
+	t.Setenv("ENGRAM_PROJECT", "")
+
+	base := t.TempDir()
+	mainRepo := filepath.Join(base, "example-repo")
+	writeFile(t, filepath.Join(mainRepo, ".git", "config"), originConfig)
+
+	// Git records the per-worktree gitdir under <main>/.git/worktrees/<name>,
+	// with a `commondir` pointing back at the shared .git directory.
+	worktreeGitDir := filepath.Join(mainRepo, ".git", "worktrees", "FEATURE-ONE")
+	writeFile(t, filepath.Join(worktreeGitDir, "commondir"), "../..\n")
+
+	worktree := filepath.Join(base, "example-repo-worktrees", "FEATURE-ONE")
+	writeFile(t, filepath.Join(worktree, ".git"), "gitdir: "+worktreeGitDir+"\n")
+
+	if got, want := inferEngramProject(worktree), "example-repo"; got != want {
+		t.Fatalf("inferEngramProject(linked worktree) = %q, want %q", got, want)
+	}
+}
+
+// TestInferEngramProjectLinkedWorktreeRelativeGitdir covers the relative
+// `gitdir:` form, which Git writes for worktrees created with a relative path.
+func TestInferEngramProjectLinkedWorktreeRelativeGitdir(t *testing.T) {
+	t.Setenv("ENGRAM_PROJECT", "")
+
+	base := t.TempDir()
+	mainRepo := filepath.Join(base, "example-repo")
+	writeFile(t, filepath.Join(mainRepo, ".git", "config"), originConfig)
+	writeFile(t, filepath.Join(mainRepo, ".git", "worktrees", "wt", "commondir"), "../..\n")
+
+	worktree := filepath.Join(base, "wt")
+	writeFile(t, filepath.Join(worktree, ".git"), "gitdir: ../example-repo/.git/worktrees/wt\n")
+
+	if got, want := inferEngramProject(worktree), "example-repo"; got != want {
+		t.Fatalf("inferEngramProject(relative gitdir) = %q, want %q", got, want)
+	}
+}
+
+// TestInferEngramProjectNoRepository keeps the basename fallback for paths that
+// genuinely belong to no repository.
+func TestInferEngramProjectNoRepository(t *testing.T) {
+	t.Setenv("ENGRAM_PROJECT", "")
+
+	root := filepath.Join(t.TempDir(), "Loose-Directory")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", root, err)
+	}
+
+	if got, want := inferEngramProject(root), "loose-directory"; got != want {
+		t.Fatalf("inferEngramProject(no repository) = %q, want %q", got, want)
+	}
+}
+
+// TestInferEngramProjectEnvOverride keeps the explicit override authoritative
+// over any discovered repository identity.
+func TestInferEngramProjectEnvOverride(t *testing.T) {
+	t.Setenv("ENGRAM_PROJECT", "Explicit-Project")
+
+	root := filepath.Join(t.TempDir(), "example-repo")
+	writeFile(t, filepath.Join(root, ".git", "config"), originConfig)
+
+	if got, want := inferEngramProject(root), "explicit-project"; got != want {
+		t.Fatalf("inferEngramProject(env override) = %q, want %q", got, want)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1153,13 +1153,57 @@ func inferEngramProject(workspaceRoot string) string {
 	if project := strings.TrimSpace(os.Getenv("ENGRAM_PROJECT")); project != "" {
 		return strings.ToLower(project)
 	}
-	config, err := os.ReadFile(filepath.Join(workspaceRoot, ".git", "config"))
-	if err == nil {
-		if project := projectFromGitConfig(string(config)); project != "" {
-			return project
+	if path := gitConfigPathFor(workspaceRoot); path != "" {
+		config, err := os.ReadFile(path)
+		if err == nil {
+			if project := projectFromGitConfig(string(config)); project != "" {
+				return project
+			}
 		}
 	}
 	return strings.ToLower(filepath.Base(workspaceRoot))
+}
+
+// gitConfigPathFor resolves the `config` file that governs workspaceRoot. The
+// `.git` entry is a directory for an ordinary checkout but a file holding a
+// `gitdir:` pointer for a linked worktree, and a linked worktree keeps `config`
+// in the shared common dir rather than under its own gitdir. Reading
+// `<root>/.git/config` blindly therefore fails for every worktree. An empty
+// result means workspaceRoot has no readable Git configuration.
+func gitConfigPathFor(workspaceRoot string) string {
+	gitEntry := filepath.Join(workspaceRoot, ".git")
+	info, err := os.Stat(gitEntry)
+	if err != nil {
+		return ""
+	}
+	if info.IsDir() {
+		return filepath.Join(gitEntry, "config")
+	}
+
+	pointer, err := os.ReadFile(gitEntry)
+	if err != nil {
+		return ""
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(pointer)), "gitdir:"))
+	if gitDir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workspaceRoot, gitDir)
+	}
+
+	// A linked worktree records the shared directory in `commondir`, relative
+	// to its own gitdir. Without it the gitdir already is the common dir.
+	commonDir := gitDir
+	if content, err := os.ReadFile(filepath.Join(gitDir, "commondir")); err == nil {
+		if trimmed := strings.TrimSpace(string(content)); trimmed != "" {
+			commonDir = trimmed
+			if !filepath.IsAbs(commonDir) {
+				commonDir = filepath.Join(gitDir, commonDir)
+			}
+		}
+	}
+	return filepath.Join(commonDir, "config")
 }
 
 func projectFromGitConfig(content string) string {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2682

> **Maintainer note:** #2682 was filed as part of preparing this fix and does not yet carry `status:approved`, so the approval check will fail until a maintainer triages it. I also could not self-apply any label — the reporting account has `pull` permission only, so `AddLabelsToLabelable` is denied. The `type:bug` label therefore needs to be applied by a maintainer. Opening the PR now so the reproduction, the regression tests, and the located code path are all reviewable in one place; happy to hold, rebase, or close if you would rather see the issue approved first.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- `inferEngramProject` read `<workspaceRoot>/.git/config` directly. In a linked worktree `.git` is a **file** holding a `gitdir:` pointer, not a directory, so the read failed, the error was discarded, and inference silently fell back to the worktree's directory basename.
- Every Engram observation persisted under the repository project then failed to match, `collectEngramChanges` returned nothing, and `sdd-status` degraded to an OpenSpec `Active OpenSpec change not found` state for a change whose artifacts all exist.
- The governing config is now resolved through the `gitdir:` pointer **and** the `commondir` the worktree records, because a linked worktree keeps `config` in the shared common dir rather than under its own gitdir. The basename fallback is preserved for paths that genuinely belong to no repository.

The repository already encoded this knowledge — `internal/sddstatus/edit_authority.go` `gitRootOf` uses `os.Lstat` and its doc comment states the `.git` entry is "a directory for ordinary repositories, a file for worktrees". `inferEngramProject` simply did not reuse it.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | New `gitConfigPathFor` helper resolving the governing `config` through `gitdir:` and `commondir`; `inferEngramProject` now uses it instead of reading `.git/config` blindly |
| `internal/sddstatus/engram_project_test.go` | New behavior-first regression coverage: ordinary checkout, linked worktree with absolute `gitdir:`, linked worktree with relative `gitdir:`, no-repository basename fallback, and `ENGRAM_PROJECT` override precedence |

---

## 🧪 Test Plan

**Failing-first evidence.** The regression tests were written before the fix and reproduced the reported failure exactly:

```
--- FAIL: TestInferEngramProjectLinkedWorktree
    inferEngramProject(linked worktree) = "feature-one", want "example-repo"
--- FAIL: TestInferEngramProjectLinkedWorktreeRelativeGitdir
    inferEngramProject(relative gitdir) = "wt", want "example-repo"
```

The three control cases (ordinary checkout, no repository, env override) passed before and after, pinning that the fallback and override paths are unchanged.

**Unit tests**

```bash
go test ./internal/sddstatus/ -run TestInferEngramProject -v
# all 5 PASS after the fix
```

**Go Format**

```bash
go run ./internal/gofmtcheck   # passes
go vet ./internal/sddstatus/   # clean
```

**End-to-end**, patched binary against a real linked worktree holding a pure-Engram change:

```shell
# before
store: openspec
next: sdd-new
Blocked: Active OpenSpec change not found: <change-name>.

# after — no ENGRAM_PROJECT needed
store: engram
planning_home: engram:sdd
next: tasks
proposal/specs/design/applyProgress/verifyReport: done
```

**Pre-existing failures, disclosed.** `go test ./...` reports three failures in `internal/sddstatus`, all in the `ReviewOffer` family:

- `TestReviewOfferDeclineNeverBlocksArchiveAtTheProjectionLevel`
- `TestReviewOfferPresentAndArchiveReadyForAGenuinelyMissingReceipt`
- `TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt`

These are **not** regressions from this PR. Verified by checking out the base commit `d94dc00c` in the same worktree and re-running: the identical three fail there, and they pass/fail independently of this change, which touches only project-name inference.

Likely cause, offered as a hypothesis rather than a claim: this machine has `gentle-ai review mode status` reporting `off (decided by global)`, and all three assert on an available review offer. If these tests read machine-global RDD state, they would be environment-dependent locally and green in CI. Worth a separate look; deliberately out of scope here.

**Benchmark validation**: not applicable. This change alters no journey-visible behavior, no CLI surface, and no lifecycle transition — it corrects a project-identity lookup that only affects which Engram observations are matched.

**E2E**: not run locally (Docker not exercised in this environment). Deferred to CI.

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — **blocked**: #2682 awaits maintainer triage, and this account cannot apply labels (see the maintainer note above)
- [x] PR stays within 400 changed lines — 157 insertions, 4 deletions
- [ ] I have added the appropriate `type:*` label to this PR — **blocked**: `AddLabelsToLabelable` denied for this account; `type:bug` is checked in the PR Type section above and needs a maintainer to apply
- [x] Unit tests pass (`go test ./...`) — for this change; three pre-existing `ReviewOffer` failures documented above and reproduced on the base commit
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferred to CI
- [x] Benchmark validation completed, or this change is not applicable — rationale in the Test Plan
- [x] I have updated documentation if necessary — no user-facing behavior documented for this lookup
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**Relationship to #1730.** This is one of two independent defects on the same path, and fixing this one alone does not fully unblock linked-worktree Engram users. #1730 (open, `status:needs-design`) covers the upstream `shouldTryEngram` eligibility gate that decides whether Engram is queried at all. Isolation evidence, also posted to #1730:

| Condition | Result |
|---|---|
| Eligibility gate forced only | still `store: openspec`, blocked — this PR's defect |
| Explicit project only | still `store: openspec`, blocked — #1730's gate |
| Both | resolves correctly |

This PR deliberately does **not** touch the `shouldTryEngram` gate, since #1730 is `status:needs-design` and the design decision there is the maintainers' to make. Once #1730 lands, this fix is what makes it actually work from a linked worktree.

**Guard population.** This change introduces no security, integrity, admission, repair, or governance guard. `gitConfigPathFor` is a path-resolution helper on a best-effort identity lookup whose failure mode is the pre-existing basename fallback, so no `guard:population` declaration applies and `.guard-population-baseline.txt` is intentionally unchanged.

**One subtlety worth reviewing.** Resolving only the `gitdir:` pointer is not sufficient — a linked worktree's own gitdir contains no `config`. The `commondir` file (relative to that gitdir) is what points back at the shared `.git`. Reading `<gitdir>/config` would have failed just as silently as the original bug, only with a different symptom, so both hops are covered by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project detection for standard Git checkouts and linked worktrees.
  * Correctly handles both absolute and relative Git directory references and shared repository configuration.
  * Preserves existing fallback behavior when Git configuration is unavailable.
  * Environment-based project overrides continue to take precedence.

* **Tests**
  * Added coverage for ordinary checkouts, linked worktrees, missing repositories, and project overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->