### PR TITLE
fix(sdd): reject consecutive rescope before commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,20 +82,16 @@ jobs:
             completed_once("j75-intended-untracked-selection-executes-printed-start")
           ' "$RUNNER_TEMP/bench-portable.json"
           # Transition axis (#2829): sequences of ordinary operations, which is
-          # how #2830 shipped. tr01 reproduces that live defect, so the runner
-          # exits non-zero on this axis until #2830 is fixed; the jq assertion
-          # below is the real gate, and it fails if the run produced no parsable
-          # report. tr01 is not pinned as "must fail" because that would make CI
-          # go red the day someone fixes it. Instead the first clause requires
-          # tr01 to be the ONLY journey not completed, so a twelfth journey
-          # regressing still turns this step red.
-          "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --axis transition --out "$RUNNER_TEMP/bench-transition.json" || true
+          # how #2830 shipped. #2830 now refuses the second consecutive rescope
+          # before publication, so every transition journey must complete.
+          "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --axis transition --out "$RUNNER_TEMP/bench-transition.json"
           jq -e '
             def completed_once($id):
               [.journeys[] | select(.id == $id)] as $matches
               | ($matches | length == 1) and ($matches[0].status == "completed");
-            ([.journeys[] | select(.status != "completed") | .id] | sort) ==
-              ["tr01-consecutive-rescope-keeps-the-ledger-readable"] and
+            ([.journeys[] | select(.id | startswith("tr"))] | length) == 11 and
+            ([.journeys[] | select((.id | startswith("tr")) and .status == "completed")] | length) == 11 and
+            completed_once("tr01-consecutive-rescope-keeps-the-ledger-readable") and
             completed_once("tr02-reset-after-rescope-keeps-the-ledger-readable") and
             completed_once("tr03-review-disabled-mid-change-keeps-sdd-moving") and
             completed_once("tr04-reset-then-rescope-keeps-the-ledger-readable") and

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -539,6 +539,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, intendedUntrackedJourneys()...)
 	journeys = append(journeys, captureResultDryRunJourneys()...)
 	journeys = append(journeys, findingIDPrefixJourneys()...)
+	journeys = append(journeys, rescopeWriteGuardJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -38,6 +38,7 @@ func journeySources() []journeySource {
 		{"journeys_intended_untracked.go", intendedUntrackedJourneys()},
 		{"journeys_capture_result_dry_run.go", captureResultDryRunJourneys()},
 		{"journeys_finding_id_prefix.go", findingIDPrefixJourneys()},
+		{"journeys_rescope_write_guard.go", rescopeWriteGuardJourneys()},
 	}
 }
 

