### PR TITLE
test(sdd): assert the status route actually resolves each sentinel state

### DIFF
--- a/internal/sddstatus/runtime_ledger_discoverability_test.go
+++ b/internal/sddstatus/runtime_ledger_discoverability_test.go
@@ -1,6 +1,7 @@
 package sddstatus
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -35,4 +36,104 @@ func TestRuntimeLedgerErrorsNameTheStatusRoute(t *testing.T) {
 			t.Errorf("sentinel %q does not name the sdd-attempt status route (want it to contain %q)", sentinel.Error(), pointer)
 		}
 	}
+}
+
+// TestStatusRouteActuallyResolvesEachSentinelState is the property guard that
+// TestRuntimeLedgerErrorsNameTheStatusRoute above cannot be (#2471).
+//
+// That test asserts a FORM: the message contains the pointer to
+// `sdd-attempt status`. The property that matters is different: pointing at
+// status is a real continuation only when status's own next_action is the move
+// that unblocks THIS caller. Three refusals passed the form guard while being
+// useless, because status answered `begin` for a caller whose failed evidence
+// proved the objective was wrong (#1974), and `complete` for a caller with more
+// work to do (#2769). The form was right and the advice was worthless.
+//
+// So this drives each sentinel's real state and asserts that next_action names
+// an operation that is genuinely admitted from it. It cannot be written as a
+// table over sentinel strings; every case has to build the state, which is
+// exactly why the cheap form guard was written instead and why both are kept:
+// the form guard catches a refusal that names nothing, this one catches a
+// refusal that names the wrong thing.
+func TestStatusRouteActuallyResolvesEachSentinelState(t *testing.T) {
+	t.Run("budget exhausted routes to a reset that is admitted", func(t *testing.T) {
+		store := mustRuntimeStore(t, initRuntimeLedgerRepo(t), "route-exhausted")
+		began, err := store.Begin(context.Background(), BeginAttemptRequest{
+			RequestID: "exhausted-1", WorkUnit: "apply", EvidenceGoal: "prove it",
+			MaxAttempts: 1, MaxChangedLines: 20,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		exhausted, err := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: began.Revision, RequestID: "exhausted-finish", Outcome: AttemptFailed,
+			EvidenceRevision: runtimeTestHash('1'), Diagnosis: "failed",
+			HarnessDisposition: HarnessReused, CleanupEvidence: "clean", ProcessEvidence: "none",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exhausted.NextAction != RuntimeActionReset {
+			t.Fatalf("next_action = %q, want reset", exhausted.NextAction)
+		}
+		if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+			ExpectedRevision: exhausted.Revision, RequestID: "exhausted-reset",
+			Reason: "budget spent", Actor: "maintainer",
+		}); err != nil {
+			t.Fatalf("status named reset, but reset is refused from this state: %v", err)
+		}
+	})
+
+	t.Run("active attempt routes to a settle that is admitted", func(t *testing.T) {
+		store := mustRuntimeStore(t, initRuntimeLedgerRepo(t), "route-active")
+		began, err := store.Begin(context.Background(), BeginAttemptRequest{
+			RequestID: "active-1", WorkUnit: "apply", EvidenceGoal: "prove it",
+			MaxAttempts: 2, MaxChangedLines: 20,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if began.NextAction != RuntimeActionFinish || began.ActiveAttempt == nil {
+			t.Fatalf("next_action = %q with active = %v, want finish", began.NextAction, began.ActiveAttempt)
+		}
+		if _, err := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: began.Revision, RequestID: "active-finish", Outcome: AttemptFailed,
+			EvidenceRevision: runtimeTestHash('2'), Diagnosis: "failed",
+			HarnessDisposition: HarnessReused, CleanupEvidence: "clean", ProcessEvidence: "none",
+		}); err != nil {
+			t.Fatalf("status named finish, but finish is refused from this state: %v", err)
+		}
+	})
+
+	t.Run("completed objective routes to an advance that is admitted", func(t *testing.T) {
+		store := mustRuntimeStore(t, initRuntimeLedgerRepo(t), "route-complete")
+		began, err := store.Begin(context.Background(), BeginAttemptRequest{
+			RequestID: "complete-1", WorkUnit: "apply", EvidenceGoal: "prove it",
+			MaxAttempts: 2, MaxChangedLines: 400,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		passed, err := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: began.Revision, RequestID: "complete-finish", Outcome: AttemptPassed,
+			EvidenceRevision: runtimeTestHash('3'), Diagnosis: "passed",
+			HarnessDisposition: HarnessReused, CleanupEvidence: "clean", ProcessEvidence: "none",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if passed.NextAction != RuntimeActionComplete {
+			t.Fatalf("next_action = %q, want complete", passed.NextAction)
+		}
+		// `complete` is honest for this caller and is NOT a dead end: the
+		// successor objective is admitted, which is what #2769's refusal now
+		// says out loud. This is the case the form guard could never express,
+		// because the sentinel text is identical either way.
+		if _, err := store.Begin(context.Background(), BeginAttemptRequest{
+			ExpectedRevision: passed.Revision, RequestID: "complete-advance", WorkUnit: "verify",
+			EvidenceGoal: "prove it", MaxAttempts: 2, MaxChangedLines: 400,
+		}); err != nil {
+			t.Fatalf("a completed objective must still admit a distinct-work-unit successor: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Closes #2785 (#2471 verification holes)

## Summary

- The existing `TestRuntimeLedgerErrorsNameTheStatusRoute` asserts each sentinel **contains** the pointer to `sdd-attempt status`. That is a form. The property that matters is whether status's `next_action` is the move that unblocks that caller, and three refusals passed the form guard this week while being worthless: #1974 and both halves of #2769, where status answered `begin` or `complete` to callers those moves could not help.
- Adds a property guard that builds each sentinel's real state and **runs** the operation `next_action` names.

Both are kept deliberately. The form guard catches a refusal that names nothing and costs one string comparison; the property guard catches a refusal that names the wrong thing and costs a fixture per state. They find different defects, so replacing one with the other would lose coverage.

## Why this could not have been the form guard

The sentinel text is byte-identical whether the advice works or not. `ErrRuntimeObjectiveDone` reads the same when a successor objective is admitted and when it is not. Only driving the state can tell them apart.

## Test Plan

- [x] Three states covered: budget exhausted routes to an admitted `reset`; an active attempt routes to an admitted `finish`; a completed objective routes to an admitted distinct-work-unit advance.
- [x] **Decoy proving the gap**: making the completed-objective successor inadmissible fails this test while `TestRuntimeLedgerErrorsNameTheStatusRoute` stays green. That is precisely the hole, demonstrated rather than argued.
- [x] `go test ./... -count=1` green at 66 packages, `go vet`, `gofmt`, deadcode ratchet clean.

## Note on the other hole

`#2471` also names `bench/classify.go` accepting an `execute` with no `command`. That one is already closed on main: `walkContinuation` judges an `execute` transition whole through `executeIsRunnable` and deliberately refuses to rescue it from a nested continuation key. No work needed there.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for runtime workflow statuses.
  * Verified that exhausted, active, and completed states report the correct next action.
  * Confirmed that valid follow-up operations—resetting, finishing, or starting the next step—are correctly accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->