### PR TITLE
fix(sdd): name the runnable exits when a zero-drift reset is refused

### DIFF
--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -1098,6 +1098,32 @@ func runtimeRemediatesArgument(remediates string) string {
 // way runtimeRemediationExitRefusal's two branches do: the recorded
 // begin-worktree path is itself always the one runnable continuation, so
 // there is only one message to construct.
+// runtimeZeroDriftResetRefusal replaces the bare ErrRuntimeResetNotAllowed at
+// the one refusal site whose state has a runnable continuation the sentinel
+// never named. The sentinel says which shapes reset admits and then points at
+// status; status answers next_action: begin, and for a caller whose failed
+// evidence proves the OBJECTIVE is wrong rather than under-attempted, re-running
+// the identical objective is the one continuation that cannot help. #1974 was
+// filed as a lifecycle deadlock for exactly that reason: rescope already owned
+// this transition and neither surface said so.
+//
+// Both named exits are real for this state, which is why both appear. Rescope
+// is admitted here by construction (this site is reached only when reset is
+// structurally permitted, the objective is neither decision-required nor
+// complete, and the candidate has not drifted, which is precisely
+// runtimeObjectiveRescopeStructurallyPermitted plus zero drift), so it needs no
+// second eligibility probe. It can only narrow or hold the budget, so a caller
+// who needs a WIDER successor scope gets the second exit instead: spend the
+// remaining attempts honestly, which is what reaches decision-required, where
+// this same reset is admitted and opens a fresh budget.
+func (store RuntimeStore) runtimeZeroDriftResetRefusal(status RuntimeStatus) error {
+	objective := status.Objective
+	return fmt.Errorf(
+		"%w: this objective's candidate has not drifted and it still has attempts left, so resetting it now would launder the per-objective budget. If the failed evidence proves this OBJECTIVE is wrong rather than under-attempted, a maintainer may open a narrower successor scope instead — `gentle-ai sdd-attempt rescope --cwd %q --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit \"<narrower-work-unit>\" --evidence-goal \"<narrower-evidence-goal>\" --max-attempts \"<n, at most %d>\" --max-changed-lines \"<n, at most %d>\" --reason \"<why-the-objective-is-narrowing>\" --actor \"<actor>\"`; rescope carries cumulative_attempts and cumulative_changed_lines forward unchanged and never widens a budget, so if the successor needs MORE than %d changed lines, spend this objective's remaining attempts first: the run that exhausts them reaches decision-required, where this reset is admitted",
+		ErrRuntimeResetNotAllowed, store.Workspace, store.Change, status.Revision,
+		objective.MaxAttempts, objective.MaxChangedLines, objective.MaxChangedLines)
+}
+
 func (store RuntimeStore) runtimeWorktreeMismatchRefusal(ordinal int, beginWorktree string) error {
 	return fmt.Errorf(
 		"%w: attempt %d began in %s, and its base candidate tree is pinned to that exact linked worktree, but this finish is running from %s — rerun with --cwd %s so the candidate capture and changed-line measurement use the worktree that actually did the work",
@@ -1297,7 +1323,7 @@ func (store RuntimeStore) Reset(ctx context.Context, request ResetObjectiveReque
 				return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check reset drift eligibility: %w", driftErr)
 			}
 			if candidate.Identity == last.FinishCandidateIdentity && candidate.CandidateTree == last.FinishCandidateTree {
-				return runtimeRecord{}, ErrRuntimeResetNotAllowed
+				return runtimeRecord{}, store.runtimeZeroDriftResetRefusal(status)
 			}
 		}
 		snapshot, err := captureRuntimeCandidate(ctx, store.Repo)

--- a/internal/sddstatus/runtime_ledger_rescope_test.go
+++ b/internal/sddstatus/runtime_ledger_rescope_test.go
@@ -3,6 +3,7 @@ package sddstatus
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -480,5 +481,140 @@ func TestRuntimeLedgerRescopeRequiresPreconditions(t *testing.T) {
 		Reason: "attempted rescope on a drifted candidate", Actor: "maintainer",
 	}); !errors.Is(err, ErrRuntimeRescopeNotAllowed) {
 		t.Fatalf("rescope on a drifted candidate error = %v, want ErrRuntimeRescopeNotAllowed", err)
+	}
+}
+
+// TestRuntimeLedgerZeroDriftResetRefusalNamesBothExits is #1974's reproduction.
+// The reporter reached a failed verification objective with the candidate
+// unchanged and budget remaining, ran reset, and concluded the lifecycle was
+// deadlocked. It was not: rescope already owned that transition. The refusal
+// they received named neither it nor the route to a wider successor budget, and
+// status answered next_action: begin, which for failed verification evidence is
+// the one continuation that cannot help.
+//
+// Both named exits are executed here, not just matched as strings, because a
+// refusal that names a command nothing can run is worse than one that names
+// nothing at all.
+func TestRuntimeLedgerZeroDriftResetRefusalNamesBothExits(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "reset-exit-1974")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "verify-begin-1", WorkUnit: "independent-verification",
+		EvidenceGoal: "independently verify the applied change", MaxAttempts: 2, MaxChangedLines: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "verify-finish-1", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('7'), Diagnosis: "verification failed with the workspace unchanged",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "verification harness exited cleanly",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.DecisionRequired || failed.Complete || failed.NextAction != RuntimeActionBegin || failed.CumulativeAttempts != 1 {
+		t.Fatalf("pre-reset failed-verification status = %#v", failed)
+	}
+
+	_, resetErr := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "verify-reset-1",
+		Reason: "failed evidence proves implementation must remediate", Actor: "maintainer",
+	})
+	if !errors.Is(resetErr, ErrRuntimeResetNotAllowed) {
+		t.Fatalf("zero-drift reset error = %v, want ErrRuntimeResetNotAllowed", resetErr)
+	}
+	for _, want := range []string{
+		"gentle-ai sdd-attempt rescope",
+		"--expected-revision " + strconv.Quote(failed.Revision),
+		"at most 40",
+		"decision-required",
+	} {
+		if !strings.Contains(resetErr.Error(), want) {
+			t.Fatalf("zero-drift reset refusal does not name %q: %v", want, resetErr)
+		}
+	}
+
+	// Exit 1 runs: the rescope the refusal names is admitted at this exact
+	// revision, with the ceiling it advertises.
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "verify-rescope-1",
+		WorkUnit: "verification-remediation", EvidenceGoal: "remediate the verification gap",
+		MaxAttempts: 2, MaxChangedLines: 40,
+		Reason: "failed evidence names the remediation", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("the rescope this refusal names was refused: %v", err)
+	}
+	if rescoped.Objective == nil || rescoped.Objective.WorkUnit != "verification-remediation" ||
+		rescoped.CumulativeAttempts != 1 {
+		t.Fatalf("rescoped objective = %#v", rescoped)
+	}
+}
+
+// TestRuntimeLedgerExhaustedAttemptsAdmitTheResetForAWiderScope is the second
+// exit #1974's refusal now names, and the reason the narrow-only rescope rule
+// is not itself a deadlock: a caller who needs a successor budget WIDER than
+// the failed objective's ceiling spends the remaining attempts honestly, and
+// the run that exhausts them reaches decision-required, where reset opens a
+// fresh budget of any size.
+func TestRuntimeLedgerExhaustedAttemptsAdmitTheResetForAWiderScope(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "reset-exit-1974-wider")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	revision := ""
+	for ordinal, request := range []string{"verify-1", "verify-2"} {
+		started, beginErr := store.Begin(context.Background(), BeginAttemptRequest{
+			ExpectedRevision: revision, RequestID: request + "-begin", WorkUnit: "independent-verification",
+			EvidenceGoal: "independently verify the applied change", MaxAttempts: 2, MaxChangedLines: 40,
+		})
+		if beginErr != nil {
+			t.Fatalf("begin %d: %v", ordinal+1, beginErr)
+		}
+		finished, finishErr := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: started.Revision, RequestID: request + "-finish", Outcome: AttemptFailed,
+			EvidenceRevision: runtimeTestHash(byte('a' + ordinal)), Diagnosis: "verification failed with the workspace unchanged",
+			HarnessDisposition: HarnessInvalidated, CleanupEvidence: "verification harness exited cleanly",
+			ProcessEvidence: "post-verification process scan found no descendants",
+		})
+		if finishErr != nil {
+			t.Fatalf("finish %d: %v", ordinal+1, finishErr)
+		}
+		revision = finished.Revision
+		if ordinal == 1 && (!finished.DecisionRequired || finished.NextAction != RuntimeActionReset) {
+			t.Fatalf("exhausting the attempt budget did not reach decision-required: %#v", finished)
+		}
+	}
+
+	after, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: revision, RequestID: "wider-reset-1",
+		Reason: "verification exhausted its budget; remediation needs a wider scope", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("reset at decision-required was refused: %v", err)
+	}
+
+	// The fresh objective may exceed the exhausted one's ceiling, which is the
+	// capability rescope structurally cannot provide.
+	wider, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: after.Revision, RequestID: "wider-begin-1", WorkUnit: "implementation-remediation",
+		EvidenceGoal: "remediate what the failed verification named", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatalf("begin with a wider budget after reset was refused: %v", err)
+	}
+	if wider.Objective == nil || wider.Objective.MaxChangedLines != 400 {
+		t.Fatalf("post-reset objective = %#v", wider.Objective)
+	}
+	if wider.LifetimeAttempts != 3 {
+		t.Fatalf("reset laundered lifetime attempts: %#v", wider)
 	}
 }


