### PR TITLE
fix(sdd): name a runnable exit in three more runtime refusals

### DIFF
--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -506,9 +506,14 @@ func compactBlockedExitText(reason CompactBlockReason, token string) string {
 			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` to see the live attempt and its " +
 			"current revision, then reissue this call against that state"
 	case CompactBlockMaintainerDecision:
+		// #2530: this said "rescope or reset", and rescope is structurally
+		// refused for exactly this state — runtimeObjectiveRescopeStructurally
+		// Permitted returns false whenever DecisionRequired is set, which is
+		// the only way this block is reached. Reset is the admitted one, and
+		// the ledger's own next_action has said so all along.
 		return "this work unit's attempt or changed-line budget needs a maintainer decision; run " +
 			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` for the accounting, then ask a " +
-			"maintainer to rescope or reset the objective, or run " + compactBlockedReviewModeDisableExit
+			"maintainer to reset the objective, or run " + compactBlockedReviewModeDisableExit
 	case CompactBlockActiveAttempt:
 		// Adversarial finding F2: the bare `sdd-attempt acquire --token <t>`
 		// / `settle --token <t>` forms are not complete commands -- each

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -717,7 +717,7 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 		advancing := false
 		if status.Complete {
 			if !runtimeObjectiveAdvanceAdmissible(status, request) {
-				return runtimeRecord{}, ErrRuntimeObjectiveDone
+				return runtimeRecord{}, store.runtimeObjectiveCompleteRefusal(status)
 			}
 			advancing = true
 		}
@@ -1124,6 +1124,40 @@ func (store RuntimeStore) runtimeZeroDriftResetRefusal(status RuntimeStatus) err
 		objective.MaxAttempts, objective.MaxChangedLines, objective.MaxChangedLines)
 }
 
+// runtimeRescopeWidenedRefusal is the complement of
+// runtimeZeroDriftResetRefusal (#1974). That one caught the caller who reached
+// for reset and was told nothing about rescope; this catches the caller who
+// reached for rescope and is told only that a wider budget is refused. The
+// state is the same one, so status answers next_action: begin, which repeats
+// the objective at the same ceiling the caller just said is too small.
+//
+// The route that does work is not another operation, it is finishing this one:
+// spending the remaining attempts reaches decision-required, and reset is
+// admitted there with a budget of any size. Naming it costs nothing and does
+// not weaken the narrowing rule, which exists so a successor scope cannot
+// launder a consumed budget.
+func (store RuntimeStore) runtimeRescopeWidenedRefusal(status RuntimeStatus, flag string, requested, allowed int) error {
+	remaining := status.Objective.MaxAttempts - status.CumulativeAttempts
+	return fmt.Errorf(
+		"%w: received %s %d, the current objective allows %d. A wider successor scope is reached by finishing this objective rather than by rescoping it: spend its %d remaining attempt(s), and the run that exhausts them reaches decision-required, where `gentle-ai sdd-attempt reset --cwd %q --change %q --expected-revision \"<revision-from-status>\" --request-id \"<unique-request-id>\" --reason \"<why-the-objective-changed>\" --actor \"<actor>\"` opens a fresh budget of any size",
+		ErrRuntimeRescopeWidened, flag, requested, allowed, remaining, store.Workspace, store.Change)
+}
+
+// runtimeObjectiveCompleteRefusal names what a completed objective's begin can
+// actually do. The sentinel said only that the objective is complete and
+// pointed at status, whose next_action is `complete` — true, and useless to a
+// caller who has more work to do on this change.
+//
+// Complete is only reachable from a passed attempt within budget, so advance is
+// admissible here whenever the sole failing condition is the repeated work
+// unit: changing --work-unit is the entire difference. Reset is admitted too,
+// for a caller who means to discard this scope rather than succeed it.
+func (store RuntimeStore) runtimeObjectiveCompleteRefusal(status RuntimeStatus) error {
+	return fmt.Errorf(
+		"%w: it passed within budget, so this change continues through a SUCCESSOR objective, not a repeat of this one — re-run this begin with a different --work-unit (everything else may stay as it is) and it is admitted as an advance that carries this objective's evidence forward. To discard this scope instead of succeeding it, run `gentle-ai sdd-attempt reset --cwd %q --change %q --expected-revision %q --request-id \"<unique-request-id>\" --reason \"<why-the-objective-changed>\" --actor \"<actor>\"`",
+		ErrRuntimeObjectiveDone, store.Workspace, store.Change, status.Revision)
+}
+
 func (store RuntimeStore) runtimeWorktreeMismatchRefusal(ordinal int, beginWorktree string) error {
 	return fmt.Errorf(
 		"%w: attempt %d began in %s, and its base candidate tree is pinned to that exact linked worktree, but this finish is running from %s — rerun with --cwd %s so the candidate capture and changed-line measurement use the worktree that actually did the work",
@@ -1402,15 +1436,12 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed
 		}
 		if request.MaxChangedLines > objective.MaxChangedLines {
-			return runtimeRecord{}, fmt.Errorf(
-				"%w: received --max-changed-lines %d, the current objective allows %d",
-				ErrRuntimeRescopeWidened, request.MaxChangedLines, objective.MaxChangedLines,
-			)
+			return runtimeRecord{}, store.runtimeRescopeWidenedRefusal(
+				status, "--max-changed-lines", request.MaxChangedLines, objective.MaxChangedLines)
 		}
 		if request.MaxAttempts > objective.MaxAttempts {
-			return runtimeRecord{}, fmt.Errorf(
-				"%w: received --max-attempts %d, the current objective allows %d",
-				ErrRuntimeRescopeWidened, request.MaxAttempts, objective.MaxAttempts,
+			return runtimeRecord{}, store.runtimeRescopeWidenedRefusal(
+				status, "--max-attempts", request.MaxAttempts, objective.MaxAttempts,
 			)
 		}
 		// The zero-drift `drift` snapshot above was captured with

--- a/internal/sddstatus/runtime_ledger_rescope_test.go
+++ b/internal/sddstatus/runtime_ledger_rescope_test.go
@@ -618,3 +618,150 @@ func TestRuntimeLedgerExhaustedAttemptsAdmitTheResetForAWiderScope(t *testing.T)
 		t.Fatalf("reset laundered lifetime attempts: %#v", wider)
 	}
 }
