### PR TITLE
fix(review): project the typed cause once for every failure envelope

### DIFF
--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -1159,3 +1159,45 @@ func decodeReviewIntegrationFailure(t *testing.T, payload []byte) ReviewIntegrat
 	}
 	return failure
 }
+
+// TestNewReviewIntegrationFailureCauseIsUniversal is root 8's structural fix
+// (#2471): Cause used to be per-branch opt-in, and 17 of 25 return sites
+// forgot it, so a caller read a constant Message while the native reason sat
+// in the discarded typed error. Cause is now projected once at construction,
+// so a branch cannot forget it; this test pins two branches that carried no
+// cause before, plus the one branch whose contract REQUIRES staying
+// content-free.
+func TestNewReviewIntegrationFailureCauseIsUniversal(t *testing.T) {
+	// A branch matched via errors.Is: contention keeps its typed code and now
+	// carries the wrapped operational context too.
+	contention := fmt.Errorf("acquire compact authority for lineage %q: %w", "cause-universal", reviewtransaction.ErrStoreLockContended)
+	failure := newReviewIntegrationFailure("review.start", nil, contention)
+	if failure.Code != "authority_lock_contention" {
+		t.Fatalf("contention envelope code = %q", failure.Code)
+	}
+	if !strings.Contains(failure.Cause, "cause-universal") {
+		t.Fatalf("contention envelope discarded the typed cause: %#v", failure)
+	}
+	if err := failure.Validate(); err != nil {
+		t.Fatalf("contention envelope with cause validation = %v", err)
+	}
+
+	// The legacy read-only refusal: constant Message, and before this change
+	// no Cause at all, so the lineage the error names never reached the
+	// caller's machine-readable envelope.
+	legacy := &reviewtransaction.LegacyReadOnlyError{Operation: "review/start", LineageID: "cause-universal-legacy"}
+	failure = newReviewIntegrationFailure("review.start", nil, legacy)
+	if failure.Code != reviewtransaction.LegacyReadOnlyErrorCode {
+		t.Fatalf("legacy envelope code = %q", failure.Code)
+	}
+	if !strings.Contains(failure.Cause, "cause-universal-legacy") {
+		t.Fatalf("legacy envelope discarded the typed cause: %#v", failure)
+	}
+
+	// The read-only catch-all is the ONE branch whose contract is
+	// content-free retry; it must clear the universal default, not inherit it.
+	readOnly := newReviewIntegrationFailure("review.status", nil, errors.New("internal detail that must not leak"))
+	if readOnly.Code != "operation_failed" || readOnly.Cause != "" {
+		t.Fatalf("read-only catch-all = %#v, want content-free", readOnly)
+	}
+}

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -422,6 +422,14 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		failure.Schema, failure.Contract = ReviewIntegrationFailureSchemaV2, ReviewIntegrationContractV2
 	}
 	failure.LineageID = safeReviewIntegrationLineage(operation, args)
+	// Root 8 (#2471): the typed cause is projected ONCE, here, for every
+	// branch below. Before this, Cause was per-branch opt-in and 17 of 25
+	// return sites forgot it, so the caller read a constant Message with the
+	// native reason already in the tool's hands and discarded. The helper
+	// scrubs and bounds to the schema's own maxLength, and the field is
+	// additive, so no branch has a reason to suppress it; a branch that needs
+	// a MORE specific cause may still overwrite this default.
+	failure.Cause = reviewIntegrationFailureCause(runErr)
 	// Both branches below refuse inside authorizeReviewStart, strictly before
 	// any review authority is created or mutated (organic-dx Phase 3b task
 	// 3b.6). Falling through to the generic operation_outcome_unknown default
@@ -521,6 +529,12 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 			failure.RequestDigest = publication.RequestDigest
 			failure.RequiredInputs = []string{}
 			failure.NextAction = "explicit-maintainer-action"
+			// Publication errors wrap raw provider/subprocess bytes, which no
+			// scrubber can prove safe; this envelope already carries lineage,
+			// request digest and exact replayability, so it stays content-free
+			// like the read-only catch-all rather than inheriting the universal
+			// cause default.
+			failure.Cause = ""
 			return failure
 		}
 		failure.Code = "receipt_publication_pending"