### PR DESCRIPTION
Closes #1974

## Summary

- A failed verification objective with an unchanged candidate and attempts remaining refused `reset` with a message naming only what reset requires, then pointed at `status`, which answers `next_action: begin`. Repeating the identical objective is the one continuation that cannot help when the failed evidence proves the objective is wrong rather than under-attempted, so the reporter concluded the lifecycle was deadlocked. It was not: `rescope` already owned that transition and neither surface said so.
- The refusal now names both exits that state genuinely has, with the exact command and the caller's real revision and ceilings.

## The two exits, and why both

`rescope` is admitted here by construction, so it needs no second eligibility probe: this site is reached only when reset is structurally permitted, the objective is neither decision-required nor complete, and the candidate has not drifted, which is exactly `runtimeObjectiveRescopeStructurallyPermitted` plus zero drift.

It can only narrow or hold the budget, so a caller who needs a **wider** successor scope gets the second exit named instead: spend the remaining attempts honestly, because the run that exhausts them reaches decision-required, where this same reset is admitted and opens a fresh budget of any size. That is also the answer to whether the narrow-only rule is itself a deadlock. It is not, it is a cost, so this needs no new verb, no new disposition, and no relaxation of the anti-laundering guard.

I did not take the fix the issue proposed. A typed `failed-evidence-remediation` disposition on `reset` would be a second operation owning a transition `rescope` already owns, and the two would then have to agree about laundering rules at the same state.

