### PR TITLE
fix(review): surface unsafe RAR mode paths

### DIFF
--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -710,6 +710,9 @@ func runReviewValidate(ctx context.Context, args []string, stdout io.Writer) err
 	if strings.TrimSpace(*cwd) == "" || strings.TrimSpace(*receiptPath) == "" {
 		return errors.New("review-validate requires --cwd and --receipt")
 	}
+	if _, err := reviewDrivenDevelopmentDisabled(ctx, *cwd); err != nil {
+		return fmt.Errorf("read review mode: %w", err)
+	}
 	receiptPayload, err := os.ReadFile(*receiptPath)
 	if err != nil {
 		return fmt.Errorf("read review receipt: %w", err)

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -3186,7 +3186,9 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 	// removed detail-visibility assertions moved to). Fencing this behind
 	// `!negotiated` used to mean the identical repository exited 0 for a
 	// human and 1 for any agent driving the negotiated contract (#2222).
-	if reviewDeliveryDisposition(ctx, root, false) == reviewtransaction.RDDDeliveryDisabledUnmanaged {
+	if delivery, err := reviewDeliveryDisposition(ctx, root, false); err != nil {
+		return err
+	} else if delivery == reviewtransaction.RDDDeliveryDisabledUnmanaged {
 		return emitDisabledUnmanagedDelivery(stdout, gateInput.Gate, negotiated, *contract)
 	}
 	// Amendment C's single shared branch (design decision 4, Wave 3 Slice

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -10,9 +10,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 )
@@ -169,6 +171,69 @@ func (err *ReviewModeUnreadableError) Error() string {
 	)
 }
 
