### PR TITLE
fix(review): preserve staged receipt governance after commit

### DIFF
--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -1546,15 +1546,22 @@ func compactStartTargetKindsCompatible(existing, requested TargetKind) bool {
 }
 
 func compactTargetProjectionsCompatible(existingKind TargetKind, existingProjection Projection, requestedKind TargetKind, requestedProjection Projection) bool {
+	if existingProjection == "" {
+		existingProjection = ProjectionWorkspace
+	}
+	if requestedProjection == "" {
+		requestedProjection = ProjectionWorkspace
+	}
 	if existingProjection == requestedProjection {
 		return true
 	}
-	existingWorkspace := existingProjection == "" || existingProjection == ProjectionWorkspace
-	requestedWorkspace := requestedProjection == "" || requestedProjection == ProjectionWorkspace
-	return (existingKind == TargetCurrentChanges && requestedKind == TargetBaseDiff ||
-		existingKind == TargetBaseDiff && requestedKind == TargetCurrentChanges) &&
-		(existingProjection == ProjectionStaged && requestedWorkspace ||
-			existingWorkspace && requestedProjection == ProjectionStaged)
+	// Staged/workspace representations are safe only for this content-equivalent
+	// kind class because surrounding predicates still bind one content boundary;
+	// workspace-overlay remains excluded.
+	return (existingKind == TargetCurrentChanges || existingKind == TargetBaseDiff) &&
+		(requestedKind == TargetCurrentChanges || requestedKind == TargetBaseDiff) &&
+		(existingProjection == ProjectionStaged && requestedProjection == ProjectionWorkspace ||
+			existingProjection == ProjectionWorkspace && requestedProjection == ProjectionStaged)
 }
 
 type compactCorrectionTargetClaim uint8

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -1527,7 +1527,7 @@ func compactApprovedRebasedScopeRecovery(ctx context.Context, repo string, exist
 // representations for the same base-to-candidate tree range.
 func compactStartDeliveryScopeMatches(existing, requested CompactState) bool {
 	original, live := existing.InitialSnapshot, requested.InitialSnapshot
-	return original.Projection == live.Projection &&
+	return compactTargetProjectionsCompatible(original.Kind, original.Projection, live.Kind, live.Projection) &&
 		compactStartTargetKindsCompatible(original.Kind, live.Kind) &&
 		live.BaseTree == original.BaseTree &&
 		live.PathsDigest == original.PathsDigest &&
@@ -1543,6 +1543,18 @@ func compactStartTargetKindsCompatible(existing, requested TargetKind) bool {
 	}
 	return existing == TargetCurrentChanges && requested == TargetBaseDiff ||
 		existing == TargetBaseDiff && requested == TargetCurrentChanges
+}
+
+func compactTargetProjectionsCompatible(existingKind TargetKind, existingProjection Projection, requestedKind TargetKind, requestedProjection Projection) bool {
+	if existingProjection == requestedProjection {
+		return true
+	}
+	existingWorkspace := existingProjection == "" || existingProjection == ProjectionWorkspace
+	requestedWorkspace := requestedProjection == "" || requestedProjection == ProjectionWorkspace
+	return (existingKind == TargetCurrentChanges && requestedKind == TargetBaseDiff ||
+		existingKind == TargetBaseDiff && requestedKind == TargetCurrentChanges) &&
+		(existingProjection == ProjectionStaged && requestedWorkspace ||
+			existingWorkspace && requestedProjection == ProjectionStaged)
 }
 
 type compactCorrectionTargetClaim uint8

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -511,7 +511,7 @@ func TestStartCompactAuthorityRunsBeforeCreateGuardOnlyAtNewAuthorityBoundary(t 
 	}
 }
 
