### PR TITLE
fix(install): add preflight check for agent runtimes

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2512,34 +2512,41 @@ func (s checkDependenciesStep) Run() error {
 	// failing with real error messages.
 	_ = system.DetectDependencies(context.Background(), s.profile)
 	for _, agent := range s.selection.Agents {
-		// Only Pi still executes anything on the user's behalf (its own
-		// already-present `pi` subcommands, which need npm/pnpm — see
-		// agentInstallStep). Every other agent's "not installed" outcome is
-		// now a printed refusal, which needs no local dependency at all, so
-		// failing this whole pipeline early over an unrelated agent's
-		// missing npm/uv would abort work agentInstallStep would otherwise
-		// complete correctly by just naming the command.
-		if agent != model.AgentPi {
-			continue
-		}
-
 		adapter, err := agents.NewAdapter(agent)
 		if err != nil {
 			return fmt.Errorf("create adapter for %q: %w", agent, err)
 		}
 
-		if s.homeDir != "" {
+		// Preflight: verify the agent runtime is installed (except Pi, which installs its own packages).
+		// This fails fast with a clear error message instead of letting
+		// the pipeline proceed only to refuse at agentInstallStep.
+		if s.homeDir != "" && agent != model.AgentPi {
 			installed, _, _, _, err := adapter.Detect(context.Background(), s.homeDir)
 			if err != nil {
 				return fmt.Errorf("detect agent %q: %w", agent, err)
 			}
-			if installed {
-				continue
+			if !installed {
+				// Agent not installed - provide actionable error with install command.
+				commands, cmdErr := adapter.InstallCommand(s.profile)
+				if cmdErr != nil {
+					return fmt.Errorf("agent %q is not installed. Gentle-AI does not install agent runtimes; run this yourself, then retry:\n  (could not resolve install command: %v)", agent, cmdErr)
+				}
+				if len(commands) == 0 {
+					return fmt.Errorf("agent %q is not installed and Gentle-AI has no install command to suggest for this platform", agent)
+				}
+				var lines []string
+				for _, cmd := range commands {
+					lines = append(lines, "  "+strings.Join(cmd, " "))
+				}
+				return fmt.Errorf("agent %q is not installed. Gentle-AI does not install agent runtimes; run this yourself, then retry:\n%s", agent, strings.Join(lines, "\n"))
 			}
 		}
 
-		if err := installcmd.ValidateAgentInstallPreflight(s.profile, agent); err != nil {
-			return fmt.Errorf("preflight for agent %q: %w", agent, err)
+		// Pi has additional preflight requirements (npm/pnpm via pi subcommands).
+		if agent == model.AgentPi {
+			if err := installcmd.ValidateAgentInstallPreflight(s.profile, agent); err != nil {
+				return fmt.Errorf("preflight for agent %q: %w", agent, err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Add a preflight check in `checkDependenciesStep` that verifies agent runtimes are installed before starting the install pipeline. This fails fast with a clear error message instead of letting the pipeline proceed only to refuse at `agentInstallStep`.

## Changes

- Modified `checkDependenciesStep.Run()` in `internal/cli/run.go` to detect all selected agents (except Pi) during preflight
- If an agent is not installed, returns a clear error message with the exact install command
- Pi is excluded from this check because it installs its own packages via `pi install` commands

## Fixes

Fixes #2820

## Testing

- All existing install tests pass
- Manual testing confirms:
  - Installing with an uninstalled agent (e.g., claude-code) fails fast with clear error
  - Installing with an installed agent (e.g., kilocode) works correctly
  - Pi installs still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added dependency checks for all selected agent runtimes before execution.
  * Improved error messages with actionable instructions when a required runtime is missing.
  * Preserved existing dependency validation for Pi agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->