### PR TITLE
fix(sdd): add atomic attempt worktree handoff

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -522,7 +522,8 @@ func Journeys() []Journey {
 	journeys = append(journeys, waveFiveJourneys()...)
 	journeys = append(journeys, advisoryJourneys()...)
 	journeys = append(journeys, zeroDeltaJourneys()...)
-	return append(journeys, localGateBaseAdvanceJourneys()...)
+	journeys = append(journeys, localGateBaseAdvanceJourneys()...)
+	return append(journeys, handoffJourneys()...)
 }
 
 func coreJourneys() []Journey {

--- a/bench/journeys_handoff.go
+++ b/bench/journeys_handoff.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var sddAttemptHandoffCapability = &Capability{
+	Verb:  []string{"sdd-attempt", "handoff"},
+	Probe: []string{"sdd-attempt", "handoff", "--destination-worktree=probe"},
+}
+
+func sddHandoffRuntimeRepo(sandbox *Sandbox) error {
+	if err := sddRuntimeRepo(sandbox); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "reset", "--", "docs/attempt.md"); err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(sandbox.Repo, "docs", "attempt.md"))
+}
+func sddHandoffDelegatedWorktree(sandbox *Sandbox) error {
+	worktree := filepath.Join(sandbox.Root, "delegated-worktree")
+	if err := sandbox.git(sandbox.Repo, "worktree", "add", "-q", "-b", "bench-handoff-delegated", worktree); err != nil {
+		return err
+	}
+	sandbox.Scratch["delegated-worktree"] = worktree
+	return nil
+}
+
+func sddHandoffAndSettleDelegatedWorktree(r *journeyRun) error {
+	acquired := r.run([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", "bench-handoff-acquire", "--work-unit", "delegated worktree proof",
+		"--evidence-goal", "prove explicit handoff preserves begin provenance", "--max-attempts", "2", "--max-changed-lines", "20",
+	}, false)
+	var acquire sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(acquired.Stdout)), &acquire); err != nil {
+		return fmt.Errorf("parse handoff acquire: %w", err)
+	}
+	if acquired.ExitCode != 0 || acquire.State != "proceed" || acquire.Token == "" {
+		return fmt.Errorf("handoff acquire = %#v exit=%d", acquire, acquired.ExitCode)
+	}
+	worktree := r.sandbox.Scratch["delegated-worktree"]
+	settle := func(requestID string) Observation {
+		return r.runAt(worktree, []string{
+			"sdd-attempt", "settle", "--cwd", worktree, "--change", sddChange, "--token", acquire.Token,
+			"--request-id", requestID, "--outcome", "failed", "--evidence-revision", sddFailedEvidence,
+			"--diagnosis", "the benchmark settles the delegated worktree once", "--harness-disposition", "reused",
+			"--cleanup-evidence", "workspace clean", "--process-evidence", "no stray processes",
+		}, false)
+	}
+	before := settle("bench-handoff-before")
+	var blocked struct {
+		State  string `json:"state"`
+		Reason string `json:"reason"`
+		Exit   string `json:"exit"`
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(before.Stdout)), &blocked); err != nil {
+		return fmt.Errorf("parse pre-handoff settle: %w", err)
+	}
+	if blocked.State != "blocked" || blocked.Reason != "worktree_mismatch" || blocked.Exit == "" || blocked.Detail == "" {
+		return fmt.Errorf("pre-handoff settle = %#v", blocked)
+	}
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	handoff := r.run([]string{
+		"sdd-attempt", "handoff", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--expected-revision", status.Revision, "--request-id", "bench-handoff-a-to-b", "--destination-worktree", worktree,
+	}, false)
+	var handoffResult sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(handoff.Stdout)), &handoffResult); err != nil {
+		return fmt.Errorf("parse handoff result: %w", err)
+	}
+	if handoff.ExitCode != 0 || handoffResult.State != "proceed" {
+		return fmt.Errorf("handoff result = %#v exit=%d", handoffResult, handoff.ExitCode)
+	}
+	if err := r.sandbox.write(filepath.Join(worktree, "docs", "delegated.md"), "delegated handoff\n"); err != nil {
+		return err
+	}
+	if err := r.sandbox.git(worktree, "add", "docs/delegated.md"); err != nil {
+		return err
+	}
+	after := settle("bench-handoff-after")
+	var settled sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(after.Stdout)), &settled); err != nil {
+		return fmt.Errorf("parse post-handoff settle: %w", err)
+	}
+	if after.ExitCode != 0 || settled.State != "proceed" {
+		return fmt.Errorf("post-handoff settle = %#v exit=%d", settled, after.ExitCode)
+	}
+	var final struct {
+		ActiveAttempt any `json:"active_attempt"`
+		Attempts      []struct {
+			Outcome           string `json:"outcome"`
+			ChangedLines      int    `json:"changed_lines"`
+			BeginWorktree     string `json:"begin_worktree"`
+			EffectiveWorktree string `json:"effective_worktree"`
+			Handoff           any    `json:"handoff"`
+		} `json:"attempts"`
+	}
+	if err := proveJSON(r.sandbox, &final, "sdd-attempt", "status", "--cwd", r.sandbox.Repo, "--change", sddChange); err != nil {
+		return err
+	}
+	if final.ActiveAttempt != nil || len(final.Attempts) != 1 || final.Attempts[0].Outcome != "failed" ||
+		final.Attempts[0].ChangedLines != 1 || final.Attempts[0].BeginWorktree != r.sandbox.Repo ||
+		final.Attempts[0].EffectiveWorktree != worktree || final.Attempts[0].Handoff == nil {
+		return fmt.Errorf("post-handoff runtime status = %#v", final)
+	}
+	return nil
+}
+func handoffJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j74-sdd-attempt-explicit-linked-worktree-handoff",
+			Title:  "Delegated linked worktree: settlement refuses until one explicit handoff binds it",
+			Source: "issue #2469: preserve Begin provenance while moving only effective execution worktree",
+			Steps: []Step{
+				{Name: "fixture: runtime repository with no candidate drift", Fixture: sddHandoffRuntimeRepo},
+				{Name: "fixture: registered delegated linked worktree", Fixture: sddHandoffDelegatedWorktree},
+				{Name: "acquire in A, refuse B, hand off A to B, and settle B once", Requires: sddAttemptHandoffCapability, Composite: sddHandoffAndSettleDelegatedWorktree},
+			},
+		},
+	}
+}

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -26,6 +26,7 @@ func journeySources() []journeySource {
 		{"journeys_edge.go", edgeJourneys()},
 		{"journeys_sdd.go", sddJourneys()},
 		{"journeys_sdd_chain.go", sddChainJourneys()},
+		{"journeys_handoff.go", handoffJourneys()},
 		{"journeys_capture_evidence_v5.go", captureEvidenceDescriptorJourneys()},
 		{"journeys_wave1.go", waveOneJourneys()},
 		{"journeys_wave3.go", waveThreeJourneys()},

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,8 +34,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	if got := len(seen); got != 73 {
-		t.Errorf("core journey count = %d, want 73", got)
+	if got := len(seen); got != 74 {
+		t.Errorf("core journey count = %d, want 74", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -38,6 +38,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	flags.SetOutput(io.Discard)
 	cwd := registerSDDAttemptStringFlag(flags, operation, "cwd")
 	change := registerSDDAttemptStringFlag(flags, operation, "change")
+	destinationWorktree := registerSDDAttemptStringFlag(flags, operation, "destination-worktree")
 	expected := registerSDDAttemptStringFlag(flags, operation, "expected-revision")
 	token := registerSDDAttemptStringFlag(flags, operation, "token")
 	requestID := registerSDDAttemptStringFlag(flags, operation, "request-id")
@@ -127,6 +128,12 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
 			ExpectedBindingRevision: *expectedBindingRevision, SuccessorLineageID: *successorLineage,
 			RemediatesEvidenceRevision: *remediatesEvidenceRevision,
+		})
+	case "handoff":
+		result, err = store.HandoffCompact(ctx, sddstatus.CompactHandoffRequest{
+			HandoffAttemptRequest: sddstatus.HandoffAttemptRequest{
+				ExpectedRevision: *expected, RequestID: *requestID, DestinationWorktree: *destinationWorktree,
+			},
 		})
 	case "reset":
 		result, err = store.Reset(ctx, sddstatus.ResetObjectiveRequest{
@@ -237,6 +244,12 @@ var sddAttemptOperationDefinitions = []sddAttemptOperationContract{
 		{name: "expected-binding-revision", usage: "optional; with successor-lineage and remediates-evidence-revision"},
 		{name: "successor-lineage", usage: "optional; lowercase approved lineage, at most 128 bytes"},
 		{name: "remediates-evidence-revision", usage: "optional; repaired sha256:<64 lowercase hex> failed evidence"},
+	}},
+	{name: "handoff", purpose: "Atomically move the active attempt to one linked worktree", flags: []sddAttemptFlagDefinition{
+		sddAttemptCWDFlag, sddAttemptChangeFlag,
+		{name: "expected-revision", required: true, usage: "required; exact sha256:<64 lowercase hex> runtime revision"},
+		{name: "request-id", required: true, usage: "required; lowercase idempotency key, at most 128 bytes"},
+		{name: "destination-worktree", required: true, usage: "required; canonical registered linked worktree of the same Git common directory"},
 	}},
 	{name: "reset", purpose: "Reset a decision-required or complete objective", flags: []sddAttemptFlagDefinition{
 		sddAttemptCWDFlag, sddAttemptChangeFlag,
@@ -496,7 +509,7 @@ func missingSDDAttemptOperationFlags(args []string, operation string) []string {
 func missingSDDAttemptOperationError(operation string, missing []string) error {
 	message := fmt.Sprintf("sdd-attempt %s requires %s", operation, strings.Join(missing, ", "))
 	switch operation {
-	case "acquire", "settle", "grant":
+	case "acquire", "settle", "handoff", "grant":
 		message += fmt.Sprintf("; rerun `gentle-ai sdd-attempt %s` with those missing flags", operation)
 	}
 	return errors.New(message)

--- a/internal/cli/sdd_attempt_compact_test.go
+++ b/internal/cli/sdd_attempt_compact_test.go
@@ -175,6 +175,36 @@ func TestRunSDDAttemptCompactBlocksWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestCompactHandoffRefusalPreservesTypedDetailAndRunnableExit(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const change = "compact-handoff-refusal"
+	started, _ := runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "handoff-owner", 2))
+	foreign := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	if err := RunSDDAttempt([]string{
+		"handoff", "--cwd", repo, "--change", change, "--expected-revision", started.Token,
+		"--request-id", "handoff-foreign", "--destination-worktree", foreign,
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var result compactAttemptOutput
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.State != "blocked" || result.Reason != "invalid_continuation" || result.Detail == "" || result.Exit != result.Detail {
+		t.Fatalf("foreign compact handoff = %#v", result)
+	}
+	wantExit := "gentle-ai sdd-attempt status --cwd \"" + repo + "\" --change \"" + change + "\""
+	if !strings.Contains(result.Exit, wantExit) {
+		t.Fatalf("handoff exit = %q, want runnable %q", result.Exit, wantExit)
+	}
+	var status bytes.Buffer
+	if err := RunSDDAttempt([]string{"status", "--cwd", repo, "--change", change}, &status); err != nil {
+		t.Fatalf("handoff exit did not name a runnable status command: %v", err)
+	}
+}
+
 // TestActiveAttemptBlockedExitNamesAGenuinelyRunnableCommand is the
 // execution-based RED-first proof for adversarial finding F2: the
 // active_attempt Exit text used to print `gentle-ai sdd-attempt acquire

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -108,11 +108,11 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "missing operation", args: nil, want: "requires status, begin, finish, reset, rescope, acquire, settle, or grant"},
+		{name: "missing operation", args: nil, want: "requires status, begin, finish, handoff, reset, rescope, acquire, settle, or grant"},
 		// The no-args refusal already enumerates every valid operation; the
 		// unknown-operation refusal must do the same instead of naming only
 		// the bad value with no route to the valid set.
-		{name: "unknown operation", args: []string{"begn"}, want: `unknown sdd-attempt operation "begn"; want one of status, begin, finish, reset, rescope, acquire, settle, or grant`},
+		{name: "unknown operation", args: []string{"begn"}, want: `unknown sdd-attempt operation "begn"; want one of status, begin, finish, handoff, reset, rescope, acquire, settle, or grant`},
 		{name: "missing change", args: []string{"status", "--cwd", repo}, want: "--change"},
 		{name: "unknown flag", args: []string{"status", "--cwd", repo, "--change", "thin", "--mystery"}, want: "flag provided but not defined"},
 		{name: "irrelevant flag", args: []string{"status", "--cwd", repo, "--change", "thin", "--outcome", "failed"}, want: "flag provided but not defined"},
@@ -145,7 +145,7 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 // all four). Mirrors the reviewIntegrationGatesInOrder /
 // reviewIntegrationGateNames pattern in review_operation_contract.go.
 func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T) {
-	want := []string{"status", "begin", "finish", "reset", "rescope", "acquire", "settle", "grant"}
+	want := []string{"status", "begin", "finish", "handoff", "reset", "rescope", "acquire", "settle", "grant"}
 	if got := sddAttemptOperationNames(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("sddAttemptOperationNames() = %v, want %v", got, want)
 	}
@@ -157,8 +157,8 @@ func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T)
 	if validSDDAttemptOperation("begn") {
 		t.Fatal(`validSDDAttemptOperation("begn") = true, want false`)
 	}
-	if got := joinSDDAttemptOperations(); got != "status, begin, finish, reset, rescope, acquire, settle, or grant" {
-		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, reset, rescope, acquire, settle, or grant")
+	if got := joinSDDAttemptOperations(); got != "status, begin, finish, handoff, reset, rescope, acquire, settle, or grant" {
+		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, handoff, reset, rescope, acquire, settle, or grant")
 	}
 }
 
@@ -248,6 +248,7 @@ func TestRunSDDAttemptHelpContractsCoverEveryOperation(t *testing.T) {
 		{"status", []string{"cwd", "change", "change-instance"}, []string{"optional", "128 bytes"}},
 		{"begin", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines"}, []string{"default 2", "default 200", "1..100", "1..1000000"}},
 		{"finish", []string{"cwd", "change", "expected-revision", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "expected-binding-revision", "successor-lineage", "remediates-evidence-revision"}, []string{"failed, interrupted, or passed", "reused or invalidated", "never none", "500 bytes"}},
+		{"handoff", []string{"cwd", "change", "expected-revision", "request-id", "destination-worktree"}, []string{"registered linked worktree", "Git common directory"}},
 		{"reset", []string{"cwd", "change", "expected-revision", "request-id", "reason", "actor"}, []string{"500 bytes", "128 bytes"}},
 		{"rescope", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor"}, []string{"explicit limit", "cannot exceed current objective"}},
 		{"acquire", []string{"cwd", "change", "token", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "remediates-evidence-revision"}, []string{"default 2", "default 200", "unmanaged remediation"}},

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -96,6 +96,10 @@ type CompactSettleRequest struct {
 	RemediatesEvidenceRevision string
 }
 
+type CompactHandoffRequest struct {
+	HandoffAttemptRequest
+}
+
 // runtimeReadinessInput is everything the one readiness predicate reads. It
 // carries the whole AttemptTokens map rather than a pre-resolved token so the
 // predicate stays the only code that inspects the readiness triple; a caller
@@ -304,6 +308,18 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 	return store.compactSettleResult()
 }
 
+func (store RuntimeStore) HandoffCompact(ctx context.Context, request CompactHandoffRequest) (CompactAttemptResult, error) {
+	_, err := store.Handoff(ctx, request.HandoffAttemptRequest)
+	if err == nil {
+		return CompactAttemptResult{State: CompactStateProceed}, nil
+	}
+	var publication *RuntimePublicationError
+	if errors.As(err, &publication) && publication.Committed {
+		return CompactAttemptResult{State: CompactStateProceed}, nil
+	}
+	return store.compactMutationFailure(err, false, BeginAttemptRequest{}), nil
+}
+
 // unmanagedRemediationSettleable reports whether a settle carrying
 // --remediates-evidence-revision failedEvidence can structurally succeed
 // against this ledger state: the immutable attempt chain must still hold that
@@ -452,6 +468,10 @@ func (store RuntimeStore) compactMutationFailure(err error, settle bool, begin B
 	// authority_failure and lose the exact --cwd the refusal names.
 	case errors.Is(err, ErrRuntimeWorktreeMismatch):
 		reason = CompactBlockWorktreeMismatch
+	case errors.Is(err, ErrRuntimeHandoffSource):
+		reason = CompactBlockWorktreeMismatch
+	case errors.Is(err, ErrRuntimeHandoffDestination), errors.Is(err, ErrRuntimeHandoffAlreadyPerformed):
+		reason = CompactBlockInvalidContinuation
 	}
 	return CompactAttemptResult{State: CompactStateBlocked, Reason: reason, Exit: detail, Detail: detail}
 }

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -40,6 +41,7 @@ const (
 	runtimeOperationReset             = "objective/reset"
 	runtimeOperationRescope           = "objective/rescope"
 	runtimeOperationAdvance           = "objective/advance"
+	runtimeOperationHandoff           = "attempt/handoff"
 	runtimeOperationBind              = "binding/set"
 	runtimeOperationGrant             = "authority/grant"
 	maximumRuntimeGrantRoots          = 32
@@ -117,7 +119,10 @@ var (
 	// under would diff a pinned base tree against an unrelated working tree —
 	// changed_lines: 0 when real work happened, or a wildly inflated delta —
 	// so this refuses before any candidate capture, not after.
-	ErrRuntimeWorktreeMismatch = errors.New("SDD runtime attempt began in a different linked worktree than this finish is running from")
+	ErrRuntimeWorktreeMismatch        = errors.New("SDD runtime attempt began in a different linked worktree than this finish is running from")
+	ErrRuntimeHandoffSource           = errors.New("SDD runtime handoff source does not equal the active attempt's effective worktree")      // refusal:by-design operator-knowledge: the RuntimeStore wrapper names the active attempt's actual status command
+	ErrRuntimeHandoffDestination      = errors.New("SDD runtime handoff destination is not a registered linked worktree of this repository") // refusal:by-design operator-knowledge: the RuntimeStore wrapper names the active attempt's actual status command
+	ErrRuntimeHandoffAlreadyPerformed = errors.New("SDD runtime attempt has already been handed off")                                        // refusal:by-design operator-knowledge: the RuntimeStore wrapper names the active attempt's actual status command
 
 	runtimeRequestIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,127}$`)
 	runtimeRevisionPattern  = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
@@ -211,6 +216,8 @@ type RuntimeAttempt struct {
 	// this field existed — that emptiness IS the legacy signal, so replay and
 	// Finish must treat it as "no binding recorded" and enforce nothing.
 	BeginWorktree              string             `json:"begin_worktree,omitempty"`
+	EffectiveWorktree          string             `json:"effective_worktree,omitempty"`
+	Handoff                    *RuntimeHandoff    `json:"handoff,omitempty"`
 	FinishCandidateIdentity    string             `json:"finish_candidate_identity,omitempty"`
 	FinishCandidateTree        string             `json:"finish_candidate_tree,omitempty"`
 	Outcome                    AttemptOutcome     `json:"outcome"`
@@ -222,6 +229,17 @@ type RuntimeAttempt struct {
 	ProcessEvidence            string             `json:"process_evidence,omitempty"`
 	RemediatesEvidenceRevision string             `json:"remediates_evidence_revision,omitempty"`
 	ChangedLineBudgetExceeded  bool               `json:"changed_line_budget_exceeded,omitempty"`
+}
+
+type RuntimeHandoff struct {
+	Ordinal                      int    `json:"ordinal"`
+	SourceWorktree               string `json:"source_worktree"`
+	DestinationWorktree          string `json:"destination_worktree"`
+	CommonDir                    string `json:"common_dir"`
+	ExpectedRevision             string `json:"expected_revision"`
+	RequestDigest                string `json:"request_digest"`
+	DestinationCandidateIdentity string `json:"destination_candidate_identity"`
+	DestinationCandidateTree     string `json:"destination_candidate_tree"`
 }
 
 type RuntimeReset struct {
@@ -329,6 +347,12 @@ type FinishAttemptRequest struct {
 	ExpectedBindingRevision    string             `json:"expected_binding_revision,omitempty"`
 	SuccessorLineageID         string             `json:"successor_lineage_id,omitempty"`
 	RemediatesEvidenceRevision string             `json:"remediates_evidence_revision,omitempty"`
+}
+
+type HandoffAttemptRequest struct {
+	ExpectedRevision    string `json:"expected_revision"`
+	RequestID           string `json:"request_id"`
+	DestinationWorktree string `json:"destination_worktree"`
 }
 
 type ResetObjectiveRequest struct {
@@ -451,6 +475,7 @@ type runtimeRecord struct {
 	Reset            *runtimeResetEvent   `json:"reset,omitempty"`
 	Rescope          *runtimeRescopeEvent `json:"rescope,omitempty"`
 	Advance          *runtimeAdvanceEvent `json:"advance,omitempty"`
+	Handoff          *RuntimeHandoff      `json:"handoff,omitempty"`
 	Binding          *runtimeBindingEvent `json:"binding,omitempty"`
 	Receipt          *runtimeReceiptEvent `json:"receipt,omitempty"`
 	Grant            *runtimeGrantEvent   `json:"grant,omitempty"`
@@ -509,7 +534,8 @@ type runtimeBeginEvent struct {
 	// ran under. omitempty is load-bearing — every record predating this field
 	// deserializes it as "", which Finish and replay both treat as "no binding
 	// recorded" rather than as a mismatch, so legacy chains replay unchanged.
-	BeginWorktree string `json:"begin_worktree,omitempty"`
+	BeginWorktree     string `json:"begin_worktree,omitempty"`
+	EffectiveWorktree string `json:"effective_worktree,omitempty"`
 }
 
 type runtimeResetEvent struct {
@@ -761,7 +787,7 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 			ObjectiveID: objectiveID, ObjectiveGeneration: generation, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal,
 			MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines,
 			Ordinal: status.NextOrdinal, BeginCandidateIdentity: snapshot.Identity, BeginCandidateTree: snapshot.CandidateTree,
-			BeginWorktree: store.Workspace,
+			BeginWorktree: store.Workspace, EffectiveWorktree: store.Workspace,
 		}
 		if advancing {
 			return runtimeRecord{Operation: runtimeOperationAdvance, Begin: event, Advance: &runtimeAdvanceEvent{
@@ -785,11 +811,11 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		if active == nil {
 			return runtimeRecord{}, ErrRuntimeNoActiveAttempt
 		}
-		// Enforce the worktree binding before any candidate capture/diff work
-		// runs (#2296 part 1). An empty recorded value means this attempt's
-		// begin record predates the field: no enforcement, byte-identical
-		// behavior to every chain recorded before this slice.
-		if active.BeginWorktree != "" && active.BeginWorktree != store.Workspace {
+		// Check the effective binding before candidate capture or line charging.
+		if active.EffectiveWorktree != "" && active.EffectiveWorktree != store.Workspace {
+			return runtimeRecord{}, store.runtimeEffectiveWorktreeMismatchRefusal(*active)
+		}
+		if active.EffectiveWorktree == "" && active.BeginWorktree != "" && active.BeginWorktree != store.Workspace {
 			return runtimeRecord{}, store.runtimeWorktreeMismatchRefusal(active.Ordinal, active.BeginWorktree)
 		}
 		remediation := finishRequestsRemediation(request)
@@ -937,6 +963,39 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 	})
 }
 
+func (store RuntimeStore) Handoff(ctx context.Context, request HandoffAttemptRequest) (RuntimeStatus, error) {
+	request, err := normalizeHandoffAttemptRequest(request)
+	if err != nil {
+		return RuntimeStatus{}, err
+	}
+	digest := runtimeValueHash("gentle-ai.sdd-runtime-handoff-request/v1", request)
+	return store.mutate(ctx, request.ExpectedRevision, request.RequestID, digest, func(replay runtimeReplay) (runtimeRecord, error) {
+		active := replay.Status.ActiveAttempt
+		if active == nil {
+			return runtimeRecord{}, ErrRuntimeNoActiveAttempt
+		}
+		if active.EffectiveWorktree == "" || active.EffectiveWorktree != store.Workspace {
+			return runtimeRecord{}, store.runtimeHandoffSourceRefusal(*active)
+		}
+		if active.Handoff != nil {
+			return runtimeRecord{}, store.runtimeHandoffAlreadyPerformedRefusal(*active)
+		}
+		commonDir, err := store.validateRuntimeHandoffDestination(ctx, request.DestinationWorktree)
+		if err != nil {
+			return runtimeRecord{}, err
+		}
+		snapshot, err := captureRuntimeHandoffCandidate(ctx, request.DestinationWorktree, active.BeginCandidateTree)
+		if err != nil {
+			return runtimeRecord{}, fmt.Errorf("capture delegated SDD runtime candidate before handoff: %w", err)
+		}
+		return runtimeRecord{Operation: runtimeOperationHandoff, Handoff: &RuntimeHandoff{
+			Ordinal: active.Ordinal, SourceWorktree: store.Workspace, DestinationWorktree: request.DestinationWorktree,
+			CommonDir: commonDir, ExpectedRevision: request.ExpectedRevision, RequestDigest: digest,
+			DestinationCandidateIdentity: snapshot.Identity, DestinationCandidateTree: snapshot.CandidateTree,
+		}}, nil
+	})
+}
+
 // runtimeRemediationExitRefusal turns the bound-passing-finish demand into a
 // refusal that names the continuation that actually clears it.
 //
@@ -1043,6 +1102,15 @@ func (store RuntimeStore) runtimeWorktreeMismatchRefusal(ordinal int, beginWorkt
 	return fmt.Errorf(
 		"%w: attempt %d began in %s, and its base candidate tree is pinned to that exact linked worktree, but this finish is running from %s — rerun with --cwd %s so the candidate capture and changed-line measurement use the worktree that actually did the work",
 		ErrRuntimeWorktreeMismatch, ordinal, pathquote.Quote(beginWorktree), pathquote.Quote(store.Workspace), pathquote.Quote(beginWorktree))
+}
+
+func (store RuntimeStore) runtimeEffectiveWorktreeMismatchRefusal(active RuntimeAttempt) error {
+	if active.EffectiveWorktree == active.BeginWorktree {
+		return store.runtimeWorktreeMismatchRefusal(active.Ordinal, active.BeginWorktree)
+	}
+	return fmt.Errorf(
+		"%w: attempt %d began in %s and was explicitly handed off to %s, but this finish is running from %s — rerun with --cwd %s so the candidate capture and changed-line measurement use the delegated worktree",
+		ErrRuntimeWorktreeMismatch, active.Ordinal, pathquote.Quote(active.BeginWorktree), pathquote.Quote(active.EffectiveWorktree), pathquote.Quote(store.Workspace), pathquote.Quote(active.EffectiveWorktree))
 }
 
 // runtimeObjectiveChangeRefusal turns the changed-objective begin demand into
@@ -1647,6 +1715,10 @@ func applyRuntimeRecord(replay *runtimeReplay, revision string, record runtimeRe
 		if err := applyRuntimeFinishEvent(replay, record.Finish, record.Finish.RemediatesEvidenceRevision != ""); err != nil {
 			return err
 		}
+	case runtimeOperationHandoff:
+		if err := applyRuntimeHandoffEvent(replay, record.Handoff); err != nil {
+			return err
+		}
 
 	case runtimeOperationFinishRemediation:
 		currentBinding := replay.Status.Binding
@@ -1781,7 +1853,8 @@ func applyRuntimeBeginEvent(replay *runtimeReplay, revision string, record runti
 	attempt := RuntimeAttempt{
 		Ordinal: event.Ordinal, ObjectiveID: event.ObjectiveID, ObjectiveGeneration: generation,
 		WorkUnit: event.WorkUnit, BeginCandidateIdentity: event.BeginCandidateIdentity,
-		BeginCandidateTree: event.BeginCandidateTree, BeginWorktree: event.BeginWorktree, Outcome: AttemptRunning,
+		BeginCandidateTree: event.BeginCandidateTree, BeginWorktree: event.BeginWorktree,
+		EffectiveWorktree: event.EffectiveWorktree, Outcome: AttemptRunning,
 	}
 	replay.Status.Attempts = append(replay.Status.Attempts, attempt)
 	replay.AttemptTokens[event.Ordinal] = revision
@@ -1791,6 +1864,22 @@ func applyRuntimeBeginEvent(replay *runtimeReplay, revision string, record runti
 	replay.Status.LifetimeAttempts++
 	replay.Status.NextOrdinal = event.Ordinal + 1
 	replay.Status.NextAction = RuntimeActionFinish
+	return nil
+}
+
+func applyRuntimeHandoffEvent(replay *runtimeReplay, event *RuntimeHandoff) error {
+	active := replay.Status.ActiveAttempt
+	if active == nil || active.Ordinal != event.Ordinal || active.EffectiveWorktree == "" ||
+		active.EffectiveWorktree != event.SourceWorktree || active.Handoff != nil ||
+		len(replay.Status.Attempts) == 0 || replay.Status.Attempts[len(replay.Status.Attempts)-1].Outcome != AttemptRunning {
+		return errors.New("handoff record does not match the active attempt") // refusal:by-design world-action: a contradictory immutable record requires restoring the authority store
+	}
+	attempt := &replay.Status.Attempts[len(replay.Status.Attempts)-1]
+	handoff := *event
+	attempt.EffectiveWorktree = event.DestinationWorktree
+	attempt.Handoff = &handoff
+	activeCopy := *attempt
+	replay.Status.ActiveAttempt = &activeCopy
 	return nil
 }
 
@@ -2022,7 +2111,8 @@ func validateRuntimeBeginEvent(record runtimeRecord) error {
 		// PRESENT value is still an identity string, not free user input: it
 		// must be a bounded, trimmed, single-line value like every other
 		// recorded text field, not raw garbage.
-		(event.BeginWorktree != "" && validateRuntimeText(event.BeginWorktree, 4096) != nil) {
+		(event.BeginWorktree != "" && validateRuntimeText(event.BeginWorktree, 4096) != nil) ||
+		(event.EffectiveWorktree != "" && (validateRuntimeText(event.EffectiveWorktree, 4096) != nil || event.EffectiveWorktree != event.BeginWorktree)) {
 		return errors.New("invalid SDD runtime begin event")
 	}
 	request := BeginAttemptRequest{
@@ -2043,14 +2133,14 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 	}
 	switch record.Operation {
 	case runtimeOperationBegin:
-		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime begin record shape")
 		}
 		if err := validateRuntimeBeginEvent(record); err != nil {
 			return err
 		}
 	case runtimeOperationAdvance:
-		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Handoff != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime objective advance record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		advance := record.Advance
@@ -2064,7 +2154,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return err
 		}
 	case runtimeOperationFinish:
-		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime finish record shape")
 		}
 		event := record.Finish
@@ -2085,8 +2175,25 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		if runtimeValueHash("gentle-ai.sdd-runtime-finish-request/v1", request) != record.RequestDigest {
 			return errors.New("SDD runtime finish request digest does not match record")
 		}
+	case runtimeOperationHandoff:
+		if record.Handoff == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
+			return errors.New("invalid SDD runtime handoff record shape") // refusal:by-design world-action: a malformed immutable record requires restoring the authority store
+		}
+		event := record.Handoff
+		if event.Ordinal < 1 || event.SourceWorktree == event.DestinationWorktree ||
+			validateRuntimeText(event.SourceWorktree, 4096) != nil || !filepath.IsAbs(event.SourceWorktree) ||
+			validateRuntimeText(event.DestinationWorktree, 4096) != nil || !filepath.IsAbs(event.DestinationWorktree) ||
+			validateRuntimeText(event.CommonDir, 4096) != nil || !filepath.IsAbs(event.CommonDir) ||
+			event.ExpectedRevision != record.PreviousRevision || event.RequestDigest != record.RequestDigest ||
+			!runtimeRevisionPattern.MatchString(event.DestinationCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.DestinationCandidateTree) {
+			return errors.New("invalid SDD runtime handoff event") // refusal:by-design world-action: a malformed immutable event requires restoring the authority store
+		}
+		request := HandoffAttemptRequest{ExpectedRevision: event.ExpectedRevision, RequestID: record.RequestID, DestinationWorktree: event.DestinationWorktree}
+		if runtimeValueHash("gentle-ai.sdd-runtime-handoff-request/v1", request) != record.RequestDigest {
+			return errors.New("SDD runtime handoff request digest does not match record") // refusal:by-design world-action: a forged immutable record requires restoring the authority store
+		}
 	case runtimeOperationFinishRemediation:
-		if record.Finish == nil || record.Binding == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Finish == nil || record.Binding == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid atomic SDD runtime remediation record shape")
 		}
 		finish, binding := record.Finish, record.Binding
@@ -2125,7 +2232,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("atomic SDD runtime remediation request digest does not match record")
 		}
 	case runtimeOperationReset:
-		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime reset record shape")
 		}
 		event := record.Reset
@@ -2141,7 +2248,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime reset request digest does not match record")
 		}
 	case runtimeOperationRescope:
-		if record.Rescope == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Rescope == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Handoff != nil || record.Binding != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime rescope record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		event := record.Rescope
@@ -2172,7 +2279,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime rescope request digest does not match record") // refusal:by-design world-action: the digest is computed from the same request at write time, so a mismatch is a mutated record and the exit is restoring the store
 		}
 	case runtimeOperationBind:
-		if record.Binding == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Receipt != nil || record.Grant != nil {
+		if record.Binding == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Receipt != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime binding record shape")
 		}
 		event := record.Binding
@@ -2199,7 +2306,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime binding request digest does not match record")
 		}
 	case runtimeOperationReceipt:
-		if record.Receipt == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Grant != nil {
+		if record.Receipt == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Binding != nil || record.Grant != nil {
 			return errors.New("invalid SDD runtime receipt record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		event := record.Receipt
@@ -2227,7 +2334,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return errors.New("SDD runtime receipt request digest does not match record") // refusal:by-design world-action: the digest is computed from the same request at write time, so a mismatch is a mutated record and the exit is restoring the store
 		}
 	case runtimeOperationGrant:
-		if record.Grant == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Binding != nil || record.Receipt != nil {
+		if record.Grant == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Binding != nil || record.Receipt != nil {
 			return errors.New("invalid SDD runtime grant record shape") // refusal:by-design world-action: this shape is constructed by the authority itself, so a violation is a mutated record and the exit is restoring the store
 		}
 		event := record.Grant
@@ -2385,6 +2492,24 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 			)
 		}
 	}
+	return request, nil
+}
+
+func normalizeHandoffAttemptRequest(request HandoffAttemptRequest) (HandoffAttemptRequest, error) {
+	if !runtimeRevisionPattern.MatchString(request.ExpectedRevision) {
+		return HandoffAttemptRequest{}, errors.New("handoff requires an exact expected runtime revision") // refusal:by-design operator-knowledge: the caller must supply the current runtime revision
+	}
+	if !runtimeRequestIDPattern.MatchString(request.RequestID) {
+		return HandoffAttemptRequest{}, errors.New("request_id must be a canonical lowercase identifier")
+	}
+	if err := validateRuntimeText(request.DestinationWorktree, 4096); err != nil {
+		return HandoffAttemptRequest{}, fmt.Errorf("invalid handoff destination worktree: %w", err)
+	}
+	destination, err := canonicalRuntimeHandoffPath(request.DestinationWorktree)
+	if err != nil {
+		return HandoffAttemptRequest{}, fmt.Errorf("resolve handoff destination worktree: %w", err)
+	}
+	request.DestinationWorktree = destination
 	return request, nil
 }
 
@@ -2585,6 +2710,84 @@ func captureRuntimeTerminalCandidate(ctx context.Context, store RuntimeStore, be
 		Kind: reviewtransaction.TargetBaseWorkspaceOverlay, BaseRef: beginCandidateTree,
 		Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{},
 	})
+}
+
+func captureRuntimeHandoffCandidate(ctx context.Context, worktree, beginCandidateTree string) (reviewtransaction.Snapshot, error) {
+	builder := reviewtransaction.SnapshotBuilder{Repo: worktree}
+	return builder.Build(ctx, reviewtransaction.Target{
+		Kind: reviewtransaction.TargetBaseWorkspaceOverlay, BaseRef: beginCandidateTree,
+		Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{},
+	})
+}
+
+func canonicalRuntimeHandoffPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", err
+	}
+	if err := validateRuntimeText(resolved, 4096); err != nil || !filepath.IsAbs(resolved) {
+		return "", errors.New("canonical worktree path is not an absolute bounded single-line directory") // refusal:by-design operator-knowledge: only the caller can choose an existing canonical destination
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func (store RuntimeStore) runtimeHandoffStatusExit() string {
+	return fmt.Sprintf("run `gentle-ai sdd-attempt status --cwd %s --change %q` to read the active attempt and its current execution worktree", pathquote.Quote(store.Workspace), store.Change)
+}
+
+func (store RuntimeStore) runtimeHandoffSourceRefusal(active RuntimeAttempt) error {
+	return fmt.Errorf("%w: attempt %d has effective worktree %s, but handoff ran from %s; %s",
+		ErrRuntimeHandoffSource, active.Ordinal, pathquote.Quote(active.EffectiveWorktree), pathquote.Quote(store.Workspace), store.runtimeHandoffStatusExit())
+}
+
+func (store RuntimeStore) runtimeHandoffAlreadyPerformedRefusal(active RuntimeAttempt) error {
+	return fmt.Errorf("%w: attempt %d already moved from %s to %s; %s",
+		ErrRuntimeHandoffAlreadyPerformed, active.Ordinal, pathquote.Quote(active.Handoff.SourceWorktree), pathquote.Quote(active.Handoff.DestinationWorktree), store.runtimeHandoffStatusExit())
+}
+
+func (store RuntimeStore) validateRuntimeHandoffDestination(ctx context.Context, destination string) (string, error) {
+	command := exec.CommandContext(ctx, "git", "-C", store.Repo, "worktree", "list", "--porcelain")
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("%w: cannot read the Git worktree registry: %v; %s", ErrRuntimeHandoffDestination, err, store.runtimeHandoffStatusExit())
+	}
+	registered := false
+	for _, line := range strings.Split(string(output), "\n") {
+		path, ok := strings.CutPrefix(line, "worktree ")
+		if !ok || path == "" {
+			continue
+		}
+		canonical, resolveErr := canonicalRuntimeHandoffPath(path)
+		if resolveErr == nil && canonical == destination {
+			registered = true
+			break
+		}
+	}
+	if !registered || destination == store.Workspace {
+		return "", fmt.Errorf("%w: %s is not a distinct registered linked worktree; %s", ErrRuntimeHandoffDestination, pathquote.Quote(destination), store.runtimeHandoffStatusExit())
+	}
+	command = exec.CommandContext(ctx, "git", "-C", destination, "rev-parse", "--git-common-dir")
+	output, err = command.Output()
+	if err != nil {
+		return "", fmt.Errorf("%w: cannot resolve destination Git common directory: %v; %s", ErrRuntimeHandoffDestination, err, store.runtimeHandoffStatusExit())
+	}
+	commonDir := strings.TrimSpace(string(output))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(destination, commonDir)
+	}
+	commonDir, err = canonicalRuntimeHandoffPath(commonDir)
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve destination Git common directory: %v; %s", ErrRuntimeHandoffDestination, err, store.runtimeHandoffStatusExit())
+	}
+	storeCommonDir, err := canonicalRuntimeHandoffPath(store.commonDir)
+	if err != nil || commonDir != storeCommonDir {
+		return "", fmt.Errorf("%w: %s does not share this ledger's Git common directory; %s", ErrRuntimeHandoffDestination, pathquote.Quote(destination), store.runtimeHandoffStatusExit())
+	}
+	return commonDir, nil
 }
 
 // runtimeResetStructurallyPermitted reports whether the ledger's terminal

--- a/internal/sddstatus/runtime_ledger_worktree_binding_test.go
+++ b/internal/sddstatus/runtime_ledger_worktree_binding_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +22,7 @@ import (
 // fix that diff silently measured the distance between two unrelated trees:
 // worktree B's own clean checkout matched the pinned base exactly, so the
 // authorized apply that really ran in worktree A was charged changed_lines: 0.
-func TestRuntimeLedgerRefusesFinishFromADifferentLinkedWorktreeThanBegin(t *testing.T) {
+func TestRuntimeLedgerFinishRefusesDelegatedWorktreeUntilHandoff(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	worktree := filepath.Join(t.TempDir(), "sibling-worktree")
 	runRuntimeLedgerGit(t, repo, "worktree", "add", "-q", "-b", "worktree-b", worktree)
@@ -89,6 +90,168 @@ func TestRuntimeLedgerRefusesFinishFromADifferentLinkedWorktreeThanBegin(t *test
 	if len(finished.Attempts) != 1 || finished.Attempts[0].ChangedLines != 1 {
 		t.Fatalf("same-worktree finish attempts = %#v, want exactly one changed line", finished.Attempts)
 	}
+}
+
+func TestRuntimeLedgerHandoffAtomicallyBindsDelegatedLinkedWorktree(t *testing.T) {
+	_, worktree, storeA, _, began := newRuntimeLedgerHandoffFixture(t, "handoff-atomic")
+
+	handedOff, err := storeA.Handoff(context.Background(), HandoffAttemptRequest{
+		ExpectedRevision: began.Revision, RequestID: "handoff-a-to-b", DestinationWorktree: worktree,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countRuntimeRecords(t, storeA.Dir) != 2 || handedOff.CumulativeAttempts != began.CumulativeAttempts ||
+		handedOff.CumulativeChangedLines != began.CumulativeChangedLines {
+		t.Fatalf("handoff must append exactly one uncharged record: %#v", handedOff)
+	}
+	active := handedOff.ActiveAttempt
+	if active == nil || active.BeginWorktree != storeA.Workspace || active.EffectiveWorktree != worktree || active.Handoff == nil {
+		t.Fatalf("handoff active attempt = %#v", active)
+	}
+	if active.BeginCandidateIdentity != began.ActiveAttempt.BeginCandidateIdentity || active.BeginCandidateTree != began.ActiveAttempt.BeginCandidateTree ||
+		active.Handoff.SourceWorktree != storeA.Workspace || active.Handoff.DestinationWorktree != worktree ||
+		active.Handoff.ExpectedRevision != began.Revision || active.Handoff.DestinationCandidateIdentity == "" || active.Handoff.DestinationCandidateTree == "" {
+		t.Fatalf("handoff provenance = %#v", active)
+	}
+	record, err := storeA.loadRecord(handedOff.Revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Operation != runtimeOperationHandoff || record.Handoff == nil || record.Handoff.RequestDigest != record.RequestDigest {
+		t.Fatalf("handoff record = %#v", record)
+	}
+	replay, err := storeA.Status()
+	if err != nil || replay.Revision != handedOff.Revision || replay.ActiveAttempt == nil || replay.ActiveAttempt.EffectiveWorktree != worktree {
+		t.Fatalf("handoff replay = %#v err=%v", replay, err)
+	}
+}
+
+func TestRuntimeLedgerHandoffPreservesOriginAndChargesOnlyFinalSettlement(t *testing.T) {
+	_, worktree, storeA, storeB, began := newRuntimeLedgerHandoffFixture(t, "handoff-final-charge")
+	handedOff, err := storeA.Handoff(context.Background(), HandoffAttemptRequest{
+		ExpectedRevision: began.Revision, RequestID: "handoff-final-charge", DestinationWorktree: worktree,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if handedOff.CumulativeAttempts != 1 || handedOff.CumulativeChangedLines != 0 || handedOff.ActiveAttempt == nil {
+		t.Fatalf("handoff changed accounting: %#v", handedOff)
+	}
+	appendRuntimeLedgerFile(t, worktree, "implemented-in-b\n")
+	finished, err := storeB.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: handedOff.Revision, RequestID: "finish-in-b", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "handoff delegates final measurement to worktree b",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(finished.Attempts) != 1 || finished.Attempts[0].BeginWorktree != storeA.Workspace ||
+		finished.Attempts[0].EffectiveWorktree != worktree || finished.Attempts[0].ChangedLines != 1 ||
+		finished.CumulativeAttempts != 1 || finished.CumulativeChangedLines != 1 {
+		t.Fatalf("final handoff settlement = %#v", finished)
+	}
+	if finished.Attempts[0].BeginCandidateIdentity != began.ActiveAttempt.BeginCandidateIdentity ||
+		finished.Attempts[0].BeginCandidateTree != began.ActiveAttempt.BeginCandidateTree || finished.Attempts[0].Handoff == nil {
+		t.Fatalf("final settlement rewrote begin provenance: %#v", finished.Attempts[0])
+	}
+}
+
+func TestRuntimeLedgerHandoffRejectsForeignOrUnregisteredWorktreeWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name        string
+		destination func(*testing.T, string) string
+	}{
+		{
+			name: "foreign repository",
+			destination: func(t *testing.T, _ string) string {
+				return initRuntimeLedgerRepo(t)
+			},
+		},
+		{
+			name: "unregistered directory",
+			destination: func(t *testing.T, repo string) string {
+				path := filepath.Join(repo, "unregistered-worktree")
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, _, storeA, _, began := newRuntimeLedgerHandoffFixture(t, "handoff-reject-"+strings.ReplaceAll(tt.name, " ", "-"))
+			beforeRecords := countRuntimeRecords(t, storeA.Dir)
+			_, err := storeA.Handoff(context.Background(), HandoffAttemptRequest{
+				ExpectedRevision: began.Revision, RequestID: "handoff-reject", DestinationWorktree: tt.destination(t, repo),
+			})
+			if !errors.Is(err, ErrRuntimeHandoffDestination) {
+				t.Fatalf("handoff error = %v, want ErrRuntimeHandoffDestination", err)
+			}
+			status, statusErr := storeA.Status()
+			if statusErr != nil || status.Revision != began.Revision || countRuntimeRecords(t, storeA.Dir) != beforeRecords ||
+				status.ActiveAttempt == nil || status.ActiveAttempt.EffectiveWorktree != storeA.Workspace {
+				t.Fatalf("rejected handoff mutated authority: status=%#v err=%v", status, statusErr)
+			}
+		})
+	}
+}
+
+func TestRuntimeLedgerHandoffReplayIsIdempotentAndCannotChargeTwice(t *testing.T) {
+	_, worktree, storeA, storeB, began := newRuntimeLedgerHandoffFixture(t, "handoff-replay")
+	request := HandoffAttemptRequest{ExpectedRevision: began.Revision, RequestID: "handoff-replay", DestinationWorktree: worktree}
+	first, err := storeA.Handoff(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := storeA.Handoff(context.Background(), request)
+	if err != nil || replayed.Revision != first.Revision || countRuntimeRecords(t, storeA.Dir) != 2 {
+		t.Fatalf("handoff replay = %#v err=%v records=%d", replayed, err, countRuntimeRecords(t, storeA.Dir))
+	}
+	appendRuntimeLedgerFile(t, worktree, "one-final-charge\n")
+	finished, err := storeB.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "finish-after-handoff-replay", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('c'), Diagnosis: "finish once after the replayed handoff",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterFinish, err := storeA.Handoff(context.Background(), request)
+	if err != nil || afterFinish.Revision != finished.Revision || afterFinish.CumulativeChangedLines != 1 || countRuntimeRecords(t, storeA.Dir) != 3 {
+		t.Fatalf("post-finish handoff replay = %#v err=%v records=%d", afterFinish, err, countRuntimeRecords(t, storeA.Dir))
+	}
+	conflict := request
+	conflict.DestinationWorktree = storeA.Workspace
+	if _, err := storeA.Handoff(context.Background(), conflict); !errors.Is(err, ErrRuntimeRequestConflict) {
+		t.Fatalf("different handoff request with replay id error = %v, want ErrRuntimeRequestConflict", err)
+	}
+}
+
+func newRuntimeLedgerHandoffFixture(t *testing.T, change string) (string, string, RuntimeStore, RuntimeStore, RuntimeStatus) {
+	t.Helper()
+	repo := initRuntimeLedgerRepo(t)
+	worktree := filepath.Join(t.TempDir(), "delegated-worktree")
+	runRuntimeLedgerGit(t, repo, "worktree", "add", "-q", "-b", change+"-b", worktree)
+	storeA, err := OpenRuntimeStore(context.Background(), repo, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeB, err := OpenRuntimeStore(context.Background(), worktree, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	began, err := storeA.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "begin-a", WorkUnit: "delegated-worktree", EvidenceGoal: "prove explicit execution handoff",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, worktree, storeA, storeB, began
 }
 
 func canonicalRuntimeLedgerWorktreePath(t *testing.T, path string) string {
@@ -200,7 +363,7 @@ func TestRuntimeLedgerLegacyBeginRecordReplaysWithoutWorktreeEnforcement(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.ActiveAttempt == nil || status.ActiveAttempt.BeginWorktree != "" {
+	if status.ActiveAttempt == nil || status.ActiveAttempt.BeginWorktree != "" || status.ActiveAttempt.EffectiveWorktree != "" {
 		t.Fatalf("legacy replay invented a begin_worktree: %#v", status.ActiveAttempt)
 	}
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2469

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

## 📝 Summary

- Add one explicit atomic `sdd-attempt handoff` from an acquiring worktree to its registered delegated linked worktree.
- Preserve immutable Begin provenance, budgets, evidence, and exactly-once settlement while changing only the effective execution worktree.
- Add typed CLI/compact refusals, focused authority tests, and driven journey `j74`.

## 📂 Changes

| Area | Change |
|------|--------|
| `internal/sddstatus` | Append-only handoff authority, replay, provenance, and effective-worktree settlement. |
| `internal/cli` | Native `sdd-attempt handoff` operation and actionable compact failures. |
| `bench/` | Driven A-to-B handoff lifecycle proof and corpus pins. |

## 🧪 Test Plan

- [x] Six required #2469 regression tests pass individually.
- [x] `go test ./internal/sddstatus -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] Bench declarations pass from the nested `bench` module.
- [x] CI-shaped driven `j74-sdd-attempt-explicit-linked-worktree-handoff`: `1 completed, 0 unsupported, 0 failed`.
- [x] `git diff --check`
- [ ] Repository Docker E2E is delegated to required CI.

## ✅ Contributor Checklist

- [x] Linked approved issue #2469.
- [x] Exactly one `type:*` label applied.
- [x] Maintainer explicitly approved `size:exception` for the measured 623 authored changed lines.
- [x] Unit, format, vet, and driven runtime evidence pass.
- [x] Commit follows Conventional Commits and contains no attribution trailer.

## 💬 Notes for Reviewers

The stale-lock hypothesis was removed from #2469. This PR addresses only the current rc.3 `worktree_mismatch` root. Handoff is explicit, single-use, same-common-dir, append-only, and never inferred from `--cwd`. Raw untracked admission remains index-gated and out of scope.

Receipt-driven review was clone-locally disabled, so this candidate was independently validated under ordinary repository policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly handing off active work between linked worktrees.
  * Added a `handoff` operation with destination worktree options and guidance.
  * Preserved attempt provenance and status details across handoffs.
  * Added safeguards for invalid, conflicting, repeated, or unregistered handoffs.

* **Bug Fixes**
  * Improved compact handoff errors with actionable status commands and structured details.

* **Tests**
  * Added comprehensive coverage for handoff behavior, validation, replay, and journey registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->