### PR TITLE
fix(agent): write Claude workspace MCP servers to .mcp.json

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1844,6 +1844,14 @@ func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection m
 				paths[path] = struct{}{}
 			}
 		}
+		if component == model.ComponentContext7 && scope == ScopeWorkspace {
+			for _, adapter := range adapters {
+				targetDir := componentPathDirScoped(homeDir, workspaceDir, scope, adapter, model.ComponentContext7)
+				if path := mcp.ClaudeWorkspaceInertSettingsPath(targetDir, adapter); path != "" {
+					paths[path] = struct{}{}
+				}
+			}
+		}
 	}
 	// Routing guidance is delivered per agent outside the component loop, so a
 	// selection whose components do not happen to cover the same file would be

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2076,9 +2076,11 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 					if targetDir == homeDir {
 						// Context7 injection writes ~/.claude.json (issue #1868).
 						paths = append(paths, claude.UserConfigPath(homeDir))
-					} else if p := adapter.SettingsPath(targetDir); p != "" {
-						// Workspace scope keeps the scoped settings merge.
-						paths = append(paths, p)
+					} else {
+						// Workspace scope writes <workspace>/.mcp.json, the file
+						// Claude Code reads project-scoped MCP servers from
+						// (issue #2213).
+						paths = append(paths, filepath.Join(targetDir, ".mcp.json"))
 					}
 					break
 				}

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -387,9 +387,34 @@ func TestComponentPathsContext7ClaudeRespectsWorkspaceScope(t *testing.T) {
 
 	paths := componentPathsWithWorkspaceScoped(home, workspace, ScopeWorkspace, model.Selection{}, adapters, model.ComponentContext7)
 
-	want := filepath.Join(workspace, ".claude", "settings.json")
+	want := filepath.Join(workspace, ".mcp.json")
 	if !containsPath(paths, want) {
 		t.Fatalf("componentPathsWithWorkspaceScoped(context7,claude) with ScopeWorkspace missing %q\npaths=%v", want, paths)
+	}
+	unwanted := filepath.Join(workspace, ".claude", "settings.json")
+	if containsPath(paths, unwanted) {
+		t.Fatalf("componentPathsWithWorkspaceScoped(context7,claude) must not require backup-only cleanup path %q\npaths=%v", unwanted, paths)
+	}
+}
+
+func TestBackupTargetsContext7ClaudeWorkspaceIncludesInertSettingsCleanup(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	selection := model.Selection{Agents: []model.AgentID{model.AgentClaudeCode}, Components: []model.ComponentID{model.ComponentContext7}}
+	resolved := planner.ResolvedPlan{Agents: selection.Agents, OrderedComponents: selection.Components}
+
+	targets, err := backupTargets(home, workspace, ScopeWorkspace, selection, resolved)
+	if err != nil {
+		t.Fatalf("backupTargets() error = %v", err)
+	}
+
+	for _, want := range []string{
+		filepath.Join(workspace, ".mcp.json"),
+		filepath.Join(workspace, ".claude", "settings.json"),
+	} {
+		if !containsPath(targets, want) {
+			t.Fatalf("backupTargets(context7,claude,workspace) missing %q\ntargets=%v", want, targets)
+		}
 	}
 }
 

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -2605,9 +2605,19 @@ func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
 		t.Fatalf("post-apply verification failed for Context7 workspace scope: %#v", result.Verify)
 	}
 
-	// Assert that Context7 MCP configuration was persisted to workspace-scoped Claude settings.
+	// Context7 MCP config must be persisted to workspace-scoped .mcp.json, the
+	// file Claude Code reads project-scoped MCP servers from (issue #2213).
+	workspaceMCPFile := filepath.Join(workspace, ".mcp.json")
+	assertFileContains(t, workspaceMCPFile, "context7")
+
+	// It must NOT be written to the inert workspace settings.json.
 	workspaceSettingsFile := filepath.Join(workspace, ".claude", "settings.json")
