### PR TITLE
fix(review): allow the Windows-required SYSTEMROOT in the codex env assertion

### DIFF
--- a/internal/advisoryreview/codex_adapter_test.go
+++ b/internal/advisoryreview/codex_adapter_test.go
@@ -267,6 +267,18 @@ func TestCodexAdapterScrubsChildEnvironmentToPathAndCodexHome(t *testing.T) {
 	if value, present := entries["CODEX_HOME"]; !present || value == "" {
 		t.Fatalf("codex child environment CODEX_HOME = %q, present=%v, want the allowlisted CODEX_HOME", value, present)
 	}
+	// Windows processes cannot start without SYSTEMROOT, so os/exec appends it
+	// to any Env that omits it. The hosted runner therefore yields a third
+	// entry the allowlist never asked for and cannot refuse (community report
+	// #2675). It is the platform's floor, not inherited ambient state: every
+	// variable the scrub exists to keep out is still asserted absent above.
+	if runtime.GOOS == "windows" {
+		for key := range entries {
+			if strings.EqualFold(key, "SYSTEMROOT") {
+				delete(entries, key)
+			}
+		}
+	}
 	if len(entries) != 2 {
 		t.Fatalf("codex child environment = %v, want exactly PATH and CODEX_HOME", entries)
 	}


### PR DESCRIPTION
Closes #2675

Test-only. The Windows Full Suite is red on main (green at fd34ea30, red from d8e71134 onward) with exactly one failing test: `TestCodexAdapterScrubsChildEnvironmentToPathAndCodexHome`, introduced by the codex env-scrub hardening in #2657. Windows processes cannot start without `SYSTEMROOT`, so `os/exec` appends it to any `Env` that omits it; the assertion demanded exactly two entries and could only pass off-Windows.

The scrub is unchanged and still asserted: `PWD`, the test sentinel, and every other inherited variable must be absent. Only the platform floor is tolerated, case-insensitively, and only on Windows.

Verified: gofmt/vet clean, `go test ./internal/advisoryreview/ -count=1` ok, `GOOS=windows go build ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows environment validation to account for a platform-required system variable, improving test reliability without changing end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->