### PR TITLE
fix(sdd): authorize evidence retry after audited rescope

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -528,6 +528,7 @@ func Journeys() []Journey {
 	journeys := append(coreJourneys(), edgeJourneys()...)
 	journeys = append(journeys, sddJourneys()...)
 	journeys = append(journeys, sddChainJourneys()...)
+	journeys = append(journeys, sddRescopeRetryJourneys()...)
 	journeys = append(journeys, captureEvidenceDescriptorJourneys()...)
 	journeys = append(journeys, scopeChangedFixtureJourneys()...)
 	journeys = append(journeys, waveOneJourneys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -26,6 +26,7 @@ func journeySources() []journeySource {
 		{"journeys_edge.go", edgeJourneys()},
 		{"journeys_sdd.go", sddJourneys()},
 		{"journeys_sdd_chain.go", sddChainJourneys()},
+		{"journeys_sdd_rescope_retry.go", sddRescopeRetryJourneys()},
 		{"journeys_handoff.go", handoffJourneys()},
 		{"journeys_capture_evidence_v5.go", captureEvidenceDescriptorJourneys()},
 		{"journeys_scope_changed_fixture.go", scopeChangedFixtureJourneys()},

--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -83,6 +83,8 @@ type sddRuntimeStatus struct {
 	Attempts []struct {
 		Ordinal                    int    `json:"ordinal"`
 		Outcome                    string `json:"outcome"`
+		BeginCandidateTree         string `json:"begin_candidate_tree"`
+		FinishCandidateTree        string `json:"finish_candidate_tree"`
 		EvidenceRevision           string `json:"evidence_revision"`
 		RemediatesEvidenceRevision string `json:"remediates_evidence_revision"`
 	} `json:"attempts"`

--- a/bench/journeys_sdd_rescope_retry.go
+++ b/bench/journeys_sdd_rescope_retry.go
@@ -1,0 +1,81 @@
+package main
+
+import "fmt"
+
+var sddRescopeRetryObjective = []string{
+	"--work-unit", "bench independent verification",
+	"--evidence-goal", "prove the unchanged candidate",
+	"--max-attempts", "3", "--max-changed-lines", "20",
+}
+
+var sddRescopeRetrySuccessor = []string{
+	"--work-unit", "bench narrower reverification",
+	"--evidence-goal", "rerun the focused independent verification",
+	"--max-attempts", "2", "--max-changed-lines", "10",
+}
+
+var sddAttemptRescopeCapability = &Capability{
+	Verb:  []string{"sdd-attempt", "rescope"},
+	Probe: []string{"sdd-attempt", "rescope", "--work-unit=probe", "--evidence-goal=probe", "--max-attempts=1", "--max-changed-lines=1", "--reason=probe", "--actor=probe"},
+}
+
+// sddRescopeEvidenceOnlyRetry reconstructs #2621 through public runtime calls.
+// Every status proof starts a new process, so the final assertion also proves
+// the successful unchanged settle survives full-chain replay.
+func sddRescopeEvidenceOnlyRetry(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-rescope-retry-begin", sddRescopeRetryObjective...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-rescope-retry-fail",
+		append([]string{"--outcome", "failed", "--evidence-revision", sddFailedEvidence}, sddTerminalEvidence...)...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "rescope", status.Revision, "bench-rescope-retry-audit",
+		append(append([]string{}, sddRescopeRetrySuccessor...),
+			"--reason", "maintainer narrowed a transient failure to one evidence-only retry",
+			"--actor", "bench maintainer")...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-rescope-retry-reverify", sddRescopeRetrySuccessor...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	observation := r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-rescope-retry-pass",
+		append([]string{
+			"--outcome", "passed", "--evidence-revision", sddCorrectedEvidence,
+			"--remediates-evidence-revision", sddFailedEvidence,
+		}, sddTerminalEvidence...)...), false)
+	if observation.ExitCode != 0 {
+		return fmt.Errorf("rescope-authorized unchanged settle exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	completed, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if !completed.Complete || completed.Binding != nil || len(completed.Attempts) != 2 ||
+		completed.Attempts[1].RemediatesEvidenceRevision != sddFailedEvidence ||
+		completed.Attempts[1].FinishCandidateTree != completed.Attempts[1].BeginCandidateTree {
+		return fmt.Errorf("rescope-authorized unchanged settle did not survive replay: %#v", completed)
+	}
+	return nil
+}
+
+func sddRescopeRetryJourneys() []Journey {
+	return []Journey{{
+		ID:     "j79-sdd-rescope-authorizes-evidence-only-retry",
+		Title:  "An audited narrower rescope authorizes unchanged successful evidence settlement",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/2621",
+		Steps: []Step{
+			{Name: "fixture: completed change with admitted failed verification", Fixture: sddPlanningArtifacts(sddFailedVerifyReport)},
+			{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+			{Name: "failed evidence, audited rescope, and unchanged passed settlement", Requires: sddAttemptRescopeCapability, Composite: sddRescopeEvidenceOnlyRetry},
+		},
+	}}
+}

--- a/bench/journeys_sdd_rescope_retry.go
+++ b/bench/journeys_sdd_rescope_retry.go
@@ -60,6 +60,10 @@ func sddRescopeEvidenceOnlyRetry(r *journeyRun) error {
 		return err
 	}
 	if !completed.Complete || completed.Binding != nil || len(completed.Attempts) != 2 ||
+		completed.Attempts[0].FinishCandidateTree == "" ||
+		completed.Attempts[1].BeginCandidateTree == "" ||
+		completed.Attempts[1].FinishCandidateTree == "" ||
+		completed.Attempts[0].FinishCandidateTree != completed.Attempts[1].BeginCandidateTree ||
 		completed.Attempts[1].RemediatesEvidenceRevision != sddFailedEvidence ||
 		completed.Attempts[1].FinishCandidateTree != completed.Attempts[1].BeginCandidateTree {
 		return fmt.Errorf("rescope-authorized unchanged settle did not survive replay: %#v", completed)

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,13 +34,13 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 79 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 80 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2) and
-	// j78-lens-finding-id-prefix-discovery (#1844).
+	// j78-lens-finding-id-prefix-discovery (#1844), plus the #2621 rescope retry.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 79 {
-		t.Errorf("core journey count = %d, want 79", got)
+	if got := len(seen); got != 80 {
+		t.Errorf("core journey count = %d, want 80", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -895,9 +895,9 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			return runtimeRecord{}, fmt.Errorf("disabled failed verification requires --remediates-evidence-revision %q on the correction settle; rerun `gentle-ai sdd-attempt settle` with that flag", chainFailedEvidence)
 		}
 		if unmanagedRemediation {
-			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, chainFailedAttempt, snapshot.CandidateTree)
+			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status, chainFailedAttempt, snapshot.CandidateTree)
 			if !evidenceOnly && (snapshot.Identity == active.BeginCandidateIdentity || snapshot.CandidateTree == active.BeginCandidateTree) {
-				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed by the active correction attempt, or an audited reset authorizing this exact unchanged candidate.
+				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed by the active correction attempt, or an audited scope transition authorizing this exact unchanged candidate.
 				return runtimeRecord{}, errors.New("unmanaged remediation requires a changed correction candidate")
 			}
 			if request.EvidenceRevision == request.RemediatesEvidenceRevision {
@@ -2074,10 +2074,10 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		// audited reset stay valid. The chain walk requires a settled failed
 		// predecessor, which subsumes the former len(Attempts) < 2 conjunct.
 		chainFailedAttempt, chainHasFailedEvidence := runtimeChainFailedAttempt(replay.Status.Attempts)
-		// #2621 lockstep twin: an audited reset that terminated the failing
-		// objective against these exact bytes authorizes one evidence-only
-		// retry, so a replayed correction may leave the candidate unchanged.
-		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, chainFailedAttempt, event.FinishCandidateTree)
+		// #2621 lockstep twin: an audited reset or rescope that terminated the
+		// failing objective against these exact bytes authorizes one
+		// evidence-only retry, so a replayed correction may stay unchanged.
+		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status, chainFailedAttempt, event.FinishCandidateTree)
 		unchangedCandidate := event.FinishCandidateIdentity == active.BeginCandidateIdentity ||
 			event.FinishCandidateTree == active.BeginCandidateTree
 		if replay.Status.Binding != nil || event.Outcome != AttemptPassed ||
@@ -2923,24 +2923,33 @@ func runtimeChainFailedAttempt(attempts []RuntimeAttempt) (RuntimeAttempt, bool)
 // weakened for candidates nobody vouched for. So the waiver rests entirely on
 // authority the ledger ALREADY records rather than on a new operator claim:
 //
-//   - The reset names a maintainer and a reason. It is an audited human act.
+//   - The reset or rescope names a maintainer and reason: an audited human act.
 //   - It terminated the exact objective+generation the failure was recorded
-//     under, so a reset taken before that failure can never authorize it.
-//   - Its candidate tree is these bytes, so the maintainer authorized the
-//     retry while looking at precisely the content that is about to pass.
+//     under, so an earlier transition can never authorize that failure.
+//   - Its candidate tree is these bytes, so the maintainer authorized the retry
+//     while looking at precisely the content that is about to pass.
 //
 // Everything else the correction owes stays enforced by the caller: review must
 // be disabled with no binding, the chain must still hold the failed evidence
 // being repaired, and the corrected evidence must be fresh and distinct. No
 // approval is fabricated -- one that a human already gave is honored.
-func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, failed RuntimeAttempt, candidateTree string) bool {
-	if reset == nil || reset.Actor == "" || reset.Reason == "" || candidateTree == "" {
+func runtimeEvidenceOnlyRetryAuthorized(status RuntimeStatus, failed RuntimeAttempt, candidateTree string) bool {
+	if candidateTree == "" {
 		return false
 	}
-	if reset.PreviousObjectiveID != failed.ObjectiveID || reset.PreviousGeneration != failed.ObjectiveGeneration {
-		return false
+	matches := func(actor, reason, previousObjectiveID string, previousGeneration int, authorityTree string) bool {
+		return actor != "" && reason != "" && previousObjectiveID == failed.ObjectiveID &&
+			previousGeneration == failed.ObjectiveGeneration && authorityTree == candidateTree
 	}
-	return reset.ResetCandidateTree == candidateTree
+	if reset := status.LastReset; reset != nil && matches(
+		reset.Actor, reset.Reason, reset.PreviousObjectiveID, reset.PreviousGeneration, reset.ResetCandidateTree,
+	) {
+		return true
+	}
+	rescope := status.LastRescope
+	return rescope != nil && matches(
+		rescope.Actor, rescope.Reason, rescope.PreviousObjectiveID, rescope.PreviousGeneration, rescope.RescopeCandidateTree,
+	)
 }
 
 func runtimeObjectiveID(change, workUnit, evidenceGoal, candidateIdentity string, generation int) string {

--- a/internal/sddstatus/runtime_ledger_evidence_only_retry_test.go
+++ b/internal/sddstatus/runtime_ledger_evidence_only_retry_test.go
@@ -91,6 +91,100 @@ func TestRuntimeEvidenceOnlyRetrySettlesOnAuditedResetAuthority(t *testing.T) {
 	}
 }
 
+func TestRuntimeEvidenceOnlyRetrySettlesOnAuditedRescopeAuthority(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "evidence-only-rescope-retry")
+	store.ReviewDisabled = true
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "rescope-retry-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 3, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('c')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "rescope-retry-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "authoritative suite failed a transient test unrelated to the candidate",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.DecisionRequired || failed.CumulativeAttempts != 1 || failed.NextAction != RuntimeActionBegin {
+		t.Fatalf("failed verification with remaining budget = %#v", failed)
+	}
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "rescope-retry-audited-rescope",
+		WorkUnit: "narrower-verification", EvidenceGoal: "rerun the focused independent verification",
+		MaxAttempts: 2, MaxChangedLines: 10,
+		Reason: "maintainer narrowed the transient verification failure to one evidence-only retry", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: rescoped.Revision, RequestID: "rescope-retry-begin-reverification",
+		WorkUnit: "narrower-verification", EvidenceGoal: "rerun the focused independent verification",
+		MaxAttempts: 2, MaxChangedLines: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "rescope-retry-finish-reverification", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('d'), Diagnosis: "focused and full suites passed against the unchanged candidate",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "retry cleanup completed",
+		ProcessEvidence: "retry process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatalf("rescope-authorized evidence-only retry was refused: %v", err)
+	}
+	last := completed.Attempts[len(completed.Attempts)-1]
+	if !completed.Complete || completed.CumulativeAttempts != 2 || completed.CumulativeChangedLines != 0 ||
+		last.RemediatesEvidenceRevision != failedEvidence || last.FinishCandidateTree != last.BeginCandidateTree {
+		t.Fatalf("rescope-authorized evidence-only retry = %#v", completed)
+	}
+	reopened := mustRuntimeStore(t, repo, "evidence-only-rescope-retry")
+	reopened.ReviewDisabled = true
+	replayed, err := reopened.Status()
+	if err != nil || replayed.Revision != completed.Revision || !replayed.Complete {
+		t.Fatalf("full-chain replay of rescope-authorized retry = %#v err=%v", replayed, err)
+	}
+}
+
+func TestRuntimeEvidenceOnlyRetryRescopeAuthorityMustMatchFailure(t *testing.T) {
+	failed := RuntimeAttempt{ObjectiveID: "failed-objective", ObjectiveGeneration: 2}
+	matching := &RuntimeRescope{
+		Actor: "maintainer", Reason: "authorize retry", PreviousObjectiveID: failed.ObjectiveID,
+		PreviousGeneration: failed.ObjectiveGeneration, RescopeCandidateTree: "candidate-tree",
+	}
+	tests := []struct {
+		name      string
+		authority *RuntimeRescope
+		tree      string
+	}{
+		{name: "missing authority", authority: nil, tree: "candidate-tree"},
+		{name: "stale objective", authority: func() *RuntimeRescope {
+			value := *matching
+			value.PreviousObjectiveID = "older-objective"
+			return &value
+		}(), tree: "candidate-tree"},
+		{name: "stale generation", authority: func() *RuntimeRescope { value := *matching; value.PreviousGeneration--; return &value }(), tree: "candidate-tree"},
+		{name: "mismatched candidate tree", authority: matching, tree: "other-tree"},
+		{name: "missing actor", authority: func() *RuntimeRescope { value := *matching; value.Actor = ""; return &value }(), tree: "candidate-tree"},
+		{name: "missing reason", authority: func() *RuntimeRescope { value := *matching; value.Reason = ""; return &value }(), tree: "candidate-tree"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if runtimeEvidenceOnlyRetryAuthorized(RuntimeStatus{LastRescope: tt.authority}, failed, tt.tree) {
+				t.Fatal("mismatched rescope authority authorized an evidence-only retry")
+			}
+		})
+	}
+}
+
 // The waiver is scoped to the audited reset that authorized it. A failure with
 // attempts still available needs no reset, so an unchanged-candidate pass there
 // is the laundering the original demand exists to refuse, and it must stay


### PR DESCRIPTION
## Linked Issue

Closes #2621

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Authorizes an unchanged evidence-only retry when an audited rescope exactly matches the failed objective, generation, and candidate tree.
- Closes the reset-versus-rescope gap left by the reset-only authorization path while preserving actor, reason, evidence freshness, disabled-review, and replay guards.
- Adds issue-linked public/runtime journey `j79-sdd-rescope-authorizes-evidence-only-retry`.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_ledger.go` | Shares exact reset/rescope authority matching across write and replay paths. |
| `internal/sddstatus/runtime_ledger_evidence_only_retry_test.go` | Covers successful rescope-authorized settlement, replay, and mismatched authority refusals. |
| `bench/` journey corpus | Registers j79 and exposes candidate-tree fields needed to prove unchanged settlement through the public runtime boundary. |

---

## Test Plan

**Focused tests and formatting**

- PASS: focused `TestRuntimeEvidenceOnlyRetry*` coverage.
- PASS: full benchmark module build, vet, and tests (`go build ./...`, `go vet ./...`, `go test ./...` from `bench/`).
- PASS: `go run ./internal/gofmtcheck`.

**Benchmark validation**

- HEAD: driven j79 completed with 1 completed, 0 unsupported, 0 failed.
- Exact base `338df329`: the same HEAD harness and j79 scenario failed with `unmanaged remediation requires a changed correction candidate`, reproducing the original gap.

**Repository-wide suite disclosure**

The repository-wide validation is not fully green: three unrelated `ReviewOffer.Available` tests fail identically on this branch and exact base `338df329`:

- `TestReviewOfferDeclineNeverBlocksArchiveAtTheProjectionLevel`
- `TestReviewOfferPresentAndArchiveReadyForAGenuinelyMissingReceipt`
- `TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt`

The root `go test ./...` invocation also exceeded the 120-second validation window. These baseline failures are outside this change; the focused #2621 tests and benchmark checks pass.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## Automated Checks

The repository automated checks run on this PR.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The authorization remains fail-closed: only audited reset or rescope records with non-empty actor/reason and exact failed objective, generation, and candidate tree can waive the changed-candidate requirement. Write-time and replay enforcement use the same predicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for evidence-only retries authorized by an audited rescope.
  - Retry authorization verifies the actor, reason, failed objective, generation, and candidate tree.
  - Runtime and replay validation now recognize approved rescope-based remediation.

- **Bug Fixes**
  - Improved retry handling, candidate-tree tracking, and failed-evidence linkage.

- **Tests**
  - Added coverage for successful rescope retries, replay consistency, unchanged candidate trees, and invalid authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->