### PR TITLE
fix(sdd): discover monorepo sub-projects during sdd-init

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -370,6 +370,54 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 	}
 }
 
+// TestSDDInitDiscoversMonorepoSubProjects pins the multi-root detection
+// contract. A workspace whose stack markers live only in sub-directories used
+// to be classified as "unclassified" with no runner, because detection was
+// anchored at the workspace root (issue #810). The skill must discover every
+// project root and keep unlike sub-projects separable.
+func TestSDDInitDiscoversMonorepoSubProjects(t *testing.T) {
+	skill := MustRead("skills/sdd-init/SKILL.md")
+	for _, want := range []string{
+		"Discover every project root before classifying",
+		"never \"unclassified\"",
+		"per sub-project",
+		"two or more project roots",
+		"exactly one project root, at the workspace root",
+		"exactly one project root, in a sub-directory",
+		"no marker within the scanned depth",
+		"override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`",
+		"no per-project marker/config but workspace default set",
+	} {
+		if !strings.Contains(skill, want) {
+			t.Fatalf("skills/sdd-init/SKILL.md missing monorepo contract %q", want)
+		}
+	}
+
+	details := MustRead("skills/sdd-init/references/init-details.md")
+	for _, want := range []string{
+		"Project Root Discovery",
+		"Cargo.toml",
+		"pyproject.toml",
+		"node_modules",
+		"go.work",
+		"projects:",
+		"sub-project name is its path relative to the workspace root",
+		"testing:",
+		"strict_tdd:",
+		"Declared members outrank both bounds",
+	} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("skills/sdd-init/references/init-details.md missing discovery rule %q", want)
+		}
+	}
+
+	for _, want := range []string{"two** directory levels", "ignored by `.gitignore`"} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("skills/sdd-init/references/init-details.md lost its scan bound %q", want)
+		}
+	}
+}
+
 func TestSDDVerifyAuthorityPreflightDenialEnvelopeContract(t *testing.T) {
 	const denialFields = `authority_only_failure: true
 missing_review_authority: true

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -1,5 +1,26 @@
 # SDD Init Details
 
+## Project Root Discovery
+
+A workspace root without stack markers does not mean the workspace is unclassified — in a monorepo the markers live one or two levels down. Discover roots before classifying anything.
+
+- **Marker files** that define a project root: `package.json`, `go.mod`, `pyproject.toml`, `setup.py`, `requirements.txt`, `Cargo.toml`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `Gemfile`, `composer.json`, `*.csproj`, `*.sln`, `mix.exs`, `pubspec.yaml`.
+- **Depth**: scan the workspace root and up to **two** directory levels below it. Deeper nesting is reported as a limitation rather than scanned, so the cost stays bounded on large trees. A depth-bounded scan can never establish that no marker exists at any depth: report "no marker within the scanned depth" together with the directories actually scanned.
+- **Skip** directories that never hold a first-party project root: `node_modules`, `vendor`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `.git`, `.gradle`, `bin`, `obj`, and any path ignored by `.gitignore`.
+- **Workspace-manager roots count once**: when a root declares members (`workspaces` in `package.json`, `[workspace] members` in `Cargo.toml`, `pnpm-workspace.yaml`, `go.work`), use the declared members as the sub-project list instead of re-deriving it from the directory walk.
+- **Declared members outrank both bounds**: a declared member deeper than two levels is still discovered, because reading a declaration costs no walk, and a declared member under a skipped or gitignored path is still discovered, because an explicit declaration beats the heuristic skip list. The skip list still applies **inside** glob expansion, so `packages/*` never yields `packages/node_modules`. A declared member with no directory on disk is reported as a limitation, never dropped silently.
+- **Naming**: the sub-project name is its path relative to the workspace root (`services/api`), not just the leaf, so two `api` directories never collide.
+
+| Discovered | Layout | Persistence shape |
+|---|---|---|
+| marker at workspace root only | single project | one context, one capability set |
+| exactly one marker, in a sub-directory | nested single project | one entry keyed by its relative path, workspace recorded as the container |
+| markers in two or more sub-directories | monorepo | one entry per sub-project, workspace recorded as the container |
+| marker at root **and** in sub-directories | monorepo with a root project | root project plus one entry per sub-project |
+| no marker within the scanned depth | unclassified | report the scanned directories, the depth bound reached, and the skip list applied |
+
+Report per sub-project: relative path, language/stack, test runner, and resolved `strict_tdd`. Never average unlike sub-projects into a single verdict — a Python service with `pytest` and a Rust crate with `cargo test` are two answers, not one.
+
 ## Testing Capability Checklist
 
 - Test runner: `package.json` scripts/deps, `pyproject.toml`, `pytest.ini`, `go.mod`, `Cargo.toml`, `Makefile`.
@@ -39,6 +60,16 @@ mem_save title/topic_key: sdd/{project}/testing-capabilities
 type: config
 content: testing capabilities markdown
 capture_prompt: false when available
+```
+
+In a monorepo, save one capability observation per sub-project and keep the
+workspace-level key as the index that lists them:
+
+```text
+mem_save title/topic_key: sdd/{project}/{sub-project-path}/testing-capabilities
+type: config
+content: testing capabilities markdown for that sub-project
+capture_prompt: false when available
 
 mem_save title/topic_key: skill-registry
 type: config
@@ -57,6 +88,25 @@ openspec/
 ```
 
 `config.yaml` should include concise context, `strict_tdd`, testing capabilities, and phase rules for proposal/spec/design/tasks/apply/verify/archive. Keep `context:` under 10 lines.
+
+For a monorepo, keep the workspace-level `context:` under 10 lines and move the per-sub-project detail into a `projects:` list so unlike stacks stay separable:
+
+```yaml
+context: |
+  workspace is a monorepo with 2 sub-projects.
+strict_tdd: false          # workspace default; each project may override
+projects:
+  - path: a
+    stack: Python
+    testing: { unit: pytest, coverage: pytest-cov }
+    strict_tdd: true
+  - path: b
+    stack: Rust
+    testing: { unit: cargo test }
+    strict_tdd: true
+```
+
+Resolution order for a sub-project's `strict_tdd`: its own entry value or agent marker → the workspace-level default → its detected test runner → `false`. Every entry under `projects:` carries its own `testing:` and `strict_tdd:`, so a workspace default never silently overwrites a sub-project that decided differently.
 
 ## Testing Capabilities Format
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -949,7 +949,7 @@ func TestRunSyncRemovesOpenCodeOnlyReviewPluginFromKilocode(t *testing.T) {
 
 	pluginsDir := filepath.Join(home, ".config", "kilo", "plugins")
 	reviewPlugin := filepath.Join(pluginsDir, "review-result-artifacts.ts")
-	mustWriteFile(t, reviewPlugin, []byte("// stale v2.1.7 managed plugin"))
+	mustWriteFile(t, reviewPlugin, []byte(assets.MustRead("opencode/plugins/review-result-artifacts.ts")))
 
 	restoreHome := osUserHomeDir
 	restoreBackupHome := backup.UserHomeDirFn
@@ -976,6 +976,50 @@ func TestRunSyncRemovesOpenCodeOnlyReviewPluginFromKilocode(t *testing.T) {
 	skillRegistry := filepath.Join(pluginsDir, "skill-registry.ts")
 	if _, err := os.Stat(skillRegistry); !os.IsNotExist(err) {
 		t.Errorf("sync must not create never-installed plugin %q; stat err = %v", skillRegistry, err)
+	}
+}
+
+// TestRunSyncPreservesUserOwnedOpenCodeOnlyReviewPluginFromKilocode ensures
+// Kilo sync does not delete a same-named plugin with arbitrary user content.
+func TestRunSyncPreservesUserOwnedOpenCodeOnlyReviewPluginFromKilocode(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"kilocode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		Persona:             "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	pluginsDir := filepath.Join(home, ".config", "kilo", "plugins")
+	reviewPlugin := filepath.Join(pluginsDir, "review-result-artifacts.ts")
+	userContent := []byte("// user-owned Kilo review plugin")
+	mustWriteFile(t, reviewPlugin, userContent)
+
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+	})
+
+	result, err := RunSync(nil)
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	got, readErr := os.ReadFile(reviewPlugin)
+	if readErr != nil {
+		t.Fatalf("sync removed user-owned Kilo review plugin: %v", readErr)
+	}
+	if !bytes.Equal(got, userContent) {
+		t.Errorf("sync changed user-owned Kilo review plugin content = %q, want %q", got, userContent)
+	}
+	if containsPath(result.ChangedFiles, reviewPlugin) {
+		t.Errorf("ChangedFiles unexpectedly includes preserved Kilocode plugin path %q\nchanged = %#v", reviewPlugin, result.ChangedFiles)
 	}
 }
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -138,11 +138,6 @@ var strongProjectMarkers = []string{
 	"build.gradle",
 }
 
-// maxAncestorDepth is the maximum number of parent directories findProjectRoot
-// will traverse before giving up. This prevents infinite loops on deeply-nested
-// trees and ensures we stop well before reaching the filesystem root.
-const maxAncestorDepth = 20
-
 // bootstrapper is an optional adapter capability: if an adapter implements
 // this interface, any injector that writes Jinja modules will first ensure
 // the base template (entry point) exists.
@@ -166,13 +161,20 @@ type bootstrapper interface {
 // the first one — we keep walking to find the highest ancestor with package.json
 // (or a monorepo root marker above it).
 func findProjectRoot(dir string) (string, bool) {
+	return findProjectRootWithin(dir, "")
+}
+
+// findProjectRootWithin walks upward from dir until it finds a project root or
+// reaches boundary. An empty boundary preserves findProjectRoot's production
+// behavior of walking to the filesystem root.
+func findProjectRootWithin(dir, boundary string) (string, bool) {
 	if dir == "" {
 		return "", false
 	}
 	current := filepath.Clean(dir)
 	var bestCandidate string // best weak (package.json-only) match found so far
 
-	for i := 0; i < maxAncestorDepth; i++ {
+	for i := 0; ; i++ {
 		// Check monorepo root markers first — highest priority; return immediately.
 		for _, marker := range monorepoRootMarkers {
 			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
@@ -194,6 +196,9 @@ func findProjectRoot(dir string) (string, bool) {
 		parent := filepath.Dir(current)
 		if parent == current {
 			// Reached filesystem root ("/" on Unix, "C:\" on Windows).
+			break
+		}
+		if boundary != "" && current == filepath.Clean(boundary) {
 			break
 		}
 		current = parent

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -4152,7 +4152,7 @@ func TestInjectKilocodeKeepsLegacyBackgroundAgentsPluginAndRemovesOpenCodeReview
 		t.Fatalf("WriteFile(background-agents.ts) error = %v", err)
 	}
 	reviewPluginPath := filepath.Join(pluginsDir, "review-result-artifacts.ts")
-	if err := os.WriteFile(reviewPluginPath, []byte("stale OpenCode-only review plugin"), 0o644); err != nil {
+	if err := os.WriteFile(reviewPluginPath, []byte(assets.MustRead("opencode/plugins/review-result-artifacts.ts")), 0o644); err != nil {
 		t.Fatalf("WriteFile(review-result-artifacts.ts) error = %v", err)
 	}
 
@@ -4182,6 +4182,56 @@ func TestInjectKilocodeKeepsLegacyBackgroundAgentsPluginAndRemovesOpenCodeReview
 	}
 	if _, err := os.Stat(reviewPluginPath); !os.IsNotExist(err) {
 		t.Fatalf("OpenCode-only review plugin remains installed for Kilo: %v", err)
+	}
+}
+
+func TestKilocodeReviewPluginCleanupPreservesUnverifiedFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		cleanup func(string, agents.Adapter) (InjectionResult, error)
+	}{
+		{
+			name: "install",
+			cleanup: func(home string, adapter agents.Adapter) (InjectionResult, error) {
+				return installOpenCodePlugins(home, adapter)
+			},
+		},
+		{
+			name:    "refresh",
+			cleanup: RefreshInstalledOpenCodePlugins,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			pluginsDir := filepath.Join(home, ".config", "kilo", "plugins")
+			if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll(plugins) error = %v", err)
+			}
+			reviewPluginPath := filepath.Join(pluginsDir, "review-result-artifacts.ts")
+			userContent := []byte("// user-owned Kilo review plugin")
+			if err := os.WriteFile(reviewPluginPath, userContent, 0o644); err != nil {
+				t.Fatalf("WriteFile(review-result-artifacts.ts) error = %v", err)
+			}
+
+			result, err := tt.cleanup(home, kilocodeAdapter())
+			if err != nil {
+				t.Fatalf("Kilo %s error = %v", tt.name, err)
+			}
+			got, err := os.ReadFile(reviewPluginPath)
+			if err != nil {
+				t.Fatalf("ReadFile(user-owned review plugin) error = %v", err)
+			}
+			if !bytes.Equal(got, userContent) {
+				t.Fatalf("user-owned review plugin changed: got %q, want %q", got, userContent)
+			}
+			for _, file := range result.Files {
+				if file == reviewPluginPath {
+					t.Fatalf("user-owned review plugin %q reported as cleanup: %v", reviewPluginPath, result.Files)
+				}
+			}
+		})
 	}
 }
 
@@ -5523,8 +5573,8 @@ func TestFindProjectRootPackageJsonFallback(t *testing.T) {
 	}
 }
 
-// TestFindProjectRootEmptyDirReturnsNotFound verifies that an empty directory
-// (no markers at all) returns false.
+// TestFindProjectRootEmptyDirReturnsNotFound verifies that an isolated directory
+// with no repository markers returns an empty root and false.
 func TestFindProjectRootEmptyDirReturnsNotFound(t *testing.T) {
 	emptyDir := t.TempDir() // No markers, isolated temp dir
 
@@ -5534,11 +5584,9 @@ func TestFindProjectRootEmptyDirReturnsNotFound(t *testing.T) {
 		t.Fatalf("MkdirAll(subDir): %v", err)
 	}
 
-	_, ok := findProjectRoot(subDir)
-	if ok {
-		// Note: this may find markers in ancestor dirs outside emptyDir
-		// on some systems. The test is best-effort for isolated environments.
-		t.Log("findProjectRoot found a marker outside the temp dir — acceptable on some systems")
+	got, ok := findProjectRootWithin(subDir, emptyDir)
+	if ok || got != "" {
+		t.Fatalf("findProjectRootWithin(%q, %q) = (%q, %v), want (\"\", false)", subDir, emptyDir, got, ok)
 	}
 }
 
@@ -5552,12 +5600,13 @@ func TestFindProjectRootEmptyStringReturnsNotFound(t *testing.T) {
 }
 
 // TestFindProjectRootDeepNested verifies that findProjectRoot handles deeply
-// nested directories without panicking or infinite looping, and that it
-// correctly returns ("", false) when the marker is beyond maxAncestorDepth.
-func TestFindProjectRootDeepNested(t *testing.T) {
+// TestFindProjectRootDeepNestedMonorepo verifies that root discovery reaches a
+// monorepo marker beyond the former fixed 20-parent traversal limit.
+func TestFindProjectRootDeepNestedMonorepo(t *testing.T) {
 	root := t.TempDir()
 
-	// Build a directory 25 levels deep (beyond maxAncestorDepth=20).
+	// Build a directory 25 levels deep so this fixture would fail with the
+	// former fixed 20-parent traversal limit.
 	deepDir := root
 	for i := 0; i < 25; i++ {
 		deepDir = filepath.Join(deepDir, fmt.Sprintf("level%02d", i))
@@ -5566,36 +5615,27 @@ func TestFindProjectRootDeepNested(t *testing.T) {
 		t.Fatalf("MkdirAll(deepDir): %v", err)
 	}
 
-	// Place a go.mod only at the root (25 levels above deepDir).
-	// With maxAncestorDepth=20, findProjectRoot cannot reach it from level 25.
-	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module test\n"), 0o644); err != nil {
-		t.Fatalf("write go.mod: %v", err)
+	if err := os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte("packages:\n  - packages/*\n"), 0o644); err != nil {
+		t.Fatalf("write pnpm-workspace.yaml: %v", err)
 	}
 
-	// This must not panic or loop infinitely.
-	// The important assertion is that it completes quickly.
-	done := make(chan struct{})
-	var gotPath string
-	var gotOk bool
+	type result struct {
+		root string
+		ok   bool
+	}
+	results := make(chan result, 1)
 	go func() {
-		defer close(done)
-		gotPath, gotOk = findProjectRoot(deepDir)
+		got, ok := findProjectRoot(deepDir)
+		results <- result{root: got, ok: ok}
 	}()
 
 	select {
-	case <-done:
-		// Completed without hanging — test passes.
-	case <-time.After(5 * time.Second):
-		t.Fatal("findProjectRoot appeared to hang on deeply nested dir")
-	}
-
-	// Correctness: starting 25 levels deep with go.mod only at level 0 and
-	// maxAncestorDepth=20, the function cannot reach level 0 — must return ("", false).
-	if gotOk {
-		t.Fatalf("findProjectRoot should return false when marker is beyond maxAncestorDepth, got path=%q ok=%v", gotPath, gotOk)
-	}
-	if gotPath != "" {
-		t.Fatalf("findProjectRoot should return empty path when not found, got %q", gotPath)
+	case r := <-results:
+		if !r.ok || r.root != root {
+			t.Fatalf("findProjectRoot(%q) = (%q, %v), want (%q, true)", deepDir, r.root, r.ok, root)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("findProjectRoot did not reach the monorepo root within one second")
 	}
 }
 

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -32,6 +32,8 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 ## Hard Rules
 
 - Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- Discover every project root before classifying: the workspace root plus any bounded-depth directory carrying its own stack marker. A workspace whose markers live only in sub-directories is never "unclassified"; classify it by the number and location of the roots found, not by the bare workspace root.
+- In a monorepo, detect stack, testing capabilities, and Strict TDD **per sub-project**; never collapse unlike sub-projects into one verdict.
 - In `engram` mode, do **not** create `openspec/`.
 - In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
 - In `hybrid` mode, write both openspec files and Engram observations.
@@ -48,15 +50,20 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| exactly one project root, at the workspace root | Single-project layout: one context, one capability set. |
+| exactly one project root, in a sub-directory | Nested single project: persist it under its relative path and record the workspace as the container, not as the project. |
+| two or more project roots | Monorepo: detect and persist per sub-project, and record the root as the workspace. |
+| no marker within the scanned depth | Report unclassified **and** list the scanned directories plus the depth bound reached; never claim a deeper marker is absent. |
+| strict TDD marker/config found | Use that value, resolved per sub-project in a monorepo. |
+| no per-project marker/config but workspace default set | Use the workspace `strict_tdd` default for that sub-project. |
+| no marker/config and no workspace default, but test runner exists | Default `strict_tdd: true`. |
 | no test runner | Set `strict_tdd: false` and explain unavailable. |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+1. Discover project roots with the marker and depth rules in `references/init-details.md`, then inspect each root's files (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, lint/test config) and summarize stack/conventions per root.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter for each discovered root.
+3. Resolve Strict TDD per root in this precedence: the root's own agent marker or `openspec/config.yaml` override → the workspace-level `strict_tdd` default → the root's detected test runner → `false`. Run the chain once per root; a root that declares its own value keeps it.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.


### PR DESCRIPTION
## Linked Issue

Closes #810
Supersedes #1565

---

## PR Type

- [x] `type:bug` — Bug fix

---

## Summary

sdd-init failed on monorepos where stack markers live in sub-directories (e.g. `a/pyproject.toml`, `b/Cargo.toml`). Detection was anchored at the workspace root, producing "Unclassified — no test runner" for every sub-project, even when they had full testing setups.

This PR unifies two coordinated changes originally split across #2027 (skill contract) and #2040 (code path):

### 1. Skill contract — sdd-init agent learns multi-root discovery

- **SKILL.md**: Hard Rules now require discovering every project root before classifying, with per-sub-project detection and Strict TDD
- **init-details.md**: New "Project Root Discovery" section with complete algorithm — 2-level depth-bounded scan, skip list for dependency directories, workspace-manager member support (`workspaces` in package.json, Cargo.toml members, pnpm-workspace.yaml, go.work), relative-path naming to prevent collisions, monorepo Engram saves (`sdd/{project}/{sub-path}/testing-capabilities`), and monorepo OpenSpec config.yaml skeleton with `projects:` list
- **Decision Gates**: New layout classification rows — single root, nested single project, monorepo, root+subs, unclassified-with-depth-report
- **Execution Steps**: Updated to walk roots first, then detect per root
- **Golden files**: All 8 agent-specific golden files updated

### 2. Code path — remove artificial depth cap from findProjectRoot

- Removed `maxAncestorDepth = 20` constant that silently dropped deeply-nested monorepo roots during sync/install
- Added `findProjectRootWithin(dir, boundary)` for deterministic testing
- Updated `TestFindProjectRootDeepNestedMonorepo` to assert a monorepo marker is now reachable at 25 levels depth
- Fixed `TestFindProjectRootEmptyDirReturnsNotFound` to use the boundary-aware variant

## Changes

| File | Change |
|------|--------|
| `internal/assets/skills/sdd-init/SKILL.md` | Multi-root rules, per-sub-project detection, Strict TDD chain |
| `internal/assets/skills/sdd-init/references/init-details.md` | Project Root Discovery section |
| `testdata/golden/sdd-*-skill-sdd-init.golden` | 8 golden files synced |
| `internal/assets/assets_test.go` | TestSDDInitDiscoversMonorepoSubProjects |
| `internal/components/sdd/inject.go` | Remove depth cap, add findProjectRootWithin |
| `internal/components/sdd/inject_test.go` | Updated deep-nested test, boundary-aware empty-dir test |
| `internal/cli/sync_test.go` | Preserve user-owned Kilo review plugin during sync |

## Test Plan

- [x] `TestSDDInitDiscoversMonorepoSubProjects` — skill contract assertions PASS
- [x] `TestFindProjectRoot*` — all 10 sub-cases PASS including DeepNestedMonorepo
- [x] `go run ./internal/gofmtcheck` PASS
- [x] `go build ./...` PASS

## Contributor Checklist

- [x] Linked approved issue #810
- [x] Under 400-line review budget (+338/-88)
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved project setup for monorepos by discovering nested projects and configuring each independently.
  * Added clearer handling for project testing capabilities, workspace defaults, and Strict TDD settings.
  * Enhanced project detection for deeply nested repository structures.

* **Bug Fixes**
  * Prevented synchronization and installation processes from removing user-owned review plugin content.
  * Improved preservation of unverified or customized plugins during refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->