## Changes

| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go` | Replace the bare `ErrRuntimeResetNotAllowed` at the zero-drift site with `runtimeZeroDriftResetRefusal`, which names both exits. The sentinel is unchanged and still wraps, so `errors.Is` callers keep working. |
| `internal/sddstatus/runtime_ledger_rescope_test.go` | #1974's reproduction, plus the exhaust-to-widen route. |

## Test Plan

- [x] `TestRuntimeLedgerZeroDriftResetRefusalNamesBothExits` reproduces #1974 and then **runs** the rescope the refusal names, at the exact revision it advertises. A refusal naming a command nothing can run is worse than one naming nothing.
- [x] `TestRuntimeLedgerExhaustedAttemptsAdmitTheResetForAWiderScope` spends both attempts as honest failures, asserts decision-required, resets, and begins a successor at 400 changed lines against the exhausted objective's 40, proving the widening route works and that lifetime attempts are not laundered.
- [x] Decoy: reverting to the bare sentinel fails `TestRuntimeLedgerZeroDriftResetRefusalNamesBothExits` on the rescope assertion. Restored to green.
- [x] `go test ./... -count=1` green at 66 packages; `cd bench && go test ./...` green; `go vet ./...`, `gofmt`, and the deadcode ratchet clean.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reset errors for terminal zero-drift objectives with actionable guidance.
  * Errors now distinguish between narrowing the scope and exhausting remaining attempts before pursuing a wider successor objective.

* **Tests**
  * Added coverage for rescoping, revision and budget details, decision-required handling, and preserving lifetime attempt limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->