### PR TITLE
fix(codegraph): reject WSL shims and restore plugin rollback

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -662,14 +662,14 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 		apply = append(apply, agentInstallStep{id: "agent:" + string(agent), agent: agent, homeDir: r.homeDir, profile: r.profile})
 	}
 
+	for _, tool := range r.selection.CommunityTools {
+		apply = append(apply, communityToolInstallStep{id: "community-tool:" + string(tool), tool: tool, workspaceDir: r.workspaceDir, homeDir: r.homeDir, state: r.state})
+	}
+
 	if containsAgent(r.resolved.Agents, model.AgentOpenCode) {
 		for _, plugin := range r.selection.OpenCodePlugins {
 			apply = append(apply, openCodePluginInstallStep{id: "opencode-plugin:" + string(plugin), plugin: plugin, homeDir: r.homeDir})
 		}
-	}
-
-	for _, tool := range r.selection.CommunityTools {
-		apply = append(apply, communityToolInstallStep{id: "community-tool:" + string(tool), tool: tool, workspaceDir: r.workspaceDir, homeDir: r.homeDir, state: r.state})
 	}
 
 	for _, component := range r.resolved.OrderedComponents {
@@ -1861,6 +1861,13 @@ func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection m
 		for _, path := range communitytool.CodeGraphManagedPaths(homeDir) {
 			paths[path] = struct{}{}
 		}
+	}
+	pluginPaths, err := opencodeplugin.InstallPaths(homeDir, selection.OpenCodePlugins)
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range pluginPaths {
+		paths[path] = struct{}{}
 	}
 
 	targets := make([]string, 0, len(paths))

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -161,6 +161,191 @@ func TestBackupTargetsSnapshotCrossAgentCodeGraphGuidance(t *testing.T) {
 	}
 }
 
