### PR TITLE
fix(hooks): make skill-registry hooks PowerShell-safe on Windows

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
@@ -1477,6 +1478,43 @@ func readMisnamedOpenCodeGentlemanSDDPrompt(settingsPath string) (string, error)
 	return prompt, nil
 }
 
+// skillRegistryHookGOOS is injected so unit tests can exercise the Windows and
+// non-Windows hook command shapes without build tags, mirroring the
+// runtimeGOOS pattern in internal/components/filemerge (issue #2124).
+var skillRegistryHookGOOS = func() string { return runtime.GOOS }
+
+// skillRegistryHookMarker uniquely identifies a gentle-ai skill-registry hook
+// regardless of the exact shell command variant. It is used for idempotency and
+// migration: an already-installed hook (bash or PowerShell) is detected and
+// replaced instead of being duplicated on the next sync (issue #2124).
+const skillRegistryHookMarker = "gentle-ai skill-registry refresh"
+
+// Bash command variants (macOS, Linux, and Windows with Git Bash). The trailing
+// `|| true` keeps the hook non-blocking when the refresh exits non-zero.
+const (
+	claudeSkillRegistryBashCommand = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" || true`
+	codexSkillRegistryBashCommand  = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$PWD" || true`
+)
+
+// PowerShell-safe command variants for Windows without Git Bash, where Claude
+// Code and Codex run the hook through PowerShell 5.1. PowerShell 5.1 rejects the
+// bash `|| true` separator and `${VAR:-default}` expansion, so we branch on the
+// project-dir env var explicitly and swallow non-zero exits with `exit 0`. The
+// `$env:` form is required; the bare `$CLAUDE_PROJECT_DIR` resolves to $null in
+// PowerShell.
+const (
+	claudeSkillRegistryPowerShellCommand = `if ($env:CLAUDE_PROJECT_DIR) { $d = $env:CLAUDE_PROJECT_DIR } else { $d = $PWD }; gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$d"; exit 0`
+	codexSkillRegistryPowerShellCommand  = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$PWD"; exit 0`
+)
+
+// isSkillRegistryHookCommand reports whether a hook command string is a
+// gentle-ai skill-registry hook in any shell variant. Used to migrate a
+// previously installed hook to the current platform's command without
+// duplicating it.
+func isSkillRegistryHookCommand(command string) bool {
+	return strings.Contains(command, skillRegistryHookMarker)
+}
+
 func installSkillRegistryAutomation(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	if adapter.Agent() == model.AgentCodex {
 		hooksPath := filepath.Join(adapter.GlobalConfigDir(homeDir), "hooks.json")
@@ -1510,11 +1548,6 @@ func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
 		return false, err
 	}
 
-	const command = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$PWD" || true`
-	if claudeHookExists(root, command) {
-		return false, nil
-	}
-
 	hooksRaw, hasHooks := root["hooks"]
 	hooksMap, _ := hooksRaw.(map[string]any)
 	if hasHooks && hooksMap == nil {
@@ -1529,14 +1562,24 @@ func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
 	if hasSessionStart && sessionStart == nil {
 		return false, fmt.Errorf("Codex hooks %q has unsupported hooks.SessionStart shape: want array", hooksPath)
 	}
+
+	// Codex runs command hooks through PowerShell on Windows, where the bash
+	// `command` fails. Codex exposes a Windows-only `commandWindows` override, so
+	// we ship the bash command plus a PowerShell-safe override and let Codex pick
+	// the right one per platform (issue #2124).
+	sessionStart, hasCurrent, migrated := pruneStaleSkillRegistryHooks(sessionStart, codexSkillRegistryBashCommand)
+	if hasCurrent && !migrated {
+		return false, nil
+	}
 	sessionStart = append(sessionStart, map[string]any{
 		"matcher": "startup|resume|clear|compact",
 		"hooks": []any{
 			map[string]any{
-				"type":          "command",
-				"command":       command,
-				"timeout":       30,
-				"statusMessage": "Refreshing skill registry",
+				"type":           "command",
+				"command":        codexSkillRegistryBashCommand,
+				"commandWindows": codexSkillRegistryPowerShellCommand,
+				"timeout":        30,
+				"statusMessage":  "Refreshing skill registry",
 			},
 		},
 	})
@@ -1568,11 +1611,6 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 		return false, err
 	}
 
-	const command = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" || true`
-	if claudeHookExists(root, command) {
-		return false, nil
-	}
-
 	hooksRaw, hasHooks := root["hooks"]
 	hooksMap, _ := hooksRaw.(map[string]any)
 	if hasHooks && hooksMap == nil {
@@ -1586,14 +1624,30 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	if hasUserPromptSubmit && userPromptSubmit == nil {
 		return false, fmt.Errorf("Claude settings %q has unsupported hooks.UserPromptSubmit shape: want array", settingsPath)
 	}
+
+	// On Windows, Claude Code runs a shell-form command hook through Git Bash when
+	// present, but falls back to PowerShell when it is not, and the bash `|| true`
+	// command fails under PowerShell 5.1. To be deterministic regardless of Git
+	// Bash presence, on Windows we emit a PowerShell-safe command tagged with the
+	// `shell: "powershell"` field so Claude Code always runs it through
+	// PowerShell; other platforms keep the bash command (issue #2124).
+	hookHandler := map[string]any{"type": "command"}
+	wantCommand := claudeSkillRegistryBashCommand
+	if skillRegistryHookGOOS() == "windows" {
+		wantCommand = claudeSkillRegistryPowerShellCommand
+		hookHandler["command"] = claudeSkillRegistryPowerShellCommand
+		hookHandler["shell"] = "powershell"
+	} else {
+		hookHandler["command"] = claudeSkillRegistryBashCommand
+	}
+
+	userPromptSubmit, hasCurrent, migrated := pruneStaleSkillRegistryHooks(userPromptSubmit, wantCommand)
+	if hasCurrent && !migrated {
+		return false, nil
+	}
 	userPromptSubmit = append(userPromptSubmit, map[string]any{
 		"matcher": "",
-		"hooks": []any{
-			map[string]any{
-				"type":    "command",
-				"command": command,
-			},
-		},
+		"hooks":   []any{hookHandler},
 	})
 	hooksMap["UserPromptSubmit"] = userPromptSubmit
 	root["hooks"] = hooksMap
@@ -1610,41 +1664,55 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	return wr.Changed, nil
 }
 
-func claudeHookExists(root map[string]any, command string) bool {
-	hooksMap, ok := root["hooks"].(map[string]any)
-	if !ok {
-		return false
-	}
-	for _, key := range []string{"UserPromptSubmit", "SessionStart"} {
-		hookEntries, ok := hooksMap[key].([]any)
-		if !ok {
-			continue
-		}
-		if claudeHookListContains(hookEntries, command) {
-			return true
-		}
-	}
-	return false
-}
-
-func claudeHookListContains(hookEntries []any, command string) bool {
+// pruneStaleSkillRegistryHooks removes any gentle-ai skill-registry hook whose
+// command differs from wantCommand (for example a bash variant left over from a
+// previous install when the current platform now needs the PowerShell variant)
+// from the given hook-event list. It reports whether the list still contains an
+// up-to-date hook with the exact wantCommand, and whether it removed anything.
+// Entries that end up with an empty inner hooks array are dropped so no empty
+// matcher groups linger.
+func pruneStaleSkillRegistryHooks(hookEntries []any, wantCommand string) (kept []any, hasCurrent bool, removed bool) {
+	kept = make([]any, 0, len(hookEntries))
 	for _, item := range hookEntries {
 		itemMap, ok := item.(map[string]any)
 		if !ok {
+			kept = append(kept, item)
 			continue
 		}
 		hooks, ok := itemMap["hooks"].([]any)
 		if !ok {
+			kept = append(kept, item)
 			continue
 		}
+		filtered := make([]any, 0, len(hooks))
 		for _, hook := range hooks {
 			hookMap, ok := hook.(map[string]any)
-			if ok && hookMap["command"] == command {
-				return true
+			if !ok {
+				filtered = append(filtered, hook)
+				continue
 			}
+			command, _ := hookMap["command"].(string)
+			if !isSkillRegistryHookCommand(command) {
+				filtered = append(filtered, hook)
+				continue
+			}
+			if command == wantCommand {
+				hasCurrent = true
+				filtered = append(filtered, hook)
+				continue
+			}
+			// Stale gentle-ai hook variant: drop it so the current-platform
+			// command replaces it instead of accumulating (issue #2124).
+			removed = true
 		}
+		if len(filtered) == 0 {
+			// The matcher group only held stale skill-registry hooks; drop it.
+			continue
+		}
+		itemMap["hooks"] = filtered
+		kept = append(kept, itemMap)
 	}
-	return false
+	return kept, hasCurrent, removed
 }
 
 // ManagedOpenCodePluginNames lists every OpenCode plugin gentle-ai manages as

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1567,7 +1567,7 @@ func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
 	// `command` fails. Codex exposes a Windows-only `commandWindows` override, so
 	// we ship the bash command plus a PowerShell-safe override and let Codex pick
 	// the right one per platform (issue #2124).
-	sessionStart, hasCurrent, migrated := pruneStaleSkillRegistryHooks(sessionStart, codexSkillRegistryBashCommand)
+	sessionStart, hasCurrent, migrated := pruneStaleSkillRegistryHooks(sessionStart, codexSkillRegistryBashCommand, codexSkillRegistryPowerShellCommand)
 	if hasCurrent && !migrated {
 		return false, nil
 	}
@@ -1641,7 +1641,7 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 		hookHandler["command"] = claudeSkillRegistryBashCommand
 	}
 
-	userPromptSubmit, hasCurrent, migrated := pruneStaleSkillRegistryHooks(userPromptSubmit, wantCommand)
+	userPromptSubmit, hasCurrent, migrated := pruneStaleSkillRegistryHooks(userPromptSubmit, wantCommand, "")
 	if hasCurrent && !migrated {
 		return false, nil
 	}
@@ -1669,9 +1669,12 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 // previous install when the current platform now needs the PowerShell variant)
 // from the given hook-event list. It reports whether the list still contains an
 // up-to-date hook with the exact wantCommand, and whether it removed anything.
+// When wantCommandWindows is non-empty (Codex), a hook is considered current
+// only when both command and commandWindows match, so a legacy bash-only hook
+// that lacks the Windows override is treated as stale and migrated (issue #2124).
 // Entries that end up with an empty inner hooks array are dropped so no empty
 // matcher groups linger.
-func pruneStaleSkillRegistryHooks(hookEntries []any, wantCommand string) (kept []any, hasCurrent bool, removed bool) {
+func pruneStaleSkillRegistryHooks(hookEntries []any, wantCommand, wantCommandWindows string) (kept []any, hasCurrent bool, removed bool) {
 	kept = make([]any, 0, len(hookEntries))
 	for _, item := range hookEntries {
 		itemMap, ok := item.(map[string]any)
@@ -1697,6 +1700,16 @@ func pruneStaleSkillRegistryHooks(hookEntries []any, wantCommand string) (kept [
 				continue
 			}
 			if command == wantCommand {
+				// For Codex (wantCommandWindows != ""), a legacy bash-only hook
+				// that lacks the Windows override is stale and must be replaced
+				// so Windows Codex gets the PowerShell command (issue #2124).
+				if wantCommandWindows != "" {
+					cw, _ := hookMap["commandWindows"].(string)
+					if cw != wantCommandWindows {
+						removed = true
+						continue
+					}
+				}
 				hasCurrent = true
 				filtered = append(filtered, hook)
 				continue

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6398,8 +6398,20 @@ func TestEnsureCodexSkillRegistryHookWritesSessionStartHookIdempotently(t *testi
 		t.Fatal(err)
 	}
 	text := string(data)
-	if strings.Count(text, "gentle-ai skill-registry refresh") != 1 {
-		t.Fatalf("hook command count mismatch:\n%s", text)
+	// The hook now carries a bash `command` plus a Windows-only `commandWindows`
+	// override, so the marker string appears twice while there is still exactly
+	// one skill-registry hook entry (issue #2124).
+	if strings.Count(text, `"commandWindows"`) != 1 {
+		t.Fatalf("expected exactly one commandWindows override:\n%s", text)
+	}
+	if strings.Count(text, `"statusMessage": "Refreshing skill registry"`) != 1 {
+		t.Fatalf("expected exactly one skill-registry hook entry:\n%s", text)
+	}
+	if !strings.Contains(text, "gentle-ai skill-registry refresh") {
+		t.Fatalf("Codex hook missing skill-registry command:\n%s", text)
+	}
+	if !strings.Contains(text, "; exit 0") {
+		t.Fatalf("Codex commandWindows should be PowerShell-safe (exit 0), got:\n%s", text)
 	}
 	if !strings.Contains(text, `"SessionStart"`) {
 		t.Fatalf("Codex hook should use SessionStart, got:\n%s", text)
@@ -6410,6 +6422,127 @@ func TestEnsureCodexSkillRegistryHookWritesSessionStartHookIdempotently(t *testi
 	if !strings.Contains(text, "echo keep") {
 		t.Fatalf("existing hooks not preserved:\n%s", text)
 	}
+}
+
+// withSkillRegistryHookGOOS overrides the injected GOOS for the duration of a
+// test and restores it afterward, mirroring the runtimeGOOS pattern in
+// internal/components/filemerge (issue #2124).
+func withSkillRegistryHookGOOS(t *testing.T, goos string) {
+	t.Helper()
+	original := skillRegistryHookGOOS
+	skillRegistryHookGOOS = func() string { return goos }
+	t.Cleanup(func() { skillRegistryHookGOOS = original })
+}
+
+func TestEnsureClaudeSkillRegistryHookUsesPowerShellOnWindows(t *testing.T) {
+	withSkillRegistryHookGOOS(t, "windows")
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := ensureClaudeSkillRegistryHook(settingsPath)
+	if err != nil {
+		t.Fatalf("ensureClaudeSkillRegistryHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	text := readFileString(t, settingsPath)
+	if !strings.Contains(text, `"shell": "powershell"`) {
+		t.Fatalf("Windows Claude hook should set shell=powershell:\n%s", text)
+	}
+	if !strings.Contains(text, "; exit 0") {
+		t.Fatalf("Windows Claude hook should be PowerShell-safe (exit 0):\n%s", text)
+	}
+	if strings.Contains(text, "|| true") {
+		t.Fatalf("Windows Claude hook must not use bash || true:\n%s", text)
+	}
+	if strings.Contains(text, "${CLAUDE_PROJECT_DIR:-$PWD}") {
+		t.Fatalf("Windows Claude hook must not use bash parameter expansion:\n%s", text)
+	}
+	if !strings.Contains(text, "$env:CLAUDE_PROJECT_DIR") {
+		t.Fatalf("Windows Claude hook should use $env: form:\n%s", text)
+	}
+}
+
+func TestEnsureClaudeSkillRegistryHookUsesBashOnUnix(t *testing.T) {
+	withSkillRegistryHookGOOS(t, "linux")
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ensureClaudeSkillRegistryHook(settingsPath); err != nil {
+		t.Fatalf("ensureClaudeSkillRegistryHook() error = %v", err)
+	}
+
+	text := readFileString(t, settingsPath)
+	if !strings.Contains(text, "|| true") {
+		t.Fatalf("Unix Claude hook should keep bash || true:\n%s", text)
+	}
+	if strings.Contains(text, `"shell"`) {
+		t.Fatalf("Unix Claude hook must not set the shell field:\n%s", text)
+	}
+}
+
+// TestEnsureClaudeSkillRegistryHookMigratesBashToPowerShell proves that a hook
+// installed as the bash variant on a prior sync is replaced (not duplicated) when
+// the same settings are later synced on Windows (issue #2124).
+func TestEnsureClaudeSkillRegistryHookMigratesBashToPowerShell(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// First sync on a Unix host writes the bash variant.
+	withSkillRegistryHookGOOS(t, "linux")
+	if _, err := ensureClaudeSkillRegistryHook(settingsPath); err != nil {
+		t.Fatalf("first (unix) sync error = %v", err)
+	}
+
+	// Later sync on Windows must replace the stale bash hook.
+	withSkillRegistryHookGOOS(t, "windows")
+	changed, err := ensureClaudeSkillRegistryHook(settingsPath)
+	if err != nil {
+		t.Fatalf("second (windows) sync error = %v", err)
+	}
+	if !changed {
+		t.Fatal("windows sync changed = false, want true (migration)")
+	}
+
+	text := readFileString(t, settingsPath)
+	if strings.Contains(text, "|| true") {
+		t.Fatalf("stale bash hook was not removed on migration:\n%s", text)
+	}
+	if strings.Count(text, "gentle-ai skill-registry refresh") != 1 {
+		t.Fatalf("migration duplicated the hook instead of replacing it:\n%s", text)
+	}
+	if !strings.Contains(text, `"shell": "powershell"`) {
+		t.Fatalf("migrated hook should be the PowerShell variant:\n%s", text)
+	}
+
+	// A repeat Windows sync is idempotent.
+	changed, err = ensureClaudeSkillRegistryHook(settingsPath)
+	if err != nil {
+		t.Fatalf("third (windows) sync error = %v", err)
+	}
+	if changed {
+		t.Fatal("repeat windows sync changed = true, want false (idempotent)")
+	}
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6424,6 +6424,72 @@ func TestEnsureCodexSkillRegistryHookWritesSessionStartHookIdempotently(t *testi
 	}
 }
 
+// TestEnsureCodexSkillRegistryHookMigratesBashOnlyLegacyHook verifies that a
+// legacy Codex hook with the correct bash command but no commandWindows
+// override is detected as stale and migrated so Windows Codex gets the
+// PowerShell-safe command (CodeRabbit finding, issue #2124).
+func TestEnsureCodexSkillRegistryHookMigratesBashOnlyLegacyHook(t *testing.T) {
+	home := t.TempDir()
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Legacy hook: has the correct bash command but NO commandWindows override.
+	// Without the migration fix, pruneStaleSkillRegistryHooks would consider
+	// this "current" and skip writing the Windows override.
+	initial := `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {"type": "command", "command": "gentle-ai skill-registry refresh --quiet --no-gitignore --cwd \"$PWD\" || true", "timeout": 30, "statusMessage": "Refreshing skill registry"}
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(hooksPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := ensureCodexSkillRegistryHook(hooksPath)
+	if err != nil {
+		t.Fatalf("ensureCodexSkillRegistryHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed = true for legacy bash-only hook migration, got false")
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+
+	// The migrated hook must now have the commandWindows override.
+	if strings.Count(text, `"commandWindows"`) != 1 {
+		t.Fatalf("legacy hook should be migrated to include commandWindows:\n%s", text)
+	}
+	if !strings.Contains(text, "; exit 0") {
+		t.Fatalf("migrated commandWindows should be PowerShell-safe (exit 0):\n%s", text)
+	}
+	// There must be exactly one skill-registry hook entry (the stale one was
+	// replaced, not duplicated).
+	if strings.Count(text, `"statusMessage": "Refreshing skill registry"`) != 1 {
+		t.Fatalf("expected exactly one skill-registry hook entry after migration:\n%s", text)
+	}
+
+	// Second call must be idempotent — the now-complete hook is current.
+	changed, err = ensureCodexSkillRegistryHook(hooksPath)
+	if err != nil {
+		t.Fatalf("second ensureCodexSkillRegistryHook() error = %v", err)
+	}
+	if changed {
+		t.Fatal("second call changed = true, want false (idempotent after migration)")
+	}
+}
+
 // withSkillRegistryHookGOOS overrides the injected GOOS for the duration of a
 // test and restores it afterward, mirroring the runtimeGOOS pattern in
 // internal/components/filemerge (issue #2124).


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2124

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

The skill-registry hook that gentle-ai writes for Claude Code and Codex used bash syntax (`|| true` and `${CLAUDE_PROJECT_DIR:-$PWD}`) that Windows PowerShell 5.1 rejects with a parser error. On Windows without Git Bash, both agents run shell-form hooks through PowerShell, so the hook failed before gentle-ai ever ran, and `skill-registry refresh` never executed.

Each agent uses its own contract for a Windows-safe command:

- **Claude Code** command hooks accept a `shell: "bash" | "powershell"` field. On Windows we emit a PowerShell-safe command (using `$env:CLAUDE_PROJECT_DIR` and `exit 0`) tagged with `"shell": "powershell"`, so Claude Code runs it through PowerShell deterministically regardless of Git Bash presence. Other platforms keep the bash command.
- **Codex** hooks use a `commandWindows` field (a Windows-only command override). We keep the bash `command` and add a PowerShell-safe `commandWindows`.

An already-installed bash-only hook is migrated (replaced, not duplicated) on the next sync, so users who already have the old hook don't end up with two entries. `runtime.GOOS` is injected via a package-level var so the Windows and Unix shapes are unit-testable without build tags (mirroring the `runtimeGOOS` pattern in `internal/components/filemerge`).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/inject.go` | Per-platform hook command generation for Claude (`shell` field) and Codex (`commandWindows`); new `pruneStaleSkillRegistryHooks` migrates/dedupes old hook variants; injectable `skillRegistryHookGOOS`; removed now-unused `claudeHookExists`/`claudeHookListContains`. |
| `internal/components/sdd/inject_test.go` | New tests for Windows PowerShell shape, Unix bash shape, and bash→PowerShell migration/idempotency; updated the existing Codex test for the `command` + `commandWindows` shape. |

---

## 🧪 Test Plan

**Unit Tests**

Ran the affected packages (the only two that reference these hooks):

```bash
go test ./internal/components/sdd/ ./internal/components/uninstall/   # ok
go build ./...                                                        # ok
go run ./internal/gofmtcheck                                          # ok (exit 0)
```

The full `go test ./...` exceeds a local 10-minute window on this machine (e2e-heavy), so I relied on CI for the complete workspace run. I verified the two packages that reference `installSkillRegistryAutomation` / the hook functions.

**Benchmark Validation**

N/A — this change does not touch review-lifecycle, gates, recovery, delivery, or the benchmark corpus/classifier. It only changes how the skill-registry hook command string is generated per platform.

- [x] Unit tests pass for affected packages (`go test ./internal/components/sdd/ ./internal/components/uninstall/`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; deferring to CI
- [ ] Manually tested on Windows PowerShell 5.1 — I'm on macOS and can't run PS 5.1 end-to-end (see the question in the issue thread). Generation logic is covered by `runtime.GOOS`-injected unit tests.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (286 changed)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass for affected packages
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — deferring to CI
- [x] Benchmark validation N/A (explained above)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

I raised two design questions in the issue thread (issuecomment-5225409015) before implementing and went with the explicit per-platform approach (`shell` for Claude, `commandWindows` for Codex). Happy to switch to a shell-neutral command if you'd prefer that.

Two things worth a close look:
1. The migration path in `pruneStaleSkillRegistryHooks` — it removes any prior gentle-ai skill-registry hook variant (matched by the `gentle-ai skill-registry refresh` marker) whose command differs from the current-platform command, so a user upgrading from the bash-only hook gets it replaced rather than duplicated.
2. I can't validate PowerShell 5.1 end-to-end on macOS. If you have a Windows environment, a manual check that the generated hook actually runs under PS 5.1 would be valuable before merge.

This change is in `internal/components/sdd`, not `internal/cli` / `internal/reviewtransaction` / `internal/sddstatus`, so the guard-population reviewer items don't apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill-registry hooks now support platform-specific Bash and PowerShell commands.
  * Windows environments use PowerShell commands where appropriate.
* **Bug Fixes**
  * Prevented duplicate hooks during installation and synchronization.
  * Automatically migrates outdated hook variants.
  * Removes obsolete managed hooks and empty matcher groups.
  * Improved consistent hook behavior across repeated synchronizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->