### PR TITLE
fix(sdd): remove tools from profile overlay generator + orchestrator bash deny (Slice 2/4)

### DIFF
--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -295,18 +295,9 @@ func GenerateProfileOverlay(profile model.Profile, homeDir, settingsPath string,
 		"prompt":      orchestratorPrompt,
 		"permission": map[string]any{
 			"question": "allow",
+			"bash":     "deny",
 			"task": map[string]any{
 				"__replace__": taskPerms,
-			},
-		},
-		"tools": map[string]any{
-			"__replace__": map[string]any{
-				"read":     true,
-				"write":    true,
-				"edit":     true,
-				"bash":     true,
-				"question": true,
-				"task":     true,
 			},
 		},
 	}
@@ -357,12 +348,6 @@ func GenerateProfileOverlay(profile model.Profile, homeDir, settingsPath string,
 			"hidden":      true,
 			"description": phaseDescriptions[phase],
 			"prompt":      prompt,
-			"tools": map[string]any{
-				"read":  true,
-				"write": true,
-				"edit":  true,
-				"bash":  true,
-			},
 		}
 		// Issue #557: consult fallback when the profile did not set the phase,
 		// so generated *-{name} agents stay consistent with what the user sees
@@ -507,10 +492,6 @@ func jdProfileAgentEntry(jd string) map[string]any {
 			"hidden":      true,
 			"description": "Adversarial code reviewer — blind judge A for judgment-day protocol",
 			"prompt":      "You are a judgment-day adversarial reviewer. Execute the review instructions provided in the task prompt exactly. Do NOT delegate further. Do NOT modify any code — your job is ONLY to find problems.",
-			"tools": map[string]any{
-				"read": true,
-				"bash": true,
-			},
 		}
 	case "jd-judge-b":
 		return map[string]any{
@@ -518,10 +499,6 @@ func jdProfileAgentEntry(jd string) map[string]any {
 			"hidden":      true,
 			"description": "Adversarial code reviewer — blind judge B for judgment-day protocol",
 			"prompt":      "You are a judgment-day adversarial reviewer. Execute the review instructions provided in the task prompt exactly. Do NOT delegate further. Do NOT modify any code — your job is ONLY to find problems.",
-			"tools": map[string]any{
-				"read": true,
-				"bash": true,
-			},
 		}
 	case "jd-fix-agent":
 		return map[string]any{
@@ -529,12 +506,6 @@ func jdProfileAgentEntry(jd string) map[string]any {
 			"hidden":      true,
 			"description": "Surgical fix agent for judgment-day protocol",
 			"prompt":      "You are a judgment-day surgical fix agent. Execute the fix instructions provided in the task prompt exactly. Do NOT delegate further. Fix ONLY the confirmed issues listed — do NOT refactor beyond what is strictly needed.",
-			"tools": map[string]any{
-				"read":  true,
-				"write": true,
-				"edit":  true,
-				"bash":  true,
-			},
 		}
 	default:
 		return map[string]any{
@@ -542,10 +513,6 @@ func jdProfileAgentEntry(jd string) map[string]any {
 			"hidden":      true,
 			"description": jd,
 			"prompt":      "Execute the task prompt exactly. Do NOT delegate further.",
-			"tools": map[string]any{
-				"read": true,
-				"bash": true,
-			},
 		}
 	}
 }

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -648,24 +648,15 @@ func TestGenerateProfileOverlay_ToolsUseReplaceSentinel(t *testing.T) {
 
 	agentMap := root["agent"].(map[string]any)
 	orch := agentMap["sdd-orchestrator-cheap"].(map[string]any)
-	toolsWrapper, ok := orch["tools"].(map[string]any)
+	if toolsWrapper, hasTools := orch["tools"]; hasTools {
+		t.Fatalf("sdd-orchestrator-cheap must not carry a tools block (deletion-first migration; permission.bash:deny + read/basic tools inherited from global policy): %#v", toolsWrapper)
+	}
+	permission, ok := orch["permission"].(map[string]any)
 	if !ok {
-		t.Fatal("sdd-orchestrator-cheap tools is not an object")
+		t.Fatal("sdd-orchestrator-cheap permission is not an object")
 	}
-	tools, hasSentinel := toolsWrapper["__replace__"].(map[string]any)
-	if !hasSentinel {
-		t.Fatal("tools block must use __replace__ sentinel to discard legacy delegate tools on sync")
-	}
-
-	for _, required := range []string{"read", "write", "edit", "bash", "task"} {
-		if enabled, _ := tools[required].(bool); !enabled {
-			t.Fatalf("required tool %q missing or disabled: %#v", required, tools)
-		}
-	}
-	for _, legacyTool := range []string{"delegate", "delegation_read", "delegation_list"} {
-		if _, exists := tools[legacyTool]; exists {
-			t.Fatalf("legacy OpenCode tool %q must not be present: %#v", legacyTool, tools)
-		}
+	if bash, _ := permission["bash"].(string); bash != "deny" {
+		t.Fatalf("sdd-orchestrator-cheap permission.bash = %q, want \"deny\"", bash)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1889

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Slice 2/4 of the chained-PR stack (stacked-to-main) for the deletion-first migration that removes the deprecated `tools` field from every managed gentle-ai OpenCode agent. OpenCode treats `tools.bash: true` as `permission.bash: "allow"`, which overrides the user's global commit/push protections and is the root cause of issue #1889. Removing the field lets the global policy govern managed agents naturally.

This slice cleans the profile-scoped overlay generator (`profiles.go`): removes `tools:` blocks from the orchestrator entry, every SDD phase sub-agent entry, and all four `jdProfileAgentEntry` cases (jd-judge-a, jd-judge-b, jd-fix-agent, default). It adds an explicit `permission.bash: "deny"` to the profile orchestrator entry so it cannot run bash directly — the orchestrator must delegate to sub-agents, which inherit bash from the user's global policy.

Builds on Slice 1 ([#2825](https://github.com/Gentleman-Programming/gentle-ai/pull/2825)): the base overlay JSONs already had `tools:` removed and `TestDefaultOverlayToolsUseReplaceSentinel` in `profiles_test.go` was already inverted. This slice extends the same deletion-first treatment to the profile-scoped overlay generator.

**Authoring note:** this slice was implemented inline by the gentle-orchestrator (not the `sdd-apply` sub-agent) because the dispatcher's `maintainer_decision` gate blocked any new `sdd-attempt acquire` on this change until dnlrsls applies `size:exception` on Slice 1. User explicitly authorized the contract deviation.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/profiles.go` | Removed `tools` block from `orchEntry` (orchestrator entry); added `permission.bash: "deny"` between `question: "allow"` and the `task` block. Removed `tools` block from the SDD phase sub-agent `entry`. Removed `tools` blocks from all four `jdProfileAgentEntry` cases. |
| `internal/components/sdd/profiles_test.go` | Inverted `TestGenerateProfileOverlay_ToolsUseReplaceSentinel` to assert (a) no `tools` block on the orchestrator entry and (b) `permission.bash == "deny"`. |

Changed lines: **8 insertions, 50 deletions across 2 files** (58 total). Well within the 400-line review budget — no `size:exception` needed.

## 🧪 Test Plan

**Unit Tests — Slice 2 focused (`go test ./internal/components/sdd/... -run Profile`)**

```text
--- PASS: TestInjectOpenCodeWithProfile_PostCheckVerifiesOrchestrator (0.95s)
--- PASS: TestInjectOpenCodeWithProfile_DefaultProfileSkipped (0.77s)
--- PASS: TestInjectOpenCodeWithProfile_RemovesStaleProfileJDAgents (1.22s)
--- PASS: TestInjectOpenCodeWithProfile_StaleJDCleanupAcceptsJSONCSettings (0.96s)
--- PASS: TestInjectOpenCodeWithTwoProfiles_BothOrchestratorsPresent (0.93s)
--- PASS: TestGenerateProfileOverlay_FallsBackToGlobalAssignments (0.00s)
--- PASS: TestProfileLifecycle_FullCRUD (0.33s)
--- PASS: TestProfileLifecycle_TwoProfiles (0.32s)
--- PASS: TestGenerateProfileOverlay_Structure (0.00s)
--- PASS: TestGenerateProfileOverlay_PermissionScoped (0.01s)
--- PASS: TestGenerateProfileOverlay_JDAssignmentsGenerateSuffixedAgents (0.01s)
--- PASS: TestGenerateProfileOverlay_NoJDAssignmentsUsesGlobalJDAgents (0.01s)
--- PASS: TestGenerateProfileOverlay_ToolsUseReplaceSentinel (0.00s)  ← inverted this slice
--- PASS: TestGenerateProfileOverlay_TaskPermissionsBlockCrossProfileDelegation (0.00s)
--- PASS: TestGenerateProfileOverlay_SubAgentFileRefs (0.00s)
--- PASS: TestGenerateProfileOverlay_OrchestratorPromptSuffixed (0.00s)
--- PASS: TestGenerateProfileOverlay_ExcludesDesktopDelegationVisibility (0.01s)
--- PASS: TestRemoveProfileAgents_RemovesProfileSDDAndJDAgents (0.04s)
--- PASS: TestRemoveProfileAgents_CannotRemoveDefault (0.00s)
--- PASS: TestGenerateProfileOverlay_VariantInjected (0.00s)
--- PASS: TestGenerateProfileOverlay_EmptyEffortClearsVariant (0.00s)
... (full profile suite — all pass)
PASS
ok  	github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd	9.722s
```

**Other checks**

- `go test ./internal/assets/...` → PASS (2.0s)
- `go test ./internal/components -run TestGoldenSDD_OpenCode_Multi` → PASS (3.5s)
- `go run ./internal/gofmtcheck` → empty (clean)
- `go vet ./internal/... ./cmd/...` → clean

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#1889 approved by maintainer dnlrsls on 2026-08-08)
- [x] PR stays within 400 changed lines (58 total — no `size:exception` needed)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## 🔗 Chain Context

Slice 2 of 4 in the `fix-1889-remove-deprecated-tools-permission` stacked-to-main chain:

```
PR #2825 (Slice 1) ✅ — overlay JSONs no-tools + 2 inverted tests + golden refresh   ← merged first
PR #XXXX (Slice 2) 📍 — profiles.go no-tools + orchestrator bash deny             ← this PR
PR #YYYY (Slice 3) — inject.go no-tools + read-only invariants + 2 new test files (~200 lines)
PR #ZZZZ (Slice 4) — amend opencode-sdd-profiles spec + #787 regression + sync idempotence
```

When Slice 1 merges to upstream/main, this PR rebases cleanly (both slices modify `profiles_test.go` but at different lines and on different test functions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Generated profile orchestrators now explicitly deny direct Bash access.
  * Generated phase and Judgment Day agents no longer include direct tool permissions, reducing unintended access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->