### PR TITLE
fix(tui): surface agent post-install failures

### DIFF
--- a/internal/tui/agent_builder_postinstall_test.go
+++ b/internal/tui/agent_builder_postinstall_test.go
@@ -1,0 +1,173 @@
+package tui
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agentbuilder"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+func TestFinishAgentBuilderInstall_RegistryFailuresSkipSDD(t *testing.T) {
+	registryErr := errors.New("registry unavailable")
+	for _, tt := range []struct {
+		name string
+		fail func(*agentBuilderPostInstallOps)
+	}{
+		{
+			name: "create registry directory",
+			fail: func(ops *agentBuilderPostInstallOps) {
+				ops.mkdirAll = func(string, os.FileMode) error { return registryErr }
+			},
+		},
+		{
+			name: "load registry",
+			fail: func(ops *agentBuilderPostInstallOps) {
+				ops.loadRegistry = func(string) (*agentbuilder.Registry, error) { return nil, registryErr }
+			},
+		},
+		{
+			name: "save registry",
+			fail: func(ops *agentBuilderPostInstallOps) {
+				ops.saveRegistry = func(string, *agentbuilder.Registry) error { return registryErr }
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			injections := 0
+			ops := successfulAgentBuilderPostInstallOps(&injections)
+			tt.fail(&ops)
+
+			err := finishAgentBuilderInstall(sddAgent(), testAgentBuilderAdapters(), successfulInstallResults(), model.AgentClaudeCode, "/registry/custom-agents.json", ops)
+			if !errors.Is(err, registryErr) {
+				t.Fatalf("error = %v, want wrapped %v", err, registryErr)
+			}
+			if injections != 0 {
+				t.Fatalf("SDD injections = %d, want 0 after registry failure", injections)
+			}
+			assertAgentBuilderInstallErrorScreen(t, err)
+		})
+	}
+}
+
+func TestFinishAgentBuilderInstall_SDDInjectionFailureShowsRetry(t *testing.T) {
+	injectionErr := errors.New("prompt is read-only")
+	injections := 0
+	ops := successfulAgentBuilderPostInstallOps(&injections)
+	ops.injectSDDReference = func(*agentbuilder.GeneratedAgent, string) error {
+		injections++
+		return injectionErr
+	}
+
+	err := finishAgentBuilderInstall(sddAgent(), testAgentBuilderAdapters(), successfulInstallResults(), model.AgentClaudeCode, "/registry/custom-agents.json", ops)
+	if !errors.Is(err, injectionErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, injectionErr)
+	}
+	if injections != 1 {
+		t.Fatalf("SDD injections = %d, want fail-fast 1", injections)
+	}
+	assertAgentBuilderInstallErrorScreen(t, err)
+}
+
+func TestFinishAgentBuilderInstall_SDDPathFailureStopsBeforeInjection(t *testing.T) {
+	pathErr := errors.New("prompt path unavailable")
+	injections := 0
+	ops := successfulAgentBuilderPostInstallOps(&injections)
+	ops.systemPromptPath = func(model.AgentID) (string, error) { return "", pathErr }
+
+	err := finishAgentBuilderInstall(sddAgent(), testAgentBuilderAdapters(), successfulInstallResults(), model.AgentClaudeCode, "/registry/custom-agents.json", ops)
+	if !errors.Is(err, pathErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, pathErr)
+	}
+	if injections != 0 {
+		t.Fatalf("SDD injections = %d, want 0 after path failure", injections)
+	}
+}
+
+func TestAgentBuilderInstallingErrorRetryRestartsInstall(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenAgentBuilderInstalling
+	m.Cursor = 0
+	m.AgentBuilder = AgentBuilderState{
+		Generated:  &agentbuilder.GeneratedAgent{Name: "test-agent"},
+		InstallErr: errors.New("registry unavailable"),
+	}
+
+	updated, cmd := m.confirmSelection()
+	state := updated.(Model)
+	if cmd == nil {
+		t.Fatal("Retry must start an installation command")
+	}
+	if state.Screen != ScreenAgentBuilderInstalling {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderInstalling", state.Screen)
+	}
+	if !state.AgentBuilder.Installing {
+		t.Fatal("Retry must set Installing")
+	}
+	if state.AgentBuilder.InstallErr != nil {
+		t.Fatalf("InstallErr = %v, want nil", state.AgentBuilder.InstallErr)
+	}
+}
+
+func successfulAgentBuilderPostInstallOps(injections *int) agentBuilderPostInstallOps {
+	return agentBuilderPostInstallOps{
+		mkdirAll:     func(string, os.FileMode) error { return nil },
+		loadRegistry: func(string) (*agentbuilder.Registry, error) { return &agentbuilder.Registry{Version: 1}, nil },
+		saveRegistry: func(string, *agentbuilder.Registry) error { return nil },
+		systemPromptPath: func(agentID model.AgentID) (string, error) {
+			return "/prompts/" + string(agentID), nil
+		},
+		injectSDDReference: func(*agentbuilder.GeneratedAgent, string) error {
+			(*injections)++
+			return nil
+		},
+	}
+}
+
+func sddAgent() *agentbuilder.GeneratedAgent {
+	return &agentbuilder.GeneratedAgent{
+		Name:      "test-agent",
+		Title:     "Test Agent",
+		SDDConfig: &agentbuilder.SDDIntegration{Mode: agentbuilder.SDDPhaseSupport, TargetPhase: "apply"},
+	}
+}
+
+func testAgentBuilderAdapters() []agentbuilder.AdapterInfo {
+	return []agentbuilder.AdapterInfo{
+		{AgentID: model.AgentClaudeCode},
+		{AgentID: model.AgentOpenCode},
+	}
+}
+
+func successfulInstallResults() []agentbuilder.InstallResult {
+	return []agentbuilder.InstallResult{{AgentID: model.AgentClaudeCode, Success: true}}
+}
+
+func assertAgentBuilderInstallErrorScreen(t *testing.T, installErr error) {
+	t.Helper()
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenAgentBuilderInstalling
+	m.AgentBuilder.Installing = true
+
+	updated, _ := m.Update(AgentBuilderInstallDoneMsg{Results: successfulInstallResults(), Err: installErr})
+	state := updated.(Model)
+	if state.Screen != ScreenAgentBuilderInstalling {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderInstalling", state.Screen)
+	}
+	if state.AgentBuilder.Installing {
+		t.Fatal("Installing should be false after AgentBuilderInstallDoneMsg")
+	}
+	if !errors.Is(state.AgentBuilder.InstallErr, installErr) {
+		t.Fatalf("InstallErr = %v, want %v", state.AgentBuilder.InstallErr, installErr)
+	}
+	view := state.View()
+	if !strings.Contains(view, "Retry") {
+		t.Fatalf("error view = %q, want Retry", view)
+	}
+	if strings.Contains(view, "Installation Complete") {
+		t.Fatalf("error view = %q, must not show success", view)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -851,7 +851,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.AgentBuilder.Installing = false
 		if msg.Err != nil {
 			m.AgentBuilder.InstallErr = msg.Err
-			m.setScreen(ScreenAgentBuilderPreview)
 		} else {
 			m.AgentBuilder.InstallResults = msg.Results
 			m.AgentBuilder.InstallErr = nil
@@ -2531,8 +2530,12 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenAgentBuilderPrompt)
 		}
 	case ScreenAgentBuilderInstalling:
-		if !m.AgentBuilder.Installing {
-			m.setScreen(ScreenAgentBuilderComplete)
+		if m.AgentBuilder.InstallErr != nil {
+			if m.Cursor == 0 {
+				return m.startInstallation()
+			}
+			m.AgentBuilder.InstallErr = nil
+			m.setScreen(ScreenAgentBuilderPreview)
 		}
 	case ScreenAgentBuilderComplete:
 		m.setScreen(ScreenWelcome)
@@ -4830,6 +4833,70 @@ func (m Model) startGeneration() (tea.Model, tea.Cmd) {
 	})
 }
 