+
+// TestRuntimeLedgerWidenedRescopeRefusalNamesTheExhaustRoute is #2769 A, the
+// complement of #1974: that caller reached for reset and heard nothing about
+// rescope, this one reaches for rescope and hears only that a wider budget is
+// refused. Status answers begin, which repeats the ceiling they just called
+// too small. The exhaust-then-reset route is executed here, not asserted as
+// prose, because a refusal naming a route nothing can walk is worse than one
+// naming nothing.
+func TestRuntimeLedgerWidenedRescopeRefusalNamesTheExhaustRoute(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "widened-2769")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "widen-begin-1", WorkUnit: "independent-verification",
+		EvidenceGoal: "independently verify the applied change", MaxAttempts: 2, MaxChangedLines: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "widen-finish-1", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('3'), Diagnosis: "verification failed with the workspace unchanged",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "verification harness exited cleanly",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.NextAction != RuntimeActionBegin {
+		t.Fatalf("status must still answer begin for this state: %#v", failed)
+	}
+
+	_, widenErr := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "widen-rescope-1",
+		WorkUnit: "implementation-remediation", EvidenceGoal: "remediate what verification named",
+		MaxAttempts: 2, MaxChangedLines: 400,
+		Reason: "remediation needs more than the verification ceiling", Actor: "maintainer",
+	})
+	if !errors.Is(widenErr, ErrRuntimeRescopeWidened) {
+		t.Fatalf("widened rescope error = %v, want ErrRuntimeRescopeWidened", widenErr)
+	}
+	for _, want := range []string{"1 remaining attempt", "decision-required", "gentle-ai sdd-attempt reset"} {
+		if !strings.Contains(widenErr.Error(), want) {
+			t.Fatalf("widened rescope refusal does not name %q: %v", want, widenErr)
+		}
+	}
+
+	// Walk the route the refusal names: spend the last attempt, land on
+	// decision-required, reset, and open the wider budget rescope refused.
+	last, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: failed.Revision, RequestID: "widen-begin-2", WorkUnit: "independent-verification",
+		EvidenceGoal: "independently verify the applied change", MaxAttempts: 2, MaxChangedLines: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exhausted, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: last.Revision, RequestID: "widen-finish-2", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('4'), Diagnosis: "verification failed again with the workspace unchanged",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "verification harness exited cleanly",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exhausted.DecisionRequired {
+		t.Fatalf("the route the refusal names did not reach decision-required: %#v", exhausted)
+	}
+	after, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: exhausted.Revision, RequestID: "widen-reset-1",
+		Reason: "remediation needs a wider scope than verification allowed", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("the reset this refusal names was refused: %v", err)
+	}
+	wider, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: after.Revision, RequestID: "widen-begin-3", WorkUnit: "implementation-remediation",
+		EvidenceGoal: "remediate what verification named", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatalf("the wider budget the refusal promises was refused: %v", err)
+	}
+	if wider.Objective == nil || wider.Objective.MaxChangedLines != 400 {
+		t.Fatalf("post-reset objective = %#v", wider.Objective)
+	}
+}
+
+// TestRuntimeLedgerCompleteObjectiveRefusalNamesTheSuccessor is #2769 B. A
+// completed objective refused a repeated begin with "objective is complete"
+// and pointed at status, whose next_action is `complete`: true, and useless to
+// a caller with more work on this change. Advance was one flag away the whole
+// time, and the code comment above the refusal already said so.
+func TestRuntimeLedgerCompleteObjectiveRefusalNamesTheSuccessor(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "complete-2769")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "done-begin-1", WorkUnit: "apply-the-change",
+		EvidenceGoal: "apply the approved change", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	passed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "done-finish-1", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('5'), Diagnosis: "the change applied and its evidence passed",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "harness exited cleanly",
+		ProcessEvidence: "post-run process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !passed.Complete || passed.NextAction != RuntimeActionComplete {
+		t.Fatalf("post-pass status = %#v", passed)
+	}
+
+	_, doneErr := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: passed.Revision, RequestID: "done-begin-2", WorkUnit: "apply-the-change",
+		EvidenceGoal: "apply the approved change", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if !errors.Is(doneErr, ErrRuntimeObjectiveDone) {
+		t.Fatalf("repeated begin error = %v, want ErrRuntimeObjectiveDone", doneErr)
+	}
+	for _, want := range []string{"--work-unit", "advance", "gentle-ai sdd-attempt reset"} {
+		if !strings.Contains(doneErr.Error(), want) {
+			t.Fatalf("complete-objective refusal does not name %q: %v", want, doneErr)
+		}
+	}
+
+	// Exit 1 runs: the same begin with only --work-unit changed is admitted.
+	advanced, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: passed.Revision, RequestID: "done-begin-3", WorkUnit: "verify-the-change",
+		EvidenceGoal: "apply the approved change", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatalf("the advance this refusal names was refused: %v", err)
+	}
+	if advanced.ActiveAttempt == nil || advanced.Objective == nil || advanced.Objective.WorkUnit != "verify-the-change" {
+		t.Fatalf("advanced objective = %#v", advanced)
+	}
+}

