### PR TITLE
feat(skills): filter injection by adapter capabilities

### DIFF
--- a/internal/catalog/skills.go
+++ b/internal/catalog/skills.go
@@ -1,12 +1,19 @@
 package catalog
 
-import "github.com/gentleman-programming/gentle-ai/v2/internal/model"
+import (
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
 
 type Skill struct {
 	ID       model.SkillID
 	Name     string
 	Category string
 	Priority string
+
+	// RequiredCapabilities declares optional adapter mechanisms required to use
+	// this skill. Its zero value keeps existing skills compatible with all agents.
+	RequiredCapabilities capabilitymanifest.AgentFeatureClaims
 }
 
 var mvpSkills = []Skill{

--- a/internal/catalog/skills_test.go
+++ b/internal/catalog/skills_test.go
@@ -1,8 +1,9 @@
-package catalog
+package catalog_test
 
 import (
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
@@ -13,7 +14,7 @@ import (
 // silently rejected by normalizeSkills in cli/validate.go.
 func TestMVPSkillsCoverAllPresetSkills(t *testing.T) {
 	catalogSet := make(map[model.SkillID]bool)
-	for _, s := range MVPSkills() {
+	for _, s := range catalog.MVPSkills() {
 		catalogSet[s.ID] = true
 	}
 
@@ -28,7 +29,7 @@ func TestMVPSkillsCoverAllPresetSkills(t *testing.T) {
 // TestMVPSkillsNoDuplicates ensures no skill is listed twice in mvpSkills.
 func TestMVPSkillsNoDuplicates(t *testing.T) {
 	seen := make(map[model.SkillID]bool)
-	for _, s := range MVPSkills() {
+	for _, s := range catalog.MVPSkills() {
 		if seen[s.ID] {
 			t.Errorf("duplicate skill %q in mvpSkills", s.ID)
 		}
@@ -51,7 +52,7 @@ func TestMVPSkillsIncludeRequestedBundledSkillsWithCanonicalNames(t *testing.T) 
 	}
 
 	found := make(map[model.SkillID]string)
-	for _, skill := range MVPSkills() {
+	for _, skill := range catalog.MVPSkills() {
 		found[skill.ID] = skill.Name
 		if skill.Name == "judgement-day" {
 			t.Fatalf("catalog uses non-canonical spelling %q; want judgment-day", skill.Name)

--- a/internal/components/skills/capability_filtering_test.go
+++ b/internal/components/skills/capability_filtering_test.go
@@ -1,0 +1,179 @@
+package skills
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/antigravity"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func TestInjectFiltersSkillsByRequiredCapabilities(t *testing.T) {
+	tests := []struct {
+		name         string
+		adapter      agents.Adapter
+		requirements capabilitymanifest.AgentFeatureClaims
+		wantSkipped  bool
+	}{
+		{
+			name:         "declared compatible skill installs",
+			adapter:      kimi.NewAdapter(),
+			requirements: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true},
+		},
+		{
+			name:         "declared incompatible skill is skipped",
+			adapter:      antigravity.NewAdapter(),
+			requirements: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true},
+			wantSkipped:  true,
+		},
+		{
+			name:    "unannotated skill remains fail open",
+			adapter: antigravity.NewAdapter(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			available := []catalog.Skill{{
+				ID:                   model.SkillCreator,
+				Name:                 "skill-creator",
+				RequiredCapabilities: tt.requirements,
+			}}
+
+			result, err := injectWithCatalog(home, tt.adapter, []model.SkillID{model.SkillCreator}, "", available)
+			if err != nil {
+				t.Fatalf("injectWithCatalog() error = %v", err)
+			}
+
+			path := SkillPathForAgent(home, tt.adapter, model.SkillCreator)
+			if tt.wantSkipped {
+				if len(result.Skipped) != 1 || result.Skipped[0] != model.SkillCreator {
+					t.Fatalf("injectWithCatalog() skipped = %v, want [%s]", result.Skipped, model.SkillCreator)
+				}
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("incompatible skill path stat error = %v, want not exist", statErr)
+				}
+				return
+			}
+
+			if len(result.Skipped) != 0 {
+				t.Fatalf("injectWithCatalog() skipped = %v, want none", result.Skipped)
+			}
+			assertNonEmptyFile(t, path)
+		})
+	}
+}
+
+func TestInjectPreflightsCatalogAndManifestBeforeWritingSkills(t *testing.T) {
+	tests := []struct {
+		name      string
+		adapter   agents.Adapter
+		available []catalog.Skill
+		wantErr   error
+	}{
+		{
+			name:    "invalid manifest",
+			adapter: invalidManifestAdapter{Adapter: claude.NewAdapter()},
+			available: []catalog.Skill{
+				{ID: model.SkillCreator, Name: "skill-creator"},
+				{ID: model.SkillGoTesting, Name: "go-testing", RequiredCapabilities: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true}},
+			},
+			wantErr: agents.ErrCapabilityManifestMismatch,
+		},
+		{
+			name:    "duplicate catalog ID",
+			adapter: claude.NewAdapter(),
+			available: []catalog.Skill{
+				{ID: model.SkillCreator, Name: "skill-creator"},
+				{ID: model.SkillCreator, Name: "duplicate-skill-creator"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			_, err := injectWithCatalog(home, tt.adapter, []model.SkillID{model.SkillCreator, model.SkillGoTesting}, "", tt.available)
+			if err == nil {
+				t.Fatal("injectWithCatalog() error = nil, want preflight failure")
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("injectWithCatalog() error = %v, want %v", err, tt.wantErr)
+			}
+
+			earlierPath := SkillPathForAgent(home, tt.adapter, model.SkillCreator)
+			if _, statErr := os.Stat(earlierPath); !os.IsNotExist(statErr) {
+				t.Fatalf("earlier skill path stat error = %v, want not exist", statErr)
+			}
+		})
+	}
+}
+
+type invalidManifestAdapter struct {
+	agents.Adapter
+}
+
+func (a invalidManifestAdapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifest {
+	return capabilitymanifest.AgentCapabilityManifest{}
+}
+
+func TestRequiredCapabilitiesAreSubsetOfProvided(t *testing.T) {
+	all := capabilitymanifest.AgentFeatureClaims{
+		OutputStyles: true, SlashCommands: true, FileSubAgents: true, Skills: true,
+		SystemPrompt: true, MCP: true, Workflows: true,
+	}
+	tests := []struct {
+		name     string
+		required capabilitymanifest.AgentFeatureClaims
+		provided capabilitymanifest.AgentFeatureClaims
+		want     bool
+	}{
+		{name: "empty requirement", provided: capabilitymanifest.AgentFeatureClaims{}, want: true},
+		{name: "all dimensions provided", required: all, provided: all, want: true},
+		{name: "output styles absent", required: capabilitymanifest.AgentFeatureClaims{OutputStyles: true}, want: false},
+		{name: "slash commands absent", required: capabilitymanifest.AgentFeatureClaims{SlashCommands: true}, want: false},
+		{name: "file subagents absent", required: capabilitymanifest.AgentFeatureClaims{FileSubAgents: true}, want: false},
+		{name: "skills absent", required: capabilitymanifest.AgentFeatureClaims{Skills: true}, want: false},
+		{name: "system prompt absent", required: capabilitymanifest.AgentFeatureClaims{SystemPrompt: true}, want: false},
+		{name: "MCP absent", required: capabilitymanifest.AgentFeatureClaims{MCP: true}, want: false},
+		{name: "workflows absent", required: capabilitymanifest.AgentFeatureClaims{Workflows: true}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requiredCapabilitiesCompatible(tt.required, tt.provided); got != tt.want {
+				t.Fatalf("requiredCapabilitiesCompatible() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileSubAgentsManifestClaims(t *testing.T) {
+	tests := []struct {
+		name    string
+		adapter agents.Adapter
+		want    bool
+	}{
+		{name: "Antigravity is incompatible", adapter: antigravity.NewAdapter(), want: false},
+		{name: "Kimi is compatible", adapter: kimi.NewAdapter(), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := agents.ResolveCapabilityManifest(tt.adapter)
+			if err != nil {
+				t.Fatalf("ResolveCapabilityManifest() error = %v", err)
+			}
+			if manifest.Features.FileSubAgents != tt.want {
+				t.Fatalf("FileSubAgents = %t, want %t", manifest.Features.FileSubAgents, tt.want)
+			}
+		})
+	}
+}

--- a/internal/components/skills/inject.go
+++ b/internal/components/skills/inject.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
@@ -29,6 +30,10 @@ type InjectionResult struct {
 // InjectWithCapability writes skill files like Inject, but for SDD skills
 // it extracts only the section matching the given capability.
 func InjectWithCapability(homeDir string, adapter agents.Adapter, skillIDs []model.SkillID, capability string) (InjectionResult, error) {
+	return injectWithCatalog(homeDir, adapter, skillIDs, capability, catalog.MVPSkills())
+}
+
+func injectWithCatalog(homeDir string, adapter agents.Adapter, skillIDs []model.SkillID, capability string, availableSkills []catalog.Skill) (InjectionResult, error) {
 	if !adapter.SupportsSkills() {
 		return InjectionResult{Skipped: skillIDs}, nil
 	}
@@ -37,7 +42,92 @@ func InjectWithCapability(homeDir string, adapter agents.Adapter, skillIDs []mod
 	if skillDir == "" {
 		return InjectionResult{Skipped: skillIDs}, nil
 	}
-	return InjectDirectoryWithCapability(skillDir, skillIDs, capability)
+
+	skillsByID, err := catalogSkillsByID(availableSkills)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	needsManifest := false
+	for _, id := range skillIDs {
+		if IsSDDSkill(id) && capability == "" {
+			continue
+		}
+		if skill, ok := skillsByID[id]; ok && skill.RequiredCapabilities != (agents.AgentFeatureClaims{}) {
+			needsManifest = true
+			break
+		}
+	}
+
+	var provided agents.AgentFeatureClaims
+	if needsManifest {
+		manifest, manifestErr := agents.ResolveCapabilityManifest(adapter)
+		if manifestErr != nil {
+			return InjectionResult{}, fmt.Errorf("resolve capabilities for agent %q: %w", adapter.Agent(), manifestErr)
+		}
+		provided = manifest.Features
+	}
+
+	candidates := make([]model.SkillID, 0, len(skillIDs))
+	skippedByCapability := make(map[model.SkillID]bool)
+	for _, id := range skillIDs {
+		if IsSDDSkill(id) && capability == "" {
+			continue
+		}
+		if skill, ok := skillsByID[id]; ok && !requiredCapabilitiesCompatible(skill.RequiredCapabilities, provided) {
+			skippedByCapability[id] = true
+			continue
+		}
+		candidates = append(candidates, id)
+	}
+
+	result, injectErr := InjectDirectoryWithCapability(skillDir, candidates, capability)
+	if injectErr != nil {
+		return InjectionResult{}, injectErr
+	}
+	if len(skippedByCapability) == 0 {
+		return result, nil
+	}
+
+	for _, id := range result.Skipped {
+		skippedByCapability[id] = true
+	}
+	result.Skipped = skippedSkills(skillIDs, skippedByCapability)
+	return result, nil
+}
+
+func catalogSkillsByID(availableSkills []catalog.Skill) (map[model.SkillID]catalog.Skill, error) {
+	skillsByID := make(map[model.SkillID]catalog.Skill, len(availableSkills))
+	for _, skill := range availableSkills {
+		if skill.ID == "" {
+			return nil, fmt.Errorf("skill catalog contains an empty skill ID")
+		}
+		if _, exists := skillsByID[skill.ID]; exists {
+			return nil, fmt.Errorf("skill catalog contains duplicate skill ID %q", skill.ID)
+		}
+		skillsByID[skill.ID] = skill
+	}
+	return skillsByID, nil
+}
+
+func requiredCapabilitiesCompatible(required, provided agents.AgentFeatureClaims) bool {
+	return (!required.OutputStyles || provided.OutputStyles) &&
+		(!required.SlashCommands || provided.SlashCommands) &&
+		(!required.FileSubAgents || provided.FileSubAgents) &&
+		(!required.Skills || provided.Skills) &&
+		(!required.SystemPrompt || provided.SystemPrompt) &&
+		(!required.MCP || provided.MCP) &&
+		(!required.Workflows || provided.Workflows)
+}
+
+func skippedSkills(skillIDs []model.SkillID, skippedByID map[model.SkillID]bool) []model.SkillID {
+	skipped := make([]model.SkillID, 0, len(skippedByID))
+	for _, id := range skillIDs {
+		if skippedByID[id] {
+			skipped = append(skipped, id)
+		}
+	}
+	return skipped
 }
 
 type directoryAsset struct {


### PR DESCRIPTION
## Summary

- Add optional catalog capability requirements and filter adapter-specific skill injection against each adapter's validated capability manifest.
- Keep unannotated skills and the shared `~/.agents/skills` refresh fail-open while reporting incompatible skills through `InjectionResult.Skipped`.
- Preflight catalog and manifest data before any write, with focused coverage for all seven capability dimensions.

## Changes

- Added `RequiredCapabilities` to `catalog.Skill` using the existing typed feature claims.
- Added capability subset filtering to adapter-specific injection without introducing delegation-model, auto-install, or SDD behavior.
- Added regression tests for compatible, incompatible, unannotated, malformed-manifest, duplicate-catalog, Antigravity, and Kimi cases.

## Verification

- `go run ./internal/gofmtcheck`
- `go test ./internal/catalog ./internal/components/skills -count=1`
- `go test ./internal/cli -run TestCompatibility -count=1`
- `go test ./... -count=1 -timeout=15m` was also attempted locally; unrelated environment/baseline-sensitive suites failed or timed out around Engram version skew, unavailable WSL, RDD-disabled fixtures, and parallel review tests. The focused affected suites are green.

## Test Plan

1. Run the formatting and focused test commands above.
2. Verify a synthetic skill requiring `FileSubAgents` installs for Kimi and is skipped for Antigravity.
3. Verify an unannotated skill still installs and shared skill refresh behavior remains unchanged.

## Related

- Replaces stale/conflicting PR #2152 with the approved narrow slice only.
- Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills are now filtered based on the capabilities supported by the selected agent.
  * Skills without capability requirements remain available for broad compatibility.
  * Skill injection now reports skipped skills consistently, including those excluded for compatibility reasons.
  * Added validation for catalog entries and capability information before making file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->