+type reviewModeUnsafePathError struct {
+	Path      string
+	Directory bool
+	Cause     error
+}
+
+func (err *reviewModeUnsafePathError) Unwrap() error { return err.Cause }
+
+func (err *reviewModeUnsafePathError) Error() string {
+	if runtime.GOOS == "windows" {
+		return fmt.Sprintf(
+			"the clone-local review mode path %s is unsafe; run `%s` in a NON-ELEVATED Windows PowerShell 5.1 shell because an elevated TokenOwner can differ from the current user, then rerun the original command",
+			pathquote.Quote(err.Path), err.repairCommand(),
+		)
+	}
+	return fmt.Sprintf(
+		"the clone-local review mode path %s is unsafe; run `%s`, then rerun the original command",
+		pathquote.Quote(err.Path), err.repairCommand(),
+	)
+}
+
+func (err *reviewModeUnsafePathError) repairCommand() string {
+	if runtime.GOOS != "windows" {
+		mode := "600"
+		if err.Directory {
+			mode = "700"
+		}
+		return "chmod " + mode + " " + quotePOSIXShellToken(err.Path)
+	}
+	securityType := "FileSecurity"
+	inheritance := "'None'"
+	if err.Directory {
+		securityType = "DirectorySecurity"
+		inheritance = "'ContainerInherit, ObjectInherit'"
+	}
+	return strings.Join([]string{
+		"$p = " + quotePowerShellLiteral(err.Path),
+		"$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User",
+		"$acl = New-Object System.Security.AccessControl." + securityType,
+		"$acl.SetOwner($sid)",
+		"$acl.SetAccessRuleProtection($true, $false)",
+		"$rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @($sid, 'FullControl', " + inheritance + ", 'None', 'Allow')",
+		"$acl.SetAccessRule($rule)",
+		"Set-Acl -LiteralPath $p -AclObject $acl",
+	}, "; ")
+}
+
+func quotePowerShellLiteral(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", "''") + "'"
+}
+
+func quotePOSIXShellToken(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'"'"'`) + "'"
+}
+
+func reviewModeUnsafePathRefusal(err error) error {
+	var unsafePath *reviewtransaction.UnsafeRARPathError
+	if errors.As(err, &unsafePath) {
+		return &reviewModeUnsafePathError{Path: unsafePath.Path, Directory: unsafePath.Directory, Cause: err}
+	}
+	return nil
+}
+
 func reviewModeCommandsByVerb(commands []string, verb string) []string {
 	selected := make([]string, 0, len(commands))
 	for _, command := range commands {
@@ -194,6 +259,9 @@ func reviewModeUnreadable(
 ) error {
 	if err == nil {
 		return nil
+	}
+	if unsafePath := reviewModeUnsafePathRefusal(err); unsafePath != nil {
+		return unsafePath
 	}
 	scopes := make([]ReviewModeUnreadableScope, 0, 2)
 	if reviewtransaction.RDDModeValueUnintelligible(global.Value) {
@@ -224,15 +292,18 @@ func reviewModeUnreadable(
 // resolved this fails closed to the managed disposition, so a broken or
 // tampered mode file can never relax a gate into reporting work as unmanaged by
 // choice.
-func reviewDeliveryDisposition(ctx context.Context, repo string, receiptPresent bool) reviewtransaction.RDDDelivery {
+func reviewDeliveryDisposition(ctx context.Context, repo string, receiptPresent bool) (reviewtransaction.RDDDelivery, error) {
 	status, err := reviewModeStatus(ctx, repo)
+	if refusal := reviewModeUnsafePathRefusal(err); refusal != nil {
+		return reviewtransaction.RDDDeliveryUnmanaged, refusal
+	}
 	if err != nil {
 		if receiptPresent {
-			return reviewtransaction.RDDDeliveryReceiptGoverned
+			return reviewtransaction.RDDDeliveryReceiptGoverned, nil
 		}
-		return reviewtransaction.RDDDeliveryUnmanaged
+		return reviewtransaction.RDDDeliveryUnmanaged, nil
 	}
-	return reviewtransaction.RDDDeliveryDisposition(status, receiptPresent)
+	return reviewtransaction.RDDDeliveryDisposition(status, receiptPresent), nil
 }
 
 // reviewDrivenDevelopmentDisabled reports whether the user's kill switch is off
@@ -243,12 +314,12 @@ func reviewDeliveryDisposition(ctx context.Context, repo string, receiptPresent 
 // An unreadable switch is not a disabled switch. It fails closed to "enabled"
 // for the same reason reviewDeliveryDisposition does: a broken or tampered mode
 // record must never be able to relax an enforcement point.
-func reviewDrivenDevelopmentDisabled(ctx context.Context, repo string) bool {
+func reviewDrivenDevelopmentDisabled(ctx context.Context, repo string) (bool, error) {
 	status, err := reviewModeStatus(ctx, repo)
 	if err != nil {
-		return false
+		return false, reviewModeUnsafePathRefusal(err)
 	}
-	return !status.Enabled()
+	return !status.Enabled(), nil
 }
 
 func applyReviewMode(

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -85,6 +85,10 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 		return errors.New("sdd-attempt requires --change")
 	}
 
+	reviewDisabled, err := reviewDrivenDevelopmentDisabled(ctx, *cwd)
+	if err != nil {
+		return fmt.Errorf("read review mode: %w", err)
+	}
 	store, err := sddstatus.OpenRuntimeStore(ctx, *cwd, *change)
 	if err != nil {
 		return fmt.Errorf("open native SDD runtime authority: %w", err)
@@ -93,7 +97,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	// knows how to read both of its sources. With reviews off, closing an
 	// attempt must not demand a review obligation the operator has no way to
 	// satisfy.
-	store.ReviewDisabled = reviewDrivenDevelopmentDisabled(ctx, *cwd)
+	store.ReviewDisabled = reviewDisabled
 	if missing := missingSDDAttemptOperationFlags(args[1:], operation); len(missing) != 0 {
 		return missingSDDAttemptOperationError(operation, missing)
 	}

--- a/internal/cli/sdd_attempt_rar_mode_read_refusal_unix_test.go
+++ b/internal/cli/sdd_attempt_rar_mode_read_refusal_unix_test.go
@@ -1,0 +1,123 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
+)
+
+func TestRunSDDAttemptSettleRefusesUnsafeDisabledRARModeWithoutMutation(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const change = "unsafe-rar-mode"
+	disableReviewForClone(t, repo)
+	started, _ := runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "unsafe-mode-acquire", 2))
+	store, err := sddstatus.OpenRuntimeStore(context.Background(), repo, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1")
+	if err := os.Chmod(privateRARDir, 0o755); err != nil {
+		t.Fatalf("make private RAR directory unsafe: %v", err)
+	}
+	defer os.Chmod(privateRARDir, 0o700)
+	runtimeBefore := snapshotRuntimeAuthorityFiles(t, store.Dir)
+	rarBefore := snapshotRuntimeAuthorityFiles(t, privateRARDir)
+	settleArgs := compactSettleArgs(repo, change, started.Token, "unsafe-mode-settle", "passed")
+	var output bytes.Buffer
+	err = RunSDDAttempt(settleArgs, &output)
+	if err == nil {
+		t.Fatalf("unsafe disabled mode settle error = nil, output=%s", output.String())
+	}
+	wantRepair := (&reviewModeUnsafePathError{Path: privateRARDir, Directory: true}).repairCommand()
+	if !strings.Contains(err.Error(), wantRepair) || !strings.Contains(err.Error(), "rerun the original command") {
+		t.Fatalf("unsafe disabled mode refusal = %q, want actionable %q", err, wantRepair)
+	}
+	if strings.Contains(err.Error(), "invalid_continuation") || output.Len() != 0 {
+		t.Fatalf("unsafe disabled mode was misclassified: error=%q output=%q", err, output.String())
+	}
+	if runtimeAfter := snapshotRuntimeAuthorityFiles(t, store.Dir); !reflect.DeepEqual(runtimeBefore, runtimeAfter) {
+		t.Fatalf("unsafe disabled mode settle mutated runtime authority\nbefore=%v\nafter=%v", runtimeBefore, runtimeAfter)
+	}
+	if rarAfter := snapshotRuntimeAuthorityFiles(t, privateRARDir); !reflect.DeepEqual(rarBefore, rarAfter) {
+		t.Fatalf("unsafe disabled mode settle mutated RAR authority\nbefore=%v\nafter=%v", rarBefore, rarAfter)
+	}
+	if output, repairErr := exec.Command("sh", "-c", wantRepair).CombinedOutput(); repairErr != nil {
+		t.Fatalf("execute printed repair %q: %v\n%s", wantRepair, repairErr, output)
+	}
+	completed, _ := runCompactSDDAttempt(t, settleArgs)
+	if completed.State != "complete" {
+		t.Fatalf("replayed settle after repair = %#v, want complete", completed)
+	}
+}
+
+func TestUnsafeDisabledRARModeRefusesStatusAndValidationBeforeTheirReaders(t *testing.T) {
+	for _, command := range []struct {
+		name string
+		run  func([]string, io.Writer) error
+		args func(string) []string
+	}{
+		{name: "sdd-status", run: RunSDDStatus, args: func(repo string) []string { return []string{"--cwd", repo, "--json"} }},
+		{name: "review-validate", run: RunReviewValidate, args: func(repo string) []string {
+			return []string{"--cwd", repo, "--receipt", filepath.Join(repo, "missing.json")}
+		}},
+		{name: "review-facade gate", run: RunReviewFacadeValidate, args: func(repo string) []string { return []string{"--cwd", repo, "--gate", "post-apply"} }},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			reviewModeHome(t)
+			repo := initReviewCLIRepo(t)
+			disableReviewForClone(t, repo)
+			privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1")
+			if err := os.Chmod(privateRARDir, 0o755); err != nil {
+				t.Fatalf("make private RAR directory unsafe: %v", err)
+			}
+			defer os.Chmod(privateRARDir, 0o700)
+			before := snapshotRuntimeAuthorityFiles(t, privateRARDir)
+
+			var output bytes.Buffer
+			err := command.run(command.args(repo), &output)
+			wantRepair := (&reviewModeUnsafePathError{Path: privateRARDir, Directory: true}).repairCommand()
+			if err == nil || !strings.Contains(err.Error(), wantRepair) || output.Len() != 0 {
+				t.Fatalf("unsafe mode %s result: error=%v output=%q, want actionable refusal", command.name, err, output.String())
+			}
+			if after := snapshotRuntimeAuthorityFiles(t, privateRARDir); !reflect.DeepEqual(before, after) {
+				t.Fatalf("unsafe mode %s mutated RAR authority\nbefore=%v\nafter=%v", command.name, before, after)
+			}
+		})
+	}
+}
+
+func TestReviewModeUnsafeFileRefusalRendersRunnableChmod600(t *testing.T) {
+	root := t.TempDir()
+	decoy := filepath.Join(root, "decoy")
+	target := filepath.Join(root, "unsafe $(chmod 000 decoy) `chmod 000 decoy` $HOME 'quote'")
+	for _, path := range []string{target, decoy} {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	command := (&reviewModeUnsafePathError{Path: target}).repairCommand()
+	for _, args := range [][]string{{"-n", "-c", command}, {"-c", command}} {
+		shell := exec.Command("sh", args...)
+		shell.Dir = root
+		if output, err := shell.CombinedOutput(); err != nil {
+			t.Fatalf("run printed repair %q: %v\n%s", command, err, output)
+		}
+	}
+	for path, want := range map[string]os.FileMode{target: 0o600, decoy: 0o644} {
+		info, err := os.Stat(path)
+		if err != nil || info.Mode().Perm() != want {
+			t.Fatalf("mode after printed repair for %q = %v, %v; want %04o", path, info.Mode(), err, want)
+		}
+	}
+}

--- a/internal/cli/sdd_attempt_rar_mode_read_refusal_windows_test.go
+++ b/internal/cli/sdd_attempt_rar_mode_read_refusal_windows_test.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
+)
+
+func TestRunSDDAttemptSettleRepairsUnsafeDisabledRARModeWithoutRecursing(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const change = "unsafe-rar-mode"
+	disableReviewForClone(t, repo)
+
+	started, _ := runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "unsafe-mode-acquire", 2))
+	store, err := sddstatus.OpenRuntimeStore(context.Background(), repo, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1")
+	child := filepath.Join(privateRARDir, "must-not-change.txt")
+	if err := os.WriteFile(child, []byte("private child\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	childBefore := windowsACLSDDL(t, child)
+	windowsRunPowerShell(t, "$acl = Get-Acl -LiteralPath "+quotePowerShellLiteral(privateRARDir)+"; $acl.SetAccessRuleProtection($false, $true); Set-Acl -LiteralPath "+quotePowerShellLiteral(privateRARDir)+" -AclObject $acl")
+
+	runtimeBefore := snapshotRuntimeAuthorityFiles(t, store.Dir)
+	rarBefore := snapshotRuntimeAuthorityFiles(t, privateRARDir)
+	settleArgs := compactSettleArgs(repo, change, started.Token, "unsafe-mode-settle", "passed")
+	var output bytes.Buffer
+	err = RunSDDAttempt(settleArgs, &output)
+	var refusal *reviewModeUnsafePathError
+	if !errors.As(err, &refusal) || refusal.Path != privateRARDir || !refusal.Directory {
+		t.Fatalf("unsafe disabled mode refusal = %v", err)
+	}
+	if !strings.Contains(err.Error(), "NON-ELEVATED") || !strings.Contains(err.Error(), "TokenOwner") {
+		t.Fatalf("unsafe disabled mode did not warn about elevation: %q", err)
+	}
+	if strings.Contains(err.Error(), "invalid_continuation") || output.Len() != 0 {
+		t.Fatalf("unsafe disabled mode was misclassified: error=%q output=%q", err, output.String())
+	}
+	if runtimeAfter := snapshotRuntimeAuthorityFiles(t, store.Dir); !reflect.DeepEqual(runtimeBefore, runtimeAfter) {
+		t.Fatalf("unsafe disabled mode settle mutated runtime authority\nbefore=%v\nafter=%v", runtimeBefore, runtimeAfter)
+	}
+	if rarAfter := snapshotRuntimeAuthorityFiles(t, privateRARDir); !reflect.DeepEqual(rarBefore, rarAfter) {
+		t.Fatalf("unsafe disabled mode settle mutated RAR authority\nbefore=%v\nafter=%v", rarBefore, rarAfter)
+	}
+
+	windowsRunPowerShell(t, refusal.repairCommand())
+	status, err := reviewtransaction.ResolveRDDMode(context.Background(), repo, reviewtransaction.RDDGlobalMode{})
+	if err != nil || status.Enabled() {
+		t.Fatalf("printed repair did not restore the real RAR predicate: status=%#v error=%v", status, err)
+	}
+	if childAfter := windowsACLSDDL(t, child); childAfter != childBefore {
+		t.Fatalf("printed repair recursively changed child ACL\nbefore=%q\nafter=%q", childBefore, childAfter)
+	}
+	completed, _ := runCompactSDDAttempt(t, settleArgs)
+	if completed.State != "complete" {
+		t.Fatalf("replayed settle after repair = %#v, want complete", completed)
+	}
+}
+
+func windowsRunPowerShell(t *testing.T, script string) {
+	t.Helper()
+	output, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("PowerShell script failed: %v\n%s", err, output)
+	}
+}
+
+func windowsACLSDDL(t *testing.T, path string) string {
+	t.Helper()
+	output, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", "(Get-Acl -LiteralPath "+quotePowerShellLiteral(path)+").Sddl").CombinedOutput()
+	if err != nil {
+		t.Fatalf("read ACL for %q: %v\n%s", path, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/internal/cli/sdd_status.go
+++ b/internal/cli/sdd_status.go
@@ -9,16 +9,16 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
 )
 
-func sddReviewDisabledForWorkspace(workspaceRoot string) bool {
+func sddReviewDisabledForWorkspace(workspaceRoot string) (bool, error) {
 	return reviewDrivenDevelopmentDisabled(context.Background(), workspaceRoot)
 }
 
 // RunSDDStatus is the CLI entry point for `gentle-ai sdd-status [change]`.
 //
 // The kill switch reaches SDD status here, at the one layer that owns the
-// single source of truth for both of its sources. An unreadable switch is not a
-// disabled switch: reviewDrivenDevelopmentDisabled fails closed to "enabled",
-// so a broken or tampered mode record can never relax the archive gate.
+// single source of truth for both of its sources. An unreadable switch fails
+// closed to "enabled", while an unsafe RAR path remains an actionable refusal
+// instead of being projected to a misleading gate result.
 func RunSDDStatus(args []string, stdout io.Writer) error {
 	parsed, err := sddstatus.ParseCommandArgs(args)
 	if err != nil {

--- a/internal/cli/sdd_status_review_disabled_test.go
+++ b/internal/cli/sdd_status_review_disabled_test.go
@@ -154,8 +154,8 @@ func TestSDDStatusArchiveGateBlocksWhileReviewIsEnabled(t *testing.T) {
 	root := t.TempDir()
 	seedScopeChangedApprovedSDDChange(t, root)
 
-	if reviewDrivenDevelopmentDisabled(context.Background(), root) {
-		t.Fatal("fixture is wrong: receipt-driven development is not enabled")
+	if disabled, err := reviewDrivenDevelopmentDisabled(context.Background(), root); err != nil || disabled {
+		t.Fatalf("fixture must enable receipt-driven development: disabled=%t err=%v", disabled, err)
 	}
 	status := resolveSDDStatusJSON(t, root)
 	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateScopeChanged {
@@ -237,8 +237,8 @@ func TestSDDStatusArchiveGateEnforcesWhenTheSwitchIsUnreadable(t *testing.T) {
 	disableReviewForClone(t, root)
 	corruptCloneLocalReviewMode(t, root)
 
-	if reviewDrivenDevelopmentDisabled(context.Background(), root) {
-		t.Fatal("an unreadable switch resolved to disabled; it must fail closed to enabled")
+	if disabled, err := reviewDrivenDevelopmentDisabled(context.Background(), root); err != nil || disabled {
+		t.Fatalf("unreadable switch must fail closed to enabled: disabled=%t err=%v", disabled, err)
 	}
 	t.Chdir(root)
 	for _, args := range [][]string{

--- a/internal/reviewtransaction/rar_path_safety.go
+++ b/internal/reviewtransaction/rar_path_safety.go
@@ -24,6 +24,27 @@ var (
 	errRARAuthorityPathReplaced = errors.New("RAR authority path changed during access")
 )
 
+// UnsafeRARPathError preserves the unsafe private RAR path for recovery.
+type UnsafeRARPathError struct {
+	Path      string
+	Directory bool
+	Cause     error
+}
+
+func (err *UnsafeRARPathError) Error() string {
+	kind := "file"
+	if err.Directory {
+		kind = "directory"
+	}
+	return fmt.Sprintf("unsafe private RAR %s %q: %v", kind, err.Path, err.Cause)
+}
+
+func (err *UnsafeRARPathError) Unwrap() error { return err.Cause }
+
+func unsafeRARPathError(path string, directory bool) error {
+	return &UnsafeRARPathError{Path: path, Directory: directory, Cause: errUnsafeRARAuthorityPath}
+}
+
 func ensureRARRepositoryRoot(commonDir, root string, create bool) error {
 	commonDir = filepath.Clean(commonDir)
 	root = filepath.Clean(root)
@@ -136,7 +157,7 @@ func ensurePrivateRARDirectoryTree(base, dir string, create bool) error {
 			return statErr
 		}
 		if rarPathUnsafe(current, info) || !info.IsDir() {
-			return errUnsafeRARAuthorityPath
+			return unsafeRARPathError(current, true)
 		}
 		if err := validatePrivateRARDirectory(current); err != nil {
 			return fmt.Errorf("validate nested private RAR directory %q: %w", current, err)
@@ -197,7 +218,7 @@ func validatePrivateRARPath(path string, directory bool) error {
 	}
 	if rarPathUnsafe(path, before) || before.IsDir() != directory ||
 		!privateRARPathSafe(path, before) {
-		return errUnsafeRARAuthorityPath
+		return unsafeRARPathError(path, directory)
 	}
 	file, err := openRARPathNoFollow(path, directory)
 	if err != nil {
@@ -226,7 +247,7 @@ func readPrivateRARFile(path string) ([]byte, error) {
 	}
 	if rarPathUnsafe(path, before) || !before.Mode().IsRegular() ||
 		!privateRARPathSafe(path, before) {
-		return nil, errUnsafeRARAuthorityPath
+		return nil, unsafeRARPathError(path, false)
 	}
 	file, err := openRARPathNoFollow(path, false)
 	if err != nil {

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -619,6 +619,10 @@ func readCloneLocalRDDOverrideHead(dir string) (rddModeOverrideRecord, bool, err
 	}
 	payload, err := readPrivateRARFile(filepath.Join(dir, rddModeGenerationName(head)))
 	if err != nil {
+		var unsafePath *UnsafeRARPathError
+		if errors.As(err, &unsafePath) {
+			return rddModeOverrideRecord{}, false, err
+		}
 		return rddModeOverrideRecord{}, false, fmt.Errorf("%w: read generation %d: %v", ErrRDDModeCorrupt, head, err)
 	}
 	record, err := parseRDDModeOverride(payload)

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -382,6 +383,36 @@ func TestUnknownRDDModeFailsClosedAsDisabled(t *testing.T) {
 	}
 	if status.Effective != RDDModeOff || status.Enabled() {
 		t.Fatalf("corrupt override did not fail closed: %#v", status)
+	}
+}
+
+func TestResolveRDDModeUnsafePrivatePathIsNotACorruptHead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions are covered by the Windows ACL test")
+	}
+	repo := initSnapshotRepo(t)
+	if _, err := SetCloneLocalRDDMode(context.Background(), repo, RDDModeOff, "", RDDGlobalMode{}); err != nil {
+		t.Fatalf("disable clone-local mode: %v", err)
+	}
+	modeRecord := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	if err := os.Chmod(modeRecord, 0o644); err != nil {
+		t.Fatalf("make private RAR file unsafe: %v", err)
+	}
+	defer os.Chmod(modeRecord, 0o600)
+
+	status, err := ResolveRDDMode(context.Background(), repo, RDDGlobalMode{})
+	if err == nil {
+		t.Fatal("unsafe private RAR path resolved without an error")
+	}
+	if errors.Is(err, ErrRDDModeCorrupt) {
+		t.Fatalf("unsafe private RAR path entered corrupt-head recovery: %v", err)
+	}
+	var unsafePath *UnsafeRARPathError
+	if !errors.As(err, &unsafePath) || unsafePath.Path != modeRecord || unsafePath.Directory {
+		t.Fatalf("unsafe private RAR path lost its typed cause: %#v", err)
+	}
+	if status.Enabled() {
+		t.Fatalf("unsafe private RAR path did not fail closed: %#v", status)
 	}
 }
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -314,7 +314,7 @@ type ResolveOptions struct {
 	// ReviewDisabledForWorkspace lets the composition root resolve the switch
 	// against the exact workspace normalized by Resolve. When set, it is called
 	// once and its result replaces ReviewDisabled for the whole status decision.
-	ReviewDisabledForWorkspace func(workspaceRoot string) bool
+	ReviewDisabledForWorkspace func(workspaceRoot string) (bool, error)
 }
 
 type CommandArgs struct {
@@ -412,7 +412,10 @@ func Resolve(options ResolveOptions) (Status, error) {
 	}
 	reviewDisabled := options.ReviewDisabled
 	if options.ReviewDisabledForWorkspace != nil {
-		reviewDisabled = options.ReviewDisabledForWorkspace(workspaceRoot)
+		reviewDisabled, err = options.ReviewDisabledForWorkspace(workspaceRoot)
+		if err != nil {
+			return Status{}, err
+		}
 	}
 	planningHome := filepath.Join(workspaceRoot, "openspec")
 	changesDir := filepath.Join(planningHome, "changes")

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -17,12 +17,12 @@ func TestResolveSharesOneNormalizedWorkspaceWithReviewMode(t *testing.T) {
 
 	modeLookups := 0
 	status, err := Resolve(ResolveOptions{
-		ReviewDisabledForWorkspace: func(workspaceRoot string) bool {
+		ReviewDisabledForWorkspace: func(workspaceRoot string) (bool, error) {
 			modeLookups++
 			if workspaceRoot != root {
 				t.Fatalf("review mode workspace = %q, want %q", workspaceRoot, root)
 			}
-			return true
+			return true, nil
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2746

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Preserves the unsafe RAR path as a typed error and surfaces one actionable refusal through mode reads, SDD settlement/status, review validation, and the facade gate rather than fabricating a later gate result.
- The CLI never automatically runs `chmod` or `Set-Acl`; it only prints the operator repair needed before rerunning the original command.
- POSIX repairs use runnable apostrophe-safe single-token shell quoting. Windows prints a non-elevated PowerShell 5.1 `Set-Acl` recipe because elevated token ownership can differ from the current user.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/rar_path_safety.go`, `rdd_mode.go` | Retain the unsafe private RAR path/type and prevent it from being misclassified as corrupt-head recovery. |
| `internal/cli/review_mode.go` and CLI callers | Render actionable external repairs and propagate unsafe mode reads before status, validation, settlement, or delivery discovery can create a misleading result. |
| `internal/cli/*rar_mode_read_refusal*_test.go` | Cover no-mutation refusal, POSIX emitted-command replay, facade/status/validation propagation, and the Windows ACL repair behavior. |

---

## 🧪 Test Plan

- [x] Focused Linux tests passed for the changed CLI and review-transaction paths, including emitted POSIX `chmod` replay against shell metacharacters and no-mutation assertions.
- [x] Windows CLI test cross-compilation passed.
- [x] Diff checks passed.
- [ ] Full `go test ./...` was not rerun for this frozen candidate.
- [ ] E2E tests were not rerun for this frozen candidate.
- [ ] Benchmark validation was not rerun; no benchmark corpus or classifier behavior changed.

The Windows runtime `Set-Acl` regression only executes in Windows CI. It cannot run on the Linux development host; it validates the printed non-recursive ACL repair against the real RAR predicate and proves that a child ACL is unchanged.

Candidate size is exactly 400 gross changed lines (376 additions and 24 deletions). No `size:exception` is requested.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines; no size exception is needed
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Full unit suite run (`go test ./...`)
- [ ] Go format command rerun (`go run ./internal/gofmtcheck`)
- [ ] E2E tests rerun (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation is not applicable to this candidate; it does not change benchmark corpus or classifier behavior
- [x] Documentation changes are not necessary; the remediation is emitted directly in the refusal
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The existing RAR security predicate is unchanged. This slice preserves and propagates its typed unsafe-path result so the operator receives an external repair command; it introduces no automatic permission or ACL mutation. No guard-population baseline change is needed.

- [x] Identified the qualifying RAR integrity guard and challenged the emitted remediation against real POSIX and Windows predicate tests.
- [x] Confirmed no guard-population direction changed; `.guard-population-baseline.txt` is unchanged.
- [x] Did not treat declaration checks as proof: the tests exercise no-mutation behavior and replay the printed repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable review-mode settings, failing safely instead of continuing with uncertain state.
  * Added clear, platform-specific repair guidance for unsafe file and directory permissions.
  * Prevented status, validation, and settlement operations from proceeding when protected review data cannot be safely read.
  * Preserved fail-closed behavior for other unreadable settings while allowing operations to resume after permissions are repaired.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->