+func TestBackupTargetsIncludeSelectedOpenCodePluginPaths(t *testing.T) {
+	home := t.TempDir()
+	targets, err := backupTargets(home, "", ScopeGlobal, model.Selection{
+		OpenCodePlugins: []model.OpenCodeCommunityPluginID{
+			model.OpenCodePluginSubAgentStatusline,
+			model.OpenCodePluginGentleLogo,
+		},
+	}, planner.ResolvedPlan{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(home, ".config", "opencode", "tui.json"),
+		filepath.Join(home, ".config", "opencode", "tui-plugins", "gentle-logo.tsx"),
+	} {
+		if !slices.Contains(targets, path) {
+			t.Fatalf("backup targets = %v, missing selected plugin path %q", targets, path)
+		}
+	}
+}
+
+func TestCodeGraphFailureDoesNotLeaveEarlierOpenCodePluginRegistration(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previousInstall := installCommunityToolWithHome
+	t.Cleanup(func() { installCommunityToolWithHome = previousInstall })
+	installCommunityToolWithHome = func(model.CommunityToolID, string, string, communitytool.Runner, communitytool.Detector) (communitytool.Result, error) {
+		return communitytool.Result{Tool: model.CommunityToolCodeGraph}, errors.New("CodeGraph reconciliation failed")
+	}
+
+	runtime, err := newInstallRuntime(home, ScopeGlobal, ChannelStable, model.Selection{
+		Agents:          []model.AgentID{model.AgentOpenCode},
+		OpenCodePlugins: []model.OpenCodeCommunityPluginID{model.OpenCodePluginSubAgentStatusline},
+		CommunityTools:  []model.CommunityToolID{model.CommunityToolCodeGraph},
+	}, planner.ResolvedPlan{Agents: []model.AgentID{model.AgentOpenCode}}, system.PlatformProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(runtime.state.cleanupCompatibilityTransaction)
+
+	result := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(runtime.stagePlan())
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "CodeGraph reconciliation failed") {
+		t.Fatalf("install pipeline error = %v, want CodeGraph reconciliation failure", result.Err)
+	}
+
+	tuiPath := filepath.Join(home, ".config", "opencode", "tui.json")
+	if _, err := os.Stat(tuiPath); !os.IsNotExist(err) {
+		t.Fatalf("OpenCode plugin registration remains after CodeGraph failure: %v", err)
+	}
+}
+
+func TestInstallRollbackRestoresSelectedOpenCodePluginPathsAfterPluginRegistration(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		preexisting bool
+	}{
+		{name: "removes paths created by plugins"},
+		{name: "restores pre-existing bytes", preexisting: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			tuiPath := filepath.Join(home, ".config", "opencode", "tui.json")
+			logoPath := filepath.Join(home, ".config", "opencode", "tui-plugins", "gentle-logo.tsx")
+			originalTUI := []byte("{\n  \"plugin\": [\"existing-plugin\"]\n}\n")
+			originalLogo := []byte("pre-existing Gentle Logo bytes\n")
+			if test.preexisting {
+				mustWriteFile(t, tuiPath, originalTUI)
+				mustWriteFile(t, logoPath, originalLogo)
+			}
+
+			previousInstall := installCommunityToolWithHome
+			t.Cleanup(func() { installCommunityToolWithHome = previousInstall })
+			codeGraphSucceeded := false
+			installCommunityToolWithHome = func(model.CommunityToolID, string, string, communitytool.Runner, communitytool.Detector) (communitytool.Result, error) {
+				codeGraphSucceeded = true
+				return communitytool.Result{Tool: model.CommunityToolCodeGraph}, nil
+			}
+
+			runtime, err := newInstallRuntime(home, ScopeGlobal, ChannelStable, model.Selection{
+				Agents: []model.AgentID{model.AgentOpenCode},
+				OpenCodePlugins: []model.OpenCodeCommunityPluginID{
+					model.OpenCodePluginSubAgentStatusline,
+					model.OpenCodePluginGentleLogo,
+				},
+				CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph},
+			}, planner.ResolvedPlan{Agents: []model.AgentID{model.AgentOpenCode}}, system.PlatformProfile{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(runtime.state.cleanupCompatibilityTransaction)
+
+			plan := runtime.stagePlan()
+			plan.Apply = append(plan.Apply, failAfterPluginRegistrationStep{
+				codeGraphSucceeded: &codeGraphSucceeded,
+				tuiPath:            tuiPath,
+				logoPath:           logoPath,
+			})
+			result := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(plan)
+			if result.Err == nil || !strings.Contains(result.Err.Error(), "late plugin rollback control") {
+				t.Fatalf("install pipeline error = %v, want late plugin rollback failure", result.Err)
+			}
+			if !result.Rollback.Success {
+				t.Fatalf("rollback = %#v, want successful outer restore", result.Rollback)
+			}
+
+			if !test.preexisting {
+				for _, path := range []string{tuiPath, logoPath} {
+					if _, err := os.Stat(path); !os.IsNotExist(err) {
+						t.Fatalf("created plugin path remains after rollback %q: %v", path, err)
+					}
+				}
+				return
+			}
+			for path, want := range map[string][]byte{tuiPath: originalTUI, logoPath: originalLogo} {
+				got, err := os.ReadFile(path)
+				if err != nil || !reflect.DeepEqual(got, want) {
+					t.Fatalf("restored %q = %q, %v; want original bytes %q", path, got, err, want)
+				}
+			}
+		})
+	}
+}
+
+type failAfterPluginRegistrationStep struct {
+	codeGraphSucceeded *bool
+	tuiPath            string
+	logoPath           string
+}
+
+func (s failAfterPluginRegistrationStep) ID() string { return "test:late-plugin-rollback-control" }
+
+func (s failAfterPluginRegistrationStep) Run() error {
+	if s.codeGraphSucceeded == nil || !*s.codeGraphSucceeded {
+		return errors.New("CodeGraph did not complete before plugin rollback control")
+	}
+	tui, err := os.ReadFile(s.tuiPath)
+	if err != nil {
+		return fmt.Errorf("read plugin registration before rollback control: %w", err)
+	}
+	if !strings.Contains(string(tui), "opencode-subagent-statusline") || !strings.Contains(string(tui), s.logoPath) {
+		return errors.New("plugins were not registered before rollback control")
+	}
+	if _, err := os.Stat(s.logoPath); err != nil {
+		return fmt.Errorf("Gentle Logo was not written before rollback control: %w", err)
+	}
+	return errors.New("late plugin rollback control")
+}
+
+func TestSuccessfulCodeGraphReconciliationStillRegistersOpenCodePlugin(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previousInstall := installCommunityToolWithHome
+	t.Cleanup(func() { installCommunityToolWithHome = previousInstall })
+	installCommunityToolWithHome = func(model.CommunityToolID, string, string, communitytool.Runner, communitytool.Detector) (communitytool.Result, error) {
+		return communitytool.Result{Tool: model.CommunityToolCodeGraph}, nil
+	}
+
+	runtime, err := newInstallRuntime(home, ScopeGlobal, ChannelStable, model.Selection{
+		Agents:          []model.AgentID{model.AgentOpenCode},
+		OpenCodePlugins: []model.OpenCodeCommunityPluginID{model.OpenCodePluginSubAgentStatusline},
+		CommunityTools:  []model.CommunityToolID{model.CommunityToolCodeGraph},
+	}, planner.ResolvedPlan{Agents: []model.AgentID{model.AgentOpenCode}}, system.PlatformProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(runtime.state.cleanupCompatibilityTransaction)
+
+	result := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(runtime.stagePlan())
+	if result.Err != nil {
+		t.Fatalf("install pipeline error = %v", result.Err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".config", "opencode", "tui.json"))
+	if err != nil || !strings.Contains(string(data), "opencode-subagent-statusline") {
+		t.Fatalf("OpenCode plugin registration = %q, %v; want successful registration", data, err)
+	}
+}
+
 func TestPiCodeGraphReconcileStepRollbackRemovesDynamicPackageOverlay(t *testing.T) {
 	home := t.TempDir()
 	overlay := filepath.Join(home, ".pi", "agent", "subagents", "package.md")

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -85,6 +87,8 @@ func (fn RunnerFunc) Run(name string, args ...string) error { return fn(name, ar
 var (
 	codeGraphPackageLookPath = exec.LookPath
 	codeGraphPnpmGlobalBin   = defaultPnpmGlobalBin
+	codeGraphCLIUsable       = defaultCodeGraphCLIUsable
+	codeGraphWSL             = defaultCodeGraphWSL
 )
 
 var definitions = []Definition{
@@ -211,13 +215,20 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 			commands = commands[:1]
 		}
 	}
-	for _, command := range commands {
+	for index, command := range commands {
 		if len(command) == 0 {
 			continue
 		}
 		result.CommandsRun = append(result.CommandsRun, strings.Join(command, " "))
 		if err := runner.Run(command[0], command[1:]...); err != nil {
 			return rollback(fmt.Errorf("run %q: %w", strings.Join(command, " "), err))
+		}
+		if before.CLI != AvailabilityAvailable && index == 0 {
+			afterPackageInstall := DetectStatus(id, homeDir, detector)
+			result.StatusAfter = &afterPackageInstall
+			if afterPackageInstall.CLI != AvailabilityAvailable {
+				return rollback(fmt.Errorf("CodeGraph package installation did not leave a runnable codegraph CLI available"))
+			}
 		}
 	}
 	if _, err := ReconcileOpenCodeCodeGraph(homeDir, runner); err != nil {
@@ -315,13 +326,40 @@ func DetectStatus(id model.CommunityToolID, homeDir string, detector Detector) S
 	if detector == nil {
 		detector = DetectorFunc(exec.LookPath)
 	}
-	if path, err := detector.LookPath(def.CommandName); err == nil && strings.TrimSpace(path) != "" {
+	if path, err := detector.LookPath(def.CommandName); err == nil && strings.TrimSpace(path) != "" && codeGraphCLIUsable(path) {
 		status.CLI = AvailabilityAvailable
 		status.CLIPath = path
 	}
 	status.Agents = detectCodeGraphAgents(homeDir)
 	status.FollowUps = append(status.FollowUps, "CodeGraph markers can vary by upstream version; detection currently checks conservative MCP entries and instruction markers containing codegraph.")
 	return status
+}
+
+// defaultCodeGraphCLIUsable rejects only the Windows npm launcher namespace
+// exposed to WSL. Admission intentionally does not inspect or execute the
+// detector result: callers may supply a valid injected path that is absent on
+// this machine, and a status read must not run an unbounded subprocess.
+func defaultCodeGraphCLIUsable(path string) bool {
+	if !codeGraphWSL() {
+		return true
+	}
+	return !isWSLWindowsNpmShim(path)
+}
+
+func isWSLWindowsNpmShim(path string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(filepath.Clean(path), "\\", "/"))
+	mountedPath := strings.TrimPrefix(normalized, "/mnt/")
+	drive, _, mounted := strings.Cut(mountedPath, "/")
+	if !mounted || len(drive) != 1 || drive[0] < 'a' || drive[0] > 'z' {
+		return false
+	}
+	return strings.HasSuffix(normalized, "/appdata/roaming/npm/codegraph") ||
+		strings.HasSuffix(normalized, "/appdata/roaming/npm/codegraph.cmd") ||
+		strings.HasSuffix(normalized, "/appdata/roaming/npm/codegraph.ps1")
+}
+
+func defaultCodeGraphWSL() bool {
+	return runtime.GOOS == "linux" && (strings.TrimSpace(os.Getenv("WSL_INTEROP")) != "" || strings.TrimSpace(os.Getenv("WSL_DISTRO_NAME")) != "")
 }
 
 func (s Status) CodeGraphReconcileSatisfied() bool {

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 	codeGraphPnpmGlobalBin = func() (string, error) {
 		return "/bin", nil
 	}
+	codeGraphCLIUsable = func(string) bool { return true }
 	piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) {
 		return PiCodeGraphMCPProbeResult{
 			AdapterAvailable: true,
@@ -1267,6 +1268,93 @@ func TestInstallRepairsMissingCLIWhenAgentMarkerExists(t *testing.T) {
 	}
 }
 
+func TestDetectStatusRejectsWSLWindowsNPMShimWithoutExecutingIt(t *testing.T) {
+	useCodeGraphWSLAdmission(t, true)
+	previousVersion := codeGraphInstalledVersion
+	t.Cleanup(func() { codeGraphInstalledVersion = previousVersion })
+	codeGraphInstalledVersion = func(string) (string, bool) {
+		t.Fatal("DetectStatus must not execute a candidate CodeGraph CLI")
+		return "", false
+	}
+
+	status := DetectStatus(model.CommunityToolCodeGraph, t.TempDir(), DetectorFunc(func(string) (string, error) {
+		return "/mnt/c/Users/alan/AppData/Roaming/npm/codegraph", nil
+	}))
+	if status.CLI != AvailabilityMissing || status.CLIPath != "" {
+		t.Fatalf("DetectStatus() = %#v, want WSL Windows npm shim rejected", status)
+	}
+}
+
+func TestDetectStatusAdmitsLinuxCLIPathsWithoutRequiringFiles(t *testing.T) {
+	useCodeGraphWSLAdmission(t, true)
+	previousVersion := codeGraphInstalledVersion
+	t.Cleanup(func() { codeGraphInstalledVersion = previousVersion })
+	codeGraphInstalledVersion = func(string) (string, bool) {
+		t.Fatal("DetectStatus must not execute a candidate CodeGraph CLI")
+		return "", false
+	}
+
+	for _, path := range []string{
+		"/bin/codegraph",
+		"/home/alan/.local/bin/codegraph",
+		"/home/alan/AppData/Roaming/npm/codegraph",
+	} {
+		t.Run(path, func(t *testing.T) {
+			status := DetectStatus(model.CommunityToolCodeGraph, t.TempDir(), DetectorFunc(func(string) (string, error) {
+				return path, nil
+			}))
+			if status.CLI != AvailabilityAvailable || status.CLIPath != path {
+				t.Fatalf("DetectStatus() = %#v, want injected Linux path available", status)
+			}
+		})
+	}
+}
+
+func TestInstallRejectsWSLWindowsNPMShimAfterPackageInstall(t *testing.T) {
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, ".claude.json"), `{}`)
+	shim := "/mnt/c/Users/alan/AppData/Roaming/npm/codegraph"
+
+	previousPackageLookPath := codeGraphPackageLookPath
+	t.Cleanup(func() { codeGraphPackageLookPath = previousPackageLookPath })
+	codeGraphPackageLookPath = func(name string) (string, error) {
+		if name == "npm" {
+			return "/bin/npm", nil
+		}
+		return "", errors.New("not found")
+	}
+	useCodeGraphWSLAdmission(t, true)
+	previousVersion := codeGraphInstalledVersion
+	t.Cleanup(func() { codeGraphInstalledVersion = previousVersion })
+	codeGraphInstalledVersion = func(string) (string, bool) {
+		t.Fatal("CodeGraph admission must not execute the stale shim")
+		return "", false
+	}
+
+	var runnerCalls []string
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(name string, args ...string) error {
+		runnerCalls = append(runnerCalls, strings.Join(append([]string{name}, args...), " "))
+		if name != "npm" {
+			return errors.New("CodeGraph runner must not receive a rejected shim")
+		}
+		return nil
+	}), DetectorFunc(func(string) (string, error) {
+		return shim, nil
+	}))
+	if err == nil || !strings.Contains(err.Error(), "did not leave a runnable codegraph CLI available") {
+		t.Fatalf("InstallWithHome() error = %v, want unavailable CodeGraph outcome after package install", err)
+	}
+	if !reflect.DeepEqual(runnerCalls, []string{"npm install -g @colbymchenry/codegraph@latest"}) {
+		t.Fatalf("runner calls = %#v, want package install before stale-shim re-admission blocks CodeGraph", runnerCalls)
+	}
+	if result.StatusBefore == nil || result.StatusBefore.CLI != AvailabilityMissing || result.StatusBefore.CLIPath != "" {
+		t.Fatalf("StatusBefore = %#v, want truthful absent CLI", result.StatusBefore)
+	}
+	if result.StatusAfter == nil || result.StatusAfter.CLI != AvailabilityMissing || result.StatusAfter.CLIPath != "" {
+		t.Fatalf("StatusAfter = %#v, want rejected shim to remain unavailable", result.StatusAfter)
+	}
+}
+
 func TestInstallFailurePaths(t *testing.T) {
 	t.Run("nil runner", func(t *testing.T) {
 		result, err := Install(model.CommunityToolCodeGraph, "/work/project", nil)
@@ -1318,6 +1406,9 @@ func TestInstallFailurePaths(t *testing.T) {
 			}
 			return nil
 		}), DetectorFunc(func(string) (string, error) {
+			if calls > 0 {
+				return "/bin/codegraph", nil
+			}
 			return "", errors.New("not found")
 		}))
 		if !errors.Is(err, boom) {
@@ -1344,6 +1435,18 @@ func mustWrite(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", path, err)
 	}
+}
+
+func useCodeGraphWSLAdmission(t *testing.T, wsl bool) {
+	t.Helper()
+	previousCLIUsable := codeGraphCLIUsable
+	previousWSL := codeGraphWSL
+	t.Cleanup(func() {
+		codeGraphCLIUsable = previousCLIUsable
+		codeGraphWSL = previousWSL
+	})
+	codeGraphCLIUsable = defaultCodeGraphCLIUsable
+	codeGraphWSL = func() bool { return wsl }
 }
 
 func findAgentStatus(t *testing.T, status Status, id model.AgentID) AgentStatus {

--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -128,6 +128,37 @@ func DefinitionFor(id model.OpenCodeCommunityPluginID) (Definition, bool) {
 	return Definition{}, false
 }
 
+// InstallPaths returns every path a selected plugin installation can mutate.
+// The outer install snapshot uses this before apply so later failures restore
+// plugin registration and plugin-owned assets together.
+func InstallPaths(homeDir string, selected []model.OpenCodeCommunityPluginID) ([]string, error) {
+	opencodeDir := filepath.Join(homeDir, ".config", "opencode")
+	tuiPath := filepath.Join(opencodeDir, "tui.json")
+	paths := make([]string, 0, len(selected)+1)
+	seen := map[string]struct{}{}
+	addPath := func(path string) {
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+
+	for _, id := range selected {
+		switch id {
+		case model.OpenCodePluginGentleLogo:
+			addPath(filepath.Join(opencodeDir, "tui-plugins", gentleLogoPluginFile))
+		default:
+			if _, ok := DefinitionFor(id); !ok {
+				return nil, fmt.Errorf("unknown OpenCode community plugin %q", id)
+			}
+		}
+		addPath(tuiPath)
+	}
+
+	return paths, nil
+}
+
 func Install(homeDir string, id model.OpenCodeCommunityPluginID) (Result, error) {
 	if id == model.OpenCodePluginGentleLogo {
 		return installGentleLogo(homeDir)
@@ -154,8 +185,7 @@ func Install(homeDir string, id model.OpenCodeCommunityPluginID) (Result, error)
 
 func installGentleLogo(homeDir string) (Result, error) {
 	opencodeDir := filepath.Join(homeDir, ".config", "opencode")
-	pluginDir := filepath.Join(opencodeDir, "tui-plugins")
-	pluginPath := filepath.Join(pluginDir, gentleLogoPluginFile)
+	pluginPath := filepath.Join(opencodeDir, "tui-plugins", gentleLogoPluginFile)
 	tuiPath := filepath.Join(opencodeDir, "tui.json")
 
 	pluginWrite, err := filemerge.WriteFileAtomic(pluginPath, []byte(gentleLogoPluginSource), 0o644)


### PR DESCRIPTION
## Linked Issue

Closes #2680

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Rejects standard Windows npm CodeGraph shims exposed through WSL without executing them.
- Re-checks CLI admission after package installation before any CodeGraph invocation.
- Makes selected OpenCode plugin writes part of the existing pre-install rollback snapshot.

## Work Units

1. `fix(codegraph): reject WSL Windows npm shims` — executable admission boundary.
2. `fix(install): include OpenCode plugins in rollback snapshot` — transactional rollback boundary.

## Changes

| Area | Change |
|---|---|
| `internal/components/communitytool` | Static WSL shim rejection and post-install re-admission |
| `internal/cli/run.go` | Orders CodeGraph before plugins and snapshots plugin paths |
| `internal/components/opencodeplugin` | Declares every selected plugin mutation path |
| Tests | Covers rejected shims, early failure, late rollback, byte restoration, and success |

## Test Plan

- [x] `go test ./... -count=1`
- [x] `go test ./... -count=1` in `bench/`
- [x] `git diff --check origin/main...HEAD`
- [x] 379 authored changed lines, below the 400-line review limit
- [x] No shell scripts changed

## Contributor Checklist

- [x] Linked an approved issue
- [x] Exactly one `type:*` label will be applied
- [x] Tests are committed with each independent work unit
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation rollback so failed setups no longer leave behind OpenCode plugin changes.
  * Community tool installation now verifies that the CLI is actually available after installation.
  * Improved WSL handling by rejecting invalid Windows npm shims while accepting valid Linux CLI paths.
  * Installation now safely handles unknown plugin selections and tracks affected configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->