### PR TITLE
fix(review): scope authority validation to the lineage under operation on the remaining walks

### DIFF
--- a/internal/cli/review_inspect_authority_test.go
+++ b/internal/cli/review_inspect_authority_test.go
@@ -174,19 +174,32 @@ func TestReviewInspectAuthorityReportsMixedCorruptionDeterministicallyWithoutMut
 		result.EntryDiagnostics[0].Problem != "malformed_compact_state" {
 		t.Fatalf("inspect-authority entry diagnostics = %#v", result.EntryDiagnostics)
 	}
-	// Wave 7 S3a: reconciliation's two anomaly classes (unchanged_target,
-	// malformed_recovery_authorization) have no surviving admitting
-	// operation now that `review reconcile-authority` is gone — neither
-	// successor here is pristine (both hold escalated recovery
-	// provenance), so both fall all the way through to Blocked, honestly,
-	// rather than naming a command that would refuse.
+	// Wave 7 S3a retired `review reconcile-authority`, so an edge in one of
+	// reconciliation's two anomaly classes (unchanged_target,
+	// malformed_recovery_authorization) no longer takes that verb: it falls
+	// through to the SAME eligibility checks every other invalid edge does.
+	//
+	// Both successors here ARE pristine reviewing authorities that merely
+	// carry recovery provenance, so abandon's own read-only prediction
+	// accepts them and the exit names `review abandon` — a command that
+	// will actually run, which is the only rule this surface has to keep.
+	//
+	// This row previously asserted Blocked, and an earlier revision of this
+	// comment explained it as "neither successor is pristine". That reading
+	// was wrong: the Blocked answer came from the unrelated `broken-entry`
+	// above poisoning InspectCompactPristineAbandonment's repository-wide
+	// walk (#2743/#2741). One unreadable entry silently locked the abandon
+	// escape valve for every lineage in the store, which is the defect the
+	// scoped walks fixed; reviewtransaction's
+	// TestPristineAbandonmentIgnoresUnreadableForeignLineage proves the
+	// advertised abandonment really executes with such an entry present.
 	if len(result.SanctionedExits) != 2 {
 		t.Fatalf("inspect-authority sanctioned exits = %#v, want 2 entries", result.SanctionedExits)
 	}
 	for index, wantSuccessor := range []string{"b-unchanged-successor", "c-malformed-successor"} {
 		exit := result.SanctionedExits[index]
-		if exit.SuccessorLineageID != wantSuccessor || exit.Operation != "" || !strings.Contains(exit.Blocked, "no advertised operation admits this edge") {
-			t.Fatalf("sanctioned exit[%d] = %#v, want SuccessorLineageID %q, empty Operation, and a Blocked reason", index, exit, wantSuccessor)
+		if exit.SuccessorLineageID != wantSuccessor || exit.Operation != "review abandon" || exit.Blocked != "" {
+			t.Fatalf("sanctioned exit[%d] = %#v, want SuccessorLineageID %q advertising `review abandon` with no Blocked reason", index, exit, wantSuccessor)
 		}
 	}
 }

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -39,6 +39,14 @@ type CompactSemanticStateError struct {
 	LineageID string
 	State     State
 	Problem   string
+	// OutdatedIdentity marks the one semantic failure a retired
+	// snapshot-identity formula leaves behind (#2743): the record's bytes
+	// parse and its structure is intact, but the identity it froze was
+	// computed by an earlier release's formula, so recomputation under the
+	// current formula no longer matches. Outdated means gate-invalid, not
+	// damaged: diagnostics classify it historical instead of malformed, and
+	// no scoped walk lets it block another lineage's operation.
+	OutdatedIdentity bool
 }
 
 func (err *CompactSemanticStateError) Error() string {
@@ -596,10 +604,21 @@ func validateCompactSnapshotMetadata(snapshot Snapshot) error {
 	}
 	wantIdentity := snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
 	if snapshot.Identity != wantIdentity {
-		return errors.New("compact snapshot identity does not match its metadata")
+		return errCompactSnapshotIdentityMismatch
 	}
 	return nil
 }
