### PR TITLE
fix(review): abandon retired reviewer result lineages

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -627,6 +627,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, reviewedSupersetJourneys()...)
 	journeys = append(journeys, stagedDeliveryJourneys()...)
 	journeys = append(journeys, managedAssetJourneys()...)
+	journeys = append(journeys, issue2539Journeys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_edge.go
+++ b/bench/journeys_edge.go
@@ -796,6 +796,7 @@ type authorityEntry struct {
 	Revision         string                 `json:"revision"`
 	SnapshotIdentity string                 `json:"snapshot_identity"`
 	DiscardedWork    authorityDiscardedWork `json:"discarded_work"`
+	Problems         []string               `json:"problems"`
 }
 
 // entry finds one lineage by name. Journeys that hold more than one authority

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -44,6 +44,7 @@ func journeySources() []journeySource {
 		{"journeys_reviewed_superset.go", reviewedSupersetJourneys()},
 		{"journeys_staged_delivery.go", stagedDeliveryJourneys()},
 		{"journeys_managed_assets.go", managedAssetJourneys()},
+		{"journeys_issue2539.go", issue2539Journeys()},
 	}
 }
 

--- a/bench/journeys_issue2539.go
+++ b/bench/journeys_issue2539.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const issue2539ApprovedLineage = "issue2539:approved-lineage"
+
+func issue2539Journeys() []Journey {
+	return []Journey{{
+		ID:     "j94-retired-reviewer-schema-abandon",
+		Title:  "Retired reviewer-result bytes remain dispositionable without becoming admitted evidence",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/2539",
+		Steps: []Step{
+			{Name: "fixture: repo with remote", Fixture: baseRepoWithRemote},
+			{Name: "fixture: stage unrelated docs", Fixture: stageDocs("unrelated-approved")},
+			{Name: "review unrelated authority", Requires: startCapability, Args: productArgs("review", "start"), After: rememberIssue2539Approved},
+			{Name: "approve unrelated authority", Requires: finalizeCapability, Args: productArgs("review", "finalize")},
+			{Name: "fixture: commit approved docs", Fixture: commitStaged("docs: approved authority")},
+			{Name: "fixture: stage retired review target", Fixture: stageOrdinaryCode},
+			{Name: "review retired-schema target", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
+			{Name: "dispose retired-schema authority", Requires: abandonCapability, Composite: exerciseIssue2539RetiredAbandon},
+		},
+	}}
+}
+
+func rememberIssue2539Approved(sandbox *Sandbox, observation Observation) error {
+	if err := rememberLineage(sandbox, observation); err != nil {
+		return err
+	}
+	sandbox.Scratch[issue2539ApprovedLineage] = sandbox.Lineage
+	return nil
+}
+
+func exerciseIssue2539RetiredAbandon(r *journeyRun) error {
+	const artifactName = "00-review-reliability.json"
+	payload := []byte(`{"lens":"review-reliability","findings":[],"evidence":["inspected stale.go"]}`)
+	authorityRoot, err := issue2539AuthorityRoot(r.sandbox)
+	if err != nil {
+		return err
+	}
+	store := filepath.Join(authorityRoot, "v2", r.sandbox.Lineage)
+	resultDir := filepath.Join(store, "reviewer-results")
+	if err := os.MkdirAll(resultDir, 0o700); err != nil {
+		return err
+	}
+	artifact := filepath.Join(resultDir, artifactName)
+	digest := sha256.Sum256(payload)
+	sidecar := []byte("sha256:" + hex.EncodeToString(digest[:]) + "\n")
+	if err := os.WriteFile(artifact, payload, 0o600); err != nil {
+		return err
+	}
+	if err := os.WriteFile(artifact+".sha256", sidecar, 0o600); err != nil {
+		return err
+	}
+
+	status := r.run([]string{"review", "status", "--cwd", r.sandbox.Repo}, false)
+	if status.ExitCode != 0 {
+		return fmt.Errorf("status rejected retired bytes: %s", firstLine(status.Stderr))
+	}
+	var inventory authorityHead
+	if err := json.Unmarshal([]byte(strings.TrimSpace(status.Stdout)), &inventory); err != nil {
+		return fmt.Errorf("decode status: %w", err)
+	}
+	entry, found := inventory.entry(r.sandbox.Lineage)
+	if !found || len(entry.DiscardedWork.CapturedLensResults) != 1 ||
+		entry.DiscardedWork.CapturedLensResults[0] != artifactName ||
+		entry.DiscardedWork.FindingsPresent || entry.DiscardedWork.EvidenceRecordsPresent {
+		return fmt.Errorf("retired discarded_work = %#v; status problems: %s", entry.DiscardedWork, strings.Join(entry.Problems, "; "))
+	}
+	const actor, reason = "bench", "retired_schema"
+	authorization := renderAbandonAuthorization(entry, actor, reason)
+	stale := r.run([]string{
+		"review", "abandon", "--cwd", r.sandbox.Repo, "--lineage", entry.LineageID,
+		"--expected-revision", "sha256:" + strings.Repeat("0", 64), "--reason", reason,
+		"--actor", actor, "--maintainer-authorization", authorization,
+	}, false)
+	if stale.ExitCode == 0 {
+		return errors.New("stale abandonment binding was accepted")
+	}
+
+	abandoned := r.run([]string{
+		"review", "abandon", "--cwd", r.sandbox.Repo, "--lineage", entry.LineageID,
+		"--expected-revision", entry.Revision, "--reason", reason,
+		"--actor", actor, "--maintainer-authorization", authorization,
+	}, false)
+	if abandoned.ExitCode != 0 {
+		return fmt.Errorf("abandon retired bytes: %s", firstLine(abandoned.Stderr))
+	}
+	var result struct {
+		Record struct {
+			Status         string `json:"status"`
+			QuarantinePath string `json:"quarantine_path"`
+		} `json:"record"`
+	}
+	if err := json.Unmarshal([]byte(abandoned.Stdout), &result); err != nil || result.Record.Status != "committed" {
+		return fmt.Errorf("decode committed abandonment: %#v, %v", result, err)
+	}
+	quarantined := filepath.Join(result.Record.QuarantinePath, "residue", "reviewer-results", artifactName)
+	moved, readErr := os.ReadFile(quarantined)
+	movedSidecar, sidecarErr := os.ReadFile(quarantined + ".sha256")
+	if readErr != nil || sidecarErr != nil || !bytes.Equal(moved, payload) || !bytes.Equal(movedSidecar, sidecar) {
+		return fmt.Errorf("quarantine did not preserve retired bytes whole: artifact=%v sidecar=%v", readErr, sidecarErr)
+	}
+	if _, err := os.Stat(store); !os.IsNotExist(err) {
+		return fmt.Errorf("abandoned authority remains live: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "residue", "review-receipt.json")); !os.IsNotExist(err) {
+		return fmt.Errorf("discarded authority retained a usable receipt: %v", err)
+	}
+	if unusable := r.run([]string{"review", "validate", "--cwd", r.sandbox.Repo, "--lineage", entry.LineageID, "--gate", "post-apply"}, false); unusable.ExitCode == 0 {
+		return errors.New("discarded authority remained usable")
+	}
+	approved := r.run([]string{"review", "validate", "--cwd", r.sandbox.Repo,
+		"--lineage", r.sandbox.Scratch[issue2539ApprovedLineage], "--gate", "pre-push"}, false)
+	if approved.ExitCode != 0 {
+		return fmt.Errorf("unrelated approved authority became unusable: %s", firstLine(approved.Stderr))
+	}
+	return nil
+}
+
+func issue2539AuthorityRoot(sandbox *Sandbox) (string, error) {
+	common, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(strings.TrimSpace(common), "gentle-ai", "review-transactions"), nil
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -50,7 +50,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// proves #2871's correction binds the immutable failure across a later interrupt;
 	// j88 proves #2843's unborn STATUS collects explicit untracked intent first;
 	// j89 proves #2758 never offers a workspace receipt for a different index;
-	// j93 proves #2822 classifies stale managed assets before START can persist.
+	// j93 proves #2822 classifies stale managed assets before START can persist;
+	// j94 proves #2539 abandons retired reviewer-result schemas.
 	// #1993 REMOVED two: j38 (the bound-passing-finish refusal routing to the
 	// review router) and j39 (the stranded-successor exit it named). Review
 	// acts after implementation and verification, so that refusal is gone and
@@ -60,8 +61,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	//
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 87 {
-		t.Errorf("core journey count = %d, want 87", got)
+	if got := len(seen); got != 88 {
+		t.Errorf("core journey count = %d, want 88", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/review_abandon_test.go
+++ b/internal/cli/review_abandon_test.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -142,6 +145,79 @@ func TestReviewAbandonRequiresFlagsAndExactBinding(t *testing.T) {
 	current, err := os.ReadFile(statePath)
 	if err != nil || !bytes.Equal(current, payload) {
 		t.Fatalf("refused abandon mutated the entry: %v", err)
+	}
+}
+
+func TestReviewAbandonDisposesRetiredReviewerResultWithoutRelaxingCurrentAdmission(t *testing.T) {
+	const retired = `{"lens":"review-reliability","findings":[],"evidence":["inspected stale.go"]}`
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string, string, string)
+	}{
+		{name: "retired envelope", setup: func(t *testing.T, repo, lineage, target string) {
+			resultDir := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", lineage, reviewtransaction.CompactReviewerResultsDir)
+			if err := os.MkdirAll(resultDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			payload := []byte(retired)
+			path := filepath.Join(resultDir, "00-review-reliability.json")
+			if err := os.WriteFile(path, payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			digest := sha256.Sum256(payload)
+			if err := os.WriteFile(path+".sha256", []byte("sha256:"+hex.EncodeToString(digest[:])+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "current admitted envelope", setup: func(t *testing.T, repo, lineage, target string) {
+			captureCLIReviewerResult(t, repo, ReviewFacadeStartResult{
+				LineageID: lineage, TargetIdentity: target, SelectedLenses: []string{reviewtransaction.LensReliability},
+			}, 0)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			revision, target := pristineReviewingCLIFixture(t, repo)
+			tt.setup(t, repo, "abandon-stale-reviewing", target)
+
+			var status bytes.Buffer
+			if err := RunReview([]string{"status", "--cwd", repo}, &status); err != nil {
+				t.Fatalf("review status: %v", err)
+			}
+			var report reviewtransaction.AuthorityStatusReport
+			decodeStrictReviewJSON(t, status.Bytes(), &report)
+			if len(report.Entries) != 1 || report.Entries[0].DiscardedWork == nil {
+				t.Fatalf("status entries = %#v", report.Entries)
+			}
+			discarded := *report.Entries[0].DiscardedWork
+			if len(discarded.CapturedLensResults) != 1 || discarded.CapturedLensResults[0] != "00-review-reliability.json" ||
+				discarded.FindingsPresent || discarded.EvidenceRecordsPresent {
+				t.Fatalf("discarded_work = %#v", discarded)
+			}
+
+			const actor = "maintainer@example.com"
+			const reason = reviewtransaction.CompactAbandonReasonRetiredSchema
+			authorization := reviewtransaction.RenderCompactAbandonAuthorization(
+				"abandon-stale-reviewing", revision, target, actor, reason, discarded)
+			var output bytes.Buffer
+			if err := RunReview([]string{
+				"abandon", "--cwd", repo, "--lineage", "abandon-stale-reviewing",
+				"--expected-revision", revision, "--reason", reason, "--actor", actor,
+				"--maintainer-authorization", authorization,
+			}, &output); err != nil {
+				t.Fatalf("review abandon: %v\n%s", err, output.String())
+			}
+			var result ReviewAbandonResult
+			decodeStrictReviewJSON(t, output.Bytes(), &result)
+			if result.Record.Status != reviewtransaction.CompactReclaimCommitted || result.Record.Abandonment == nil ||
+				!reflect.DeepEqual(result.Record.Abandonment.DiscardedWork, discarded) {
+				t.Fatalf("abandon result = %#v", result)
+			}
+			if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "residue", "review-receipt.json")); !os.IsNotExist(err) {
+				t.Fatalf("discarded lineage produced a usable receipt: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/reviewtransaction/compact_abandon.go
+++ b/internal/reviewtransaction/compact_abandon.go
@@ -112,10 +112,8 @@ func compactDiscardedWorkSummary(ctx context.Context, store CompactStore, record
 		return CompactDiscardedWorkSummary{}, errors.New("reviewer result store has no repository")
 	}
 	builder := SnapshotBuilder{Repo: store.repo}
-	frozen, err := builder.FrozenCandidateContext(ctx, record.State.InitialSnapshot)
-	if err != nil {
-		return CompactDiscardedWorkSummary{}, fmt.Errorf("derive frozen reviewer context: %w", err)
-	}
+	var frozen FrozenCandidateContext
+	frozenReady := false
 	for _, name := range captured {
 		payload, _, err := readCompactReviewerArtifact(filepath.Join(store.Dir, CompactReviewerResultsDir, name))
 		if err != nil {
@@ -125,7 +123,15 @@ func compactDiscardedWorkSummary(ctx context.Context, store CompactStore, record
 		decoder := json.NewDecoder(bytes.NewReader(payload))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&envelope); err != nil {
-			return CompactDiscardedWorkSummary{}, fmt.Errorf("decode captured reviewer result %q: %w", name, err)
+			findings, retired, retiredErr := compactRetiredReviewerResultSummary(payload, name, record.State.SelectedLenses)
+			if retiredErr != nil {
+				return CompactDiscardedWorkSummary{}, fmt.Errorf("decode retired captured reviewer result %q: %w", name, retiredErr)
+			}
+			if !retired {
+				return CompactDiscardedWorkSummary{}, fmt.Errorf("decode captured reviewer result %q: %w", name, err)
+			}
+			summary.FindingsPresent = summary.FindingsPresent || findings
+			continue
 		}
 		if err := decoder.Decode(new(struct{})); err != io.EOF ||
 			envelope.Subject.SelectedOrder < 0 || envelope.Subject.SelectedOrder >= len(record.State.SelectedLenses) ||
@@ -133,6 +139,13 @@ func compactDiscardedWorkSummary(ctx context.Context, store CompactStore, record
 			name != fmt.Sprintf("%02d-%s.json", envelope.Subject.SelectedOrder, envelope.Subject.Lens) {
 			// refusal:by-design world-action: malformed persisted reviewer bytes cannot be safely discarded as admitted work
 			return CompactDiscardedWorkSummary{}, fmt.Errorf("decode captured reviewer result %q", name)
+		}
+		if !frozenReady {
+			frozen, err = builder.FrozenCandidateContext(ctx, record.State.InitialSnapshot)
+			if err != nil {
+				return CompactDiscardedWorkSummary{}, fmt.Errorf("derive frozen reviewer context: %w", err)
+			}
+			frozenReady = true
 		}
 		nativeFrozen, expected, err := artifactSubjectForSchema(ctx, builder, record.State, envelope.Subject.AuthorityRevision,
 			frozen, envelope.Subject.Lens, envelope.Subject.SelectedOrder, envelope.Subject.CorrectionTargetIdentity, envelope.Subject.Schema)
@@ -150,6 +163,90 @@ func compactDiscardedWorkSummary(ctx context.Context, store CompactStore, record
 		}
 	}
 	return summary, nil
+}
+
+// compactRetiredReviewerResultSummary recognizes only the byte shape persisted
+// before admitted-result envelopes existed. It is an audit projection, never a
+// reviewer-result admission or a source of gate evidence.
+func compactRetiredReviewerResultSummary(payload []byte, name string, selected []string) (findings, retired bool, err error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return false, false, nil
+	}
+	fields := make(map[string]json.RawMessage, 3)
+	duplicate, unknown := "", ""
+	currentLike := false
+	for decoder.More() {
+		token, err = decoder.Token()
+		if err != nil {
+			return false, fields["lens"] != nil && !currentLike, err
+		}
+		key, ok := token.(string)
+		if !ok {
+			// refusal:by-design world-action: a structurally invalid historical object has no safe audit projection.
+			return false, fields["lens"] != nil && !currentLike, errors.New("retired reviewer result contains a non-string field name")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return false, fields["lens"] != nil && !currentLike, err
+		}
+		switch key {
+		case "lens", "findings", "evidence":
+			if fields[key] != nil && duplicate == "" {
+				duplicate = key
+			}
+			fields[key] = raw
+		case "schema", "subject", "admission", "result":
+			currentLike = true
+		default:
+			if unknown == "" {
+				unknown = key
+			}
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return false, fields["lens"] != nil && !currentLike, err
+	}
+	if err := decoder.Decode(new(struct{})); err != io.EOF {
+		// refusal:by-design world-action: trailing persisted JSON makes the historical audit meaning ambiguous.
+		return false, fields["lens"] != nil && !currentLike, errors.New("retired reviewer result contains trailing JSON")
+	}
+	if fields["lens"] == nil || currentLike {
+		return false, false, nil
+	}
+	if duplicate != "" {
+		// refusal:by-design world-action: duplicate historical fields make the persisted audit meaning ambiguous.
+		return false, true, fmt.Errorf("retired reviewer result repeats field %q", duplicate)
+	}
+	if unknown != "" {
+		// refusal:by-design world-action: unrecognized historical fields cannot be safely interpreted for disposition.
+		return false, true, fmt.Errorf("retired reviewer result contains unknown field %q", unknown)
+	}
+	var result struct {
+		Lens     string            `json:"lens"`
+		Findings []json.RawMessage `json:"findings"`
+		Evidence []string          `json:"evidence"`
+	}
+	if err := json.Unmarshal(fields["lens"], &result.Lens); err != nil {
+		return false, true, err
+	}
+	if err := json.Unmarshal(fields["findings"], &result.Findings); err != nil {
+		return false, true, err
+	}
+	if err := json.Unmarshal(fields["evidence"], &result.Evidence); err != nil {
+		return false, true, err
+	}
+	if result.Findings == nil || result.Evidence == nil {
+		// refusal:by-design world-action: corrupt persisted audit bytes have no safe automatic repair.
+		return false, true, errors.New("retired reviewer result requires one JSON object with explicit findings and evidence arrays")
+	}
+	order := stringIndex(selected, result.Lens)
+	if order < 0 || name != fmt.Sprintf("%02d-%s.json", order, result.Lens) {
+		// refusal:by-design world-action: a mismatched historical slot cannot be safely attributed or discarded.
+		return false, true, errors.New("retired reviewer result lens does not match its selected slot")
+	}
+	return len(result.Findings) > 0, true, nil
 }
 
 func compactAbandonV2Rerun(repo, lineage, revision, snapshotIdentity, actor, reason string, discarded CompactDiscardedWorkSummary) string {

--- a/internal/reviewtransaction/compact_abandon_test.go
+++ b/internal/reviewtransaction/compact_abandon_test.go
@@ -285,6 +285,35 @@ func TestAbandonRefusesTerminalInvalidatedLineage(t *testing.T) {
 	}
 }
 
+func TestRetiredReviewerResultSummaryRejectsCorruptHistoricalShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		wantErr bool
+	}{
+		{name: "exact retired envelope", payload: `{"lens":"review-reliability","findings":[],"evidence":["inspected stale.go"]}`},
+		{name: "finding present", payload: `{"lens":"review-reliability","findings":[{}],"evidence":[]}`},
+		{name: "duplicate keys hide slot and finding", payload: `{"lens":"review-risk","lens":"review-reliability","findings":[{}],"findings":[],"evidence":[]}`, wantErr: true},
+		{name: "duplicate evidence", payload: `{"lens":"review-reliability","findings":[],"evidence":["first"],"evidence":[]}`, wantErr: true},
+		{name: "duplicate identical lens", payload: `{"lens":"review-reliability","lens":"review-reliability","findings":[],"evidence":[]}`, wantErr: true},
+		{name: "wrong findings type", payload: `{"lens":"review-reliability","findings":{},"evidence":[]}`, wantErr: true},
+		{name: "wrong evidence type", payload: `{"lens":"review-reliability","findings":[],"evidence":"x"}`, wantErr: true},
+		{name: "unknown field", payload: `{"lens":"review-reliability","findings":[],"evidence":[],"gate":true}`, wantErr: true},
+		{name: "wrong selected slot", payload: `{"lens":"review-risk","findings":[],"evidence":[]}`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, retired, err := compactRetiredReviewerResultSummary([]byte(tt.payload), "00-review-reliability.json", []string{LensReliability})
+			if !retired || (err != nil) != tt.wantErr {
+				t.Fatalf("summary = findings:%t retired:%t err:%v", findings, retired, err)
+			}
+			if tt.name == "finding present" && !findings {
+				t.Fatal("retired finding was omitted from the audit summary")
+			}
+		})
+	}
+}
+
 func TestAbandonRefusesIneligibleTargetsAndBindings(t *testing.T) {
 	repo := initSnapshotRepo(t)
 

--- a/internal/reviewtransaction/compact_abandon_test.go
+++ b/internal/reviewtransaction/compact_abandon_test.go
@@ -287,28 +287,38 @@ func TestAbandonRefusesTerminalInvalidatedLineage(t *testing.T) {
 
 func TestRetiredReviewerResultSummaryRejectsCorruptHistoricalShapes(t *testing.T) {
 	tests := []struct {
-		name    string
-		payload string
-		wantErr bool
+		name         string
+		payload      string
+		wantFindings bool
+		wantRetired  bool
+		wantErr      bool
 	}{
-		{name: "exact retired envelope", payload: `{"lens":"review-reliability","findings":[],"evidence":["inspected stale.go"]}`},
-		{name: "finding present", payload: `{"lens":"review-reliability","findings":[{}],"evidence":[]}`},
-		{name: "duplicate keys hide slot and finding", payload: `{"lens":"review-risk","lens":"review-reliability","findings":[{}],"findings":[],"evidence":[]}`, wantErr: true},
-		{name: "duplicate evidence", payload: `{"lens":"review-reliability","findings":[],"evidence":["first"],"evidence":[]}`, wantErr: true},
-		{name: "duplicate identical lens", payload: `{"lens":"review-reliability","lens":"review-reliability","findings":[],"evidence":[]}`, wantErr: true},
-		{name: "wrong findings type", payload: `{"lens":"review-reliability","findings":{},"evidence":[]}`, wantErr: true},
-		{name: "wrong evidence type", payload: `{"lens":"review-reliability","findings":[],"evidence":"x"}`, wantErr: true},
-		{name: "unknown field", payload: `{"lens":"review-reliability","findings":[],"evidence":[],"gate":true}`, wantErr: true},
-		{name: "wrong selected slot", payload: `{"lens":"review-risk","findings":[],"evidence":[]}`, wantErr: true},
+		{name: "exact retired envelope", payload: `{"lens":"review-reliability","findings":[],"evidence":["inspected stale.go"]}`, wantRetired: true},
+		{name: "finding present", payload: `{"lens":"review-reliability","findings":[{}],"evidence":[]}`, wantFindings: true, wantRetired: true},
+		{name: "duplicate keys hide slot and finding", payload: `{"lens":"review-risk","lens":"review-reliability","findings":[{}],"findings":[],"evidence":[]}`, wantRetired: true, wantErr: true},
+		{name: "duplicate evidence", payload: `{"lens":"review-reliability","findings":[],"evidence":["first"],"evidence":[]}`, wantRetired: true, wantErr: true},
+		{name: "duplicate identical lens", payload: `{"lens":"review-reliability","lens":"review-reliability","findings":[],"evidence":[]}`, wantRetired: true, wantErr: true},
+		{name: "wrong findings type", payload: `{"lens":"review-reliability","findings":{},"evidence":[]}`, wantRetired: true, wantErr: true},
+		{name: "wrong evidence type", payload: `{"lens":"review-reliability","findings":[],"evidence":"x"}`, wantRetired: true, wantErr: true},
+		{name: "unknown field", payload: `{"lens":"review-reliability","findings":[],"evidence":[],"gate":true}`, wantRetired: true, wantErr: true},
+		{name: "wrong selected slot", payload: `{"lens":"review-risk","findings":[],"evidence":[]}`, wantRetired: true, wantErr: true},
+		{name: "non-object payload", payload: `[]`},
+		{name: "current schema marker", payload: `{"lens":"review-reliability","schema":"gentle-ai.review-admitted-result/v2"}`},
+		{name: "current subject marker", payload: `{"lens":"review-reliability","subject":{}}`},
+		{name: "current admission marker", payload: `{"lens":"review-reliability","admission":{}}`},
+		{name: "current result marker", payload: `{"lens":"review-reliability","result":{}}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			findings, retired, err := compactRetiredReviewerResultSummary([]byte(tt.payload), "00-review-reliability.json", []string{LensReliability})
-			if !retired || (err != nil) != tt.wantErr {
-				t.Fatalf("summary = findings:%t retired:%t err:%v", findings, retired, err)
+			if findings != tt.wantFindings {
+				t.Errorf("findings = %t, want %t", findings, tt.wantFindings)
 			}
-			if tt.name == "finding present" && !findings {
-				t.Fatal("retired finding was omitted from the audit summary")
+			if retired != tt.wantRetired {
+				t.Errorf("retired = %t, want %t", retired, tt.wantRetired)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %t", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2539

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Lets generalized V2 abandonment derive an auditable discarded-work summary from the exact retired reviewer-result envelope reported in #2539.
- Keeps current reviewer admission strict and treats retired bytes only as disposition audit data, never gate evidence.
- Adds public CLI coverage and issue-linked driven journey `j79-retired-reviewer-schema-abandon`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_abandon.go` | Adds a narrow token-level retired-envelope projection with duplicate, unknown, malformed, type, slot, path, and hash failures remaining fail-closed. |
| `internal/reviewtransaction/compact_abandon_test.go` | Pins historical-shape compatibility and adversarial duplicate-field controls. |
| `internal/cli/review_abandon_test.go` | Proves status publishes the binding and public abandon quarantines retired and current envelopes without producing a receipt. |
| `bench/journeys_issue2539.go` | Replays the original #2539 runtime dead end and makes the corrected quarantine observable. |
| `bench` registration | Registers unique j79 and updates the deliberate corpus count. |

---

## 🧪 Test Plan

**Unit and static verification**

```bash
go run ./internal/gofmtcheck
go test ./internal/reviewtransaction ./internal/cli -count=1
HOME=<isolated> go test ./... -count=1
go vet ./...
(cd bench && go test ./... -count=1 && go vet ./...)
```

All passed on commit `053779f0` after rebasing onto current `main` `3d1e6735`.

**Driven benchmark**

Freshly built product and bench binaries:

```text
j79-retired-reviewer-schema-abandon: 1 completed, 0 unsupported, 0 failed
```

Differential control against exact merge base `3d1e6735` fails for the original reason:

```text
inspect discarded work: decode captured reviewer result "00-review-reliability.json": json: unknown field "lens"
```

E2E Docker lanes were not run locally; CI owns those platform lanes.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to CI
- [x] Manually tested locally through the public driven boundary

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 369 changed lines, within the 400-line budget. |
| Check Issue Reference | ⏳ | Links approved issue #2539. |
| Check Issue Has `status:approved` | ⏳ | #2539 is approved. |
| Check PR Has `type:*` Label | ⏳ | Awaiting maintainer approval for the exact label. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label — awaiting explicit approval
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to CI
- [x] Benchmark validation completed: j79 is issue-linked and driven against fresh binaries
- [x] Documentation is not required for this focused compatibility correction
- [x] My commit follows Conventional Commits format
- [x] My commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The compatibility parser is intentionally narrower than admission. It recognizes only the historically proven top-level `lens/findings/evidence` object after the artifact and sidecar have passed existing byte-integrity checks. Duplicate known keys, unknown keys, malformed or trailing JSON, wrong types, slot mismatch, unsafe paths, and invalid sidecars remain refusals.

The projected findings boolean is bound into the abandonment authorization and audit record only. Retired findings are never reintroduced as current admitted findings or gate evidence.

RDD mode was globally disabled during development, so verification is reported as `disabled/unmanaged`; no receipt or native approval is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review abandonment handling for retired and active results.
  - Retired results remain inspectable without being treated as findings or evidence.
  - Invalid or ambiguous historical result data is rejected safely.
  - Abandoning a review lineage removes usable receipts and authority while preserving unrelated approved authority.
- **Tests**
  - Added coverage for disposal, quarantine behavior, stale authorization rejection, and malformed historical data.
  - Expanded journey coverage with an additional review-abandonment scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->