### PR TITLE
fix(sdd): admit rescope-authorized evidence retry

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -540,6 +540,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, captureResultDryRunJourneys()...)
 	journeys = append(journeys, findingIDPrefixJourneys()...)
 	journeys = append(journeys, rescopeWriteGuardJourneys()...)
+	journeys = append(journeys, rescopeEvidenceOnlyRetryJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -39,6 +39,7 @@ func journeySources() []journeySource {
 		{"journeys_capture_result_dry_run.go", captureResultDryRunJourneys()},
 		{"journeys_finding_id_prefix.go", findingIDPrefixJourneys()},
 		{"journeys_rescope_write_guard.go", rescopeWriteGuardJourneys()},
+		{"journeys_rescope_evidence_retry.go", rescopeEvidenceOnlyRetryJourneys()},
 	}
 }
 

--- a/bench/journeys_rescope_evidence_retry.go
+++ b/bench/journeys_rescope_evidence_retry.go
@@ -1,0 +1,110 @@
+package main
+
+import "fmt"
+
+// #2621: j79 is reserved by the independent #2830 branch, so this branch uses
+// j80 to keep the black-box corpus collision-free when the two fixes converge.
+var sddRescopeEvidenceObjectiveA = []string{
+	"--work-unit", "verification objective A",
+	"--evidence-goal", "record the failed verification evidence",
+	"--max-attempts", "2", "--max-changed-lines", "20",
+}
+
+var sddRescopeEvidenceObjectiveB = []string{
+	"--work-unit", "runtime proof objective B",
+	"--evidence-goal", "rerun evidence against objective A's unchanged candidate",
+	"--max-attempts", "2", "--max-changed-lines", "10",
+}
+
+func sddRescopeEvidenceFailureA(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-rescope-evidence-begin-a", sddRescopeEvidenceObjectiveA...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-rescope-evidence-finish-a",
+		append([]string{"--outcome", "failed", "--evidence-revision", sddFailedEvidence}, sddTerminalEvidence...)...), false)
+	failed, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if failed.ActiveAttempt != nil || len(failed.Attempts) != 1 || failed.Attempts[0].Outcome != "failed" ||
+		failed.NextAction != "begin" {
+		return fmt.Errorf("failed objective A did not retain an ordinary rescope continuation: %#v", failed)
+	}
+	return nil
+}
+
+func sddRescopeEvidenceAuditAtoB(r *journeyRun) error {
+	failed, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "rescope", failed.Revision, "bench-rescope-evidence-a-to-b",
+		append(sddRescopeEvidenceObjectiveB,
+			"--reason", "maintainer authorized a narrower runtime proof for the unchanged candidate",
+			"--actor", "bench")...), false)
+	rescoped, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if rescoped.NextAction != "begin" || rescoped.LastRescope == nil ||
+		rescoped.LastRescope.Actor != "bench" || rescoped.LastRescope.Reason == "" ||
+		rescoped.LastRescope.PreviousObjectiveID != failed.Attempts[0].ObjectiveID ||
+		rescoped.LastRescope.PreviousGeneration != failed.Attempts[0].ObjectiveGeneration ||
+		rescoped.LastRescope.RescopeCandidateTree != failed.Attempts[0].FinishCandidateTree {
+		return fmt.Errorf("audited A-to-B rescope did not preserve authority facts: %#v", rescoped)
+	}
+	return nil
+}
+
+func sddRescopeEvidenceOnlyPassB(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-rescope-evidence-begin-b", sddRescopeEvidenceObjectiveB...), false)
+	if status, err = readRuntimeStatus(r); err != nil {
+		return err
+	}
+	finished := r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-rescope-evidence-finish-b",
+		append([]string{
+			"--outcome", "passed", "--evidence-revision", sddCorrectedEvidence,
+			"--remediates-evidence-revision", sddFailedEvidence,
+		}, sddTerminalEvidence...)...), false)
+	if finished.ExitCode != 0 {
+		return fmt.Errorf("rescope-authorized evidence-only pass was refused: %s", firstLine(finished.Stderr))
+	}
+	completed, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if !completed.Complete || completed.NextAction != "complete" || completed.ActiveAttempt != nil || completed.Binding != nil ||
+		len(completed.Attempts) != 2 {
+		return fmt.Errorf("rescope-authorized evidence-only pass did not leave readable complete status: %#v", completed)
+	}
+	failed, retried := completed.Attempts[0], completed.Attempts[1]
+	if retried.RemediatesEvidenceRevision != sddFailedEvidence || retried.BeginCandidateTree != failed.FinishCandidateTree ||
+		retried.FinishCandidateTree != failed.FinishCandidateTree {
+		return fmt.Errorf("rescope-authorized pass did not preserve the failed evidence link and unchanged candidate: %#v", completed)
+	}
+	return nil
+}
+
+func rescopeEvidenceOnlyRetryJourneys() []Journey {
+	return []Journey{{
+		ID:     "j80-rescope-authorized-evidence-only-retry",
+		Title:  "Audited rescope authorizes one unchanged evidence-only retry",
+		Source: "#2621: failed A -> audited rescope B -> unchanged PASS linked to A",
+		Steps: []Step{
+			{Name: "fixture: runtime repository with one staged candidate", Fixture: sddRuntimeRepo},
+			{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+			{Name: "objective A fails with unused capacity", Requires: sddAttemptBeginCapability, Composite: sddRescopeEvidenceFailureA},
+			{Name: "audited rescope carries A authority into B", Requires: sddAttemptRescopeCapability, Composite: sddRescopeEvidenceAuditAtoB},
+			{Name: "unchanged evidence-only PASS for B links A and leaves complete status", Requires: sddAttemptRemediationCapability, Composite: sddRescopeEvidenceOnlyPassB},
+		},
+	}}
+}

--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -82,6 +82,10 @@ type sddRuntimeStatus struct {
 	} `json:"active_attempt"`
 	Attempts []struct {
 		Ordinal                    int    `json:"ordinal"`
+		ObjectiveID                string `json:"objective_id"`
+		ObjectiveGeneration        int    `json:"objective_generation"`
+		BeginCandidateTree         string `json:"begin_candidate_tree"`
+		FinishCandidateTree        string `json:"finish_candidate_tree"`
 		Outcome                    string `json:"outcome"`
 		EvidenceRevision           string `json:"evidence_revision"`
 		RemediatesEvidenceRevision string `json:"remediates_evidence_revision"`
@@ -92,6 +96,13 @@ type sddRuntimeStatus struct {
 		Change  string `json:"change"`
 		Lineage string `json:"lineage"`
 	} `json:"binding"`
+	LastRescope *struct {
+		PreviousObjectiveID  string `json:"previous_objective_id"`
+		PreviousGeneration   int    `json:"previous_generation"`
+		RescopeCandidateTree string `json:"rescope_candidate_tree"`
+		Reason               string `json:"reason"`
+		Actor                string `json:"actor"`
+	} `json:"last_rescope"`
 	NextAction string `json:"next_action"`
 	Complete   bool   `json:"complete"`
 }

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -34,14 +34,15 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 80 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
-	// j77-capture-result-input-preflight-is-read-only (#2630 D2) and
-	// j78-lens-finding-id-prefix-discovery (#1844), and j79-consecutive-
-	// rescope-refuses-before-publication (#2830).
+	// 81 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
+	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
+	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-
+	// only-retry (#2621).
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 80 {
-		t.Errorf("core journey count = %d, want 80", got)
+	if got := len(seen); got != 81 {
+		t.Errorf("core journey count = %d, want 81", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -895,9 +895,9 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			return runtimeRecord{}, fmt.Errorf("disabled failed verification requires --remediates-evidence-revision %q on the correction settle; rerun `gentle-ai sdd-attempt settle` with that flag", chainFailedEvidence)
 		}
 		if unmanagedRemediation {
-			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, chainFailedAttempt, snapshot.CandidateTree)
+			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, status.LastRescope, chainFailedAttempt, snapshot.CandidateTree)
 			if !evidenceOnly && (snapshot.Identity == active.BeginCandidateIdentity || snapshot.CandidateTree == active.BeginCandidateTree) {
-				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed by the active correction attempt, or an audited reset authorizing this exact unchanged candidate.
+				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed by the active correction attempt, or an audited reset or rescope authorizing this exact unchanged candidate.
 				return runtimeRecord{}, errors.New("unmanaged remediation requires a changed correction candidate")
 			}
 			if request.EvidenceRevision == request.RemediatesEvidenceRevision {
@@ -2075,10 +2075,10 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		// audited reset stay valid. The chain walk requires a settled failed
 		// predecessor, which subsumes the former len(Attempts) < 2 conjunct.
 		chainFailedAttempt, chainHasFailedEvidence := runtimeChainFailedAttempt(replay.Status.Attempts)
-		// #2621 lockstep twin: an audited reset that terminated the failing
-		// objective against these exact bytes authorizes one evidence-only
+		// #2621 lockstep twin: an audited reset or rescope that terminated the
+		// failing objective against these exact bytes authorizes one evidence-only
 		// retry, so a replayed correction may leave the candidate unchanged.
-		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, chainFailedAttempt, event.FinishCandidateTree)
+		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, chainFailedAttempt, event.FinishCandidateTree)
 		unchangedCandidate := event.FinishCandidateIdentity == active.BeginCandidateIdentity ||
 			event.FinishCandidateTree == active.BeginCandidateTree
 		if replay.Status.Binding != nil || event.Outcome != AttemptPassed ||
@@ -2913,8 +2913,8 @@ func runtimeChainFailedAttempt(attempts []RuntimeAttempt) (RuntimeAttempt, bool)
 	return RuntimeAttempt{}, false
 }
 