+type agentBuilderPostInstallOps struct {
+	mkdirAll           func(string, os.FileMode) error
+	loadRegistry       func(string) (*agentbuilder.Registry, error)
+	saveRegistry       func(string, *agentbuilder.Registry) error
+	systemPromptPath   func(model.AgentID) (string, error)
+	injectSDDReference func(*agentbuilder.GeneratedAgent, string) error
+}
+
+// finishAgentBuilderInstall persists physical install results, then injects SDD references.
+// It never compensates physical writes: retries must converge on the installed skill files.
+func finishAgentBuilderInstall(agent *agentbuilder.GeneratedAgent, adapters []agentbuilder.AdapterInfo, results []agentbuilder.InstallResult, engineID model.AgentID, registryPath string, ops agentBuilderPostInstallOps) error {
+	if err := ops.mkdirAll(filepath.Dir(registryPath), 0755); err != nil {
+		return fmt.Errorf("create custom-agent registry directory: %w", err)
+	}
+
+	reg, err := ops.loadRegistry(registryPath)
+	if err != nil {
+		return fmt.Errorf("load custom-agent registry: %w", err)
+	}
+
+	installedIDs := make([]model.AgentID, 0, len(results))
+	for _, result := range results {
+		if result.Success {
+			installedIDs = append(installedIDs, result.AgentID)
+		}
+	}
+	entry := agentbuilder.RegistryEntry{
+		Name:             agent.Name,
+		Title:            agent.Title,
+		Description:      agent.Description,
+		CreatedAt:        time.Now(),
+		GenerationEngine: engineID,
+		SDDIntegration:   agent.SDDConfig,
+		InstalledAgents:  installedIDs,
+	}
+	if existing := reg.FindByName(agent.Name); existing != nil {
+		existing.Title = entry.Title
+		existing.Description = entry.Description
+		existing.CreatedAt = entry.CreatedAt
+		existing.GenerationEngine = entry.GenerationEngine
+		existing.SDDIntegration = entry.SDDIntegration
+		existing.InstalledAgents = entry.InstalledAgents
+	} else {
+		reg.Add(entry)
+	}
+	if err := ops.saveRegistry(registryPath, reg); err != nil {
+		return fmt.Errorf("save custom-agent registry: %w", err)
+	}
+
+	if agent.SDDConfig == nil || agent.SDDConfig.Mode == agentbuilder.SDDStandalone {
+		return nil
+	}
+	for _, adapter := range adapters {
+		systemPromptPath, err := ops.systemPromptPath(adapter.AgentID)
+		if err != nil {
+			return fmt.Errorf("resolve SDD system prompt for %s: %w", adapter.AgentID, err)
+		}
+		if err := ops.injectSDDReference(agent, systemPromptPath); err != nil {
+			return fmt.Errorf("inject SDD reference for %s: %w", adapter.AgentID, err)
+		}
+	}
+	return nil
+}
+
 // startInstallation launches the agent installation goroutine.
 func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 	m.AgentBuilder.Installing = true
