### PR TITLE
fix(review): reject finding-location lines that overflow a positive int

### DIFF
--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -1107,6 +1107,16 @@ type findingLocation struct {
 	EndLine   int
 }
 
+// findingLocationHasPositiveLines reports whether a parsed finding location
+// carries strictly positive 1-based line numbers. It is a defense-in-depth
+// lower bound for causality: source lines are numbered from 1, so a location
+// whose start or end line is below 1 can never designate a line that exists in
+// the candidate and must never be treated as candidate-causal. This holds the
+// invariant even if a parser path ever yielded a non-positive line.
+func findingLocationHasPositiveLines(finding findingLocation) bool {
+	return finding.StartLine >= 1 && finding.EndLine >= 1
+}
+
 func parseFindingLocation(location string) (findingLocation, error) {
 	fail := func(reason FindingLocationErrorReason) (findingLocation, error) {
 		return findingLocation{}, &FindingLocationError{Location: location, Reason: reason}
@@ -1161,7 +1171,13 @@ func parseFindingLocationLine(value string) (int, FindingLocationErrorReason) {
 			return 0, FindingLocationLineNotInteger
 		}
 	}
-	line, err := strconv.ParseUint(value, 10, strconv.IntSize)
+	// The all-digits check above guarantees no sign character reaches here, so
+	// the value is a non-negative literal. Parse it as an unsigned integer that
+	// must fit a positive Go int: bit size strconv.IntSize-1 caps the result at
+	// the platform's MaxInt, so any value above it (including the [2^63, 2^64-1]
+	// band that a full 64-bit parse accepted before wrapping negative via int())
+	// refuses as an overflow instead of silently becoming a negative line.
+	line, err := strconv.ParseUint(value, 10, strconv.IntSize-1)
 	if err != nil {
 		return 0, FindingLocationLineOverflowsInteger
 	}

--- a/internal/reviewtransaction/compact_reviewer_capture_test.go
+++ b/internal/reviewtransaction/compact_reviewer_capture_test.go
@@ -592,6 +592,8 @@ func TestCompactStoreCaptureRefusesInvalidLocationsWithoutConsumingTheSlot(t *te
 		{"internal/a.go:3-2", FindingLocationErrorReason("range_must_be_ascending")},
 		{"internal/a.go:0-1", FindingLocationLineNotPositive},
 		{"internal/a.go:" + strings.Repeat("9", 64), FindingLocationErrorReason("line_overflows_integer")},
+		{"internal/a.go:9223372036854775808", FindingLocationErrorReason("line_overflows_integer")},
+		{"internal/a.go:18446744073709551615", FindingLocationErrorReason("line_overflows_integer")},
 		{"internal/a.go", FindingLocationExpectedPathAndLine},
 	} {
 		t.Run(tt.location, func(t *testing.T) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -2720,6 +2720,33 @@ func TestSnapshotCandidateLocationSupportsStructuredCausality(t *testing.T) {
 			}
 		})
 	}
