### PR TITLE
fix(agentbuilder): restore skills on install rollback

### DIFF
--- a/internal/agentbuilder/installer.go
+++ b/internal/agentbuilder/installer.go
@@ -1,10 +1,12 @@
 package agentbuilder
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/mutationjournal"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
@@ -14,48 +16,54 @@ type AdapterInfo struct {
 	SkillsDir string
 }
 
+type installJournal interface {
+	Capture(string) error
+	WriteWithMode(string, []byte, os.FileMode) (mutationjournal.OwnedFile, error)
+	Restore() error
+}
+
+type installOperations struct {
+	mkdirAll   func(string, os.FileMode) error
+	newJournal func(...string) installJournal
+}
+
 // Install writes the SKILL.md for agent into each adapter's skills directory.
-// On any write failure all previously written files are rolled back (deleted).
-// Returns one InstallResult per adapter.
+// On failure, every changed SKILL.md is restored to its before-image.
 func Install(agent *GeneratedAgent, adapters []AdapterInfo, _ string) ([]InstallResult, error) {
+	return install(agent, adapters, installOperations{
+		mkdirAll:   os.MkdirAll,
+		newJournal: newInstallJournal,
+	})
+}
+
+func install(agent *GeneratedAgent, adapters []AdapterInfo, ops installOperations) ([]InstallResult, error) {
 	if agent == nil {
 		return nil, fmt.Errorf("install: agent must not be nil")
 	}
 
 	results := make([]InstallResult, 0, len(adapters))
-	written := make([]string, 0, len(adapters)) // paths written so far, for rollback
+	roots := make([]string, 0, len(adapters))
+	for _, adapter := range adapters {
+		roots = append(roots, adapter.SkillsDir)
+	}
+	journal := ops.newJournal(roots...)
 
 	for _, adapter := range adapters {
 		skillDir := filepath.Join(adapter.SkillsDir, agent.Name)
 		skillFile := filepath.Join(skillDir, "SKILL.md")
 
-		if err := os.MkdirAll(skillDir, 0755); err != nil {
-			// Rollback previously written files and mark all results as failed.
-			rollback(written)
-			markAllFailed(results)
-			results = append(results, InstallResult{
-				AgentID: adapter.AgentID,
-				Path:    skillFile,
-				Success: false,
-				Err:     fmt.Errorf("create directory %s: %w", skillDir, err),
-			})
-			return results, fmt.Errorf("install failed for %s: %w", adapter.AgentID, err)
+		if err := journal.Capture(skillFile); err != nil {
+			return rollback(journal, results, adapter, skillFile, fmt.Errorf("capture before-image %s: %w", skillFile, err))
 		}
 
-		if err := os.WriteFile(skillFile, []byte(agent.Content), 0644); err != nil {
-			// Rollback previously written files and mark all results as failed.
-			rollback(written)
-			markAllFailed(results)
-			results = append(results, InstallResult{
-				AgentID: adapter.AgentID,
-				Path:    skillFile,
-				Success: false,
-				Err:     fmt.Errorf("write %s: %w", skillFile, err),
-			})
-			return results, fmt.Errorf("install failed for %s: %w", adapter.AgentID, err)
+		if err := ops.mkdirAll(skillDir, 0755); err != nil {
+			return rollback(journal, results, adapter, skillFile, fmt.Errorf("create directory %s: %w", skillDir, err))
 		}
 
-		written = append(written, skillFile)
+		if _, err := journal.WriteWithMode(skillFile, []byte(agent.Content), 0644); err != nil {
+			return rollback(journal, results, adapter, skillFile, fmt.Errorf("write %s: %w", skillFile, err))
+		}
+
 		results = append(results, InstallResult{
 			AgentID: adapter.AgentID,
 			Path:    skillFile,
@@ -66,11 +74,20 @@ func Install(agent *GeneratedAgent, adapters []AdapterInfo, _ string) ([]Install
 	return results, nil
 }
 
-// rollback removes all files in paths, ignoring errors (best-effort cleanup).
-func rollback(paths []string) {
-	for _, p := range paths {
-		_ = os.Remove(p)
-	}
+func newInstallJournal(roots ...string) installJournal {
+	return mutationjournal.New(roots...)
+}
+
+func rollback(journal installJournal, results []InstallResult, adapter AdapterInfo, skillFile string, cause error) ([]InstallResult, error) {
+	restoreErr := journal.Restore()
+	markAllFailed(results)
+	results = append(results, InstallResult{
+		AgentID: adapter.AgentID,
+		Path:    skillFile,
+		Success: false,
+		Err:     cause,
+	})
+	return results, errors.Join(cause, restoreErr)
 }
 
 // markAllFailed sets Success=false on every result in the slice.

--- a/internal/agentbuilder/installer_test.go
+++ b/internal/agentbuilder/installer_test.go
@@ -1,10 +1,12 @@
 package agentbuilder
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/mutationjournal"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
@@ -15,6 +17,28 @@ func makeAgent(name, content string) *GeneratedAgent {
 		Title:   "Test Agent",
 		Content: content,
 	}
+}
+
+type writeFailureJournal struct {
+	installJournal
+	err error
+}
+
+func (j writeFailureJournal) WriteWithMode(path string, data []byte, mode os.FileMode) (mutationjournal.OwnedFile, error) {
+	owned, err := j.installJournal.WriteWithMode(path, data, mode)
+	if err != nil {
+		return owned, err
+	}
+	return owned, j.err
+}
+
+type restoreFailureJournal struct {
+	installJournal
+	err error
+}
+
+func (j restoreFailureJournal) Restore() error {
+	return j.err
 }
 
 func TestInstall_HappyPath_WritesFilesToBothDirs(t *testing.T) {
@@ -63,6 +87,13 @@ func TestInstall_FileContentMatchesAgentContent(t *testing.T) {
 	if string(data) != content {
 		t.Errorf("file content = %q, want %q", string(data), content)
 	}
+	info, err := os.Stat(skillFile)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0644); got != want {
+		t.Errorf("file mode = %04o, want %04o", got, want)
+	}
 
 	if results[0].Path != skillFile {
 		t.Errorf("Path = %q, want %q", results[0].Path, skillFile)
@@ -93,21 +124,22 @@ func TestInstall_MissingDirectory_CreatedAutomatically(t *testing.T) {
 	}
 }
 
-func TestInstall_RollbackOnSecondWriteFailure(t *testing.T) {
-	// dir1: writable — first write succeeds
+func TestInstall_RollbackOnMkdirFailure_RestoresExistingFile(t *testing.T) {
 	dir1 := t.TempDir()
+	firstFile := filepath.Join(dir1, "my-agent", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(firstFile), 0755); err != nil {
+		t.Fatalf("setup first skill directory: %v", err)
+	}
+	before := []byte("# Existing Agent\n\x00preserve these bytes\n")
+	if err := os.WriteFile(firstFile, before, 0640); err != nil {
+		t.Fatalf("setup first skill: %v", err)
+	}
+	if err := os.Chmod(firstFile, 0640); err != nil {
+		t.Fatalf("chmod first skill: %v", err)
+	}
 
-	// dir2: make it read-only so the mkdir inside it fails
 	dir2 := t.TempDir()
-	// Create a file with the same name as the agent skill dir so MkdirAll fails
-	blocker := filepath.Join(dir2, "my-agent")
-	if err := os.WriteFile(blocker, []byte("block"), 0444); err != nil {
-		t.Fatalf("setup blocker: %v", err)
-	}
-	// Make blocker read-only to prevent overwrite
-	if err := os.Chmod(blocker, 0444); err != nil {
-		t.Fatalf("chmod blocker: %v", err)
-	}
+	mkdirErr := errors.New("mkdir failed")
 
 	agent := makeAgent("my-agent", "# Agent\n")
 	adapters := []AdapterInfo{
@@ -115,15 +147,115 @@ func TestInstall_RollbackOnSecondWriteFailure(t *testing.T) {
 		{AgentID: model.AgentOpenCode, SkillsDir: dir2},
 	}
 
-	_, err := Install(agent, adapters, "")
+	results, err := install(agent, adapters, installOperations{
+		mkdirAll: func(path string, mode os.FileMode) error {
+			if path == filepath.Join(dir2, agent.Name) {
+				return mkdirErr
+			}
+			return os.MkdirAll(path, mode)
+		},
+		newJournal: newInstallJournal,
+	})
 	if err == nil {
-		t.Fatal("expected error when second write fails")
+		t.Fatal("expected error when second directory creation fails")
+	}
+	if !errors.Is(err, mkdirErr) {
+		t.Errorf("error = %v, want wrapped %v", err, mkdirErr)
 	}
 
-	// Verify rollback: the first file should be removed.
-	firstFile := filepath.Join(dir1, "my-agent", "SKILL.md")
-	if _, statErr := os.Stat(firstFile); statErr == nil {
-		t.Errorf("expected first file to be rolled back, but it still exists: %s", firstFile)
+	got, readErr := os.ReadFile(firstFile)
+	if readErr != nil {
+		t.Fatalf("read restored first skill: %v", readErr)
+	}
+	if string(got) != string(before) {
+		t.Errorf("restored first skill = %q, want %q", got, before)
+	}
+	info, statErr := os.Stat(firstFile)
+	if statErr != nil {
+		t.Fatalf("stat restored first skill: %v", statErr)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0640); got != want {
+		t.Errorf("restored first skill mode = %04o, want %04o", got, want)
+	}
+	for _, result := range results {
+		if result.Success {
+			t.Errorf("result for %s remained successful after rollback", result.AgentID)
+		}
+	}
+}
+
+func TestInstall_RestoresWriteThatLandedBeforeFailure(t *testing.T) {
+	dir := t.TempDir()
+	skillFile := filepath.Join(dir, "my-agent", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillFile), 0755); err != nil {
+		t.Fatalf("setup skill directory: %v", err)
+	}
+	before := []byte("# Existing Agent\n\x00preserve this too\n")
+	if err := os.WriteFile(skillFile, before, 0600); err != nil {
+		t.Fatalf("setup skill: %v", err)
+	}
+	if err := os.Chmod(skillFile, 0600); err != nil {
+		t.Fatalf("chmod skill: %v", err)
+	}
+	writeErr := errors.New("write failed after publication")
+
+	results, err := install(makeAgent("my-agent", "# Replacement\n"), []AdapterInfo{{
+		AgentID:   model.AgentClaudeCode,
+		SkillsDir: dir,
+	}}, installOperations{
+		mkdirAll: os.MkdirAll,
+		newJournal: func(roots ...string) installJournal {
+			return writeFailureJournal{installJournal: newInstallJournal(roots...), err: writeErr}
+		},
+	})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, writeErr)
+	}
+	if len(results) != 1 || results[0].Success {
+		t.Fatalf("results = %#v, want one failed result", results)
+	}
+
+	got, readErr := os.ReadFile(skillFile)
+	if readErr != nil {
+		t.Fatalf("read restored skill: %v", readErr)
+	}
+	if string(got) != string(before) {
+		t.Errorf("restored skill = %q, want %q", got, before)
+	}
+	info, statErr := os.Stat(skillFile)
+	if statErr != nil {
+		t.Fatalf("stat restored skill: %v", statErr)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0600); got != want {
+		t.Errorf("restored skill mode = %04o, want %04o", got, want)
+	}
+}
+
+func TestInstall_JoinsRestoreFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeErr := errors.New("write failed after publication")
+	restoreErr := errors.New("restore failed")
+
+	results, err := install(makeAgent("my-agent", "# Replacement\n"), []AdapterInfo{{
+		AgentID:   model.AgentClaudeCode,
+		SkillsDir: dir,
+	}}, installOperations{
+		mkdirAll: os.MkdirAll,
+		newJournal: func(roots ...string) installJournal {
+			return restoreFailureJournal{
+				installJournal: writeFailureJournal{installJournal: newInstallJournal(roots...), err: writeErr},
+				err:            restoreErr,
+			}
+		},
+	})
+	if !errors.Is(err, writeErr) {
+		t.Errorf("error = %v, want wrapped %v", err, writeErr)
+	}
+	if !errors.Is(err, restoreErr) {
+		t.Errorf("error = %v, want joined %v", err, restoreErr)
+	}
+	if len(results) != 1 || results[0].Success {
+		t.Errorf("results = %#v, want one failed result", results)
 	}
 }
 

--- a/internal/tui/agent_builder_postinstall_test.go
+++ b/internal/tui/agent_builder_postinstall_test.go
@@ -1,0 +1,173 @@
+package tui
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agentbuilder"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+func TestFinishAgentBuilderInstall_RegistryFailuresSkipSDD(t *testing.T) {
+	registryErr := errors.New("registry unavailable")
+	for _, tt := range []struct {
+		name string
+		fail func(*agentBuilderPostInstallOps)
+	}{
+		{
+			name: "create registry directory",
+			fail: func(ops *agentBuilderPostInstallOps) {
+				ops.mkdirAll = func(string, os.FileMode) error { return registryErr }
+			},
+		},
+		{
+			name: "load registry",
+			fail: func(ops *agentBuilderPostInstallOps) {
+				ops.loadRegistry = func(string) (*agentbuilder.Registry, error) { return nil, registryErr }
+			},
+		},
+		{
+			name: "save registry",
+			fail: func(ops *agentBuilderPostInstallOps) {
+				ops.saveRegistry = func(string, *agentbuilder.Registry) error { return registryErr }
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			injections := 0
+			ops := successfulAgentBuilderPostInstallOps(&injections)
+			tt.fail(&ops)
+
+			err := finishAgentBuilderInstall(sddAgent(), testAgentBuilderAdapters(), successfulInstallResults(), model.AgentClaudeCode, "/registry/custom-agents.json", ops)
+			if !errors.Is(err, registryErr) {
+				t.Fatalf("error = %v, want wrapped %v", err, registryErr)
+			}
+			if injections != 0 {
+				t.Fatalf("SDD injections = %d, want 0 after registry failure", injections)
+			}
+			assertAgentBuilderInstallErrorScreen(t, err)
+		})
+	}
+}
+
+func TestFinishAgentBuilderInstall_SDDInjectionFailureShowsRetry(t *testing.T) {
+	injectionErr := errors.New("prompt is read-only")
+	injections := 0
+	ops := successfulAgentBuilderPostInstallOps(&injections)
+	ops.injectSDDReference = func(*agentbuilder.GeneratedAgent, string) error {
+		injections++
+		return injectionErr
+	}
+
+	err := finishAgentBuilderInstall(sddAgent(), testAgentBuilderAdapters(), successfulInstallResults(), model.AgentClaudeCode, "/registry/custom-agents.json", ops)
+	if !errors.Is(err, injectionErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, injectionErr)
+	}
+	if injections != 1 {
+		t.Fatalf("SDD injections = %d, want fail-fast 1", injections)
+	}
+	assertAgentBuilderInstallErrorScreen(t, err)
+}
+
+func TestFinishAgentBuilderInstall_SDDPathFailureStopsBeforeInjection(t *testing.T) {
+	pathErr := errors.New("prompt path unavailable")
+	injections := 0
+	ops := successfulAgentBuilderPostInstallOps(&injections)
+	ops.systemPromptPath = func(model.AgentID) (string, error) { return "", pathErr }
+
+	err := finishAgentBuilderInstall(sddAgent(), testAgentBuilderAdapters(), successfulInstallResults(), model.AgentClaudeCode, "/registry/custom-agents.json", ops)
+	if !errors.Is(err, pathErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, pathErr)
+	}
+	if injections != 0 {
+		t.Fatalf("SDD injections = %d, want 0 after path failure", injections)
+	}
+}
+
+func TestAgentBuilderInstallingErrorRetryRestartsInstall(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenAgentBuilderInstalling
+	m.Cursor = 0
+	m.AgentBuilder = AgentBuilderState{
+		Generated:  &agentbuilder.GeneratedAgent{Name: "test-agent"},
+		InstallErr: errors.New("registry unavailable"),
+	}
+
+	updated, cmd := m.confirmSelection()
+	state := updated.(Model)
+	if cmd == nil {
+		t.Fatal("Retry must start an installation command")
+	}
+	if state.Screen != ScreenAgentBuilderInstalling {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderInstalling", state.Screen)
+	}
+	if !state.AgentBuilder.Installing {
+		t.Fatal("Retry must set Installing")
+	}
+	if state.AgentBuilder.InstallErr != nil {
+		t.Fatalf("InstallErr = %v, want nil", state.AgentBuilder.InstallErr)
+	}
+}
+
+func successfulAgentBuilderPostInstallOps(injections *int) agentBuilderPostInstallOps {
+	return agentBuilderPostInstallOps{
+		mkdirAll:     func(string, os.FileMode) error { return nil },
+		loadRegistry: func(string) (*agentbuilder.Registry, error) { return &agentbuilder.Registry{Version: 1}, nil },
+		saveRegistry: func(string, *agentbuilder.Registry) error { return nil },
+		systemPromptPath: func(agentID model.AgentID) (string, error) {
+			return "/prompts/" + string(agentID), nil
+		},
+		injectSDDReference: func(*agentbuilder.GeneratedAgent, string) error {
+			(*injections)++
+			return nil
+		},
+	}
+}
+
+func sddAgent() *agentbuilder.GeneratedAgent {
+	return &agentbuilder.GeneratedAgent{
+		Name:      "test-agent",
+		Title:     "Test Agent",
+		SDDConfig: &agentbuilder.SDDIntegration{Mode: agentbuilder.SDDPhaseSupport, TargetPhase: "apply"},
+	}
+}
+
+func testAgentBuilderAdapters() []agentbuilder.AdapterInfo {
+	return []agentbuilder.AdapterInfo{
+		{AgentID: model.AgentClaudeCode},
+		{AgentID: model.AgentOpenCode},
+	}
+}
+
+func successfulInstallResults() []agentbuilder.InstallResult {
+	return []agentbuilder.InstallResult{{AgentID: model.AgentClaudeCode, Success: true}}
+}
+
+func assertAgentBuilderInstallErrorScreen(t *testing.T, installErr error) {
+	t.Helper()
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenAgentBuilderInstalling
+	m.AgentBuilder.Installing = true
+
+	updated, _ := m.Update(AgentBuilderInstallDoneMsg{Results: successfulInstallResults(), Err: installErr})
+	state := updated.(Model)
+	if state.Screen != ScreenAgentBuilderInstalling {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderInstalling", state.Screen)
+	}
+	if state.AgentBuilder.Installing {
+		t.Fatal("Installing should be false after AgentBuilderInstallDoneMsg")
+	}
+	if !errors.Is(state.AgentBuilder.InstallErr, installErr) {
+		t.Fatalf("InstallErr = %v, want %v", state.AgentBuilder.InstallErr, installErr)
+	}
+	view := state.View()
+	if !strings.Contains(view, "Retry") {
+		t.Fatalf("error view = %q, want Retry", view)
+	}
+	if strings.Contains(view, "Installation Complete") {
+		t.Fatalf("error view = %q, must not show success", view)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -851,7 +851,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.AgentBuilder.Installing = false
 		if msg.Err != nil {
 			m.AgentBuilder.InstallErr = msg.Err
-			m.setScreen(ScreenAgentBuilderPreview)
 		} else {
 			m.AgentBuilder.InstallResults = msg.Results
 			m.AgentBuilder.InstallErr = nil
@@ -2531,8 +2530,12 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenAgentBuilderPrompt)
 		}
 	case ScreenAgentBuilderInstalling:
-		if !m.AgentBuilder.Installing {
-			m.setScreen(ScreenAgentBuilderComplete)
+		if m.AgentBuilder.InstallErr != nil {
+			if m.Cursor == 0 {
+				return m.startInstallation()
+			}
+			m.AgentBuilder.InstallErr = nil
+			m.setScreen(ScreenAgentBuilderPreview)
 		}
 	case ScreenAgentBuilderComplete:
 		m.setScreen(ScreenWelcome)
@@ -4830,6 +4833,70 @@ func (m Model) startGeneration() (tea.Model, tea.Cmd) {
 	})
 }
 
+type agentBuilderPostInstallOps struct {
+	mkdirAll           func(string, os.FileMode) error
+	loadRegistry       func(string) (*agentbuilder.Registry, error)
+	saveRegistry       func(string, *agentbuilder.Registry) error
+	systemPromptPath   func(model.AgentID) (string, error)
+	injectSDDReference func(*agentbuilder.GeneratedAgent, string) error
+}
+
+// finishAgentBuilderInstall persists physical install results, then injects SDD references.
+// It never compensates physical writes: retries must converge on the installed skill files.
+func finishAgentBuilderInstall(agent *agentbuilder.GeneratedAgent, adapters []agentbuilder.AdapterInfo, results []agentbuilder.InstallResult, engineID model.AgentID, registryPath string, ops agentBuilderPostInstallOps) error {
+	if err := ops.mkdirAll(filepath.Dir(registryPath), 0755); err != nil {
+		return fmt.Errorf("create custom-agent registry directory: %w", err)
+	}
+
+	reg, err := ops.loadRegistry(registryPath)
+	if err != nil {
+		return fmt.Errorf("load custom-agent registry: %w", err)
+	}
+
+	installedIDs := make([]model.AgentID, 0, len(results))
+	for _, result := range results {
+		if result.Success {
+			installedIDs = append(installedIDs, result.AgentID)
+		}
+	}
+	entry := agentbuilder.RegistryEntry{
+		Name:             agent.Name,
+		Title:            agent.Title,
+		Description:      agent.Description,
+		CreatedAt:        time.Now(),
+		GenerationEngine: engineID,
+		SDDIntegration:   agent.SDDConfig,
+		InstalledAgents:  installedIDs,
+	}
+	if existing := reg.FindByName(agent.Name); existing != nil {
+		existing.Title = entry.Title
+		existing.Description = entry.Description
+		existing.CreatedAt = entry.CreatedAt
+		existing.GenerationEngine = entry.GenerationEngine
+		existing.SDDIntegration = entry.SDDIntegration
+		existing.InstalledAgents = entry.InstalledAgents
+	} else {
+		reg.Add(entry)
+	}
+	if err := ops.saveRegistry(registryPath, reg); err != nil {
+		return fmt.Errorf("save custom-agent registry: %w", err)
+	}
+
+	if agent.SDDConfig == nil || agent.SDDConfig.Mode == agentbuilder.SDDStandalone {
+		return nil
+	}
+	for _, adapter := range adapters {
+		systemPromptPath, err := ops.systemPromptPath(adapter.AgentID)
+		if err != nil {
+			return fmt.Errorf("resolve SDD system prompt for %s: %w", adapter.AgentID, err)
+		}
+		if err := ops.injectSDDReference(agent, systemPromptPath); err != nil {
+			return fmt.Errorf("inject SDD reference for %s: %w", adapter.AgentID, err)
+		}
+	}
+	return nil
+}
+
 // startInstallation launches the agent installation goroutine.
 func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 	m.AgentBuilder.Installing = true
@@ -4868,68 +4935,34 @@ func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 			return AgentBuilderInstallDoneMsg{Results: results, Err: err}
 		}
 
-		// Persist entry to registry.
+		ops := agentBuilderPostInstallOps{
+			mkdirAll:           os.MkdirAll,
+			loadRegistry:       agentbuilder.LoadRegistry,
+			saveRegistry:       agentbuilder.SaveRegistry,
+			systemPromptPath:   agentBuilderSystemPromptPath,
+			injectSDDReference: agentbuilder.InjectSDDReference,
+		}
 		registryPath := filepath.Join(homeDir(), ".config", "gentle-ai", "custom-agents.json")
-		_ = os.MkdirAll(filepath.Dir(registryPath), 0755)
-		if reg, loadErr := agentbuilder.LoadRegistry(registryPath); loadErr == nil {
-			// Collect IDs of agents that were successfully installed.
-			var installedIDs []model.AgentID
-			for _, r := range results {
-				if r.Success {
-					installedIDs = append(installedIDs, r.AgentID)
-				}
-			}
-			entry := agentbuilder.RegistryEntry{
-				Name:             installAgent.Name,
-				Title:            installAgent.Title,
-				Description:      installAgent.Description,
-				CreatedAt:        time.Now(),
-				GenerationEngine: engineID,
-				SDDIntegration:   installAgent.SDDConfig,
-				InstalledAgents:  installedIDs,
-			}
-			// Update existing entry if present; otherwise append.
-			if existing := reg.FindByName(installAgent.Name); existing != nil {
-				existing.Title = entry.Title
-				existing.Description = entry.Description
-				existing.CreatedAt = entry.CreatedAt
-				existing.GenerationEngine = entry.GenerationEngine
-				existing.SDDIntegration = entry.SDDIntegration
-				existing.InstalledAgents = entry.InstalledAgents
-			} else {
-				reg.Add(entry)
-			}
-			// Best-effort save — ignore save errors.
-			_ = agentbuilder.SaveRegistry(registryPath, reg)
+		if err := finishAgentBuilderInstall(installAgent, adapters, results, engineID, registryPath, ops); err != nil {
+			return AgentBuilderInstallDoneMsg{Results: results, Err: err}
 		}
-
-		// Wire SDD injection: append custom-agent reference blocks to system prompts.
-		// Best-effort — don't fail the whole install if SDD injection fails.
-		if installAgent.SDDConfig != nil && installAgent.SDDConfig.Mode != agentbuilder.SDDStandalone {
-			for _, adapter := range adapters {
-				if systemPromptPath, ok := agentBuilderSystemPromptPath(adapter.AgentID); ok {
-					_ = agentbuilder.InjectSDDReference(installAgent, systemPromptPath)
-				}
-			}
-		}
-
-		return AgentBuilderInstallDoneMsg{Results: results, Err: nil}
+		return AgentBuilderInstallDoneMsg{Results: results}
 	})
 }
 
 // agentBuilderSystemPromptPath returns the system prompt file path for the given agent.