+
+// errCompactSnapshotIdentityMismatch is the exact semantic failure a record
+// frozen under a retired snapshot-identity formula produces when the current
+// formula recomputes its identity (#2743: every pre-rc.2 compact-v2 record
+// fails here after the #2659/PR-#2667 identity purification). It is a
+// sentinel so parseCompactRecord can mark the resulting typed
+// *CompactSemanticStateError as OutdatedIdentity — the clean-break policy
+// keeps such records gate-invalid without rewriting their bytes, and
+// diagnostics owe them an honest historical classification instead of
+// narrating them as damage.
+var errCompactSnapshotIdentityMismatch = errors.New("compact snapshot identity does not match its metadata")
 
 func validateCompactFindings(state CompactState) error {
 	if state.State == StateReviewing || state.State == StateInvalidated {

--- a/internal/reviewtransaction/compact_abandon.go
+++ b/internal/reviewtransaction/compact_abandon.go
@@ -201,18 +201,15 @@ func InspectCompactPristineAbandonment(ctx context.Context, repo, lineage string
 			return CompactAbandonEligibility{}, nil
 		}
 	}
-	stores, err := DiscoverCompactStores(ctx, repo)
+	// Scoped like every other authority walk (#2743): the probe answers for
+	// THIS lineage, whose own record already loaded above. An unreadable
+	// foreign record is absent from the graph, never a repository-wide
+	// not-eligible verdict that silently locks the abandon escape valve.
+	scan, err := scanCompactAuthority(ctx, repo)
 	if err != nil {
 		return CompactAbandonEligibility{}, err
 	}
-	records := make(map[string]CompactRecord, len(stores))
-	for _, related := range stores {
-		relatedRecord, loadErr := related.Load()
-		if loadErr != nil {
-			return CompactAbandonEligibility{}, nil
-		}
-		records[relatedRecord.State.LineageID] = relatedRecord
-	}
+	records := scan.records
 	for _, related := range records {
 		if related.State.Recovery != nil && related.State.Recovery.PredecessorLineageID == lineage {
 			return CompactAbandonEligibility{}, nil
@@ -369,18 +366,17 @@ func AbandonPristineCompactStore(ctx context.Context, repo string, request Compa
 		return CompactReclaimRecord{}, fmt.Errorf("review abandon requires an exact maintainer authorization binding (schema %s over lineage %s@%s and snapshot %s)",
 			CompactAbandonAuthorizationSchema, request.LineageID, record.Revision, record.State.InitialSnapshot.Identity)
 	}
-	stores, err := DiscoverCompactStores(ctx, repo)
+	// Scoped like every other authority walk (#2743): abandon quarantines
+	// THIS lineage, whose record, revision, and authorization binding were
+	// already validated above. An unreadable foreign record is absent from
+	// the graph — the superseded and remaining-graph rules below judge only
+	// the records that actually load — so one historical entry can never
+	// refuse every abandonment in the repository.
+	scan, err := scanCompactAuthority(ctx, repo)
 	if err != nil {
 		return CompactReclaimRecord{}, err
 	}
-	records := make(map[string]CompactRecord, len(stores))
-	for _, related := range stores {
-		relatedRecord, loadErr := related.Load()
-		if loadErr != nil {
-			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: related compact authority %q does not load: %w", related.lineageID, loadErr)
-		}
-		records[relatedRecord.State.LineageID] = relatedRecord
-	}
+	records := scan.records
 	for lineage, related := range records {
 		if related.State.Recovery != nil && related.State.Recovery.PredecessorLineageID == request.LineageID {
 			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: lineage %q is superseded by recovery successor %q; superseded history is never abandoned", request.LineageID, lineage)

--- a/internal/reviewtransaction/compact_inspect.go
+++ b/internal/reviewtransaction/compact_inspect.go
@@ -17,6 +17,12 @@ const (
 	compactInspectionEntryMissing    = "missing_compact_state"
 	compactInspectionEntryUnreadable = "unreadable_compact_state"
 	compactInspectionEntryMalformed  = "malformed_compact_state"
+	// compactInspectionEntryOutdated classifies a record whose bytes parse
+	// intact but whose frozen snapshot identity was computed by an earlier
+	// release's retired formula (#2743). It is historical, not damaged:
+	// gate-invalid under the clean-break policy, preserved unrewritten for
+	// forensics, and never a verdict on any other lineage.
+	compactInspectionEntryOutdated   = "outdated_compact_state"
 	compactInspectionEntryUnexpected = "unexpected_authority_root_entry"
 )
 
@@ -253,7 +259,9 @@ func CompactAuthorityDamageKinds(report CompactRecoveryInspectionReport) []strin
 	for _, diagnostic := range report.EntryDiagnostics {
 		switch diagnostic.Problem {
 		case compactInspectionEntryMalformed:
-			kinds = append(kinds, fmt.Sprintf("store entry %q holds a record that does not parse (%s), which an interrupted write leaves behind", diagnostic.LineageID, diagnostic.Problem))
+			kinds = append(kinds, fmt.Sprintf("store entry %q holds a record that does not load (%s): either its bytes do not parse — what an interrupted write leaves behind — or its persisted state is semantically invalid", diagnostic.LineageID, diagnostic.Problem))
+		case compactInspectionEntryOutdated:
+			kinds = append(kinds, fmt.Sprintf("store entry %q holds authority frozen by an earlier release under a retired snapshot-identity formula (%s); it is outdated — gate-invalid, preserved for forensics — not damaged, and it never blocks another lineage's operation", diagnostic.LineageID, diagnostic.Problem))
 		case compactInspectionEntryMissing:
 			kinds = append(kinds, fmt.Sprintf("store entry %q holds no compact state (%s)", diagnostic.LineageID, diagnostic.Problem))
 		case compactInspectionEntryUnreadable:
@@ -419,6 +427,10 @@ func compactRecoveryEntryProblem(err error) string {
 	var pathErr *os.PathError
 	if errors.As(err, &pathErr) {
 		return compactInspectionEntryUnreadable
+	}
+	var semantic *CompactSemanticStateError
+	if errors.As(err, &semantic) && semantic.OutdatedIdentity {
+		return compactInspectionEntryOutdated
 	}
 	return compactInspectionEntryMalformed
 }

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -202,7 +202,7 @@ func compactReclaimAuthorityRefusal(ctx context.Context, repo, dir, lineageID, a
 			return fmt.Errorf("%s The entry holds no readable review-state.json beside that artifact, so nothing can prove the artifact never carried authority, and no advertised operation admits this shape today."+
 				" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %s` and escalate that report", refused, pathquote.Quote(repo))
 		}
-		return fmt.Errorf("%s Its record cannot be loaded (%v) — inspection classifies it %s, which an interrupted write leaves behind — and no advertised operation admits an unreadable record:"+
+		return fmt.Errorf("%s Its record cannot be loaded (%v) — inspection classifies it %s — and no advertised operation admits an unreadable record:"+
 			" reconciliation re-derives its proof from readable state, and admitting bytes that can prove nothing is a maintainer policy decision, not a repair."+
 			" Capture the complete machine-readable diagnosis with `gentle-ai review inspect-authority --cwd %s` and escalate that report",
 			refused, loadErr, compactRecoveryEntryProblem(loadErr), pathquote.Quote(repo))

--- a/internal/reviewtransaction/compact_scoped_walks_test.go
+++ b/internal/reviewtransaction/compact_scoped_walks_test.go
@@ -1,0 +1,345 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests pin issues #2743/#2741: a compact record frozen by an earlier
+// release under the retired snapshot-identity formula fails semantic
+// validation and becomes unreadable to every consumer. The scoped-authority
+// rule (#2495, `scanCompactAuthority`) says an entry nobody can read is ABSENT
+// from the graph, not a verdict on it — but four walks still iterated every
+// discovered store and failed closed on the first unreadable foreign record:
+// RecoverCompactAuthority's recovery-graph loop (#2741),
+// InspectCompactFinalVerificationRetrySource (the STATUS path that turned one
+// escalated lineage plus one historical record into repository-wide
+// `corrupted_or_unverifiable_authority`, #2743), the two `review abandon`
+// walks, and the RAR receipt superseded probe.
+
+// retiredSnapshotIdentity recomputes a snapshot's identity with the EXACT
+// formula every pre-rc.2 release used (verbatim from fbb55080^, the commit
+// PR #2667 landed for #2659): the v1/v2 domain tags instead of v3/v4, the
+// untracked-replay proof folded into the hashed values, and the
+// intended-untracked paths hashed after them. A test that merely zeroed the
+// identity would fail validation for the wrong reason; this reproduces the
+// bytes a 2.2.x binary actually froze.
+func retiredSnapshotIdentity(snapshot Snapshot) string {
+	hash := sha256.New()
+	if snapshot.Kind == TargetBaseWorkspaceOverlay {
+		hash.Write([]byte("gentle-ai.review-snapshot/base-workspace-overlay/v1\x00"))
+	} else if snapshot.Projection == ProjectionStaged {
+		hash.Write([]byte("gentle-ai.review-snapshot/v2\x00"))
+	} else {
+		hash.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
+	}
+	values := []string{string(snapshot.Kind), snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof}
+	if snapshot.Projection == ProjectionStaged {
+		values = []string{string(snapshot.Kind), string(snapshot.Projection), snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof}
+	}
+	for _, value := range values {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	for _, value := range snapshot.IntendedUntracked {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	for _, value := range snapshot.LedgerIDs {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+// outdateCompactSnapshotIdentity rewrites an already-persisted, checksum-valid
+// compact state on disk so that its frozen snapshot identities carry the
+// RETIRED pre-rc.2 formula's value — exactly what a record written by a 2.2.x
+// release looks like to the current reader (#2743). Because Validate() runs
+// before the checksum comparison in parseCompactRecord, the load failure is
+// the same typed *CompactSemanticStateError the released binaries produce for
+// historical authority.
+func outdateCompactSnapshotIdentity(t *testing.T, store CompactStore) {
+	t.Helper()
+	record := mustLoadCompactRecord(t, store)
+	payload, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outdated := payload
+	for _, snapshot := range []Snapshot{record.State.InitialSnapshot, record.State.CurrentSnapshot} {
+		retired := retiredSnapshotIdentity(snapshot)
+		if retired == snapshot.Identity {
+			t.Fatalf("retired identity formula reproduced the current identity %q; the fixture would prove nothing", snapshot.Identity)
+		}
+		outdated = bytes.ReplaceAll(outdated, []byte(`"identity": "`+snapshot.Identity+`"`), []byte(`"identity": "`+retired+`"`))
+	}
+	if bytes.Equal(outdated, payload) {
+		t.Fatal("fixture did not contain the expected snapshot identity markers")
+	}
+	if err := os.WriteFile(store.StatePath(), outdated, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, loadErr := store.Load()
+	var semanticErr *CompactSemanticStateError
+	if loadErr == nil || !errors.As(loadErr, &semanticErr) || !semanticErr.OutdatedIdentity ||
+		!strings.Contains(semanticErr.Problem, "identity does not match its metadata") {
+		t.Fatalf("retired-identity fixture load error = %v, want an outdated snapshot identity mismatch", loadErr)
+	}
+}
+
+// outdatedForeignLineage plants one unrelated historical-style lineage whose
+// record no longer loads, removing its worktree residue so the fixture never
+// changes what any other lineage's live snapshot sees.
+func outdatedForeignLineage(t *testing.T, repo, lineage string) {
+	t.Helper()
+	foreign := quarantineFixtureHealthyLineage(t, repo, lineage, "foreign historical candidate\n")
+	if err := os.Remove(filepath.Join(repo, foreign+".txt")); err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, foreign)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outdateCompactSnapshotIdentity(t, store)
+}
+
+// TestRecoverCompactAuthorityIgnoresUnreadableForeignLineage is #2741: a
+// healthy correction-required lineage authorized for scope-changed recovery
+// must recover even though an unrelated stored lineage no longer loads. The
+// unscoped "validate recovery graph" loop used to abort on the foreign record
+// before attempting anything for the lineage actually being recovered.
+func TestRecoverCompactAuthorityIgnoresUnreadableForeignLineage(t *testing.T) {
+	repo, predecessor, _, predecessorRecord := correctionScopeRecoveryFixture(t, "recover-scoped-predecessor")
+	outdatedForeignLineage(t, repo, "recover-scoped-foreign")
+
+	writeSnapshotFile(t, repo, "process_helper.go", "package processhelper\n")
+	successor := newCompactTestStateWithIntended(t, repo, "recover-scoped-successor", []string{"process_helper.go"})
+	successor.Generation = predecessor.Generation + 1
+	request := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRecord.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "correction requires a process helper",
+		Actor: "maintainer", RecoveredAt: time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC),
+	}
+	request.MaintainerAuthorization = recoveryAuthorizationFixture(request)
+
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("recovery of a healthy lineage with an unreadable foreign record = %v", err)
+	}
+	if recovered.State.Recovery == nil || recovered.State.Recovery.PredecessorLineageID != predecessor.LineageID {
+		t.Fatalf("recovered successor = %#v", recovered.State)
+	}
+}
+
+// TestRecoverCompactAuthorityStillRefusesTheOutdatedLineageItself is the
+// fail-closed control for the scoping above: absence from the graph is only
+// ever the answer for a FOREIGN record. A recovery whose own predecessor is
+// the outdated record must still refuse, because scoping never widens
+// authority — an outdated record stays gate-invalid, it just stops taking
+// unrelated lineages down with it.
+func TestRecoverCompactAuthorityStillRefusesTheOutdatedLineageItself(t *testing.T) {
+	repo, predecessor, store, predecessorRecord := correctionScopeRecoveryFixture(t, "recover-outdated-predecessor")
+	outdateCompactSnapshotIdentity(t, store)
+
+	writeSnapshotFile(t, repo, "process_helper.go", "package processhelper\n")
+	successor := newCompactTestStateWithIntended(t, repo, "recover-outdated-successor", []string{"process_helper.go"})
+	successor.Generation = predecessor.Generation + 1
+	request := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRecord.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "correction requires a process helper",
+		Actor: "maintainer", RecoveredAt: time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC),
+	}
+	request.MaintainerAuthorization = recoveryAuthorizationFixture(request)
+
+	before := compactAuthorityFileSnapshot(t, repo)
+	if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil {
+		t.Fatal("recovery whose own predecessor is an outdated record succeeded")
+	}
+	if after := compactAuthorityFileSnapshot(t, repo); !reflect.DeepEqual(after, before) {
+		t.Fatalf("refused recovery mutated authority: %#v != %#v", after, before)
+	}
+}
+
+// TestInspectFinalVerificationRetrySourceIgnoresUnreadableForeignLineage is
+// #2743's STATUS mechanism: any escalated lineage routes negotiated status
+// through the retry-source inspection, whose unscoped store walk returned the
+// first foreign load error and flipped the whole repository to
+// corrupted_or_unverifiable_authority.
+func TestInspectFinalVerificationRetrySourceIgnoresUnreadableForeignLineage(t *testing.T) {
+	fixture := newFinalVerificationRetryFixture(t, "retry-scoped-source", "retry-scoped-successor")
+	outdatedForeignLineage(t, fixture.repo, "retry-scoped-foreign")
+
+	eligibility, ok, err := InspectCompactFinalVerificationRetrySource(
+		context.Background(), fixture.repo, fixture.predecessor.State.LineageID, fixture.predecessor.Revision)
+	if err != nil {
+		t.Fatalf("retry-source inspection with an unreadable foreign record = %v", err)
+	}
+	if !ok {
+		t.Fatal("escalated lineage lost retry-source eligibility because of an unreadable foreign record")
+	}
+	if eligibility.IncidentClass != FinalVerificationIncidentProceduralToolingFailure {
+		t.Fatalf("eligibility = %#v", eligibility)
+	}
+}
+
+// TestTargetStatusStaysHealthyWithOutdatedHistoricalAuthority reproduces
+// #2743's reported shape end-to-end at the status layer: a repository holding
+// pre-rc.2 compact-v2 history, one unrelated new lineage that escalates, and
+// the immediately following STATUS. Every escalated lineage routes through
+// InspectCompactFinalVerificationRetrySource, whose unscoped walk turned the
+// first outdated historical record into `applicability: corrupted` with a
+// terminal `corrupted_or_unverifiable_authority` stop and zero eligible
+// repair candidates. Status must classify the live target normally instead.
+func TestTargetStatusStaysHealthyWithOutdatedHistoricalAuthority(t *testing.T) {
+	fixture := newFinalVerificationRetryFixture(t, "status-scoped-escalated", "status-scoped-successor")
+	if fixture.predecessor.State.State != StateEscalated {
+		t.Fatalf("fixture predecessor state = %s, want escalated", fixture.predecessor.State.State)
+	}
+	outdatedForeignLineage(t, fixture.repo, "status-scoped-historical")
+
+	status, err := AssessTargetStatus(context.Background(), fixture.repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}},
+	})
+	if err != nil {
+		t.Fatalf("negotiated status with outdated historical authority = %v", err)
+	}
+	if status.Applicability == TargetApplicabilityCorrupted {
+		t.Fatalf("outdated historical authority made the whole repository report corrupted: %#v", status)
+	}
+	if status.Action == TargetStatusActionRepairAuthority {
+		t.Fatalf("status demanded authority repair for an outdated historical record: %#v", status)
+	}
+}
+
+// TestPreCommitGateAllowsApprovedReceiptWithOutdatedHistoricalAuthority pins
+// the delivery half: the pre-commit gate validates the approved lineage's own
+// receipt and must keep allowing it while outdated pre-rc.2 records sit in
+// the same store. Delivery never widens — the approved lineage still proves
+// its own authority — it simply stops being hostage to unrelated history.
+func TestPreCommitGateAllowsApprovedReceiptWithOutdatedHistoricalAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	outdatedForeignLineage(t, repo, "gate-scoped-historical")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\napproved delivery\n")
+	state, _, receipt := approvedCompactCurrentChangesFixture(t, repo, "gate-scoped-approved", []string{})
+
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
+		Gate: GatePreCommit, LineageID: state.LineageID,
+	})
+	if got.Result != GateAllow {
+		t.Fatalf("pre-commit gate with outdated historical authority = %#v, want allow", got)
+	}
+	if got.Context.CandidateTree != receipt.FinalCandidateTree {
+		t.Fatalf("gate context candidate tree = %q, want the approved %q", got.Context.CandidateTree, receipt.FinalCandidateTree)
+	}
+}
+
+// TestPristineAbandonmentIgnoresUnreadableForeignLineage: both the read-only
+// eligibility probe and the abandon operation itself walked every store and
+// refused repository-wide when one unrelated record did not load — locking the
+// escape valve exactly when it is needed.
+func TestPristineAbandonmentIgnoresUnreadableForeignLineage(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	outdatedForeignLineage(t, repo, "abandon-scoped-foreign")
+
+	writeSnapshotFile(t, repo, "tracked.txt", "base\naccidental change\n")
+	record, _ := pristineReviewingFixture(t, repo, "abandon-scoped-pristine")
+
+	eligibility, err := InspectCompactPristineAbandonment(context.Background(), repo, record.State.LineageID)
+	if err != nil {
+		t.Fatalf("abandon eligibility with an unreadable foreign record = %v", err)
+	}
+	if !eligibility.Eligible || eligibility.Revision != record.Revision {
+		t.Fatalf("pristine lineage lost abandon eligibility because of an unreadable foreign record: %#v", eligibility)
+	}
+
+	committed, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record))
+	if err != nil {
+		t.Fatalf("abandon with an unreadable foreign record = %v", err)
+	}
+	if committed.Status != CompactReclaimCommitted || committed.LineageID != record.State.LineageID {
+		t.Fatalf("abandonment record = %#v", committed)
+	}
+}
+
+// TestCompactLineageSupersededUnderMaintenanceIgnoresUnreadableForeignLineage:
+// the RAR receipt binding probe walked every store to prove the approved
+// lineage has no recovery successor, and failed the whole receipt derivation
+// on the first unreadable foreign record.
+func TestCompactLineageSupersededUnderMaintenanceIgnoresUnreadableForeignLineage(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\napproved change\n")
+	approved, _ := approvedCompactFixture(t, repo, "rar-scoped-approved")
+	outdatedForeignLineage(t, repo, "rar-scoped-foreign")
+
+	superseded, err := compactLineageSupersededUnderMaintenance(context.Background(), repo, approved.State.LineageID)
+	if err != nil {
+		t.Fatalf("superseded probe with an unreadable foreign record = %v", err)
+	}
+	if superseded {
+		t.Fatal("approved lineage reported superseded without any recovery successor")
+	}
+}
+
+// TestInspectAuthorityClassifiesOutdatedIdentityAsOutdated pins the honest
+// diagnostics half of #2743: a record whose only load failure is the retired
+// snapshot-identity formula is OUTDATED — gate-invalid, preserved for
+// forensics — not malformed, and the damage narration must stop describing it
+// as the residue of an interrupted write.
+func TestInspectAuthorityClassifiesOutdatedIdentityAsOutdated(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	lineage := quarantineFixtureHealthyLineage(t, repo, "inspect-outdated-identity", "outdated candidate\n")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outdateCompactSnapshotIdentity(t, store)
+
+	report, err := InspectCompactRecoveryEdges(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.EntryDiagnostics) != 1 || report.EntryDiagnostics[0].LineageID != lineage ||
+		report.EntryDiagnostics[0].Problem != "outdated_compact_state" {
+		t.Fatalf("entry diagnostics = %#v", report.EntryDiagnostics)
+	}
+
+	kinds := CompactAuthorityDamageKinds(report)
+	if len(kinds) != 1 {
+		t.Fatalf("damage kinds = %#v", kinds)
+	}
+	if strings.Contains(kinds[0], "interrupted write") || strings.Contains(kinds[0], "does not parse") {
+		t.Fatalf("outdated record still narrated as damage: %q", kinds[0])
+	}
+	if !strings.Contains(kinds[0], "outdated_compact_state") || !strings.Contains(kinds[0], "earlier release") {
+		t.Fatalf("outdated record narration is not honest about its class: %q", kinds[0])
+	}
+}
+
+// TestInspectAuthorityKeepsGenuineSemanticDamageMalformed proves the outdated
+// class is exactly as narrow as the retired-identity signature: any other
+// semantic-validation failure keeps the existing malformed classification.
+func TestInspectAuthorityKeepsGenuineSemanticDamageMalformed(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	lineage := quarantineFixtureHealthyLineage(t, repo, "inspect-semantic-damage", "damaged candidate\n")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corruptCompactStateSemantics(t, store)
+
+	report, err := InspectCompactRecoveryEdges(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.EntryDiagnostics) != 1 || report.EntryDiagnostics[0].Problem != "malformed_compact_state" {
+		t.Fatalf("entry diagnostics = %#v", report.EntryDiagnostics)
+	}
+}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -349,11 +349,14 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 			importCompactRecoveredEvidence(&request.Successor, predecessor.State, evidence)
 		}
 	}
