### PR TITLE
ci(release): add stable RC promotion workflow

### DIFF
--- a/.github/workflows/promote-stable-rc.yml
+++ b/.github/workflows/promote-stable-rc.yml
@@ -1,0 +1,263 @@
+name: Promote stable RC
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_prerelease_tag:
+        description: Canonical immutable RC tag, for example v2.3.0-rc.3
+        required: true
+        type: string
+      stable_tag:
+        description: Matching canonical stable tag, for example v2.3.0
+        required: true
+        type: string
+      release_environment_policy_id:
+        description: Temporary release/main deployment-policy ID to remove after publication
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote-stable-${{ inputs.stable_tag }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      source_sha: ${{ steps.provenance.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ENVIRONMENT_POLICY_ID: ${{ inputs.release_environment_policy_id }}
+          SOURCE_PRERELEASE_TAG: ${{ inputs.source_prerelease_tag }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
+        run: ./scripts/promote-stable-preflight.sh
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ steps.provenance.outputs.source_sha }}
+          path: source
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: source/go.mod
+      - name: Verify immutable source checkout
+        working-directory: source
+        env:
+          SOURCE_SHA: ${{ steps.provenance.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          go mod tidy -diff
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+      - name: Recheck immutable source tests
+        working-directory: source
+        run: |
+          go test ./... -count=1
+          go vet ./...
+          go run ./internal/gofmtcheck
+      - name: Mark release distribution snapshot start
+        working-directory: source
+        run: |
+          set -euo pipefail
+          marker="$RUNNER_TEMP/gentle-ai-release-policy-snapshot-start"
+          umask 077
+          printf '%s:%s:%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$GITHUB_JOB" >"$marker"
+          printf 'RELEASE_POLICY_SNAPSHOT_MARKER=%s\n' "$marker" >>"$GITHUB_ENV"
+          printf 'RELEASE_POLICY_SNAPSHOT_RUN_ID=%s:%s:%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$GITHUB_JOB" >>"$GITHUB_ENV"
+      - name: Resolve source distribution plan without publishing
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: v2.15.2
+          workdir: source
+          args: release --snapshot --clean --skip=sign,publish
+        env:
+          MINISIGN_PUBLIC_KEYS_CANONICAL: release-policy-validation-only
+      - name: Verify source distribution policy
+        working-directory: source
+        run: ./scripts/verify-release-distribution-policy.sh
+
+  release:
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    # The operator adds main immediately before dispatch and passes only the
+    # policy ID it created, while the required reviewer gate remains active.
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Create and verify stable tag
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SOURCE_PRERELEASE_TAG: ${{ inputs.source_prerelease_tag }}
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const sourceTag = process.env.SOURCE_PRERELEASE_TAG;
+            const sourceSHA = process.env.SOURCE_SHA;
+            const stableTag = process.env.STABLE_TAG;
+            const absent = async (label, request) => {
+              try { await request(); } catch (error) {
+                if (error.status === 404) return;
+                throw error;
+              }
+              throw new Error(`${label} already exists`);
+            };
+            const sourceRef = await github.rest.git.getRef({ owner, repo, ref: `tags/${sourceTag}` });
+            let source = sourceRef.data.object;
+            if (source.type === 'tag') source = (await github.rest.git.getTag({ owner, repo, tag_sha: source.sha })).data.object;
+            if (source.type !== 'commit' || source.sha !== sourceSHA) throw new Error('source prerelease tag drifted');
+            const sourceRelease = await github.rest.repos.getReleaseByTag({ owner, repo, tag: sourceTag });
+            if (sourceRelease.data.draft || !sourceRelease.data.prerelease || !sourceRelease.data.immutable) throw new Error('source prerelease release drifted');
+            await absent('stable tag', () => github.rest.git.getRef({ owner, repo, ref: `tags/${stableTag}` }));
+            await absent('stable release', () => github.rest.repos.getReleaseByTag({ owner, repo, tag: stableTag }));
+            // GITHUB_TOKEN-created refs do not emit a push workflow run. Using a PAT
+            // or git push here would race release.yml from the RC source tree.
+            const created = await github.rest.git.createTag({ owner, repo, tag: stableTag, message: `Promote ${sourceTag} to ${stableTag}`, object: sourceSHA, type: 'commit' });
+            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${stableTag}`, sha: created.data.sha });
+            const ref = await github.rest.git.getRef({ owner, repo, ref: `tags/${stableTag}` });
+            const tag = await github.rest.git.getTag({ owner, repo, tag_sha: ref.data.object.sha });
+            if (ref.data.object.sha !== created.data.sha || tag.data.tag !== stableTag || tag.data.object.type !== 'commit' || tag.data.object.sha !== sourceSHA) throw new Error('stable tag readback failed');
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ inputs.stable_tag }}
+          path: source
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: source/go.mod
+      - name: Recheck stable tag source
+        working-directory: source
+        env:
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force --quiet origin "refs/tags/$STABLE_TAG:refs/tags/$STABLE_TAG"
+          test "$(git cat-file -t "refs/tags/$STABLE_TAG")" = tag
+          test "$(git rev-parse "refs/tags/$STABLE_TAG^{commit}")" = "$SOURCE_SHA"
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(git describe --tags --exact-match HEAD)" = "$STABLE_TAG"
+          go mod tidy -diff
+      - name: Export canonical release trust anchors
+        id: trust-anchors
+        working-directory: source
+        env:
+          MINISIGN_PUBLIC_KEYS: ${{ vars.MINISIGN_PUBLIC_KEYS }}
+        run: |
+          set -euo pipefail
+          canonical=$(./scripts/canonicalize-release-public-keys.sh)
+          printf 'canonical=%s\n' "$canonical" >>"$GITHUB_OUTPUT"
+      - name: Configure ephemeral signing paths
+        run: |
+          printf 'MINISIGN_SECRET_KEY_FILE=%s/gentle-ai-release.key\n' "$RUNNER_TEMP" >>"$GITHUB_ENV"
+          printf 'MINISIGN_SIGNING_PUBLIC_KEY_FILE=%s/gentle-ai-release-signing.pub\n' "$RUNNER_TEMP" >>"$GITHUB_ENV"
+      - name: Install Minisign
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y minisign
+      - name: Materialize signing key
+        env:
+          SIGNING_KEY_B64: ${{ secrets.MINISIGN_SECRET_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          test -n "$SIGNING_KEY_B64"
+          printf '%s' "$SIGNING_KEY_B64" | base64 --decode >"$MINISIGN_SECRET_KEY_FILE"
+          test -s "$MINISIGN_SECRET_KEY_FILE"
+          chmod 600 "$MINISIGN_SECRET_KEY_FILE"
+      - name: Verify signing credential and identity binding
+        working-directory: source
+        env:
+          GITHUB_REF_NAME: ${{ inputs.stable_tag }}
+          MINISIGN_PUBLIC_KEYS: ${{ vars.MINISIGN_PUBLIC_KEYS }}
+          MINISIGN_PUBLIC_KEYS_CANONICAL: ${{ steps.trust-anchors.outputs.canonical }}
+        run: ./scripts/release-signing-preflight.sh
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: v2.15.2
+          workdir: source
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          MINISIGN_SECRET_KEY_FILE: ${{ env.MINISIGN_SECRET_KEY_FILE }}
+          MINISIGN_PUBLIC_KEYS_CANONICAL: ${{ steps.trust-anchors.outputs.canonical }}
+      - name: Remove signing material
+        if: always()
+        run: |
+          if command -v shred >/dev/null 2>&1; then shred --remove "$MINISIGN_SECRET_KEY_FILE" 2>/dev/null || true; else rm -f "$MINISIGN_SECRET_KEY_FILE"; fi
+          rm -f "$MINISIGN_SIGNING_PUBLIC_KEY_FILE"
+
+  verify:
+    needs: [preflight, release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ inputs.stable_tag }}
+          path: source
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Install Minisign
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y minisign
+      - name: Verify published assets from GitHub
+        working-directory: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REF_NAME: ${{ inputs.stable_tag }}
+          MINISIGN_PUBLIC_KEYS: ${{ vars.MINISIGN_PUBLIC_KEYS }}
+        run: ./scripts/verify-release-assets.sh
+      - name: Verify immutable public provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$STABLE_TAG" | jq -e --arg tag "$STABLE_TAG" '.tag_name == $tag and .draft == false and .prerelease == false and .immutable == true' >/dev/null
+          test "$(git ls-remote origin "refs/tags/$STABLE_TAG^{}" | awk 'NR == 1 { print $1 }')" = "$SOURCE_SHA"
+
+  restore-main-access:
+    needs: [release, verify]
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Require temporary environment-policy restoration
+        env:
+          GH_TOKEN: ${{ github.token }}
+          POLICY_ID: ${{ inputs.release_environment_policy_id }}
+        run: |
+          set -euo pipefail
+          [[ "$POLICY_ID" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/environments/release/deployment-branch-policies/$POLICY_ID" | jq -e '.name == "main" and .type == "branch"' >/dev/null
+          # GITHUB_TOKEN cannot administer environments, so no admin credential enters the publisher.
+          printf 'After this run, remove only the temporary main policy with:\n' >>"$GITHUB_STEP_SUMMARY"
+          printf 'GH_TOKEN=<environment-admin-token> gh api --method DELETE repos/%s/environments/release/deployment-branch-policies/%s\n' "$GITHUB_REPOSITORY" "$POLICY_ID" >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-stable-rc.yml
+++ b/.github/workflows/promote-stable-rc.yml
@@ -1,28 +1,18 @@
 name: Promote stable RC
-
 on:
   workflow_dispatch:
     inputs:
       source_prerelease_tag:
-        description: Canonical immutable RC tag, for example v2.3.0-rc.3
         required: true
-        type: string
       stable_tag:
-        description: Matching canonical stable tag, for example v2.3.0
         required: true
-        type: string
       release_environment_policy_id:
-        description: Temporary release/main deployment-policy ID to remove after publication
         required: true
-        type: string
-
 permissions:
   contents: read
-
 concurrency:
   group: promote-stable-${{ inputs.stable_tag }}
   cancel-in-progress: false
-
 jobs:
   preflight:
     runs-on: ubuntu-24.04
@@ -32,6 +22,7 @@ jobs:
       actions: read
     outputs:
       source_sha: ${{ steps.provenance.outputs.source_sha }}
+      recovery_state: ${{ steps.provenance.outputs.recovery_state }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -64,9 +55,6 @@ jobs:
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           go mod tidy -diff
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
-      - name: Recheck immutable source tests
-        working-directory: source
-        run: |
           go test ./... -count=1
           go vet ./...
           go run ./internal/gofmtcheck
@@ -90,23 +78,23 @@ jobs:
       - name: Verify source distribution policy
         working-directory: source
         run: ./scripts/verify-release-distribution-policy.sh
-
   release:
     needs: preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    # The operator adds main immediately before dispatch and passes only the
-    # policy ID it created, while the required reviewer gate remains active.
+    # The operator adds main immediately before dispatch, retaining reviewers.
     environment: release
     permissions:
       contents: write
     steps:
       - name: Create and verify stable tag
+        id: tag
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SOURCE_PRERELEASE_TAG: ${{ inputs.source_prerelease_tag }}
           SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
           STABLE_TAG: ${{ inputs.stable_tag }}
+          RECOVERY_STATE: ${{ needs.preflight.outputs.recovery_state }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -114,12 +102,13 @@ jobs:
             const sourceTag = process.env.SOURCE_PRERELEASE_TAG;
             const sourceSHA = process.env.SOURCE_SHA;
             const stableTag = process.env.STABLE_TAG;
-            const absent = async (label, request) => {
-              try { await request(); } catch (error) {
-                if (error.status === 404) return;
+            const recovery = process.env.RECOVERY_STATE;
+            const expectedAssets = [`gentle-ai_${stableTag.slice(1)}_darwin_amd64.tar.gz`, `gentle-ai_${stableTag.slice(1)}_darwin_arm64.tar.gz`, `gentle-ai_${stableTag.slice(1)}_linux_amd64.tar.gz`, `gentle-ai_${stableTag.slice(1)}_linux_arm64.tar.gz`, 'checksums.txt', 'checksums.txt.minisig'].sort().join('\n');
+            const optional = async (request) => {
+              try { return await request(); } catch (error) {
+                if (error.status === 404) return null;
                 throw error;
               }
-              throw new Error(`${label} already exists`);
             };
             const sourceRef = await github.rest.git.getRef({ owner, repo, ref: `tags/${sourceTag}` });
             let source = sourceRef.data.object;
@@ -127,15 +116,30 @@ jobs:
             if (source.type !== 'commit' || source.sha !== sourceSHA) throw new Error('source prerelease tag drifted');
             const sourceRelease = await github.rest.repos.getReleaseByTag({ owner, repo, tag: sourceTag });
             if (sourceRelease.data.draft || !sourceRelease.data.prerelease || !sourceRelease.data.immutable) throw new Error('source prerelease release drifted');
-            await absent('stable tag', () => github.rest.git.getRef({ owner, repo, ref: `tags/${stableTag}` }));
-            await absent('stable release', () => github.rest.repos.getReleaseByTag({ owner, repo, tag: stableTag }));
-            // GITHUB_TOKEN-created refs do not emit a push workflow run. Using a PAT
-            // or git push here would race release.yml from the RC source tree.
-            const created = await github.rest.git.createTag({ owner, repo, tag: stableTag, message: `Promote ${sourceTag} to ${stableTag}`, object: sourceSHA, type: 'commit' });
-            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${stableTag}`, sha: created.data.sha });
-            const ref = await github.rest.git.getRef({ owner, repo, ref: `tags/${stableTag}` });
+            let ref = await optional(() => github.rest.git.getRef({ owner, repo, ref: `tags/${stableTag}` }));
+            let release = await optional(() => github.rest.repos.getReleaseByTag({ owner, repo, tag: stableTag }));
+            if (recovery === 'fresh') {
+              if (ref || release) throw new Error('stable state appeared after preflight');
+              // A GITHUB_TOKEN-created ref cannot race release.yml from the RC source tree.
+              const created = await github.rest.git.createTag({ owner, repo, tag: stableTag, message: `Promote ${sourceTag} to ${stableTag}`, object: sourceSHA, type: 'commit' });
+              await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${stableTag}`, sha: created.data.sha });
+              ref = await github.rest.git.getRef({ owner, repo, ref: `tags/${stableTag}` });
+            } else {
+              if (!ref || ref.data.object.type !== 'tag') throw new Error('stable tag recovery identity changed');
+              const existingTag = await github.rest.git.getTag({ owner, repo, tag_sha: ref.data.object.sha });
+              if (existingTag.data.tag !== stableTag || existingTag.data.object.type !== 'commit' || existingTag.data.object.sha !== sourceSHA) throw new Error('stable tag recovery identity changed');
+              if (recovery === 'resume-tag' && release) throw new Error('stable release appeared during tag-only recovery');
+              if (recovery === 'reset-empty-draft') {
+                if (!release || !release.data.draft || release.data.assets.length !== 0) throw new Error('stable draft recovery state changed');
+                await github.rest.repos.deleteRelease({ owner, repo, release_id: release.data.id });
+                release = null;
+              }
+              if (recovery === 'verify-existing' && (!release || release.data.draft || release.data.prerelease || !release.data.immutable || release.data.assets.map((asset) => asset.name).sort().join('\n') !== expectedAssets)) throw new Error('stable published recovery state changed');
+              if (!['resume-tag', 'reset-empty-draft', 'verify-existing'].includes(recovery)) throw new Error('unknown stable recovery state');
+            }
             const tag = await github.rest.git.getTag({ owner, repo, tag_sha: ref.data.object.sha });
-            if (ref.data.object.sha !== created.data.sha || tag.data.tag !== stableTag || tag.data.object.type !== 'commit' || tag.data.object.sha !== sourceSHA) throw new Error('stable tag readback failed');
+            if (tag.data.tag !== stableTag || tag.data.object.type !== 'commit' || tag.data.object.sha !== sourceSHA) throw new Error('stable tag readback failed');
+            core.setOutput('publish', recovery === 'verify-existing' ? 'false' : 'true');
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.stable_tag }}
@@ -157,7 +161,6 @@ jobs:
           test "$(git cat-file -t "refs/tags/$STABLE_TAG")" = tag
           test "$(git rev-parse "refs/tags/$STABLE_TAG^{commit}")" = "$SOURCE_SHA"
           test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
-          test "$(git describe --tags --exact-match HEAD)" = "$STABLE_TAG"
           go mod tidy -diff
       - name: Export canonical release trust anchors
         id: trust-anchors
@@ -169,9 +172,7 @@ jobs:
           canonical=$(./scripts/canonicalize-release-public-keys.sh)
           printf 'canonical=%s\n' "$canonical" >>"$GITHUB_OUTPUT"
       - name: Configure ephemeral signing paths
-        run: |
-          printf 'MINISIGN_SECRET_KEY_FILE=%s/gentle-ai-release.key\n' "$RUNNER_TEMP" >>"$GITHUB_ENV"
-          printf 'MINISIGN_SIGNING_PUBLIC_KEY_FILE=%s/gentle-ai-release-signing.pub\n' "$RUNNER_TEMP" >>"$GITHUB_ENV"
+        run: printf 'MINISIGN_SECRET_KEY_FILE=%s/gentle-ai-release.key\n' "$RUNNER_TEMP" >>"$GITHUB_ENV"; printf 'MINISIGN_SIGNING_PUBLIC_KEY_FILE=%s/gentle-ai-release-signing.pub\n' "$RUNNER_TEMP" >>"$GITHUB_ENV"
       - name: Install Minisign
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y minisign
       - name: Materialize signing key
@@ -180,10 +181,7 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          test -n "$SIGNING_KEY_B64"
-          printf '%s' "$SIGNING_KEY_B64" | base64 --decode >"$MINISIGN_SECRET_KEY_FILE"
-          test -s "$MINISIGN_SECRET_KEY_FILE"
-          chmod 600 "$MINISIGN_SECRET_KEY_FILE"
+          test -n "$SIGNING_KEY_B64"; printf '%s' "$SIGNING_KEY_B64" | base64 --decode >"$MINISIGN_SECRET_KEY_FILE"; test -s "$MINISIGN_SECRET_KEY_FILE"; chmod 600 "$MINISIGN_SECRET_KEY_FILE"
       - name: Verify signing credential and identity binding
         working-directory: source
         env:
@@ -192,6 +190,7 @@ jobs:
           MINISIGN_PUBLIC_KEYS_CANONICAL: ${{ steps.trust-anchors.outputs.canonical }}
         run: ./scripts/release-signing-preflight.sh
       - name: Run GoReleaser
+        if: steps.tag.outputs.publish == 'true'
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: v2.15.2
@@ -199,22 +198,19 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.stable_tag }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           MINISIGN_SECRET_KEY_FILE: ${{ env.MINISIGN_SECRET_KEY_FILE }}
           MINISIGN_PUBLIC_KEYS_CANONICAL: ${{ steps.trust-anchors.outputs.canonical }}
       - name: Remove signing material
         if: always()
-        run: |
-          if command -v shred >/dev/null 2>&1; then shred --remove "$MINISIGN_SECRET_KEY_FILE" 2>/dev/null || true; else rm -f "$MINISIGN_SECRET_KEY_FILE"; fi
-          rm -f "$MINISIGN_SIGNING_PUBLIC_KEY_FILE"
-
+        run: if command -v shred >/dev/null 2>&1; then shred --remove "$MINISIGN_SECRET_KEY_FILE" 2>/dev/null || true; else rm -f "$MINISIGN_SECRET_KEY_FILE"; fi; rm -f "$MINISIGN_SIGNING_PUBLIC_KEY_FILE"
   verify:
     needs: [preflight, release]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
-      actions: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -233,6 +229,7 @@ jobs:
           MINISIGN_PUBLIC_KEYS: ${{ vars.MINISIGN_PUBLIC_KEYS }}
         run: ./scripts/verify-release-assets.sh
       - name: Verify immutable public provenance
+        working-directory: source
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
@@ -241,23 +238,21 @@ jobs:
           set -euo pipefail
           gh api "repos/$GITHUB_REPOSITORY/releases/tags/$STABLE_TAG" | jq -e --arg tag "$STABLE_TAG" '.tag_name == $tag and .draft == false and .prerelease == false and .immutable == true' >/dev/null
           test "$(git ls-remote origin "refs/tags/$STABLE_TAG^{}" | awk 'NR == 1 { print $1 }')" = "$SOURCE_SHA"
-
   restore-main-access:
     needs: [release, verify]
     if: always()
     runs-on: ubuntu-24.04
+    environment: release
     permissions:
-      contents: read
-      actions: read
+      contents: none
     steps:
-      - name: Require temporary environment-policy restoration
+      - name: Restore temporary environment policy
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_ENVIRONMENT_POLICY_TOKEN }}
           POLICY_ID: ${{ inputs.release_environment_policy_id }}
         run: |
           set -euo pipefail
+          test -n "$GH_TOKEN"
           [[ "$POLICY_ID" =~ ^[1-9][0-9]*$ ]]
           gh api "repos/$GITHUB_REPOSITORY/environments/release/deployment-branch-policies/$POLICY_ID" | jq -e '.name == "main" and .type == "branch"' >/dev/null
-          # GITHUB_TOKEN cannot administer environments, so no admin credential enters the publisher.
-          printf 'After this run, remove only the temporary main policy with:\n' >>"$GITHUB_STEP_SUMMARY"
-          printf 'GH_TOKEN=<environment-admin-token> gh api --method DELETE repos/%s/environments/release/deployment-branch-policies/%s\n' "$GITHUB_REPOSITORY" "$POLICY_ID" >>"$GITHUB_STEP_SUMMARY"
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/environments/release/deployment-branch-policies/$POLICY_ID"

--- a/internal/update/release_security_test.go
+++ b/internal/update/release_security_test.go
@@ -75,6 +75,54 @@ func TestReleaseWorkflowUsesFailClosedLeastPrivilegeGates(t *testing.T) {
 	}
 }
 
+func TestStablePromotionWorkflowUsesBoundSourceAndProtectedPublication(t *testing.T) {
+	workflow := readRepositoryFile(t, ".github", "workflows", "promote-stable-rc.yml")
+	for _, required := range []string{
+		"workflow_dispatch:",
+		"source_prerelease_tag:",
+		"stable_tag:",
+		"release_environment_policy_id:",
+		"concurrency:",
+		"./scripts/promote-stable-preflight.sh",
+		"ref: ${{ steps.provenance.outputs.source_sha }}",
+		"workdir: source",
+		"environment: release",
+		"actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
+		"source prerelease tag drifted",
+		"stable tag readback failed",
+		"go mod tidy -diff",
+		"./scripts/release-signing-preflight.sh",
+		"HOMEBREW_TAP_TOKEN",
+		"./scripts/verify-release-assets.sh",
+		".immutable == true",
+		"restore-main-access:",
+		"deployment-branch-policies/$POLICY_ID",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("stable promotion workflow is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"actions/workflows/", "disable"} {
+		if strings.Contains(strings.ToLower(workflow), forbidden) {
+			t.Errorf("stable promotion workflow must not %q", forbidden)
+		}
+	}
+	if regexp.MustCompile(`(?m)^\s*run:.*\bgit push\b`).MatchString(workflow) {
+		t.Error("stable promotion workflow must not push a tag from a shell step")
+	}
+	action := regexp.MustCompile(`^\s*(-\s*)?uses:\s*[^@\s]+@([0-9a-f]{40})(?:\s|$)`)
+	scanner := bufio.NewScanner(strings.NewReader(workflow))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "uses:") && !action.MatchString(line) {
+			t.Errorf("stable promotion action is not pinned to a full commit SHA: %s", strings.TrimSpace(line))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestReleaseAssetVerifierPreservesReadOnlyRotationVerification(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("release verification runtime is Ubuntu-specific")
@@ -215,6 +263,16 @@ func TestReleaseSecurityScriptsAreSyntacticallyValidAndFailClosed(t *testing.T) 
 				`head_sha=$GITHUB_SHA`,
 				`actions/workflows/$workflow_ref/runs`,
 				`[[ "$conclusion" == "success" ]]`,
+			},
+		},
+		{
+			path: "promote-stable-preflight.sh",
+			required: []string{
+				`source prerelease tag must be canonical`,
+				`release environment policy ID is invalid`,
+				`stable tag must be $expected_stable`,
+				`source prerelease release must be immutable, published, and prerelease`,
+				`GITHUB_SHA=$source_sha ./scripts/require-ci-success.sh`,
 			},
 		},
 		{

--- a/internal/update/release_security_test.go
+++ b/internal/update/release_security_test.go
@@ -85,29 +85,27 @@ func TestStablePromotionWorkflowUsesBoundSourceAndProtectedPublication(t *testin
 		"concurrency:",
 		"./scripts/promote-stable-preflight.sh",
 		"ref: ${{ steps.provenance.outputs.source_sha }}",
-		"workdir: source",
+		"reset-empty-draft",
 		"environment: release",
 		"actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
-		"source prerelease tag drifted",
-		"stable tag readback failed",
-		"go mod tidy -diff",
+		"recovery_state",
+		"stable tag recovery identity changed",
+		"test -n \"$GH_TOKEN\"",
 		"./scripts/release-signing-preflight.sh",
-		"HOMEBREW_TAP_TOKEN",
+		"GORELEASER_CURRENT_TAG",
 		"./scripts/verify-release-assets.sh",
-		".immutable == true",
-		"restore-main-access:",
-		"deployment-branch-policies/$POLICY_ID",
+		"stable published recovery state changed",
+		"RELEASE_ENVIRONMENT_POLICY_TOKEN",
+		"--method DELETE",
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Errorf("stable promotion workflow is missing %q", required)
 		}
 	}
-	for _, forbidden := range []string{"actions/workflows/", "disable"} {
-		if strings.Contains(strings.ToLower(workflow), forbidden) {
-			t.Errorf("stable promotion workflow must not %q", forbidden)
-		}
+	if regexp.MustCompile(`(?i)actions/workflows/.*/disable`).MatchString(workflow) {
+		t.Error("stable promotion workflow must not disable the legacy publisher")
 	}
-	if regexp.MustCompile(`(?m)^\s*run:.*\bgit push\b`).MatchString(workflow) {
+	if regexp.MustCompile(`(?m)\bgit push\b`).MatchString(workflow) {
 		t.Error("stable promotion workflow must not push a tag from a shell step")
 	}
 	action := regexp.MustCompile(`^\s*(-\s*)?uses:\s*[^@\s]+@([0-9a-f]{40})(?:\s|$)`)
@@ -269,9 +267,10 @@ func TestReleaseSecurityScriptsAreSyntacticallyValidAndFailClosed(t *testing.T) 
 			path: "promote-stable-preflight.sh",
 			required: []string{
 				`source prerelease tag must be canonical`,
-				`release environment policy ID is invalid`,
-				`stable tag must be $expected_stable`,
-				`source prerelease release must be immutable, published, and prerelease`,
+				`workflow revision is not exact current origin/main`,
+				`stable tag is incompatible with the admitted source`,
+				`stable release state is incompatible with safe recovery`,
+				`recovery_state=%s`,
 				`GITHUB_SHA=$source_sha ./scripts/require-ci-success.sh`,
 			},
 		},

--- a/scripts/promote-stable-preflight.sh
+++ b/scripts/promote-stable-preflight.sh
@@ -53,12 +53,31 @@ jq -e --arg tag "$source_tag" \
   die "source prerelease release must be immutable, published, and prerelease"
 
 # shellcheck disable=SC2016 # GraphQL receives its own $tag variable.
-stable_ref=$(gh api graphql -f 'query=query($tag: String!) { repository(owner: "Gentleman-Programming", name: "gentle-ai") { ref(qualifiedName: $tag) { target { oid } } } }' -f "tag=refs/tags/$stable_tag" --jq '.data.repository.ref.target.oid // empty')
-[[ -z "$stable_ref" ]] || die "stable tag already exists"
-# shellcheck disable=SC2016 # GraphQL receives its own $tag variable.
 stable_release=$(gh api graphql -f 'query=query($tag: String!) { repository(owner: "Gentleman-Programming", name: "gentle-ai") { release(tagName: $tag) { id } } }' -f "tag=$stable_tag" --jq '.data.repository.release.id // empty')
-[[ -z "$stable_release" ]] || die "stable release already exists"
+stable_ref=$(git ls-remote origin "refs/tags/$stable_tag" | awk 'NR == 1 { print $1 }')
+stable_peeled=$(git ls-remote origin "refs/tags/$stable_tag^{}" | awk 'NR == 1 { print $1 }')
+recovery_state=fresh
+if [[ -z "$stable_ref" ]]; then
+  [[ -z "$stable_release" ]] || die "stable release exists without its tag"
+else
+  [[ -n "$stable_peeled" && "$stable_peeled" == "$source_sha" ]] || die "stable tag is incompatible with the admitted source"
+  if [[ -z "$stable_release" ]]; then
+    recovery_state=resume-tag
+  else
+    release=$(gh api "repos/$GITHUB_REPOSITORY/releases/$stable_release") || die "stable release is unavailable"
+    version=${stable_tag#v}
+    if jq -e '.draft == true and (.assets | length) == 0' <<<"$release" >/dev/null; then
+      recovery_state=reset-empty-draft
+    elif jq -e '.draft == false and .prerelease == false and .immutable == true' <<<"$release" >/dev/null &&
+      diff -u <(printf '%s\n' "gentle-ai_${version}_darwin_amd64.tar.gz" "gentle-ai_${version}_darwin_arm64.tar.gz" "gentle-ai_${version}_linux_amd64.tar.gz" "gentle-ai_${version}_linux_arm64.tar.gz" checksums.txt checksums.txt.minisig | LC_ALL=C sort) <(jq -r '.assets[].name' <<<"$release" | LC_ALL=C sort); then
+      recovery_state=verify-existing
+    else
+      die "stable release state is incompatible with safe recovery"
+    fi
+  fi
+fi
 
 GITHUB_SHA=$source_sha ./scripts/require-ci-success.sh
 printf 'source_sha=%s\n' "$source_sha" >>"$GITHUB_OUTPUT"
-printf 'stable promotion preflight: %s promotes %s\n' "$stable_tag" "$source_sha"
+printf 'recovery_state=%s\n' "$recovery_state" >>"$GITHUB_OUTPUT"
+printf 'stable promotion preflight: %s promotes %s (%s)\n' "$stable_tag" "$source_sha" "$recovery_state"

--- a/scripts/promote-stable-preflight.sh
+++ b/scripts/promote-stable-preflight.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'stable promotion preflight: %s\n' "$*" >&2
+  exit 1
+}
+
+require_env() {
+  local name=$1
+  [[ -n "${!name:-}" ]] || die "$name is required"
+}
+
+for name in GITHUB_OUTPUT GITHUB_REF GITHUB_REPOSITORY GITHUB_SHA GH_TOKEN RELEASE_ENVIRONMENT_POLICY_ID SOURCE_PRERELEASE_TAG STABLE_TAG; do
+  require_env "$name"
+done
+
+[[ "$GITHUB_REPOSITORY" == "Gentleman-Programming/gentle-ai" ]] || die "unexpected repository $GITHUB_REPOSITORY"
+[[ "$GITHUB_REF" == "refs/heads/main" ]] || die "promotion must run from main"
+[[ "$RELEASE_ENVIRONMENT_POLICY_ID" =~ ^[1-9][0-9]*$ ]] || die "release environment policy ID is invalid"
+
+source_tag=${SOURCE_PRERELEASE_TAG:?}
+stable_tag=${STABLE_TAG:?}
+if [[ ! "$source_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$ ]]; then
+  die "source prerelease tag must be canonical vMAJOR.MINOR.PATCH-rc.N"
+fi
+expected_stable="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+[[ "$stable_tag" == "$expected_stable" ]] || die "stable tag must be $expected_stable for $source_tag"
+
+git fetch --no-tags --quiet origin '+refs/heads/main:refs/remotes/origin/main'
+[[ "$(git rev-parse "$GITHUB_SHA^{commit}")" == "$(git rev-parse 'refs/remotes/origin/main^{commit}')" ]] ||
+  die "workflow revision is not exact current origin/main"
+
+mapfile -t refs < <(git ls-remote origin "refs/tags/$source_tag" "refs/tags/$source_tag^{}")
+(( ${#refs[@]} > 0 && ${#refs[@]} < 3 )) || die "source prerelease tag has an invalid remote identity"
+direct_sha=
+peeled_sha=
+for ref in "${refs[@]}"; do
+  sha=${ref%%$'\t'*}
+  name=${ref#*$'\t'}
+  case "$name" in
+    "refs/tags/$source_tag") [[ -z "$direct_sha" ]] || die "source prerelease tag is duplicated"; direct_sha=$sha ;;
+    "refs/tags/$source_tag^{}") [[ -z "$peeled_sha" ]] || die "source prerelease tag peel is duplicated"; peeled_sha=$sha ;;
+    *) die "source prerelease tag has an unexpected remote ref" ;;
+  esac
+done
+source_sha=${peeled_sha:-$direct_sha}
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || die "source prerelease tag does not resolve to a commit"
+
+release=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$source_tag") || die "source prerelease release is unavailable"
+jq -e --arg tag "$source_tag" \
+  '.tag_name == $tag and .draft == false and .prerelease == true and .immutable == true' <<<"$release" >/dev/null ||
+  die "source prerelease release must be immutable, published, and prerelease"
+
+# shellcheck disable=SC2016 # GraphQL receives its own $tag variable.
+stable_ref=$(gh api graphql -f 'query=query($tag: String!) { repository(owner: "Gentleman-Programming", name: "gentle-ai") { ref(qualifiedName: $tag) { target { oid } } } }' -f "tag=refs/tags/$stable_tag" --jq '.data.repository.ref.target.oid // empty')
+[[ -z "$stable_ref" ]] || die "stable tag already exists"
+# shellcheck disable=SC2016 # GraphQL receives its own $tag variable.
+stable_release=$(gh api graphql -f 'query=query($tag: String!) { repository(owner: "Gentleman-Programming", name: "gentle-ai") { release(tagName: $tag) { id } } }' -f "tag=$stable_tag" --jq '.data.repository.release.id // empty')
+[[ -z "$stable_release" ]] || die "stable release already exists"
+
+GITHUB_SHA=$source_sha ./scripts/require-ci-success.sh
+printf 'source_sha=%s\n' "$source_sha" >>"$GITHUB_OUTPUT"
+printf 'stable promotion preflight: %s promotes %s\n' "$stable_tag" "$source_sha"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1860

---

## 🏷️ PR Type

- [x] `type:chore` — Build, CI, or tooling changes

---

## 📝 Summary

- Adds a protected manual promotion path that binds a canonical RC tag to its matching stable tag and immutable source SHA.
- Rebuilds, signs, publishes, verifies, and updates Homebrew from the exact RC checkout without using current-main product bytes.
- Creates the stable annotated tag with `GITHUB_TOKEN`, preserving the legacy publisher without disabling it, and records the exact temporary environment-policy restoration command.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `.github/workflows/promote-stable-rc.yml` | Protected manual promotion, source-bound package/release verification, and restoration reminder |
| `scripts/promote-stable-preflight.sh` | Canonical input, immutable release, exact-CI, remote source identity, and idempotency gates |
| `internal/update/release_security_test.go` | Promotion workflow and fail-closed script contract guards |

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `actionlint`
- [x] `shellcheck scripts/promote-stable-preflight.sh`
- [x] Read-only RC3 preflight verified immutable release, exact SHA, complete CI, and absent stable state.
- [x] Isolated RC3 GoReleaser snapshot built all Linux/macOS archives and passed distribution policy validation.
- [x] E2E is gated by the required complete CI run for the exact RC SHA; no product runtime path changed here.
- [x] Benchmark validation is N/A: no `bench/`, journey, or product-semantic path changed.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 385 additions
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E coverage is provided by the exact RC CI gate
- [x] Benchmark validation is not applicable
- [x] Documentation is embedded with the protected operational restoration step
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for promoting validated prereleases to stable releases.
  * Added preflight checks for source tags, release status, repository state, policies, and CI results.
  * Added protected stable-tag creation, signed release publishing, and asset verification.
  * Added configurable release environment policies and stable promotion inputs.
  * Added recovery handling for interrupted or partially completed promotions.

* **Tests**
  * Added security coverage for promotion controls, protected publishing, prohibited operations, and action pinning.
  * Added validation for stable promotion preflight checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->