### PR TITLE
fix(review): reuse frozen inspector for lens context

### DIFF
--- a/internal/advisoryreview/contract.go
+++ b/internal/advisoryreview/contract.go
@@ -21,7 +21,7 @@ const (
 	// invented cap. Refusal happens before any evidence reaches a model;
 	// evidence is never truncated to fit.
 	maxEvidenceBytes   = reviewtransaction.MaxFrozenCandidateDiffBytes
-	maxEvidenceEntries = 32
+	MaxEvidenceEntries = 32
 	maxResultBytes     = 64 << 10
 )
 
@@ -146,7 +146,7 @@ func validateRequest(request Request) error {
 	if err := reviewtransaction.ValidateReviewerResultBinding(request.ArtifactSubject, request.ChangedPathManifest); err != nil {
 		return fmt.Errorf("validate advisory reviewer binding: %w", err)
 	}
-	if len(request.Evidence) == 0 || len(request.Evidence) > maxEvidenceEntries || len(request.Evidence) != len(request.ChangedPathManifest) {
+	if len(request.Evidence) == 0 || len(request.Evidence) > MaxEvidenceEntries || len(request.Evidence) != len(request.ChangedPathManifest) {
 		// refusal:by-design operator-knowledge: advisory review requires bounded provider-owned evidence
 		return fmt.Errorf("advisory review requires one bounded evidence entry for every frozen candidate path")
 	}

--- a/internal/cli/review_advisory.go
+++ b/internal/cli/review_advisory.go
@@ -119,12 +119,7 @@ func resolveAdvisoryRequest(ctx context.Context, deps reviewLensContextDeps, rep
 		return advisoryreview.Request{}, err
 	}
 	defer func() {
-		if cleanupErr := authority.Inspector.Close(); cleanupErr != nil {
-			request = advisoryreview.Request{}
-			if err == nil {
-				err = reviewLensContextInspectionFailure(ctx, cleanupErr)
-			}
-		}
+		request, err = reviewLensContextCleanup(ctx, request, err, func() error { return deps.close(authority.Inspector) })
 	}()
 	if len(authority.Frozen.ChangedPathManifest) > advisoryreview.MaxEvidenceEntries {
 		return advisoryreview.Request{}, reviewLensContextRefusal("lens_context_budget_exceeded", reviewLensContextCapacityAction(len(authority.Frozen.ChangedPathManifest)))

--- a/internal/cli/review_advisory.go
+++ b/internal/cli/review_advisory.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/advisoryreview"
-	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
 // RunReviewAdvisory exposes the generic prompt/text seam. It is intentionally
@@ -114,16 +113,26 @@ func runReviewAdvisoryValidate(args []string, stdout io.Writer) error {
 // candidate in memory before a single check. This is the same refuse-before-
 // invocation, never-truncate discipline, applied to the same budget, not a
 // second competing one.
-func resolveAdvisoryRequest(ctx context.Context, deps reviewLensContextDeps, repositoryContext, lens string) (advisoryreview.Request, error) {
+func resolveAdvisoryRequest(ctx context.Context, deps reviewLensContextDeps, repositoryContext, lens string) (request advisoryreview.Request, err error) {
 	authority, err := resolveReviewLensAuthority(ctx, deps, repositoryContext, lens)
 	if err != nil {
 		return advisoryreview.Request{}, err
 	}
-	builder := reviewtransaction.SnapshotBuilder{Repo: authority.Root}
+	defer func() {
+		if cleanupErr := authority.Inspector.Close(); cleanupErr != nil {
+			request = advisoryreview.Request{}
+			if err == nil {
+				err = reviewLensContextInspectionFailure(ctx, cleanupErr)
+			}
+		}
+	}()
+	if len(authority.Frozen.ChangedPathManifest) > advisoryreview.MaxEvidenceEntries {
+		return advisoryreview.Request{}, reviewLensContextRefusal("lens_context_budget_exceeded", reviewLensContextCapacityAction(len(authority.Frozen.ChangedPathManifest)))
+	}
 	budget := reviewLensContextByteBudget
 	evidence := make([]advisoryreview.Evidence, 0, len(authority.Frozen.ChangedPathManifest))
 	for index, entry := range authority.Frozen.ChangedPathManifest {
-		payload, err := deps.inspect(builder, ctx, authority.State.InitialSnapshot, "patch", index, "")
+		payload, err := deps.inspect(ctx, authority.Inspector, "patch", index, "")
 		if err != nil {
 			return advisoryreview.Request{}, reviewLensContextInspectionFailure(ctx, err)
 		}

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -128,6 +128,7 @@ type reviewLensContextDeps struct {
 	discover func(context.Context, string, string, bool) (reviewtransaction.CompactStore, reviewtransaction.CompactRecord, error)
 	prepare  func(reviewtransaction.SnapshotBuilder, context.Context, reviewtransaction.Snapshot) (reviewLensCandidateInspector, error)
 	inspect  func(context.Context, reviewLensCandidateInspector, string, int, string) ([]byte, error)
+	close    func(reviewLensCandidateInspector) error
 	record   func(string, reviewtransaction.LensContextEmission) error
 }
 
@@ -148,6 +149,7 @@ func reviewLensContextDependencies() reviewLensContextDeps {
 		inspect: func(ctx context.Context, inspector reviewLensCandidateInspector, operation string, pathIndex int, side string) ([]byte, error) {
 			return inspector.Inspect(ctx, operation, pathIndex, side)
 		},
+		close:  func(inspector reviewLensCandidateInspector) error { return inspector.Close() },
 		record: reviewtransaction.PublishLensContextEmission,
 	}
 }
@@ -180,12 +182,7 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 		return nil, err
 	}
 	defer func() {
-		if cleanupErr := authority.Inspector.Close(); cleanupErr != nil {
-			payload = nil
-			if err == nil {
-				err = reviewLensContextInspectionFailure(ctx, cleanupErr)
-			}
-		}
+		payload, err = reviewLensContextCleanup(ctx, payload, err, func() error { return deps.close(authority.Inspector) })
 	}()
 	if len(authority.Frozen.ChangedPathManifest) > advisoryreview.MaxEvidenceEntries {
 		return nil, reviewLensContextRefusal("lens_context_budget_exceeded", reviewLensContextCapacityAction(len(authority.Frozen.ChangedPathManifest)))
@@ -430,6 +427,18 @@ func reviewLensContextInspectionFailure(ctx context.Context, err error) error {
 	return reviewLensContextRefusal("lens_context_inspection_failed", reviewLensContextRefreshAction)
 }
 
+func reviewLensContextCleanup[T any](ctx context.Context, result T, operationErr error, close func() error) (T, error) {
+	cleanupErr := close()
+	if cleanupErr == nil {
+		return result, operationErr
+	}
+	var zero T
+	if operationErr != nil {
+		return zero, errors.Join(operationErr, cleanupErr)
+	}
+	return zero, reviewLensContextInspectionFailure(ctx, cleanupErr)
+}
+
 // reviewLensContextDeadline reports the aggregate-deadline refusal when either
 // the operation context expired or the failure itself carries a cancellation,
 // and nil when the failure has an unrelated cause. It never invents a
@@ -445,5 +454,5 @@ func reviewLensContextDeadline(ctx context.Context, err error) error {
 }
 
 func reviewLensContextCapacityAction(entries int) string {
-	return fmt.Sprintf("immutable candidate evidence has %d paths but advisory review accepts at most %d evidence entries; retrying this candidate cannot succeed; split the candidate into a chained sequence of smaller reviewable commits, then start a review for the reduced scope by running %s", entries, advisoryreview.MaxEvidenceEntries, reviewNextTransitionRefreshCommandV21)
+	return fmt.Sprintf("immutable candidate evidence has %d paths but provider-owned reviewer context accepts at most %d evidence entries; retrying this candidate cannot succeed; split the candidate into a chained sequence of smaller reviewable commits, then start a review for the reduced scope by running %s", entries, advisoryreview.MaxEvidenceEntries, reviewNextTransitionRefreshCommandV21)
 }

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/advisoryreview"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -82,6 +83,8 @@ const (
 	reviewLensContextEmptyPatchAction = "one content-changing path produced no patch bytes at all, which no legitimate candidate does; " +
 		"refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 +
 		" and run this operation again, and if the same path keeps producing no patch treat it as a native inspection defect and stop retrying"
+	reviewLensContextDeadlineAction = "refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 +
+		", then retry this operation once with the tokens it returns; if the same lens slot reaches the same deadline again, an identical retry cannot change its frozen scope or deadline, so split the candidate into a chained sequence of smaller reviewable commits, then start a review for the reduced scope by running " + reviewNextTransitionRefreshCommandV21
 	reviewLensContextConflictAction = "this frozen lens slot already recorded a reviewer context produced by a different mechanism, and audit history is never rewritten; " +
 		"produce this lens context by the same mechanism that already recorded one, or start a review for a fresh candidate by running " +
 		reviewNextTransitionRefreshCommandV21
@@ -123,8 +126,15 @@ type reviewLensContextDeps struct {
 	timeout  time.Duration
 	resolve  func(context.Context, string) (string, reviewtransaction.ReviewRepositoryContextBinding, error)
 	discover func(context.Context, string, string, bool) (reviewtransaction.CompactStore, reviewtransaction.CompactRecord, error)
-	inspect  func(reviewtransaction.SnapshotBuilder, context.Context, reviewtransaction.Snapshot, string, int, string) ([]byte, error)
+	prepare  func(reviewtransaction.SnapshotBuilder, context.Context, reviewtransaction.Snapshot) (reviewLensCandidateInspector, error)
+	inspect  func(context.Context, reviewLensCandidateInspector, string, int, string) ([]byte, error)
 	record   func(string, reviewtransaction.LensContextEmission) error
+}
+
+type reviewLensCandidateInspector interface {
+	FrozenCandidateContext() reviewtransaction.FrozenCandidateContext
+	Inspect(context.Context, string, int, string) ([]byte, error)
+	Close() error
 }
 
 func reviewLensContextDependencies() reviewLensContextDeps {
@@ -132,12 +142,17 @@ func reviewLensContextDependencies() reviewLensContextDeps {
 		timeout:  reviewLensContextTimeout,
 		resolve:  reviewtransaction.ResolveReviewRepositoryContextBinding,
 		discover: discoverCompactFacadeReview,
-		inspect:  reviewtransaction.SnapshotBuilder.InspectCandidate,
-		record:   reviewtransaction.PublishLensContextEmission,
+		prepare: func(builder reviewtransaction.SnapshotBuilder, ctx context.Context, snapshot reviewtransaction.Snapshot) (reviewLensCandidateInspector, error) {
+			return builder.PrepareCandidateInspector(ctx, snapshot)
+		},
+		inspect: func(ctx context.Context, inspector reviewLensCandidateInspector, operation string, pathIndex int, side string) ([]byte, error) {
+			return inspector.Inspect(ctx, operation, pathIndex, side)
+		},
+		record: reviewtransaction.PublishLensContextEmission,
 	}
 }
 
-func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextDeps) ([]byte, error) {
+func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextDeps) (payload []byte, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), deps.timeout)
 	defer cancel()
 	flags := newReviewFlagSet("review lens-context", help,
@@ -164,9 +179,19 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if cleanupErr := authority.Inspector.Close(); cleanupErr != nil {
+			payload = nil
+			if err == nil {
+				err = reviewLensContextInspectionFailure(ctx, cleanupErr)
+			}
+		}
+	}()
+	if len(authority.Frozen.ChangedPathManifest) > advisoryreview.MaxEvidenceEntries {
+		return nil, reviewLensContextRefusal("lens_context_budget_exceeded", reviewLensContextCapacityAction(len(authority.Frozen.ChangedPathManifest)))
+	}
 
-	block, err := reviewLensContextBlock(ctx, deps, reviewtransaction.SnapshotBuilder{Repo: authority.Root}, authority.State,
-		authority.Binding, authority.Subject, authority.Frozen)
+	block, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen)
 	if err != nil {
 		return nil, err
 	}
@@ -198,12 +223,11 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 // opaque repository context and a lens name into native authority -- never
 // two independent copies of that resolution.
 type reviewLensAuthority struct {
-	Root    string
-	Store   reviewtransaction.CompactStore
-	State   reviewtransaction.CompactState
-	Binding reviewLensContextBinding
-	Subject reviewtransaction.ArtifactSubject
-	Frozen  reviewtransaction.FrozenCandidateContext
+	Store     reviewtransaction.CompactStore
+	Binding   reviewLensContextBinding
+	Subject   reviewtransaction.ArtifactSubject
+	Frozen    reviewtransaction.FrozenCandidateContext
+	Inspector reviewLensCandidateInspector
 }
 
 // resolveReviewLensAuthority recovers the exact lineage, target, revision,
@@ -240,22 +264,26 @@ func resolveReviewLensAuthority(ctx context.Context, deps reviewLensContextDeps,
 	}
 
 	builder := reviewtransaction.SnapshotBuilder{Repo: root}
-	frozen, err := builder.FrozenCandidateContext(ctx, state.InitialSnapshot)
+	inspector, err := deps.prepare(builder, ctx, state.InitialSnapshot)
 	if err != nil {
 		return reviewLensAuthority{}, reviewLensContextInspectionFailure(ctx, err)
 	}
+	frozen := inspector.FrozenCandidateContext()
 	subject, err := reviewtransaction.NewArtifactSubject(state, record.Revision, frozen, state.SelectedLenses[order], order, "")
 	if err != nil {
+		if cleanupErr := inspector.Close(); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
 		return reviewLensAuthority{}, reviewLensContextInspectionFailure(ctx, err)
 	}
 
 	return reviewLensAuthority{
-		Root: root, Store: store, State: state,
+		Store: store,
 		Binding: reviewLensContextBinding{
 			Lineage: binding.LineageID, Target: binding.TargetIdentity, Lens: state.SelectedLenses[order], Order: order,
 			Revision: binding.Revision, RepositoryContext: repositoryContext, SubjectHash: subject.SubjectHash,
 		},
-		Subject: subject, Frozen: frozen,
+		Subject: subject, Frozen: frozen, Inspector: inspector,
 	}, nil
 }
 
@@ -277,7 +305,7 @@ func reviewLensContextSelectedOrder(selected []string, lens string) (int, error)
 }
 
 func reviewLensContextBlock(
-	ctx context.Context, deps reviewLensContextDeps, builder reviewtransaction.SnapshotBuilder, state reviewtransaction.CompactState,
+	ctx context.Context, deps reviewLensContextDeps, inspector reviewLensCandidateInspector,
 	binding reviewLensContextBinding, subject reviewtransaction.ArtifactSubject, frozen reviewtransaction.FrozenCandidateContext,
 ) ([]byte, error) {
 	// RepositoryRoot stays empty: this block is produced only for an opaque
@@ -323,7 +351,7 @@ func reviewLensContextBlock(
 		{header: reviewLensContextNameStatus, operation: "name-status"},
 		{header: reviewLensContextNumstat, operation: "numstat"},
 	} {
-		payload, err := deps.inspect(builder, ctx, state.InitialSnapshot, discovery.operation, -1, "")
+		payload, err := deps.inspect(ctx, inspector, discovery.operation, -1, "")
 		if err != nil {
 			return nil, reviewLensContextInspectionFailure(ctx, err)
 		}
@@ -332,7 +360,7 @@ func reviewLensContextBlock(
 		}
 	}
 	for index, entry := range frozen.ChangedPathManifest {
-		payload, err := deps.inspect(builder, ctx, state.InitialSnapshot, "patch", index, "")
+		payload, err := deps.inspect(ctx, inspector, "patch", index, "")
 		if err != nil {
 			return nil, reviewLensContextInspectionFailure(ctx, err)
 		}
@@ -408,10 +436,14 @@ func reviewLensContextInspectionFailure(ctx context.Context, err error) error {
 // cancellation: a nil return means the caller should classify normally.
 func reviewLensContextDeadline(ctx context.Context, err error) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
-		return reviewLensContextRefusal("lens_context_deadline_exceeded", reviewLensContextRefreshAction)
+		return reviewLensContextRefusal("lens_context_deadline_exceeded", reviewLensContextDeadlineAction)
 	}
 	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
 		return reviewLensContextRefusal("lens_context_canceled", reviewLensContextRefreshAction)
 	}
 	return nil
+}
+
+func reviewLensContextCapacityAction(entries int) string {
+	return fmt.Sprintf("immutable candidate evidence has %d paths but advisory review accepts at most %d evidence entries; retrying this candidate cannot succeed; split the candidate into a chained sequence of smaller reviewable commits, then start a review for the reduced scope by running %s", entries, advisoryreview.MaxEvidenceEntries, reviewNextTransitionRefreshCommandV21)
 }

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -78,13 +78,13 @@ const (
 	reviewLensContextRefreshAction = "ask the parent orchestrator to refresh the exact native next transition by running " +
 		reviewNextTransitionRefreshCommandV21 + ", then run this operation again with the tokens it returns"
 	reviewLensContextBudgetAction = "immutable candidate evidence is never truncated and retrying this candidate cannot succeed; " +
-		"split the candidate into a chained sequence of smaller reviewable commits, each under the budget, then start a review " +
-		"for the reduced scope by running " + reviewNextTransitionRefreshCommandV21
+		"split the candidate into a chained sequence of smaller reviewable commits, each under the budget, then refresh the exact native next transition by running " +
+		reviewNextTransitionRefreshCommandV21 + " and execute the returned transition for the reduced scope"
 	reviewLensContextEmptyPatchAction = "one content-changing path produced no patch bytes at all, which no legitimate candidate does; " +
 		"refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 +
 		" and run this operation again, and if the same path keeps producing no patch treat it as a native inspection defect and stop retrying"
 	reviewLensContextDeadlineAction = "refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 +
-		", then retry this operation once with the tokens it returns; if the same lens slot reaches the same deadline again, an identical retry cannot change its frozen scope or deadline, so split the candidate into a chained sequence of smaller reviewable commits, then start a review for the reduced scope by running " + reviewNextTransitionRefreshCommandV21
+		", then execute the returned transition once; if the same lens slot reaches the same deadline again, an identical retry cannot change its frozen scope or deadline, so split the candidate into a chained sequence of smaller reviewable commits, then refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 + " and execute the returned transition for the reduced scope"
 	reviewLensContextConflictAction = "this frozen lens slot already recorded a reviewer context produced by a different mechanism, and audit history is never rewritten; " +
 		"produce this lens context by the same mechanism that already recorded one, or start a review for a fresh candidate by running " +
 		reviewNextTransitionRefreshCommandV21
@@ -427,7 +427,7 @@ func reviewLensContextInspectionFailure(ctx context.Context, err error) error {
 	return reviewLensContextRefusal("lens_context_inspection_failed", reviewLensContextRefreshAction)
 }
 
-func reviewLensContextCleanup[T any](ctx context.Context, result T, operationErr error, close func() error) (T, error) {
+func reviewLensContextCleanup[T any](_ context.Context, result T, operationErr error, close func() error) (T, error) {
 	cleanupErr := close()
 	if cleanupErr == nil {
 		return result, operationErr
@@ -436,7 +436,9 @@ func reviewLensContextCleanup[T any](ctx context.Context, result T, operationErr
 	if operationErr != nil {
 		return zero, errors.Join(operationErr, cleanupErr)
 	}
-	return zero, reviewLensContextInspectionFailure(ctx, cleanupErr)
+	// Cleanup is outside the bounded operation, so its error cannot inherit the
+	// operation context's cancellation or deadline classification.
+	return zero, reviewLensContextRefusal("lens_context_inspection_failed", reviewLensContextRefreshAction)
 }
 
 // reviewLensContextDeadline reports the aggregate-deadline refusal when either
@@ -454,5 +456,5 @@ func reviewLensContextDeadline(ctx context.Context, err error) error {
 }
 
 func reviewLensContextCapacityAction(entries int) string {
-	return fmt.Sprintf("immutable candidate evidence has %d paths but provider-owned reviewer context accepts at most %d evidence entries; retrying this candidate cannot succeed; split the candidate into a chained sequence of smaller reviewable commits, then start a review for the reduced scope by running %s", entries, advisoryreview.MaxEvidenceEntries, reviewNextTransitionRefreshCommandV21)
+	return fmt.Sprintf("immutable candidate evidence has %d paths but provider-owned reviewer context accepts at most %d evidence entries; retrying this candidate cannot succeed; split the candidate into a chained sequence of smaller reviewable commits, then refresh the exact native next transition by running %s and execute the returned transition for the reduced scope", entries, advisoryreview.MaxEvidenceEntries, reviewNextTransitionRefreshCommandV21)
 }

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -438,7 +438,10 @@ func reviewLensContextCleanup[T any](_ context.Context, result T, operationErr e
 	}
 	// Cleanup is outside the bounded operation, so its error cannot inherit the
 	// operation context's cancellation or deadline classification.
-	return zero, reviewLensContextRefusal("lens_context_inspection_failed", reviewLensContextRefreshAction)
+	return zero, errors.Join(
+		reviewLensContextRefusal("lens_context_inspection_failed", reviewLensContextRefreshAction),
+		cleanupErr,
+	)
 }
 
 // reviewLensContextDeadline reports the aggregate-deadline refusal when either

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -267,7 +268,8 @@ func TestReviewLensContextRefusesManifestOverAdvisoryCapacityBeforePatchInspecti
 	if err == nil || !strings.Contains(err.Error(), "lens_context_budget_exceeded") {
 		t.Fatalf("entry-capacity error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "33") || !strings.Contains(err.Error(), "32") ||
+	if strings.Contains(err.Error(), "advisory review") || !strings.Contains(err.Error(), "provider-owned reviewer context accepts at most") ||
+		!strings.Contains(err.Error(), "33") || !strings.Contains(err.Error(), "32") || !strings.Contains(err.Error(), "retrying this candidate cannot succeed") ||
 		!strings.Contains(err.Error(), "chained sequence of smaller reviewable commits") || !strings.Contains(err.Error(), reviewNextTransitionRefreshCommandV21) {
 		t.Fatalf("entry-capacity guidance does not name its limit and runnable continuation: %q", err)
 	}
@@ -276,6 +278,61 @@ func TestReviewLensContextRefusesManifestOverAdvisoryCapacityBeforePatchInspecti
 	}
 	if len(block) != 0 {
 		t.Fatalf("entry-capacity refusal emitted %d bytes of reviewer context", len(block))
+	}
+}
+
+func TestReviewLensContextCallersFailClosedOnInspectorCleanupFailure(t *testing.T) {
+	cleanupErr := errors.New("close inspector")
+	for _, caller := range []struct {
+		name string
+		call func(reviewLensContextDeps, string, string) (error, bool)
+	}{
+		{"lens context", func(deps reviewLensContextDeps, handle, lens string) (error, bool) {
+			payload, err := runReviewLensContext([]string{"--repository-context", handle, "--lens", lens}, io.Discard, deps)
+			return err, payload == nil
+		}},
+		{"advisory request", func(deps reviewLensContextDeps, handle, lens string) (error, bool) {
+			request, err := resolveAdvisoryRequest(context.Background(), deps, handle, lens)
+			return err, request.ArtifactSubject == (reviewtransaction.ArtifactSubject{}) && request.ChangedPathManifest == nil && request.Evidence == nil
+		}},
+	} {
+		for _, operation := range []bool{false, true} {
+			t.Run(caller.name, func(t *testing.T) {
+				_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+				handle, lens := args[slices.Index(args, "--repository-context")+1], args[slices.Index(args, "--lens")+1]
+				deps := reviewLensContextDependencies()
+				deps.close = func(inspector reviewLensCandidateInspector) error {
+					if err := inspector.Close(); err != nil {
+						return err
+					}
+					return cleanupErr
+				}
+				if operation {
+					inspect := deps.inspect
+					deps.inspect = func(ctx context.Context, inspector reviewLensCandidateInspector, kind string, index int, side string) ([]byte, error) {
+						if kind == "patch" {
+							return nil, nil
+						}
+						return inspect(ctx, inspector, kind, index, side)
+					}
+				}
+				err, zero := caller.call(deps, handle, lens)
+				if !zero {
+					t.Fatal("cleanup did not zero the result")
+				}
+				if !operation {
+					want := reviewLensContextInspectionFailure(context.Background(), cleanupErr).Error()
+					if err == nil || err.Error() != want {
+						t.Fatalf("cleanup-only error = %v, want %q", err, want)
+					}
+					return
+				}
+				var refusal *reviewLensContextError
+				if !errors.As(err, &refusal) || refusal.Code != "lens_context_empty_patch" || !errors.Is(err, cleanupErr) {
+					t.Fatalf("operation and cleanup error = %v, want empty-patch refusal and cleanup cause", err)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/advisoryreview"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -239,9 +240,9 @@ func TestReviewLensContextCarriesAggregateDeadline(t *testing.T) {
 	if err.Error() != want {
 		t.Fatalf("deadline guidance = %q, want %q", err, want)
 	}
-	if !strings.Contains(err.Error(), "retry this operation once") || !strings.Contains(err.Error(), "if the same lens slot reaches the same deadline again") ||
+	if !strings.Contains(err.Error(), "execute the returned transition once") || !strings.Contains(err.Error(), "if the same lens slot reaches the same deadline again") ||
 		!strings.Contains(err.Error(), "split the candidate into a chained sequence of smaller reviewable commits") || !strings.Contains(err.Error(), reviewNextTransitionRefreshCommandV21) {
-		t.Fatalf("deadline guidance is not a single retry followed by a runnable reduced-scope exit: %q", err)
+		t.Fatalf("deadline guidance is not a single transition execution followed by a runnable reduced-scope exit: %q", err)
 	}
 }
 
@@ -278,6 +279,60 @@ func TestReviewLensContextRefusesManifestOverAdvisoryCapacityBeforePatchInspecti
 	}
 	if len(block) != 0 {
 		t.Fatalf("entry-capacity refusal emitted %d bytes of reviewer context", len(block))
+	}
+}
+
+func TestReviewLensContextRecoveryGuidanceRefreshesThenExecutesNextTransition(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+	}{
+		{name: "evidence capacity", action: reviewLensContextBudgetAction},
+		{name: "entry capacity", action: reviewLensContextCapacityAction(advisoryreview.MaxEvidenceEntries + 1)},
+		{name: "deadline", action: reviewLensContextDeadlineAction},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !strings.Contains(test.action, reviewNextTransitionRefreshCommandV21) ||
+				!strings.Contains(test.action, "refresh the exact native next transition") ||
+				!strings.Contains(test.action, "execute the returned transition") {
+				t.Fatalf("recovery guidance = %q, want STATUS to refresh the exact transition and the caller to execute it", test.action)
+			}
+			if strings.Contains(test.action, "start a review") {
+				t.Fatalf("recovery guidance = %q, must not claim STATUS itself starts a review", test.action)
+			}
+		})
+	}
+}
+
+func TestReviewLensContextCleanupClassifiesCleanupFailureIndependentlyOfOperationContext(t *testing.T) {
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	expired, cancelExpired := context.WithTimeout(context.Background(), 0)
+	defer cancelExpired()
+
+	for _, test := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{name: "canceled", ctx: canceled},
+		{name: "deadline exceeded", ctx: expired},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := reviewLensContextCleanup(test.ctx, "reviewer context", nil, func() error {
+				return errors.New("close inspector")
+			})
+			if result != "" {
+				t.Fatalf("cleanup-only result = %q, want zero result", result)
+			}
+			var refusal *reviewLensContextError
+			if !errors.As(err, &refusal) || refusal.Code != "lens_context_inspection_failed" {
+				t.Fatalf("cleanup-only error = %v, want ordinary inspection-failed refusal", err)
+			}
+			if refusal.Code == "lens_context_deadline_exceeded" || refusal.Code == "lens_context_canceled" {
+				t.Fatalf("cleanup-only error = %v, must not inherit the operation context classification", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -312,15 +312,16 @@ func TestReviewLensContextCleanupClassifiesCleanupFailureIndependentlyOfOperatio
 	defer cancelExpired()
 
 	for _, test := range []struct {
-		name string
-		ctx  context.Context
+		name     string
+		ctx      context.Context
+		closeErr error
 	}{
-		{name: "canceled", ctx: canceled},
-		{name: "deadline exceeded", ctx: expired},
+		{name: "canceled", ctx: canceled, closeErr: errors.New("close canceled inspector")},
+		{name: "deadline exceeded", ctx: expired, closeErr: errors.New("close expired inspector")},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := reviewLensContextCleanup(test.ctx, "reviewer context", nil, func() error {
-				return errors.New("close inspector")
+				return test.closeErr
 			})
 			if result != "" {
 				t.Fatalf("cleanup-only result = %q, want zero result", result)
@@ -329,8 +330,8 @@ func TestReviewLensContextCleanupClassifiesCleanupFailureIndependentlyOfOperatio
 			if !errors.As(err, &refusal) || refusal.Code != "lens_context_inspection_failed" {
 				t.Fatalf("cleanup-only error = %v, want ordinary inspection-failed refusal", err)
 			}
-			if refusal.Code == "lens_context_deadline_exceeded" || refusal.Code == "lens_context_canceled" {
-				t.Fatalf("cleanup-only error = %v, must not inherit the operation context classification", err)
+			if !errors.Is(err, test.closeErr) {
+				t.Fatalf("cleanup-only error = %v, want close error %v", err, test.closeErr)
 			}
 		})
 	}
@@ -376,9 +377,8 @@ func TestReviewLensContextCallersFailClosedOnInspectorCleanupFailure(t *testing.
 					t.Fatal("cleanup did not zero the result")
 				}
 				if !operation {
-					want := reviewLensContextInspectionFailure(context.Background(), cleanupErr).Error()
-					if err == nil || err.Error() != want {
-						t.Fatalf("cleanup-only error = %v, want %q", err, want)
+					if !errors.Is(err, cleanupErr) {
+						t.Fatalf("cleanup-only error = %v, want cleanup cause %v", err, cleanupErr)
 					}
 					return
 				}

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -203,11 +203,11 @@ func TestReviewLensContextRefusesEmptyPatchForContentChangingPath(t *testing.T) 
 	handle := args[slices.Index(args, "--repository-context")+1]
 	lens := args[slices.Index(args, "--lens")+1]
 	deps := reviewLensContextDependencies()
-	deps.inspect = func(builder reviewtransaction.SnapshotBuilder, ctx context.Context, snapshot reviewtransaction.Snapshot, operation string, pathIndex int, side string) ([]byte, error) {
+	deps.inspect = func(ctx context.Context, inspector reviewLensCandidateInspector, operation string, pathIndex int, side string) ([]byte, error) {
 		if operation == "patch" {
 			return nil, nil
 		}
-		return builder.InspectCandidate(ctx, snapshot, operation, pathIndex, side)
+		return inspector.Inspect(ctx, operation, pathIndex, side)
 	}
 	block, err := runReviewLensContext([]string{"--repository-context", handle, "--lens", lens}, io.Discard, deps)
 	if err == nil || !strings.Contains(err.Error(), "lens_context_empty_patch") {
@@ -233,6 +233,49 @@ func TestReviewLensContextCarriesAggregateDeadline(t *testing.T) {
 	}
 	if len(block) != 0 {
 		t.Fatalf("deadline refusal emitted %d bytes of reviewer context", len(block))
+	}
+	want := "lens_context_deadline_exceeded: provider-owned reviewer lens context was not produced; " + reviewLensContextDeadlineAction
+	if err.Error() != want {
+		t.Fatalf("deadline guidance = %q, want %q", err, want)
+	}
+	if !strings.Contains(err.Error(), "retry this operation once") || !strings.Contains(err.Error(), "if the same lens slot reaches the same deadline again") ||
+		!strings.Contains(err.Error(), "split the candidate into a chained sequence of smaller reviewable commits") || !strings.Contains(err.Error(), reviewNextTransitionRefreshCommandV21) {
+		t.Fatalf("deadline guidance is not a single retry followed by a runnable reduced-scope exit: %q", err)
+	}
+}
+
+func TestReviewLensContextRefusesManifestOverAdvisoryCapacityBeforePatchInspection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	repo := initReviewCLIRepo(t)
+	for index := range 33 {
+		writeReviewStartCandidate(t, repo, fmt.Sprintf("path-%02d.txt", index), "candidate\n", 0o644)
+	}
+	started := runNegotiatedReviewStart(t, repo, "lens-context-entry-capacity")
+	deps := reviewLensContextDependencies()
+	inspect := deps.inspect
+	patchReads := 0
+	deps.inspect = func(ctx context.Context, inspector reviewLensCandidateInspector, operation string, pathIndex int, side string) ([]byte, error) {
+		if operation == "patch" {
+			patchReads++
+		}
+		return inspect(ctx, inspector, operation, pathIndex, side)
+	}
+	block, err := runReviewLensContext([]string{
+		"--repository-context", started.RepositoryContext.Handle, "--lens", started.SelectedLenses[0],
+	}, io.Discard, deps)
+	if err == nil || !strings.Contains(err.Error(), "lens_context_budget_exceeded") {
+		t.Fatalf("entry-capacity error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "33") || !strings.Contains(err.Error(), "32") ||
+		!strings.Contains(err.Error(), "chained sequence of smaller reviewable commits") || !strings.Contains(err.Error(), reviewNextTransitionRefreshCommandV21) {
+		t.Fatalf("entry-capacity guidance does not name its limit and runnable continuation: %q", err)
+	}
+	if patchReads != 0 {
+		t.Fatalf("patch inspections before entry-capacity refusal = %d, want 0", patchReads)
+	}
+	if len(block) != 0 {
+		t.Fatalf("entry-capacity refusal emitted %d bytes of reviewer context", len(block))
 	}
 }
 

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -454,7 +454,7 @@ func newFrozenRepositoryPathLookup(ctx context.Context, frozen FrozenCandidateCo
 	}
 	return &frozenRepositoryPathLookup{
 		ctx: ctx, repo: frozen.repositoryRoot, isolation: isolation, trees: trees, cache: make(map[string]bool),
-	}, cleanup, nil
+	}, func() { _ = cleanup() }, nil
 }
 
 func (lookup *frozenRepositoryPathLookup) contains(logicalPath string) (bool, error) {

--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -94,6 +94,13 @@ type FrozenCandidateContext struct {
 	repositoryRoot      string
 }
 
+type PreparedCandidateInspector struct {
+	frozen    FrozenCandidateContext
+	isolation []string
+	cleanup   func() error
+	closed    bool
+}
+
 // WithLegacyCandidateDiff adds the exact published v1 candidate transport.
 // Callers use it only after explicitly negotiating the legacy contract.
 func (builder SnapshotBuilder) WithLegacyCandidateDiff(ctx context.Context, snapshot Snapshot, frozen FrozenCandidateContext) (FrozenCandidateContext, error) {
@@ -127,19 +134,36 @@ func (builder SnapshotBuilder) WithLegacyCandidateDiff(ctx context.Context, snap
 // FrozenCandidateContext returns immutable Git tree references and their typed
 // path manifest. Reviewers read only path-scoped diffs between these trees.
 func (builder SnapshotBuilder) FrozenCandidateContext(ctx context.Context, snapshot Snapshot) (FrozenCandidateContext, error) {
-	repo, err := builder.repositoryRoot(ctx)
+	inspector, err := builder.PrepareCandidateInspector(ctx, snapshot)
 	if err != nil {
 		return FrozenCandidateContext{}, err
 	}
+	frozen := inspector.FrozenCandidateContext()
+	if err := inspector.Close(); err != nil {
+		return FrozenCandidateContext{}, err
+	}
+	return frozen, nil
+}
+
+func (builder SnapshotBuilder) PrepareCandidateInspector(ctx context.Context, snapshot Snapshot) (*PreparedCandidateInspector, error) {
+	repo, err := builder.repositoryRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
 	builder.Repo = repo
 	if err := builder.ValidateEvidence(ctx, snapshot); err != nil {
-		return FrozenCandidateContext{}, fmt.Errorf("validate frozen candidate snapshot: %w", err)
+		return nil, fmt.Errorf("validate frozen candidate snapshot: %w", err)
 	}
 	isolation, cleanup, err := isolatedImmutableTreeGit(ctx, repo)
 	if err != nil {
-		return FrozenCandidateContext{}, fmt.Errorf("prepare isolated frozen candidate Git view: %w", err)
+		return nil, fmt.Errorf("prepare isolated frozen candidate Git view: %w", err)
 	}
-	defer cleanup()
+	fail := func(err error) (*PreparedCandidateInspector, error) {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			return nil, errors.Join(err, fmt.Errorf("clean up prepared frozen candidate Git view: %w", cleanupErr))
+		}
+		return nil, err
+	}
 
 	raw, err := runGitLimited(ctx, repo, isolation, nil, maxFrozenCandidateManifestBytes,
 		"diff",
@@ -155,14 +179,14 @@ func (builder SnapshotBuilder) FrozenCandidateContext(ctx context.Context, snaps
 		"--",
 	)
 	if err != nil {
-		return FrozenCandidateContext{}, fmt.Errorf("render frozen candidate manifest: %w", err)
+		return fail(fmt.Errorf("render frozen candidate manifest: %w", err))
 	}
 	modesByPath, err := parseRawDiffModes(raw)
 	if err != nil {
-		return FrozenCandidateContext{}, err
+		return fail(err)
 	}
 	if len(modesByPath) != len(snapshot.Paths) {
-		return FrozenCandidateContext{}, errors.New("immutable raw tree diff does not exactly match snapshot paths")
+		return fail(errors.New("immutable raw tree diff does not exactly match snapshot paths"))
 	}
 
 	intended := make(map[string]struct{}, len(snapshot.IntendedUntracked))
@@ -173,7 +197,7 @@ func (builder SnapshotBuilder) FrozenCandidateContext(ctx context.Context, snaps
 	for _, path := range snapshot.Paths {
 		modes, ok := modesByPath[path]
 		if !ok {
-			return FrozenCandidateContext{}, fmt.Errorf("immutable snapshot path %q is missing from raw tree diff", path)
+			return fail(fmt.Errorf("immutable snapshot path %q is missing from raw tree diff", path))
 		}
 		_, wasIntendedUntracked := intended[path]
 		entry := ChangedPathManifestEntry{
@@ -183,26 +207,32 @@ func (builder SnapshotBuilder) FrozenCandidateContext(ctx context.Context, snaps
 			IntendedUntracked: wasIntendedUntracked,
 		}
 		if err := validateChangedPathManifestEntry(entry); err != nil {
-			return FrozenCandidateContext{}, err
+			return fail(err)
 		}
 		manifest = append(manifest, entry)
 	}
-	return FrozenCandidateContext{
-		BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree,
-		ChangedPathManifest: manifest, repositoryRoot: repo,
+	return &PreparedCandidateInspector{
+		frozen: FrozenCandidateContext{
+			BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree,
+			ChangedPathManifest: manifest, repositoryRoot: repo,
+		},
+		isolation: isolation, cleanup: cleanup,
 	}, nil
 }
 
-// InspectCandidate renders one bounded, read-only frozen-candidate view; path operations select only by canonical manifest index.
-func (builder SnapshotBuilder) InspectCandidate(ctx context.Context, snapshot Snapshot, operation string, pathIndex int, side string) ([]byte, error) {
-	repo, err := builder.repositoryRoot(ctx)
-	if err != nil {
-		return nil, err
+// FrozenCandidateContext returns a copy that cannot mutate later inspection scope.
+func (inspector *PreparedCandidateInspector) FrozenCandidateContext() FrozenCandidateContext {
+	frozen := inspector.frozen
+	frozen.ChangedPathManifest = append(frozen.ChangedPathManifest[:0:0], frozen.ChangedPathManifest...)
+	return frozen
+}
+
+// Inspect renders one bounded view selected only by canonical manifest index.
+func (inspector *PreparedCandidateInspector) Inspect(ctx context.Context, operation string, pathIndex int, side string) ([]byte, error) {
+	if inspector == nil || inspector.closed {
+		return nil, errors.New("prepared candidate inspector is closed") // refusal:by-design operator-knowledge: provider code must retain and use its invocation-owned inspector before closing it
 	}
-	frozen, err := builder.FrozenCandidateContext(ctx, snapshot)
-	if err != nil {
-		return nil, err
-	}
+	frozen := inspector.frozen
 	pathOperation := operation == "stat" || operation == "patch" || operation == "object"
 	if pathOperation != (pathIndex >= 0) || pathIndex >= len(frozen.ChangedPathManifest) {
 		return nil, errors.New("candidate inspection operation requires its exact canonical path index") // refusal:by-design operator-knowledge: the native CLI validates this closed combination before calling the provider boundary
@@ -215,11 +245,6 @@ func (builder SnapshotBuilder) InspectCandidate(ctx context.Context, snapshot Sn
 		return nil, errors.New("candidate inspection side is valid only for object content") // refusal:by-design operator-knowledge: reaching this means provider code bypassed the validated native CLI contract
 	}
 
-	isolation, cleanup, err := isolatedImmutableTreeGit(ctx, repo)
-	if err != nil {
-		return nil, err
-	}
-	defer cleanup()
 	common := []string{"--no-pager", "-c", "color.ui=false", "-c", "core.attributesFile=" + os.DevNull, "-c", "diff.external="}
 	var args []string
 	switch operation {
@@ -240,38 +265,69 @@ func (builder SnapshotBuilder) InspectCandidate(ctx context.Context, snapshot Sn
 	default:
 		return nil, fmt.Errorf("unknown candidate inspection operation %q", operation) // refusal:by-design operator-knowledge: the native CLI validates the closed operation enum before calling this boundary
 	}
-	return runGitLimited(ctx, repo, isolation, nil, MaxFrozenCandidateDiffBytes, args...)
+	return runGitLimited(ctx, frozen.repositoryRoot, inspector.isolation, nil, MaxFrozenCandidateDiffBytes, args...)
 }
 
-func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(), error) {
+func (inspector *PreparedCandidateInspector) Close() error {
+	if inspector == nil || inspector.closed {
+		return nil
+	}
+	inspector.closed = true
+	if inspector.cleanup == nil {
+		return nil
+	}
+	return inspector.cleanup()
+}
+
+// InspectCandidate preserves the one-shot inspection boundary.
+func (builder SnapshotBuilder) InspectCandidate(ctx context.Context, snapshot Snapshot, operation string, pathIndex int, side string) ([]byte, error) {
+	inspector, err := builder.PrepareCandidateInspector(ctx, snapshot)
+	if err != nil {
+		return nil, err
+	}
+	payload, inspectErr := inspector.Inspect(ctx, operation, pathIndex, side)
+	if cleanupErr := inspector.Close(); cleanupErr != nil {
+		if inspectErr != nil {
+			return nil, errors.Join(inspectErr, cleanupErr)
+		}
+		return nil, cleanupErr
+	}
+	return payload, inspectErr
+}
+
+func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func() error, error) {
 	identity, err := reviewRepositoryIdentity(ctx, repo)
 	if err != nil {
-		return nil, func() {}, err
+		return nil, func() error { return nil }, err
 	}
 	objectFormatOutput, err := runGit(ctx, identity.RepositoryRoot, nil, nil, "rev-parse", "--show-object-format")
 	if err != nil {
-		return nil, func() {}, err
+		return nil, func() error { return nil }, err
 	}
 	objectFormat := strings.TrimSpace(string(objectFormatOutput))
 	if objectFormat != "sha1" && objectFormat != "sha256" {
-		return nil, func() {}, fmt.Errorf("unsupported Git object format %q", objectFormat)
+		return nil, func() error { return nil }, fmt.Errorf("unsupported Git object format %q", objectFormat)
 	}
 	// The repository Git directory is the reliable writable location when a
 	// sandboxed caller does not expose an accessible process temp directory.
 	gitDir, err := os.MkdirTemp(identity.GitDir, ".gentle-ai-frozen-git-*")
 	if err != nil {
-		return nil, func() {}, err
+		return nil, func() error { return nil }, err
 	}
-	cleanup := func() { _ = os.RemoveAll(gitDir) }
+	cleanup := func() error { return os.RemoveAll(gitDir) }
+	fail := func(err error) ([]string, func() error, error) {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("clean up isolated frozen candidate Git view: %w", cleanupErr))
+		}
+		return nil, func() error { return nil }, err
+	}
 	for _, dir := range []string{"objects", "refs"} {
 		if err := os.Mkdir(filepath.Join(gitDir, dir), 0o700); err != nil {
-			cleanup()
-			return nil, func() {}, err
+			return fail(err)
 		}
 	}
 	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/frozen-context\n"), 0o600); err != nil {
-		cleanup()
-		return nil, func() {}, err
+		return fail(err)
 	}
 	repositoryFormatVersion := "0"
 	extensions := ""
@@ -281,8 +337,7 @@ func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(
 	}
 	config := "[core]\n\trepositoryFormatVersion = " + repositoryFormatVersion + "\n\tbare = true\n" + extensions
 	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o600); err != nil {
-		cleanup()
-		return nil, func() {}, err
+		return fail(err)
 	}
 	return []string{
 		"GIT_DIR=" + gitDir,

--- a/internal/reviewtransaction/frozen_candidate_context_test.go
+++ b/internal/reviewtransaction/frozen_candidate_context_test.go
@@ -3,6 +3,7 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -228,7 +229,10 @@ func TestFrozenCandidateReviewerDiffIgnoresMutableAttributeSources(t *testing.T)
 	if err != nil {
 		t.Fatalf("FrozenCandidateContext() error = %v", err)
 	}
-	baseline := frozenCandidateGitDiff(t, repo, frozen, "attribute-target.txt")
+	baseline, err := (SnapshotBuilder{Repo: repo}).InspectCandidate(context.Background(), snapshot, "patch", 0, "")
+	if err != nil {
+		t.Fatalf("InspectCandidate() error = %v", err)
+	}
 	if !bytes.Contains(baseline, []byte("+candidate")) || bytes.Contains(baseline, []byte("GIT binary patch")) {
 		t.Fatalf("baseline reviewer diff is not canonical text:\n%s", baseline)
 	}
@@ -256,7 +260,10 @@ func TestFrozenCandidateReviewerDiffIgnoresMutableAttributeSources(t *testing.T)
 	t.Setenv("GIT_CONFIG_KEY_0", "core.attributesFile")
 	t.Setenv("GIT_CONFIG_VALUE_0", attributes)
 
-	replayed := frozenCandidateGitDiff(t, repo, frozen, "attribute-target.txt")
+	replayed, err := (SnapshotBuilder{Repo: repo}).InspectCandidate(context.Background(), snapshot, "patch", 0, "")
+	if err != nil {
+		t.Fatalf("InspectCandidate() under hostile configuration: %v", err)
+	}
 	if !bytes.Equal(replayed, baseline) {
 		t.Fatalf("reviewer tree diff changed under mutable Git attributes\nfirst=%s\nreplayed=%s", baseline, replayed)
 	}
@@ -380,6 +387,119 @@ func TestFrozenCandidateContextRejectsSnapshotMetadataMismatch(t *testing.T) {
 	}
 }
 
+func TestPreparedCandidateInspectorReusesOneSetupForFourReads(t *testing.T) {
+	requireSnapshotGit(t)
+	repo, snapshot := preparedCandidateSnapshot(t)
+	original := gitCommandContext
+	children := 0
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		children++
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+	inspector, err := (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(t.Context(), snapshot)
+	if err != nil {
+		t.Fatalf("PrepareCandidateInspector() error = %v", err)
+	}
+	if got := inspector.FrozenCandidateContext(); !reflect.DeepEqual(manifestPaths(got.ChangedPathManifest), snapshot.Paths) {
+		t.Fatalf("prepared manifest paths = %v, want %v", manifestPaths(got.ChangedPathManifest), snapshot.Paths)
+	}
+	for _, read := range []struct {
+		operation string
+		pathIndex int
+	}{
+		{"name-status", -1}, {"numstat", -1}, {"patch", 0}, {"patch", 1},
+	} {
+		if _, err := inspector.Inspect(t.Context(), read.operation, read.pathIndex, ""); err != nil {
+			t.Fatalf("Inspect(%q, %d) error = %v", read.operation, read.pathIndex, err)
+		}
+	}
+	if children != 11 {
+		t.Fatalf("Git children for prepare plus four reads = %d, want 11", children)
+	}
+	if err := inspector.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreparedCandidateInspectorMatchesOneShotInspection(t *testing.T) {
+	requireSnapshotGit(t)
+	repo, snapshot := preparedCandidateSnapshot(t)
+	builder := SnapshotBuilder{Repo: repo}
+	inspector, err := builder.PrepareCandidateInspector(t.Context(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inspector.Close()
+	for _, inspection := range []struct {
+		operation string
+		pathIndex int
+		side      string
+	}{
+		{"name-status", -1, ""}, {"numstat", -1, ""}, {"stat", 0, ""},
+		{"patch", 0, ""}, {"object", 0, "base"}, {"object", 0, "candidate"},
+	} {
+		got, err := inspector.Inspect(t.Context(), inspection.operation, inspection.pathIndex, inspection.side)
+		if err != nil {
+			t.Fatalf("prepared Inspect(%q, %d, %q): %v", inspection.operation, inspection.pathIndex, inspection.side, err)
+		}
+		want, err := builder.InspectCandidate(t.Context(), snapshot, inspection.operation, inspection.pathIndex, inspection.side)
+		if err != nil {
+			t.Fatalf("one-shot InspectCandidate(%q, %d, %q): %v", inspection.operation, inspection.pathIndex, inspection.side, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("prepared Inspect(%q, %d, %q) differs from one-shot", inspection.operation, inspection.pathIndex, inspection.side)
+		}
+	}
+}
+
+func TestPreparedCandidateInspectorClosesAfterInspectionError(t *testing.T) {
+	requireSnapshotGit(t)
+	repo, snapshot := preparedCandidateSnapshot(t)
+	inspector, err := (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(t.Context(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inspector.Inspect(t.Context(), "patch", -1, ""); err == nil {
+		t.Fatal("Inspect() error = nil, want missing canonical path index refusal")
+	}
+	if err := inspector.Close(); err != nil {
+		t.Fatalf("Close() after inspection error = %v", err)
+	}
+	calls := 0
+	failing := &PreparedCandidateInspector{cleanup: func() error {
+		calls++
+		return errors.New("cleanup failed")
+	}}
+	if err := failing.Close(); err == nil || !strings.Contains(err.Error(), "cleanup failed") {
+		t.Fatalf("Close() error = %v, want cleanup failure", err)
+	}
+	if err := failing.Close(); err != nil {
+		t.Fatalf("second Close() = %v, want idempotent cleanup", err)
+	}
+	if calls != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", calls)
+	}
+}
+
+func preparedCandidateSnapshot(t *testing.T) (string, Snapshot) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "one.txt", "base\n")
+	writeSnapshotFile(t, repo, "two.txt", "base\n")
+	gitSnapshot(t, repo, "add", "--", "one.txt", "two.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	writeSnapshotFile(t, repo, "one.txt", "candidate one.txt\n")
+	writeSnapshotFile(t, repo, "two.txt", "candidate two.txt\n")
+	gitSnapshot(t, repo, "add", "--", "one.txt", "two.txt")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	candidate := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(t.Context(), Target{Kind: TargetExactRevision, Revision: candidate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, snapshot
+}
+
 func gitSnapshotInput(t *testing.T, repo string, input []byte, args ...string) string {
 	t.Helper()
 	command := exec.Command("git", append([]string{"-C", repo}, args...)...)
@@ -414,7 +534,7 @@ func frozenCandidateGitDiff(t *testing.T, repo string, frozen FrozenCandidateCon
 	if err != nil {
 		t.Fatalf("create isolated reviewer Git environment: %v", err)
 	}
-	t.Cleanup(cleanup)
+	t.Cleanup(func() { _ = cleanup() })
 	args := []string{
 		"--no-pager", "diff-tree", "-p", "--binary", "--full-index", "--no-color", "--no-renames",
 		"--no-ext-diff", "--no-textconv", "--diff-algorithm=myers", "--no-indent-heuristic", "--unified=3",

--- a/internal/reviewtransaction/frozen_candidate_context_test.go
+++ b/internal/reviewtransaction/frozen_candidate_context_test.go
@@ -417,20 +417,7 @@ func TestPreparedCandidateInspectorReusesOneSetupForFourReads(t *testing.T) {
 	if children != 11 {
 		t.Fatalf("Git children for prepare plus four reads = %d, want 11", children)
 	}
-	if err := inspector.Close(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestPreparedCandidateInspectorMatchesOneShotInspection(t *testing.T) {
-	requireSnapshotGit(t)
-	repo, snapshot := preparedCandidateSnapshot(t)
 	builder := SnapshotBuilder{Repo: repo}
-	inspector, err := builder.PrepareCandidateInspector(t.Context(), snapshot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer inspector.Close()
 	for _, inspection := range []struct {
 		operation string
 		pathIndex int
@@ -450,15 +437,6 @@ func TestPreparedCandidateInspectorMatchesOneShotInspection(t *testing.T) {
 		if !bytes.Equal(got, want) {
 			t.Fatalf("prepared Inspect(%q, %d, %q) differs from one-shot", inspection.operation, inspection.pathIndex, inspection.side)
 		}
-	}
-}
-
-func TestPreparedCandidateInspectorClosesAfterInspectionError(t *testing.T) {
-	requireSnapshotGit(t)
-	repo, snapshot := preparedCandidateSnapshot(t)
-	inspector, err := (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(t.Context(), snapshot)
-	if err != nil {
-		t.Fatal(err)
 	}
 	if _, err := inspector.Inspect(t.Context(), "patch", -1, ""); err == nil {
 		t.Fatal("Inspect() error = nil, want missing canonical path index refusal")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2693

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Prepare and validate frozen candidate inspection once per lens-context invocation instead of rebuilding it for every logical read.
- Refuse manifests above the existing 32-evidence advisory limit before reading per-path patches.
- Keep transient deadline retry while making repeated same-slot deadline guidance truthful and actionable, and preserve both operation and isolated-Git cleanup failures.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/frozen_candidate_context.go` | Added invocation-local `PreparedCandidateInspector`, one isolated Git environment, idempotent cleanup, and one-shot compatibility wrapper. |
| `internal/cli/review_lens_context.go` | Reused one inspector, added early capacity refusal, and corrected deadline guidance. |
| `internal/cli/review_advisory.go` | Reused the prepared inspector while assembling same-invocation advisory evidence. |
| `internal/advisoryreview/contract.go` | Exposed the existing authoritative 32-entry capacity without changing it. |
| `internal/reviewtransaction/*_test.go`, `internal/cli/review_lens_context_test.go` | Added spawn-count, byte-equivalence, cleanup, capacity, and refusal regressions. |

---

## 🧪 Test Plan

- [x] Genuine RED reproduced against `3e8d4533`: new tests fail because the prepared inspector and corrected deadline action do not exist.
- [x] Exact spawn proof: P=2/U=0 uses 7 Git children for preparation plus 4 reads, 11 total.
- [x] A 33-entry manifest refuses before any patch inspection and reports actual `33` / limit `32`.
- [x] Prepared and one-shot inspections are byte-equivalent across supported operations.
- [x] Both real cleanup call sites preserve operation and cleanup failures, zero unusable results, and retain cleanup-only classification.
- [x] Unit tests pass: `go test ./... -count=1`.
- [x] Go format passes: `go run ./internal/gofmtcheck`.
- [x] Driven advisory journey passes: `j68-review-advisory-prompt-shared-across-runtimes` — `1 completed, 0 unsupported, 0 failed`.
- [ ] Docker E2E was not run locally; required CI owns this check.

No benchmark journey pinned the old deadline or repeated-materialization behavior. Deterministic unit tests prove the spawn count and pre-patch refusal; j68 proves the affected advisory runtime surface.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 438 authored additions/deletions; maintainer-approved `size:exception` covers 38 lines of real call-site cleanup evidence. |
| Check Issue Reference | ⏳ | Links approved issue #2693. |
| Check Issue Has `status:approved` | ⏳ | Verified before implementation. |
| Check PR Has `type:*` Label | ⏳ | `type:bug` will be applied. |
| Unit Tests | ⏳ | CI confirmation pending. |
| Go Format | ⏳ | CI confirmation pending. |
| E2E Tests | ⏳ | CI confirmation pending. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] Maintainer explicitly approved `size:exception` for the 438-line cohesive fix after direct call-site tests pushed it 38 lines over budget.
- [x] I have added the appropriate `type:*` label to this PR.
- [x] Unit tests pass (`go test ./... -count=1`).
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] Docker E2E will be confirmed by CI.
- [x] Benchmark validation completed.
- [x] Documentation is not required; the public reason codes remain compatible and guidance becomes truthful.
- [x] My commits follow Conventional Commits format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## 💬 Notes for Reviewers

This PR removes repeated immutable work; it does not raise the 120-second lens deadline, change the 25-second one-shot inspection deadline, change the 32-entry product limit, batch diffs, or add caches, states, flags, or verbs.

The capacity guard population is the already-invalid advisory population above 32 evidence entries. The change moves that existing decision before patch reads and tests both legitimate 32-entry admission and 33-entry rejection. Git isolation, exact trees, literal pathspecs, deterministic flags, output limits, manifest ordering, and byte-budget enforcement remain intact.

`size:exception` rationale: independent verification rejected helper-only cleanup tests. Exercising both actual defers for cleanup-only and operation-plus-cleanup behavior requires 38 additional review lines. Splitting those tests from the production lifecycle they verify would weaken reviewability, so the maintainer explicitly approved keeping this one cohesive PR at 438 authored lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Advisory reviews now provide consistent inspection across multiple candidate checks.
  - Reviews exceeding the 32-entry advisory capacity are declined before processing begins.
- **Bug Fixes**
  - Improved cleanup and error handling during review preparation and inspection.
  - Deadline-related refusals now provide guidance to retry or continue with reduced scope.
  - Recovery guidance now refreshes context before executing the next transition.
- **Tests**
  - Expanded coverage for capacity limits, repeated inspections, invalid requests, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->