### PR TITLE
fix(review): bind the real runtime identity in the consent envelope

### DIFF
--- a/internal/cli/review_consent_contract.go
+++ b/internal/cli/review_consent_contract.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/consentenvelope"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -221,11 +222,21 @@ func reviewConsentSpanishSignalSubject(signal reviewtransaction.RiskSignal) stri
 // assessment, and the caller's own invocation into the typed consent question.
 // Every phrase comes from the same wording sources the interactive prompt
 // uses, so the relayed question and the terminal question cannot drift.
+//
+// runtimeAgent is the exact generated runtime identity the caller's own
+// negotiated START already validated (review_facade.go's
+// reviewRuntimeWithImmutableTransport gate runs before this constructor is
+// ever reached whenever a runtime is declared at all), never a re-parse of
+// followUpBase: parsing a rendered command back into structured data is
+// exactly the class of bug this repo refuses. An undeclared runtime (the
+// manual/non-agent compatibility path -- see review_facade.go's own comment
+// on that path being "not gated") keeps today's compatibility default.
 func newReviewIntegrationConsentResult(
 	snapshot reviewtransaction.Snapshot,
 	assessment reviewtransaction.RiskAssessment,
 	followUpBase string,
 	contract string,
+	runtimeAgent string,
 	locale reviewConsentLocale,
 ) (ReviewIntegrationConsentResult, error) {
 	// The evidence phrases may legitimately be empty (a large change with no
@@ -270,7 +281,18 @@ func newReviewIntegrationConsentResult(
 		},
 	}
 	if contract == ReviewIntegrationContractV2 {
-		result.Schema, result.Contract, result.Agent = ReviewIntegrationConsentSchemaV3, ReviewIntegrationContractV2, "claude-code"
+		// Issue #2676: this literal used to be unconditional, so a negotiated
+		// START explicitly bound to another runtime (OpenCode, Codex) still
+		// reported "claude-code" here while its own follow-up invocations
+		// below were already rendered from the real binding. Bind the same
+		// declared identity the caller proved eligible; only the undeclared
+		// compatibility path (no runtime named at all) keeps the historical
+		// default, matching every existing manual-caller test and fixture.
+		agent := strings.TrimSpace(runtimeAgent)
+		if agent == "" {
+			agent = "claude-code"
+		}
+		result.Schema, result.Contract, result.Agent = ReviewIntegrationConsentSchemaV3, ReviewIntegrationContractV2, agent
 	}
 	if err := result.Validate(); err != nil {
 		return ReviewIntegrationConsentResult{}, fmt.Errorf("validate consent question: %w", err)
@@ -297,7 +319,18 @@ func validateReviewConsentInvocations(result ReviewIntegrationConsentResult, fol
 func (result ReviewIntegrationConsentResult) Validate() error {
 	legacyContract := result.Schema == ReviewIntegrationConsentSchema && result.Contract == ReviewIntegrationContractV1
 	historicalNativeGitContract := result.Schema == ReviewIntegrationConsentSchemaV2 && result.Contract == ReviewIntegrationContractV2 && result.Agent == ""
-	currentNativeGitContract := result.Schema == ReviewIntegrationConsentSchemaV3 && result.Contract == ReviewIntegrationContractV2 && result.Agent == "claude-code"
+	// The v3 shape must name a runtime that can actually carry immutable
+	// receipt-review transport -- the exact same authority
+	// reviewRuntimeWithImmutableTransport gates negotiated START on (Wave 4
+	// S4's fixed RDD policy) -- rather than a fresh allowlist that could drift
+	// from it. This accepts every declared runtime proven eligible at START
+	// (claude-code, opencode, codex today), and fail-closed rejects an empty
+	// identity, an unknown string, and a runtime that is eligible under the
+	// RDD policy but still dormant for this contract (e.g. Kilocode has no
+	// proven fresh-reviewer boundary yet), because none of those can ever
+	// legitimately reach this envelope.
+	currentNativeGitContract := result.Schema == ReviewIntegrationConsentSchemaV3 && result.Contract == ReviewIntegrationContractV2 &&
+		reviewImmutableRuntimeCapability(model.AgentID(result.Agent)).supportsImmutableReceiptReview()
 	if (!legacyContract && !historicalNativeGitContract && !currentNativeGitContract) ||
 		result.Operation != "review.start" || result.Action != reviewConsentActionRequired || !result.Blocking {
 		return errors.New("invalid consent question identity") // refusal:by-design world-action: this envelope is built and validated by the same file; the exit is a code fix, not a command

--- a/internal/cli/review_consent_runtime_identity_test.go
+++ b/internal/cli/review_consent_runtime_identity_test.go
@@ -1,0 +1,113 @@
+package cli
+
+// Issue #2676: a negotiated START explicitly bound to a non-Claude runtime
+// (OpenCode, Codex) reported "claude-code" as the consent/v3 envelope's
+// top-level `agent`, while the envelope's own follow-up invocations were
+// already correctly bound to the real runtime. These tests pin the fix: the
+// top-level identity now matches the declared binding, and Validate() stays
+// fail-closed about which identities the v3 shape may ever name.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNegotiatedConsentEnvelopeBindsTheDeclaredRuntimeIdentity drives a
+// negotiated v2 START explicitly bound to each supported immutable-transport
+// runtime and asserts the consent envelope's top-level agent matches the
+// declared binding, exactly like its follow-up invocations already did. The
+// claude-code case is the regression check: it must stay exactly as today.
+func TestNegotiatedConsentEnvelopeBindsTheDeclaredRuntimeIdentity(t *testing.T) {
+	for _, agent := range []string{"opencode", "codex", "claude-code"} {
+		t.Run(agent, func(t *testing.T) {
+			reviewModeHome(t)
+			repo := initReviewCLIRepo(t)
+			stubReviewConsole(t, false, "")
+			writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+
+			output := runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+				"start", "--contract", ReviewIntegrationContractV2, "--agent", agent, "--cwd", repo,
+				"--lineage", "review-consent-runtime-" + agent, "--consent", "relay",
+			}))
+			question := decodeConsentQuestion(t, output.Bytes())
+			if err := question.Validate(); err != nil {
+				t.Fatalf("consent envelope bound to %q does not validate: %v\n%s", agent, err, output.String())
+			}
+			if question.Schema != ReviewIntegrationConsentSchemaV3 || question.Contract != ReviewIntegrationContractV2 || question.Agent != agent {
+				t.Fatalf("consent envelope identity = %#v, want top-level agent %q", question, agent)
+			}
+			// The reported bug was exactly this divergence: the follow-up
+			// invocations were already bound to the real runtime while the
+			// top-level identity lied about it. Assert both stay bound together.
+			for _, choice := range question.Choices {
+				if !strings.Contains(choice.Invocation, "--agent "+agent) {
+					t.Fatalf("choice invocation for %q diverges from its own consent envelope identity: %#v", agent, choice)
+				}
+			}
+		})
+	}
+}
+
+// TestConsentValidateRejectsUnknownOrEmptyRuntimeIdentity keeps Validate()
+// fail-closed: the v3 shape must name a runtime that actually carries the
+// immutable receipt-review transport (the same authority
+// reviewRuntimeWithImmutableTransport gates START on), never an arbitrary
+// string, and never empty.
+func TestConsentValidateRejectsUnknownOrEmptyRuntimeIdentity(t *testing.T) {
+	payload, err := os.ReadFile(filepath.Join("..", "..", "contracts", "review-integration", "v2", "fixtures", "consent-v3.fixture.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var base ReviewIntegrationConsentResult
+	if err := json.Unmarshal(payload, &base); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name  string
+		agent string
+	}{
+		{name: "unknown runtime", agent: "not-a-real-runtime"},
+		// Kilocode is eligible under the fixed RDD policy but dormant for the
+		// immutable-review-executor contract (no proven fresh-reviewer
+		// boundary yet), so it can never legitimately reach negotiated START
+		// consent; the v3 envelope must not name it either.
+		{name: "eligible but unsupported runtime", agent: "kilocode"},
+		{name: "empty runtime", agent: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mutated := base
+			mutated.Agent = tt.agent
+			if err := mutated.Validate(); err == nil {
+				t.Fatalf("consent envelope validated with runtime identity %q", tt.agent)
+			}
+		})
+	}
+}
+
+// TestConsentValidateAcceptsHistoricalShapes pins that neither the v1 legacy
+// contract nor the pre-v3 v2-schema/empty-agent shape were disturbed by
+// making Validate() fail-closed about the runtime identity.
+func TestConsentValidateAcceptsHistoricalShapes(t *testing.T) {
+	for _, path := range []string{
+		filepath.Join("..", "..", "contracts", "review-integration", "v1", "fixtures", "consent.fixture.json"),
+		filepath.Join("..", "..", "contracts", "review-integration", "v2", "fixtures", "consent.fixture.json"),
+	} {
+		t.Run(path, func(t *testing.T) {
+			payload, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result ReviewIntegrationConsentResult
+			if err := json.Unmarshal(payload, &result); err != nil {
+				t.Fatal(err)
+			}
+			if err := result.Validate(); err != nil {
+				t.Fatalf("historical shape %s no longer validates: %v", path, err)
+			}
+		})
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1631,7 +1631,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			question, questionErr := newReviewIntegrationConsentResult(snapshot, assessment,
 				reviewConsentFollowUpBase(*cwd, snapshot.Identity, selectedProjection, strings.TrimSpace(*lineage),
 					strings.TrimSpace(*baseRef), strings.TrimSpace(*policySource), strings.TrimSpace(*focus),
-					strings.TrimSpace(*tracePath), *committedOnly, *workspaceOverlay, *contract, *runtimeAgent, strings.TrimSpace(*locale)), *contract, consentLocale)
+					strings.TrimSpace(*tracePath), *committedOnly, *workspaceOverlay, *contract, *runtimeAgent, strings.TrimSpace(*locale)), *contract, *runtimeAgent, consentLocale)
 			if questionErr != nil {
 				return questionErr
 			}


### PR DESCRIPTION
Closes #2676

Community report against the published rc.2: a negotiated START bound to OpenCode returned a consent/v3 envelope whose top-level `agent` said `claude-code`, while the follow-up invocations inside it correctly said `agent opencode`.

Two-part fix, because the second half made the first impossible on its own:

- `review_consent_contract.go` hardcoded `result.Agent = "claude-code"` for every v2-contract envelope. It now takes the declared runtime, threaded from the same `*runtimeAgent` value the caller already passes to `reviewConsentFollowUpBase`. No re-parsing of the rendered command; an explicit parameter.
- `Validate()` enforced that literal, so populating the real runtime would have failed the envelope's own validation. It now accepts exactly what `reviewRuntimeWithImmutableTransport` already lets through negotiated START (`capabilitymanifest.Advertises(ContractImmutableReviewExecutorV1)`), so the accepted set cannot drift from what START itself permits. Fail-closed preserved: empty, unknown, and eligible-but-dormant runtimes are rejected. Historical v1 and v2-empty-agent shapes validate unchanged.

The follow-up invocations were already correct, so the flow was never misrouted. What was wrong is the identity a consumer reads off a typed blocking envelope.

**Known scope boundary:** the undeclared/manual compatibility path, where no `--agent` is passed at all, keeps the historical `claude-code` default rather than omitting the field. Changing it touches the byte-pinned `consent-v3.fixture.json` and several manual-caller tests, so it is a separate maintainer decision. The reported defect class, a declared runtime being overwritten, is fixed here.

## Test Plan

```bash
go test ./internal/cli/ -count=1              # ok (181.8s)
go test ./internal/reviewtransaction/ -count=1 # ok (113.7s)
cd bench && go test ./... -count=1             # ok
gofmt -l . && go vet ./... && go build ./...   # clean
scripts/deadcode-ratchet.sh                    # no new unreachable functions
```

New tests: `TestNegotiatedConsentEnvelopeBindsTheDeclaredRuntimeIdentity` (opencode, codex, claude-code; asserts top level and every choice invocation stay bound together), `TestConsentValidateRejectsUnknownOrEmptyRuntimeIdentity` (unknown, dormant `kilocode`, empty), `TestConsentValidateAcceptsHistoricalShapes`.

Review budget: 149 additions + 3 deletions = 152 changed lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Consent responses now identify the negotiated runtime used to process the review.
  - Supported runtime identities are validated based on their receipt-review capabilities.

- **Bug Fixes**
  - Invalid, empty, or unsupported runtime identities are rejected safely.
  - Existing integrations using historical consent formats remain supported.
  - Undeclared runtimes continue to work through a compatibility default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->