### PR TITLE
fix(tui): preserve Codex capabilities and OpenCode fast variants - slice 1/3 (foundation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Cross-cutting notes for gentle-ai capabilities, one entry per change. PR
+release notes still live in `docs/releases/v*.md`; this file is the index
+for capability additions that span multiple slices or PRs.
+
+## Unreleased
+
+- `model-capability-discovery` capability (foundation): the Codex
+  adapter now exposes a synchronous `Capabilities(ctx, lookup)` sibling
+  to `Tier()` that returns a `model.CapabilityRecord` with
+  `reasoning`, `speed_tiers`, `service_tiers`, `multi_agent_version`,
+  and `capability_source` fields. Discovery is bounded by a 2-second
+  timeout and falls back to a curated `gpt-5.6-sol` row whenever the
+  runtime `codex debug models` call is missing, times out, or parses
+  with errors; the picker never blocks. The curated matrix
+  (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) is pinned in
+  `internal/model/codex_capabilities_test.go` — `luna` never carries
+  `max` or `ultra`, and `fast` never appears in `reasoning`. See
+  Gentleman-Programming/gentle-ai#2218.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,23 @@ for capability additions that span multiple slices or PRs.
 ## Unreleased
 
 - `model-capability-discovery` capability (foundation): the Codex
-  adapter now exposes a synchronous `Capabilities(ctx, lookup)` sibling
-  to `Tier()` that returns a `model.CapabilityRecord` with
+  adapter now exposes a synchronous `Capabilities(ctx, lookup, modelID)`
+  sibling to `Tier()` that returns a `model.CapabilityRecord` with
   `reasoning`, `speed_tiers`, `service_tiers`, `multi_agent_version`,
   and `capability_source` fields. Discovery is bounded by a 2-second
-  timeout and falls back to a curated `gpt-5.6-sol` row whenever the
-  runtime `codex debug models` call is missing, times out, or parses
-  with errors; the picker never blocks. The curated matrix
+  timeout and falls back to a curated row for the requested `modelID`
+  (or the conservative `unknown` row when the model id has no curated
+  entry) whenever the runtime `codex debug models` call is missing,
+  times out, parses with errors, or names a slug not in the catalog.
+  The picker never blocks. The real `codex debug models` envelope
+  `{"models":[{"slug":...,"reasoning":...,"speed_tiers":...,
+  "service_tiers":...,"multi_agent_version":...}, ...]}` is parsed
+  per-model via `RecordFromRuntimeForModel`; the legacy flat top-level
+  shape stays accepted for empty-modelID callers. The curated matrix
   (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) is pinned in
   `internal/model/codex_capabilities_test.go` — `luna` never carries
-  `max` or `ultra`, and `fast` never appears in `reasoning`. See
+  `ultra`, and `fast` never appears in `reasoning`. Partition
+  validation (`firstOverlap` + `containsValue`) is now case-insensitive
+  on both paths so a mixed-case payload cannot let one partition check
+  slide past while the other catches it. See
   Gentleman-Programming/gentle-ai#2218.

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -2,9 +2,11 @@ package codex
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -12,6 +14,24 @@ import (
 )
 
 var LookPathOverride = exec.LookPath
+
+// capabilitiesProbeTimeout bounds the live `codex debug models` invocation
+// inside Capabilities. The picker renders inside 2s or it falls back to
+// curated — a hung CLI must never block the TUI.
+const capabilitiesProbeTimeout = 2 * time.Second
+
+// runCapabilitiesCommand is the package-level hook for the
+// `codex debug models` invocation. Tests swap it via
+// SetCapabilitiesProbeForTest; production code calls the default below.
+var runCapabilitiesCommand = func(ctx context.Context, binaryPath string) ([]byte, error) {
+	return exec.CommandContext(ctx, binaryPath, "debug", "models").CombinedOutput()
+}
+
+// curatedFallbackModelID is the model identifier the curated fallback
+// uses when the runtime catalog is unavailable. sol is the broadest of the
+// three Codex rails (low through ultra), so it is the safest default when
+// the picker cannot ask the CLI.
+const curatedFallbackModelID = "gpt-5.6-sol"
 
 type statResult struct {
 	isDir bool
@@ -38,6 +58,73 @@ func (a *Adapter) Agent() model.AgentID {
 
 func (a *Adapter) Tier() model.SupportTier {
 	return model.TierFull
+}
+
+// --- Capability discovery ---
+
+// Capabilities returns the Codex capability record the picker renders:
+// reasoning/speed/service tiers, the multi-agent version stamp, and the
+// provenance of the data. It is a synchronous sibling of Tier(): Tier()
+// reports agent support (Full/Partial); Capabilities reports what the
+// model itself can do. The two never share fields and never replace each
+// other.
+//
+// Behavior:
+//   - Invoke `codex debug models` with a 2s timeout. On success, parse the
+//     JSON payload and stamp CapabilitySource = "runtime".
+//   - On any failure (lookup, timeout, non-zero exit, parse error) fall
+//     back to the curated sol row and stamp CapabilitySource = "curated".
+//     The picker MUST receive a non-nil record even when the CLI is
+//     missing or hanging — discovery never blocks the UI.
+//
+// The method is intentionally synchronous: no goroutines, no tea.Cmd,
+// returns before the picker's first Update(). Callers wire it into the
+// picker's initial state.
+func (a *Adapter) Capabilities(ctx context.Context, lookup func(string) (string, error)) (model.CapabilityRecord, error) {
+	lookPath := a.lookPath
+	if lookup != nil {
+		lookPath = lookup
+	}
+
+	if lookPath == nil {
+		return curatedFallback(), nil
+	}
+
+	binaryPath, err := lookPath("codex")
+	if err != nil || binaryPath == "" {
+		return curatedFallback(), nil
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, capabilitiesProbeTimeout)
+	defer cancel()
+
+	output, err := runCapabilitiesCommand(probeCtx, binaryPath)
+	if err != nil {
+		// Distinguish "codex not on PATH" errors from a hung timeout using
+		// context.DeadlineExceeded so future diagnostics can attribute the
+		// fallback correctly. We always fall back, regardless.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return curatedFallback(), nil
+		}
+		// Non-zero exit also falls back. The combined output may carry an
+		// error message we deliberately ignore — the picker only needs the
+		// curated matrix in this branch.
+		_ = output
+		return curatedFallback(), nil
+	}
+
+	rec, parseErr := model.RecordFromRuntime(output)
+	if parseErr != nil {
+		return curatedFallback(), nil
+	}
+	return rec, nil
+}
+
+// curatedFallback returns the curated CapabilityRecord stamped with
+// CapabilitySource = "curated". It is the universal fallback whenever the
+// runtime cannot answer — the picker relies on a non-nil record.
+func curatedFallback() model.CapabilityRecord {
+	return model.RecordFromCurated(curatedFallbackModelID)
 }
 
 // --- Detection ---

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
@@ -62,37 +63,41 @@ func (a *Adapter) Tier() model.SupportTier {
 
 // --- Capability discovery ---
 
-// Capabilities returns the Codex capability record the picker renders:
-// reasoning/speed/service tiers, the multi-agent version stamp, and the
-// provenance of the data. It is a synchronous sibling of Tier(): Tier()
-// reports agent support (Full/Partial); Capabilities reports what the
-// model itself can do. The two never share fields and never replace each
-// other.
+// Capabilities returns the Codex capability record the picker renders
+// for the requested model: reasoning/speed/service tiers, the multi-agent
+// version stamp, and the provenance of the data. It is a synchronous
+// sibling of Tier(): Tier() reports agent support (Full/Partial);
+// Capabilities reports what the model itself can do. The two never share
+// fields and never replace each other.
 //
 // Behavior:
-//   - Invoke `codex debug models` with a 2s timeout. On success, parse the
-//     JSON payload and stamp CapabilitySource = "runtime".
-//   - On any failure (lookup, timeout, non-zero exit, parse error) fall
-//     back to the curated sol row and stamp CapabilitySource = "curated".
-//     The picker MUST receive a non-nil record even when the CLI is
-//     missing or hanging — discovery never blocks the UI.
+//   - Invoke `codex debug models` with a 2s timeout. On success, parse
+//     the real envelope `{"models":[{slug, reasoning, speed_tiers,
+//     service_tiers, multi_agent_version}, ...]}` and look up the
+//     entry whose slug matches modelID. Stamp CapabilitySource = "runtime".
+//     If the model is not in the catalog, fall back to the curated row for
+//     modelID (or the conservative `unknown` row if modelID is empty).
+//   - On any runtime failure (lookup, timeout, non-zero exit, parse error,
+//     missing slug) fall back to the curated row for modelID. The picker
+//     MUST receive a non-nil record even when the CLI is missing or
+//     hanging — discovery never blocks the UI.
 //
 // The method is intentionally synchronous: no goroutines, no tea.Cmd,
 // returns before the picker's first Update(). Callers wire it into the
 // picker's initial state.
-func (a *Adapter) Capabilities(ctx context.Context, lookup func(string) (string, error)) (model.CapabilityRecord, error) {
+func (a *Adapter) Capabilities(ctx context.Context, lookup func(string) (string, error), modelID string) (model.CapabilityRecord, error) {
 	lookPath := a.lookPath
 	if lookup != nil {
 		lookPath = lookup
 	}
 
 	if lookPath == nil {
-		return curatedFallback(), nil
+		return curatedFallbackForModel(modelID), nil
 	}
 
 	binaryPath, err := lookPath("codex")
 	if err != nil || binaryPath == "" {
-		return curatedFallback(), nil
+		return curatedFallbackForModel(modelID), nil
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, capabilitiesProbeTimeout)
@@ -104,27 +109,56 @@ func (a *Adapter) Capabilities(ctx context.Context, lookup func(string) (string,
 		// context.DeadlineExceeded so future diagnostics can attribute the
 		// fallback correctly. We always fall back, regardless.
 		if errors.Is(err, context.DeadlineExceeded) {
-			return curatedFallback(), nil
+			return curatedFallbackForModel(modelID), nil
 		}
 		// Non-zero exit also falls back. The combined output may carry an
 		// error message we deliberately ignore — the picker only needs the
 		// curated matrix in this branch.
 		_ = output
-		return curatedFallback(), nil
+		return curatedFallbackForModel(modelID), nil
 	}
 
-	rec, parseErr := model.RecordFromRuntime(output)
+	// Empty modelID falls back to the legacy flat parser: the picker
+	// handed us an empty ID (pre-picker-bootstrap path), so we accept
+	// whatever flat payload the CLI returned. A real model ID requires
+	// the wrapping envelope shape; the helper returns an error that the
+	// caller maps into the curated fallback.
+	if strings.TrimSpace(modelID) == "" {
+		rec, parseErr := model.RecordFromRuntime(output)
+		if parseErr != nil {
+			return curatedFallbackForModel(modelID), nil
+		}
+		return rec, nil
+	}
+	rec, parseErr := model.RecordFromRuntimeForModel(output, modelID)
 	if parseErr != nil {
-		return curatedFallback(), nil
+		// Model missing from runtime catalog OR runtime payload failed to
+		// validate. Either way, the curated row for modelID is the right
+		// answer (defaults to the conservative unknown row when modelID
+		// has no curated entry).
+		return curatedFallbackForModel(modelID), nil
 	}
 	return rec, nil
 }
 
 // curatedFallback returns the curated CapabilityRecord stamped with
-// CapabilitySource = "curated". It is the universal fallback whenever the
-// runtime cannot answer — the picker relies on a non-nil record.
+// CapabilitySource = "curated" for the historical single-row fallback
+// (the broadest of the three Codex rails). It survives the cut-over to
+// per-model fallbacks so existing call sites stay compiling.
 func curatedFallback() model.CapabilityRecord {
 	return model.RecordFromCurated(curatedFallbackModelID)
+}
+
+// curatedFallbackForModel returns the curated CapabilityRecord stamped
+// with CapabilitySource = "curated" for the requested model id. When
+// modelID is empty or unknown to the curated matrix, it returns the
+// conservative unknown row (only low/medium/high reasoning, no speed
+// or service tiers).
+func curatedFallbackForModel(modelID string) model.CapabilityRecord {
+	if strings.TrimSpace(modelID) == "" {
+		return curatedFallback()
+	}
+	return model.RecordFromCurated(modelID)
 }
 
 // --- Detection ---

--- a/internal/agents/codex/adapter_capabilities_test.go
+++ b/internal/agents/codex/adapter_capabilities_test.go
@@ -1,0 +1,316 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// stubLookPath returns a function that always resolves "codex" to a
+// caller-supplied path (or always errors). Mirrors the style used in
+// TestDetect so the new tests read the same way.
+func stubLookPath(path string, err error) func(string) (string, error) {
+	return func(string) (string, error) {
+		return path, err
+	}
+}
+
+// capabilitiesProbeFingerprint is the JSON shape a fake `codex debug
+// models` returns. Tests substitute or mutate this string per scenario.
+const capabilitiesProbeFingerprint = `{
+	"reasoning": ["low","medium","high","xhigh","max","ultra"],
+	"speed_tiers": ["fast"],
+	"service_tiers": ["priority","standard"],
+	"multi_agent_version": "0.42.0"
+}`
+
+// withCapabilitiesProbe swaps the runCapabilitiesCommand hook for the
+// duration of the test. It returns a teardown that callers defer.
+func withCapabilitiesProbe(t *testing.T, probe func(ctx context.Context, _ string) ([]byte, error)) {
+	t.Helper()
+	original := runCapabilitiesCommand
+	runCapabilitiesCommand = probe
+	t.Cleanup(func() {
+		runCapabilitiesCommand = original
+	})
+}
+
+// TestAdapterCapabilitiesDiscovery is the table-driven proof that
+// Capabilities sources its record from the runtime when the live catalog
+// answers, and from the curated fallback whenever the runtime cannot —
+// lookup failure, timeout, non-zero exit, or parse error.
+//
+// Each table row maps to a scenario in
+// openspec/changes/2218-.../specs/model-capability-discovery/spec.md:
+//   - S1-R2: Live catalog → record comes from runtime.
+//   - S1-R2: Catalog unavailable → curated fallback takes over.
+//   - S1-R2: Bounded by the timeout, never blocks the UI.
+func TestAdapterCapabilitiesDiscovery(t *testing.T) {
+	tests := []struct {
+		name              string
+		lookPath          func(string) (string, error)
+		probe             func(ctx context.Context, _ string) ([]byte, error)
+		wantSource        string
+		wantReasoning     []string
+		wantVersion       string
+		wantContainsError string
+	}{
+		{
+			name:     "live catalog — runtime payload is parsed",
+			lookPath: stubLookPath("/usr/local/bin/codex", nil),
+			probe: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(capabilitiesProbeFingerprint), nil
+			},
+			wantSource:    model.SourceRuntime,
+			wantReasoning: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:   "0.42.0",
+		},
+		{
+			name:     "lookup fails — curated fallback",
+			lookPath: stubLookPath("", errors.New("codex not on PATH")),
+			probe: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(capabilitiesProbeFingerprint), nil
+			},
+			wantSource:        model.SourceCurated,
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:       "",
+			wantContainsError: "",
+		},
+		{
+			name:     "lookup returns empty path — curated fallback",
+			lookPath: stubLookPath("", nil),
+			probe: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(capabilitiesProbeFingerprint), nil
+			},
+			wantSource:    model.SourceCurated,
+			wantReasoning: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:   "",
+		},
+		{
+			name:     "process timeout — curated fallback",
+			lookPath: stubLookPath("/usr/local/bin/codex", nil),
+			probe: func(ctx context.Context, _ string) ([]byte, error) {
+				// Block until the inherited WithTimeout fires. The picker's
+				// 2s budget is exercised end-to-end: the command returns
+				// context.DeadlineExceeded just like a hung CLI would.
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			wantSource:    model.SourceCurated,
+			wantReasoning: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:   "",
+		},
+		{
+			name:     "non-zero exit — curated fallback",
+			lookPath: stubLookPath("/usr/local/bin/codex", nil),
+			probe: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte("codex: internal error"), &exec.ExitError{}
+			},
+			wantSource:    model.SourceCurated,
+			wantReasoning: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:   "",
+		},
+		{
+			name:     "invalid JSON payload — curated fallback",
+			lookPath: stubLookPath("/usr/local/bin/codex", nil),
+			probe: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"reasoning": ["low",`), nil
+			},
+			wantSource:    model.SourceCurated,
+			wantReasoning: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:   "",
+		},
+		{
+			name:     "fast in reasoning payload — curated fallback",
+			lookPath: stubLookPath("/usr/local/bin/codex", nil),
+			probe: func(_ context.Context, _ string) ([]byte, error) {
+				// Runtime side tried to leak "fast" into reasoning. The
+				// runtime constructor rejects it, so we fall back. This
+				// guards the picker's reasoning dropdown from a broken
+				// runtime that happened to compile.
+				return []byte(`{"reasoning":["low","medium","fast"]}`), nil
+			},
+			wantSource:    model.SourceCurated,
+			wantReasoning: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantVersion:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withCapabilitiesProbe(t, tt.probe)
+
+			a := &Adapter{
+				lookPath: tt.lookPath,
+				statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+			}
+
+			rec, err := a.Capabilities(context.Background(), tt.lookPath)
+			if err != nil {
+				t.Fatalf("Capabilities() returned error %v, want nil (picker must never block)", err)
+			}
+			if rec.CapabilitySource != tt.wantSource {
+				t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, tt.wantSource)
+			}
+			if !reflect.DeepEqual(rec.Reasoning, tt.wantReasoning) {
+				t.Fatalf("Reasoning = %v, want %v", rec.Reasoning, tt.wantReasoning)
+			}
+			if rec.MultiAgentVersion != tt.wantVersion {
+				t.Fatalf("MultiAgentVersion = %q, want %q", rec.MultiAgentVersion, tt.wantVersion)
+			}
+		})
+	}
+}
+
+// TestAdapterCapabilities_NilLookupUsesAdapterField asserts that when the
+// caller passes a nil lookup, the adapter falls back to its own
+// lookPath field. The picker is allowed to omit the lookup argument
+// once it has wired the adapter.
+func TestAdapterCapabilities_NilLookupUsesAdapterField(t *testing.T) {
+	withCapabilitiesProbe(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(capabilitiesProbeFingerprint), nil
+	})
+
+	a := &Adapter{
+		lookPath: stubLookPath("/usr/local/bin/codex", nil),
+		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+	}
+
+	rec, err := a.Capabilities(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Capabilities() with nil lookup returned error %v", err)
+	}
+	if rec.CapabilitySource != model.SourceRuntime {
+		t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, model.SourceRuntime)
+	}
+}
+
+// TestAdapterCapabilities_NilAdapterLookPathCoversDefensive asserts the
+// fully-degenerate case: a caller that constructs an Adapter without
+// setting lookPath (e.g. a future test helper) still receives a curated
+// fallback. The picker must never see a nil-deref panic.
+func TestAdapterCapabilities_NilAdapterLookPathCoversDefensive(t *testing.T) {
+	withCapabilitiesProbe(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(capabilitiesProbeFingerprint), nil
+	})
+
+	a := &Adapter{
+		lookPath: nil,
+		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+	}
+
+	rec, err := a.Capabilities(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Capabilities() returned error %v", err)
+	}
+	if rec.CapabilitySource != model.SourceCurated {
+		t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, model.SourceCurated)
+	}
+}
+
+// TestAdapterCapabilities_NeverPropagatesError is the picker contract
+// gate: no matter what the runtime does, Capabilities returns a non-nil
+// record and a nil error. The TUI discards the error and renders the
+// record — if Capabilities ever bubbles an error up, the picker's first
+// Update() would render a blank screen.
+func TestAdapterCapabilities_NeverPropagatesError(t *testing.T) {
+	withCapabilitiesProbe(t, func(_ context.Context, _ string) ([]byte, error) {
+		return nil, errors.New("synthetic boom")
+	})
+
+	a := &Adapter{
+		lookPath: stubLookPath("/usr/local/bin/codex", nil),
+		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+	}
+
+	rec, err := a.Capabilities(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Capabilities() returned error %v — picker contract requires nil error", err)
+	}
+	if rec.CapabilitySource == "" {
+		t.Fatal("CapabilitySource is empty — picker cannot render footer")
+	}
+	if rec.CapabilitySource != model.SourceCurated {
+		t.Fatalf("CapabilitySource = %q, want %q on synthetic probe failure", rec.CapabilitySource, model.SourceCurated)
+	}
+}
+
+// TestAdapterCapabilities_DoesNotMutateTier checks that adding the
+// Capabilities method does not change the existing Tier() contract.
+// Tier() reports agent support (Full/Partial) and is unrelated to
+// service tier; this regression guard prevents a future refactor from
+// collapsing the two methods.
+func TestAdapterCapabilities_DoesNotMutateTier(t *testing.T) {
+	a := NewAdapter()
+	if got := a.Tier(); got != model.TierFull {
+		t.Fatalf("Tier() = %v, want TierFull (Capabilities must not change Tier)", got)
+	}
+}
+
+// TestAdapterCapabilities_CuratedFallbackMentionsSol pins the
+// curatedFallbackModelID constant. The picker footer surfaces this
+// fallback; if a future refactor renames sol to terra by mistake, the
+// reasoning dropdown would gain "ultra" for luna and break the spec.
+func TestAdapterCapabilities_CuratedFallbackMentionsSol(t *testing.T) {
+	withCapabilitiesProbe(t, func(_ context.Context, _ string) ([]byte, error) {
+		return nil, errors.New("probe must not be called")
+	})
+
+	a := &Adapter{
+		lookPath: stubLookPath("/usr/local/bin/codex", nil),
+		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+	}
+
+	rec, err := a.Capabilities(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Capabilities() returned error %v", err)
+	}
+	if rec.CapabilitySource != model.SourceCurated {
+		t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, model.SourceCurated)
+	}
+	// The curated sol row carries the full ladder including ultra.
+	hasUltra := false
+	for _, v := range rec.Reasoning {
+		if v == "ultra" {
+			hasUltra = true
+			break
+		}
+	}
+	if !hasUltra {
+		t.Fatalf("curated fallback reasoning = %v — must contain ultra (this is the sol row)", rec.Reasoning)
+	}
+}
+
+// TestAdapterCapabilities_EmptyParentContextDoesNotPanic guards the
+// degnerate case where the supplied context is already cancelled. The
+// probe returns DeadlineExceeded immediately and the adapter falls back.
+func TestAdapterCapabilities_EmptyParentContextDoesNotPanic(t *testing.T) {
+	withCapabilitiesProbe(t, func(ctx context.Context, _ string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	a := &Adapter{
+		lookPath: stubLookPath("/usr/local/bin/codex", nil),
+		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	rec, err := a.Capabilities(ctx, nil)
+	if err != nil {
+		t.Fatalf("Capabilities() returned error %v", err)
+	}
+	if rec.CapabilitySource != model.SourceCurated {
+		t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, model.SourceCurated)
+	}
+	if strings.TrimSpace(rec.CapabilitySource) == "" {
+		t.Fatal("CapabilitySource is empty after pre-cancelled context")
+	}
+}

--- a/internal/agents/codex/adapter_capabilities_test.go
+++ b/internal/agents/codex/adapter_capabilities_test.go
@@ -150,7 +150,7 @@ func TestAdapterCapabilitiesDiscovery(t *testing.T) {
 				statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
 			}
 
-			rec, err := a.Capabilities(context.Background(), tt.lookPath)
+			rec, err := a.Capabilities(context.Background(), tt.lookPath, "")
 			if err != nil {
 				t.Fatalf("Capabilities() returned error %v, want nil (picker must never block)", err)
 			}
@@ -181,7 +181,7 @@ func TestAdapterCapabilities_NilLookupUsesAdapterField(t *testing.T) {
 		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
 	}
 
-	rec, err := a.Capabilities(context.Background(), nil)
+	rec, err := a.Capabilities(context.Background(), nil, "")
 	if err != nil {
 		t.Fatalf("Capabilities() with nil lookup returned error %v", err)
 	}
@@ -204,7 +204,7 @@ func TestAdapterCapabilities_NilAdapterLookPathCoversDefensive(t *testing.T) {
 		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
 	}
 
-	rec, err := a.Capabilities(context.Background(), nil)
+	rec, err := a.Capabilities(context.Background(), nil, "")
 	if err != nil {
 		t.Fatalf("Capabilities() returned error %v", err)
 	}
@@ -228,7 +228,7 @@ func TestAdapterCapabilities_NeverPropagatesError(t *testing.T) {
 		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
 	}
 
-	rec, err := a.Capabilities(context.Background(), nil)
+	rec, err := a.Capabilities(context.Background(), nil, "")
 	if err != nil {
 		t.Fatalf("Capabilities() returned error %v — picker contract requires nil error", err)
 	}
@@ -266,7 +266,7 @@ func TestAdapterCapabilities_CuratedFallbackMentionsSol(t *testing.T) {
 		statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
 	}
 
-	rec, err := a.Capabilities(context.Background(), nil)
+	rec, err := a.Capabilities(context.Background(), nil, "")
 	if err != nil {
 		t.Fatalf("Capabilities() returned error %v", err)
 	}
@@ -303,7 +303,7 @@ func TestAdapterCapabilities_EmptyParentContextDoesNotPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
-	rec, err := a.Capabilities(ctx, nil)
+	rec, err := a.Capabilities(ctx, nil, "")
 	if err != nil {
 		t.Fatalf("Capabilities() returned error %v", err)
 	}
@@ -312,5 +312,146 @@ func TestAdapterCapabilities_EmptyParentContextDoesNotPanic(t *testing.T) {
 	}
 	if strings.TrimSpace(rec.CapabilitySource) == "" {
 		t.Fatal("CapabilitySource is empty after pre-cancelled context")
+	}
+}
+
+// realEnvelopeFixture is the shape `codex debug models` returns when
+// invoked against a live Codex CLI: a `models` array carrying one entry
+// per model, each with the four capability fields the picker renders.
+// Field names come from the existing flat parser (reasoning/speed_tiers/
+// service_tiers/multi_agent_version) and have not been re-probed against
+// a live Codex binary in this slice; if a real CLI uses different names,
+// runtimeModelEnvelope in internal/model/codex_capabilities.go is the one
+// place to update.
+const realEnvelopeFixture = `{
+	"models": [
+		{
+			"slug": "gpt-5.6-sol",
+			"reasoning": ["low","medium","high","xhigh","max","ultra"],
+			"speed_tiers": ["fast"],
+			"service_tiers": ["priority","standard"],
+			"multi_agent_version": "0.42.0"
+		},
+		{
+			"slug": "gpt-5.6-luna",
+			"reasoning": ["low","medium","high","xhigh","max"],
+			"speed_tiers": ["fast"],
+			"service_tiers": ["priority"]
+		},
+		{
+			"slug": "gpt-5.6-terra",
+			"reasoning": ["low","medium","high","xhigh","max","ultra"],
+			"speed_tiers": ["fast","balanced"],
+			"service_tiers": ["priority","standard"],
+			"multi_agent_version": "0.42.0"
+		}
+	]
+}`
+
+// TestAdapterCapabilitiesPerModelEnvelope pins the per-model lookup:
+// when the runtime returns the real envelope `{"models":[{slug,...}]}`
+// shape, Capabilities must look up the requested modelID and return its
+// per-model capability slice. decode2 (2026-08-18) PR #2761 review.
+func TestAdapterCapabilitiesPerModelEnvelope(t *testing.T) {
+	tests := []struct {
+		name              string
+		modelID           string
+		envelope          string
+		wantSource        string
+		wantReasoning     []string
+		wantSpeedTiers    []string
+		wantServiceTiers  []string
+		wantMultiAgentVer string
+	}{
+		{
+			name:              "sol runtime: full ladder including ultra",
+			modelID:           "gpt-5.6-sol",
+			envelope:          realEnvelopeFixture,
+			wantSource:        model.SourceRuntime,
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantSpeedTiers:    []string{"fast"},
+			wantServiceTiers:  []string{"priority", "standard"},
+			wantMultiAgentVer: "0.42.0",
+		},
+		{
+			name:              "luna runtime: no ultra (spec regression guard)",
+			modelID:           "gpt-5.6-luna",
+			envelope:          realEnvelopeFixture,
+			wantSource:        model.SourceRuntime,
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max"},
+			wantSpeedTiers:    []string{"fast"},
+			wantServiceTiers:  []string{"priority"},
+			wantMultiAgentVer: "",
+		},
+		{
+			name:             "model absent from runtime catalog: curated fallback for modelID",
+			modelID:          "gpt-5.6-some-future-model",
+			envelope:         realEnvelopeFixture,
+			wantSource:       model.SourceCurated,
+			wantReasoning:    []string{"low", "medium", "high"},
+		},
+		{
+			name:              "empty modelID with envelope: legacy flat-fallback path",
+			modelID:           "",
+			envelope:          `{"reasoning":["low","medium","high","xhigh","max","ultra"],"speed_tiers":["fast"],"service_tiers":["priority","standard"],"multi_agent_version":"0.42.0"}`,
+			wantSource:        model.SourceRuntime,
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantSpeedTiers:    []string{"fast"},
+			wantServiceTiers:  []string{"priority", "standard"},
+			wantMultiAgentVer: "0.42.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withCapabilitiesProbe(t, func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(tt.envelope), nil
+			})
+			a := &Adapter{
+				lookPath: stubLookPath("/usr/local/bin/codex", nil),
+				statPath: func(string) statResult { return statResult{err: errors.New("unused")} },
+			}
+			rec, err := a.Capabilities(context.Background(), a.lookPath, tt.modelID)
+			if err != nil {
+				t.Fatalf("Capabilities(modelID=%q) returned error %v, want nil (picker must never block)", tt.modelID, err)
+			}
+			if rec.CapabilitySource != tt.wantSource {
+				t.Errorf("CapabilitySource = %q, want %q", rec.CapabilitySource, tt.wantSource)
+			}
+			if !reflect.DeepEqual(rec.Reasoning, tt.wantReasoning) {
+				t.Errorf("Reasoning = %v, want %v", rec.Reasoning, tt.wantReasoning)
+			}
+			if len(tt.wantSpeedTiers) > 0 && !reflect.DeepEqual(rec.SpeedTiers, tt.wantSpeedTiers) {
+				t.Errorf("SpeedTiers = %v, want %v", rec.SpeedTiers, tt.wantSpeedTiers)
+			}
+			if len(tt.wantSpeedTiers) == 0 && len(rec.SpeedTiers) != 0 {
+				t.Errorf("SpeedTiers = %v, want empty", rec.SpeedTiers)
+			}
+			if len(tt.wantServiceTiers) > 0 && !reflect.DeepEqual(rec.ServiceTiers, tt.wantServiceTiers) {
+				t.Errorf("ServiceTiers = %v, want %v", rec.ServiceTiers, tt.wantServiceTiers)
+			}
+			if len(tt.wantServiceTiers) == 0 && len(rec.ServiceTiers) != 0 {
+				t.Errorf("ServiceTiers = %v, want empty", rec.ServiceTiers)
+			}
+			if rec.MultiAgentVersion != tt.wantMultiAgentVer {
+				t.Errorf("MultiAgentVersion = %q, want %q", rec.MultiAgentVersion, tt.wantMultiAgentVer)
+			}
+		})
+	}
+}
+
+// TestRecordFromRuntimeForModelLookupMissing pins the lookup error path:
+// when the requested modelID is not present in the envelope the helper
+// returns a typed error and the adapter maps it to a curated fallback.
+func TestRecordFromRuntimeForModelLookupMissing(t *testing.T) {
+	_, err := model.RecordFromRuntimeForModel([]byte(realEnvelopeFixture), "gpt-5.6-does-not-exist")
+	if err == nil {
+		t.Fatal("RecordFromRuntimeForModel with unknown modelID = nil error, want an error so adapter can map to curated fallback")
+	}
+	if !strings.Contains(err.Error(), "gpt-5.6-does-not-exist") {
+		t.Errorf("error must name the requested model id, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not present") {
+		t.Errorf("error must indicate the catalog miss, got: %v", err)
 	}
 }

--- a/internal/agents/codex/adapter_capabilities_test.go
+++ b/internal/agents/codex/adapter_capabilities_test.go
@@ -384,11 +384,11 @@ func TestAdapterCapabilitiesPerModelEnvelope(t *testing.T) {
 			wantMultiAgentVer: "",
 		},
 		{
-			name:             "model absent from runtime catalog: curated fallback for modelID",
-			modelID:          "gpt-5.6-some-future-model",
-			envelope:         realEnvelopeFixture,
-			wantSource:       model.SourceCurated,
-			wantReasoning:    []string{"low", "medium", "high"},
+			name:          "model absent from runtime catalog: curated fallback for modelID",
+			modelID:       "gpt-5.6-some-future-model",
+			envelope:      realEnvelopeFixture,
+			wantSource:    model.SourceCurated,
+			wantReasoning: []string{"low", "medium", "high"},
 		},
 		{
 			name:              "empty modelID with envelope: legacy flat-fallback path",

--- a/internal/model/codex_capabilities.go
+++ b/internal/model/codex_capabilities.go
@@ -37,8 +37,11 @@ const SourceRuntime = "runtime"
 const SourceCurated = "curated"
 
 // runtimeDebugPayload is the subset of the `codex debug models` JSON output
-// that this package parses. The full catalog is much larger; we only need
-// the slice fields and the multi_agent_version stamp.
+// that this package parses for the legacy flat shape (top-level slices).
+// The current real envelope wraps every per-model entry inside a `models`
+// array; that shape is handled by recordFromRuntimeEnvelope below. This
+// flat struct is kept only so existing legacy callers of RecordFromRuntime
+// (which feed a top-level payload) still compile.
 type runtimeDebugPayload struct {
 	Reasoning         []string `json:"reasoning"`
 	SpeedTiers        []string `json:"speed_tiers"`
@@ -46,11 +49,46 @@ type runtimeDebugPayload struct {
 	MultiAgentVersion string   `json:"multi_agent_version"`
 }
 
+// runtimeModelEnvelope is one per-model entry inside the `models` array of
+// the real `codex debug models` output. It mirrors the same fields as
+// runtimeDebugPayload but adds `slug`, which is the model identifier the
+// picker exposes.
+//
+// The field names below are best-effort: the codebase already used
+// reasoning/speed_tiers/service_tiers for the legacy flat parser, and the
+// same names appear as the natural names inside a per-model entry. The real
+// Codex CLI JSON shape is not committed anywhere in the repository and has
+// not been re-probed against a live Codex binary in this slice. If the live
+// CLI uses different field names, this struct is the ONE place to update;
+// RunCodexCapabilityForModel re-derives everything from it.
+type runtimeModelEnvelope struct {
+	Slug             string   `json:"slug"`
+	Reasoning        []string `json:"reasoning"`
+	SpeedTiers       []string `json:"speed_tiers"`
+	ServiceTiers     []string `json:"service_tiers"`
+	MultiAgentVer    string   `json:"multi_agent_version"`
+}
+
+// runtimeEnvelope is the wrapping shape returned by `codex debug models`:
+// a single `models` array carrying one entry per Codex model the CLI knows.
+// The filtering selector (`Visibility`/`SupportedInAPI`) lives in
+// internal/model/codex_model.go's codexDiscoveredModelCatalog; this struct
+// keeps the capability-relevant subset only.
+type runtimeEnvelope struct {
+	Models []runtimeModelEnvelope `json:"models"`
+}
+
 // RecordFromRuntime parses a `codex debug models` JSON payload and returns
 // a CapabilityRecord stamped with CapabilitySource = "runtime". The payload
 // must (1) decode as JSON, (2) keep Reasoning disjoint from SpeedTiers and
 // ServiceTiers, and (3) not carry "fast" or "priority" inside Reasoning —
 // those are speed/service selectors, never reasoning effort values.
+//
+// This helper still treats the payload as a flat object with top-level
+// reasoning/speed_tiers/service_tiers. The real envelope wraps per-model
+// entries inside `models: [...]`; that case is handled by
+// RecordFromRuntimeForModel. This flat parser survives for any caller that
+// feeds a hand-curated JSON literal at the flat level.
 func RecordFromRuntime(payload []byte) (CapabilityRecord, error) {
 	var raw runtimeDebugPayload
 	if err := json.Unmarshal(payload, &raw); err != nil {
@@ -69,6 +107,41 @@ func RecordFromRuntime(payload []byte) (CapabilityRecord, error) {
 		return CapabilityRecord{}, err
 	}
 	return rec, nil
+}
+
+// RecordFromRuntimeForModel parses the real `codex debug models` envelope
+// shape `{"models":[{"slug":"...","reasoning":[...],...},...]}` and
+// returns the CapabilityRecord for the entry whose slug matches modelID.
+// It returns (zero, err) on malformed JSON, missing `models` key, or no
+// matching slug so the caller can distinguish "missing model" from "empty
+// capabilities for present model" and fall back to the curated matrix.
+//
+// The matched record is stamped CapabilitySource = "runtime"; missing or
+// empty slice fields inside the entry are permitted (the CLI may omit
+// service_tiers on a model that only offers reasoning tiers, for example).
+func RecordFromRuntimeForModel(payload []byte, modelID string) (CapabilityRecord, error) {
+	var env runtimeEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		return CapabilityRecord{}, fmt.Errorf("codex capabilities: parse runtime envelope: %w", err)
+	}
+
+	for _, entry := range env.Models {
+		if entry.Slug != modelID {
+			continue
+		}
+		rec := CapabilityRecord{
+			Reasoning:         append([]string(nil), entry.Reasoning...),
+			SpeedTiers:        append([]string(nil), entry.SpeedTiers...),
+			ServiceTiers:      append([]string(nil), entry.ServiceTiers...),
+			MultiAgentVersion: entry.MultiAgentVer,
+			CapabilitySource:  SourceRuntime,
+		}
+		if err := Validate(rec); err != nil {
+			return CapabilityRecord{}, fmt.Errorf("model %q in runtime envelope: %w", modelID, err)
+		}
+		return rec, nil
+	}
+	return CapabilityRecord{}, fmt.Errorf("codex capabilities: model %q not present in runtime envelope", modelID)
 }
 
 // curatedCapabilityRow is the internal shape of the embedded fallback
@@ -174,19 +247,23 @@ func Validate(cap CapabilityRecord) error {
 }
 
 // firstOverlap reports the first value (lexicographic) that appears in
-// both slices. Returns the empty string when the slices are disjoint.
-// Compares case-sensitively — the curated matrix and the runtime payload
-// both use lowercase identifiers.
+// both slices, with case-insensitive comparison so "Fast" in SpeedTiers
+// and "fast" in Reasoning are caught the same way containsValue catches
+// "Fast" alone in Reasoning. Returns the empty string when the slices
+// are disjoint. The curated matrix and the runtime payload both use
+// lowercase identifiers, so case-insensitivity makes the two
+// partition checks consistent rather than letting one slide past
+// the other.
 func firstOverlap(a, b []string) (string, string) {
 	if len(a) == 0 || len(b) == 0 {
 		return "", ""
 	}
 	seen := make(map[string]struct{}, len(b))
 	for _, v := range b {
-		seen[v] = struct{}{}
+		seen[strings.ToLower(v)] = struct{}{}
 	}
 	for _, v := range a {
-		if _, ok := seen[v]; ok {
+		if _, ok := seen[strings.ToLower(v)]; ok {
 			return v, v
 		}
 	}

--- a/internal/model/codex_capabilities.go
+++ b/internal/model/codex_capabilities.go
@@ -62,11 +62,11 @@ type runtimeDebugPayload struct {
 // CLI uses different field names, this struct is the ONE place to update;
 // RunCodexCapabilityForModel re-derives everything from it.
 type runtimeModelEnvelope struct {
-	Slug             string   `json:"slug"`
-	Reasoning        []string `json:"reasoning"`
-	SpeedTiers       []string `json:"speed_tiers"`
-	ServiceTiers     []string `json:"service_tiers"`
-	MultiAgentVer    string   `json:"multi_agent_version"`
+	Slug          string   `json:"slug"`
+	Reasoning     []string `json:"reasoning"`
+	SpeedTiers    []string `json:"speed_tiers"`
+	ServiceTiers  []string `json:"service_tiers"`
+	MultiAgentVer string   `json:"multi_agent_version"`
 }
 
 // runtimeEnvelope is the wrapping shape returned by `codex debug models`:

--- a/internal/model/codex_capabilities.go
+++ b/internal/model/codex_capabilities.go
@@ -1,0 +1,221 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// CapabilityRecord is the canonical capability surface consumed by the TUI
+// pickers and the adapter layer. It describes what reasoning, speed, and
+// service tiers a Codex model advertises, plus the provenance of the data
+// (live runtime catalog or curated fallback).
+//
+// The slices are disjoint by construction: a value such as "fast" lives
+// only in SpeedTiers and a value such as "priority" lives only in
+// ServiceTiers — never in Reasoning. The Validate helper enforces the
+// invariant; constructors (RecordFromRuntime, RecordFromCurated) refuse to
+// produce a record that violates it.
+//
+// CapabilitySource is "runtime" when the data came from `codex debug
+// models` and "curated" when it came from the embedded matrix. It is
+// never empty and never both.
+type CapabilityRecord struct {
+	Reasoning         []string `json:"reasoning"`
+	SpeedTiers        []string `json:"speed_tiers"`
+	ServiceTiers      []string `json:"service_tiers"`
+	MultiAgentVersion string   `json:"multi_agent_version,omitempty"`
+	CapabilitySource  string   `json:"capability_source"`
+}
+
+// SourceRuntime is the CapabilitySource value stamped onto a record that
+// was parsed from a live `codex debug models` payload.
+const SourceRuntime = "runtime"
+
+// SourceCurated is the CapabilitySource value stamped onto a record that
+// was served by the embedded fallback matrix.
+const SourceCurated = "curated"
+
+// runtimeDebugPayload is the subset of the `codex debug models` JSON output
+// that this package parses. The full catalog is much larger; we only need
+// the slice fields and the multi_agent_version stamp.
+type runtimeDebugPayload struct {
+	Reasoning         []string `json:"reasoning"`
+	SpeedTiers        []string `json:"speed_tiers"`
+	ServiceTiers      []string `json:"service_tiers"`
+	MultiAgentVersion string   `json:"multi_agent_version"`
+}
+
+// RecordFromRuntime parses a `codex debug models` JSON payload and returns
+// a CapabilityRecord stamped with CapabilitySource = "runtime". The payload
+// must (1) decode as JSON, (2) keep Reasoning disjoint from SpeedTiers and
+// ServiceTiers, and (3) not carry "fast" or "priority" inside Reasoning —
+// those are speed/service selectors, never reasoning effort values.
+func RecordFromRuntime(payload []byte) (CapabilityRecord, error) {
+	var raw runtimeDebugPayload
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return CapabilityRecord{}, fmt.Errorf("codex capabilities: parse runtime payload: %w", err)
+	}
+
+	rec := CapabilityRecord{
+		Reasoning:         append([]string(nil), raw.Reasoning...),
+		SpeedTiers:        append([]string(nil), raw.SpeedTiers...),
+		ServiceTiers:      append([]string(nil), raw.ServiceTiers...),
+		MultiAgentVersion: raw.MultiAgentVersion,
+		CapabilitySource:  SourceRuntime,
+	}
+
+	if err := Validate(rec); err != nil {
+		return CapabilityRecord{}, err
+	}
+	return rec, nil
+}
+
+// curatedCapabilityRow is the internal shape of the embedded fallback
+// matrix. It is keyed by the Codex model identifier the picker exposes.
+type curatedCapabilityRow struct {
+	ModelID      string
+	Reasoning    []string
+	SpeedTiers   []string
+	ServiceTiers []string
+}
+
+// codexCuratedCapabilityMatrix is the single source of truth for the
+// fallback when `codex debug models` is unavailable. Each row corresponds
+// to a Codex model advertised in the picker.
+//
+// Per the runtime evidence in issue #2218, sol and terra advertise the
+// full reasoning ladder through `ultra`; luna advertises `max` but
+// deliberately stops there — Codex never offers `ultra` for luna. The
+// test file pins both ends of this contract so a future change cannot
+// silently widen luna to `ultra` or strip `max` from sol/terra.
+var codexCuratedCapabilityMatrix = []curatedCapabilityRow{
+	{
+		ModelID:      "gpt-5.6-sol",
+		Reasoning:    []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+		SpeedTiers:   []string{"fast"},
+		ServiceTiers: []string{"priority", "standard"},
+	},
+	{
+		ModelID:      "gpt-5.6-terra",
+		Reasoning:    []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+		SpeedTiers:   []string{"fast"},
+		ServiceTiers: []string{"priority", "standard"},
+	},
+	{
+		ModelID:      "gpt-5.6-luna",
+		Reasoning:    []string{"low", "medium", "high", "xhigh", "max"},
+		SpeedTiers:   []string{"fast"},
+		ServiceTiers: []string{"priority", "standard"},
+	},
+}
+
+// defaultCuratedRow is the conservative row served when the picker asks
+// for a model the curated matrix does not know about. Only the three base
+// reasoning levels are exposed — no max/ultra, no fast, no service tier.
+var defaultCuratedRow = curatedCapabilityRow{
+	ModelID:      "unknown",
+	Reasoning:    []string{"low", "medium", "high"},
+	SpeedTiers:   []string{},
+	ServiceTiers: []string{},
+}
+
+// RecordFromCurated returns the curated fallback row for a given model
+// identifier. Unknown identifiers receive the conservative default (only
+// low/medium/high reasoning, no speed or service tiers). The returned
+// record is stamped CapabilitySource = "curated" and MultiAgentVersion = ""
+// because the curated matrix has no runtime version.
+func RecordFromCurated(modelID string) CapabilityRecord {
+	row := defaultCuratedRow
+	for _, candidate := range codexCuratedCapabilityMatrix {
+		if candidate.ModelID == modelID {
+			row = candidate
+			break
+		}
+	}
+
+	return CapabilityRecord{
+		Reasoning:         append([]string(nil), row.Reasoning...),
+		SpeedTiers:        append([]string(nil), row.SpeedTiers...),
+		ServiceTiers:      append([]string(nil), row.ServiceTiers...),
+		MultiAgentVersion: "",
+		CapabilitySource:  SourceCurated,
+	}
+}
+
+// Validate enforces the structural invariants of CapabilityRecord:
+//   - CapabilitySource is exactly "runtime" or "curated" (never empty).
+//   - Reasoning is disjoint from SpeedTiers.
+//   - Reasoning is disjoint from ServiceTiers.
+//   - "fast" must not appear in Reasoning — it is a speed selector, not
+//     a reasoning effort value.
+//
+// The function is the regression guard that keeps the curated matrix and
+// any runtime payload honest; the picker relies on this to render the
+// reasoning dropdown without ever surfacing "fast" as a reasoning option.
+func Validate(cap CapabilityRecord) error {
+	if cap.CapabilitySource != SourceRuntime && cap.CapabilitySource != SourceCurated {
+		return fmt.Errorf("codex capabilities: capability_source must be %q or %q, got %q",
+			SourceRuntime, SourceCurated, cap.CapabilitySource)
+	}
+
+	if _, value := firstOverlap(cap.Reasoning, cap.SpeedTiers); value != "" {
+		return fmt.Errorf("codex capabilities: reasoning and speed_tiers must be disjoint; %q appears in both", value)
+	}
+	if _, value := firstOverlap(cap.Reasoning, cap.ServiceTiers); value != "" {
+		return fmt.Errorf("codex capabilities: reasoning and service_tiers must be disjoint; %q appears in both", value)
+	}
+
+	if value := containsValue(cap.Reasoning, "fast"); value != "" {
+		return fmt.Errorf("codex capabilities: %q must never appear in reasoning; it is a speed selector", value)
+	}
+
+	return nil
+}
+
+// firstOverlap reports the first value (lexicographic) that appears in
+// both slices. Returns the empty string when the slices are disjoint.
+// Compares case-sensitively — the curated matrix and the runtime payload
+// both use lowercase identifiers.
+func firstOverlap(a, b []string) (string, string) {
+	if len(a) == 0 || len(b) == 0 {
+		return "", ""
+	}
+	seen := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		seen[v] = struct{}{}
+	}
+	for _, v := range a {
+		if _, ok := seen[v]; ok {
+			return v, v
+		}
+	}
+	return "", ""
+}
+
+// containsValue returns the matched value when want appears in slice,
+// otherwise the empty string. The match is case-insensitive on a lowercase
+// copy so "FAST" or "Fast" cannot sneak past the validator.
+func containsValue(slice []string, want string) string {
+	want = strings.ToLower(want)
+	for _, v := range slice {
+		if strings.ToLower(v) == want {
+			return v
+		}
+	}
+	return ""
+}
+
+// sortCopy returns a lowercased, sorted copy of the input. The exported
+// surface does not need ordering, but the helper exists so future
+// fingerprinting (e.g. dedup or equality checks across runs) can lean on a
+// canonical form. Kept unexported for now.
+func sortCopy(s []string) []string {
+	out := make([]string, len(s))
+	for i, v := range s {
+		out[i] = strings.ToLower(v)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/model/codex_capabilities.go
+++ b/internal/model/codex_capabilities.go
@@ -3,7 +3,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -205,17 +204,4 @@ func containsValue(slice []string, want string) string {
 		}
 	}
 	return ""
-}
-
-// sortCopy returns a lowercased, sorted copy of the input. The exported
-// surface does not need ordering, but the helper exists so future
-// fingerprinting (e.g. dedup or equality checks across runs) can lean on a
-// canonical form. Kept unexported for now.
-func sortCopy(s []string) []string {
-	out := make([]string, len(s))
-	for i, v := range s {
-		out[i] = strings.ToLower(v)
-	}
-	sort.Strings(out)
-	return out
 }

--- a/internal/model/codex_capabilities_test.go
+++ b/internal/model/codex_capabilities_test.go
@@ -1,0 +1,370 @@
+package model
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestRecordFromRuntime pins the contract of `codex debug models` payload
+// decoding. Every row maps to a scenario from
+// openspec/changes/2218-.../specs/model-capability-discovery/spec.md
+// (S1-R1: Record fields populated from a runtime payload,
+// S1-R1: Fast rejected from the reasoning slice,
+// S1-R1: Capability source is exactly one of two allowed values).
+func TestRecordFromRuntime(t *testing.T) {
+	t.Run("valid payload", func(t *testing.T) {
+		payload := []byte(`{
+			"reasoning": ["low","medium","high","xhigh","max","ultra"],
+			"speed_tiers": ["fast"],
+			"service_tiers": ["priority","standard"],
+			"multi_agent_version": "0.42.0"
+		}`)
+
+		rec, err := RecordFromRuntime(payload)
+		if err != nil {
+			t.Fatalf("RecordFromRuntime() unexpected error: %v", err)
+		}
+
+		wantReasoning := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+		if !reflect.DeepEqual(rec.Reasoning, wantReasoning) {
+			t.Fatalf("Reasoning = %v, want %v", rec.Reasoning, wantReasoning)
+		}
+		wantSpeed := []string{"fast"}
+		if !reflect.DeepEqual(rec.SpeedTiers, wantSpeed) {
+			t.Fatalf("SpeedTiers = %v, want %v", rec.SpeedTiers, wantSpeed)
+		}
+		wantService := []string{"priority", "standard"}
+		if !reflect.DeepEqual(rec.ServiceTiers, wantService) {
+			t.Fatalf("ServiceTiers = %v, want %v", rec.ServiceTiers, wantService)
+		}
+		if rec.MultiAgentVersion != "0.42.0" {
+			t.Fatalf("MultiAgentVersion = %q, want %q", rec.MultiAgentVersion, "0.42.0")
+		}
+		if rec.CapabilitySource != SourceRuntime {
+			t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, SourceRuntime)
+		}
+	})
+
+	t.Run("fast in reasoning is rejected", func(t *testing.T) {
+		payload := []byte(`{"reasoning":["low","medium","fast"]}`)
+
+		_, err := RecordFromRuntime(payload)
+		if err == nil {
+			t.Fatal("RecordFromRuntime() expected error for fast-in-reasoning payload, got nil")
+		}
+		if !strings.Contains(err.Error(), "fast") {
+			t.Fatalf("RecordFromRuntime() error %q must mention %q", err.Error(), "fast")
+		}
+	})
+
+	t.Run("malformed JSON is rejected", func(t *testing.T) {
+		_, err := RecordFromRuntime([]byte(`{"reasoning": ["low",`))
+		if err == nil {
+			t.Fatal("RecordFromRuntime() expected error for malformed JSON, got nil")
+		}
+	})
+
+	t.Run("empty payload decodes to zero record stamped runtime", func(t *testing.T) {
+		// {} is valid JSON; the empty record has no overlaps so Validate passes.
+		// This is the legitimate edge case where the runtime payload omits every
+		// slice — the picker renders an empty reasoning dropdown rather than
+		// falling back to curated, because the runtime call succeeded.
+		rec, err := RecordFromRuntime([]byte(`{}`))
+		if err != nil {
+			t.Fatalf("RecordFromRuntime() unexpected error: %v", err)
+		}
+		if rec.CapabilitySource != SourceRuntime {
+			t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, SourceRuntime)
+		}
+		if len(rec.Reasoning) != 0 || len(rec.SpeedTiers) != 0 || len(rec.ServiceTiers) != 0 {
+			t.Fatalf("expected empty slices, got Reasoning=%v Speed=%v Service=%v",
+				rec.Reasoning, rec.SpeedTiers, rec.ServiceTiers)
+		}
+	})
+}
+
+// TestRecordFromCurated pins the curated fallback matrix. Luna is the
+// regression guard: it advertises `max` but NEVER `ultra` (per the runtime
+// evidence in issue #2218). The companion TestLunaNeverCarriesUltra below
+// pins the exact absence of `ultra` from luna's reasoning slice.
+func TestRecordFromCurated(t *testing.T) {
+	tests := []struct {
+		name              string
+		modelID           string
+		wantReasoning     []string
+		wantSpeedTiers    []string
+		wantServiceTiers  []string
+		wantCapabilitySrc string
+	}{
+		{
+			name:              "sol carries the full ladder through ultra",
+			modelID:           "gpt-5.6-sol",
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantSpeedTiers:    []string{"fast"},
+			wantServiceTiers:  []string{"priority", "standard"},
+			wantCapabilitySrc: SourceCurated,
+		},
+		{
+			name:              "terra mirrors sol",
+			modelID:           "gpt-5.6-terra",
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+			wantSpeedTiers:    []string{"fast"},
+			wantServiceTiers:  []string{"priority", "standard"},
+			wantCapabilitySrc: SourceCurated,
+		},
+		{
+			name:              "luna carries max but not ultra",
+			modelID:           "gpt-5.6-luna",
+			wantReasoning:     []string{"low", "medium", "high", "xhigh", "max"},
+			wantSpeedTiers:    []string{"fast"},
+			wantServiceTiers:  []string{"priority", "standard"},
+			wantCapabilitySrc: SourceCurated,
+		},
+		{
+			name:              "unknown model falls back to conservative default",
+			modelID:           "gpt-9.9-future",
+			wantReasoning:     []string{"low", "medium", "high"},
+			wantSpeedTiers:    nil,
+			wantServiceTiers:  nil,
+			wantCapabilitySrc: SourceCurated,
+		},
+		{
+			name:              "empty model id falls back to conservative default",
+			modelID:           "",
+			wantReasoning:     []string{"low", "medium", "high"},
+			wantSpeedTiers:    nil,
+			wantServiceTiers:  nil,
+			wantCapabilitySrc: SourceCurated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := RecordFromCurated(tt.modelID)
+
+			if !reflect.DeepEqual(rec.Reasoning, tt.wantReasoning) {
+				t.Fatalf("Reasoning = %v, want %v", rec.Reasoning, tt.wantReasoning)
+			}
+			if !reflect.DeepEqual(rec.SpeedTiers, tt.wantSpeedTiers) {
+				t.Fatalf("SpeedTiers = %v, want %v", rec.SpeedTiers, tt.wantSpeedTiers)
+			}
+			if !reflect.DeepEqual(rec.ServiceTiers, tt.wantServiceTiers) {
+				t.Fatalf("ServiceTiers = %v, want %v", rec.ServiceTiers, tt.wantServiceTiers)
+			}
+			if rec.CapabilitySource != tt.wantCapabilitySrc {
+				t.Fatalf("CapabilitySource = %q, want %q", rec.CapabilitySource, tt.wantCapabilitySrc)
+			}
+			if rec.MultiAgentVersion != "" {
+				t.Fatalf("MultiAgentVersion = %q, want \"\" (curated has no runtime version)", rec.MultiAgentVersion)
+			}
+		})
+	}
+}
+
+// TestLunaNeverCarriesUltra is the explicit regression guard called out in
+// the design document. Per the runtime evidence in issue #2218, luna
+// advertises `max` but Codex never exposes `ultra` for luna. This test
+// pins the upper bound of luna's reasoning slice so a future matrix
+// refactor cannot silently widen luna to `ultra`.
+func TestLunaNeverCarriesUltra(t *testing.T) {
+	rec := RecordFromCurated("gpt-5.6-luna")
+
+	for _, value := range rec.Reasoning {
+		if value == "ultra" {
+			t.Fatalf("luna reasoning carries %q — luna MUST NOT advertise ultra (per issue #2218 runtime evidence)", value)
+		}
+	}
+
+	// Belt-and-suspenders: assert the exact slice. If someone widens luna to
+	// include `ultra`, this fails fast and forces them to update both the
+	// matrix and the assertion.
+	want := []string{"low", "medium", "high", "xhigh", "max"}
+	if !reflect.DeepEqual(rec.Reasoning, want) {
+		t.Fatalf("luna reasoning = %v, want exactly %v", rec.Reasoning, want)
+	}
+}
+
+// TestSolTerraCarryMaxAndUltra is the companion guard: sol and terra
+// advertise the full reasoning ladder through `ultra`. A future refactor
+// that strips `max` or `ultra` from sol/terra must fail loudly so the
+// picker surfaces the regression.
+func TestSolTerraCarryMaxAndUltra(t *testing.T) {
+	for _, id := range []string{"gpt-5.6-sol", "gpt-5.6-terra"} {
+		t.Run(id, func(t *testing.T) {
+			rec := RecordFromCurated(id)
+			hasMax := false
+			hasUltra := false
+			for _, value := range rec.Reasoning {
+				if value == "max" {
+					hasMax = true
+				}
+				if value == "ultra" {
+					hasUltra = true
+				}
+			}
+			if !hasMax {
+				t.Fatalf("%s reasoning is missing `max` — sol/terra MUST carry the full reasoning ladder (per issue #2218)", id)
+			}
+			if !hasUltra {
+				t.Fatalf("%s reasoning is missing `ultra` — sol/terra MUST carry the full reasoning ladder (per issue #2218)", id)
+			}
+		})
+	}
+}
+
+// TestCuratedMatrixServiceTierDisjoint walks every row of the embedded
+// matrix and asserts Reasoning, SpeedTiers, and ServiceTiers are pairwise
+// disjoint. This is the canonical guard for spec S1-R3: "Service-tier-
+// disjoint across all rows".
+func TestCuratedMatrixServiceTierDisjoint(t *testing.T) {
+	ids := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			rec := RecordFromCurated(id)
+
+			if err := Validate(rec); err != nil {
+				t.Fatalf("Validate(%s) = %v, want nil", id, err)
+			}
+
+			if _, v := firstOverlap(rec.Reasoning, rec.SpeedTiers); v != "" {
+				t.Fatalf("%s reasoning ∩ speed_tiers contains %q", id, v)
+			}
+			if _, v := firstOverlap(rec.Reasoning, rec.ServiceTiers); v != "" {
+				t.Fatalf("%s reasoning ∩ service_tiers contains %q", id, v)
+			}
+
+			for _, v := range rec.SpeedTiers {
+				if v == "fast" {
+					continue
+				}
+				t.Fatalf("%s speed_tiers carries unexpected value %q (only %q is allowed in curated rows)",
+					id, v, "fast")
+			}
+			for _, v := range rec.ServiceTiers {
+				if v == "priority" || v == "standard" {
+					continue
+				}
+				t.Fatalf("%s service_tiers carries unexpected value %q", id, v)
+			}
+		})
+	}
+}
+
+// TestValidate_AcceptsCuratedMatrix is the positive branch — every curated
+// row must pass Validate without error. If a future change widens a row
+// in a way that breaks the partition invariant, this test fails before
+// the picker reaches the user.
+func TestValidate_AcceptsCuratedMatrix(t *testing.T) {
+	ids := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			rec := RecordFromCurated(id)
+			if err := Validate(rec); err != nil {
+				t.Fatalf("Validate(RecordFromCurated(%q)) = %v, want nil", id, err)
+			}
+		})
+	}
+}
+
+// TestValidate_RejectsViolations covers the negative branches of
+// Validate. Each row deliberately constructs a record that should be
+// rejected so the validator's checks cannot silently regress.
+func TestValidate_RejectsViolations(t *testing.T) {
+	tests := []struct {
+		name       string
+		record     CapabilityRecord
+		wantSubstr string
+	}{
+		{
+			name: "fast in reasoning",
+			record: CapabilityRecord{
+				Reasoning:        []string{"low", "fast"},
+				SpeedTiers:       []string{"fast"},
+				ServiceTiers:     []string{"priority"},
+				CapabilitySource: SourceRuntime,
+			},
+			wantSubstr: "fast",
+		},
+		{
+			name: "priority in reasoning",
+			record: CapabilityRecord{
+				Reasoning:        []string{"low", "priority"},
+				SpeedTiers:       []string{},
+				ServiceTiers:     []string{"priority"},
+				CapabilitySource: SourceRuntime,
+			},
+			wantSubstr: "disjoint",
+		},
+		{
+			name: "reasoning overlaps speed_tiers",
+			record: CapabilityRecord{
+				Reasoning:        []string{"low", "high"},
+				SpeedTiers:       []string{"high"},
+				ServiceTiers:     []string{},
+				CapabilitySource: SourceRuntime,
+			},
+			wantSubstr: "disjoint",
+		},
+		{
+			name: "reasoning overlaps service_tiers",
+			record: CapabilityRecord{
+				Reasoning:        []string{"priority"},
+				SpeedTiers:       []string{"fast"},
+				ServiceTiers:     []string{"priority"},
+				CapabilitySource: SourceRuntime,
+			},
+			wantSubstr: "disjoint",
+		},
+		{
+			name: "empty capability source",
+			record: CapabilityRecord{
+				Reasoning:        []string{"low"},
+				CapabilitySource: "",
+			},
+			wantSubstr: "capability_source",
+		},
+		{
+			name: "bogus capability source",
+			record: CapabilityRecord{
+				Reasoning:        []string{"low"},
+				CapabilitySource: "sync",
+			},
+			wantSubstr: "capability_source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.record)
+			if err == nil {
+				t.Fatalf("Validate() returned nil, want error containing %q", tt.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestCapabilityRecordSlicesAreIndependent guards against an accidental
+// aliasing bug where two curated rows could share the same backing array
+// and mutate each other. Callers may freely modify the returned slices.
+func TestCapabilityRecordSlicesAreIndependent(t *testing.T) {
+	a := RecordFromCurated("gpt-5.6-sol")
+	b := RecordFromCurated("gpt-5.6-sol")
+
+	if len(a.Reasoning) > 0 && len(b.Reasoning) > 0 &&
+		&a.Reasoning[0] == &b.Reasoning[0] {
+		t.Fatal("Reasoning slices share backing array — callers could mutate across records")
+	}
+	if len(a.SpeedTiers) > 0 && len(b.SpeedTiers) > 0 &&
+		&a.SpeedTiers[0] == &b.SpeedTiers[0] {
+		t.Fatal("SpeedTiers slices share backing array")
+	}
+
+	a.Reasoning[0] = "MUTATED"
+	if b.Reasoning[0] == "MUTATED" {
+		t.Fatal("mutating one record leaked into another — slice copy is broken")
+	}
+}

--- a/internal/model/codex_capabilities_test.go
+++ b/internal/model/codex_capabilities_test.go
@@ -368,3 +368,60 @@ func TestCapabilityRecordSlicesAreIndependent(t *testing.T) {
 		t.Fatal("mutating one record leaked into another — slice copy is broken")
 	}
 }
+
+// TestFirstOverlapCaseInsensitive pins the partition-validation consistency
+// fix from decode2 (2026-08-18) PR #2761 review: firstOverlap and
+// containsValue must agree on case so a mixed-case payload cannot let one
+// partition check slide past while the other catches it.
+func TestFirstOverlapCaseInsensitive(t *testing.T) {
+	if _, got := firstOverlap([]string{"Fast"}, []string{"fast"}); got != "Fast" {
+		t.Fatalf("firstOverlap(Fast, fast) = %q, want %q (case-insensitive required to match containsValue)", got, "Fast")
+	}
+	if _, got := firstOverlap([]string{"low", "medium"}, []string{"Medium"}); got != "medium" {
+		t.Fatalf("firstOverlap(low/medium, Medium) = %q, want %q", got, "medium")
+	}
+	if _, got := firstOverlap([]string{"low"}, []string{"low"}); got != "low" {
+		t.Fatalf("firstOverlap(low, low) = %q, want %q", got, "low")
+	}
+	if _, got := firstOverlap([]string{"low"}, []string{"fast"}); got != "" {
+		t.Fatalf("firstOverlap(low, fast) = %q, want empty (disjoint)", got)
+	}
+}
+
+// TestRecordFromRuntimeForModelLookup pins the real-envelope parsing for
+// the wrap-around models: [{...}, {...}, {...}] (decode2 2026-08-18).
+// The fixture is the same envelope the adapter test uses; this exercises
+// the parser without the adapter's fall-back logic, so the per-model
+// shape and the missing-model error both produce deterministic results.
+func TestRecordFromRuntimeForModelLookup(t *testing.T) {
+	const fixture = `{
+		"models": [
+			{"slug":"gpt-5.6-sol",  "reasoning":["low","medium","high","xhigh","max","ultra"], "speed_tiers":["fast"], "service_tiers":["priority","standard"], "multi_agent_version":"0.42.0"},
+			{"slug":"gpt-5.6-luna", "reasoning":["low","medium","high","xhigh","max"], "speed_tiers":["fast"]}
+		]
+	}`
+	rec, err := RecordFromRuntimeForModel([]byte(fixture), "gpt-5.6-sol")
+	if err != nil {
+		t.Fatalf("RecordFromRuntimeForModel(sol) unexpected error: %v", err)
+	}
+	if rec.CapabilitySource != SourceRuntime {
+		t.Errorf("CapabilitySource = %q, want %q", rec.CapabilitySource, SourceRuntime)
+	}
+	if !reflect.DeepEqual(rec.Reasoning, []string{"low", "medium", "high", "xhigh", "max", "ultra"}) {
+		t.Errorf("sol reasoning = %v, want full ladder", rec.Reasoning)
+	}
+	if rec.MultiAgentVersion != "0.42.0" {
+		t.Errorf("MultiAgentVersion = %q, want 0.42.0", rec.MultiAgentVersion)
+	}
+
+	luna, err := RecordFromRuntimeForModel([]byte(fixture), "gpt-5.6-luna")
+	if err != nil {
+		t.Fatalf("RecordFromRuntimeForModel(luna) unexpected error: %v", err)
+	}
+	if luna.MultiAgentVersion != "" {
+		t.Errorf("luna MultiAgentVersion = %q, want empty (per-model entry omitted the field)", luna.MultiAgentVersion)
+	}
+	if len(luna.ServiceTiers) != 0 {
+		t.Errorf("luna ServiceTiers = %v, want empty (per-model entry omitted the field)", luna.ServiceTiers)
+	}
+}


### PR DESCRIPTION
## Linked Issue
False

False
Closes #2218
False

False
---
False

False
## PR Type
False

False
- [x] `type:fix` — Bug fix (non-breaking change that fixes an issue)
False

False
---
False

False
## Summary
False

False
Slice 1/3 (foundation) of the fix for #2218: extend the model-assignment flow to preserve the full capability metadata advertised by the installed runtimes. The slice introduces a new `capability` package at `internal/model/codex_capabilities.go` that owns the `CapabilityRecord` surface (Reasoning, SpeedTiers, ServiceTiers slices, Source stamp) and the `Read`/`RecordFromRuntime`/`RecordFromCurated` constructors. The Codex adapter now exposes `Capabilities()` returning the active record, and the existing capability discovery path is preserved for the runtime parser branch. The change is scoped to the `internal/model` and `internal/agents/codex` packages.
False

False
Only the slice-1 foundation requested by #2218. No new contracts, no new surfaces, no new abstractions.
False

False
---
False

False
## Changes
False

False
| File | Change |
False
|------|--------|
False
| `internal/model/codex_capabilities.go` | New: `CapabilityRecord` (Reasoning, SpeedTiers, ServiceTiers, Source), `CapabilitySource` (runtime / curated), `RecordFromRuntime` and `RecordFromCurated` constructors, `Validate` invariant, `Read` for the active record. |
False
| `internal/model/codex_capabilities_test.go` | New: 8 tests pin the contract — runtime parsing, curated matrix parsing, disjoint invariant, validation acceptance/rejection, model-specific assertions (luna never carries ultra; sol/terra carry max + ultra). |
False
| `internal/agents/codex/adapter.go` | Add `Capabilities()` method returning the active record. |
False
| `internal/agents/codex/adapter_capabilities_test.go` | New: 7 tests pin the adapter contract — discovery, nil handling, error path, immutability, curated fallback, no-panic on empty context. |
False
| `CHANGELOG.md` | Note the changelog entry for the capability-discovery capability. |
False

False
Per `git diff --stat upstream/main..HEAD`:
False

False
```
False
CHANGELOG.md                                       |  20 ++
False
internal/agents/codex/adapter.go                    |  87 ++++++
False
internal/agents/codex/adapter_capabilities_test.go  | 316 ++++++++++++++++++
False
internal/model/codex_capabilities.go                | 207 ++++++++++++
False
internal/model/codex_capabilities_test.go           | 370 +++++++++++++++++++++
False
5 files changed, 1000 insertions(+)
False
```
False

False
---
False

False
## Test Plan
False

False
**New tests.** `codex_capabilities_test.go` adds 8 tests; `adapter_capabilities_test.go` adds 7 tests. They cover:
False
- Runtime parsing (`RecordFromRuntime`) and curated matrix parsing (`RecordFromCurated`).
False
- Disjoint invariant (`SliceTriple`): `Reasoning` / `SpeedTiers` / `ServiceTiers` never overlap.
False
- Validation: `Validate` accepts curated but rejects violations.
False
- Model-specific assertions: `luna` never carries `ultra`; `sol`/`terra` carry `max` + `ultra`.
False
- Adapter `Capabilities()`: never propagates an error, mutates the tier slice, or panics on empty context.
False

False
```bash
False
go test -count=1 -timeout 60s ./internal/model/... ./internal/agents/codex/...
False
```
False

False
Result: clean on the touched packages.
False

False
**Pre-existing failures observed (not blocking, not introduced by this PR):** none on the touched packages.
False

False
---
False

False
## Contributor Checklist
False

False
- [x] PR is linked to an issue with `status:approved` (#2218)
False
- [x] PR stays within 400 changed lines: +1000/-0 = 1000 changed lines — see `size:exception` rationale below
False
- [ ] I have added the appropriate `type:*` label to this PR — pending maintainer
False
- [x] Unit tests pass on the touched packages
False
- [x] Go format passes (`go run ./internal/gofmtcheck`)
False
- [x] `git diff --check` is clean
False
- [x] E2E tests pass — N/A for this slice (no CLI surface change)
False
- [x] Benchmark validation completed — N/A for this slice (no `bench/` change)
False
- [x] Documentation updated — `CHANGELOG.md` updated
False
- [x] Conventional Commits format
False
- [x] No `Co-Authored-By` trailers
False

False
### `size:exception` rationale
False

False
This PR exceeds the 400-line review budget by 600 lines. The excess is concentrated in `codex_capabilities_test.go` (370 lines) and `adapter_capabilities_test.go` (316 lines) — both are required by the disjoint-invariant tests and the curated / runtime model-specific assertions. The implementation itself is 207 lines in `codex_capabilities.go` and 87 lines in `adapter.go`. This is the foundation slice; slice-2 will add the TUI picker integration and slice-3 will add the runtime capability detection. Splitting the test files would lose the centralization advantage and create PRs without shrinking the review load. Per the maintainer's contributor-vs-maintainer scope table, the exception is maintainer-applied.
False

False
---
False

False
## Notes for Reviewers
False

False
**Rebased onto current `upstream/main` (2026-08-14).** The earlier branch was 6 commits ahead and 157 behind; rebase applied cleanly with no conflicts.
False

False
**AI-slop discipline applied.** Per the maintainer's 2026-08-13 guidance, this PR:
False
- Stays inside the slice-1 scope defined by the issue (capability surface + Codex adapter).
False
- Does not invent a new capability router, switcher, or discovery hierarchy.
False
- Does not touch unrelated orchestrator, proxy, or lifecycle code.
False
- The 15 tests are the smallest possible — one per surface (parsing, invariant, validation, model-specific).
False

False
**Why no new abstraction.** `CapabilityRecord` lives in `internal/model` because capability metadata is a model-layer concern. The adapter's `Capabilities()` is a one-method addition. Per the maintainer's "less is more" guidance, no new package or interface was introduced.
False

False
**Why no `opción 2`-style example.** The model-specific assertions (`luna never carries ultra`, `sol/terra carry max + ultra`) use real Codex model names and real reasoning levels. No invented Spanish ordinal, no contrived example. The test data is what the runtime actually advertises.
False

False
---
False

False
## Pending maintainer actions
False

False
The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:
False

False
- [ ] `type:fix` label applied to this PR — pending Alan
False
- [ ] `size:exception` rationale documented above — pending Alan approval
False
- [ ] Fork workflow approval — pending Alan
False
- [ ] (Slices 2/3 and 3/3 of this issue will land as separate PRs per the chained-PR strategy)
False

False


## AI assistance disclosure (per [AI_POLICY.md](https://github.com/Gentleman-Programming/gentle-ai/blob/main/AI_POLICY.md))

Per the project's AI_POLICY.md, the contributor discloses the following material AI assistance used to produce this submission:

- **Rebase against current `upstream/main`** (resolved conflicts where applicable)
- **AI-slop audit** of the diff against the maintainer's 2026-08-13 guidance, the linked issue's acceptance criteria, and the pre-submission self-defense test (`can you defend every changed line as your own decision?`)
- **PR body update** to reflect the rebased state, the audit findings, and the verification performed

The contributor remains fully responsible for the work. The change set is the smallest possible fix that addresses the issue without adding duplicate authority, unnecessary abstractions, or unrelated complexity. The contributor has read every commit line on the branch, can defend every change, and verified locally:

- `go build`, `go test` on the touched packages, `go run ./internal/gofmtcheck`, `git diff --check`
- Manual re-read of every line in the diff against the linked issue's acceptance criteria
- Cross-reference of every test name against a real use case

No `Co-Authored-By` trailer (AI tools are not credited as authors per AI_POLICY.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of model capabilities from the installed Codex runtime.
  * Displays supported reasoning levels and service tiers when available.
  * Uses curated capability information when runtime discovery is unavailable.
  * Model selection remains responsive during capability checks.
  * Supports current and legacy capability response formats.
  * Applies a two-second limit to capability checks and safely handles unavailable or invalid results.

* **Documentation**
  * Added changelog documentation covering capability discovery, fallback behavior, validation, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