@@ -532,6 +546,12 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		failure.RequestDigest = publication.RequestDigest
 		failure.RequiredInputs = []string{"lineage_id"}
 		failure.NextAction = "review.finalize"
+		// Publication errors wrap raw provider/subprocess bytes, which no
+		// scrubber can prove safe; this envelope already carries lineage,
+		// request digest and exact replayability, so it stays content-free
+		// like the read-only catch-all rather than inheriting the universal
+		// cause default.
+		failure.Cause = ""
 		return failure
 	}
 	var bindingPublication *sddstatus.ReviewBindingPublicationError
@@ -546,6 +566,12 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		failure.RequestDigest = facadeValueHash("bind-sdd-request", args)
 		failure.RequiredInputs = []string{"change", "lineage_id", "expected_binding_revision"}
 		failure.NextAction = ReviewIntegrationOperationBindSDD
+		// Publication errors wrap raw provider/subprocess bytes, which no
+		// scrubber can prove safe; this envelope already carries lineage,
+		// request digest and exact replayability, so it stays content-free
+		// like the read-only catch-all rather than inheriting the universal
+		// cause default.
+		failure.Cause = ""
 		return failure
 	}
 	var startContext *reviewStartContextError
@@ -947,6 +973,11 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		failure.RetrySafe = true
 		failure.Replayability = reviewtransaction.ReplayabilityNotReplayable
 		failure.NextAction = "retry"
+		// The read-only catch-all is deliberately content-free: it is the one
+		// envelope whose whole contract is "retry safely", so it clears the
+		// universal cause default rather than leaking an arbitrary internal
+		// error to a caller who has nothing to repair.
+		failure.Cause = ""
 		return failure
 	}
 	// The true operation_outcome_unknown default: no typed branch above


### PR DESCRIPTION
Closes #2776 (#2471 root 8)

## Summary

- Root 8's structural half, on the negotiated failure envelope: `Cause` was per-branch opt-in and 17 of 25 return sites forgot it, so the caller read a constant `Message` while the native reason sat discarded in the typed error. It is now projected once at construction, where no branch can forget it, through the existing scrubbed and schema-bounded helper. #2718 fixed the three Git branches by hand this morning; this makes the remaining fourteen impossible to miss rather than adding fourteen more opt-ins.
- Two envelope classes deliberately clear the default, and each says why in place: the read-only catch-all, whose entire contract is content-free retry, and the three publication branches, which wrap raw provider bytes no scrubber can prove safe and already carry lineage, request digest, and exact replayability.

That second exclusion was found by the existing sanitization test, not by inspection: the universal default leaked `token=secret` from provider stderr through the receipt-publication envelope, because the env-assignment scrubber does not match that shape. The boundary is now principled instead of accidental: the product's own composed error text projects; foreign bytes never do.

## Changes

| File | Change |
|------|--------|
| `internal/cli/review_operation_contract.go` | Universal `Cause` default at construction; explicit content-free clears on the read-only catch-all and the three publication branches. |
| `internal/cli/review_failure_contract_test.go` | Pins two branches that carried no cause before (lock contention via `errors.Is`, legacy read-only via `errors.As`), and the content-free contract of the catch-all. |

## Test Plan

- [x] Decoy: removing the universal default fails `TestNewReviewIntegrationFailureCauseIsUniversal`; restored to green.
- [x] `TestNegotiatedReceiptPublicationFailureIsSanitizedAndExactlyReplayable` green, proving the publication exclusion.
- [x] Full `internal/cli` green (144s), `go vet`, `gofmt`, deadcode ratchet clean.

## Contributor Checklist

- [x] Linked issue (#2471, root 8)
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for review operations by preserving useful underlying causes where appropriate.
  * Prevented sensitive provider and subprocess details from appearing in publication failures and generic read-only errors.
  * Ensured error information is consistently bounded and sanitized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- linked issue #2776 is approved; this line re-triggers PR validation after the body was corrected -->
