### PR TITLE
fix(windows): restore full suite reliability

### DIFF
--- a/.github/workflows/windows-full-suite.yml
+++ b/.github/workflows/windows-full-suite.yml
@@ -69,9 +69,12 @@ jobs:
           - name: cli-d-q
             packages: ./internal/cli
             run: ^Test[D-Q]
-          - name: cli-r
+          - name: cli-r-a-m
             packages: ./internal/cli
-            run: ^Test[R-R]
+            run: ^TestR[A-Ma-m]
+          - name: cli-r-n-z
+            packages: ./internal/cli
+            run: ^TestR[N-Zn-z]
           - name: cli-s-z
             packages: ./internal/cli
             run: ^Test[S-Z]

--- a/.github/workflows/windows-full-suite.yml
+++ b/.github/workflows/windows-full-suite.yml
@@ -43,9 +43,9 @@ jobs:
   #
   # Split by measured cost: internal/cli and internal/reviewtransaction are
   # ~44% and ~33% of total test time. internal/cli alone exceeded the 30m
-  # go-test timeout, so it takes four shards and TestR* -- 453 of its 960
-  # tests -- keeps one to itself. `rest` is derived from `go list` rather than
-  # listed, so a new package is covered the day it is added.
+  # go-test timeout, so it takes five shards; TestR* dominates the package and
+  # is split again by its next letter. `rest` is derived from `go list` rather
+  # than listed, so a new package is covered the day it is added.
   #
   # Intra-package t.Parallel() would be the deeper fix, but internal/cli has 89
   # os.Setenv/t.Setenv sites and t.Setenv panics in a parallel test, so that is
@@ -57,11 +57,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Ranges are contiguous and disjoint over A-Z, which is what keeps
-        # sharding honest: internal/assets asserts that, so a shard cannot be
-        # edited into leaving a letter uncovered and silently skipping tests
-        # while the lane still reports green. Every Go test name begins with
-        # "Test" plus an uppercase letter, so A-Z is the whole space.
+        # Top-level ranges are contiguous and disjoint over A-Z. R is further
+        # partitioned by its next letter; internal/assets requires that exact
+        # pair and treats it as the R tile. A shard therefore cannot leave a
+        # letter uncovered and silently skip tests while the lane reports green.
         shard:
           - name: cli-a-c
             packages: ./internal/cli