+	// A non-positive line can no longer be expressed as a location string, so
+	// these rows enter at the level the causality comparisons consume. They pin
+	// the defense-in-depth lower bound against the real snapshot: without it a
+	// negative EndLine satisfies the behavior-activated `EndLine <= lines` test
+	// for every tracked file, fabricating causality on a line that cannot exist.
+	for _, tt := range []struct {
+		name      string
+		finding   findingLocation
+		causality CausalDisposition
+		want      bool
+	}{
+		{"activated wrapped min int", findingLocation{Path: "tracked.txt", StartLine: math.MinInt64, EndLine: math.MinInt64}, CausalBehaviorActivated, false},
+		{"activated negative range", findingLocation{Path: "tracked.txt", StartLine: -5, EndLine: -1}, CausalBehaviorActivated, false},
+		{"activated negative end", findingLocation{Path: "tracked.txt", StartLine: 1, EndLine: -1}, CausalBehaviorActivated, false},
+		{"activated zero", findingLocation{Path: "tracked.txt", StartLine: 0, EndLine: 0}, CausalBehaviorActivated, false},
+		{"introduced negative range", findingLocation{Path: "tracked.txt", StartLine: -5, EndLine: -1}, CausalIntroduced, false},
+		{"worsened negative range", findingLocation{Path: "tracked.txt", StartLine: -5, EndLine: -1}, CausalWorsened, false},
+		{"activated positive range still causal", findingLocation{Path: "tracked.txt", StartLine: 1, EndLine: 5}, CausalBehaviorActivated, true},
+		{"introduced positive line still causal", findingLocation{Path: "tracked.txt", StartLine: 2, EndLine: 2}, CausalIntroduced, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (SnapshotBuilder{Repo: repo}).candidateFindingSupportsCausality(context.Background(), snapshot, tt.finding, tt.causality)
+			if err != nil || got != tt.want {
+				t.Fatalf("candidateFindingSupportsCausality(%#v, %q) = %t, %v; want %t", tt.finding, tt.causality, got, err, tt.want)
+			}
+		})
+	}
 }
 
 // TestParseFindingLocationLineRejectsPositiveIntOverflowBand pins the boundary

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -2715,6 +2717,60 @@ func TestSnapshotCandidateLocationSupportsStructuredCausality(t *testing.T) {
 				if got || !errors.Is(err, ErrInvalidFindingLocation) || !errors.As(err, &locationErr) || locationErr.Reason != tt.wantError {
 					t.Fatalf("CandidateLocationSupportsCausality(%q) = %t, %v; want typed %q", tt.location, got, err, tt.wantError)
 				}
+			}
+		})
+	}
+}
+
+// TestParseFindingLocationLineRejectsPositiveIntOverflowBand pins the boundary
+// that hid the integer-wraparound defect: a value in [2^63, 2^64-1] once parsed
+// without error under a 64-bit unsigned parse and then wrapped to a negative
+// line via int() conversion. The largest legal line (MaxInt64) must still be
+// admitted, while the whole overflow band must refuse with the overflow reason.
+func TestParseFindingLocationLineRejectsPositiveIntOverflowBand(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		value  string
+		want   int
+		reason FindingLocationErrorReason
+	}{
+		{"max int64 admits", strconv.Itoa(math.MaxInt64), math.MaxInt64, ""},
+		{"two to the sixty-three overflows", "9223372036854775808", 0, FindingLocationLineOverflowsInteger},
+		{"max uint64 overflows", "18446744073709551615", 0, FindingLocationLineOverflowsInteger},
+		{"max int64 with trailing zero overflows", strconv.Itoa(math.MaxInt64) + "0", 0, FindingLocationLineOverflowsInteger},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := parseFindingLocationLine(tt.value)
+			if got != tt.want || reason != tt.reason {
+				t.Fatalf("parseFindingLocationLine(%q) = %d, %q; want %d, %q", tt.value, got, reason, tt.want, tt.reason)
+			}
+			if got < 0 {
+				t.Fatalf("parseFindingLocationLine(%q) returned negative line %d", tt.value, got)
+			}
+		})
+	}
+}
+
+// TestFindingLocationHasPositiveLinesRejectsNonPositive proves the causality
+// lower bound independently of the parser: a synthesized finding whose line is
+// non-positive (as an out-of-band parse or a future regression could yield) is
+// never treated as candidate-causal, even if the parser guard were reverted.
+func TestFindingLocationHasPositiveLinesRejectsNonPositive(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		finding findingLocation
+		want    bool
+	}{
+		{"wrapped min int", findingLocation{Path: "internal/a.go", StartLine: math.MinInt64, EndLine: math.MinInt64}, false},
+		{"negative both", findingLocation{Path: "internal/a.go", StartLine: -1, EndLine: -1}, false},
+		{"negative end only", findingLocation{Path: "internal/a.go", StartLine: 1, EndLine: -1}, false},
+		{"zero end", findingLocation{Path: "internal/a.go", StartLine: 1, EndLine: 0}, false},
+		{"zero start", findingLocation{Path: "internal/a.go", StartLine: 0, EndLine: 5}, false},
+		{"positive range", findingLocation{Path: "internal/a.go", StartLine: 1, EndLine: 5}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findingLocationHasPositiveLines(tt.finding); got != tt.want {
+				t.Fatalf("findingLocationHasPositiveLines(%#v) = %t; want %t", tt.finding, got, tt.want)
 			}
 		})
 	}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -359,6 +359,9 @@ func (builder SnapshotBuilder) CandidateLocationSupportsCausality(ctx context.Co
 	if stringIndex(snapshot.Paths, finding.Path) < 0 {
 		return false, nil
 	}
+	if !findingLocationHasPositiveLines(finding) {
+		return false, nil
+	}
 	if causality == CausalBehaviorActivated {
 		entry, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", snapshot.CandidateTree, "--", literalPathspec(finding.Path))
 		if err != nil || len(entry) == 0 {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -356,6 +356,15 @@ func (builder SnapshotBuilder) CandidateLocationSupportsCausality(ctx context.Co
 	if err != nil {
 		return false, err
 	}
+	return builder.candidateFindingSupportsCausality(ctx, snapshot, finding, causality)
+}
+
+// candidateFindingSupportsCausality answers causality for an already parsed
+// finding location. The non-positive line refusal lives here, at the level the
+// causality comparisons actually consume, so a start or end line below 1 can
+// never be judged causal even when it reaches this point without having been
+// filtered by the location parser.
+func (builder SnapshotBuilder) candidateFindingSupportsCausality(ctx context.Context, snapshot Snapshot, finding findingLocation, causality CausalDisposition) (bool, error) {
 	if stringIndex(snapshot.Paths, finding.Path) < 0 {
 		return false, nil
 	}


### PR DESCRIPTION
Closes #2753

Found during the post-merge review of Cluster 1 (#2731). Security-relevant: a reviewer could manufacture a blocking finding against a line that does not exist and have it verified as candidate-causal.

## The defect

`parseFindingLocationLine` parsed with `strconv.ParseUint(value, 10, strconv.IntSize)` and cast with an unchecked `int()`. On 64-bit, values in `[2^63, 2^64-1]` parse with **no error** and wrap negative:

```
ParseUint("9223372036854775808",10,64)  -> err=nil, int() = -9223372036854775808
ParseUint("18446744073709551615",10,64) -> err=nil, int() = -1
```

The `line == 0` guard misses the band, so `parseFindingLocation` returns a negative StartLine/EndLine with a nil error. `AdmitArtifact` only checks path membership, and `CandidateLocationSupportsCausality` then tests `finding.EndLine <= lines` — which a negative EndLine satisfies for **every file**. A CRITICAL or BLOCKER finding with `causal_disposition: behavior-activated` on a fabricated location was therefore verified candidate-causal and drove blocking and correction machinery against nothing. The tests added with the original change covered only 64 nines (above 2^64, which correctly errors), leaving the whole exploitable band untested.

## The fix, two independent layers

**Parser** (`compact.go`): `strconv.ParseUint(value, 10, strconv.IntSize-1)`. This is deliberately not `ParseInt(..., 64)`, which would leave the identical wrap on 32-bit platforms; `IntSize-1` caps at the platform MaxInt on both word sizes, so `int(line)` can never be negative and anything larger fails as `line_overflows_integer`. The all-digits pre-check above guarantees no sign literal reaches the parse, so the three refusal reasons keep their meanings. `math.MaxInt64` still admits as the largest legal line.

**Causality lower bound** (`snapshot.go`): a start or end line below 1 is never causal, for any disposition, independent of the parser. This survives a future parser regression.

## Verification

Both layers were decoy-verified independently, by the author and again by me before opening this PR:

- Revert the parser to `strconv.IntSize` → the admission rows for `9223372036854775808` and `18446744073709551615` fail.
- Delete the causality guard → eight rows fail, including `math.MinInt64`, the exact value the old parser produced.

The second decoy initially found **nothing**, because the first attempt tested the predicate helper directly rather than its call site: the exported entry point takes a location string, and layer 1 now refuses the whole band, so no input could drive a negative line into the causality comparisons. The function was split so the causality logic is reachable with an already-parsed location, which is what makes "layer 2 holds when layer 1 does not" testable at all. That seam is the point of the second commit.

```bash
go test ./internal/reviewtransaction/ -count=1   # ok (114s)
go test ./internal/cli/ -count=1                 # ok (186s)
cd bench && go test ./... -count=1               # ok
gofmt -l . && go vet ./... && go build ./...     # clean
```

No goldens touched. Two commits kept separate so the parser fix and the wiring proof stay independently reviewable.

## Scope

Only this defect. The other Cluster-1 review findings — `--committed-only` value ignored in status, frozen-manifest faults attributed to the reviewer, slot-replay idempotency after reordering, and j12's vacuous unordered-manifest proof — are recorded on #2731 and deliberately untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of finding locations to reject zero, negative, or invalid line ranges.
  * Prevented oversized line numbers from being misinterpreted as negative values.
  * Improved causality checks so only valid positive line ranges are considered.

* **Tests**
  * Added coverage for line-number overflow and invalid finding locations.
  * Verified valid maximum-range values continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->