-func TestStartCompactAuthorityKeepsStagedAndWorkspaceAuthoritiesDistinct(t *testing.T) {
+func TestStartCompactAuthorityReusesContentEquivalentStagedAndWorkspaceAuthority(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
 	gitSnapshot(t, repo, "add", "--", "tracked.txt")
@@ -523,9 +523,9 @@ func TestStartCompactAuthorityKeepsStagedAndWorkspaceAuthoritiesDistinct(t *test
 	}
 	storeCompactStartAuthority(t, repo, staged)
 
-	created, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: workspace})
-	if err != nil || created.Action != CompactStartCreated || created.Record.State.LineageID != workspace.LineageID {
-		t.Fatalf("workspace start against staged authority = %#v, %v", created, err)
+	reused, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: workspace})
+	if err != nil || reused.Action != CompactStartResumed || reused.Record.State.LineageID != staged.LineageID {
+		t.Fatalf("workspace start against staged authority = %#v, %v", reused, err)
 	}
 	replayed, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: staged})
 	if err != nil || replayed.Action != CompactStartResumed || replayed.Record.State.LineageID != staged.LineageID {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -533,7 +533,7 @@ func TestStartCompactAuthorityKeepsStagedAndWorkspaceAuthoritiesDistinct(t *test
 	}
 }
 