@@ -4868,68 +4935,34 @@ func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 			return AgentBuilderInstallDoneMsg{Results: results, Err: err}
 		}
 
-		// Persist entry to registry.
+		ops := agentBuilderPostInstallOps{
+			mkdirAll:           os.MkdirAll,
+			loadRegistry:       agentbuilder.LoadRegistry,
+			saveRegistry:       agentbuilder.SaveRegistry,
+			systemPromptPath:   agentBuilderSystemPromptPath,
+			injectSDDReference: agentbuilder.InjectSDDReference,
+		}
 		registryPath := filepath.Join(homeDir(), ".config", "gentle-ai", "custom-agents.json")
-		_ = os.MkdirAll(filepath.Dir(registryPath), 0755)
-		if reg, loadErr := agentbuilder.LoadRegistry(registryPath); loadErr == nil {
-			// Collect IDs of agents that were successfully installed.
-			var installedIDs []model.AgentID
-			for _, r := range results {
-				if r.Success {
-					installedIDs = append(installedIDs, r.AgentID)
-				}
-			}
-			entry := agentbuilder.RegistryEntry{
-				Name:             installAgent.Name,
-				Title:            installAgent.Title,
-				Description:      installAgent.Description,
-				CreatedAt:        time.Now(),
-				GenerationEngine: engineID,
-				SDDIntegration:   installAgent.SDDConfig,
-				InstalledAgents:  installedIDs,
-			}
-			// Update existing entry if present; otherwise append.
-			if existing := reg.FindByName(installAgent.Name); existing != nil {
-				existing.Title = entry.Title
-				existing.Description = entry.Description
-				existing.CreatedAt = entry.CreatedAt
-				existing.GenerationEngine = entry.GenerationEngine
-				existing.SDDIntegration = entry.SDDIntegration
-				existing.InstalledAgents = entry.InstalledAgents
-			} else {
-				reg.Add(entry)
-			}
-			// Best-effort save — ignore save errors.
-			_ = agentbuilder.SaveRegistry(registryPath, reg)
+		if err := finishAgentBuilderInstall(installAgent, adapters, results, engineID, registryPath, ops); err != nil {
+			return AgentBuilderInstallDoneMsg{Results: results, Err: err}
 		}
-
-		// Wire SDD injection: append custom-agent reference blocks to system prompts.
-		// Best-effort — don't fail the whole install if SDD injection fails.
-		if installAgent.SDDConfig != nil && installAgent.SDDConfig.Mode != agentbuilder.SDDStandalone {
-			for _, adapter := range adapters {
-				if systemPromptPath, ok := agentBuilderSystemPromptPath(adapter.AgentID); ok {
-					_ = agentbuilder.InjectSDDReference(installAgent, systemPromptPath)
-				}
-			}
-		}
-
-		return AgentBuilderInstallDoneMsg{Results: results, Err: nil}
+		return AgentBuilderInstallDoneMsg{Results: results}
 	})
 }
 
 // agentBuilderSystemPromptPath returns the system prompt file path for the given agent.
