### PR TITLE
fix(review): admit unsorted inspection paths that cover the candidate manifest

### DIFF
--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -175,7 +175,7 @@ func AdmitArtifact(request ArtifactAdmissionRequest) (LensResult, ArtifactAdmiss
 		return fail(ArtifactAdmissionIncomplete, "reviewer did not report completed candidate inspection")
 	}
 	inspectionPaths, err := canonicalPaths(request.Inspection.Paths)
-	if err != nil || !equalStrings(inspectionPaths, request.Inspection.Paths) {
+	if err != nil {
 		return fail(ArtifactAdmissionOutOfScope, "reviewer inspection paths are not canonical candidate paths")
 	}
 	for _, path := range inspectionPaths {

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -152,6 +152,15 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 			t.Fatalf("AdmitArtifact() = %q, %v; want completed", admission.Decision, err)
 		}
 	})
+	t.Run("out of scope path mixed with valid paths is still refused", func(t *testing.T) {
+		request := admittedCandidateCausalArtifactFixture(t)
+		request.CandidateCausalFindingIDs = []string{"R3-001"}
+		request.Inspection.Paths = []string{"internal/a.go", "outside/evil.go", "internal/b.go"}
+		_, admission, err := AdmitArtifact(request)
+		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {
+			t.Fatalf("AdmitArtifact() = %q, %v; want out_of_scope", admission.Decision, err)
+		}
+	})
 	t.Run("canonicalization error becomes incomplete and names the offending id", func(t *testing.T) {
 		request := admittedCandidateCausalArtifactFixture(t)
 		request.CandidateCausalFindingIDs = []string{"R3-001", "R3-001"}

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -66,6 +66,16 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 		t.Fatalf("admission.Validate() error = %v", err)
 	}
 
+	// Test line range location
+	request.Result.Findings[0].Location = "internal/a.go:44-62"
+	_, admissionRange, errRange := AdmitArtifact(request)
+	if errRange != nil {
+		t.Fatalf("AdmitArtifact() line range error = %v", errRange)
+	}
+	if admissionRange.Decision != ArtifactAdmissionCompleted {
+		t.Fatalf("admission line range decision = %v; want completed", admissionRange.Decision)
+	}
+
 	tests := []struct {
 		name     string
 		mutate   func(*ArtifactAdmissionRequest)
@@ -97,6 +107,10 @@ func TestAdmitArtifactRequiresCompletedBoundInScopeInspection(t *testing.T) {
 		{name: "root path proof outside scope", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings[0].ProofRefs = []string{"diff: secret.go:42"}
 		}, decision: ArtifactAdmissionOutOfScope},
+		{name: "location range incomplete end", mutate: func(r *ArtifactAdmissionRequest) { r.Result.Findings[0].Location = "internal/a.go:7-" }, decision: ArtifactAdmissionOutOfScope},
+		{name: "location range incomplete start", mutate: func(r *ArtifactAdmissionRequest) { r.Result.Findings[0].Location = "internal/a.go:-7" }, decision: ArtifactAdmissionOutOfScope},
+		{name: "location zero", mutate: func(r *ArtifactAdmissionRequest) { r.Result.Findings[0].Location = "internal/a.go:0-0" }, decision: ArtifactAdmissionOutOfScope},
+		{name: "location zero end", mutate: func(r *ArtifactAdmissionRequest) { r.Result.Findings[0].Location = "internal/a.go:7-0" }, decision: ArtifactAdmissionOutOfScope},
 		{name: "non ASCII finding id", mutate: func(r *ArtifactAdmissionRequest) {
 			r.Result.Findings[0].ID = "R3-é"
 		}, decision: ArtifactAdmissionBindingMismatch},

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -143,6 +143,15 @@ func TestArtifactAdmissionCandidateCausalCanonicalization(t *testing.T) {
 			t.Fatalf("admission.CandidateCausalFindingIDs = %v, want canonical [R3-001]", admission.CandidateCausalFindingIDs)
 		}
 	})