--- a/internal/sddstatus/runtime_readiness_test.go
+++ b/internal/sddstatus/runtime_readiness_test.go
@@ -2,6 +2,7 @@ package sddstatus
 
 import (
 	"context"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -215,4 +216,64 @@ func isRuntimeStatusExpression(expression ast.Expr, bound map[string]bool) bool 
 		return node.Sel.Name == "Status" || node.Sel.Name == "RuntimeStatus"
 	}
 	return false
+}
+
+// TestMaintainerDecisionExitNamesOnlyTheAdmittedOperation is #2530. The
+// maintainer-decision block told the caller to "rescope or reset", and
+// runtimeObjectiveRescopeStructurallyPermitted returns false whenever
+// DecisionRequired is set, which is the only way this block is reached. Half
+// that advice could never run, and a wrong exit is worse than a missing one:
+// a dead end says stop, while advice that cannot work sends the caller in
+// circles blaming themselves.
+//
+// Both operations are executed against the real blocked state rather than
+// matched as strings, because the defect was precisely that the text and the
+// admissibility rules disagreed.
+func TestMaintainerDecisionExitNamesOnlyTheAdmittedOperation(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	seedReadyChange(t, repo, "decision-exit", "- [ ] 1.1 Work\n")
+	store := mustRuntimeStore(t, repo, "decision-exit")
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "begin-decision-exit", WorkUnit: "apply-auth",
+		EvidenceGoal: "prove the auth runtime", MaxAttempts: 1, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "finish-decision-exit", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('8'), Diagnosis: "bounded runtime reproduced the failure",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "runtime process group exited",
+		ProcessEvidence: "post-run scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !blocked.DecisionRequired {
+		t.Fatalf("fixture did not reach the maintainer-decision state: %#v", blocked)
+	}
+
+	exit := compactBlockedExitText(CompactBlockMaintainerDecision, "")
+	if strings.Contains(exit, "rescope") {
+		t.Fatalf("maintainer-decision exit still names rescope, which this state refuses: %s", exit)
+	}
+	if !strings.Contains(exit, "reset the objective") {
+		t.Fatalf("maintainer-decision exit stopped naming reset: %s", exit)
+	}
+
+	// The advice it dropped is genuinely refused here.
+	if _, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: blocked.Revision, RequestID: "decision-exit-rescope", WorkUnit: "narrower-auth",
+		EvidenceGoal: "prove a narrower auth runtime", MaxAttempts: 1, MaxChangedLines: 20,
+		Reason: "attempted the exit the old message named", Actor: "maintainer",
+	}); !errors.Is(err, ErrRuntimeRescopeNotAllowed) {
+		t.Fatalf("rescope at decision-required error = %v, want ErrRuntimeRescopeNotAllowed", err)
+	}
+	// The advice it kept genuinely runs.
+	if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: blocked.Revision, RequestID: "decision-exit-reset",
+		Reason: "maintainer decided the budget is spent", Actor: "maintainer",
+	}); err != nil {
+		t.Fatalf("the reset this exit names was refused: %v", err)
+	}
 }


