### PR TITLE
test(bench): prove reviewed subset delivery

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -549,6 +549,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, rescopeWriteGuardJourneys()...)
 	journeys = append(journeys, rescopeEvidenceOnlyRetryJourneys()...)
 	journeys = append(journeys, consecutiveRescopeRepairJourneys()...)
+	journeys = append(journeys, reviewedSupersetJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -41,6 +41,7 @@ func journeySources() []journeySource {
 		{"journeys_rescope_write_guard.go", rescopeWriteGuardJourneys()},
 		{"journeys_rescope_evidence_retry.go", rescopeEvidenceOnlyRetryJourneys()},
 		{"journeys_consecutive_rescope_repair.go", consecutiveRescopeRepairJourneys()},
+		{"journeys_reviewed_superset.go", reviewedSupersetJourneys()},
 	}
 }
 

--- a/bench/journeys_reviewed_superset.go
+++ b/bench/journeys_reviewed_superset.go
@@ -139,11 +139,11 @@ func readReviewedSupersetStatus(run *journeyRun) (reviewedSupersetStatus, error)
 	observation := run.run(productArgsFor(run, "review", "status", "--contract", reviewContract, "--next-transition",
 		"--lineage", reviewedSupersetLineage, "--base-ref", run.sandbox.Scratch["reviewed-superset-base"]), false)
 	var status reviewedSupersetStatus
-	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &status); err != nil {
-		return status, fmt.Errorf("parse reviewed-superset receipt status: %w (stderr: %s)", err, firstLine(observation.Stderr))
-	}
 	if observation.ExitCode != 0 {
 		return status, fmt.Errorf("reviewed-superset receipt status exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &status); err != nil {
+		return status, fmt.Errorf("parse reviewed-superset receipt status: %w (stderr: %s)", err, firstLine(observation.Stderr))
 	}
 	return status, nil
 }
