### PR TITLE
fix(sdd): stop naming a refused operation in the maintainer_decision exit

### DIFF
--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -486,9 +486,26 @@ func compactBlockedExitText(reason CompactBlockReason, token string) string {
 			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` to see the live attempt and its " +
 			"current revision, then reissue this call against that state"
 	case CompactBlockMaintainerDecision:
+		// #2530: this arm used to name "rescope or reset the objective". It is
+		// reached from exactly one call site -- compactTerminalState's
+		// DecisionRequired arm -- and runtimeObjectiveRescopeStructurallyPermitted
+		// refuses every decision-required objective, so half of that pair was an
+		// operation the runtime is guaranteed to reject in the only state that
+		// can print it. Naming a refused operation is the dead end this file's
+		// exit-naming audit exists to prevent.
+		//
+		// compactBlockedExitText is a pure function of (reason, token) and never
+		// receives the RuntimeStatus, so it cannot tell which continuation is
+		// admissible here. Rather than widen the signature for one arm, it defers
+		// to the field that already carries the answer: Status publishes
+		// next_action, and the same status command was already being named for
+		// the accounting. This is the convention runtimeLedgerStatusPointer
+		// applies everywhere else -- name the status, let next_action name the
+		// operation.
 		return "this work unit's attempt or changed-line budget needs a maintainer decision; run " +
-			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` for the accounting, then ask a " +
-			"maintainer to rescope or reset the objective, or run " + compactBlockedReviewModeDisableExit
+			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` for the accounting and for " +
+			"next_action, which names the one audited continuation this objective admits, then ask a " +
+			"maintainer to authorize that continuation, or run " + compactBlockedReviewModeDisableExit
 	case CompactBlockActiveAttempt:
 		// Adversarial finding F2: the bare `sdd-attempt acquire --token <t>`
 		// / `settle --token <t>` forms are not complete commands -- each

--- a/internal/sddstatus/runtime_compact_maintainer_exit_test.go
+++ b/internal/sddstatus/runtime_compact_maintainer_exit_test.go
@@ -1,0 +1,83 @@
+package sddstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestMaintainerDecisionExitNamesNoRefusedOperation is #2530's regression guard.
+//
+// The maintainer_decision exit used to name "rescope or reset the objective".
+// That text is emitted from exactly one call site — the DecisionRequired arm of
+// compactTerminalState — and runtimeObjectiveRescopeStructurallyPermitted
+// refuses every decision-required objective. So the advertised exit named an
+// operation the runtime is guaranteed to reject in the only state that can
+// produce it, which is the dead end #2530 reported.
+//
+// The assertion is deliberately tied to the admissibility predicates rather
+// than to a fixed string: the exit may name an operation only when that
+// operation would actually be accepted for this same status.
+func TestMaintainerDecisionExitNamesNoRefusedOperation(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	seedReadyChange(t, repo, "maintainer-exit", "- [ ] 1.1 Work\n")
+	store := mustRuntimeStore(t, repo, "maintainer-exit")
+
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "begin-maintainer-exit", WorkUnit: "apply-auth",
+		EvidenceGoal: "prove the auth runtime", MaxAttempts: 1, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "finish-maintainer-exit", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('7'), Diagnosis: "bounded runtime reproduced the failure",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "runtime process group exited",
+		ProcessEvidence: "post-run scan found no descendants",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Guard the premise: this really is the state that emits the exit.
+	if !status.DecisionRequired {
+		t.Fatalf("precondition lost: a budget-exhausted failed attempt no longer requires a maintainer decision: %#v", status)
+	}
+	if status.NextAction != RuntimeActionReset {
+		t.Fatalf("precondition lost: next_action = %q, want %q", status.NextAction, RuntimeActionReset)
+	}
+
+	// The two predicates that decide which operation may legally be named.
+	rescopeAdmissible := runtimeObjectiveRescopeStructurallyPermitted(status)
+	resetAdmissible := store.runtimeObjectiveResetAdmissible(context.Background(), status)
+	if rescopeAdmissible {
+		t.Fatalf("precondition lost: rescope became admissible for a decision-required objective, so #2530's contradiction no longer exists")
+	}
+	if !resetAdmissible {
+		t.Fatalf("precondition lost: reset is not admissible either, leaving the state with no continuation at all")
+	}
+
+	exit := compactBlockedExitText(CompactBlockMaintainerDecision, "")
+	if exit == "" {
+		t.Fatal("maintainer_decision shipped a blocked result with no exit at all")
+	}
+
+	// A message may name a command only when running it resolves the block.
+	if strings.Contains(exit, "rescope") {
+		t.Fatalf("maintainer_decision exit names rescope, which runtimeObjectiveRescopeStructurallyPermitted refuses for every decision-required objective:\n%s", exit)
+	}
+
+	// It must still hand the caller somewhere runnable: status publishes the
+	// admissible continuation as next_action, so the exit points there.
+	if !strings.Contains(exit, "gentle-ai sdd-attempt status") {
+		t.Fatalf("maintainer_decision exit stopped naming the status command that carries the real continuation:\n%s", exit)
+	}
+	if !strings.Contains(exit, "next_action") {
+		t.Fatalf("maintainer_decision exit does not point at next_action, so the caller must still guess the operation:\n%s", exit)
+	}
+}


### PR DESCRIPTION
Closes #2530.

> **Note on process:** #2530 is not yet labelled `status:approved`. This PR is opened early so the proposed shape is concrete and reviewable — happy to hold, rework, or close it if the maintainers want the approval gate respected first, or if they prefer the alternative shape described below.

## The defect

`compactBlockedExitText`'s `CompactBlockMaintainerDecision` arm named `rescope or reset the objective`.

That arm is reached from exactly one call site — `compactTerminalState`'s `DecisionRequired` arm (`runtime_compact.go:163`) — and `runtimeObjectiveRescopeStructurallyPermitted` (`runtime_ledger.go:1260`) opens with:

```go
if status.DecisionRequired || status.Complete {
	return false
}
```

So the exit named `rescope` in the one state where `rescope` is structurally guaranteed to be refused. A consumer that followed the advertised exit hit a non-mutating refusal and had no continuation left, which is the dead end #2530 reported.

## Why the text could not have been right

`compactBlockedExitText(reason CompactBlockReason, token string)` never receives the `RuntimeStatus`. It has no way to distinguish which of the two operations is admissible for the objective in hand, so it named both unconditionally.

This is the same class as #2174 — a surface offering an operation the effective state rejects.

## The fix

Defer to the field that already carries the answer. `Status` publishes `next_action`, and the `sdd-attempt status` command was already being named in this same exit for the accounting, so the caller is sent to a place that resolves the block rather than to a guessed operation. This is the convention `runtimeLedgerStatusPointer` already applies elsewhere in the file: *name the status, let `next_action` name the operation.*

No lifecycle behavior changes — this is guidance text plus its regression guard.

## Why not the other option

#2530's "Expected Behavior" offered two exits: let `rescope` accept this state, or stop advertising it. This PR takes the second.

The first would reopen the budget-laundering path the surrounding code explicitly guards. `runtimeObjectiveResetAdmissible`'s comment records that reset is refused one layer deeper for a non-drifted candidate precisely so an elective early reset cannot launder the per-objective budget, and `Rescope`'s own doc comment scopes it to a *terminal, non-complete, zero-drift* objective. Admitting `rescope` into the decision-required state would be that same laundering under a different name.

## Alternative shape considered

Widening `compactBlockedExitText` to take the `RuntimeStatus` and name only the admissible operation — mirroring what `runtimeObjectiveChangeRefusal` (`runtime_ledger.go:1077`) already does — would let this arm print a complete command. It was not taken here because it changes the signature for all 20 call sites to serve one arm, and `next_action` already exists as the published answer. Glad to switch if maintainers prefer the stronger form.

## Test

`TestMaintainerDecisionExitNamesNoRefusedOperation` drives a real store to a decision-required objective and asserts against the admissibility predicates rather than a fixed string:

- `status.DecisionRequired` is true and `next_action` is `reset` (the premise holds)
- `runtimeObjectiveRescopeStructurallyPermitted` is **false** for that same status
- `runtimeObjectiveResetAdmissible` is **true** (the state does have a continuation)
- the exit does not name `rescope`, and still points at `sdd-attempt status` / `next_action`

The precondition assertions mean the test fails loudly if the underlying lifecycle rules ever change, instead of silently guarding a string.

Verified RED before the fix:

```
--- FAIL: TestMaintainerDecisionExitNamesNoRefusedOperation
    maintainer_decision exit names rescope, which
    runtimeObjectiveRescopeStructurallyPermitted refuses for every
    decision-required objective
```

## Verification

- `go build ./...` — clean
- `gofmt -l ./internal/ ./cmd/` — clean
- `go vet ./internal/sddstatus/` — clean
- focused: `TestMaintainerDecisionExitNamesNoRefusedOperation` and `TestSDDStatusStillStopsForAMaintainerDecision` both pass
- `go test ./...` — all packages pass except three in `internal/sddstatus` that also fail on unmodified `origin/main` in my environment (`TestReviewOfferDeclineNeverBlocksArchiveAtTheProjectionLevel`, `TestReviewOfferPresentAndArchiveReadyForAGenuinelyMissingReceipt`, `TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt`). All three concern `ReviewOfferBlock.Available` and appear to depend on machine-global review mode, which is disabled here. Confirmed pre-existing by stashing this branch's changes and re-running them on clean `origin/main`. Not touched by this PR.

## Rollback

Revert the single commit — the change is one exit string plus one new test file, with no persisted state, schema, or lifecycle surface involved.

Changed lines: 102 additions + 2 deletions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the maintainer-decision blocked message to direct callers to the audited status and `next_action` continuation.
  * Removed guidance to use a rejected rescope or reset operation.

* **Tests**
  * Added regression coverage to verify the decision-required state and ensure the compact exit provides the correct continuation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->