-// runtimeEvidenceOnlyRetryAuthorized reports whether an audited reset already
-// authorized one evidence-only correction of this exact candidate (#2621).
+// runtimeEvidenceOnlyRetryAuthorized reports whether an audited reset or rescope
+// already authorized one evidence-only correction of this exact candidate (#2621).
 //
 // A verification failure is not always candidate-caused: when the authoritative
 // suite fails on a transient defect the candidate never introduced, the honest
@@ -2924,9 +2924,11 @@ func runtimeChainFailedAttempt(attempts []RuntimeAttempt) (RuntimeAttempt, bool)
 // weakened for candidates nobody vouched for. So the waiver rests entirely on
 // authority the ledger ALREADY records rather than on a new operator claim:
 //
-//   - The reset names a maintainer and a reason. It is an audited human act.
+//   - The reset or rescope names a maintainer and a reason. It is an audited
+//     human act.
 //   - It terminated the exact objective+generation the failure was recorded
-//     under, so a reset taken before that failure can never authorize it.
+//     under, so an authority transition taken before that failure can never
+//     authorize it.
 //   - Its candidate tree is these bytes, so the maintainer authorized the
 //     retry while looking at precisely the content that is about to pass.
 //
@@ -2934,14 +2936,18 @@ func runtimeChainFailedAttempt(attempts []RuntimeAttempt) (RuntimeAttempt, bool)
 // be disabled with no binding, the chain must still hold the failed evidence
 // being repaired, and the corrected evidence must be fresh and distinct. No
 // approval is fabricated -- one that a human already gave is honored.
