### PR TITLE
test(sdd): canonicalize handoff worktree paths

### DIFF
--- a/internal/sddstatus/runtime_ledger_worktree_binding_test.go
+++ b/internal/sddstatus/runtime_ledger_worktree_binding_test.go
@@ -94,6 +94,8 @@ func TestRuntimeLedgerFinishRefusesDelegatedWorktreeUntilHandoff(t *testing.T) {
 
 func TestRuntimeLedgerHandoffAtomicallyBindsDelegatedLinkedWorktree(t *testing.T) {
 	_, worktree, storeA, _, began := newRuntimeLedgerHandoffFixture(t, "handoff-atomic")
+	originWorktree := canonicalRuntimeLedgerWorktreePath(t, storeA.Workspace)
+	destinationWorktree := canonicalRuntimeLedgerWorktreePath(t, worktree)
 
 	handedOff, err := storeA.Handoff(context.Background(), HandoffAttemptRequest{
 		ExpectedRevision: began.Revision, RequestID: "handoff-a-to-b", DestinationWorktree: worktree,
@@ -106,11 +108,13 @@ func TestRuntimeLedgerHandoffAtomicallyBindsDelegatedLinkedWorktree(t *testing.T
 		t.Fatalf("handoff must append exactly one uncharged record: %#v", handedOff)
 	}
 	active := handedOff.ActiveAttempt
-	if active == nil || active.BeginWorktree != storeA.Workspace || active.EffectiveWorktree != worktree || active.Handoff == nil {
+	if active == nil || canonicalRuntimeLedgerWorktreePath(t, active.BeginWorktree) != originWorktree ||
+		canonicalRuntimeLedgerWorktreePath(t, active.EffectiveWorktree) != destinationWorktree || active.Handoff == nil {
 		t.Fatalf("handoff active attempt = %#v", active)
 	}
 	if active.BeginCandidateIdentity != began.ActiveAttempt.BeginCandidateIdentity || active.BeginCandidateTree != began.ActiveAttempt.BeginCandidateTree ||
-		active.Handoff.SourceWorktree != storeA.Workspace || active.Handoff.DestinationWorktree != worktree ||
+		canonicalRuntimeLedgerWorktreePath(t, active.Handoff.SourceWorktree) != originWorktree ||
+		canonicalRuntimeLedgerWorktreePath(t, active.Handoff.DestinationWorktree) != destinationWorktree ||
 		active.Handoff.ExpectedRevision != began.Revision || active.Handoff.DestinationCandidateIdentity == "" || active.Handoff.DestinationCandidateTree == "" {
 		t.Fatalf("handoff provenance = %#v", active)
 	}
@@ -122,13 +126,16 @@ func TestRuntimeLedgerHandoffAtomicallyBindsDelegatedLinkedWorktree(t *testing.T
 		t.Fatalf("handoff record = %#v", record)
 	}
 	replay, err := storeA.Status()
-	if err != nil || replay.Revision != handedOff.Revision || replay.ActiveAttempt == nil || replay.ActiveAttempt.EffectiveWorktree != worktree {
+	if err != nil || replay.Revision != handedOff.Revision || replay.ActiveAttempt == nil ||
+		canonicalRuntimeLedgerWorktreePath(t, replay.ActiveAttempt.EffectiveWorktree) != destinationWorktree {
 		t.Fatalf("handoff replay = %#v err=%v", replay, err)
 	}
 }
 
 func TestRuntimeLedgerHandoffPreservesOriginAndChargesOnlyFinalSettlement(t *testing.T) {
 	_, worktree, storeA, storeB, began := newRuntimeLedgerHandoffFixture(t, "handoff-final-charge")
+	originWorktree := canonicalRuntimeLedgerWorktreePath(t, storeA.Workspace)
+	destinationWorktree := canonicalRuntimeLedgerWorktreePath(t, worktree)
 	handedOff, err := storeA.Handoff(context.Background(), HandoffAttemptRequest{
 		ExpectedRevision: began.Revision, RequestID: "handoff-final-charge", DestinationWorktree: worktree,
 	})
@@ -147,8 +154,8 @@ func TestRuntimeLedgerHandoffPreservesOriginAndChargesOnlyFinalSettlement(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(finished.Attempts) != 1 || finished.Attempts[0].BeginWorktree != storeA.Workspace ||
-		finished.Attempts[0].EffectiveWorktree != worktree || finished.Attempts[0].ChangedLines != 1 ||
+	if len(finished.Attempts) != 1 || canonicalRuntimeLedgerWorktreePath(t, finished.Attempts[0].BeginWorktree) != originWorktree ||
+		canonicalRuntimeLedgerWorktreePath(t, finished.Attempts[0].EffectiveWorktree) != destinationWorktree || finished.Attempts[0].ChangedLines != 1 ||
 		finished.CumulativeAttempts != 1 || finished.CumulativeChangedLines != 1 {
 		t.Fatalf("final handoff settlement = %#v", finished)
 	}


### PR DESCRIPTION
## Linked Issue

Closes #2783

## PR Type

- [x] `type:chore` - Test maintenance

## Summary

Production already canonicalizes worktree paths. Two Windows-sensitive handoff tests compared raw fixture paths with canonical paths stored by the runtime ledger.

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/sddstatus/runtime_ledger_worktree_binding_test.go` | Canonicalizes the four affected handoff assertion groups through the existing helper before comparison. |

No production, workflow, or healthprobe changes are included.

## Test Plan

- [x] Two target tests with `-count=1`: PASS.
- [x] Two target tests with `-count=10`: PASS.
- [x] Neighboring rejection, replay, and finish tests: PASS.
- [ ] Local `rest` shard: PARTIAL because `sh`/WSL is unavailable, global review is disabled, and a separate healthprobe race remains.
- [ ] Full `go test ./...`: not clean locally because of those unrelated environment and healthprobe failures.
- [ ] E2E: not run; this is an internal assertion-only correction with no product or workflow change.
- [x] Benchmark validation: N/A, no benchmark-facing behavior changed.

Healthprobe remains a separate issue. Root 17 closure still requires CI on exact SHA `9278cd45dc6e877f8d390113caa7c7e7e78b70e6`.

## Contributor Checklist

- [x] PR links approved issue #2783.
- [x] PR is within the 400 changed-line budget (17 lines).
- [x] Exactly one permitted `type:*` label is applied.
- [x] Commit follows Conventional Commits and has no `Co-Authored-By` trailer.
- [x] Scope is limited to the test correction described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved runtime-ledger handoff test reliability by comparing standardized worktree paths.
  * Preserved validation of handoff provenance, active attempts, replay behavior, final settlement, and changed-line accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->