### PR DESCRIPTION
Closes #2769
Closes #2530

## Summary

A sweep of the SDD runtime refusal surface after #1974, looking for the same defect: a refusal that names an exit the state structurally refuses, or names none while a runnable one exists. Two new sites carry it, and #2530 was the third, already filed and still open. One root, one fix.

## The three sites

**A. Widened rescope named no route to a wider budget.** It refused with "received X, allows Y" and pointed at `status`, whose `next_action` in that state is `begin`, which repeats the ceiling the caller had just called too small. It now names the route that works: spend the remaining attempts, and the run that exhausts them reaches decision-required, where `reset` opens a fresh budget of any size. This is the exact complement of #1974, which was the caller reaching for `reset` and hearing nothing about `rescope`; #2765 fixed only that direction.

**B. A completed objective refused a repeated `begin` and named no successor.** It said "objective is complete" and pointed at status, whose `next_action` is `complete`: true, and useless to a caller with more work on this change. The comment three lines above the refusal already stated the answer, "the ordinary continuation is the successor objective", and `Complete` is only reachable from a passed in-budget attempt, so advance is admissible whenever the sole failing condition is the repeated work unit. Changing `--work-unit` was the entire difference, unsaid.

**C. #2530.** The maintainer-decision block said "rescope or reset", and `runtimeObjectiveRescopeStructurallyPermitted` returns false whenever `DecisionRequired` is set, which is the only way that block is reached. Dropped the half that cannot run.

No new operation, no new state, no relaxed guard. Three messages.

## Changes

| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go` | `runtimeRescopeWidenedRefusal` and `runtimeObjectiveCompleteRefusal`; both sentinels still wrap, so `errors.Is` callers are unaffected. |
| `internal/sddstatus/runtime_compact.go` | Maintainer-decision exit stops naming `rescope`. |
| `internal/sddstatus/runtime_ledger_rescope_test.go` | A and B, each walking its named exit. |
| `internal/sddstatus/runtime_readiness_test.go` | C, executing both the dropped advice and the kept advice against the real blocked state. |

## Test Plan

- [x] Every test **runs** the exit its refusal names rather than matching a string, because the defect in all three cases was the text and the admissibility rules disagreeing. A walks exhaust to decision-required to reset to a 400-line successor against a 40-line ceiling; B runs the advance with only `--work-unit` changed; C proves `rescope` is refused at decision-required and `reset` is admitted.
- [x] Three decoys, one per site, each failing only its own test, then restored to green.
- [x] `go test ./... -count=1` green at 66 packages; `cd bench && go test ./...` green; `go vet ./...`, `gofmt`, and the deadcode ratchet clean.

## Contributor Checklist

- [x] Linked approved issues
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance when work is already complete, including actionable options to change the work unit or reset the objective.
  * Clarified recovery guidance when a rescope request exceeds allowed limits.
  * Removed the invalid rescope option from maintainer-decision instructions.
  * Prevented status checks from blocking attempts that have already been admitted.

* **Tests**
  * Added coverage for completion, reset, rescope, and maintainer-decision recovery paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->