-func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, failed RuntimeAttempt, candidateTree string) bool {
-	if reset == nil || reset.Actor == "" || reset.Reason == "" || candidateTree == "" {
+func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, rescope *RuntimeRescope, failed RuntimeAttempt, candidateTree string) bool {
+	if candidateTree == "" {
 		return false
 	}
-	if reset.PreviousObjectiveID != failed.ObjectiveID || reset.PreviousGeneration != failed.ObjectiveGeneration {
-		return false
+	if reset != nil && reset.Actor != "" && reset.Reason != "" &&
+		reset.PreviousObjectiveID == failed.ObjectiveID && reset.PreviousGeneration == failed.ObjectiveGeneration &&
+		reset.ResetCandidateTree == candidateTree {
+		return true
 	}
-	return reset.ResetCandidateTree == candidateTree
+	return rescope != nil && rescope.Actor != "" && rescope.Reason != "" &&
+		rescope.PreviousObjectiveID == failed.ObjectiveID && rescope.PreviousGeneration == failed.ObjectiveGeneration &&
+		rescope.RescopeCandidateTree == candidateTree
 }
 
 func runtimeObjectiveID(change, workUnit, evidenceGoal, candidateIdentity string, generation int) string {

--- a/internal/sddstatus/runtime_ledger_evidence_only_retry_test.go
+++ b/internal/sddstatus/runtime_ledger_evidence_only_retry_test.go
@@ -140,3 +140,153 @@ func TestRuntimeUnchangedRetryWithoutAuditedResetStaysRefused(t *testing.T) {
 		t.Fatalf("unauthorized refusal mutated runtime: status=%#v err=%v records=%d", status, statusErr, countRuntimeRecords(t, store.Dir))
 	}
 }
+
+func TestRuntimeEvidenceOnlyRetrySettlesOnAuditedRescopeAuthority(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "rescope-evidence-only-retry")
+	store.ReviewDisabled = true
+
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "rescope-retry-begin-a", WorkUnit: "verify-objective-a",
+		EvidenceGoal: "independent verification of objective A", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('c')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "rescope-retry-finish-a", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "objective A verification failed with the candidate unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.DecisionRequired || failed.NextAction != RuntimeActionBegin || failed.CumulativeAttempts != 1 {
+		t.Fatalf("failed objective A did not retain unused capacity: %#v", failed)
+	}
+	failedObjective := *failed.Objective
+	failedCandidateTree := failed.Attempts[0].FinishCandidateTree
+
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "rescope-retry-a-to-b",
+		WorkUnit: "runtime-proof-objective-b", EvidenceGoal: "rerun evidence for objective A",
+		MaxAttempts: 2, MaxChangedLines: 10,
+		Reason: "maintainer authorized a narrower runtime proof for the unchanged candidate", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rescoped.LastRescope == nil || rescoped.LastRescope.PreviousObjectiveID != failedObjective.ID ||
+		rescoped.LastRescope.PreviousGeneration != failedObjective.Generation ||
+		rescoped.LastRescope.RescopeCandidateTree != failedCandidateTree {
+		t.Fatalf("audited A-to-B rescope did not preserve the failed authority facts: %#v", rescoped.LastRescope)
+	}
+
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: rescoped.Revision, RequestID: "rescope-retry-begin-b", WorkUnit: "runtime-proof-objective-b",
+		EvidenceGoal: "rerun evidence for objective A", MaxAttempts: 2, MaxChangedLines: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "rescope-retry-finish-b", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('d'), Diagnosis: "fresh runtime proof passed with the candidate unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "runtime proof cleanup completed",
+		ProcessEvidence: "runtime proof process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatalf("rescope-authorized evidence-only retry was refused: %v", err)
+	}
+	if !completed.Complete || completed.ActiveAttempt != nil || completed.Binding != nil {
+		t.Fatalf("rescope-authorized evidence-only retry = %#v", completed)
+	}
+	last := completed.Attempts[len(completed.Attempts)-1]
+	if last.RemediatesEvidenceRevision != failedEvidence || last.BeginCandidateTree != failedCandidateTree ||
+		last.FinishCandidateTree != failedCandidateTree {
+		t.Fatalf("rescope-authorized retry did not preserve the evidence link and candidate tree: %#v", last)
+	}
+
+	reopened := mustRuntimeStore(t, repo, "rescope-evidence-only-retry")
+	replayed, err := reopened.Status()
+	if err != nil || replayed.Revision != completed.Revision || !replayed.Complete || replayed.LastRescope == nil {
+		t.Fatalf("full-chain replay of the rescope-authorized retry = %#v err=%v", replayed, err)
+	}
+}
+
+func TestRuntimeRescopeBeforeObjectiveBFailureDoesNotAuthorizeEvidenceOnlyRetry(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "rescope-precedes-failure")
+	store.ReviewDisabled = true
+
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "precedes-begin-a", WorkUnit: "verify-objective-a",
+		EvidenceGoal: "independent verification of objective A", MaxAttempts: 3, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "precedes-finish-a", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('e'), Diagnosis: "objective A verification failed with the candidate unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedA, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failedA.Revision, RequestID: "precedes-a-to-b",
+		WorkUnit: "verify-objective-b", EvidenceGoal: "independent verification of objective B",
+		MaxAttempts: 3, MaxChangedLines: 10,
+		Reason: "maintainer narrowed the objective after objective A", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: rescoped.Revision, RequestID: "precedes-begin-b-failure", WorkUnit: "verify-objective-b",
+		EvidenceGoal: "independent verification of objective B", MaxAttempts: 3, MaxChangedLines: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedBEvidence := runtimeTestHash('f')
+	failedB, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: second.Revision, RequestID: "precedes-finish-b-failure", Outcome: AttemptFailed,
+		EvidenceRevision: failedBEvidence, Diagnosis: "objective B verification failed with the candidate unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: failedB.Revision, RequestID: "precedes-begin-b-retry", WorkUnit: "verify-objective-b",
+		EvidenceGoal: "independent verification of objective B", MaxAttempts: 3, MaxChangedLines: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := countRuntimeRecords(t, store.Dir)
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: retry.Revision, RequestID: "precedes-finish-b-retry", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "unchanged objective B retry claims a correction from the older rescope",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "retry cleanup completed",
+		ProcessEvidence: "retry process scan completed", RemediatesEvidenceRevision: failedBEvidence,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unmanaged remediation requires a changed correction candidate") {
+		t.Fatalf("older rescope authorized objective B retry = %v, want the changed-candidate refusal", err)
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil || status.Revision != retry.Revision || status.ActiveAttempt == nil ||
+		countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("older-rescope refusal mutated or damaged runtime state: status=%#v err=%v records=%d", status, statusErr, countRuntimeRecords(t, store.Dir))
+	}
+}


