### PR TITLE
fix(agentbuilder): make installation transactional

### DIFF
--- a/internal/agentbuilder/installer.go
+++ b/internal/agentbuilder/installer.go
@@ -1,11 +1,20 @@
 package agentbuilder
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+var (
+	installerReadFile   = os.ReadFile
+	installerStat       = os.Stat
+	installerWriteFile  = os.WriteFile
+	installerRemoveFile = os.Remove
+	installerChmod      = os.Chmod
 )
 
 // AdapterInfo pairs an AgentID with the path to its skills directory.
@@ -15,47 +24,35 @@ type AdapterInfo struct {
 }
 
 // Install writes the SKILL.md for agent into each adapter's skills directory.
-// On any write failure all previously written files are rolled back (deleted).
+// finalize runs after the files are written and before the installation commits.
+// On any failure every destination is restored to its state before install.
 // Returns one InstallResult per adapter.
-func Install(agent *GeneratedAgent, adapters []AdapterInfo, _ string) ([]InstallResult, error) {
+func Install(agent *GeneratedAgent, adapters []AdapterInfo, finalize func([]InstallResult) error) ([]InstallResult, error) {
 	if agent == nil {
 		return nil, fmt.Errorf("install: agent must not be nil")
 	}
 
 	results := make([]InstallResult, 0, len(adapters))
-	written := make([]string, 0, len(adapters)) // paths written so far, for rollback
+	before := make([]beforeImage, 0, len(adapters))
 
 	for _, adapter := range adapters {
 		skillDir := filepath.Join(adapter.SkillsDir, agent.Name)
 		skillFile := filepath.Join(skillDir, "SKILL.md")
 
 		if err := os.MkdirAll(skillDir, 0755); err != nil {
-			// Rollback previously written files and mark all results as failed.
-			rollback(written)
-			markAllFailed(results)
-			results = append(results, InstallResult{
-				AgentID: adapter.AgentID,
-				Path:    skillFile,
-				Success: false,
-				Err:     fmt.Errorf("create directory %s: %w", skillDir, err),
-			})
-			return results, fmt.Errorf("install failed for %s: %w", adapter.AgentID, err)
+			return installFailure(results, before, adapter, skillFile, "create directory", err)
 		}
 
-		if err := os.WriteFile(skillFile, []byte(agent.Content), 0644); err != nil {
-			// Rollback previously written files and mark all results as failed.
-			rollback(written)
-			markAllFailed(results)
-			results = append(results, InstallResult{
-				AgentID: adapter.AgentID,
-				Path:    skillFile,
-				Success: false,
-				Err:     fmt.Errorf("write %s: %w", skillFile, err),
-			})
-			return results, fmt.Errorf("install failed for %s: %w", adapter.AgentID, err)
+		snapshot, err := captureBeforeImage(skillFile)
+		if err != nil {
+			return installFailure(results, before, adapter, skillFile, "snapshot", err)
+		}
+		before = append(before, snapshot)
+
+		if err := installerWriteFile(skillFile, []byte(agent.Content), 0644); err != nil {
+			return installFailure(results, before, adapter, skillFile, "write", err)
 		}
 
-		written = append(written, skillFile)
 		results = append(results, InstallResult{
 			AgentID: adapter.AgentID,
 			Path:    skillFile,
@@ -63,14 +60,83 @@ func Install(agent *GeneratedAgent, adapters []AdapterInfo, _ string) ([]Install
 		})
 	}
 
+	if finalize != nil {
+		if err := finalize(results); err != nil {
+			return finalizeFailure(results, before, err)
+		}
+	}
+
 	return results, nil
 }
 
-// rollback removes all files in paths, ignoring errors (best-effort cleanup).
-func rollback(paths []string) {
-	for _, p := range paths {
-		_ = os.Remove(p)
+type beforeImage struct {
+	path    string
+	content []byte
+	mode    os.FileMode
+	exists  bool
+}
+
+func captureBeforeImage(path string) (beforeImage, error) {
+	info, err := installerStat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return beforeImage{path: path}, nil
 	}
+	if err != nil {
+		return beforeImage{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	content, err := installerReadFile(path)
+	if err != nil {
+		return beforeImage{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return beforeImage{path: path, content: content, mode: info.Mode(), exists: true}, nil
+}
+
+func installFailure(results []InstallResult, before []beforeImage, adapter AdapterInfo, skillFile, operation string, cause error) ([]InstallResult, error) {
+	rollbackErr := rollback(before)
+	markAllFailed(results)
+	results = append(results, InstallResult{
+		AgentID: adapter.AgentID,
+		Path:    skillFile,
+		Success: false,
+		Err:     fmt.Errorf("%s %s: %w", operation, skillFile, cause),
+	})
+	installErr := fmt.Errorf("install failed for %s: %w", adapter.AgentID, cause)
+	if rollbackErr != nil {
+		return results, errors.Join(installErr, fmt.Errorf("rollback: %w", rollbackErr))
+	}
+	return results, installErr
+}
+
+func finalizeFailure(results []InstallResult, before []beforeImage, cause error) ([]InstallResult, error) {
+	rollbackErr := rollback(before)
+	markAllFailed(results)
+	installErr := fmt.Errorf("complete installation: %w", cause)
+	if rollbackErr != nil {
+		return results, errors.Join(installErr, fmt.Errorf("rollback: %w", rollbackErr))
+	}
+	return results, installErr
+}
+
+// rollback restores overwritten files and removes files created by this install.
+func rollback(before []beforeImage) error {
+	var rollbackErrors []error
+	for i := len(before) - 1; i >= 0; i-- {
+		snapshot := before[i]
+		if !snapshot.exists {
+			if err := installerRemoveFile(snapshot.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				rollbackErrors = append(rollbackErrors, fmt.Errorf("remove %s: %w", snapshot.path, err))
+			}
+			continue
+		}
+		if err := installerWriteFile(snapshot.path, snapshot.content, snapshot.mode); err != nil {
+			rollbackErrors = append(rollbackErrors, fmt.Errorf("restore %s: %w", snapshot.path, err))
+			continue
+		}
+		if err := installerChmod(snapshot.path, snapshot.mode); err != nil {
+			rollbackErrors = append(rollbackErrors, fmt.Errorf("restore mode %s: %w", snapshot.path, err))
+		}
+	}
+	return errors.Join(rollbackErrors...)
 }
 
 // markAllFailed sets Success=false on every result in the slice.

--- a/internal/agentbuilder/installer_test.go
+++ b/internal/agentbuilder/installer_test.go
@@ -1,6 +1,7 @@
 package agentbuilder
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +28,7 @@ func TestInstall_HappyPath_WritesFilesToBothDirs(t *testing.T) {
 		{AgentID: model.AgentOpenCode, SkillsDir: dir2},
 	}
 
-	results, err := Install(agent, adapters, "")
+	results, err := Install(agent, adapters, nil)
 	if err != nil {
 		t.Fatalf("Install error: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestInstall_FileContentMatchesAgentContent(t *testing.T) {
 		{AgentID: model.AgentClaudeCode, SkillsDir: dir},
 	}
 
-	results, err := Install(agent, adapters, "")
+	results, err := Install(agent, adapters, nil)
 	if err != nil {
 		t.Fatalf("Install error: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestInstall_MissingDirectory_CreatedAutomatically(t *testing.T) {
 		{AgentID: model.AgentClaudeCode, SkillsDir: skillsDir},
 	}
 
-	results, err := Install(agent, adapters, "")
+	results, err := Install(agent, adapters, nil)
 	if err != nil {
 		t.Fatalf("Install error: %v", err)
 	}
@@ -115,7 +116,7 @@ func TestInstall_RollbackOnSecondWriteFailure(t *testing.T) {
 		{AgentID: model.AgentOpenCode, SkillsDir: dir2},
 	}
 
-	_, err := Install(agent, adapters, "")
+	_, err := Install(agent, adapters, nil)
 	if err == nil {
 		t.Fatal("expected error when second write fails")
 	}
@@ -127,10 +128,79 @@ func TestInstall_RollbackOnSecondWriteFailure(t *testing.T) {
 	}
 }
 
+func TestInstall_RollbackRestoresOverwrittenFile(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	firstFile := filepath.Join(dir1, "my-agent", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(firstFile), 0755); err != nil {
+		t.Fatalf("create existing skill directory: %v", err)
+	}
+	const original = "# User-authored skill\n"
+	if err := os.WriteFile(firstFile, []byte(original), 0600); err != nil {
+		t.Fatalf("write existing skill: %v", err)
+	}
+
+	blocker := filepath.Join(dir2, "my-agent")
+	if err := os.WriteFile(blocker, []byte("block"), 0444); err != nil {
+		t.Fatalf("setup blocker: %v", err)
+	}
+
+	_, err := Install(makeAgent("my-agent", "# Generated skill\n"), []AdapterInfo{
+		{AgentID: model.AgentClaudeCode, SkillsDir: dir1},
+		{AgentID: model.AgentOpenCode, SkillsDir: dir2},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error when second adapter cannot be installed")
+	}
+
+	data, readErr := os.ReadFile(firstFile)
+	if readErr != nil {
+		t.Fatalf("read restored skill: %v", readErr)
+	}
+	if string(data) != original {
+		t.Errorf("restored content = %q, want %q", data, original)
+	}
+	info, statErr := os.Stat(firstFile)
+	if statErr != nil {
+		t.Fatalf("stat restored skill: %v", statErr)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0600); got != want {
+		t.Errorf("restored mode = %04o, want %04o", got, want)
+	}
+}
+
+func TestInstall_ReturnsRollbackRemovalFailure(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	firstFile := filepath.Join(dir1, "my-agent", "SKILL.md")
+	blocker := filepath.Join(dir2, "my-agent")
+	if err := os.WriteFile(blocker, []byte("block"), 0444); err != nil {
+		t.Fatalf("setup blocker: %v", err)
+	}
+
+	rollbackErr := errors.New("rollback removal failed")
+	originalRemove := installerRemoveFile
+	installerRemoveFile = func(path string) error {
+		if path == firstFile {
+			return rollbackErr
+		}
+		return originalRemove(path)
+	}
+	t.Cleanup(func() { installerRemoveFile = originalRemove })
+
+	_, err := Install(makeAgent("my-agent", "# Agent\n"), []AdapterInfo{
+		{AgentID: model.AgentClaudeCode, SkillsDir: dir1},
+		{AgentID: model.AgentOpenCode, SkillsDir: dir2},
+	}, nil)
+	if !errors.Is(err, rollbackErr) {
+		t.Fatalf("Install error = %v, want rollback error %v", err, rollbackErr)
+	}
+}
+
 func TestInstall_EmptyAdapters_NoErrorAndEmptyResults(t *testing.T) {
 	agent := makeAgent("my-agent", "# Agent\n")
 
-	results, err := Install(agent, []AdapterInfo{}, "")
+	results, err := Install(agent, []AdapterInfo{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error with empty adapters: %v", err)
 	}
@@ -140,8 +210,50 @@ func TestInstall_EmptyAdapters_NoErrorAndEmptyResults(t *testing.T) {
 }
 
 func TestInstall_NilAgent_ReturnsError(t *testing.T) {
-	_, err := Install(nil, []AdapterInfo{}, "")
+	_, err := Install(nil, []AdapterInfo{}, nil)
 	if err == nil {
 		t.Fatal("expected error for nil agent")
+	}
+}
+
+func TestInstall_FinalizationFailureRollsBack(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{name: "registry persistence", err: errors.New("registry is read-only")},
+		{name: "SDD wiring", err: errors.New("system prompt is read-only")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			skillFile := filepath.Join(dir, "my-agent", "SKILL.md")
+			if err := os.MkdirAll(filepath.Dir(skillFile), 0755); err != nil {
+				t.Fatalf("create skill directory: %v", err)
+			}
+			const original = "# User-authored skill\n"
+			if err := os.WriteFile(skillFile, []byte(original), 0600); err != nil {
+				t.Fatalf("write existing skill: %v", err)
+			}
+
+			results, err := Install(makeAgent("my-agent", "# Generated skill\n"), []AdapterInfo{
+				{AgentID: model.AgentClaudeCode, SkillsDir: dir},
+			}, func([]InstallResult) error {
+				return tt.err
+			})
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("Install error = %v, want finalization error %v", err, tt.err)
+			}
+			if len(results) != 1 || results[0].Success {
+				t.Fatalf("results = %#v, want one failed result", results)
+			}
+
+			data, readErr := os.ReadFile(skillFile)
+			if readErr != nil {
+				t.Fatalf("read restored skill: %v", readErr)
+			}
+			if string(data) != original {
+				t.Errorf("restored content = %q, want %q", data, original)
+			}
+		})
 	}
 }

--- a/internal/agentbuilder/integration_test.go
+++ b/internal/agentbuilder/integration_test.go
@@ -88,7 +88,7 @@ func TestIntegration_FullAgentBuilderFlow(t *testing.T) {
 		{AgentID: model.AgentOpenCode, SkillsDir: dir2},
 	}
 
-	results, err := Install(agent, adapters, "")
+	results, err := Install(agent, adapters, nil)
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}

--- a/internal/tui/agent_builder_nav_test.go
+++ b/internal/tui/agent_builder_nav_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/textarea"
@@ -243,6 +245,209 @@ func TestAgentBuilder_InstallDoneMsg_MovesToComplete(t *testing.T) {
 	if len(state.AgentBuilder.InstallResults) != 1 {
 		t.Errorf("InstallResults len = %d, want 1", len(state.AgentBuilder.InstallResults))
 	}
+}
+
+func TestAgentBuilder_RegistryWriteFailurePreventsSuccess(t *testing.T) {
+	registryErr := errors.New("registry is read-only")
+	_, _ = installAgentBuilderDependencies(t, registryErr, nil)
+
+	started, cmd := agentBuilderInstallModel().startInstallation()
+	done := agentBuilderInstallDoneFromCmd(t, cmd)
+	if !errors.Is(done.Err, registryErr) {
+		t.Fatalf("install error = %v, want registry error %v", done.Err, registryErr)
+	}
+	if len(done.Results) != 1 || done.Results[0].Success {
+		t.Fatalf("results = %#v, want one failed result", done.Results)
+	}
+	updated, _ := started.Update(done)
+	if state := updated.(Model); state.Screen != ScreenAgentBuilderPreview {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderPreview", state.Screen)
+	}
+}
+
+func TestAgentBuilder_SDDReferenceWriteFailurePreventsSuccess(t *testing.T) {
+	sddErr := errors.New("system prompt is read-only")
+	savedRegistries, _ := installAgentBuilderDependencies(t, nil, sddErr)
+	m := agentBuilderInstallModel()
+	m.AgentBuilder.Generated.SDDConfig = &agentbuilder.SDDIntegration{Mode: agentbuilder.SDDPhaseSupport, TargetPhase: "apply"}
+
+	started, cmd := m.startInstallation()
+	done := agentBuilderInstallDoneFromCmd(t, cmd)
+	if !errors.Is(done.Err, sddErr) {
+		t.Fatalf("install error = %v, want SDD error %v", done.Err, sddErr)
+	}
+	if len(done.Results) != 1 || done.Results[0].Success {
+		t.Fatalf("results = %#v, want one failed result", done.Results)
+	}
+	if len(*savedRegistries) != 2 {
+		t.Fatalf("registry save calls = %d, want 2 (persist then restore)", len(*savedRegistries))
+	}
+	if got := len((*savedRegistries)[1].Agents); got != 0 {
+		t.Fatalf("restored registry agents = %d, want 0", got)
+	}
+	updated, _ := started.Update(done)
+	if state := updated.(Model); state.Screen != ScreenAgentBuilderPreview {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderPreview", state.Screen)
+	}
+}
+
+func TestAgentBuilder_LaterSDDReferenceFailureRestoresEarlierSystemPrompt(t *testing.T) {
+	sddErr := errors.New("later system prompt is read-only")
+	_, home := installAgentBuilderDependencies(t, nil, nil)
+	original := []byte("# Existing Claude instructions\n")
+	claudePrompt := filepath.Join(home, ".claude", "CLAUDE.md")
+	openCodePrompt := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	for _, path := range []string{claudePrompt, openCodePrompt} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(claudePrompt, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(openCodePrompt, []byte("# Existing OpenCode instructions\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	agentBuilderInjectSDDReferenceFn = func(_ *agentbuilder.GeneratedAgent, path string) error {
+		if path == openCodePrompt {
+			return sddErr
+		}
+		if err := os.WriteFile(path, []byte("modified"), 0o644); err != nil {
+			return err
+		}
+		return os.Chmod(path, 0o644)
+	}
+	m := agentBuilderInstallModel()
+	m.AgentBuilder.AvailableEngines = []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode}
+	m.AgentBuilder.Generated.SDDConfig = &agentbuilder.SDDIntegration{Mode: agentbuilder.SDDPhaseSupport, TargetPhase: "apply"}
+
+	_, cmd := m.startInstallation()
+	done := agentBuilderInstallDoneFromCmd(t, cmd)
+	if !errors.Is(done.Err, sddErr) {
+		t.Fatalf("install error = %v, want SDD error %v", done.Err, sddErr)
+	}
+	content, err := os.ReadFile(claudePrompt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != string(original) {
+		t.Fatalf("earlier system prompt = %q, want exact before-image %q", content, original)
+	}
+	info, err := os.Stat(claudePrompt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("earlier system prompt mode = %o, want 600", got)
+	}
+}
+
+func TestAgentBuilder_SDDReferenceFailureJoinsPromptRollbackError(t *testing.T) {
+	sddErr := errors.New("later system prompt is read-only")
+	rollbackErr := errors.New("restore system prompt failed")
+	_, _ = installAgentBuilderDependencies(t, nil, nil)
+	injections := 0
+	agentBuilderInjectSDDReferenceFn = func(*agentbuilder.GeneratedAgent, string) error {
+		injections++
+		if injections == 2 {
+			return sddErr
+		}
+		return nil
+	}
+	originalRestore := agentBuilderRestoreSystemPromptsFn
+	agentBuilderRestoreSystemPromptsFn = func([]agentBuilderSystemPromptBeforeImage) error { return rollbackErr }
+	t.Cleanup(func() { agentBuilderRestoreSystemPromptsFn = originalRestore })
+	m := agentBuilderInstallModel()
+	m.AgentBuilder.AvailableEngines = []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode}
+	m.AgentBuilder.Generated.SDDConfig = &agentbuilder.SDDIntegration{Mode: agentbuilder.SDDPhaseSupport, TargetPhase: "apply"}
+
+	_, cmd := m.startInstallation()
+	done := agentBuilderInstallDoneFromCmd(t, cmd)
+	if !errors.Is(done.Err, sddErr) {
+		t.Fatalf("install error = %v, want SDD error %v", done.Err, sddErr)
+	}
+	if !errors.Is(done.Err, rollbackErr) {
+		t.Fatalf("install error = %v, want prompt rollback error %v", done.Err, rollbackErr)
+	}
+}
+
+func agentBuilderInstallModel() Model {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.AgentBuilder = AgentBuilderState{
+		AvailableEngines: []model.AgentID{model.AgentClaudeCode},
+		SelectedEngine:   model.AgentClaudeCode,
+		Generated: &agentbuilder.GeneratedAgent{
+			Name:    "my-agent",
+			Title:   "My Agent",
+			Content: "# My Agent\n",
+		},
+	}
+	return m
+}
+
+func installAgentBuilderDependencies(t *testing.T, registryErr, sddErr error) (*[]agentbuilder.Registry, string) {
+	t.Helper()
+	originalInstall := agentBuilderInstallFn
+	originalMkdirAll := agentBuilderMkdirAllFn
+	originalLoadRegistry := agentBuilderLoadRegistryFn
+	originalSaveRegistry := agentBuilderSaveRegistryFn
+	originalInjectSDDReference := agentBuilderInjectSDDReferenceFn
+	originalHomeDir := agentBuilderHomeDirFn
+	agentBuilderInstallFn = func(_ *agentbuilder.GeneratedAgent, adapters []agentbuilder.AdapterInfo, finalize func([]agentbuilder.InstallResult) error) ([]agentbuilder.InstallResult, error) {
+		results := make([]agentbuilder.InstallResult, 0, len(adapters))
+		for _, adapter := range adapters {
+			results = append(results, agentbuilder.InstallResult{AgentID: adapter.AgentID, Success: true})
+		}
+		if err := finalize(results); err != nil {
+			for i := range results {
+				results[i].Success = false
+			}
+			return results, err
+		}
+		return results, nil
+	}
+	agentBuilderMkdirAllFn = func(string, os.FileMode) error { return nil }
+	agentBuilderLoadRegistryFn = func(string) (*agentbuilder.Registry, error) { return &agentbuilder.Registry{Version: 1}, nil }
+	savedRegistries := []agentbuilder.Registry{}
+	agentBuilderSaveRegistryFn = func(_ string, reg *agentbuilder.Registry) error {
+		snapshot := *reg
+		snapshot.Agents = append([]agentbuilder.RegistryEntry(nil), reg.Agents...)
+		savedRegistries = append(savedRegistries, snapshot)
+		if len(savedRegistries) == 1 {
+			return registryErr
+		}
+		return nil
+	}
+	agentBuilderInjectSDDReferenceFn = func(*agentbuilder.GeneratedAgent, string) error { return sddErr }
+	home := t.TempDir()
+	agentBuilderHomeDirFn = func() string { return home }
+	t.Cleanup(func() {
+		agentBuilderInstallFn = originalInstall
+		agentBuilderMkdirAllFn = originalMkdirAll
+		agentBuilderLoadRegistryFn = originalLoadRegistry
+		agentBuilderSaveRegistryFn = originalSaveRegistry
+		agentBuilderInjectSDDReferenceFn = originalInjectSDDReference
+		agentBuilderHomeDirFn = originalHomeDir
+	})
+	return &savedRegistries, home
+}
+
+func agentBuilderInstallDoneFromCmd(t *testing.T, cmd tea.Cmd) AgentBuilderInstallDoneMsg {
+	t.Helper()
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, batchCmd := range batch {
+			if done, ok := batchCmd().(AgentBuilderInstallDoneMsg); ok {
+				return done
+			}
+		}
+	}
+	if done, ok := msg.(AgentBuilderInstallDoneMsg); ok {
+		return done
+	}
+	t.Fatalf("message = %T, want AgentBuilderInstallDoneMsg", msg)
+	return AgentBuilderInstallDoneMsg{}
 }
 
 // ─── T-28.13: Enter on Complete → back to Welcome ────────────────────────────

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -104,6 +104,13 @@ var osRemoveFn = os.Remove
 var execCommandFn = exec.Command
 var communityToolInstallFn = communitytool.Install
 var communityToolStatusFn = communitytool.DetectStatus
+var agentBuilderInstallFn = agentbuilder.Install
+var agentBuilderMkdirAllFn = os.MkdirAll
+var agentBuilderLoadRegistryFn = agentbuilder.LoadRegistry
+var agentBuilderSaveRegistryFn = agentbuilder.SaveRegistry
+var agentBuilderInjectSDDReferenceFn = agentbuilder.InjectSDDReference
+var agentBuilderHomeDirFn = homeDir
+var agentBuilderRestoreSystemPromptsFn = restoreAgentBuilderSystemPrompts
 
 // readCurrentAssignmentsFn is a package-level variable so tests can override
 // how current model assignments are read from opencode.json. It wraps
@@ -4863,15 +4870,27 @@ func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 			installAgent = &copy
 		}
 
-		results, err := agentbuilder.Install(installAgent, adapters, "")
-		if err != nil {
-			return AgentBuilderInstallDoneMsg{Results: results, Err: err}
-		}
+		results, err := agentBuilderInstallFn(installAgent, adapters, func(results []agentbuilder.InstallResult) error {
+			var promptBefore []agentBuilderSystemPromptBeforeImage
+			if installAgent.SDDConfig != nil && installAgent.SDDConfig.Mode != agentbuilder.SDDStandalone {
+				var err error
+				promptBefore, err = captureAgentBuilderSystemPrompts(adapters)
+				if err != nil {
+					return fmt.Errorf("snapshot system prompts: %w", err)
+				}
+			}
 
-		// Persist entry to registry.
-		registryPath := filepath.Join(homeDir(), ".config", "gentle-ai", "custom-agents.json")
-		_ = os.MkdirAll(filepath.Dir(registryPath), 0755)
-		if reg, loadErr := agentbuilder.LoadRegistry(registryPath); loadErr == nil {
+			// Persist entry to registry.
+			registryPath := filepath.Join(agentBuilderHomeDirFn(), ".config", "gentle-ai", "custom-agents.json")
+			if err := agentBuilderMkdirAllFn(filepath.Dir(registryPath), 0755); err != nil {
+				return fmt.Errorf("create custom-agent registry directory: %w", err)
+			}
+			reg, err := agentBuilderLoadRegistryFn(registryPath)
+			if err != nil {
+				return fmt.Errorf("load custom-agent registry: %w", err)
+			}
+			registryBefore := *reg
+			registryBefore.Agents = append([]agentbuilder.RegistryEntry(nil), reg.Agents...)
 			// Collect IDs of agents that were successfully installed.
 			var installedIDs []model.AgentID
 			for _, r := range results {
@@ -4899,18 +4918,30 @@ func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 			} else {
 				reg.Add(entry)
 			}
-			// Best-effort save — ignore save errors.
-			_ = agentbuilder.SaveRegistry(registryPath, reg)
-		}
+			if err := agentBuilderSaveRegistryFn(registryPath, reg); err != nil {
+				return fmt.Errorf("save custom-agent registry: %w", err)
+			}
 
-		// Wire SDD injection: append custom-agent reference blocks to system prompts.
-		// Best-effort — don't fail the whole install if SDD injection fails.
-		if installAgent.SDDConfig != nil && installAgent.SDDConfig.Mode != agentbuilder.SDDStandalone {
-			for _, adapter := range adapters {
-				if systemPromptPath, ok := agentBuilderSystemPromptPath(adapter.AgentID); ok {
-					_ = agentbuilder.InjectSDDReference(installAgent, systemPromptPath)
+			// Wire SDD injection: append custom-agent reference blocks to system prompts.
+			if installAgent.SDDConfig != nil && installAgent.SDDConfig.Mode != agentbuilder.SDDStandalone {
+				for _, adapter := range adapters {
+					if systemPromptPath, ok := agentBuilderSystemPromptPath(adapter.AgentID); ok {
+						if err := agentBuilderInjectSDDReferenceFn(installAgent, systemPromptPath); err != nil {
+							wireErr := fmt.Errorf("wire SDD reference for %s: %w", adapter.AgentID, err)
+							promptRestoreErr := agentBuilderRestoreSystemPromptsFn(promptBefore)
+							var registryRestoreErr error
+							if restoreErr := agentBuilderSaveRegistryFn(registryPath, &registryBefore); restoreErr != nil {
+								registryRestoreErr = fmt.Errorf("restore custom-agent registry: %w", restoreErr)
+							}
+							return errors.Join(wireErr, promptRestoreErr, registryRestoreErr)
+						}
+					}
 				}
 			}
+			return nil
+		})
+		if err != nil {
+			return AgentBuilderInstallDoneMsg{Results: results, Err: err}
 		}
 
 		return AgentBuilderInstallDoneMsg{Results: results, Err: nil}
@@ -4919,7 +4950,7 @@ func (m Model) startInstallation() (tea.Model, tea.Cmd) {
 
 // agentBuilderSystemPromptPath returns the system prompt file path for the given agent.
 func agentBuilderSystemPromptPath(agentID model.AgentID) (string, bool) {
-	home := homeDir()
+	home := agentBuilderHomeDirFn()
 	switch agentID {
 	case model.AgentClaudeCode:
 		return filepath.Join(home, ".claude", "CLAUDE.md"), true
@@ -4932,4 +4963,61 @@ func agentBuilderSystemPromptPath(agentID model.AgentID) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+type agentBuilderSystemPromptBeforeImage struct {
+	path    string
+	content []byte
+	mode    os.FileMode
+	exists  bool
+}
+
+func captureAgentBuilderSystemPrompts(adapters []agentbuilder.AdapterInfo) ([]agentBuilderSystemPromptBeforeImage, error) {
+	before := make([]agentBuilderSystemPromptBeforeImage, 0, len(adapters))
+	for _, adapter := range adapters {
+		path, ok := agentBuilderSystemPromptPath(adapter.AgentID)
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			before = append(before, agentBuilderSystemPromptBeforeImage{path: path})
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, err)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		before = append(before, agentBuilderSystemPromptBeforeImage{
+			path:    path,
+			content: content,
+			mode:    info.Mode(),
+			exists:  true,
+		})
+	}
+	return before, nil
+}
+
+func restoreAgentBuilderSystemPrompts(before []agentBuilderSystemPromptBeforeImage) error {
+	var restoreErrors []error
+	for i := len(before) - 1; i >= 0; i-- {
+		snapshot := before[i]
+		if !snapshot.exists {
+			if err := os.Remove(snapshot.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				restoreErrors = append(restoreErrors, fmt.Errorf("remove system prompt %s: %w", snapshot.path, err))
+			}
+			continue
+		}
+		if err := os.WriteFile(snapshot.path, snapshot.content, snapshot.mode); err != nil {
+			restoreErrors = append(restoreErrors, fmt.Errorf("restore system prompt %s: %w", snapshot.path, err))
+			continue
+		}
+		if err := os.Chmod(snapshot.path, snapshot.mode); err != nil {
+			restoreErrors = append(restoreErrors, fmt.Errorf("restore system prompt mode %s: %w", snapshot.path, err))
+		}
+	}
+	return errors.Join(restoreErrors...)
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2723

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Restores overwritten custom-agent files, including their exact bytes and modes, when installation fails.
- Makes registry persistence and requested SDD wiring part of the installation transaction.
- Restores registry and system-prompt before-images after later failures and surfaces rollback errors.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agentbuilder/installer.go` | Captures before-images and performs reverse rollback across installation and finalization failures. |
| `internal/agentbuilder/installer_test.go` | Covers overwritten files, mode restoration, finalization failures, and rollback errors. |
| `internal/agentbuilder/integration_test.go` | Updates the full agent-builder flow for transactional finalization. |
| `internal/tui/model.go` | Makes registry and SDD prompt persistence transactional with compensating restoration. |
| `internal/tui/agent_builder_nav_test.go` | Covers registry failures, multi-adapter prompt rollback, and joined restoration errors. |

---

## 🧪 Test Plan

- [x] Focused unit tests pass: `go test ./internal/agentbuilder ./internal/tui`
- [x] Go files are formatted with `gofmt`; `git diff --check` passes
- [ ] Full unit suite (`go test ./...`) — delegated to CI
- [ ] E2E tests — not run locally; no external-process or Docker behavior changed
- [x] Benchmark validation: N/A — this change does not touch review lifecycle, gates, recovery, delivery, benchmark code, corpus, classifiers, or benchmark claims

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #2723 with `status:approved`
- [x] Maintainer accepted `size:exception`: 579 changed lines are one atomic transaction; splitting installer and TUI would create an incomplete intermediate state
- [x] Appropriate `type:bug` label requested
- [x] Focused tests pass
- [x] Go formatting passes
- [x] Documentation is not required; this fixes existing behavior without adding a user-facing workflow
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Please focus on transaction boundaries and rollback ordering. Before-images are restored in reverse order, and rollback failures are joined with the primary installation error.

Rollback boundary: reverting commit `6cf4273c` removes the transactional installer and all associated tests without affecting unrelated behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Installations now support a finalization step after files are written.
  - Failed installations automatically roll back changes, restoring overwritten files and removing newly created files.

- **Bug Fixes**
  - Installation failures now report both the original error and any rollback errors.
  - Registry and system-prompt updates are restored when later installation steps fail.
  - Errors during registry, prompt, or directory operations are no longer silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->