-func TestStartCompactAuthoritySelectsProjectionSpecificBaseDiffAuthorityAfterCommit(t *testing.T) {
+func TestStartCompactAuthorityRejectsAmbiguousProjectionCompatibleBaseDiffAuthorityAfterCommit(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
@@ -551,16 +551,15 @@ func TestStartCompactAuthoritySelectsProjectionSpecificBaseDiffAuthorityAfterCom
 	for _, tt := range []struct {
 		name       string
 		projection Projection
-		want       string
 	}{
-		{name: "staged", projection: ProjectionStaged, want: staged.LineageID},
-		{name: "workspace", projection: ProjectionWorkspace, want: workspace.LineageID},
+		{name: "staged", projection: ProjectionStaged},
+		{name: "workspace", projection: ProjectionWorkspace},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			requested := newCompactStartStateForTarget(t, repo, "compact-start-"+tt.name+"-base-request", Target{Kind: TargetBaseDiff, Projection: tt.projection, BaseRef: base, IntendedUntracked: []string{}})
 			result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
-			if err != nil || result.Action != CompactStartResumed || result.Record.State.LineageID != tt.want {
-				t.Fatalf("%s base-diff authority selection = %#v, %v", tt.name, result, err)
+			if err != nil || result.Action != CompactStartBlocked {
+				t.Fatalf("%s ambiguous base-diff authority = %#v, %v", tt.name, result, err)
 			}
 		})
 	}

--- a/internal/reviewtransaction/projection_compatibility_test.go
+++ b/internal/reviewtransaction/projection_compatibility_test.go
@@ -21,19 +21,59 @@ func TestCompactTargetProjectionsCompatible(t *testing.T) {
 			want:                true,
 		},
 		{
-			name:                "staged current changes accepts workspace base diff",
+			name:                "workspace alias accepts default workspace",
 			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetCurrentChanges,
+			existingProjection:  ProjectionWorkspace,
+			requestedProjection: "",
+			want:                true,
+		},
+		{
+			name:                "default workspace alias accepts workspace",
+			existingKind:        TargetBaseWorkspaceOverlay,
+			requestedKind:       TargetBaseWorkspaceOverlay,
+			existingProjection:  "",
+			requestedProjection: ProjectionWorkspace,
+			want:                true,
+		},
+		{
+			name:                "staged current changes accepts workspace current changes",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetCurrentChanges,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: ProjectionWorkspace,
+			want:                true,
+		},
+		{
+			name:                "workspace current changes accepts staged current changes",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetCurrentChanges,
+			existingProjection:  ProjectionWorkspace,
+			requestedProjection: ProjectionStaged,
+			want:                true,
+		},
+		{
+			name:                "staged base diff accepts workspace base diff",
+			existingKind:        TargetBaseDiff,
 			requestedKind:       TargetBaseDiff,
 			existingProjection:  ProjectionStaged,
 			requestedProjection: ProjectionWorkspace,
 			want:                true,
 		},
 		{
-			name:                "staged current changes accepts default base diff",
+			name:                "workspace base diff accepts staged base diff",
+			existingKind:        TargetBaseDiff,
+			requestedKind:       TargetBaseDiff,
+			existingProjection:  ProjectionWorkspace,
+			requestedProjection: ProjectionStaged,
+			want:                true,
+		},
+		{
+			name:                "staged current changes accepts workspace base diff",
 			existingKind:        TargetCurrentChanges,
 			requestedKind:       TargetBaseDiff,
 			existingProjection:  ProjectionStaged,
-			requestedProjection: "",
+			requestedProjection: ProjectionWorkspace,
 			want:                true,
 		},
 		{
@@ -60,14 +100,6 @@ func TestCompactTargetProjectionsCompatible(t *testing.T) {
 			requestedProjection: ProjectionWorkspace,
 			want:                false,
 		},
-		{
-			name:                "staged current changes does not accept workspace current changes",
-			existingKind:        TargetCurrentChanges,
-			requestedKind:       TargetCurrentChanges,
-			existingProjection:  ProjectionStaged,
-			requestedProjection: ProjectionWorkspace,
-			want:                false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -79,6 +111,7 @@ func TestCompactTargetProjectionsCompatible(t *testing.T) {
 }
 
 func TestProjectionCompatibilityGovernancePredicates(t *testing.T) {
+	emptyProof := hashCanonical("gentle-ai.intended-untracked/v1")
 	base := Snapshot{
 		Kind:                   TargetCurrentChanges,
 		Projection:             ProjectionStaged,
@@ -86,97 +119,83 @@ func TestProjectionCompatibilityGovernancePredicates(t *testing.T) {
 		CandidateTree:          "candidate",
 		PathsDigest:            digestPaths([]string{"tracked.go"}),
 		Paths:                  []string{"tracked.go"},
-		IntendedUntracked:      []string{"draft.md"},
-		IntendedUntrackedProof: "proof",
+		IntendedUntracked:      []string{},
+		IntendedUntrackedProof: emptyProof,
 	}
-	tests := []struct {
-		name    string
-		initial Snapshot
-		live    Snapshot
-		want    bool
-	}{
-		{
-			name:    "exact projection remains governing",
-			initial: base,
-			live:    base,
-			want:    true,
-		},
-		{
-			name:    "staged current changes governs workspace base diff",
-			initial: base,
-			live: Snapshot{
-				Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
-				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
-				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
-				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
-			},
-			want: true,
-		},
-		{
-			name: "staged overlay recovery does not govern workspace base diff",
-			initial: Snapshot{
-				Kind: TargetBaseWorkspaceOverlay, Projection: ProjectionStaged,
-				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
-				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
-				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
-			},
-			live: Snapshot{
-				Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
-				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
-				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
-				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
-			},
-			want: false,
-		},
-		{
-			name:    "unrelated staged workspace kinds do not govern",
-			initial: base,
-			live: Snapshot{
-				Kind: TargetFixDiff, Projection: ProjectionWorkspace,
-				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
-				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
-				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
-			},
-			want: false,
-		},
-		{
-			name:    "intended untracked mismatch remains rejected",
-			initial: base,
-			live: Snapshot{
-				Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
-				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
-				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
-				IntendedUntracked: []string{"other.md"}, IntendedUntrackedProof: base.IntendedUntrackedProof,
-			},
-			want: false,
-		},
+	live := Snapshot{
+		Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
+		BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+		PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+		IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			state := CompactState{
-				InitialSnapshot: tt.initial,
-				CurrentSnapshot: tt.initial,
-				GenesisPaths:    append([]string(nil), tt.initial.Paths...),
-			}
-			requested := state
-			requested.InitialSnapshot = tt.live
-			transaction := Transaction{
-				Snapshot:           tt.initial,
-				GenesisPaths:       append([]string(nil), tt.initial.Paths...),
-				BaseTree:           tt.initial.BaseTree,
-				FinalCandidateTree: tt.initial.CandidateTree,
-			}
+	state := CompactState{
+		InitialSnapshot: base,
+		CurrentSnapshot: base,
+		GenesisPaths:    append([]string(nil), base.Paths...),
+	}
+	requested := state
+	requested.InitialSnapshot = live
+	transaction := Transaction{
+		Snapshot:           base,
+		GenesisPaths:       append([]string(nil), base.Paths...),
+		BaseTree:           base.BaseTree,
+		FinalCandidateTree: base.CandidateTree,
+	}
 
-			if got := compactStartDeliveryScopeMatches(state, requested); got != tt.want {
-				t.Fatalf("compactStartDeliveryScopeMatches() = %t, want %t", got, tt.want)
-			}
-			if got := compactLiveTargetMatchesValidatedSnapshot(state, tt.live, true); got != tt.want {
-				t.Fatalf("compactLiveTargetMatchesValidatedSnapshot() = %t, want %t", got, tt.want)
-			}
-			if got := legacyLiveTargetMatchesValidatedSnapshot(transaction, tt.live); got != tt.want {
-				t.Fatalf("legacyLiveTargetMatchesValidatedSnapshot() = %t, want %t", got, tt.want)
-			}
-		})
+	if !compactStartDeliveryScopeMatches(state, requested) {
+		t.Fatal("compactStartDeliveryScopeMatches() rejected equivalent content scope")
+	}
+	if !compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
+		t.Fatal("compactLiveTargetMatchesValidatedSnapshot() rejected exact candidate")
+	}
+	if !legacyLiveTargetMatchesValidatedSnapshot(transaction, live) {
+		t.Fatal("legacyLiveTargetMatchesValidatedSnapshot() rejected exact candidate")
+	}
+}
+
+func TestDiscoveryExactCandidateIgnoresIntendedUntrackedSideBand(t *testing.T) {
+	emptyProof := hashCanonical("gentle-ai.intended-untracked/v1")
+	base := Snapshot{
+		Kind:                   TargetCurrentChanges,
+		Projection:             ProjectionStaged,
+		BaseTree:               "base",
+		CandidateTree:          "candidate",
+		PathsDigest:            digestPaths([]string{"tracked.go"}),
+		Paths:                  []string{"tracked.go"},
+		IntendedUntracked:      []string{},
+		IntendedUntrackedProof: emptyProof,
+	}
+	live := Snapshot{
+		Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
+		BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+		PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+		IntendedUntracked: []string{"draft.md"}, IntendedUntrackedProof: "different-proof",
+	}
+	state := CompactState{
+		InitialSnapshot: base,
+		CurrentSnapshot: base,
+		GenesisPaths:    append([]string(nil), base.Paths...),
+	}
+	requested := state
+	requested.InitialSnapshot = live
+	transaction := Transaction{
+		Snapshot:           base,
+		GenesisPaths:       append([]string(nil), base.Paths...),
+		BaseTree:           base.BaseTree,
+		FinalCandidateTree: live.CandidateTree,
+	}
+
+	if compactStartDeliveryScopeMatches(state, requested) {
+		t.Fatal("compactStartDeliveryScopeMatches() accepted differing intended-untracked side-band")
+	}
+	if !compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
+		t.Fatal("compactLiveTargetMatchesValidatedSnapshot() rejected exact candidate side-band variation")
+	}
+	if compactLiveTargetMatchesValidatedSnapshot(state, live, false) {
+		t.Fatal("compactLiveTargetMatchesValidatedSnapshot() accepted side-band variation without exact candidate requirement")
+	}
+	if !legacyLiveTargetMatchesValidatedSnapshot(transaction, live) {
+		t.Fatal("legacyLiveTargetMatchesValidatedSnapshot() rejected exact candidate side-band variation")
 	}
 }
 

--- a/internal/reviewtransaction/projection_compatibility_test.go
+++ b/internal/reviewtransaction/projection_compatibility_test.go
@@ -1,0 +1,205 @@
+package reviewtransaction
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCompactTargetProjectionsCompatible(t *testing.T) {
+	tests := []struct {
+		name                                    string
+		existingKind, requestedKind             TargetKind
+		existingProjection, requestedProjection Projection
+		want                                    bool
+	}{
+		{
+			name:                "exact projection remains compatible",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetCurrentChanges,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: ProjectionStaged,
+			want:                true,
+		},
+		{
+			name:                "staged current changes accepts workspace base diff",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetBaseDiff,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: ProjectionWorkspace,
+			want:                true,
+		},
+		{
+			name:                "staged current changes accepts default base diff",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetBaseDiff,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: "",
+			want:                true,
+		},
+		{
+			name:                "workspace base diff accepts staged current changes",
+			existingKind:        TargetBaseDiff,
+			requestedKind:       TargetCurrentChanges,
+			existingProjection:  ProjectionWorkspace,
+			requestedProjection: ProjectionStaged,
+			want:                true,
+		},
+		{
+			name:                "staged overlay does not accept workspace base diff",
+			existingKind:        TargetBaseWorkspaceOverlay,
+			requestedKind:       TargetBaseDiff,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: ProjectionWorkspace,
+			want:                false,
+		},
+		{
+			name:                "staged current changes does not accept workspace fix diff",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetFixDiff,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: ProjectionWorkspace,
+			want:                false,
+		},
+		{
+			name:                "staged current changes does not accept workspace current changes",
+			existingKind:        TargetCurrentChanges,
+			requestedKind:       TargetCurrentChanges,
+			existingProjection:  ProjectionStaged,
+			requestedProjection: ProjectionWorkspace,
+			want:                false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compactTargetProjectionsCompatible(tt.existingKind, tt.existingProjection, tt.requestedKind, tt.requestedProjection); got != tt.want {
+				t.Fatalf("compactTargetProjectionsCompatible() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectionCompatibilityGovernancePredicates(t *testing.T) {
+	base := Snapshot{
+		Kind:                   TargetCurrentChanges,
+		Projection:             ProjectionStaged,
+		BaseTree:               "base",
+		CandidateTree:          "candidate",
+		PathsDigest:            digestPaths([]string{"tracked.go"}),
+		Paths:                  []string{"tracked.go"},
+		IntendedUntracked:      []string{"draft.md"},
+		IntendedUntrackedProof: "proof",
+	}
+	tests := []struct {
+		name    string
+		initial Snapshot
+		live    Snapshot
+		want    bool
+	}{
+		{
+			name:    "exact projection remains governing",
+			initial: base,
+			live:    base,
+			want:    true,
+		},
+		{
+			name:    "staged current changes governs workspace base diff",
+			initial: base,
+			live: Snapshot{
+				Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
+				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
+			},
+			want: true,
+		},
+		{
+			name: "staged overlay recovery does not govern workspace base diff",
+			initial: Snapshot{
+				Kind: TargetBaseWorkspaceOverlay, Projection: ProjectionStaged,
+				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
+			},
+			live: Snapshot{
+				Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
+				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
+			},
+			want: false,
+		},
+		{
+			name:    "unrelated staged workspace kinds do not govern",
+			initial: base,
+			live: Snapshot{
+				Kind: TargetFixDiff, Projection: ProjectionWorkspace,
+				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+				IntendedUntracked: append([]string(nil), base.IntendedUntracked...), IntendedUntrackedProof: base.IntendedUntrackedProof,
+			},
+			want: false,
+		},
+		{
+			name:    "intended untracked mismatch remains rejected",
+			initial: base,
+			live: Snapshot{
+				Kind: TargetBaseDiff, Projection: ProjectionWorkspace,
+				BaseTree: base.BaseTree, CandidateTree: base.CandidateTree,
+				PathsDigest: base.PathsDigest, Paths: append([]string(nil), base.Paths...),
+				IntendedUntracked: []string{"other.md"}, IntendedUntrackedProof: base.IntendedUntrackedProof,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := CompactState{
+				InitialSnapshot: tt.initial,
+				CurrentSnapshot: tt.initial,
+				GenesisPaths:    append([]string(nil), tt.initial.Paths...),
+			}
+			requested := state
+			requested.InitialSnapshot = tt.live
+			transaction := Transaction{
+				Snapshot:           tt.initial,
+				GenesisPaths:       append([]string(nil), tt.initial.Paths...),
+				BaseTree:           tt.initial.BaseTree,
+				FinalCandidateTree: tt.initial.CandidateTree,
+			}
+
+			if got := compactStartDeliveryScopeMatches(state, requested); got != tt.want {
+				t.Fatalf("compactStartDeliveryScopeMatches() = %t, want %t", got, tt.want)
+			}
+			if got := compactLiveTargetMatchesValidatedSnapshot(state, tt.live, true); got != tt.want {
+				t.Fatalf("compactLiveTargetMatchesValidatedSnapshot() = %t, want %t", got, tt.want)
+			}
+			if got := legacyLiveTargetMatchesValidatedSnapshot(transaction, tt.live); got != tt.want {
+				t.Fatalf("legacyLiveTargetMatchesValidatedSnapshot() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApprovedStagedCurrentChangesReceiptGovernsWorkspaceBaseDiffAfterCommit(t *testing.T) {
+	repo, state, _, _ := approvedCurrentChangesScopeRecoveryFixtureForProjection(t, "projection-compatible-status", ProjectionStaged)
+	gitSnapshot(t, repo, "commit", "-m", "deliver staged candidate")
+
+	target := Target{
+		Kind: TargetBaseDiff, BaseRef: state.InitialSnapshot.BaseTree,
+		IntendedUntracked: []string{},
+	}
+	requested := newCompactStartStateForTarget(t, repo, "projection-compatible-start", target)
+	requested.PolicyHash = state.PolicyHash
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil || started.Action != CompactStartReuseReceipt || started.Record.State.LineageID != state.LineageID {
+		t.Fatalf("START after commit = %#v, %v", started, err)
+	}
+
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+		Target: target, LineageID: state.LineageID,
+	})
+	if err != nil || status.Applicability != TargetApplicabilityCurrent || status.State != StateApproved ||
+		status.Action != TargetStatusActionValidate || status.ReceiptIdentity == "" || status.LineageID != state.LineageID {
+		t.Fatalf("STATUS after commit = %#v, %v", status, err)
+	}
+}

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -326,7 +326,8 @@ func compactLiveTargetMatchesValidatedSnapshot(state CompactState, live Snapshot
 	if requireCurrentCandidate {
 		proof = state.CurrentSnapshot.IntendedUntrackedProof
 	}
-	return initial.Projection == live.Projection && compactStartTargetKindsCompatible(initial.Kind, live.Kind) &&
+	return compactTargetProjectionsCompatible(initial.Kind, initial.Projection, live.Kind, live.Projection) &&
+		compactStartTargetKindsCompatible(initial.Kind, live.Kind) &&
 		initial.BaseTree == live.BaseTree && (!requireCurrentCandidate || state.CurrentSnapshot.CandidateTree == live.CandidateTree) &&
 		pathsAreSubset(live.Paths, state.GenesisPaths) == nil && equalStrings(initial.IntendedUntracked, live.IntendedUntracked) &&
 		proof == live.IntendedUntrackedProof && len(live.LedgerIDs) == 0
@@ -339,7 +340,8 @@ func legacyLiveTargetMatchesValidatedSnapshot(transaction Transaction, live Snap
 	}
 	kindsMatch := compactStartTargetKindsCompatible(transaction.Snapshot.Kind, live.Kind) ||
 		transaction.Snapshot.Kind == TargetFixDiff && (live.Kind == TargetCurrentChanges || live.Kind == TargetBaseDiff)
-	return transaction.Snapshot.Projection == live.Projection && kindsMatch && transaction.BaseTree == live.BaseTree &&
+	return compactTargetProjectionsCompatible(transaction.Snapshot.Kind, transaction.Snapshot.Projection, live.Kind, live.Projection) &&
+		kindsMatch && transaction.BaseTree == live.BaseTree &&
 		transaction.FinalCandidateTree == live.CandidateTree && pathsAreSubset(live.Paths, genesis) == nil &&
 		equalStrings(transaction.Snapshot.IntendedUntracked, live.IntendedUntracked) &&
 		transaction.Snapshot.IntendedUntrackedProof == live.IntendedUntrackedProof && len(live.LedgerIDs) == 0

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -322,15 +322,13 @@ func projectCompactTerminalHistory(state CompactState, live Snapshot) compactTer
 
 func compactLiveTargetMatchesValidatedSnapshot(state CompactState, live Snapshot, requireCurrentCandidate bool) bool {
 	initial := state.InitialSnapshot
-	proof := initial.IntendedUntrackedProof
-	if requireCurrentCandidate {
-		proof = state.CurrentSnapshot.IntendedUntrackedProof
-	}
+	sideBandMatches := requireCurrentCandidate ||
+		(equalStrings(initial.IntendedUntracked, live.IntendedUntracked) &&
+			initial.IntendedUntrackedProof == live.IntendedUntrackedProof)
 	return compactTargetProjectionsCompatible(initial.Kind, initial.Projection, live.Kind, live.Projection) &&
 		compactStartTargetKindsCompatible(initial.Kind, live.Kind) &&
 		initial.BaseTree == live.BaseTree && (!requireCurrentCandidate || state.CurrentSnapshot.CandidateTree == live.CandidateTree) &&
-		pathsAreSubset(live.Paths, state.GenesisPaths) == nil && equalStrings(initial.IntendedUntracked, live.IntendedUntracked) &&
-		proof == live.IntendedUntrackedProof && len(live.LedgerIDs) == 0
+		pathsAreSubset(live.Paths, state.GenesisPaths) == nil && sideBandMatches && len(live.LedgerIDs) == 0
 }
 
 func legacyLiveTargetMatchesValidatedSnapshot(transaction Transaction, live Snapshot) bool {
@@ -343,8 +341,7 @@ func legacyLiveTargetMatchesValidatedSnapshot(transaction Transaction, live Snap
 	return compactTargetProjectionsCompatible(transaction.Snapshot.Kind, transaction.Snapshot.Projection, live.Kind, live.Projection) &&
 		kindsMatch && transaction.BaseTree == live.BaseTree &&
 		transaction.FinalCandidateTree == live.CandidateTree && pathsAreSubset(live.Paths, genesis) == nil &&
-		equalStrings(transaction.Snapshot.IntendedUntracked, live.IntendedUntracked) &&
-		transaction.Snapshot.IntendedUntrackedProof == live.IntendedUntrackedProof && len(live.LedgerIDs) == 0
+		len(live.LedgerIDs) == 0
 }
 
 func classifyCompactCorrectionTargetForStatus(ctx context.Context, repo string, existing CompactState, live Snapshot) (compactCorrectionTargetClaim, error) {

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -464,7 +464,7 @@ func TestCorrectionScopeExpansionPrioritizesPendingFinalize(t *testing.T) {
 	}
 }
 
-func TestCompactTargetStatusUsesCurrentProofAndLiveProjection(t *testing.T) {
+func TestCompactTargetStatusUsesExactCurrentCandidateAndLiveProjection(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
 	writeSnapshotFile(t, repo, "new.txt", "initial\n")
@@ -475,12 +475,12 @@ func TestCompactTargetStatusUsesCurrentProofAndLiveProjection(t *testing.T) {
 	fix, _ := builder.Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: initial.CandidateTree, IntendedUntracked: []string{"new.txt"}, LedgerIDs: []string{"R1-001"}})
 	state := CompactState{InitialSnapshot: initial, CurrentSnapshot: fix, GenesisPaths: initial.Paths}
 	if !compactLiveTargetMatchesSnapshot(context.Background(), repo, state, live, true) {
-		t.Fatal("terminal correction did not match current intended-untracked proof")
+		t.Fatal("terminal correction did not match the exact current candidate")
 	}
 	wrongProof := state
 	wrongProof.CurrentSnapshot.IntendedUntrackedProof = initial.IntendedUntrackedProof
-	if compactLiveTargetMatchesSnapshot(context.Background(), repo, wrongProof, live, true) {
-		t.Fatal("terminal correction accepted a stale intended-untracked proof")
+	if !compactLiveTargetMatchesSnapshot(context.Background(), repo, wrongProof, live, true) {
+		t.Fatal("terminal correction rejected an exact candidate for a stale intended-untracked proof")
 	}
 	projection := targetProjectionFromCompact(state, targetProjectionFromSnapshot(live))
 	if projection.Kind != live.Kind || projection.PathsDigest != live.PathsDigest || projection.IntendedUntrackedProof != live.IntendedUntrackedProof || projection.CurrentSnapshotIdentity != live.Identity || projection.InitialSnapshotIdentity != initial.Identity {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2688

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Recognize an approved staged `current-changes` receipt when the exact candidate is later evaluated as a workspace `base-diff`.
- Centralize projection compatibility across all three receipt-governance predicates, including same-kind and cross-kind staged/workspace representations inside the `current-changes`/`base-diff` content class.
- Treat intended-untracked declarations and proofs as side-band only after exact candidate-tree equality is established; keep workspace overlays, unrelated kinds, and scope-only START comparisons fail-closed.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_store.go` | Added the shared projection content class while preserving strict scope-only START side-band checks. |
| `internal/reviewtransaction/target_status_projection.go` | Applied projection compatibility and representation-invariant side-band handling only where exact candidate trees are already bound. |
| `internal/reviewtransaction/projection_compatibility_test.go` | Added helper, same/cross-kind, side-band, ambiguity, and end-to-end STATUS regressions. |
| `internal/reviewtransaction/compact_store_test.go`, `target_status_test.go` | Kept store and discovery fixtures aligned with valid staged representations and exact-candidate semantics. |

---

## 🧪 Test Plan

- [x] RED reproduced against `origin/main` and again against the first PR commit for the same-kind/side-band correction.
- [x] Focused regression tests pass on this branch.
- [x] Unit tests pass: `go test ./... -count=1`.
- [x] Go format passes: `go run ./internal/gofmtcheck`.
- [x] Benchmark declarations pass: `go vet ./...` and `go test ./...` from `bench/`.
- [x] Driven benchmark passes: `j44-corrected-current-changes-delivery` — `1 completed, 0 unsupported, 0 failed`.
- [ ] Docker E2E was not run locally; required CI owns this check.
- [x] Manually exercised the affected delivery shape through regression tests and the driven benchmark.

No journey pins the old #2688 behavior. `j44` provides indirect pre-push delivery coverage; the exact post-commit STATUS behavior is covered by the new Go regression.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 236 authored additions/deletions, below the 400-line limit. |
| Check Issue Reference | ⏳ | Links approved issue #2688. |
| Check Issue Has `status:approved` | ⏳ | Verified before implementation. |
| Check PR Has `type:*` Label | ⏳ | `type:bug` will be applied. |
| Unit Tests | ⏳ | CI confirmation pending. |
| Go Format | ⏳ | CI confirmation pending. |
| E2E Tests | ⏳ | CI confirmation pending. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines.
- [x] I have added the appropriate `type:*` label to this PR.
- [x] Unit tests pass (`go test ./... -count=1`).
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] Docker E2E will be confirmed by CI.
- [x] Benchmark validation completed.
- [x] Documentation is not required; this restores documented receipt continuity without adding a new user-facing surface.
- [x] My commits follow Conventional Commits format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## 💬 Notes for Reviewers

The helper broadens the legitimate governance population only inside the `current-changes`/`base-diff` content-equivalent class. Intended-untracked declarations and proofs may differ only after exact candidate-tree equality is established; predicates that do not bind the candidate remain strict. Tests challenge the negative population explicitly: `base-workspace-overlay`, unrelated kinds, non-exact side-band mismatches, tree/path mismatches, and ambiguous authorities remain rejected. No guard-population baseline change is required because the production change does not add a new refusal guard; it narrows existing false negatives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery and target validation when switching between current-changes and base-diff views.
  - Compatible staged and workspace projections can now continue across related operations without unnecessary interruptions.
  - Added safeguards to reject ambiguous matches instead of resuming the wrong change set.
  - Preserved validation for incompatible target types, projections, and intended untracked changes.
  - Improved reuse of approved staged-change results when checking corresponding workspace base-diff operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->