--- a/bench/journeys_rescope_write_guard.go
+++ b/bench/journeys_rescope_write_guard.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+var sddAttemptRescopeCapability = &Capability{
+	Verb: []string{"sdd-attempt", "rescope"},
+	Probe: []string{
+		"sdd-attempt", "rescope", "--expected-revision=probe", "--request-id=probe",
+		"--work-unit=probe", "--evidence-goal=probe", "--max-attempts=1", "--max-changed-lines=1",
+		"--reason=probe", "--actor=bench",
+	},
+}
+
+var sddRescopeObjectiveA = []string{
+	"--work-unit", "bench objective A",
+	"--evidence-goal", "prove the original bounded objective",
+	"--max-attempts", "3", "--max-changed-lines", "90",
+}
+
+var sddRescopeObjectiveB = []string{
+	"--work-unit", "bench objective B",
+	"--evidence-goal", "prove the narrower successor objective",
+	"--max-attempts", "3", "--max-changed-lines", "60",
+}
+
+var sddRescopeObjectiveC = []string{
+	"--work-unit", "bench objective C",
+	"--evidence-goal", "prove the still narrower successor objective",
+	"--max-attempts", "3", "--max-changed-lines", "30",
+}
+
+// sddConsecutiveRescopeRefusal drives #2830 exactly as an operator does. A
+// rescope successor has no terminal attempt of its own, so the next rescope
+// must fail before publication and leave the readable authority unchanged.
+func sddConsecutiveRescopeRefusal(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	if begin := r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-2830-begin-a", sddRescopeObjectiveA...), false); begin.ExitCode != 0 {
+		return fmt.Errorf("begin objective A exit=%d: %s", begin.ExitCode, firstLine(begin.Stderr))
+	}
+
+	status, err = readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	if finish := r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-2830-finish-a",
+		append([]string{"--outcome", "failed", "--evidence-revision", sddFailedEvidence}, sddTerminalEvidence...)...), false); finish.ExitCode != 0 {
+		return fmt.Errorf("finish objective A exit=%d: %s", finish.ExitCode, firstLine(finish.Stderr))
+	}
+
+	status, err = readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	if len(status.Attempts) != 1 || status.NextAction != "begin" || status.ActiveAttempt != nil {
+		return fmt.Errorf("failed zero-drift objective A status = %#v", status)
+	}
+	if rescope := r.run(sddAttemptArgs(r, "rescope", status.Revision, "bench-2830-rescope-a-to-b",
+		append(append([]string{}, sddRescopeObjectiveB...), "--reason", "maintainer narrowed A into B", "--actor", "bench")...), false); rescope.ExitCode != 0 {
+		return fmt.Errorf("rescope objective A to B exit=%d: %s", rescope.ExitCode, firstLine(rescope.Stderr))
+	}
+
+	beforeRefusal, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	if len(beforeRefusal.Attempts) != 1 || beforeRefusal.NextAction != "begin" || beforeRefusal.ActiveAttempt != nil {
+		return fmt.Errorf("rescoped objective B status = %#v", beforeRefusal)
+	}
+	refusal := r.run(sddAttemptArgs(r, "rescope", beforeRefusal.Revision, "bench-2830-rescope-b-to-c",
+		append(append([]string{}, sddRescopeObjectiveC...), "--reason", "attempted B to C before B has an attempt", "--actor", "bench")...), false)
+	if refusal.ExitCode == 0 {
+		return errors.New("consecutive rescope before B has an attempt was accepted")
+	}
+
+	afterRefusal, err := readRuntimeStatus(r)
+	if err != nil {
+		return fmt.Errorf("status after refused consecutive rescope: %w", err)
+	}
+	if afterRefusal.Revision != beforeRefusal.Revision || len(afterRefusal.Attempts) != 1 ||
+		afterRefusal.NextAction != "begin" || afterRefusal.ActiveAttempt != nil {
+		return fmt.Errorf("refused consecutive rescope changed authority: before=%#v after=%#v", beforeRefusal, afterRefusal)
+	}
+	return nil
+}
+
+func rescopeWriteGuardJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j79-consecutive-rescope-refuses-before-publication",
+			Title:  "Failed zero-drift objective: a second rescope refuses before it can corrupt status",
+			Source: "issue #2830: rescope successors require their own terminal attempt",
+			Steps: []Step{
+				{Name: "fixture: runtime repository with no candidate drift", Fixture: sddRuntimeRepo},
+				{Name: "begin, fail zero-drift, rescope once, refuse a second rescope, and read status", Requires: sddAttemptRescopeCapability, Composite: sddConsecutiveRescopeRefusal},
+			},
+		},
+	}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,13 +34,14 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 79 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 80 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2) and
-	// j78-lens-finding-id-prefix-discovery (#1844).
+	// j78-lens-finding-id-prefix-discovery (#1844), and j79-consecutive-
+	// rescope-refuses-before-publication (#2830).
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 79 {
-		t.Errorf("core journey count = %d, want 79", got)
+	if got := len(seen); got != 80 {
+		t.Errorf("core journey count = %d, want 80", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/journeys_transition.go
+++ b/bench/journeys_transition.go
@@ -52,19 +52,18 @@ func transitionJourneys() []Journey {
 			// rescope it belongs to the previous generation, so the record is
 			// committed and then rejected by its own validator.
 			//
-			// This journey deliberately does NOT assert that the second rescope
-			// succeeds. Whether consecutive rescopes are supported is a product
-			// decision that is still open. What is not open is the last step:
-			// after any answer, `status` must still work. That is the assertion
-			// that would have caught #2830 before it shipped.
+			// #2830's ratified boundary rejects the second rescope before
+			// publication. The unit regression pins that exact writer behavior;
+			// this journey proves the operator-visible invariant that follows it:
+			// `status` still works after the refusal.
 			Steps: []Step{
 				{Name: "fixture: repository with a committed OpenSpec change", Fixture: sddRuntimeRepo},
 				{Name: "begin an objective and fail it with the workspace unchanged",
 					Requires: sddAttemptBeginCapability, Composite: transitionBeginAndFail},
-				{Name: "narrow the objective once", Requires: sddAttemptResetCapability,
+				{Name: "narrow the objective once", Requires: sddAttemptRescopeCapability,
 					Composite: transitionRescope("bench-rescope-one", "narrower work unit one")},
 				{Name: "narrow it again, which is where the report lands",
-					Requires:  sddAttemptResetCapability,
+					Requires:  sddAttemptRescopeCapability,
 					Composite: transitionRescope("bench-rescope-two", "narrower work unit two")},
 				{Name: "the ledger still answers", Composite: transitionProveLedgerReadable},
 			},
@@ -95,7 +94,7 @@ func transitionJourneys() []Journey {
 				{Name: "fixture: repository with a committed OpenSpec change", Fixture: sddRuntimeRepo},
 				{Name: "begin an objective and fail it with the workspace unchanged",
 					Requires: sddAttemptBeginCapability, Composite: transitionBeginAndFail},
-				{Name: "narrow the objective", Requires: sddAttemptResetCapability,
+				{Name: "narrow the objective", Requires: sddAttemptRescopeCapability,
 					Composite: transitionRescope("bench-rescope-before-reset", "narrower before reset")},
 				{Name: "spend the narrowed objective's remaining attempts",
 					Requires: sddAttemptBeginCapability, Composite: transitionExhaustAttempts},
@@ -122,7 +121,7 @@ func transitionJourneys() []Journey {
 					Requires: sddAttemptBeginCapability, Composite: transitionExhaustOriginal},
 				{Name: "reset the objective", Requires: sddAttemptResetCapability,
 					Composite: transitionReset("bench-reset-before-rescope")},
-				{Name: "then narrow the fresh objective", Requires: sddAttemptResetCapability,
+				{Name: "then narrow the fresh objective", Requires: sddAttemptRescopeCapability,
 					Composite: transitionRescope("bench-rescope-after-reset", "narrower after reset")},
 				{Name: "the ledger still answers", Composite: transitionProveLedgerReadable},
 			},
@@ -208,7 +207,7 @@ func transitionJourneys() []Journey {
 					Requires: sddAttemptHandoffCapability, Composite: sddHandoffAndSettleDelegatedWorktree},
 				{Name: "the ledger answers after the handoff", Composite: transitionProveLedgerReadable},
 				{Name: "now change the scope of the handed-off objective",
-					Requires:  sddAttemptResetCapability,
+					Requires:  sddAttemptRescopeCapability,
 					Composite: transitionRescope("bench-rescope-after-handoff", "narrower after handoff")},
 				{Name: "the ledger still answers", Composite: transitionProveLedgerReadable},
 			},
@@ -261,7 +260,7 @@ func transitionJourneys() []Journey {
 				{Name: "bind the approved review to the change", Requires: bindSDDCapability,
 					Composite: sddBindApprovedReview},
 				{Name: "now move the objective the binding names",
-					Requires:  sddAttemptResetCapability,
+					Requires:  sddAttemptRescopeCapability,
 					Composite: transitionRescope("bench-rescope-after-bind", "narrower after binding")},
 				{Name: "the ledger still answers", Composite: transitionProveLedgerReadable},
 				{Name: "and so does review status", Requires: statusCapability,
@@ -343,9 +342,9 @@ func transitionBeginAndFail(r *journeyRun) error {
 	return nil
 }
 
-// transitionRescope narrows the objective. It tolerates a refusal: whether the
-// product admits this call is the open question, and the journey measures what
-// happens to the store either way rather than demanding one answer.
+// transitionRescope narrows the objective. A journey's following status check
+// measures whether the result, including a correct refusal, left the store
+// readable; #2830's unit regression separately pins its exact refusal.
 func transitionRescope(requestID, workUnit string) func(*journeyRun) error {
 	return func(r *journeyRun) error {
 		status, err := readRuntimeStatus(r)

--- a/bench/journeys_transition_test.go
+++ b/bench/journeys_transition_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+// TestTransitionCorpusRequiresRescopeCapability keeps unsupported
+// classification tied to the command transitionRescope actually invokes. A
+// reset probe can succeed while a binary lacks rescope, silently turning this
+// axis's rescope coverage into a false completed result.
+func TestTransitionCorpusRequiresRescopeCapability(t *testing.T) {
+	want := map[string]map[string]bool{
+		"tr01-consecutive-rescope-keeps-the-ledger-readable": {
+			"narrow the objective once":                        false,
+			"narrow it again, which is where the report lands": false,
+		},
+		"tr02-reset-after-rescope-keeps-the-ledger-readable": {
+			"narrow the objective": false,
+		},
+		"tr04-reset-then-rescope-keeps-the-ledger-readable": {
+			"then narrow the fresh objective": false,
+		},
+		"tr08-scope-change-after-a-delegated-handoff": {
+			"now change the scope of the handed-off objective": false,
+		},
+		"tr10-scope-change-after-the-review-is-bound": {
+			"now move the objective the binding names": false,
+		},
+	}
+
+	journeys := transitionJourneys()
+	if got := len(journeys); got != 11 {
+		t.Fatalf("transition journey count = %d, want 11", got)
+	}
+	for _, journey := range journeys {
+		steps, tracked := want[journey.ID]
+		if !tracked {
+			continue
+		}
+		for _, step := range journey.Steps {
+			found, tracked := steps[step.Name]
+			if !tracked {
+				continue
+			}
+			if step.Requires != sddAttemptRescopeCapability {
+				t.Errorf("%s / %s capability = %#v, want sddAttemptRescopeCapability", journey.ID, step.Name, step.Requires)
+			}
+			if found {
+				t.Errorf("%s / %s is listed more than once", journey.ID, step.Name)
+			}
+			steps[step.Name] = true
+		}
+	}
+	for journeyID, steps := range want {
+		for stepName, found := range steps {
+			if !found {
+				t.Errorf("%s / %s is missing from the transition corpus", journeyID, stepName)
+			}
+		}
+	}
+}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -1388,14 +1388,15 @@ func (store RuntimeStore) Reset(ctx context.Context, request ResetObjectiveReque
 // replaying one from the immutable chain (applyRuntimeRecord), so a
 // committed rescope always replays deterministically.
 func runtimeObjectiveRescopeStructurallyPermitted(status RuntimeStatus) bool {
-	if status.DecisionRequired || status.Complete {
+	if status.Objective == nil || status.DecisionRequired || status.Complete {
 		return false
 	}
 	if len(status.Attempts) == 0 {
 		return false
 	}
 	last := status.Attempts[len(status.Attempts)-1]
-	return last.Outcome == AttemptFailed || last.Outcome == AttemptInterrupted
+	return last.ObjectiveID == status.Objective.ID &&
+		(last.Outcome == AttemptFailed || last.Outcome == AttemptInterrupted)
 }
 
 // Rescope implements AUDITED NARROWING RESCOPE (#2298, #2296 part 2): the
@@ -1982,7 +1983,7 @@ func applyRuntimeRescopeEvent(replay *runtimeReplay, revision string, record run
 	// is comparable across them. RescopeCandidateIdentity is NOT compared
 	// here for the same reason; it is still shape-validated and reused
 	// verbatim to derive ObjectiveID below.
-	if last.ObjectiveID != objective.ID || (last.Outcome != AttemptFailed && last.Outcome != AttemptInterrupted) ||
+	if (last.Outcome != AttemptFailed && last.Outcome != AttemptInterrupted) ||
 		last.FinishCandidateTree != event.RescopeCandidateTree {
 		return errors.New("objective rescope candidate does not match the terminal zero-drift finish") // refusal:by-design world-action: the zero-drift candidate was verified before publication, so a mismatch is a mutated record and the exit is restoring the store
 	}

--- a/internal/sddstatus/runtime_ledger_rescope_test.go
+++ b/internal/sddstatus/runtime_ledger_rescope_test.go
@@ -134,6 +134,112 @@ func TestRuntimeLedgerRescopeRecoversZeroDriftDeadlock(t *testing.T) {
 	}
 }
 
+// TestRuntimeLedgerRescopeRefusesConsecutiveRescopeWithoutOwnAttempt proves
+// #2830's ratified boundary: a rescope successor needs its own terminal
+// attempt before it can itself be rescoped. Its predecessor's terminal attempt
+// remains immutable provenance, not authority for another successor.
+func TestRuntimeLedgerRescopeRefusesConsecutiveRescopeWithoutOwnAttempt(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "rescope-2830")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "2830-begin-a", WorkUnit: "objective-a",
+		EvidenceGoal: "prove the original bounded objective", MaxAttempts: 3, MaxChangedLines: 90,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "2830-finish-a", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "objective A failed with the workspace unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "workspace remained unchanged",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.CumulativeChangedLines != 0 || failed.DecisionRequired || failed.Complete || failed.NextAction != RuntimeActionBegin {
+		t.Fatalf("failed objective A status = %#v", failed)
+	}
+
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "2830-rescope-a-to-b",
+		WorkUnit: "objective-b", EvidenceGoal: "prove the narrower successor objective",
+		MaxAttempts: 3, MaxChangedLines: 60,
+		Reason: "maintainer narrowed objective A into successor B", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("first rescope was refused: %v", err)
+	}
+	if rescoped.Objective == nil || rescoped.Objective.WorkUnit != "objective-b" || rescoped.Objective.MaxAttempts != 3 ||
+		rescoped.Objective.MaxChangedLines != 60 || rescoped.NextAction != RuntimeActionBegin || rescoped.ActiveAttempt != nil {
+		t.Fatalf("rescoped objective B status = %#v", rescoped)
+	}
+	if len(rescoped.Attempts) != 1 || rescoped.Attempts[0].ObjectiveID == rescoped.Objective.ID {
+		t.Fatalf("successor B must have no attempt of its own yet: %#v", rescoped)
+	}
+
+	beforeRevision := rescoped.Revision
+	beforeRecords := countRuntimeRecords(t, store.Dir)
+	_, err = store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: beforeRevision, RequestID: "2830-rescope-b-to-c-before-attempt",
+		WorkUnit: "objective-c", EvidenceGoal: "prove the still narrower successor objective",
+		MaxAttempts: 3, MaxChangedLines: 30,
+		Reason: "maintainer attempted to rescope B before B has an attempt", Actor: "maintainer",
+	})
+	if !errors.Is(err, ErrRuntimeRescopeNotAllowed) {
+		t.Errorf("consecutive rescope error = %v, want ErrRuntimeRescopeNotAllowed", err)
+	}
+	if records := countRuntimeRecords(t, store.Dir); records != beforeRecords {
+		t.Errorf("refused consecutive rescope published a record: records=%d, want %d", records, beforeRecords)
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil {
+		t.Errorf("status after refused consecutive rescope = %v", statusErr)
+	} else if status.Revision != beforeRevision || status.Objective == nil || status.Objective.ID != rescoped.Objective.ID ||
+		len(status.Attempts) != 1 || status.ActiveAttempt != nil || status.NextAction != RuntimeActionBegin {
+		t.Errorf("refused consecutive rescope changed authoritative status: %#v", status)
+	}
+	if statusErr != nil {
+		return
+	}
+
+	// Negative control: the same narrowing transition is admitted once objective
+	// B owns a terminal attempt, so the refusal above cannot be a generic rescope
+	// failure unrelated to objective ownership.
+	startedB, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: status.Revision, RequestID: "2830-begin-b", WorkUnit: "objective-b",
+		EvidenceGoal: "prove the narrower successor objective", MaxAttempts: 3, MaxChangedLines: 60,
+	})
+	if err != nil {
+		t.Fatalf("begin objective B for negative control: %v", err)
+	}
+	failedB, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: startedB.Revision, RequestID: "2830-finish-b", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "objective B failed with the workspace unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "workspace remained unchanged",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatalf("finish objective B for negative control: %v", err)
+	}
+	accepted, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failedB.Revision, RequestID: "2830-rescope-b-to-c-after-attempt",
+		WorkUnit: "objective-c", EvidenceGoal: "prove the still narrower successor objective",
+		MaxAttempts: 3, MaxChangedLines: 30,
+		Reason: "maintainer narrowed B only after B recorded its own attempt", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("rescope after objective B's terminal attempt was refused: %v", err)
+	}
+	if accepted.Objective == nil || accepted.Objective.WorkUnit != "objective-c" || accepted.NextAction != RuntimeActionBegin {
+		t.Fatalf("accepted post-attempt rescope status = %#v", accepted)
+	}
+}
+
 // TestRuntimeLedgerRescopeNarrowsFailedVerificationToTestOnlyRemediation is
 // #2296 part 2's distinct scenario reusing the exact same rescope mechanism:
 // after an admitted failed independent verification (zero drift once


### PR DESCRIPTION
Closes #2830

## Summary

- Reject a second rescope before publication until the current objective has its own terminal attempt.
- Use one shared writer/replay predicate, removing the asymmetry that poisoned the ledger.
- Make the new transition axis and CI require the corrected behavior.

## Changes

| File | Change |
|---|---|
| `internal/sddstatus/runtime_ledger.go` | Move objective ownership into the shared rescope admissibility predicate. |
| `internal/sddstatus/runtime_ledger_rescope_test.go` | Prove refusal is non-mutating, status remains readable, and later legitimate rescope still works. |
| `bench/journeys_rescope_write_guard.go` | Add core journey `j79` for the operator flow. |
| `bench/journeys_transition.go` | Bind rescope steps to the rescope capability. |
| `.github/workflows/ci.yml` | Require `tr01` and all transition journeys to complete. |

## Test Plan

- [x] `go test ./internal/sddstatus -run ^TestRuntimeLedgerRescopeRefusesConsecutiveRescopeWithoutOwnAttempt -count=1`
- [x] `go test ./internal/sddstatus -count=1`
- [x] `go test ./... -count=1`
- [x] `cd bench && go test ./... -count=1`
- [x] `cd bench && go vet ./...`
- [x] CI-shaped driven core: 80 completed, 0 unsupported, 0 failed
- [x] CI-shaped transition axis: 91 completed, 0 unsupported, 0 failed; 11/11 transition journeys completed
- [x] Exact CI `jq` gates returned true
- [x] Independent read-only validation passed on `990493109722a704d1295cfc9d7f2a7d0bb35501`

## Contributor Checklist

- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commits only
- [x] No source-mutating checks after final normalization
- [x] No `Co-Authored-By` trailers
- [x] Recovery of stores already poisoned by the released RC remains separately scoped to #2839

Changed-line budget: 330 additions plus deletions. Receipt-driven development is clone-disabled, so delivery follows ordinary repository policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rescoping objectives with clearer validation of successor attempts and statuses.
  * Consecutive rescopes are now rejected until the successor records its own terminal attempt.
  * Expanded transition benchmarks to cover rescope behavior across handoffs, reviews, and reset sequences.

* **Bug Fixes**
  * Prevented superseded objective attempts from incorrectly authorizing rescopes.
  * Ensured rejected rescopes leave runtime authority and status unchanged.

* **Tests**
  * Added regression coverage for rescope validation and expanded transition journey verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->