### PR TITLE
fix(sdd): carry the provider cause in the task failure envelope

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -519,6 +519,14 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 		`"sdd_task_result_malformed"`,
 		`failedSDDSessions`,
 		`extractionClass(cause, "sddClass")`,
+		// #2677: an empty result means the child produced no output at all
+		// (for example a provider rejection before generation), and the
+		// handoff must say so and carry the one causal fact the hook
+		// receives -- the child's provider/model route -- after validation.
+		`function taskRouteModel(`,
+		`produced no task output at all`,
+		`provider rejected the request before generation (authentication, region, or model access)`,
+		`taskRouteModel(metadata)`,
 		`export default ReviewResultArtifactsPlugin`,
 	} {
 		if !strings.Contains(source, want) {

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -132,9 +132,55 @@ type SDDTaskFailureError = Error & { sddFailure: SDDTaskFailure }
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
-function sddTaskFailure(phase: string, cwd: string, cause: unknown): SDDTaskFailureError {
+// SDD_TASK_ROUTE_TOKEN bounds one provider or model identifier before it may
+// enter the failure handoff. The hook cannot see the child session's own
+// provider failure -- a pre-inference rejection (for example an HTTP 403
+// region refusal, #2677) is recorded on the child session record, which this
+// plugin deliberately cannot query since the client argument was removed --
+// so the child's model route from the task result metadata is the one causal
+// fact available at this boundary. A value is carried only when it looks
+// like a plain route identifier; anything with separators, whitespace, or
+// path shapes is omitted entirely rather than truncated, so hostile or
+// accidental metadata (absolute paths, provider dumps) never reaches the
+// session transcript.
+const SDD_TASK_ROUTE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/
+
+// taskRouteModel extracts the child task's provider/model route from the
+// task tool's result metadata ({parentSessionId, sessionId, model:
+// {providerID, modelID}}), or undefined when the metadata does not carry a
+// valid route. Absence is tolerated, never invented: the handoff simply
+// omits the field.
+function taskRouteModel(metadata: unknown): string | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined
+  const model = (metadata as Record<string, unknown>).model
+  if (!model || typeof model !== "object" || Array.isArray(model)) return undefined
+  const providerID = (model as Record<string, unknown>).providerID
+  const modelID = (model as Record<string, unknown>).modelID
+  if (typeof providerID !== "string" || typeof modelID !== "string") return undefined
+  if (!SDD_TASK_ROUTE_TOKEN.test(providerID) || !SDD_TASK_ROUTE_TOKEN.test(modelID)) return undefined
+  return `${providerID}/${modelID}`
+}
+
+// sddTaskFailure builds the terminal transport handoff for one failed SDD
+// phase task. Two different truths get two different summaries (#2677): an
+// empty result means the child task produced no output at all -- observed
+// when the provider rejects the request before generation (authentication,
+// region, or model access), when the task is interrupted, or when a phase
+// genuinely writes nothing -- while a malformed result means the child did
+// produce output that failed the envelope contract. The old single summary
+// claimed "no valid task result" for both, which hid that in the empty case
+// the child never ran inference at all.
+function sddTaskFailure(phase: string, cwd: string, cause: unknown, metadata?: unknown): SDDTaskFailureError {
   const classification = extractionClass(cause, "sddClass")
-  const code = classification === "empty_result" ? "sdd_task_result_empty" : "sdd_task_result_malformed"
+  const empty = classification === "empty_result"
+  const code = empty ? "sdd_task_result_empty" : "sdd_task_result_malformed"
+  const taskModel = taskRouteModel(metadata)
+  const guidance = "Do not retry or advance SDD; inspect the existing artifact state and surface the terminal failure to the user."
+  const summary = empty
+    ? `${phase} produced no task output at all. The child task returned nothing, which most often means the ` +
+      "provider rejected the request before generation (authentication, region, or model access), the task was " +
+      `interrupted, or the phase genuinely wrote nothing. ${guidance}`
+    : `${phase} returned no valid task result. ${guidance}`
   const failure: SDDTaskFailure = {
     phase,
     code,
@@ -143,7 +189,8 @@ function sddTaskFailure(phase: string, cwd: string, cause: unknown): SDDTaskFail
       status: "blocked",
       code,
       phase,
-      summary: `${phase} returned no valid task result. Do not retry or advance SDD; inspect the existing artifact state and surface the terminal failure to the user.`,
+      ...(taskModel === undefined ? {} : { taskModel }),
+      summary,
       continuation: `gentle-ai sdd-status --cwd ${shellQuote(cwd)} --json`,
     }),
   }
@@ -334,7 +381,7 @@ const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => {
       try {
         taskResult(output.output, "SDD phase", "sddClass")
       } catch (cause) {
-        const failure = sddTaskFailure(subagent, captureCwd(worktree, directory), cause)
+        const failure = sddTaskFailure(subagent, captureCwd(worktree, directory), cause, output.metadata)
         failedSDDSessions.set(input.sessionID, failure.sddFailure)
         throw failure
       }

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -76,7 +76,17 @@ try {
     const artifact = cwd + "/proposal.md"
     await writeFile(artifact, "existing artifact")
     const input = { tool: "task", sessionID: "sdd-session", callID: "call-sdd", args: { subagent_type: phase, prompt: "phase work" } }
-    const output = { title: "", output: result, metadata: {} }
+    // The task tool's real result metadata carries the child route
+    // ({parentSessionId, sessionId, model: {providerID, modelID}}); the
+    // hostile shape proves path-like or dump-like values are omitted from
+    // the handoff entirely, and the no-model shape proves absence is
+    // tolerated rather than invented.
+    const metadata = scenario.includes("hostile-model")
+      ? { sessionId: "child", model: { providerID: "/home/user/secret-provider", modelID: "x".repeat(400) + " RegionError: request rejected" } }
+      : scenario.includes("no-model")
+        ? {}
+        : { parentSessionId: "sdd-session", sessionId: "child", model: { providerID: "opencode-go", modelID: "deepseek-v4-flash" } }
+    const output = { title: "", output: result, metadata }
     let failure = "NO_ERROR"
     try { await hooks["tool.execute.after"](input, output) } catch (cause: unknown) { failure = cause instanceof Error ? cause.message : String(cause) }
     if (scenario === "sdd-lifecycle") {
@@ -255,6 +265,17 @@ func TestReviewPluginRejectsMissingOrMalformedBindingBeforeReviewerLaunch(t *tes
 	}
 }
 
+// sddEmptySummaryFragment is the truthful empty-result summary (#2677): an
+// empty result means the child task produced no output at all -- observed
+// when the provider rejects the request before generation -- and the summary
+// must say so instead of claiming the child "returned no valid task result".
+const sddEmptySummaryFragment = "produced no task output at all"
+
+// sddEmptyCauseFragment names the likeliest cause class for a child that
+// produced nothing, so the operator is pointed at the provider boundary
+// rather than at the phase's artifact contract.
+const sddEmptyCauseFragment = "provider rejected the request before generation (authentication, region, or model access)"
+
 func TestSDDTaskResultFailuresAreTerminalAndScoped(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -262,9 +283,32 @@ func TestSDDTaskResultFailuresAreTerminalAndScoped(t *testing.T) {
 		wantCode    string
 		wantPhase   string
 		wantBlocked bool
+		wantSummary string
+		wantModel   string
+		forbid      []string
 	}{
-		{name: "empty unsuffixed phase", scenario: "sdd-empty", wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true},
-		{name: "malformed profile-suffixed phase", scenario: "sdd-profile-malformed", wantCode: "sdd_task_result_malformed", wantPhase: "sdd-propose-cheap", wantBlocked: true},
+		{
+			name: "empty unsuffixed phase", scenario: "sdd-empty",
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true,
+			wantSummary: sddEmptySummaryFragment, wantModel: "opencode-go/deepseek-v4-flash",
+		},
+		{
+			name: "empty phase without model metadata", scenario: "sdd-empty-no-model",
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true,
+			wantSummary: sddEmptySummaryFragment,
+		},
+		{
+			name: "empty phase with hostile model metadata", scenario: "sdd-empty-hostile-model",
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true,
+			wantSummary: sddEmptySummaryFragment,
+			forbid:      []string{"/home/user/secret-provider", "RegionError", "xxxxxxxxxx"},
+		},
+		{
+			name: "malformed profile-suffixed phase", scenario: "sdd-profile-malformed",
+			wantCode: "sdd_task_result_malformed", wantPhase: "sdd-propose-cheap", wantBlocked: true,
+			wantSummary: "returned no valid task result", wantModel: "opencode-go/deepseek-v4-flash",
+			forbid: []string{sddEmptySummaryFragment},
+		},
 		{name: "unrelated sdd-prefixed agent", scenario: "sdd-unrelated", wantCode: "NO_ERROR"},
 	}
 	for _, tt := range tests {
@@ -283,8 +327,13 @@ func TestSDDTaskResultFailuresAreTerminalAndScoped(t *testing.T) {
 				t.Fatalf("downstream SDD launch was not terminally blocked: %q", parts[1])
 			}
 			if tt.wantBlocked {
-				assertSDDTaskResultHandoff(t, parts[0], tt.wantCode, tt.wantPhase)
-				assertSDDTaskResultHandoff(t, parts[1], tt.wantCode, tt.wantPhase)
+				assertSDDTaskResultHandoff(t, parts[0], tt.wantCode, tt.wantPhase, tt.wantSummary, tt.wantModel)
+				assertSDDTaskResultHandoff(t, parts[1], tt.wantCode, tt.wantPhase, tt.wantSummary, tt.wantModel)
+			}
+			for _, leaked := range tt.forbid {
+				if strings.Contains(parts[0], leaked) || strings.Contains(parts[1], leaked) {
+					t.Fatalf("failure handoff leaked %q: %q", leaked, parts[:2])
+				}
 			}
 			if !tt.wantBlocked && parts[1] != "NOT_ATTEMPTED" {
 				t.Fatalf("unrelated agent unexpectedly entered SDD routing: %q", parts[1])
@@ -296,24 +345,41 @@ func TestSDDTaskResultFailuresAreTerminalAndScoped(t *testing.T) {
 	}
 }
 
-func assertSDDTaskResultHandoff(t *testing.T, message, code, phase string) {
+func assertSDDTaskResultHandoff(t *testing.T, message, code, phase, summary, model string) {
 	t.Helper()
 	const prefix = "GENTLE_AI_SDD_FAILURE "
 	if !strings.HasPrefix(message, prefix) {
 		t.Fatalf("failure lacks a machine-readable handoff: %q", message)
 	}
+	raw := strings.TrimPrefix(message, prefix)
 	var handoff struct {
 		SchemaName   string `json:"schemaName"`
 		Status       string `json:"status"`
 		Code         string `json:"code"`
 		Phase        string `json:"phase"`
+		TaskModel    string `json:"taskModel"`
+		Summary      string `json:"summary"`
 		Continuation string `json:"continuation"`
 	}
-	if err := json.Unmarshal([]byte(strings.TrimPrefix(message, prefix)), &handoff); err != nil {
+	if err := json.Unmarshal([]byte(raw), &handoff); err != nil {
 		t.Fatalf("failure handoff is not JSON: %v: %q", err, message)
 	}
 	if handoff.SchemaName != "gentle-ai.sdd-task-result-failure/v1" || handoff.Status != "blocked" || handoff.Code != code || handoff.Phase != phase {
 		t.Fatalf("failure handoff = %#v", handoff)
+	}
+	if !strings.Contains(handoff.Summary, summary) {
+		t.Fatalf("failure handoff summary = %q, want it to contain %q", handoff.Summary, summary)
+	}
+	if code == "sdd_task_result_empty" && !strings.Contains(handoff.Summary, sddEmptyCauseFragment) {
+		t.Fatalf("empty-result summary does not name the likeliest cause class: %q", handoff.Summary)
+	}
+	if handoff.TaskModel != model {
+		t.Fatalf("failure handoff taskModel = %q, want %q", handoff.TaskModel, model)
+	}
+	// An absent route is omitted, never invented: the key itself must not
+	// appear when no valid provider/model identity was available.
+	if model == "" && strings.Contains(raw, `"taskModel"`) {
+		t.Fatalf("failure handoff carries an empty taskModel field: %q", raw)
 	}
 	if !strings.HasPrefix(handoff.Continuation, "gentle-ai sdd-status --cwd '") || !strings.HasSuffix(handoff.Continuation, "' --json") {
 		t.Fatalf("failure handoff names no runnable sdd-status continuation: %#v", handoff)


### PR DESCRIPTION
Closes #2677

Refs #2609 (same class for general workers; this PR fixes the SDD half — the general-worker envelope needs its twin and stays open).

## Summary

Eight reports across six reporters, three SDD phases, two platforms and two artifact modes, all showing `sdd_task_result_empty`. The decisive evidence is the controlled two-arm experiment in the thread: identical fixtures, only the child model differing, and the failing arm's provider rejected the request with HTTP 403 **before generation**. Our wrapper replaced that with a summary claiming the phase "returned no valid task result" — the child never ran.

**What the hook can and cannot see, established empirically** (installed `@opencode-ai/plugin` types + OpenCode 1.18.14 task-tool source):

- The provider error text is **not available** at `tool.execute.after`: it lives on the child session record, reachable only via the `client` the transport reduction removed by design. Worse, when the child job status is `error` the after-hook never fires at all. No `cause` field is added for a fact that does not exist at this line.
- The child's **model route** (`providerID/modelID`) IS available in `output.metadata` and was being discarded. It is exactly the discriminating variable of the two-arm experiment, so it now travels as `taskModel` in the envelope.

**Two truths, two summaries.** The empty case now states the child produced no output at all and names the likeliest causes (provider rejection before generation: authentication, region, or model access; interruption; or a phase that genuinely wrote nothing). The malformed case keeps its existing wording byte-identical.

**Hostile values are omitted, not truncated**: `taskModel` is validated per token (provider and model separately); an absolute path or a provider dump never enters the transcript, proven by test.

**Explicitly not done**: retries, recovery-from-disk (a 403 leaves no artifact to recover), new states or flags, `client` reintroduction. Reviewer transport untouched — the diff is confined to the SDD block. Schema stays `v1`: every consumer tolerates the additive field (verified pin by pin); docs and goldens pin only codes and contract, none needed regeneration.

**Exit-0 note for the thread**: the outer process exiting 0 on failure is OpenCode host behavior, unreachable from the plugin; that half belongs upstream.

## Test Plan

```bash
go test ./internal/assets/... ./internal/components/... -count=1   # ok
go test ./internal/cli/ -count=1                                   # ok (210s)
cd bench && go test ./... -count=1                                 # ok
gofmt -l . && go vet ./... && go build ./...                       # clean
```

New/updated cases in `TestSDDTaskResultFailuresAreTerminalAndScoped`: truthful empty summary with `taskModel`; key absent without metadata; hostile path and 400-char provider dump proven absent from the handoff; malformed wording pinned unchanged. Reviewer independently decoy-verified the hostile-value guard (weakened the token regex; the test failed naming the case).

Review budget: 132 additions + 11 deletions = 143 changed lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed task results, including clear distinction between empty and malformed output.
  * Added clearer reporting when a provider or model rejects a task.
  * Preserved available task routing details in failure summaries while omitting missing or unsafe metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->