### PR DESCRIPTION
Closes #2621

## Summary

- Admit one unchanged evidence-only PASS when an audited rescope carries the same authority already accepted after reset.
- Bind the retry to actor, reason, failed objective/generation, and candidate tree without adding state or commands.
- Preserve reset-only, stale-rescope, and no-authority refusals.

## Chain Context

```text
main
├── ✅ #2847  #2830 prevention merged as c7807930
└── 📍 this PR  #2621 rescope-authorized retry
```

Start: #2847 is now on main and rejects consecutive rescope before publication.
End: this PR adds only the #2621 authorization predicate, tests, and j80.
Out of scope: #2839 recovery for ledgers already poisoned by the released RC.

## Changes

| File | Change |
|---|---|
| `internal/sddstatus/runtime_ledger.go` | Accept equivalent audited `LastRescope` authority in the existing evidence-only retry predicate. |
| `internal/sddstatus/runtime_ledger_evidence_only_retry_test.go` | Add positive rescope and stale-rescope negative behavior tests. |
| `bench/journeys_rescope_evidence_retry.go` | Add j80 black-box proof for the operator flow. |
| Bench registration/count files | Register the independent child journey without colliding with j79. |

## Test Plan

- [x] Focused rescope/reset/no-authority evidence-only retry tests passed with `-count=1`
- [x] `go test ./internal/sddstatus -count=1`
- [x] `go test ./... -count=1`
- [x] `cd bench && go test ./... -count=1`
- [x] `cd bench && go vet ./...`
- [x] CI-shaped core: 81 completed, 0 unsupported, 0 failed
- [x] CI-shaped transition axis: 92 completed, 0 unsupported, 0 failed; 11/11 transition journeys completed
- [x] Exact CI `jq` gates returned true
- [x] Independent read-only validation passed on `535259d7d7792978733764abe509d53c7450430a`

## Contributor Checklist

- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [x] Child diff is independently reviewable and rollback-safe

Child changed-line budget: 320 additions plus deletions. Receipt-driven development is clone-disabled, so delivery follows ordinary repository policy.