-	stores, err := DiscoverCompactStores(ctx, repo)
+	// The recovery graph is scoped the same way every other authority walk is
+	// (#2495, finished here for #2741/#2743): a foreign record nobody can read
+	// is ABSENT from the graph, never a repository-wide refusal issued to a
+	// healthy, unrelated recovery. scanCompactAuthority still propagates
+	// operational failures, and the predecessor's own readability was already
+	// proven by its explicit load above.
+	scan, err := scanCompactAuthority(ctx, repo)
 	if err != nil {
-		return CompactRecord{}, err
-	}
-	if _, err := CompactAuthorityLeaves(ctx, repo); err != nil {
 		return CompactRecord{}, err
 	}
 	if existingErr == nil {
@@ -362,11 +365,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 		}
 		return CompactRecord{}, errors.New("recovery successor lineage already exists with different authority")
 	}
-	for _, store := range stores {
-		record, loadErr := store.Load()
-		if loadErr != nil {
-			return CompactRecord{}, fmt.Errorf("validate recovery graph: %w", loadErr)
-		}
+	for _, record := range scan.records {
 		if record.State.Recovery != nil && record.State.Recovery.PredecessorLineageID == request.PredecessorLineageID {
 			return CompactRecord{}, errors.New("recovery predecessor already has successor")
 		}
@@ -2245,7 +2244,8 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		return CompactRecord{}, errors.New("invalid compact review state record")
 	}
 	if err := record.State.Validate(); err != nil {
-		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error()}
+		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
+			OutdatedIdentity: errors.Is(err, errCompactSnapshotIdentityMismatch)}
 	}
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")

