### PR TITLE
fix(review): publish lens-bound finding ID prefixes with the admission contract

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -185,12 +185,20 @@ func reviewNegotiatedStartCommand(snapshot reviewtransaction.Snapshot, runtimeAg
 type ReviewFacadeLensBinding struct {
 	Lens  string `json:"lens"`
 	Order int    `json:"order"`
+	// FindingIDPrefix is the prefix admission requires for explicit finding
+	// IDs bound to this lens. It follows the lens, not the selection order:
+	// high-risk START selects review-resilience at order 1, but its explicit
+	// IDs must still carry R4-.
+	FindingIDPrefix string `json:"finding_id_prefix"`
 }
 
 func facadeLensBindings(lenses []string) []ReviewFacadeLensBinding {
 	bindings := make([]ReviewFacadeLensBinding, len(lenses))
 	for order, lens := range lenses {
-		bindings[order] = ReviewFacadeLensBinding{Lens: lens, Order: order}
+		bindings[order] = ReviewFacadeLensBinding{
+			Lens: lens, Order: order,
+			FindingIDPrefix: reviewtransaction.FindingIDPrefixForLens(lens),
+		}
 	}
 	return bindings
 }

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -21,6 +21,35 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
 )
 
+// TestFacadeLensBindingsPublishFindingIDPrefix proves START output carries the
+// lens-bound finding-ID prefix admission enforces, in the canonical high-risk
+// selection order where lens order and prefix number diverge.
+func TestFacadeLensBindingsPublishFindingIDPrefix(t *testing.T) {
+	lenses := []string{
+		reviewtransaction.LensRisk,
+		reviewtransaction.LensResilience,
+		reviewtransaction.LensReadability,
+		reviewtransaction.LensReliability,
+	}
+	bindings := facadeLensBindings(lenses)
+	if len(bindings) != len(lenses) {
+		t.Fatalf("facadeLensBindings() = %#v, want one binding per lens %v", bindings, lenses)
+	}
+	for index, binding := range bindings {
+		want := reviewtransaction.FindingIDPrefixForLens(lenses[index])
+		if want == "" || binding.FindingIDPrefix != want {
+			t.Fatalf("binding[%d] finding ID prefix = %q, want %q for lens %q", index, binding.FindingIDPrefix, want, lenses[index])
+		}
+	}
+	encoded, err := json.Marshal(bindings[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"finding_id_prefix":"R4-"`) {
+		t.Fatalf("binding JSON = %s, want published finding_id_prefix R4- for %q", encoded, reviewtransaction.LensResilience)
+	}
+}
+
 func TestReviewFacadeStartStagedProjectionFreezesOnlyIndex(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))

--- a/internal/reviewtransaction/reviewer_envelope.go
+++ b/internal/reviewtransaction/reviewer_envelope.go
@@ -17,7 +17,7 @@ import (
 // Three independent prose copies of this envelope are what let a lens agent
 // emit findings/evidence with no subject_hash and no inspection (community
 // report, PR #1801).
-const ReviewerResultSchema = `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://gentle-ai.dev/schema/review/reviewer/v1","title":"Gentle AI reviewer result","type":"object","additionalProperties":false,"required":["subject_hash","inspection","findings","evidence"],"properties":{"subject_hash":{"type":"string","pattern":"^sha256:[0-9a-f]{64}$"},"inspection":{"type":"object","additionalProperties":false,"required":["status","paths"],"properties":{"status":{"const":"completed"},"paths":{"type":"array","description":"Complete unique unordered set of every changed_path_manifest.path.","uniqueItems":true,"items":{"type":"string","minLength":1}}}},"lens":{"type":"string","enum":["risk","resilience","readability","reliability","review-risk","review-resilience","review-readability","review-reliability"]},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["location","severity","claim","proof_refs"],"allOf":[{"if":{"properties":{"severity":{"enum":["BLOCKER","CRITICAL"]}},"required":["severity"]},"then":{"required":["evidence_class","causal_disposition"]}}],"properties":{"id":{"type":"string","pattern":"^R[1-4]-[A-Za-z0-9][A-Za-z0-9._-]*$"},"lens":{"type":"string","enum":["risk","resilience","readability","reliability"]},"location":{"type":"string","description":"One canonical repository-relative path:line or inclusive path:start-end span.","pattern":"^.+:[1-9][0-9]*(?:-[1-9][0-9]*)?$"},"severity":{"type":"string","enum":["BLOCKER","CRITICAL","WARNING","SUGGESTION"]},"claim":{"type":"string","minLength":1},"proof_refs":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S","not":{"pattern":"^\\s*(?:[nN]/[aA]|[nN][aA]|[nN][oO][nN][eE]|[tT][oO][dD][oO]|[tT][bB][dD]|[pP][aA][sS][sS]|[pP][aA][sS][sS][eE][dD]|[sS][uU][cC][cC][eE][sS][sS]|[pP][lL][aA][cC][eE][hH][oO][lL][dD][eE][rR])\\s*$"}}},"evidence_class":{"type":"string","enum":["deterministic","inferential","insufficient"]},"causal_disposition":{"type":"string","enum":["introduced","behavior-activated","worsened","pre-existing","base-only","unknown"]}}}},"evidence":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S","not":{"pattern":"^\\s*(?:[nN]/[aA]|[nN][aA]|[nN][oO][nN][eE]|[tT][oO][dD][oO]|[tT][bB][dD]|[pP][aA][sS][sS]|[pP][aA][sS][sS][eE][dD]|[sS][uU][cC][cC][eE][sS][sS]|[pP][lL][aA][cC][eE][hH][oO][lL][dD][eE][rR])\\s*$"}}}},"examples":[{"subject_hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000","inspection":{"status":"completed","paths":["internal/example.go"]},"findings":[],"evidence":["reviewed the complete candidate scope"]}]}`
+const ReviewerResultSchema = `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://gentle-ai.dev/schema/review/reviewer/v1","title":"Gentle AI reviewer result","type":"object","additionalProperties":false,"required":["subject_hash","inspection","findings","evidence"],"properties":{"subject_hash":{"type":"string","pattern":"^sha256:[0-9a-f]{64}$"},"inspection":{"type":"object","additionalProperties":false,"required":["status","paths"],"properties":{"status":{"const":"completed"},"paths":{"type":"array","description":"Complete unique unordered set of every changed_path_manifest.path.","uniqueItems":true,"items":{"type":"string","minLength":1}}}},"lens":{"type":"string","enum":["risk","resilience","readability","reliability","review-risk","review-resilience","review-readability","review-reliability"]},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["location","severity","claim","proof_refs"],"allOf":[{"if":{"properties":{"severity":{"enum":["BLOCKER","CRITICAL"]}},"required":["severity"]},"then":{"required":["evidence_class","causal_disposition"]}}],"properties":{"id":{"type":"string","pattern":"^R[1-4]-[A-Za-z0-9][A-Za-z0-9._-]*$","description":"Optional explicit ID; omit it to receive a native-assigned ID. When present it must carry the prefix bound to the selected lens, not the selection order: review-risk=R1-, review-readability=R2-, review-reliability=R3-, review-resilience=R4-."},"lens":{"type":"string","enum":["risk","resilience","readability","reliability"]},"location":{"type":"string","description":"One canonical repository-relative path:line or inclusive path:start-end span.","pattern":"^.+:[1-9][0-9]*(?:-[1-9][0-9]*)?$"},"severity":{"type":"string","enum":["BLOCKER","CRITICAL","WARNING","SUGGESTION"]},"claim":{"type":"string","minLength":1},"proof_refs":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S","not":{"pattern":"^\\s*(?:[nN]/[aA]|[nN][aA]|[nN][oO][nN][eE]|[tT][oO][dD][oO]|[tT][bB][dD]|[pP][aA][sS][sS]|[pP][aA][sS][sS][eE][dD]|[sS][uU][cC][cC][eE][sS][sS]|[pP][lL][aA][cC][eE][hH][oO][lL][dD][eE][rR])\\s*$"}}},"evidence_class":{"type":"string","enum":["deterministic","inferential","insufficient"]},"causal_disposition":{"type":"string","enum":["introduced","behavior-activated","worsened","pre-existing","base-only","unknown"]}}}},"evidence":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S","not":{"pattern":"^\\s*(?:[nN]/[aA]|[nN][aA]|[nN][oO][nN][eE]|[tT][oO][dD][oO]|[tT][bB][dD]|[pP][aA][sS][sS]|[pP][aA][sS][sS][eE][dD]|[sS][uU][cC][cC][eE][sS][sS]|[pP][lL][aA][cC][eE][hH][oO][lL][dD][eE][rR])\\s*$"}}}},"examples":[{"subject_hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000","inspection":{"status":"completed","paths":["internal/example.go"]},"findings":[],"evidence":["reviewed the complete candidate scope"]}]}`
 
 // ReviewerResultEnvelope is the machine-readable summary of what admission
 // demands of a reviewer result, parsed out of ReviewerResultSchema. Callers
@@ -137,6 +137,21 @@ func requiredReviewerResultFields(fields map[string]json.RawMessage) bool {
 	return true
 }
 
+// findingIDPrefixByLens is the single authoritative lens→finding-ID-prefix
+// mapping: admission enforces it and START publishes it, so the two can never
+// drift apart.
+var findingIDPrefixByLens = map[string]string{
+	LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-",
+}
+
+// FindingIDPrefixForLens returns the prefix an explicit finding ID must carry
+// to be admitted for the given lens, or "" for an unsupported lens. The
+// published reviewer schema regex admits any R[1-4]- prefix, so this mapping
+// is the only machine-readable source of the per-lens namespace.
+func FindingIDPrefixForLens(lens string) string {
+	return findingIDPrefixByLens[lens]
+}
+
 // canonicalReviewerResult contains the result-shape checks shared by native
 // admission and read-only advisory transport validation.
 func canonicalReviewerResult(result LensResult, expectedLens string) (LensResult, error) {
@@ -150,7 +165,7 @@ func canonicalReviewerResult(result LensResult, expectedLens string) (LensResult
 			message:  "reviewer result is not bound to the selected lens",
 		}
 	}
-	wantPrefix := map[string]string{LensRisk: "R1-", LensReadability: "R2-", LensReliability: "R3-", LensResilience: "R4-"}[canonical.Lens]
+	wantPrefix := FindingIDPrefixForLens(canonical.Lens)
 	for _, finding := range canonical.Findings {
 		if !artifactFindingID.MatchString(finding.ID) {
 			return LensResult{}, &reviewerResultShapeError{
@@ -161,7 +176,7 @@ func canonicalReviewerResult(result LensResult, expectedLens string) (LensResult
 		if !strings.HasPrefix(finding.ID, wantPrefix) {
 			return LensResult{}, &reviewerResultShapeError{
 				decision: ArtifactAdmissionBindingMismatch,
-				message:  "reviewer finding ID is not bound to the selected lens",
+				message:  fmt.Sprintf("reviewer finding ID is not bound to the selected lens: expected_prefix=%s received_id=%s", wantPrefix, finding.ID),
 			}
 		}
 		if isSevereSeverity(finding.Severity) && (!isSupportedEvidenceClass(finding.EvidenceClass) || !isSupportedCausalDisposition(finding.CausalDisposition)) {

--- a/internal/reviewtransaction/reviewer_envelope_test.go
+++ b/internal/reviewtransaction/reviewer_envelope_test.go
@@ -86,6 +86,51 @@ func TestSchemaExampleShapedResultIsAdmitted(t *testing.T) {
 	}
 }
 
+// TestFindingIDPrefixForLensPublishesAdmissionMapping pins the exported
+// lens→prefix mapping to the exact prefixes admission enforces, so START can
+// publish the same namespace the published regex leaves ambiguous.
+func TestFindingIDPrefixForLensPublishesAdmissionMapping(t *testing.T) {
+	want := map[string]string{
+		LensRisk:        "R1-",
+		LensReadability: "R2-",
+		LensReliability: "R3-",
+		LensResilience:  "R4-",
+	}
+	for _, lens := range supportedLenses {
+		if got := FindingIDPrefixForLens(lens); got != want[lens] {
+			t.Fatalf("FindingIDPrefixForLens(%q) = %q, want %q", lens, got, want[lens])
+		}
+	}
+	if got := FindingIDPrefixForLens("review-unknown"); got != "" {
+		t.Fatalf("FindingIDPrefixForLens(unknown) = %q, want empty", got)
+	}
+
+	// The published schema is the only artifact a reviewer reads before
+	// submitting, so its explicit-ID property must name the same mapping.
+	var document struct {
+		Properties struct {
+			Findings struct {
+				Items struct {
+					Properties struct {
+						ID struct {
+							Description string `json:"description"`
+						} `json:"id"`
+					} `json:"properties"`
+				} `json:"items"`
+			} `json:"findings"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(ReviewerResultSchema), &document); err != nil {
+		t.Fatal(err)
+	}
+	description := document.Properties.Findings.Items.Properties.ID.Description
+	for lens, prefix := range want {
+		if !strings.Contains(description, lens+"="+prefix) {
+			t.Fatalf("schema finding id description %q does not publish %s=%s", description, lens, prefix)
+		}
+	}
+}
+
 func TestValidateReviewerResultMatchesNativeAdmissionShape(t *testing.T) {
 	subject, frozen, request := admittedArtifactFixture(t)
 	base := ReviewerResult{
@@ -111,6 +156,9 @@ func TestValidateReviewerResultMatchesNativeAdmissionShape(t *testing.T) {
 		{name: "binding hash", mutate: func(result *ReviewerResult) { result.SubjectHash = "sha256:" + strings.Repeat("0", 64) }, wantErr: true},
 		{name: "selected lens", mutate: func(result *ReviewerResult) { result.Lens = LensRisk }, wantErr: true},
 		{name: "missing lens binding", mutate: func(result *ReviewerResult) { result.Lens = "" }, wantErr: true},
+		{name: "foreign lens prefix names expected and received", mutate: func(result *ReviewerResult) {
+			result.Findings[0].ID = "R2-001"
+		}, wantErr: true, wantMessage: "reviewer finding ID is not bound to the selected lens: expected_prefix=R3- received_id=R2-001"},
 		{name: "missing frozen path", mutate: func(result *ReviewerResult) { result.Inspection.Paths = result.Inspection.Paths[:1] }, wantErr: true, wantMessage: "reviewer inspection coverage: missing_frozen_manifest_paths=1"},
 		{name: "foreign path", mutate: func(result *ReviewerResult) {
 			result.Inspection.Paths = append(result.Inspection.Paths, "outside/private.go")

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -369,7 +369,7 @@ func canonicalLensResult(result LensResult, allowMissingSevereLocation bool) (Le
 		return LensResult{}, errors.New("lens result requires explicit findings and concrete evidence")
 	}
 	wantFindingLens := strings.TrimPrefix(result.Lens, "review-")
-	idPrefix := map[string]string{LensRisk: "R1", LensReadability: "R2", LensReliability: "R3", LensResilience: "R4"}[result.Lens]
+	idPrefix := strings.TrimSuffix(FindingIDPrefixForLens(result.Lens), "-")
 	findings := make([]Finding, len(result.Findings))
 	for index, finding := range result.Findings {
 		finding.ID = strings.TrimSpace(finding.ID)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1844

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Reviewer artifact admission enforces a hard-coded finding-ID prefix per lens (`review-risk=R1-`, `review-readability=R2-`, `review-reliability=R3-`, `review-resilience=R4-`), but neither the published reviewer schema nor START output exposed that mapping, and the `binding_mismatch` diagnostic did not say which prefix was expected. Because high-risk START selects lenses in a different order than the prefix numbering (`review-resilience` at order 1 needs `R4-`), a reviewer could build a schema-valid artifact that native admission rejects with no discoverable reason outside the source code.

This PR publishes the mapping everywhere the contract is read, keeps a single authoritative copy of it in source, and makes the rejection self-explanatory:

1. **Single source**: `reviewtransaction.FindingIDPrefixForLens()` is now the one mapping; admission (`reviewer_envelope.go`) and native ID assignment (`transaction.go`, which had a second dash-less copy of the same map) both derive from it.
2. **START publishes it**: every `lens_bindings` entry now carries `finding_id_prefix` (additive JSON field).
3. **Actionable error**: the `binding_mismatch` diagnostic now names `expected_prefix` and `received_id`.
4. **Schema documents it**: the published reviewer schema's finding `id` property description states the per-lens mapping and that omitting the ID yields a native-assigned one.

**Intentionally out of scope**: the negotiated v2 START envelope (`artifact_subjects`, `additionalProperties: false`) is unchanged. Extending `artifact-subject.schema.json` has subject-hashing implications and deserves its own scoped change if maintainers want the prefix there too.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/reviewer_envelope.go` | Exported `FindingIDPrefixForLens()` as the single authoritative mapping; admission uses it; `binding_mismatch` message now includes `expected_prefix`/`received_id`; schema `id` description documents the namespace |
| `internal/reviewtransaction/transaction.go` | Native ID assignment derives its prefix from the shared mapping instead of a second in-place map copy |
| `internal/cli/review_facade.go` | `ReviewFacadeLensBinding` publishes `finding_id_prefix` (additive field) |
| `internal/reviewtransaction/reviewer_envelope_test.go` | New test pinning the exported mapping and the schema description; new admission case asserting the enriched diagnostic |
| `internal/cli/review_facade_test.go` | New test proving bindings publish the prefix in canonical high-risk order (where lens order and prefix number diverge) |

---

## 🧪 Test Plan

Followed strict TDD: each test was written first and shown failing before its fix piece landed.

**Unit Tests**
```bash
go test ./... -count=1
```
Run twice for an A/B regression comparison on macOS ARM64 (Darwin 25.5.0):
- **With this change**: 27 failing tests.
- **Baseline (change stashed)**: 27 failing tests.
- `comm` on the sorted, normalized failing-test-name sets in both directions: **empty both ways** — the sets are identical. All 27 are pre-existing environmental failures on this host (predominantly `internal/reviewtransaction` "review store lock could not be acquired: not a directory", plus known failures in `advisoryreview`, `components/engram`, `sddstatus`, and `update`), none in the packages' tests touched here.

Targeted suites pass:
```bash
go test ./internal/reviewtransaction/ -run 'TestFindingIDPrefix|TestValidateReviewerResult|TestReviewerResultEnvelope|TestSchemaExample'  # ok
go test ./internal/cli/ -run 'TestFacadeLensBindings'  # ok
go test ./internal/cli -run TestEveryRegisteredGuardPopulationDeclarationMatchesProduction -count=1  # ok, baseline unchanged
```

**Go Format**
```bash
go run ./internal/gofmtcheck  # clean
go vet ./internal/reviewtransaction/ ./internal/cli/  # clean
```

**E2E Tests** (Docker required)

Not run locally (no Docker on this machine) — declared honestly rather than ticked. Relying on the CI E2E job.

**Benchmark Validation**

N/A in driven mode: this change does not alter lens selection, risk classification, budgets, gate decisions, or any lifecycle transition. It adds one additive JSON field to START output, enriches one diagnostic string, and documents an existing constraint in the published schema. No benchmark journey asserts the absence of `finding_id_prefix` or the exact `binding_mismatch` wording.

- [x] Unit tests pass (`go test ./...`) — A/B-identical failing set; all failures pre-existing and environmental, see above
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally, deferring to CI
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (110 total: 105 additions + 5 deletions)
- [ ] I have added the appropriate `type:*` label to this PR — **external contributors cannot apply labels; requesting `type:bug` from a maintainer below**
- [x] Unit tests pass (`go test ./...`) — see A/B evidence in Test Plan
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferring to CI, no local Docker
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan)
- [x] I have updated documentation if necessary (the published schema description is the consumer-facing documentation for this contract)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The `binding_mismatch` prefix check in `canonicalReviewerResult` is an admission-shape check, not a registered guard-population family: `TestEveryRegisteredGuardPopulationDeclarationMatchesProduction` passes with `.guard-population-baseline.txt` unchanged.
- `finding_id_prefix` cannot leak into the negotiated v2 START envelope: `ReviewIntegrationStartResult` is a separate struct that never carried `lens_bindings`, and no published contract or fixture pins the legacy binding's field set (verified by searching `contracts/`, `docs/`, and `internal/assets/`).
- `FindingIDPrefixForLens` returns `""` for the short lens forms (`"risk"`, …) exactly as the old inline maps did, so `canonicalLensResult` behavior for those forms is byte-identical.

**Maintainer request**: please apply the `type:bug` label — external contributors cannot self-apply labels.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence — no qualifying guard family is touched; the modified message lives inside an existing admission check whose decision logic is unchanged.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed — baseline unchanged, declaration test passes.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reviewer results now include the finding-ID prefix associated with the selected lens.
  * Finding-ID validation provides clearer errors when a finding uses an incorrect prefix.
  * Published schemas document the required prefix for explicit finding IDs.

* **Bug Fixes**
  * Finding IDs are now consistently generated and validated using the correct lens-specific prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->