-func agentBuilderSystemPromptPath(agentID model.AgentID) (string, bool) {
+func agentBuilderSystemPromptPath(agentID model.AgentID) (string, error) {
 	home := homeDir()
 	switch agentID {
 	case model.AgentClaudeCode:
-		return filepath.Join(home, ".claude", "CLAUDE.md"), true
+		return filepath.Join(home, ".claude", "CLAUDE.md"), nil
 	case model.AgentOpenCode:
-		return filepath.Join(home, ".config", "opencode", "AGENTS.md"), true
+		return filepath.Join(home, ".config", "opencode", "AGENTS.md"), nil
 	case model.AgentGeminiCLI:
-		return filepath.Join(home, ".gemini", "GEMINI.md"), true
+		return filepath.Join(home, ".gemini", "GEMINI.md"), nil
 	case model.AgentCodex:
-		return filepath.Join(home, ".codex", "AGENTS.md"), true
+		return filepath.Join(home, ".codex", "AGENTS.md"), nil
 	default:
-		return "", false
+		return "", fmt.Errorf("unsupported agent %q", agentID)
 	}
 }


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #2723

<!-- This child PR has a non-default base, so the issue remains open through the chain. -->

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Makes registry persistence and SDD-reference failures visible in the Agent Builder instead of reporting a false successful install.
- Keeps the failed-install screen active so users can retry or return to preview.
- Adds focused failure-path tests while keeping this final behavior slice within 312 changed lines.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Return and display registry/SDD post-install errors, with retry and cancel behavior. |
| `internal/tui/agent_builder_postinstall_test.go` | Cover registry, prompt resolution, SDD injection, and retry failure paths. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/tui
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A. This slice changes Agent Builder TUI post-install error handling and does not affect review lifecycle, gates, recovery, delivery, or benchmark implementation/corpus/classifier behavior.

- [x] Focused unit tests passed before delivery: `go test ./internal/tui` (provided candidate evidence; deliberately not re-run for this delivery).
- [ ] Unit tests pass (`go test ./...`) — not re-run for this delivery.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — not re-run for this delivery.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run; not required for this focused TUI slice.
- [ ] Manually tested locally — not performed for this delivery.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR has 312 changed lines (`259 additions + 53 deletions`), within the 400-line limit. |
| Check Issue Reference | ⏳ | Body contains `Closes #2723`. |
| Check Issue Has `status:approved` | ⏳ | Issue #2723 was API-verified with `status:approved`. |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:bug` label will be applied through the REST API. |
| Unit Tests | ⏳ | `go test ./...` runs in CI. |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` runs in CI. |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` runs in CI. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines; no `size:exception` is needed.
- [x] I have added the appropriate `type:*` label to this PR.
- [ ] Unit tests pass (`go test ./...`) — CI will provide this evidence.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — CI will provide this evidence.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI will provide this evidence.
- [x] Benchmark validation is not applicable; rationale is in the Test Plan.
- [x] Documentation is not required because this is an internal TUI behavior correction.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] My commits do not include `Co-Authored-By` trailers.

---

## 💬 Notes for Reviewers

### Chain Context

Strategy: Feature Branch Chain. The tracker `feat/2723-agentbuilder-transaction` is intentionally a branch only; no tracker PR exists yet.

```text
origin/main
  |
  +-- feat/2723-agentbuilder-transaction (tracker, no PR)
        |
        +-- PR A: fix/2723-agentbuilder-rollback
              |
              +-- 📍 PR B: fix/2723-truthful-postinstall
```

### Slice Boundary

- Start: PR A head `1cd70faa`, which establishes safe physical skill-file rollback.
- End: registry writes, SDD prompt resolution, and SDD injection failures remain visible on the installing screen and present retry/cancel behavior.
- Dependency: this PR targets PR A directly and is the final behavior slice in the chain.
- Follow-up: after both children integrate, open the tracker PR to `main`; do not create it before then.
- Out of scope: changing filesystem rollback semantics, which belongs exclusively to PR A.
- Rollback: revert `43149bc6` to remove only `internal/tui/model.go` post-install error propagation and `internal/tui/agent_builder_postinstall_test.go`; PR A remains independently valid.

This is the final behavior slice. Issue #2723 remains open through this chain because this PR targets a non-default branch.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [ ] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.
