### PR TITLE
fix(review): avoid NUL config paths in isolated Git view on Windows

### DIFF
--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -339,12 +339,22 @@ func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(
 	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o600); err != nil {
 		return fail(err)
 	}
+	// Create empty config files instead of using os.DevNull. On Windows,
+	// os.DevNull resolves to "NUL" which Git for Windows rejects as a
+	// config-file path (exit code 128: "unable to access 'NUL': Invalid
+	// argument"). Empty regular files preserve the isolation boundary while
+	// working on every platform. These files live inside gitDir which is
+	// already removed by the cleanup function.
+	emptyConfig := filepath.Join(gitDir, "empty-git-config")
+	if err := os.WriteFile(emptyConfig, nil, 0o600); err != nil {
+		return fail(err)
+	}
 	return []string{
 		"GIT_DIR=" + gitDir,
 		"GIT_OBJECT_DIRECTORY=" + filepath.Join(identity.GitCommonDir, "objects"),
 		"GIT_CONFIG_NOSYSTEM=1",
-		"GIT_CONFIG_SYSTEM=" + os.DevNull,
-		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_SYSTEM=" + emptyConfig,
+		"GIT_CONFIG_GLOBAL=" + emptyConfig,
 		"GIT_CONFIG_COUNT=0",
 		"GIT_ATTR_NOSYSTEM=1",
 		"LANG=C",

--- a/internal/reviewtransaction/git_authority_path_test.go
+++ b/internal/reviewtransaction/git_authority_path_test.go
@@ -404,6 +404,36 @@ func TestGitAuthorityPathHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+func TestIsolatedImmutableTreeGitUsesEmptyFilesInsteadOfDevNull(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	isolation, cleanup, err := isolatedImmutableTreeGit(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cleanup() })
+
+	for _, env := range isolation {
+		for _, prefix := range []string{"GIT_CONFIG_SYSTEM=", "GIT_CONFIG_GLOBAL="} {
+			if !strings.HasPrefix(env, prefix) {
+				continue
+			}
+			path := strings.TrimPrefix(env, prefix)
+			if path == os.DevNull {
+				t.Errorf("isolation env %s still uses os.DevNull (%q); want an empty regular file", prefix, os.DevNull)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Errorf("isolation env %s points to inaccessible path %q: %v", prefix, path, err)
+				continue
+			}
+			if info.IsDir() {
+				t.Errorf("isolation env %s points to directory %q; want a regular file", prefix, path)
+			}
+		}
+	}
+}
+
 func slicesContain(values []string, target string) bool {
 	for _, value := range values {
 		if strings.EqualFold(value, target) {


### PR DESCRIPTION
## Closes #2206

### Summary

- Replace `os.DevNull` with empty regular config files for `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_GLOBAL` in the isolated immutable-tree Git view
- On Windows, `os.DevNull` resolves to `NUL` which Git for Windows rejects as a config-file path (exit code 128)
- Empty files preserve the isolation boundary while working on every platform

### Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/frozen_candidate_context.go` | Create `empty-git-config` file in `gitDir` and point `GIT_CONFIG_SYSTEM`/`GIT_CONFIG_GLOBAL` to it instead of `os.DevNull` |
| `internal/reviewtransaction/git_authority_path_test.go` | New test `TestIsolatedImmutableTreeGitUsesEmptyFilesInsteadOfDevNull` verifying env vars point to real files |

### Test Plan

- [x] New test `TestIsolatedImmutableTreeGitUsesEmptyFilesInsteadOfDevNull` passes
- [x] All existing `isolatedImmutableTreeGit` tests pass (15/15)
- [x] `TestFrozenCandidateContext*` tests pass
- [x] `TestGitAuthority*` tests pass
- [x] `TestGitCommonDirectoryMismatchFailsBeforeAuthorityMutation` passes

### Contributor Checklist

- [x] Linked an approved issue (`Closes #2206`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when performing isolated Git operations by ensuring valid configuration files are available.
  * Prevented failures caused by inaccessible or invalid Git configuration paths.

* **Tests**
  * Added regression coverage to verify isolated Git configurations use accessible regular files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->