-func agentBuilderSystemPromptPath(agentID model.AgentID) (string, bool) {
+func agentBuilderSystemPromptPath(agentID model.AgentID) (string, error) {
 	home := homeDir()
 	switch agentID {
 	case model.AgentClaudeCode:
-		return filepath.Join(home, ".claude", "CLAUDE.md"), true
+		return filepath.Join(home, ".claude", "CLAUDE.md"), nil
 	case model.AgentOpenCode:
-		return filepath.Join(home, ".config", "opencode", "AGENTS.md"), true
+		return filepath.Join(home, ".config", "opencode", "AGENTS.md"), nil
 	case model.AgentGeminiCLI:
-		return filepath.Join(home, ".gemini", "GEMINI.md"), true
+		return filepath.Join(home, ".gemini", "GEMINI.md"), nil
 	case model.AgentCodex:
-		return filepath.Join(home, ".codex", "AGENTS.md"), true
+		return filepath.Join(home, ".codex", "AGENTS.md"), nil
 	default:
-		return "", false
+		return "", fmt.Errorf("unsupported agent %q", agentID)
 	}
 }


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #2723

<!-- This child PR has a non-default base, so the issue remains open through the chain. -->

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Restores a skill file's exact before-image and mode if any adapter installation step fails.
- Joins rollback failures with the original install error instead of silently discarding restoration failures.
- Covers directory creation and post-publication write failures while keeping the slice within 247 changed lines.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agentbuilder/installer.go` | Replace delete-only rollback with `mutationjournal` before-image capture and restoration. |
| `internal/agentbuilder/installer_test.go` | Cover restored content, permissions, landed-write rollback, and joined restoration errors. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/agentbuilder
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A. This slice changes local agent installation rollback and does not affect review lifecycle, gates, recovery, delivery, or benchmark implementation/corpus/classifier behavior.

- [x] Focused unit tests passed before delivery: `go test ./internal/agentbuilder` (provided candidate evidence; deliberately not re-run for this delivery).
- [ ] Unit tests pass (`go test ./...`) — not re-run for this delivery.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — not re-run for this delivery.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run; not required for this focused rollback slice.
- [ ] Manually tested locally — not performed for this delivery.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR has 247 changed lines (`198 additions + 49 deletions`), within the 400-line limit. |
| Check Issue Reference | ⏳ | Body contains `Closes #2723`. |
| Check Issue Has `status:approved` | ⏳ | Issue #2723 was API-verified with `status:approved`. |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:bug` label will be applied through the REST API. |
| Unit Tests | ⏳ | `go test ./...` runs in CI. |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` runs in CI. |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` runs in CI. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines; no `size:exception` is needed.
- [x] I have added the appropriate `type:*` label to this PR.
- [ ] Unit tests pass (`go test ./...`) — CI will provide this evidence.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — CI will provide this evidence.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI will provide this evidence.
- [x] Benchmark validation is not applicable; rationale is in the Test Plan.
- [x] Documentation is not required because this is an internal rollback correction.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## 💬 Notes for Reviewers

### Chain Context

Strategy: Feature Branch Chain. The tracker `feat/2723-agentbuilder-transaction` is intentionally a branch only; no tracker PR exists yet.

```text
origin/main
  |
  +-- feat/2723-agentbuilder-transaction (tracker, no PR)
        |
        +-- 📍 PR A: fix/2723-agentbuilder-rollback
              |
              +-- PR B: fix/2723-truthful-postinstall
```

### Slice Boundary

- Start: tracker branch at `origin/main` commit `070270b60d3e88a884aadacfd57ae88ff2e8780c`.
- End: a failed install restores every changed `SKILL.md` to its captured content and file mode, with restoration failure retained in the returned error.
- Dependency: this is the first child PR and targets the tracker branch.
- Follow-up: PR B adds truthful registry and SDD post-install failure handling in the TUI.
- Out of scope: TUI error presentation and retry behavior belong exclusively to PR B.
- Rollback: revert `1cd70faa` to remove only `internal/agentbuilder/installer.go` journal integration and its focused tests; no later slice is required to reverse this behavior.

Issue #2723 remains open through this chain because this PR targets a non-default branch.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [ ] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.
