### PR TITLE
fix(review): represent the approved scope-changed recovery status reports

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -935,13 +935,23 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 							record.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseDiff &&
 							target.Kind == reviewtransaction.TargetBaseWorkspaceOverlay &&
 							selector.Projection == reviewtransaction.ProjectionStaged && selector.WorkspaceOverlay
-						approvedRebasedRecovery := result.Action == reviewtransaction.TargetStatusActionRecover &&
+						// The store already decided this. It admits an approved
+						// predecessor as a scope-changed recovery through a
+						// deliberately kind-agnostic predicate
+						// (compactStartTargetKindsCompatible pairs
+						// current-changes with base-diff on purpose), so
+						// re-deriving representability from kind equality here
+						// withholds a RECOVER the store accepts and leaves the
+						// candidate with no reachable continuation. Consume the
+						// classification instead of reconstructing it: this
+						// replaces the narrower rebased-only reconstruction,
+						// which recognized only the disjoint base advance and
+						// missed the ordinary committed-delivery shape whose
+						// base tree is unchanged by construction.
+						approvedScopeChangedRecovery := result.Action == reviewtransaction.TargetStatusActionRecover &&
 							result.ActionDisposition == reviewtransaction.RecoveryScopeChanged &&
-							record.State.State == reviewtransaction.StateApproved &&
-							record.State.InitialSnapshot.Kind == reviewtransaction.TargetCurrentChanges &&
-							target.Kind == reviewtransaction.TargetBaseDiff &&
-							record.State.InitialSnapshot.BaseTree != liveSnapshot.BaseTree
-						selector.RecoveryRepresentable = record.State.InitialSnapshot.Kind == target.Kind || stagedScopeRecovery || approvedRebasedRecovery
+							record.State.State == reviewtransaction.StateApproved
+						selector.RecoveryRepresentable = record.State.InitialSnapshot.Kind == target.Kind || stagedScopeRecovery || approvedScopeChangedRecovery
 						if stagedScopeRecovery || selector.RecoveryRepresentable && result.ActionDisposition == reviewtransaction.RecoveryInvalidated && target.Kind == reviewtransaction.TargetBaseWorkspaceOverlay && selector.Projection == reviewtransaction.ProjectionStaged {
 							selector.RecoveryProjection = reviewtransaction.ProjectionStaged
 						} else if selector.RecoveryRepresentable && predecessorProjection != selector.Projection {

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -569,6 +569,70 @@ func TestStatusStopsUnrepresentableRecoveryWithoutMutation(t *testing.T) {
 	}
 }
 