@@ -214,11 +214,12 @@ func publishReviewedPrefix(sandbox *Sandbox) error {
 func requireReviewedSupersetPrePushAllow(sandbox *Sandbox, observation Observation) error {
 	var gate waveGateResult
 	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate); err != nil {
+		if observation.ExitCode != 0 {
+			return fmt.Errorf("reviewed supersets pre-push exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+		}
 		return fmt.Errorf("parse reviewed-superset pre-push result: %w (stderr: %s)", err, firstLine(observation.Stderr))
 	}
-	if observation.ExitCode != 0 || !gate.Allowed || gate.Result != "allow" ||
-		gate.Context.LineageID != sandbox.Lineage ||
-		sandbox.Scratch["reviewed-superset-head-tree"] != sandbox.Scratch["reviewed-superset-tree"] {
+	if !gate.Allowed || gate.Result != "allow" || gate.Context.LineageID != sandbox.Lineage {
 		stage, code := "", ""
 		if gate.Context.Denial != nil {
 			stage, code = gate.Context.Denial.Stage, gate.Context.Denial.Code

--- a/bench/journeys_reviewed_superset.go
+++ b/bench/journeys_reviewed_superset.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	reviewedSupersetJourneyID = "j82-reviewed-superset-pre-push-allows-unpublished-subset"
+	reviewedSupersetLineage   = "reviewed-superset-pre-push"
+	reviewedSupersetPathA     = "docs/reviewed-a.md"
+	reviewedSupersetPathB     = "docs/reviewed-b.md"
+)
+
+var reviewedSupersetFinalizeCapability = &Capability{
+	Verb:  []string{"review", "finalize"},
+	Flags: []string{"--cwd", "--lineage"},
+}
+
+// reviewedSupersetStatus is the native status envelope evidence this journey
+// needs to distinguish an approved full receipt from a merely valid Git setup.
+type reviewedSupersetStatus struct {
+	Authority *struct {
+		LineageID string `json:"lineage_id"`
+		State     string `json:"state"`
+	} `json:"authority"`
+	Receipt struct {
+		Status   string `json:"status"`
+		Identity string `json:"identity"`
+	} `json:"receipt"`
+	Projection struct {
+		BaseTree             string   `json:"base_tree"`
+		CurrentCandidateTree string   `json:"current_candidate_tree"`
+		PathsDigest          string   `json:"paths_digest"`
+		Paths                []string `json:"paths"`
+	} `json:"projection"`
+}
+
+// reviewedSupersetFixture creates the approved candidate's real publication
+// topology before review: feature tracks origin/feature while both start at
+// main, and the committed candidate changes exactly A and B.
+func reviewedSupersetFixture(sandbox *Sandbox) error {
+	if err := baseRepoWithRemote(sandbox); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "-b", "feature"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "push", "-q", "-u", "origin", "feature"); err != nil {
+		return err
+	}
+	upstream, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "--abbrev-ref", "@{upstream}")
+	if err != nil {
+		return err
+	}
+	if upstream != "origin/feature" {
+		return fmt.Errorf("fixture feature upstream = %q, want origin/feature", upstream)
+	}
+	base, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["reviewed-superset-base"] = base
+	baseTree, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD^{tree}")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["reviewed-superset-base-tree"] = baseTree
+
+	for path, content := range map[string]string{
+		reviewedSupersetPathA: "# reviewed A\n\nFirst reviewed path.\n",
+		reviewedSupersetPathB: "# reviewed B\n\nSecond reviewed path.\n",
+	} {
+		if err := sandbox.write(filepath.Join(sandbox.Repo, path), content); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "--", reviewedSupersetPathA); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "docs: reviewed A"); err != nil {
+		return err
+	}
+	prefix, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["reviewed-superset-prefix"] = prefix
+	if err := sandbox.git(sandbox.Repo, "add", "--", reviewedSupersetPathB); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "docs: reviewed B"); err != nil {
+		return err
+	}
+	paths, err := gitOut(sandbox, sandbox.Repo, "diff", "--name-only", base+"..HEAD")
+	if err != nil {
+		return err
+	}
+	if paths != reviewedSupersetPathA+"\n"+reviewedSupersetPathB {
+		return fmt.Errorf("fixture candidate paths = %q, want {%s,%s}", paths, reviewedSupersetPathA, reviewedSupersetPathB)
+	}
+	tree, err := gitOut(sandbox, sandbox.Repo, "write-tree")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["reviewed-superset-tree"] = tree
+	return nil
+}
+
+// startReviewedSupersetBaseDiff follows the product's negotiated path because
+// direct committed base-diff starts are a distinct compatibility surface.
+func startReviewedSupersetBaseDiff(run *journeyRun) error {
+	envelope, err := readStatusFor(run, "--lineage", reviewedSupersetLineage, "--base-ref", run.sandbox.Scratch["reviewed-superset-base"])
+	if err != nil {
+		return err
+	}
+	if envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("committed reviewed-superset start transition = %+v", envelope.NextTransition)
+	}
+	started, err := runPrintedTransition(run, envelope)
+	if err != nil {
+		return err
+	}
+	if started.ExitCode != 0 {
+		return fmt.Errorf("committed reviewed-superset start exited %d: %s", started.ExitCode, firstLine(started.Stderr))
+	}
+	if err := rememberLineage(run.sandbox, started); err != nil {
+		return err
+	}
+	if run.sandbox.Lineage != reviewedSupersetLineage {
+		return fmt.Errorf("committed reviewed-superset start lineage = %q, want %q", run.sandbox.Lineage, reviewedSupersetLineage)
+	}
+	return nil
+}
+
+func readReviewedSupersetStatus(run *journeyRun) (reviewedSupersetStatus, error) {
+	observation := run.run(productArgsFor(run, "review", "status", "--contract", reviewContract, "--next-transition",
+		"--lineage", reviewedSupersetLineage, "--base-ref", run.sandbox.Scratch["reviewed-superset-base"]), false)
+	var status reviewedSupersetStatus
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &status); err != nil {
+		return status, fmt.Errorf("parse reviewed-superset receipt status: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if observation.ExitCode != 0 {
+		return status, fmt.Errorf("reviewed-superset receipt status exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	return status, nil
+}
+
+func proveReviewedSupersetReceipt(run *journeyRun) error {
+	status, err := readReviewedSupersetStatus(run)
+	if err != nil {
+		return err
+	}
+	if status.Authority == nil || status.Authority.LineageID != run.sandbox.Lineage || status.Authority.State != "approved" ||
+		status.Receipt.Status != "present" || status.Receipt.Identity == "" ||
+		status.Projection.BaseTree != run.sandbox.Scratch["reviewed-superset-base-tree"] ||
+		status.Projection.CurrentCandidateTree != run.sandbox.Scratch["reviewed-superset-tree"] ||
+		status.Projection.PathsDigest == "" ||
+		strings.Join(status.Projection.Paths, "\x00") != reviewedSupersetPathA+"\x00"+reviewedSupersetPathB {
+		return fmt.Errorf("approved full receipt was not proven: %+v", status)
+	}
+	return nil
+}
+
+// publishReviewedPrefix publishes only the already reviewed A prefix and proves
+// that B is the sole outgoing path while HEAD stays the exact full candidate.
+func publishReviewedPrefix(sandbox *Sandbox) error {
+	prefix := sandbox.Scratch["reviewed-superset-prefix"]
+	if err := sandbox.git(sandbox.Repo, "push", "-q", "origin", prefix+":feature"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "fetch", "-q", "origin", "feature"); err != nil {
+		return err
+	}
+
+	head, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	headTree, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD^{tree}")
+	if err != nil {
+		return err
+	}
+	upstream, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "@{upstream}")
+	if err != nil {
+		return err
+	}
+	outgoingPaths, err := gitOut(sandbox, sandbox.Repo, "diff", "--name-only", "@{upstream}..HEAD")
+	if err != nil {
+		return err
+	}
+	unpublished, err := gitOut(sandbox, sandbox.Repo, "rev-list", "--count", "@{upstream}..HEAD")
+	if err != nil {
+		return err
+	}
+	clean, err := gitOut(sandbox, sandbox.Repo, "status", "--porcelain")
+	if err != nil {
+		return err
+	}
+	if head == prefix || headTree != sandbox.Scratch["reviewed-superset-tree"] || upstream != prefix ||
+		outgoingPaths != reviewedSupersetPathB || unpublished != "1" || clean != "" {
+		return fmt.Errorf("reviewed-prefix publication proof failed: head=%s prefix=%s head_tree=%s receipt_tree=%s upstream=%s outgoing_paths=%q unpublished=%s status=%q",
+			head, prefix, headTree, sandbox.Scratch["reviewed-superset-tree"], upstream, outgoingPaths, unpublished, clean)
+	}
+	sandbox.Scratch["reviewed-superset-head-tree"] = headTree
+	sandbox.Scratch["reviewed-superset-outgoing-paths"] = outgoingPaths
+	return nil
+}
+
+// requireReviewedSupersetPrePushAllow records the native gate's denial stage and
+// code in the RED failure, so a setup error cannot masquerade as issue #2127.
+func requireReviewedSupersetPrePushAllow(sandbox *Sandbox, observation Observation) error {
+	var gate waveGateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate); err != nil {
+		return fmt.Errorf("parse reviewed-superset pre-push result: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if observation.ExitCode != 0 || !gate.Allowed || gate.Result != "allow" ||
+		gate.Context.LineageID != sandbox.Lineage ||
+		sandbox.Scratch["reviewed-superset-head-tree"] != sandbox.Scratch["reviewed-superset-tree"] {
+		stage, code := "", ""
+		if gate.Context.Denial != nil {
+			stage, code = gate.Context.Denial.Stage, gate.Context.Denial.Code
+		}
+		return fmt.Errorf("reviewed supersets pre-push rejected: exit=%d result=%q allowed=%t receipt_tree=%s local_head_tree=%s receipt_paths={%s,%s} outgoing_paths={%s} denial_stage=%q denial_code=%q gate=%+v; want allow for the monotonic unpublished subset",
+			observation.ExitCode, gate.Result, gate.Allowed, sandbox.Scratch["reviewed-superset-tree"], sandbox.Scratch["reviewed-superset-head-tree"], reviewedSupersetPathA, reviewedSupersetPathB, sandbox.Scratch["reviewed-superset-outgoing-paths"], stage, code, gate)
+	}
+	return nil
+}
+
+func reviewedSupersetJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     reviewedSupersetJourneyID,
+			Title:  "Approved full receipt: pre-push allows the unpublished reviewed subset",
+			Source: "#2127 ratified content-addressed authorization: an outgoing subset of the exact approved candidate remains authorized",
+			Steps: []Step{
+				{Name: "fixture: feature tracks origin and commits reviewed paths A and B", Fixture: reviewedSupersetFixture},
+				{Name: "negotiate and execute review start for the full candidate against main", Requires: statusCapability, Composite: startReviewedSupersetBaseDiff},
+				{Name: "review finalize the full candidate", Requires: reviewedSupersetFinalizeCapability, Args: productArgs("review", "finalize", "--lineage", reviewedSupersetLineage)},
+				{Name: "native status proves the approved receipt covers the exact full candidate and paths A and B", Requires: statusCapability, Composite: proveReviewedSupersetReceipt},
+				{Name: "fixture: publish only reviewed prefix A and prove B remains unpublished", Fixture: publishReviewedPrefix},
+				{Name: "pre-push allows the one-path unpublished subset B", Requires: validateCapability, Args: productArgs("review", "validate", "--gate", "pre-push"), After: requireReviewedSupersetPrePushAllow},
+			},
+		},
+	}
+}