-	assertFileContains(t, workspaceSettingsFile, "context7")
+	if _, err := os.Stat(workspaceSettingsFile); err == nil {
+		content, _ := os.ReadFile(workspaceSettingsFile)
+		if strings.Contains(string(content), "context7") {
+			t.Errorf("Context7 must not be written to inert workspace settings.json: %q", workspaceSettingsFile)
+		}
+	}
 
 	// Assert that no Context7 configuration was written to home directory settings.
 	homeSettingsFile := filepath.Join(home, ".claude", "settings.json")

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -2556,15 +2556,21 @@ func TestRunInstallWorkspaceScopeVerification(t *testing.T) {
 // TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace verifies that executing
 // a real workspace operation with --scope workspace and Context7 component:
 // 1. Returns a successful result with verification ready.
-// 2. Persists Context7 MCP configuration directly into the workspace-managed settings file.
+// 2. Persists Context7 MCP configuration directly into workspace .mcp.json.
 // 3. Leaves the user's home directory settings untouched.
 func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
 	home := t.TempDir()
+	resolvedHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatalf("resolve temp home: %v", err)
+	}
+	home = resolvedHome
 	workspace := t.TempDir()
 
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
+	restoreBackupHome := backup.UserHomeDirFn
 	originalCwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get current working directory: %v", err)
@@ -2574,12 +2580,14 @@ func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
 		osUserHomeDir = restoreHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
+		backup.UserHomeDirFn = restoreBackupHome
 		if err := os.Chdir(originalCwd); err != nil {
 			t.Errorf("failed to restore working directory: %v", err)
 		}
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) {
 		return "/usr/local/bin/" + name, nil
@@ -2630,15 +2638,21 @@ func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
 }
 
 // TestRunInstall_Context7WorkspaceScope_FailurePath verifies that executing
-// Context7 workspace installation when workspace target is unwriteable fails gracefully,
-// returning an error and reporting verification failure.
+// Context7 workspace installation when the workspace .mcp.json target is invalid
+// fails gracefully.
 func TestRunInstall_Context7WorkspaceScope_FailurePath(t *testing.T) {
 	home := t.TempDir()
+	resolvedHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatalf("resolve temp home: %v", err)
+	}
+	home = resolvedHome
 	workspace := t.TempDir()
 
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
+	restoreBackupHome := backup.UserHomeDirFn
 	originalCwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get current working directory: %v", err)