+// TestStatusRepresentsApprovedScopeChangedRecoveryAcrossTargetKinds covers the
+// ordinary committed-delivery shape: an approved current-changes candidate is
+// committed, the work continues on the same paths, and the caller then asks for
+// base-diff authority. The store classifies that as a scope-changed recovery --
+// compactStartTargetKindsCompatible admits current-changes into base-diff on
+// purpose -- so STATUS must be able to represent the recovery it just reported.
+func TestStatusRepresentsApprovedScopeChangedRecoveryAcrossTargetKinds(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-scope-changed"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	result := filepath.Join(t.TempDir(), "clean.json")
+	writeReviewCLIJSON(t, result, facadeReviewerResult{
+		Lens: started.SelectedLenses[0], Findings: []facadeFinding{},
+		Evidence: []string{"reviewed exact current changes"},
+	})
+	if err := finalizeReviewCLIArgs(t, repo, []string{"--cwd", repo, "--lineage", started.LineageID, "--result", result}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	evidence := filepath.Join(t.TempDir(), "tests.txt")
+	if err := os.WriteFile(evidence, []byte("go test ./...: pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidence}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State.State != reviewtransaction.StateApproved {
+		t.Fatalf("predecessor state = %q, want approved", record.State.State)
+	}
+	// Commit the approved candidate, then keep working on the exact same path so
+	// the delivery scope still matches while the candidate tree moves on.
+	runReviewCLIGit(t, repo, "add", "candidate.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "commit approved candidate")
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 2 }\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "continue on the reviewed path")
+	before, _ := os.ReadFile(store.StatePath())
+	storesBefore, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	status := selectorTransitionStatus(t, repo, "--lineage", record.State.LineageID, "--base-ref", base)
+	if status.Action != reviewtransaction.TargetStatusActionRecover ||
+		status.ActionDisposition != reviewtransaction.RecoveryScopeChanged {
+		t.Fatalf("scope-changed status action = %q disposition = %q", status.Action, status.ActionDisposition)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "recovery_authorization_required" {
+		t.Fatalf("scope-changed recovery transition = %#v", status.NextTransition)
+	}
+	after, _ := os.ReadFile(store.StatePath())
+	storesAfter, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if !bytes.Equal(before, after) || len(storesAfter) != len(storesBefore) {
+		t.Fatal("scope-changed recovery status mutated authority")
+	}
+}
+
 func TestTransitionSelectorFlagsRejectMixedAliases(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2763

> **Note for maintainers:** #2763 is currently `status:needs-review`, so the `Check Issue Has status:approved` job will fail until it is triaged. Opening early because the diagnosis is reproduced and the change is small; happy to hold, rework, or close if the approach is not the one you want.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Negotiated STATUS reported `action: recover` / `action_disposition: scope_changed`, then refused to construct that recovery and returned `stop / recovery_target_unrepresentable`. The candidate had no reachable continuation, and the stop's narration recommended the base-diff selector the caller had already supplied.
- The refusal was the CLI's alone: invoking `review recover` directly with the same selector succeeds and the lifecycle resumes, so the store accepted the operation all along.
- STATUS now consumes the store's classification instead of reconstructing it, replacing the narrower rebased-only reconstruction rather than adding a term next to it.

### Why the ordinary shape was the one that failed

Two predicates decided the same question and were **disjoint**:

| | base tree | target kinds |
|---|---|---|
| `compactApprovedScopeChangedRecovery` (store, admitted this candidate) | `live.BaseTree == original.BaseTree` | kind-agnostic — `compactStartTargetKindsCompatible` pairs `current-changes` with `base-diff` deliberately |
| `approvedRebasedRecovery` (CLI reconstruction) | `InitialSnapshot.BaseTree != liveSnapshot.BaseTree` | `current-changes` → `base-diff` only |

The CLI implemented only the rebased case, which requires the base to have *moved*. The ordinary committed-delivery shape — approve uncommitted work, commit it, then ask for base-diff authority — leaves the base tree untouched by construction, so it satisfied the store's predicate and none of the CLI's.

Since `action_disposition` already reports whichever store predicate admitted the recovery, the reconstruction is redundant and is removed rather than extended.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Replaced the `approvedRebasedRecovery` reconstruction with `approvedScopeChangedRecovery`, derived from the store's own `Action`/`ActionDisposition`/state. Net −4 lines of predicate logic; the rest is the comment explaining the ownership boundary. |
| `internal/cli/review_selector_transition_test.go` | Added `TestStatusRepresentsApprovedScopeChangedRecoveryAcrossTargetKinds` covering approve → commit → continue on the same paths → base-diff STATUS. |

Scope is deliberately narrow: `RecoveryRepresentable` is read in exactly one place (`review_next_transition.go:744`), and the projection guard immediately below is untouched, so a projection change still requires an escalated disposition.

---

## 🧪 Test Plan

**Red first.** The new test fails on unmodified `main` (e1ad166d) with:

```
scope-changed recovery transition = &cli.ReviewNextTransition{Kind:"stop",
  ReasonCode:"recovery_target_unrepresentable", Execute:(nil), Collect:(nil)}
```

It reaches that line having already asserted `action: recover` and `disposition: scope_changed`, so it fails on the representation gap and nothing else. With the change it returns `collect / recovery_authorization_required`.

**Negative control retained.** `TestStatusStopsUnrepresentableRecoveryWithoutMutation` still passes unchanged. Its predecessor is not `approved` (its finalize carries a CRITICAL finding), so the new term does not fire and the cross-kind stop is preserved for non-approved predecessors. This is not a blanket cross-kind relaxation.

**Manual end-to-end**, synthetic repository, binary built from this branch:

1. Approve a `current-changes` candidate, commit it, then commit one further change on the same path.
2. `review status --contract gentle-ai.review-integration/v2 --base-ref <base> --committed-only --next-transition` → `collect: recovery_authorization_required` (was `stop`).
3. Executing the resulting `review.recover` with `--base-ref <base> --committed-only` succeeds; STATUS then proceeds normally against the base-diff target.

Step 3 also reproduces on unmodified `main` when `review recover` is invoked by hand, which is the evidence that STATUS was withholding a valid operation rather than protecting an invalid one.

- [x] Unit tests pass — `go test ./internal/cli/ ./internal/reviewtransaction/` (143.9s / 122.0s, both ok). Full `go test ./...` not run locally; deferring to CI.
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally, deferring to CI.
- [x] Manually tested locally

**Benchmark validation:** this touches the recovery lifecycle, so bench validation applies. I did not author a journey — `bench/` has no existing coverage for `recovery_target_unrepresentable` or the scope-changed disposition, so this needs a new journey rather than an edit to an existing one, and I would rather agree the shape with a maintainer first than guess at it. Happy to add it to this PR on request.

**Changed lines:** 86 (`additions + deletions`), within the 400 budget.

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — **not yet**; #2763 is `status:needs-review`. Flagged above.
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass for the affected packages (full `./...` deferred to CI)
- [x] Go format passes
- [ ] E2E tests pass — deferred to CI
- [ ] Benchmark validation completed — see the Test Plan; needs a new journey, shape not agreed yet
- [x] I have updated documentation if necessary — no user-facing docs describe this predicate
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**On the guard.** This relaxes an admission gate, so it deserves the scrutiny the template asks for. The argument is that `RecoveryRepresentable` was never the authority on this population — the store is, and it had already answered before this line runs. The legitimate population is exactly "recoveries the store admits", which `Action` + `ActionDisposition` + `StateApproved` names precisely; the previous kind-equality test was a narrower proxy for it that excluded the most common member. No `guard:population` declaration changes and `.guard-population-baseline.txt` is untouched: the only declared guard in this file is `finalize-result-admission`, far from this region.

**On scope.** This fixes one instance. The root is tracked in #2645 — `internal/cli` makes 57 independent relation judgments over snapshot `Kind`/`BaseTree`/`CandidateTree`/`Identity`/`Projection` while consuming 0 of the store's 15 relation predicates, which are package-private and therefore unreachable. Both drift directions have open instances: STATUS withholding what the store accepts (this, #1984) and STATUS emitting what the native operation refuses (#2756, #1951, #2478, #2758). I deliberately did not widen this PR toward that refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `review status --next-transition` handling for approved scope-changed recovery.
  * Supports recovery after committed delivery continues along the same path.
  * Correctly identifies recovery transitions requiring authorization without altering existing authority or creating unnecessary records.

* **Tests**
  * Added coverage for scope-changed recovery and authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->