+	t.Run("unsorted inspection paths covering manifest admit cleanly", func(t *testing.T) {
+		request := admittedCandidateCausalArtifactFixture(t)
+		request.CandidateCausalFindingIDs = []string{"R3-001"}
+		request.Inspection.Paths = []string{"internal/b.go", "internal/a.go"}
+		_, admission, err := AdmitArtifact(request)
+		if err != nil || admission.Decision != ArtifactAdmissionCompleted {
+			t.Fatalf("AdmitArtifact() = %q, %v; want completed", admission.Decision, err)
+		}
+	})
 	t.Run("canonicalization error becomes incomplete and names the offending id", func(t *testing.T) {
 		request := admittedCandidateCausalArtifactFixture(t)
 		request.CandidateCausalFindingIDs = []string{"R3-001", "R3-001"}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -955,12 +955,35 @@ func findingLocationInGenesis(location string, genesisPaths []string) bool {
 		return false
 	}
 	line := location[separator+1:]
-	nonzero := false
-	for index := range line {
-		if line[index] < '0' || line[index] > '9' {
+	
+	checkNum := func(s string) bool {
+		if s == "" {
 			return false
 		}
-		nonzero = nonzero || line[index] != '0'
+		nz := false
+		for i := 0; i < len(s); i++ {
+			if s[i] < '0' || s[i] > '9' {
+				return false
+			}
+			nz = nz || s[i] != '0'
+		}
+		return nz
+	}
+
+	nonzero := false
+	if dash := strings.IndexByte(line, '-'); dash >= 0 {
+		if strings.IndexByte(line[dash+1:], '-') >= 0 {
+			return false
+		}
+		if !checkNum(line[:dash]) || !checkNum(line[dash+1:]) {
+			return false
+		}
+		nonzero = true
+	} else {
+		if !checkNum(line) {
+			return false
+		}
+		nonzero = true
 	}
 	logicalPath := location[:separator]
 	if len(logicalPath) >= 3 && logicalPath[1] == ':' && logicalPath[2] == '/' &&

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -375,6 +375,7 @@ func canonicalLensResult(result LensResult, allowMissingSevereLocation bool) (Le
 			finding.ID = fmt.Sprintf("%s-%03d", idPrefix, index+1)
 		}
 		finding.Lens = strings.TrimSpace(finding.Lens)
+		finding.Lens = strings.TrimPrefix(finding.Lens, "review-")
 		if finding.Lens == "" {
 			finding.Lens = wantFindingLens
 		}

--- a/internal/reviewtransaction/transaction_test.go
+++ b/internal/reviewtransaction/transaction_test.go
@@ -794,3 +794,27 @@ func freezeTestFindings(tx *Transaction, findings []Finding) error {
 func tree(char string) string {
 	return strings.Repeat(char, 40)
 }
+
+func TestCanonicalLensResultNormalizesLongForm(t *testing.T) {
+	result := LensResult{
+		Lens: "review-reliability",
+		Findings: []Finding{{
+			Location: "internal/a.go:42",
+			Severity: "WARNING",
+			Claim:    "test claim",
+			ProofRefs: []string{"diff: internal/a.go:42"},
+			Lens: "review-reliability",
+		}},
+		Evidence: []string{"test evidence"},
+	}
+	canonical, err := canonicalLensResult(result, false)
+	if err != nil {
+		t.Fatalf("canonicalLensResult() error = %v", err)
+	}
+	if canonical.Lens != "review-reliability" {
+		t.Errorf("result lens mutated")
+	}
+	if canonical.Findings[0].Lens != "reliability" {
+		t.Errorf("finding lens not normalized to short form, got %q", canonical.Findings[0].Lens)
+	}
+}


### PR DESCRIPTION
Closes #2614
Partially addresses #2630 (D3 location ranges, D4 unsorted paths, D6 lens form normalization)
Refs #2618, #2611

### Summary
Three admission logic fixes in `internal/reviewtransaction/`:

#### 1. Unsorted inspection paths admitted (#2630 D4)
`AdmitArtifact` previously required `request.Inspection.Paths` to match `canonicalPaths` in exact array element ordering. When reviewer agents returned valid paths in non-lexicographical order, admission falsely rejected with `out_of_scope`. Fix: remove the pre-sorted input requirement; both sides are canonicalized before set comparison.

#### 2. Line ranges accepted in finding locations (#2614 §1, #2630 D3)
`findingLocationInGenesis` enforced a single-integer suffix (`path:42`), rejecting valid line ranges like `path:44-62`. The schema declares `location` as `string (minLength 1)` with no format constraint. Fix: accept `N-M` range suffixes where both components are positive integers.

#### 3. Long-form lens names normalized in findings (#2630 D6)
`selected_lenses` emits `review-risk` (long form) but findings validate against `risk` (short form). When a reviewer echoes the emitted form, admission rejects with `binding_mismatch`. Fix: normalize the `review-` prefix to the short enum form before validation.

### Verification
- Positive tests: unsorted paths admit, line ranges admit, long-form lens normalizes
- Negative tests: out-of-scope paths refused, incomplete ranges refused, zero ranges refused

### Scope note
The referenced issues describe additional distinct defects (CLI flag gaps, recovery successor binding asymmetry) addressed in separate PRs.