@@ -2648,12 +2662,14 @@ func TestRunInstall_Context7WorkspaceScope_FailurePath(t *testing.T) {
 		osUserHomeDir = restoreHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
+		backup.UserHomeDirFn = restoreBackupHome
 		if err := os.Chdir(originalCwd); err != nil {
 			t.Errorf("failed to restore working directory: %v", err)
 		}
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) {
 		return "/usr/local/bin/" + name, nil
@@ -2663,10 +2679,10 @@ func TestRunInstall_Context7WorkspaceScope_FailurePath(t *testing.T) {
 		t.Fatalf("failed to change working directory to temp workspace: %v", err)
 	}
 
-	// Create .claude as a read-only file (not directory) so writing settings.json fails.
-	claudePath := filepath.Join(workspace, ".claude")
-	if err := os.WriteFile(claudePath, []byte("blocking directory creation"), 0o444); err != nil {
-		t.Fatalf("failed to block workspace .claude path: %v", err)
+	// Create .mcp.json as a directory so writing the workspace MCP config fails.
+	mcpPath := filepath.Join(workspace, ".mcp.json")
+	if err := os.Mkdir(mcpPath, 0o755); err != nil {
+		t.Fatalf("failed to block workspace .mcp.json path: %v", err)
 	}
 
 	args := []string{
@@ -2678,6 +2694,6 @@ func TestRunInstall_Context7WorkspaceScope_FailurePath(t *testing.T) {
 
 	_, err = RunInstall(args, system.DetectionResult{})
 	if err == nil {
-		t.Fatalf("RunInstall() with unwriteable workspace target expected error, got nil")
+		t.Fatalf("RunInstall() with invalid workspace .mcp.json target expected error, got nil")
 	}
 }

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -300,13 +300,22 @@ func injectClaudeWorkspaceConfig(targetDir string, adapter agents.Adapter) (Inje
 	// Best-effort cleanup of the inert mcpServers block previously written to
 	// settings.json. A settings file that cannot be rewritten must not fail the
 	// .mcp.json injection that already succeeded above.
-	settingsPath := adapter.SettingsPath(targetDir)
+	settingsPath := ClaudeWorkspaceInertSettingsPath(targetDir, adapter)
 	if settingsChanged, cleanupErr := removeInertSettingsMCPServers(settingsPath); cleanupErr == nil && settingsChanged {
 		changed = true
 		files = append(files, settingsPath)
 	}
 
 	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
+// ClaudeWorkspaceInertSettingsPath is the backup-only cleanup target for the
+// legacy workspace settings location that earlier Context7 injection wrote.
+func ClaudeWorkspaceInertSettingsPath(targetDir string, adapter agents.Adapter) string {
+	if adapter.Agent() != model.AgentClaudeCode || adapter.MCPStrategy() != model.StrategySeparateMCPFiles {
+		return ""
+	}
+	return adapter.SettingsPath(targetDir)
 }
 
 // removeInertSettingsMCPServers deletes the inert top-level mcpServers key

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
@@ -34,7 +35,7 @@ func Inject(homeDir, targetDir string, adapter agents.Adapter) (InjectionResult,
 			if targetDir == homeDir {
 				return injectClaudeUserConfig(homeDir, adapter)
 			}
-			return injectMergeIntoSettings(targetDir, adapter)
+			return injectClaudeWorkspaceConfig(targetDir, adapter)
 		}
 		return injectSeparateFile(targetDir, adapter)
 	case model.StrategyMergeIntoSettings:
@@ -271,6 +272,35 @@ func injectClaudeUserConfig(homeDir string, adapter agents.Adapter) (InjectionRe
 	// Best-effort: the block is inert, so a settings.json that cannot be
 	// rewritten must not fail the injection that already succeeded above.
 	settingsPath := adapter.SettingsPath(homeDir)
+	if settingsChanged, cleanupErr := removeInertSettingsMCPServers(settingsPath); cleanupErr == nil && settingsChanged {
+		changed = true
+		files = append(files, settingsPath)
+	}
+
+	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
+// injectClaudeWorkspaceConfig registers Context7 as a project-scoped MCP server
+// in <workspace>/.mcp.json, the location Claude Code reads workspace-scoped MCP
+// servers from. Earlier versions merged the entry into <workspace>/.claude/
+// settings.json, which Claude Code silently ignores for MCP discovery, so this
+// mirrors the user-scope fix in injectClaudeUserConfig for workspace scope
+// (issue #2213, sibling of #1868). The managed entry is merged so unrelated
+// project servers are preserved, and the project server is not auto-approved —
+// Claude Code requires native project approval on first use.
+func injectClaudeWorkspaceConfig(targetDir string, adapter agents.Adapter) (InjectionResult, error) {
+	mcpPath := filepath.Join(targetDir, ".mcp.json")
+	writeResult, err := mergeJSONFile(mcpPath, DefaultContext7OverlayJSON())
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	changed := writeResult.Changed
+	files := []string{mcpPath}
+	// Best-effort cleanup of the inert mcpServers block previously written to
+	// settings.json. A settings file that cannot be rewritten must not fail the
+	// .mcp.json injection that already succeeded above.
+	settingsPath := adapter.SettingsPath(targetDir)
 	if settingsChanged, cleanupErr := removeInertSettingsMCPServers(settingsPath); cleanupErr == nil && settingsChanged {
 		changed = true
 		files = append(files, settingsPath)

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -624,6 +624,142 @@ func TestInjectClaudeRefusesCorruptUserConfig(t *testing.T) {
 	}
 }
 
+// TestInjectClaudeWorkspaceWritesMCPJson: workspace-scope injection
+// (targetDir != homeDir) must register context7 in <workspace>/.mcp.json — the
+// file Claude Code reads project-scoped MCP servers from — and must not leave a
+// managed mcpServers block in <workspace>/.claude/settings.json (issue #2213).
+func TestInjectClaudeWorkspaceWritesMCPJson(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	mcpPath := filepath.Join(workspace, ".mcp.json")
+
+	first, err := Inject(home, workspace, claudeAdapter())
+	if err != nil {
+		t.Fatalf("Inject() first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject() first changed = false; want true")
+	}
+
+	raw, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("workspace .mcp.json must be written; ReadFile error = %v", err)
+	}
+	root := map[string]any{}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("Unmarshal(.mcp.json) error = %v", err)
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	context7, _ := servers["context7"].(map[string]any)
+	if context7["command"] != "npx" {
+		t.Fatalf(".mcp.json mcpServers.context7.command = %#v; want npx", context7["command"])
+	}
+	if args := fmt.Sprintf("%v", context7["args"]); !strings.Contains(args, versions.Context7MCP) {
+		t.Fatalf("context7.args = %s; want pinned version %s", args, versions.Context7MCP)
+	}
+
+	// The managed entry must NOT be written to the inert settings.json.
+	settingsPath := filepath.Join(workspace, ".claude", "settings.json")
+	if settingsRaw, statErr := os.ReadFile(settingsPath); statErr == nil {
+		settings := map[string]any{}
+		if err := json.Unmarshal(settingsRaw, &settings); err == nil {
+			if _, hasMCP := settings["mcpServers"]; hasMCP {
+				t.Fatalf("workspace settings.json must not carry the managed mcpServers block; got %s", settingsRaw)
+			}
+		}
+	}
+
+	// Idempotent second run.
+	second, err := Inject(home, workspace, claudeAdapter())
+	if err != nil {
+		t.Fatalf("Inject() second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject() second changed = true; want false (idempotent)")
+	}
+}
+
+// TestInjectClaudeWorkspacePreservesForeignServers: an existing .mcp.json with
+// an unrelated MCP server must keep that server after the managed context7 entry
+// is merged in (issue #2213).
+func TestInjectClaudeWorkspacePreservesForeignServers(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	mcpPath := filepath.Join(workspace, ".mcp.json")
+	existing := `{"mcpServers":{"my-server":{"command":"my-own-server","args":["--serve"]}}}`
+	if err := os.WriteFile(mcpPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing .mcp.json) error = %v", err)
+	}
+
+	if _, err := Inject(home, workspace, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("ReadFile(.mcp.json) error = %v", err)
+	}
+	root := map[string]any{}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("Unmarshal(.mcp.json) error = %v", err)
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	if mine, _ := servers["my-server"].(map[string]any); mine["command"] != "my-own-server" {
+		t.Fatalf("unrelated my-server must be preserved; got %#v", servers["my-server"])
+	}
+	if context7, _ := servers["context7"].(map[string]any); context7["command"] != "npx" {
+		t.Fatalf("managed context7 must be merged in; got %#v", servers["context7"])
+	}
+}
+
+// TestInjectClaudeWorkspaceCleansInertSettings: a managed mcpServers block left
+// in workspace settings.json by an earlier version is removed once the real
+// registration lives in .mcp.json, while a foreign block is left untouched
+// (issue #2213).
+func TestInjectClaudeWorkspaceCleansInertSettings(t *testing.T) {
+	cases := []struct {
+		name           string
+		settings       string
+		wantKeyRemoved bool
+	}{
+		{"managed-only block is removed", `{"theme":"dark","mcpServers":{"context7":{"command":"npx","args":["--","context7-mcp"]}}}`, true},
+		{"foreign block is left alone", `{"theme":"dark","mcpServers":{"stranded":{"command":"stranded-server"}}}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			settingsPath := filepath.Join(workspace, ".claude", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(settings dir) error = %v", err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(tc.settings), 0o644); err != nil {
+				t.Fatalf("WriteFile(settings) error = %v", err)
+			}
+
+			if _, err := Inject(home, workspace, claudeAdapter()); err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+
+			settingsRaw, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("ReadFile(settings) error = %v", err)
+			}
+			settings := map[string]any{}
+			if err := json.Unmarshal(settingsRaw, &settings); err != nil {
+				t.Fatalf("Unmarshal(settings) error = %v", err)
+			}
+			_, hasKey := settings["mcpServers"]
+			if tc.wantKeyRemoved && hasKey {
+				t.Fatalf("inert mcpServers key must be removed; got %s", settingsRaw)
+			}
+			if !tc.wantKeyRemoved && !hasKey {
+				t.Fatalf("foreign mcpServers block must be left untouched; got %s", settingsRaw)
+			}
+		})
+	}
+}
+
 func TestInjectCursorWithMalformedMCPJsonRecovery(t *testing.T) {
 	// Real Windows users may have a ~/.cursor/mcp.json that starts with non-JSON
 	// content (e.g. "allow: all" or just "a"). The installer should recover by


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2213

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Workspace-scoped Context7 injection for Claude Code merged `mcpServers` into `<workspace>/.claude/settings.json`, a file Claude Code ignores for MCP discovery. Installation and file-level verification looked successful while `claude mcp list` reported no configured server.

This mirrors the user-scope fix from #1868 for workspace scope:

- Write the managed entry to `<workspace>/.mcp.json` — the file Claude Code reads project-scoped MCP servers from — preserving unrelated servers via the existing JSON merge.
- Clean up the inert `mcpServers` block previously written to `settings.json`, reusing `removeInertSettingsMCPServers` (only removes it when it holds nothing beyond the managed `context7` entry, so user-authored servers are never touched).
- The project server is **not** auto-approved; Claude Code requires native project approval on first use, so this only writes the file.
- Post-apply verification now checks `<workspace>/.mcp.json` for Claude workspace scope.

The existing `DefaultContext7OverlayJSON()` already produces the `{ "mcpServers": { "context7": ... } }` shape `.mcp.json` expects, so no new overlay was needed.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/mcp/inject.go` | New `injectClaudeWorkspaceConfig` writes/merges the managed entry into `<workspace>/.mcp.json` and cleans up the inert `settings.json` block; `Inject` routes Claude workspace scope to it. |
| `internal/cli/run.go` | Post-apply verification for Claude workspace-scope Context7 now checks `<workspace>/.mcp.json` instead of the inert `settings.json`. |
| `internal/components/mcp/inject_test.go` | New tests: writes to `.mcp.json` (not `settings.json`), preserves unrelated servers, idempotency, and inert-block cleanup. |
| `internal/cli/run_integration_test.go` | Updated the workspace-scope assertion to expect `.mcp.json`. |

---

## 🧪 Test Plan

```bash
go test ./internal/components/mcp/   # ok — includes the 3 new workspace tests
go build ./...                       # ok
go run ./internal/gofmtcheck         # ok (exit 0)
go vet ./internal/components/mcp/ ./internal/cli/   # ok
```

**Transparency on the CLI integration tests:** four `internal/cli` integration tests that touch this area (`TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace`, `TestRunInstallWorkspaceScopeVerification`, `TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets`, `TestRunInstallEngramFallsBackToInjectWhenSetupFails`) fail on my local macOS machine with `review store lock could not be acquired: not a directory` (from `store_lock.go`). I verified this is a **pre-existing environment failure, not caused by this change**: the same tests fail identically on a clean `main` checkout with my changes stashed, on both a linked worktree and the primary clone. I've updated the workspace-scope assertion to expect `.mcp.json`, but I can't confirm the pass locally because of that lock. Deferring to CI for the full integration run — happy to dig further if it reproduces there.

**Benchmark Validation:** N/A — this change is limited to MCP config file placement for Claude workspace scope; it does not touch review-lifecycle, gates, recovery, delivery, or the benchmark corpus.

- [x] Unit tests pass for the affected package (`go test ./internal/components/mcp/`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — not run locally; deferring to CI
- [x] Manually verifiable on macOS (matches the issue environment) via `claude mcp list`

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (190 changed)
- [x] I have added the appropriate `type:*` label to this PR (needs maintainer to apply — external contributors can't set labels)
- [x] Unit tests pass for the affected package
- [x] Go format passes
- [ ] E2E tests pass — deferring to CI
- [x] Benchmark validation N/A (explained above)
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is the workspace-scope sibling of #1868 (which fixed user scope). The pattern is intentionally identical: write to the file Claude actually reads, then best-effort clean up the inert block, preserving anything the user authored.

Please take a look at the `store_lock` integration-test failure I described in the Test Plan — if it doesn't reproduce in CI, great; if it does, it looks like a separate pre-existing issue worth its own report rather than something this PR introduced.

This change is in `internal/components/mcp` and `internal/cli` post-apply verification, not `internal/reviewtransaction` / `internal/sddstatus`, so the guard-population reviewer items don't apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace-scoped Context7 configuration is now stored in the workspace’s `.mcp.json` file.
  - Existing MCP servers are preserved during configuration updates.
  - Obsolete managed entries are cleaned up from legacy workspace settings without removing unrelated entries.
  - Repeated configuration updates remain safe and consistent.
  - Workspace configuration backups now include the active MCP configuration and legacy settings needed for cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->