--- a/internal/reviewtransaction/final_verification_retry.go
+++ b/internal/reviewtransaction/final_verification_retry.go
@@ -717,22 +717,23 @@ func InspectCompactFinalVerificationRetrySource(ctx context.Context, repo, linea
 		}
 		return FinalVerificationRetryEligibility{}, false, err
 	}
-	stores, err := DiscoverCompactStores(ctx, store.repo)
+	// This inspection is on the negotiated STATUS path for every escalated
+	// lineage, so its walk must be scoped exactly like the rest of the
+	// authority graph (#2743): one unreadable foreign record used to abort
+	// it, and the aborted STATUS then declared the whole repository
+	// authority corrupted. An unreadable record is absent from the graph;
+	// an absent ancestor already makes the ancestry check below answer
+	// ineligible for this one lineage, which is the honest scoped verdict.
+	scan, err := scanCompactAuthority(ctx, store.repo)
 	if err != nil {
 		return FinalVerificationRetryEligibility{}, false, err
 	}
-	records := make(map[string]CompactRecord, len(stores))
-	for _, candidateStore := range stores {
-		candidate, loadErr := candidateStore.LoadContext(ctx)
-		if loadErr != nil {
-			return FinalVerificationRetryEligibility{}, false, loadErr
-		}
-		records[candidate.State.LineageID] = candidate
+	for _, candidate := range scan.records {
 		if candidate.State.Recovery != nil && candidate.State.Recovery.PredecessorLineageID == lineageID {
 			return FinalVerificationRetryEligibility{}, false, nil
 		}
 	}
-	if err := finalVerificationRetryAncestryEligible(record, records); err != nil {
+	if err := finalVerificationRetryAncestryEligible(record, scan.records); err != nil {
 		return FinalVerificationRetryEligibility{}, false, nil
 	}
 	return source.eligibility, true, nil

--- a/internal/reviewtransaction/rar_native_receipt.go
+++ b/internal/reviewtransaction/rar_native_receipt.go
@@ -239,7 +239,16 @@ func compactLineageSupersededUnderMaintenance(
 	for _, store := range stores {
 		record, loadErr := store.loadCompactRecordLocked()
 		if loadErr != nil {
-			return false, loadErr
+			// Scoped like every other authority walk (#2743): the probe
+			// answers whether THIS lineage has a recovery successor, so an
+			// unreadable foreign record is absent from the graph, not a
+			// receipt-derivation failure. The caller already holds the
+			// maintenance lock, hence the locked read instead of
+			// scanCompactAuthority; operational failures still propagate.
+			if IsCompactAuthorityOperationalFailure(loadErr) {
+				return false, loadErr
+			}
+			continue
 		}
 		if record.State.Recovery != nil &&
 			record.State.Recovery.PredecessorLineageID == lineageID {


### PR DESCRIPTION
Closes #2743
Closes #2741

Stable-release regression, two independent reporters within 48h of v2.3.0. Written by one agent, adversarially audited by a second that wrote none of the code; decoy results are inline below because on a regression like this "the tests pass" is not evidence.

## Root cause, proven by experiment

Identity validation runs inside record parsing, so a record frozen under the retired pre-rc.2 formula is **unloadable** to every consumer rather than merely gate-invalid. Commit `285464bf` removed the repository-global refusal for some paths but missed others, so one outdated record aborts whole operations. Reproduced with real binaries: a `v2.2.4` binary created a lineage, the released `v2.3.0` binary then reported it `malformed_compact_state` with `sanctioned_exits: []` — #2743 at 1:1 scale, where the reporter's 52 is simply "every pre-rc.2 record". The STATUS flip fires through `InspectCompactFinalVerificationRetrySource`, whose sibling in the same file `285464bf` had already scoped.

This violated a recorded invariant: outdated means gate-invalid, never unreadable, never obstructive.

## The fix, subtractive

Four walks converted to `scanCompactAuthority` semantics — unreadable means absent from the graph, operational failures still propagate: the `RecoverCompactAuthority` recovery-graph loop (#2741's exact refusal), `InspectCompactFinalVerificationRetrySource` (#2743's mechanism), both `review abandon` walks, and `compactLineageSupersededUnderMaintenance`. A now-redundant `CompactAuthorityLeaves` re-walk was deleted with them.

Diagnostics made honest: a typed `OutdatedIdentity` semantic error surfaces as a new `outdated_compact_state` class instead of `malformed_compact_state`, and the "interrupted write" narration that misdescribed it is corrected in two files.

Deliberately absent: identity-version markers, reader-side legacy recomputation, migration rewrites. All are dual recognition or stored-byte rewriting, forbidden by the clean-break policy. Pre-rc.2 receipts stay gate-invalid; they become non-obstructive and honestly labeled. Verified zero retired-tag references in production code.

## Audit evidence

**A test was pinning the defect.** `review_inspect_authority_test.go` asserted both recovery successors report `Blocked`, justified by a comment claiming neither is pristine. That reading was wrong: the `Blocked` came from an unrelated `broken-entry` fixture poisoning the abandon probe's repo-wide walk. The auditor did not take that on reasoning — reverting only the pristine-abandonment scoping regenerates the old blocked state verbatim, and an independent throwaway test confirmed the advertised `review abandon` now actually commits with an unreadable entry present, flipping to ineligible under the decoy.

**Decoy A** (revert the recover-walk scoping) fails the foreign-lineage case with #2741's reported string verbatim: `validate recovery graph: compact lineage ... initial snapshot: compact snapshot identity does not match its metadata`.

**Decoy B** (flip the classification back to malformed) fails the outdated test while its sibling still keeps genuine semantic damage classified as malformed — the pair bites and does not over-broaden.

**Honest caveat, recorded rather than hidden:** `TestRecoverCompactAuthorityStillRefusesTheOutdatedLineageItself` passes under the decoy too. Its refusal comes from an earlier explicit load plus revision CAS, upstream of the scan. It is a fail-closed outcome pin (refuses, and zero authority mutation verified byte-wise), not a regression detector for the scoping. Kept, but not credited as proof the scoping stayed narrow.

**The delivery-gate test is a pin, not a reproduction** — it passes with the walks reverted, confirming the mechanism map's finding that gates were never broken by this defect. Kept as the guard on the one property the fix must not weaken.

The retired-identity fixture was verified byte-for-byte against `fbb55080^` and asserts it differs from the current formula before use, so it cannot go vacuous if the formula changes again.

## Verification

```bash
go test ./internal/reviewtransaction/ -count=1   # ok (120.6s)
go test ./internal/cli/ -count=1                 # ok (196.3s)
cd bench && go test ./... -count=1               # ok
gofmt -l . && go vet ./... && go build ./...     # clean
```

## Follow-up, not blocking

`retiredSnapshotIdentity` duplicates `legacyPreCutSnapshotIdentityForTest` in the same package — two copies of a formula that must stay byte-exact. Worth collapsing later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recovery, status checks, abandonment, and supersession now ignore unreadable records from unrelated historical lineages while continuing to protect the affected lineage.
  - Approved receipts can remain valid when associated with outdated historical snapshot identities.
  - Updated authority inspection to distinguish outdated records from genuinely malformed or damaged records.
  - Certain unchanged or malformed-recovery states now correctly offer `review abandon` as an available exit.
- **Diagnostics**
  - Added clearer classification for records created with retired snapshot identity formulas.
  - Improved messaging for unreadable records without assuming they resulted from interrupted writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->