--- a/internal/assets/formatter_ordering_test.go
+++ b/internal/assets/formatter_ordering_test.go
@@ -242,7 +242,12 @@ func TestWindowsFullSuiteShardsCoverEveryTestName(t *testing.T) {
 	// Ranges are read straight out of the matrix, so this cannot drift from
 	// what actually runs the way a copy of the list would.
 	type shard struct{ pkg, lo, hi string }
+	const (
+		cliRAM = "^TestR[A-Ma-m]"
+		cliRNZ = "^TestR[N-Zn-z]"
+	)
 	var shards []shard
+	var cliRSelectors []string
 	var pkg string
 	for _, line := range strings.Split(section, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -257,14 +262,33 @@ func TestWindowsFullSuiteShardsCoverEveryTestName(t *testing.T) {
 		if value == "" {
 			continue
 		}
-		if len(value) != len(`^Test[A-Z]`) || !strings.HasPrefix(value, "^Test[") || !strings.HasSuffix(value, "]") {
-			t.Fatalf("shard selector %q is not the ^Test[A-Z] form this guard can verify", value)
+		if len(value) == len(`^Test[A-Z]`) && strings.HasPrefix(value, "^Test[") && strings.HasSuffix(value, "]") {
+			shards = append(shards, shard{pkg: pkg, lo: value[6:7], hi: value[8:9]})
+			continue
 		}
-		shards = append(shards, shard{pkg: pkg, lo: value[6:7], hi: value[8:9]})
+		if pkg != "./internal/cli" || (value != cliRAM && value != cliRNZ) {
+			t.Fatalf("shard selector %q is neither a ^Test[A-Z] range nor a required cli TestR partition", value)
+		}
+		cliRSelectors = append(cliRSelectors, value)
 	}
 	if len(shards) == 0 {
 		t.Fatal("no range shards found; the guard would pass vacuously")
 	}
+	if len(cliRSelectors) != 2 {
+		t.Fatalf("cli TestR partitions = %v, want exactly %q and %q", cliRSelectors, cliRAM, cliRNZ)
+	}
+	seenRSelector := map[string]bool{}
+	for _, selector := range cliRSelectors {
+		seenRSelector[selector] = true
+	}
+	for _, selector := range []string{cliRAM, cliRNZ} {
+		if !seenRSelector[selector] {
+			t.Fatalf("cli TestR partition %q is required", selector)
+		}
+	}
+	// The two required selectors split TestR's next letter across uppercase and
+	// lowercase A-Z, so together they are the cli range shard for R.
+	shards = append(shards, shard{pkg: "./internal/cli", lo: "R", hi: "R"})
 
 	byPackage := map[string][]shard{}
 	for _, s := range shards {

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -304,8 +304,16 @@ func (s failAfterPluginRegistrationStep) Run() error {
 	if err != nil {
 		return fmt.Errorf("read plugin registration before rollback control: %w", err)
 	}
-	if !strings.Contains(string(tui), "opencode-subagent-statusline") || !strings.Contains(string(tui), s.logoPath) {
-		return errors.New("plugins were not registered before rollback control")
+	var config struct {
+		Plugin []string `json:"plugin"`
+	}
+	if err := json.Unmarshal(tui, &config); err != nil {
+		return fmt.Errorf("decode plugin registration %q: %w", s.tuiPath, err)
+	}
+	for _, plugin := range []string{"opencode-subagent-statusline", s.logoPath} {
+		if !slices.Contains(config.Plugin, plugin) {
+			return fmt.Errorf("plugin registration %q is missing exact plugin %q", s.tuiPath, plugin)
+		}
 	}
 	if _, err := os.Stat(s.logoPath); err != nil {
 		return fmt.Errorf("Gentle Logo was not written before rollback control: %w", err)


### PR DESCRIPTION
Closes #2701

## Summary

- Decode OpenCode plugin registration JSON before asserting exact plugin membership, avoiding Windows backslash-escaping false negatives.
- Split the oversized `cli-r` Windows shard into two disjoint `TestR` partitions without increasing the 30-minute timeout.
- Strengthen the workflow guard so both R partitions are required while A-Z coverage remains gap-free and non-overlapping.

## Changes

| File | Change |
|---|---|
| `.github/workflows/windows-full-suite.yml` | Replaces the single R shard with A-M/a-m and N-Z/n-z partitions. |
| `internal/assets/formatter_ordering_test.go` | Requires both nested R selectors and preserves the full shard coverage invariant. |
| `internal/cli/run_community_tool_test.go` | Compares decoded plugin entries instead of raw escaped JSON bytes. |

## Test Plan

- [x] `go test ./internal/cli -run "^TestInstallRollbackRestoresSelectedOpenCodePluginPathsAfterPluginRegistration$" -count=1`
- [x] `go test ./internal/assets -run "^TestWindowsFullSuiteShardsCoverEveryTestName$" -count=1`
- [x] `go test ./internal/cli -run "^TestR[A-Ma-m]" -count=1 -timeout=10m`
- [x] `go test ./internal/cli -run "^TestR[N-Zn-z]" -count=1 -timeout=10m`
- [x] `go test ./... -count=1`
- [x] `(cd bench && go test ./... -count=1)`
- [x] `git diff --check`
- [ ] Windows Full Suite CI proves the original platform-specific failure and shard budget are resolved.

## Contributor Checklist

- [x] Linked approved issue #2701.
- [x] Added exactly one `type:*` label.
- [x] No shell scripts changed.
- [x] Documentation is not required for this CI/test-only correction.
- [x] Commits use Conventional Commit format.
- [x] No `Co-Authored-By` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Windows test-shard coverage by splitting CLI tests across two R-range partitions.
  * Strengthened validation to ensure all test ranges are represented correctly.
  * Added more precise checks for OpenCode plugin entries during rollback-control testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->