### PR TITLE
test(engram): retry transient empty PID file

### DIFF
--- a/internal/components/engram/healthprobe_test.go
+++ b/internal/components/engram/healthprobe_test.go
@@ -260,20 +260,121 @@ func TestStdioHandshake_TerminatesDescendantOnContextEnd(t *testing.T) {
 	}
 }
 
+func TestWaitForHelperPID_RetriesTransientEmptyContent(t *testing.T) {
+	const wantPID = 2858
+	pidPath := filepath.Join(t.TempDir(), "descendant.pid")
+	if err := os.WriteFile(pidPath, nil, 0o600); err != nil {
+		t.Fatalf("create empty descendant pid file: %v", err)
+	}
+
+	firstRead := make(chan []byte, 1)
+	allowRetry := make(chan struct{})
+	readCount := 0
+	readFile := func(path string) ([]byte, error) {
+		raw, err := os.ReadFile(path)
+		if readCount == 0 {
+			firstRead <- raw
+			<-allowRetry
+		}
+		readCount++
+		return raw, err
+	}
+	type waitResult struct {
+		pid int
+		err error
+	}
+	result := make(chan waitResult, 1)
+	go func() {
+		pid, err := waitForHelperPIDWithReadFile(pidPath, 100*time.Millisecond, readFile)
+		result <- waitResult{pid: pid, err: err}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-allowRetry:
+		default:
+			close(allowRetry)
+		}
+	})
+
+	select {
+	case raw := <-firstRead:
+		if string(raw) != "" {
+			t.Fatalf("first descendant pid content = %q, want empty", raw)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForHelperPID() did not read the empty pid file")
+	}
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(wantPID)), 0o600); err != nil {
+		t.Fatalf("write descendant pid: %v", err)
+	}
+	close(allowRetry)
+
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatalf("waitForHelperPID() error = %v", got.err)
+		}
+		if got.pid != wantPID {
+			t.Fatalf("descendant pid = %d, want %d", got.pid, wantPID)
+		}
+		if readCount < 2 {
+			t.Fatalf("descendant pid reads = %d, want retry after empty content", readCount)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForHelperPID() did not retry after empty pid content")
+	}
+}
+
+func TestWaitForHelperPIDWithTimeout_PermanentMalformedContent(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "descendant.pid")
+	if err := os.WriteFile(pidPath, []byte("not-a-pid"), 0o600); err != nil {
+		t.Fatalf("write malformed descendant pid: %v", err)
+	}
+
+	_, err := waitForHelperPIDWithTimeout(pidPath, 30*time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForHelperPIDWithTimeout() error = nil, want malformed PID diagnostic")
+	}
+	if !strings.Contains(err.Error(), `last content = "not-a-pid"`) || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("waitForHelperPIDWithTimeout() error = %v, want last malformed content and parse error", err)
+	}
+}
+
 func waitForHelperPID(t *testing.T, path string) int {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	pid, err := waitForHelperPIDWithTimeout(path, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pid
+}
+
+func waitForHelperPIDWithTimeout(path string, timeout time.Duration) (int, error) {
+	return waitForHelperPIDWithReadFile(path, timeout, os.ReadFile)
+}
+
+func waitForHelperPIDWithReadFile(path string, timeout time.Duration, readFile func(string) ([]byte, error)) (int, error) {
+	deadline := time.Now().Add(timeout)
+	var lastContent []byte
+	var lastErr error
 	for {
-		raw, err := os.ReadFile(path)
+		raw, err := readFile(path)
 		if err == nil {
 			pid, parseErr := strconv.Atoi(string(raw))
-			if parseErr != nil || pid <= 0 {
-				t.Fatalf("descendant pid = %q, parse error = %v", raw, parseErr)
+			if parseErr == nil && pid > 0 {
+				return pid, nil
 			}
-			return pid
+			lastContent = raw
+			if parseErr != nil {
+				lastErr = parseErr
+			} else {
+				lastErr = fmt.Errorf("pid must be positive, got %d", pid)
+			}
+		} else {
+			lastErr = err
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("wait for descendant pid: %v", err)
+		if !time.Now().Before(deadline) {
+			return 0, fmt.Errorf("wait for descendant pid: last content = %q, last error = %w", lastContent, lastErr)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}


### PR DESCRIPTION
Closes #2858

## Summary

- Retry the create/truncate-before-write PID-file window until the existing deadline.
- Preserve bounded failure and final malformed-content diagnostics.
- Add deterministic eventual-success and permanent-malformed tests without changing production handshake code.

## Changes

| File | Change |
|---|---|
| `internal/components/engram/healthprobe_test.go` | Make the test helper retry transient PID content and add deterministic race regressions. |

## Test Plan

- [x] Empty-to-valid, malformed-timeout, and both original descendant callers passed 100 uncached repetitions
- [x] Focused tests passed under `go test -race`
- [x] `go test ./internal/components/engram -count=1`
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`
- [x] Independent read-only validation passed on `af68fb564099ff047ee74cfdd6e2e70bad605701`

Bench validation: N/A. This is test-only synchronization and changes no product lifecycle or journey behavior.

## Contributor Checklist

- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [x] Production code unchanged

Changed-line budget: 115 additions plus deletions. Native Windows CI remains the platform-specific proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved handling of temporarily empty or malformed process status information during health checks.
  * Timeout failures now provide clearer diagnostics, including the latest status content and error details.

* **Tests**
  * Added coverage for transient empty status data and permanently malformed status data.
  * Strengthened verification of retry and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->