--- a/bench/journeys_reviewed_superset_test.go
+++ b/bench/journeys_reviewed_superset_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRequireReviewedSupersetPrePushAllowObservationFailures(t *testing.T) {
+	sandbox := &Sandbox{
+		Lineage: reviewedSupersetLineage,
+		Scratch: map[string]string{
+			"reviewed-superset-tree":           "receipt-tree",
+			"reviewed-superset-head-tree":      "local-head-tree",
+			"reviewed-superset-outgoing-paths": reviewedSupersetPathB,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		observation Observation
+		want        []string
+		notWant     string
+	}{
+		{
+			name: "typed gate denial preserves receipt binding evidence",
+			observation: Observation{
+				ExitCode: 1,
+				Stdout:   `{"result":"scope-changed","allowed":false,"context":{"lineage_id":"reviewed-superset-pre-push","denial":{"stage":"receipt-binding","code":"candidate-or-paths-mismatch"}}}`,
+			},
+			want: []string{
+				"exit=1",
+				`result="scope-changed"`,
+				"receipt_tree=receipt-tree",
+				"local_head_tree=local-head-tree",
+				"receipt_paths={docs/reviewed-a.md,docs/reviewed-b.md}",
+				"outgoing_paths={docs/reviewed-b.md}",
+				`denial_stage="receipt-binding"`,
+				`denial_code="candidate-or-paths-mismatch"`,
+			},
+		},
+		{
+			name: "malformed stdout reports command failure",
+			observation: Observation{
+				ExitCode: 23,
+				Stdout:   "not-json",
+				Stderr:   "review validate unavailable\nretry later",
+			},
+			want:    []string{"exited 23: review validate unavailable"},
+			notWant: "parse reviewed-superset pre-push result",
+		},
+		{
+			name: "empty stdout reports command failure",
+			observation: Observation{
+				ExitCode: 24,
+				Stderr:   "review validate produced no envelope\nretry later",
+			},
+			want:    []string{"exited 24: review validate produced no envelope"},
+			notWant: "parse reviewed-superset pre-push result",
+		},
+		{
+			name: "malformed successful stdout reports parse failure",
+			observation: Observation{
+				Stdout: "not-json",
+				Stderr: "review validate returned malformed JSON",
+			},
+			want: []string{"parse reviewed-superset pre-push result", "stderr: review validate returned malformed JSON"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireReviewedSupersetPrePushAllow(sandbox, tt.observation)
+			if err == nil {
+				t.Fatal("accepted an invalid pre-push observation")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want %q", err, want)
+				}
+			}
+			if tt.notWant != "" && strings.Contains(err.Error(), tt.notWant) {
+				t.Errorf("error = %q, must not contain %q", err, tt.notWant)
+			}
+		})
+	}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,17 +36,19 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 82 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 83 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-
 	// only-retry (#2621).
 	// j81's RC-created repair fixture (#2839) follows the independently-owned
 	// #2621 journey.
+	// j82 proves #2127's reviewed full candidate can publish an unpublished
+	// monotonic subset without reopening review.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 82 {
-		t.Errorf("core journey count = %d, want 82", got)
+	if got := len(seen); got != 83 {
+		t.Errorf("core journey count = %d, want 83", got)
 	}
 	for id, found := range want {
 		if !found {


### PR DESCRIPTION
## 🔗 Linked Issue

Fixes #2127

> This is work unit 2 for root R1. PR #2873 delivered the product correction. Repository automation requires a closing keyword, but #2127 must remain open for independent root R2 (moving pre-PR bases).

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds driven journey j82 for the exact #2127 partial-publication flow.
- Proves the receipt covers full candidate `{A,B}`, publishes reviewed prefix A, and leaves only B outgoing.
- Requires selector-free pre-push validation to allow the immutable unpublished subset.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_reviewed_superset.go` | Adds the negotiated black-box review, partial publication, and pre-push journey. |
| `bench/journeys_reviewed_superset_test.go` | Preserves typed denial stage/code for nonzero semantic gate results while surfacing operational failures first. |
| `bench/journeys.go` | Registers the new core journey. |
| `bench/journeys_id_collision_test.go` | Adds j82 to cross-file ID collision coverage. |
| `bench/journeys_sdd_test.go` | Ratchets the core journey count from 82 to 83. |

---

## 🧪 Test Plan

**Benchmark declarations**

```bash
cd bench
go build -o "$RUNNER_TEMP/gentle-ai-bench" .
go vet ./...
go test ./... -count=1
go test ./... -run '^TestRequireReviewedSupersetPrePushAllowObservationFailures$' -count=1 -v
```

**Driven black-box execution**

```bash
go build -trimpath -o "$RUNNER_TEMP/gentle-ai" ./cmd/gentle-ai
"$RUNNER_TEMP/gentle-ai-bench" run \
  --binary "$RUNNER_TEMP/gentle-ai" \
  --only j82-reviewed-superset-pre-push-allows-unpublished-subset \
  --out "$RUNNER_TEMP/issue-2127-j82.json"
```

Result:

```text
journeys: 1 completed, 0 unsupported, 0 failed
```

Also passed:

```bash
go run ./internal/gofmtcheck
git diff --check
```

- [x] Unit tests pass (`bench/go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to CI
- [x] Manually tested through driven mode

---

## 🔗 Chain Context

```text
main
└── ✅ PR #2873: immutable pre-push monotonic-subset authorization + unit controls
    └── 📍 PR 2: driven j82 journey + corpus ratchets
        └── Follow-up root R2: advertised remote tip / unique pre-PR merge-base
```

- **Start state:** product correction is merged, but the black-box behavior is not yet part of the journey corpus.
- **End state:** CI can execute the real negotiated lifecycle and prove partial publication remains authorized.
- **Rollback:** revert this PR's two commits; product behavior remains unchanged and only j82, its diagnostics coverage, and ratchets are removed.
- **Out of scope:** product logic and pre-PR moving-base authorization.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (345 additions + deletions)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Benchmark declaration tests pass
- [x] Go format passes
- [ ] E2E tests pass — delegated to CI
- [x] Driven benchmark validation completed
- [x] Documentation is not required beyond the journey's intent and source fields
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- `go test ./bench` validates declarations only. The evidence above comes from CI's locally built driven harness and product binary.
- The fixture proves full receipt scope and exact candidate tree before publishing A, then proves B is the sole unpublished path before invoking pre-push.
- Typed nonzero gate denials retain their receipt-binding stage/code; malformed operational failures surface exit code and stderr instead of a misleading JSON error.
- Receipt-driven development is clone-locally disabled for this delivery; validation follows ordinary repository policy (`disabled/unmanaged`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for pre-push authorization when only part of an approved change is published.
  * Verified that remaining unpublished changes are correctly permitted.
  * Added validation for review receipts, status information, repository state, and authorization results.
  * Expanded diagnostic coverage for denied checks, command failures, malformed output, and parsing errors.
  * Updated journey coverage to include the new reviewed-superset scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->