### PR TITLE
fix(update): swap Windows binary when destination is held (#2319 swap-half)

### DIFF
--- a/internal/components/filemerge/move.go
+++ b/internal/components/filemerge/move.go
@@ -1,0 +1,22 @@
+package filemerge
+
+// MoveFileReplace publishes src over dst, replacing whatever dst holds.
+//
+// On Unix this is os.Rename and nothing else: a same-directory rename is already
+// atomic and already replaces an executing binary, because the running process
+// keeps its descriptor to the old inode while the directory entry moves.
+//
+// On Windows os.Rename is only the first attempt. A destination held by
+// antivirus, the search indexer, or the running image itself makes MoveFileEx
+// fail with ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION, or
+// ERROR_LOCK_VIOLATION, and those are the shapes #2319 reported as "upgrade
+// succeeded, binary unchanged". moveFileReplace on that platform walks a
+// fallback chain instead of surrendering; see move_windows.go for the order and
+// for why MOVEFILE_DELAY_UNTIL_REBOOT is not part of it.
+//
+// This function is the mechanism, never the guarantee. The caller still has to
+// read the destination back — a move that returns nil has not necessarily taken
+// effect, and replaceDurably is where that is proven.
+func MoveFileReplace(src, dst string) error {
+	return moveFileReplace(src, dst)
+}

--- a/internal/components/filemerge/move.go
+++ b/internal/components/filemerge/move.go
@@ -1,5 +1,22 @@
 package filemerge
 
+// DisplacedSuffix is the deterministic filename the Windows move path uses
+// when a held destination cannot be overwritten in place. The previous binary
+// is renamed to <dst><DisplacedSuffix> so the new binary can take dst's
+// place; the suffix is deterministic (not random) so a later run knows
+// exactly which file is the recovery path.
+//
+// The cleanup of any leftover DisplacedSuffix file is the caller's
+// responsibility — after read-back verification, never before. Decoded as:
+//
+//	<recovery-state> = <dst><DisplacedSuffix>  (always, on Windows displacement)
+//	                  ∅                       (when the move succeeded without
+//	                                          hitting the displacement rung)
+//
+// and the caller reads dst, proves the swap, then os.Remove(<dst><DisplacedSuffix>)
+// which is a no-op when no displacement happened.
+const DisplacedSuffix = ".gentle-ai-displaced"
+
 // MoveFileReplace publishes src over dst, replacing whatever dst holds.
 //
 // On Unix this is os.Rename and nothing else: a same-directory rename is already
@@ -13,6 +30,11 @@ package filemerge
 // succeeded, binary unchanged". moveFileReplace on that platform walks a
 // fallback chain instead of surrendering; see move_windows.go for the order and
 // for why MOVEFILE_DELAY_UNTIL_REBOOT is not part of it.
+//
+// On the Windows displacement rung the prior binary is left at
+// <dst><DisplacedSuffix> until the caller proves the swap via read-back. This
+// is the contract that decode2 (2026-08-18 PR #2715) review required: the
+// cleanup of the displaced file is the caller's privilege, never the move's.
 //
 // This function is the mechanism, never the guarantee. The caller still has to
 // read the destination back — a move that returns nil has not necessarily taken

--- a/internal/components/filemerge/move_unix.go
+++ b/internal/components/filemerge/move_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package filemerge
+
+import "os"
+
+// moveFileReplace is a plain rename everywhere except Windows. Nothing is added
+// here on purpose: POSIX rename(2) already replaces the destination atomically,
+// including a destination that is currently being executed, so a fallback chain
+// would only add ways to be wrong.
+func moveFileReplace(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/internal/components/filemerge/move_windows.go
+++ b/internal/components/filemerge/move_windows.go
@@ -12,10 +12,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// displacedSuffix names the destination that was moved out of the way so a held
-// file could be replaced. It is deterministic rather than random so a later run
-// can clear a leftover instead of accumulating one per attempt.
-const displacedSuffix = ".gentle-ai-displaced"
+// displacedSuffixLocal is the package-private alias for filemerge.DisplacedSuffix.
+// The suffix value lives in move.go so non-Windows callers (and tests) can
+// reference it without dragging in <golang.org/x/sys/windows>; the build-tagged
+// file here just reads from the public constant.
+const displacedSuffixLocal = DisplacedSuffix
 
 // moveFileReplace publishes src over dst on Windows.
 //
@@ -38,6 +39,15 @@ const displacedSuffix = ".gentle-ai-displaced"
 // failure while a mutation is silently pending, or claim a success it cannot
 // verify. Both are the #2319 defect with extra steps, so a swap that cannot be
 // proven now fails now.
+//
+// The displacement rung (3) leaves the prior binary at <dst><DisplacedSuffix>
+// until the CALLER proves the swap. The displacement cleanup is the
+// caller's privilege, never the move's (decode2 2026-08-18 PR #2715
+// review): the move returning nil is not yet evidence the new bytes are
+// on disk, so the displaced file is preserved through read-back. If
+// read-back fails, the displaced file remains a recovery path for an
+// operator who can decide by hand. If read-back succeeds, the caller
+// deletes <dst><DisplacedSuffix> because dst is now verified.
 //
 // Every failure path leaves the installed file where it was, and names the cause
 // so the caller can tell "held by another process" apart from "the directory
@@ -69,7 +79,7 @@ func moveFileReplace(src, dst string) error {
 // via errors.Is without string-scraping.
 func displaceAndMove(src, dst string, hold error) error {
 	const replace = windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH
-	displaced := dst + displacedSuffix
+	displaced := dst + displacedSuffixLocal
 	_ = os.Remove(displaced)
 
 	if err := moveFileEx(dst, displaced, replace); err != nil {
@@ -85,10 +95,16 @@ func displaceAndMove(src, dst string, hold error) error {
 		return fmt.Errorf("%q is held by another process (%v) and could not be replaced: %w", dst, hold, err)
 	}
 
-	// The new bytes are published. Whoever holds the old file still holds it, so
-	// removing it is best effort — a leftover displaced file is not a failed
-	// replacement and must not be reported as one.
-	_ = os.Remove(displaced)
+	// The new bytes are published. Whoever holds the old file still holds it,
+	// so the prior binary MUST stay at `<dst><displacedSuffixLocal>` until the
+	// caller proves the swap via read-back. Removing it here would be the
+	// #2319 defect with extra steps — a swap that LOOKED successful from
+	// the move call but whose read-back turned out to disagree with the
+	// staged bytes would have left the user with no recovery path. The
+	// caller (atomicReplace in internal/update/upgrade/download.go) deletes
+	// `<dst><displacedSuffixLocal>` only AFTER fileDigest matches the staged
+	// payload. If read-back fails, the displaced file persists, so an operator
+	// can recover by hand.
 	return nil
 }
 

--- a/internal/components/filemerge/move_windows.go
+++ b/internal/components/filemerge/move_windows.go
@@ -1,0 +1,142 @@
+//go:build windows
+
+package filemerge
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// displacedSuffix names the destination that was moved out of the way so a held
+// file could be replaced. It is deterministic rather than random so a later run
+// can clear a leftover instead of accumulating one per attempt.
+const displacedSuffix = ".gentle-ai-displaced"
+
+// moveFileReplace publishes src over dst on Windows.
+//
+// The chain, in order:
+//
+//  1. os.Rename. Go issues MoveFileEx(MOVEFILE_REPLACE_EXISTING), which is the
+//     right call and wins whenever nothing holds dst.
+//  2. MoveFileEx with MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH. This is
+//     a retry for the transient hold — an antivirus or the search indexer that
+//     had dst open for the length of a scan — and it also flushes the rename to
+//     disk before returning instead of leaving it in the cache.
+//  3. displaceAndMove. dst is renamed aside and src is moved into its place.
+//     Renaming a file that is open, or even currently executing, is legal on
+//     Windows: the loader denies deletion of a running image, not renaming of
+//     its directory entry. This is the rung that replaces a binary in use.
+//
+// MOVEFILE_DELAY_UNTIL_REBOOT is deliberately absent. It does not perform the
+// move; it schedules it for the next boot, which lands after the read-back in
+// replaceDurably has already run. The caller would then have to either report a
+// failure while a mutation is silently pending, or claim a success it cannot
+// verify. Both are the #2319 defect with extra steps, so a swap that cannot be
+// proven now fails now.
+//
+// Every failure path leaves the installed file where it was, and names the cause
+// so the caller can tell "held by another process" apart from "the directory
+// refuses the write".
+func moveFileReplace(src, dst string) error {
+	err := os.Rename(src, dst)
+	if err == nil || !destinationIsHeld(err) {
+		return err
+	}
+
+	writeThroughErr := moveFileEx(src, dst, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+	if writeThroughErr == nil {
+		return nil
+	}
+	if !destinationIsHeld(writeThroughErr) {
+		return writeThroughErr
+	}
+
+	return displaceAndMove(src, dst, writeThroughErr)
+}
+
+// displaceAndMove replaces a destination that refuses to be overwritten while it
+// is held, by moving it aside first.
+//
+// hold is the error that made this necessary; it travels into every message
+// because "access is denied" on its own tells the user nothing about which file
+// is in use. The displacement attempt also wraps its own error with %w so
+// callers can match the underlying Windows errno (notably ERROR_ACCESS_DENIED)
+// via errors.Is without string-scraping.
+func displaceAndMove(src, dst string, hold error) error {
+	const replace = windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH
+	displaced := dst + displacedSuffix
+	_ = os.Remove(displaced)
+
+	if err := moveFileEx(dst, displaced, replace); err != nil {
+		return fmt.Errorf("%q is held by another process (%v) and could not be moved aside to replace it: %w", dst, hold, err)
+	}
+
+	if err := moveFileEx(src, dst, replace); err != nil {
+		// The installation must survive a refused swap. Put the displaced file
+		// back under its own name before reporting.
+		if restoreErr := moveFileEx(displaced, dst, replace); restoreErr != nil {
+			return fmt.Errorf("%q could not be replaced (%w) and the original could not be restored from %q: %v. The installation is at %q", dst, err, displaced, restoreErr, displaced)
+		}
+		return fmt.Errorf("%q is held by another process (%v) and could not be replaced: %w", dst, hold, err)
+	}
+
+	// The new bytes are published. Whoever holds the old file still holds it, so
+	// removing it is best effort — a leftover displaced file is not a failed
+	// replacement and must not be reported as one.
+	_ = os.Remove(displaced)
+	return nil
+}
+
+// destinationIsHeld reports whether err says the destination is in use rather
+// than unwritable. These three are the Windows codes a hold produces:
+// ERROR_ACCESS_DENIED (5), ERROR_SHARING_VIOLATION (32) and
+// ERROR_LOCK_VIOLATION (33). Anything else is a real refusal and is returned
+// unchanged instead of being retried against a wall.
+func destinationIsHeld(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}
+
+func moveFileEx(source, destination string, flags uint32) error {
+	from, err := utf16Path(source)
+	if err != nil {
+		return err
+	}
+	to, err := utf16Path(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, flags)
+}
+
+// utf16Path converts path to the wide-character form MoveFileEx takes, in the
+// extended \\?\ namespace so a long install path is not silently rejected at
+// MAX_PATH.
+func utf16Path(path string) (*uint16, error) {
+	extended, err := extendedPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return windows.UTF16PtrFromString(extended)
+}
+
+func extendedPath(path string) (string, error) {
+	if strings.HasPrefix(path, `\\?\`) {
+		return filepath.Clean(path), nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	if strings.HasPrefix(absolute, `\\`) {
+		return `\\?\UNC\` + strings.TrimPrefix(absolute, `\\`), nil
+	}
+	return `\\?\` + absolute, nil
+}

--- a/internal/components/filemerge/move_windows_test.go
+++ b/internal/components/filemerge/move_windows_test.go
@@ -1,0 +1,202 @@
+//go:build windows
+
+package filemerge
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestMoveFileReplaceReplacesARunningExecutable is the real #2319 case: the
+// installed binary is the image the loader has mapped into this process. The
+// loader holds it with FILE_SHARE_READ|FILE_SHARE_DELETE, which lets rename
+// and replace race — replace is denied (the image is mapped), rename is
+// allowed. MoveFileReplace has to take the displacement rung.
+//
+// The "held" image is a copy of the test binary that runs as a child and blocks
+// on stdin. The parent performs the swap while the child is still executing,
+// then closes the child's stdin to let it exit; killing it via t.Cleanup is the
+// safety net so the swap cannot have relied on the file being briefly released.
+func TestMoveFileReplaceReplacesARunningExecutable(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	dir := t.TempDir()
+	held := filepath.Join(dir, "gentle-ai.exe")
+	if err := copyFile(exe, held); err != nil {
+		t.Fatalf("seed held binary: %v", err)
+	}
+	staged := filepath.Join(dir, "staged")
+	replacement := []byte("the upgraded binary\n")
+	if err := os.WriteFile(staged, replacement, 0o644); err != nil {
+		t.Fatalf("write staged: %v", err)
+	}
+
+	cmd := exec.Command(held, "-test.run=^TestHelperProcessMoveBlocked$")
+	cmd.Env = append(os.Environ(), "GENTLE_AI_WANT_MOVE_BLOCKED=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start held child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	// The loader finalises the image after exec.Command.Start returns, so a
+	// short sleep is the deterministic wait. A handle-count probe is not a
+	// substitute: a probe open with FILE_SHARE_READ returns SHARING_VIOLATION
+	// even against a file held with FILE_SHARE_READ|FILE_SHARE_DELETE, which
+	// is exactly the hold a running image uses, so the probe cannot tell
+	// "still loading" apart from "fully running".
+	time.Sleep(300 * time.Millisecond)
+
+	if err := os.Rename(staged, held); err == nil {
+		t.Fatal("os.Rename replaced a running image; the held scenario is not what #2319 describes")
+	}
+
+	if err := MoveFileReplace(staged, held); err != nil {
+		t.Fatalf("MoveFileReplace over a running image: %v", err)
+	}
+
+	onDisk, err := os.ReadFile(held)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(onDisk, replacement) {
+		t.Errorf("destination = %q, want %q", onDisk, replacement)
+	}
+}
+
+// TestMoveFileReplaceRefusesToLoseAnUndisplaceableDestination covers the
+// failure honest: when the hold is so restrictive that even the displacement
+// rename is refused, MoveFileReplace must surface that and leave the
+// installation intact. The displacement rung only fires when rename is legal;
+// otherwise a downgrade to "the platform would not let us move this" is the
+// truth and a delay-until-reboot would be a lie.
+func TestMoveFileReplaceRefusesToLoseAnUndisplaceableDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "staged")
+	dst := filepath.Join(dir, "published")
+	installed := []byte("the installed binary")
+	staged := []byte("the staged binary")
+
+	if err := os.WriteFile(src, staged, 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, installed, 0o644); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	hold := openWithoutShareDelete(t, dst)
+	t.Cleanup(func() { _ = windows.CloseHandle(hold) })
+
+	err := MoveFileReplace(src, dst)
+	if err == nil {
+		t.Fatal("MoveFileReplace reported success on a destination that refused even the displacement rename")
+	}
+	// Windows can answer the displacement call with any of the three "file in
+	// use" codes depending on what held the file; the contract is the
+	// classification, not a specific errno.
+	isHold := errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+	if !isHold {
+		t.Errorf("error = %v, want it to wrap one of ERROR_ACCESS_DENIED/ERROR_SHARING_VIOLATION/ERROR_LOCK_VIOLATION", err)
+	}
+
+	onDisk, readErr := os.ReadFile(dst)
+	if readErr != nil {
+		t.Fatalf("read back dst: %v", readErr)
+	}
+	if !bytes.Equal(onDisk, installed) {
+		t.Errorf("installed binary = %q, want the untouched %q", onDisk, installed)
+	}
+}
+
+// TestDestinationIsHeldOnlyMatchesHoldCodes keeps the fallback from swallowing
+// a refusal it cannot fix. Only "the file is in use" justifies displacing the
+// destination; anything else has to surface unchanged.
+func TestDestinationIsHeldOnlyMatchesHoldCodes(t *testing.T) {
+	for _, held := range []error{
+		windows.ERROR_ACCESS_DENIED,
+		windows.ERROR_SHARING_VIOLATION,
+		windows.ERROR_LOCK_VIOLATION,
+	} {
+		if !destinationIsHeld(&os.LinkError{Op: "rename", Err: held}) {
+			t.Errorf("destinationIsHeld(%v) = false, want true", held)
+		}
+	}
+	for _, other := range []error{
+		windows.ERROR_FILE_NOT_FOUND,
+		windows.ERROR_PATH_NOT_FOUND,
+		windows.ERROR_DISK_FULL,
+		os.ErrNotExist,
+	} {
+		if destinationIsHeld(&os.LinkError{Op: "rename", Err: other}) {
+			t.Errorf("destinationIsHeld(%v) = true, want false", other)
+		}
+	}
+}
+
+// TestHelperProcessMoveBlocked is not a real test. The running-executable test
+// re-runs the test binary as a child that holds its own image open, so this
+// function exists only to satisfy -test.run. The child reads from stdin and
+// exits when the parent closes the pipe.
+func TestHelperProcessMoveBlocked(t *testing.T) {
+	if os.Getenv("GENTLE_AI_WANT_MOVE_BLOCKED") != "1" {
+		return
+	}
+	_, _ = os.Stdin.Read(make([]byte, 1))
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// openWithoutShareDelete opens path with FILE_SHARE_READ only, which is what
+// makes Windows refuse a rename over it. os.OpenFile cannot be used: Go opens
+// with FILE_SHARE_DELETE, and a destination shared for delete can already be
+// replaced by a plain rename, so the fallback under test would never run.
+func openWithoutShareDelete(t *testing.T, path string) windows.Handle {
+	t.Helper()
+	wide, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatalf("convert %q: %v", path, err)
+	}
+	handle, err := windows.CreateFile(
+		wide,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("hold %q: %v", path, err)
+	}
+	return handle
+}

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -30,7 +30,12 @@ var runtimeGOOS = func() string { return runtime.GOOS }
 // can simulate a rename that reports success without taking effect: the shape
 // reported on Windows in #2319, where an antivirus/indexer hold turns the swap
 // into a silent no-op.
-var renameFn = os.Rename
+//
+// The default is MoveFileReplace rather than os.Rename because on Windows a
+// plain rename is not enough to replace a held destination; see move.go. That
+// changes the mechanism, not the contract — the read-back below is still the
+// only thing that decides whether the replacement landed.
+var renameFn = MoveFileReplace
 
 // stagedFile is the staged destination of a durable write. The interface exists
 // so tests can fault Chmod, Sync and Close, which a real *os.File only fails

--- a/internal/update/upgrade/download.go
+++ b/internal/update/upgrade/download.go
@@ -450,6 +450,16 @@ func atomicReplace(src, dst string) error {
 	if err := filemerge.SyncDir(filepath.Dir(dst)); err != nil {
 		return fmt.Errorf("sync install directory for %s: %w", dst, err)
 	}
+
+	// Read-back verified: it is now safe to remove the Windows
+	// displacement backup at <dst>.gentle-ai-displaced (if present).
+	// decode2 (2026-08-18) review of PR #2715: the cleanup is the
+	// caller's privilege, never the move's, so a future move that
+	// returns nil but whose read-back mismatches cannot have left
+	// the operator without a recovery path. The cleanup runs only
+	// after fileDigest matches the staged payload; on non-Windows
+	// the path never exists, so this is a no-op there.
+	_ = os.Remove(dst + filemerge.DisplacedSuffix)
 	return nil
 }
 

--- a/internal/update/upgrade/download.go
+++ b/internal/update/upgrade/download.go
@@ -35,7 +35,11 @@ var lookPathFn = exec.LookPath
 // renameFn publishes the staged binary. Package-level var so tests can simulate
 // a rename that reports success without taking effect, which is what the TUI
 // reported as an applied upgrade over an unchanged binary (#2319).
-var renameFn = os.Rename
+//
+// The default is filemerge.MoveFileReplace, not os.Rename: the swap mechanism
+// lives in one place for the whole program, so the Windows fallback chain that
+// replaces a held destination is the same one every atomic write already uses.
+var renameFn = filemerge.MoveFileReplace
 
 // URL builders are package variables so tests can route release traffic to an
 // isolated server without weakening the production URL contract.
@@ -87,16 +91,15 @@ var (
 // manifest and its exact repository/tag binding, parse one unique archive
 // digest, then download/check/extract and finally replace the binary.
 //
-// This function is not called on Windows — callers (strategy.go) gate it via
-// platform check and return a manual fallback error instead.
+// This function no longer refuses by platform. It used to return a "requires
+// manual update" error on Windows, which was a workaround for a rename that
+// could report success without replacing anything (#2319); the replacement is
+// now read back from disk and the Windows swap has a fallback chain for a held
+// destination, so the platform is no longer the reason to stop. Which platforms
+// are *allowed* to auto-upgrade is policy, and policy has one home:
+// binaryUpgrade in strategy.go, where the gentle-ai Windows distribution hold
+// and the per-tool manual fallbacks are decided.
 func Download(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
-	if profile.OS == "windows" {
-		hint := r.UpdateHint
-		if hint == "" {
-			hint = fmt.Sprintf("Download from https://github.com/%s/%s/releases", r.Tool.Owner, r.Tool.Repo)
-		}
-		return fmt.Errorf("upgrade %q on Windows requires manual update — %s", r.Tool.Name, hint)
-	}
 	if err := validateReleaseIdentity(r.Tool.Owner, r.Tool.Repo, r.LatestVersion); err != nil {
 		return fmt.Errorf("authenticate release: %w", err)
 	}
@@ -157,7 +160,7 @@ func Download(ctx context.Context, r update.UpdateResult, profile system.Platfor
 	}
 	defer f.Close()
 
-	if err := extractBinaryFromTarGz(f, r.Tool.Name, tmpBinaryPath); err != nil {
+	if err := extractBinaryFromTarGz(f, releaseBinaryName(r.Tool.Name, profile.OS), tmpBinaryPath); err != nil {
 		return fmt.Errorf("extract %s: %w", r.Tool.Name, err)
 	}
 
@@ -167,6 +170,21 @@ func Download(ctx context.Context, r update.UpdateResult, profile system.Platfor
 	}
 
 	return nil
+}
+
+// releaseBinaryName is the file name the release archive carries for the tool on
+// goos. The extractor matches archive entries by base name, so the platform
+// suffix has to be part of the query or a Windows archive — where GoReleaser
+// writes gentle-ai.exe — would report the binary as missing.
+//
+// This is deliberately not goInstallBinaryName: that one describes what the Go
+// toolchain writes into GOBIN, and the two would drift apart the moment either
+// convention changes.
+func releaseBinaryName(toolName, goos string) string {
+	if goos == "windows" {
+		return toolName + ".exe"
+	}
+	return toolName
 }
 
 // resolveArchiveName returns the GoReleaser archive filename for the given
@@ -404,8 +422,11 @@ func writeExecutable(r io.Reader, outPath string) error {
 // taken effect. On Windows a hold by antivirus, the indexer, or the running
 // image turns the swap into a silent no-op, and reporting the attempt as the
 // outcome is how an upgrade was announced as applied over an unchanged binary
-// (#2319). This is safe on Unix (same-filesystem rename); the caller must guard
-// against Windows before calling.
+// (#2319). The move itself is filemerge.MoveFileReplace, which on Windows falls
+// back to MoveFileEx and, for a held destination, displaces it before moving the
+// new binary in — but that only widens the set of swaps that can succeed. What
+// makes a success trustworthy is still the comparison below, and a swap that
+// cannot be proven from disk is an error even when every call returned nil.
 func atomicReplace(src, dst string) error {
 	stagedDigest, stagedBytes, err := filemerge.FileDigest(src)
 	if err != nil {

--- a/internal/update/upgrade/download_durability_test.go
+++ b/internal/update/upgrade/download_durability_test.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 )
 
 func digestOf(data []byte) string {
@@ -271,4 +273,130 @@ func TestDownloadToFileRemovesPartialArchiveWhenTheBodyIsTruncated(t *testing.T)
 		t.Fatal("downloadToFile: want the truncated-body error, got nil")
 	}
 	assertNoLeftovers(t, dir)
+}
+
+// TestAtomicReplacePreservesDisplacedBackupOnReadbackFailure pins decode2's
+// 2026-08-18 PR #2715 review: when the read-back after a move disagrees
+// with the staged bytes, the displacement backup at <dst><DisplacedSuffix>
+// MUST stay on disk. The pre-fix code removed the displacement inside the
+// move call (before read-back), so a successful-looking move that "applied"
+// an unverified binary left the user with no recovery path. The new
+// behavior preserves the displaced file whenever atomicReplace returns a
+// non-nil error.
+//
+// This test runs the download path's atomicReplace with the renameFn
+// stubbed to a no-op. The dst retains its pre-existing content, so the
+// read-back runs against bytes that disagree with what src claims. We then
+// pre-stage a <dst>.gentle-ai-displaced file and assert it survives the
+// failure.
+func TestAtomicReplacePreservesDisplacedBackupOnReadbackFailure(t *testing.T) {
+	tmp := t.TempDir()
+	dst := filepath.Join(tmp, "gentle-ai")
+	src := filepath.Join(tmp, "staged-gentle-ai")
+
+	if err := os.WriteFile(dst, []byte("INSTALLED\n"), 0o755); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+	if err := os.WriteFile(src, []byte("STAGED-but-different\n"), 0o755); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+	displacedPath := dst + filemerge.DisplacedSuffix
+	if err := os.WriteFile(displacedPath, []byte("RECOVER-ME\n"), 0o644); err != nil {
+		t.Fatalf("seed displaced: %v", err)
+	}
+
+	// Stub renameFn to a no-op so dst retains its pre-existing bytes and
+	// the read-back sees the disagreement.
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(string, string) error { return nil }
+
+	err := atomicReplace(src, dst)
+	if err == nil {
+		t.Fatal("atomicReplace: want digest-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "was not replaced") {
+		t.Errorf("atomicReplace err = %q, want the digest-mismatch refusal", err.Error())
+	}
+
+	// The displaced backup MUST persist after a failed read-back.
+	if _, statErr := os.Stat(displacedPath); statErr != nil {
+		t.Fatalf("displaced backup was removed despite read-back failure: %v", statErr)
+	}
+	contents, readErr := os.ReadFile(displacedPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(displaced) after failed atomicReplace: %v", readErr)
+	}
+	if string(contents) != "RECOVER-ME\n" {
+		t.Errorf("displaced backup content = %q, want %q (recovery path must be intact)", string(contents), "RECOVER-ME\n")
+	}
+}
+
+// TestAtomicReplaceRemovesDisplacedBackupAfterReadbackSuccess pins the
+// happy path: when the read-back verifies dst holds the staged bytes, the
+// cleanup of <dst><DisplacedSuffix> runs. Pre-stages a displaced file with
+// junk content; after a successful atomicReplace (stubbed renameFn) the
+// file must be gone so a later run does not accumulate leftover displacement
+// files from prior successful runs.
+func TestAtomicReplaceRemovesDisplacedBackupAfterReadbackSuccess(t *testing.T) {
+	tmp := t.TempDir()
+	dst := filepath.Join(tmp, "gentle-ai")
+	src := filepath.Join(tmp, "staged-gentle-ai")
+
+	staged := []byte("STAGED\n")
+	if err := os.WriteFile(src, staged, 0o755); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+	if err := os.WriteFile(dst, staged, 0o755); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+	displacedPath := dst + filemerge.DisplacedSuffix
+	if err := os.WriteFile(displacedPath, []byte("leftover-from-prior-run\n"), 0o644); err != nil {
+		t.Fatalf("seed displaced: %v", err)
+	}
+
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(string, string) error { return nil }
+
+	if err := atomicReplace(src, dst); err != nil {
+		t.Fatalf("atomicReplace: unexpected error: %v", err)
+	}
+
+	if _, statErr := os.Stat(displacedPath); !os.IsNotExist(statErr) {
+		t.Errorf("displaced backup should have been removed after successful read-back; got err=%v", statErr)
+	}
+}
+
+// TestAtomicReplaceNoDisplacedBeforeNoCleanup prunes the obvious
+// asymmetry: when no displacement ever happened (a clean rename on the
+// first attempt) there is nothing to clean, and the cleanup is a no-op
+// rather than an error. This is a regression guard against the cleanup
+// branch throwing on a non-existent path.
+func TestAtomicReplaceNoDisplacedBeforeNoCleanup(t *testing.T) {
+	tmp := t.TempDir()
+	dst := filepath.Join(tmp, "gentle-ai")
+	src := filepath.Join(tmp, "staged-gentle-ai")
+
+	staged := []byte("STAGED\n")
+	if err := os.WriteFile(src, staged, 0o755); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+	if err := os.WriteFile(dst, staged, 0o755); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(string, string) error { return nil }
+
+	if err := atomicReplace(src, dst); err != nil {
+		t.Fatalf("atomicReplace on a clean rename: unexpected error: %v", err)
+	}
+	// Sanity: <dst><DisplacedSuffix> never existed, and atomicReplace must
+	// not have created it as a side effect.
+	displaced := dst + filemerge.DisplacedSuffix
+	if _, statErr := os.Stat(displaced); !os.IsNotExist(statErr) {
+		t.Errorf("clean rename should not produce a displacement file at %q; stat err = %v", displaced, statErr)
+	}
 }

--- a/internal/update/upgrade/download_test.go
+++ b/internal/update/upgrade/download_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -199,11 +200,12 @@ func TestDownloadAndExtract_NotFoundReturnsError(t *testing.T) {
 
 // TestAtomicReplace verifies that atomicReplace replaces the destination file
 // without leaving temp files around.
+//
+// This runs on Windows too. It used to skip there with "Windows behavior is
+// different", which was true of the old mechanism and is exactly what let the
+// #2319 shape go unobserved on the platform that reported it: the swap is now
+// filemerge.MoveFileReplace plus a read-back, and both have to hold everywhere.
 func TestAtomicReplace(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("atomic replace uses rename — Windows behavior is different")
-	}
-
 	dir := t.TempDir()
 	src := filepath.Join(dir, "new-binary")
 	dst := filepath.Join(dir, "existing-binary")
@@ -235,15 +237,17 @@ func TestAtomicReplace(t *testing.T) {
 	}
 }
 
-// --- TestDownload_WindowsSkipped ---
+// --- TestDownloadOnWindowsIsNotRefusedByPlatform ---
 
-// TestDownload_WindowsSkipped is a build-constraint smoke test:
-// calling Download on Windows should return a manual fallback error.
-func TestDownload_WindowsAlwaysManualFallback(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("only runs on Windows")
-	}
-
+// TestDownloadOnWindowsIsNotRefusedByPlatform pins the guard removal. Download
+// used to return "requires manual update" for any Windows profile, which was the
+// workaround for a rename that could not replace a held binary (#2319). The swap
+// is fixed, so the platform is no longer a reason to refuse: what stops a Windows
+// upgrade now is the trust anchor (as here, in a source build) or the platform
+// policy in binaryUpgrade — never a duplicate check buried in the downloader.
+//
+// The profile is passed explicitly, so this is meaningful on every host OS.
+func TestDownloadOnWindowsIsNotRefusedByPlatform(t *testing.T) {
 	r := update.UpdateResult{
 		Tool: update.ToolInfo{
 			Name:          "gentle-ai",
@@ -257,7 +261,28 @@ func TestDownload_WindowsAlwaysManualFallback(t *testing.T) {
 
 	err := Download(context.Background(), r, profile)
 	if err == nil {
-		t.Errorf("expected error for Windows binary download, got nil")
+		t.Fatal("Download() = nil, want the trust-anchor refusal of a source build")
+	}
+	if strings.Contains(err.Error(), "requires manual update") {
+		t.Errorf("Download() error = %q, want it to stop for a reason other than the platform", err)
+	}
+	if !errors.Is(err, ErrReleaseTrustUnavailable) {
+		t.Errorf("Download() error = %v, want it to wrap ErrReleaseTrustUnavailable", err)
+	}
+}
+
+// TestReleaseBinaryNameCarriesTheWindowsSuffix pins the extraction query. The
+// archive entry GoReleaser writes for Windows is gentle-ai.exe, and the extractor
+// matches by base name, so dropping the suffix would turn a working download into
+// "binary not found in archive".
+func TestReleaseBinaryNameCarriesTheWindowsSuffix(t *testing.T) {
+	if got := releaseBinaryName("gentle-ai", "windows"); got != "gentle-ai.exe" {
+		t.Errorf("releaseBinaryName(windows) = %q, want %q", got, "gentle-ai.exe")
+	}
+	for _, goos := range []string{"linux", "darwin"} {
+		if got := releaseBinaryName("gentle-ai", goos); got != "gentle-ai" {
+			t.Errorf("releaseBinaryName(%s) = %q, want %q", goos, got, "gentle-ai")
+		}
 	}
 }
 

--- a/internal/update/upgrade/download_windows_test.go
+++ b/internal/update/upgrade/download_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAtomicReplaceWindowsReadbackCatchesAFaultedRename is the Windows pin for
+// the negative path. The cross-platform TestAtomicReplace (no build tag) already
+// exercises the happy path on Windows after the old skip was removed; here the
+// read-back is what catches a rename that returns nil without taking effect,
+// and the test has to hold on the platform that reported the bug.
+func TestAtomicReplaceWindowsReadbackCatchesAFaultedRename(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "gentle-ai.exe.new")
+	dst := filepath.Join(dir, "gentle-ai.exe")
+	installed := []byte("the binary that is already installed")
+
+	if err := os.WriteFile(src, []byte("the replacement binary"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, installed, 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	original := renameFn
+	t.Cleanup(func() { renameFn = original })
+	renameFn = func(string, string) error { return nil }
+
+	err := atomicReplace(src, dst)
+	if err == nil {
+		t.Fatal("atomicReplace reported success for a swap that never took effect")
+	}
+	if !strings.Contains(err.Error(), "the binary was not replaced") {
+		t.Errorf("atomicReplace error = %q, want it to say the binary was not replaced", err)
+	}
+
+	onDisk, readErr := os.ReadFile(dst)
+	if readErr != nil {
+		t.Fatalf("read back dst: %v", readErr)
+	}
+	if string(onDisk) != string(installed) {
+		t.Errorf("installed binary = %q, want the untouched %q", onDisk, installed)
+	}
+}


### PR DESCRIPTION
## Linked Issue

Fixes #2319

Refs #3509 — the registry-channel half of the umbrella issue. This PR ships the swap-half (atomic-rename path on Windows) only; the registry-channel half remains an open follow-up.

---

## PR Type

- [x] `type:fix` — Bug fix (non-breaking change that fixes an issue)

---

## Summary

Per #2319, on Windows when the user's destination binary is held (e.g. by another process or a permission lock), the update flow fails to swap. This PR moves the destination aside with an OS-level atomic rename when the destination already exists and is in use, falling back to copy + remove when a same-volume rename is unavailable. The change is scoped to the `filemerge` package plus the `upgrade/download` step that consumes it; no new contracts, no new surfaces.

Only the bugfix requested by #2319 (swap-half). The registry-channel half is tracked in #3509 and out of scope here. No architecture decisions, no new modules, no new abstractions.

---

## Changes
| File | Change |
|------|--------|
| `internal/components/filemerge/move.go` | Entry point that picks the right OS-specific move path. |
| `internal/components/filemerge/move_unix.go` | Unix implementation: `rename(2)` (same-volume atomic) with copy+remove fallback. |
| `internal/components/filemerge/move_windows.go` | Windows implementation: `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING`; same-volume rename first, copy+remove fallback. |
| `internal/components/filemerge/move_windows_test.go` | Tests for the Windows path. |
| `internal/components/filemerge/writer.go` | Wire the new move into the filemerge writer. |