### PR TITLE
fix(sdd): make terminal task blocks actionable

### DIFF
--- a/bench/axis_sdd_task_result.go
+++ b/bench/axis_sdd_task_result.go
@@ -16,10 +16,10 @@ const sddTaskResultAxis = "sdd-task-result"
 func init() {
 	RegisterAxis(Axis{
 		Name:     sddTaskResultAxis,
-		Title:    "OpenCode SDD task-result transport failures",
+		Title:    "OpenCode SDD task-result terminal enforcement",
 		BlackBox: false,
 		Properties: []string{
-			"Runs the installed OpenCode plugin through Node with a provider-shaped empty task_result; it does not drive the gentle-ai CLI alone.",
+			"Runs the installed OpenCode plugin through Node with a provider-shaped empty task_result and proves it hard-blocks a downstream SDD launch with a truthful new-session recovery; it does not drive the gentle-ai CLI alone.",
 			"Requires GENTLE_AI_BENCH_SDD_PLUGIN and a Node runtime that executes .mts files with built-in TypeScript type stripping; skips honestly when the plugin or runtime capability is unavailable.",
 		},
 		Journeys: sddTaskResultJourneys,
@@ -29,7 +29,7 @@ func init() {
 func sddTaskResultJourneys() []Journey {
 	return []Journey{{
 		ID:     "tr01-sdd-empty-task-result",
-		Title:  "Empty SDD task result: typed terminal failure without artifact mutation or downstream launch",
+		Title:  "Empty SDD task result: terminal downstream block with new-session recovery",
 		Source: "issue #2117 provider transport report",
 		Steps: []Step{{
 			Name:      "provider-shaped empty task result reaches the installed OpenCode plugin",
@@ -137,8 +137,11 @@ func sddEmptyTaskResult(r *journeyRun) error {
 	if len(parts) != 3 {
 		return fmt.Errorf("task-result harness output = %q", output.String())
 	}
-	if !strings.Contains(parts[0], "sdd_task_result_empty") || !strings.Contains(parts[1], "sdd_task_result_empty") {
-		return fmt.Errorf("empty result was not routed as one typed terminal failure: %q", parts[:2])
+	if !strings.Contains(parts[0], "sdd_task_result_empty") || !strings.Contains(parts[0], "Do not retry or advance SDD") {
+		return fmt.Errorf("empty result did not produce a typed terminal handoff: %q", parts[0])
+	}
+	if !strings.Contains(parts[1], "sdd_task_result_empty") || !strings.Contains(parts[1], `"phase":"sdd-propose"`) || !strings.Contains(parts[1], "sdd-apply was not launched") || !strings.Contains(parts[1], "start a new OpenCode session/conversation") {
+		return fmt.Errorf("downstream SDD launch was not truthfully blocked: %q", parts[1])
 	}
 	if parts[2] != "existing artifact" {
 		return fmt.Errorf("task-result failure mutated artifact state: %q", parts[2])

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -518,6 +518,7 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 		`"sdd_task_result_empty"`,
 		`"sdd_task_result_malformed"`,
 		`failedSDDSessions`,
+		`function blockedSDDTaskFailure(`,
 		`extractionClass(cause, "sddClass")`,
 		// #2677: an empty result means the child produced no output at all
 		// (for example a provider rejection before generation), and the

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -127,7 +127,7 @@ function isSDDPhase(agent: string): boolean {
   return SDD_PHASES.some((phase) => agent === phase || agent.startsWith(phase + "-"))
 }
 const SDD_TASK_FAILURE_PREFIX = "GENTLE_AI_SDD_FAILURE "
-type SDDTaskFailure = { phase: string, code: string, handoff: string }
+type SDDTaskFailure = { phase: string, code: string, taskModel?: string, summary: string, continuation: string }
 type SDDTaskFailureError = Error & { sddFailure: SDDTaskFailure }
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
@@ -170,6 +170,28 @@ function taskRouteModel(metadata: unknown): string | undefined {
 // produce output that failed the envelope contract. The old single summary
 // claimed "no valid task result" for both, which hid that in the empty case
 // the child never ran inference at all.
+function sddFailureError(failure: SDDTaskFailure): SDDTaskFailureError {
+  const handoff = SDD_TASK_FAILURE_PREFIX + JSON.stringify({
+    schemaName: "gentle-ai.sdd-task-result-failure/v1",
+    status: "blocked",
+    code: failure.code,
+    phase: failure.phase,
+    ...(failure.taskModel === undefined ? {} : { taskModel: failure.taskModel }),
+    summary: failure.summary,
+    continuation: failure.continuation,
+  })
+  return Object.assign(new Error(handoff), { sddFailure: failure }) as SDDTaskFailureError
+}
+
+function blockedSDDTaskFailure(failure: SDDTaskFailure, requestedPhase: string): SDDTaskFailureError {
+  return sddFailureError({
+    ...failure,
+    summary: `${failure.phase} previously failed. ${requestedPhase} was not launched. ` +
+      "The original failure remains terminal for this parent session. " +
+      `Run \`${failure.continuation}\` exactly once, surface the prior failure, and after an explicit user decision start a new OpenCode session/conversation to continue.`,
+  })
+}
+
 function sddTaskFailure(phase: string, cwd: string, cause: unknown, metadata?: unknown): SDDTaskFailureError {
   const classification = extractionClass(cause, "sddClass")
   const empty = classification === "empty_result"
@@ -184,20 +206,11 @@ function sddTaskFailure(phase: string, cwd: string, cause: unknown, metadata?: u
   const failure: SDDTaskFailure = {
     phase,
     code,
-    handoff: SDD_TASK_FAILURE_PREFIX + JSON.stringify({
-      schemaName: "gentle-ai.sdd-task-result-failure/v1",
-      status: "blocked",
-      code,
-      phase,
-      ...(taskModel === undefined ? {} : { taskModel }),
-      summary,
-      continuation: `gentle-ai sdd-status --cwd ${shellQuote(cwd)} --json`,
-    }),
+    ...(taskModel === undefined ? {} : { taskModel }),
+    summary,
+    continuation: `gentle-ai sdd-status --cwd ${shellQuote(cwd)} --json`,
   }
-  return Object.assign(
-    new Error(failure.handoff),
-    { sddFailure: failure },
-  ) as SDDTaskFailureError
+  return sddFailureError(failure)
 }
 
 function captureCwd(worktree: string | undefined, directory: string): string {
@@ -356,9 +369,7 @@ const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => {
     const subagent = output.args.subagent_type
     if (isSDDPhase(subagent)) {
       const failure = failedSDDSessions.get(input.sessionID)
-      if (failure) {
-        throw new Error(failure.handoff)
-      }
+      if (failure) throw blockedSDDTaskFailure(failure, subagent)
       return
     }
     if (!REVIEW_AGENTS.has(subagent)) return

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -71,7 +71,7 @@ const runAfter = async (outputText: string) => {
 
 try {
   if (scenario.startsWith("sdd-")) {
-    const phase = scenario.startsWith("sdd-profile-") ? "sdd-propose-cheap" : scenario === "sdd-unrelated" ? "sdd-custom" : "sdd-propose"
+    const phase = scenario.startsWith("sdd-profile-") ? "sdd-propose-cheap" : scenario.startsWith("sdd-design-") ? "sdd-design" : scenario === "sdd-unrelated" ? "sdd-custom" : "sdd-propose"
     const result = scenario.includes("malformed") ? "<task_result>broken" : scenario.includes("empty") ? "<task id=\"phase\" state=\"completed\">\n<task_result>\n\n</task_result>\n</task>" : ""
     const artifact = cwd + "/proposal.md"
     await writeFile(artifact, "existing artifact")
@@ -96,12 +96,19 @@ try {
       let afterDispose = "NO_ERROR"
       try { await hooks["tool.execute.before"]({ ...input, callID: "call-after-dispose" }, { args: { subagent_type: phase, prompt: "reuse" } }) } catch (cause: unknown) { afterDispose = cause instanceof Error ? cause.message : String(cause) }
       console.log([failure, beforeDispose, afterDispose, await readFile(artifact, "utf8")].join("\n---\n"))
+    } else if (scenario === "sdd-unrelated") {
+      console.log([failure, "NOT_ATTEMPTED", "NOT_ATTEMPTED", await readFile(artifact, "utf8")].join("\n---\n"))
     } else {
-      let downstream = "NOT_ATTEMPTED"
-      if (scenario !== "sdd-unrelated") {
-        try { await hooks["tool.execute.before"]({ ...input, callID: "call-next", args: { subagent_type: "sdd-apply", prompt: "downstream" } }, { args: { subagent_type: "sdd-apply", prompt: "downstream" } }) } catch (cause: unknown) { downstream = cause instanceof Error ? cause.message : String(cause) }
-      }
-      console.log([failure, downstream, await readFile(artifact, "utf8")].join("\n---\n"))
+      let sameSession = "NO_ERROR"
+      const nextPhase = scenario.startsWith("sdd-design-") ? "sdd-spec" : "sdd-apply"
+      try {
+        await hooks["tool.execute.before"]({ ...input, callID: "call-next", args: { subagent_type: nextPhase, prompt: "downstream" } }, { args: { subagent_type: nextPhase, prompt: "downstream" } })
+      } catch (cause: unknown) { sameSession = cause instanceof Error ? cause.message : String(cause) }
+      let otherSession = "NO_ERROR"
+      try {
+        await hooks["tool.execute.before"]({ ...input, sessionID: "other-sdd-session", callID: "call-other", args: { subagent_type: nextPhase, prompt: "downstream" } }, { args: { subagent_type: nextPhase, prompt: "downstream" } })
+      } catch (cause: unknown) { otherSession = cause instanceof Error ? cause.message : String(cause) }
+      console.log([failure, sameSession, otherSession, await readFile(artifact, "utf8")].join("\n---\n"))
     }
   } else if (scenario === "before-background") {
     console.log(await runBefore("review-risk", true))
@@ -169,7 +176,7 @@ func runReviewPluginScenario(t *testing.T, scenario, nativeStderr string) string
 
 func runReviewPluginScenarioStub(t *testing.T, scenario string, stub reviewPluginStub) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && !strings.HasPrefix(scenario, "sdd-") {
 		t.Skip("the stub native binary requires a POSIX shell")
 	}
 	node, err := exec.LookPath("node")
@@ -282,39 +289,50 @@ func TestSDDTaskResultFailuresAreTerminalAndScoped(t *testing.T) {
 		scenario    string
 		wantCode    string
 		wantPhase   string
-		wantBlocked bool
+		nextPhase   string
 		wantSummary string
 		wantModel   string
 		forbid      []string
 	}{
 		{
 			name: "empty unsuffixed phase", scenario: "sdd-empty",
-			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true,
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", nextPhase: "sdd-apply",
 			wantSummary: sddEmptySummaryFragment, wantModel: "opencode-go/deepseek-v4-flash",
 		},
 		{
 			name: "empty phase without model metadata", scenario: "sdd-empty-no-model",
-			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true,
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", nextPhase: "sdd-apply",
 			wantSummary: sddEmptySummaryFragment,
 		},
 		{
 			name: "empty phase with hostile model metadata", scenario: "sdd-empty-hostile-model",
-			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", wantBlocked: true,
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-propose", nextPhase: "sdd-apply",
 			wantSummary: sddEmptySummaryFragment,
 			forbid:      []string{"/home/user/secret-provider", "RegionError", "xxxxxxxxxx"},
 		},
 		{
 			name: "malformed profile-suffixed phase", scenario: "sdd-profile-malformed",
-			wantCode: "sdd_task_result_malformed", wantPhase: "sdd-propose-cheap", wantBlocked: true,
+			wantCode: "sdd_task_result_malformed", wantPhase: "sdd-propose-cheap", nextPhase: "sdd-apply",
 			wantSummary: "returned no valid task result", wantModel: "opencode-go/deepseek-v4-flash",
 			forbid: []string{sddEmptySummaryFragment},
+		},
+		{
+			name: "malformed design does not replay into spec", scenario: "sdd-design-malformed",
+			wantCode: "sdd_task_result_malformed", wantPhase: "sdd-design", nextPhase: "sdd-spec",
+			wantSummary: "returned no valid task result", wantModel: "opencode-go/deepseek-v4-flash",
+			forbid: []string{sddEmptySummaryFragment},
+		},
+		{
+			name: "empty design does not replay into spec", scenario: "sdd-design-empty",
+			wantCode: "sdd_task_result_empty", wantPhase: "sdd-design", nextPhase: "sdd-spec",
+			wantSummary: sddEmptySummaryFragment, wantModel: "opencode-go/deepseek-v4-flash",
 		},
 		{name: "unrelated sdd-prefixed agent", scenario: "sdd-unrelated", wantCode: "NO_ERROR"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parts := strings.Split(runReviewPluginScenario(t, tt.scenario, "unused"), "\n---\n")
-			if len(parts) != 3 {
+			if len(parts) != 4 {
 				t.Fatalf("scenario output = %q", parts)
 			}
 			if !strings.Contains(parts[0], tt.wantCode) {
@@ -323,25 +341,43 @@ func TestSDDTaskResultFailuresAreTerminalAndScoped(t *testing.T) {
 			if tt.wantPhase != "" && !strings.Contains(parts[0], tt.wantPhase) {
 				t.Fatalf("failure = %q, want phase %q", parts[0], tt.wantPhase)
 			}
-			if tt.wantBlocked && (!strings.Contains(parts[1], tt.wantCode) || !strings.Contains(parts[1], "Do not retry or advance SDD")) {
-				t.Fatalf("downstream SDD launch was not terminally blocked: %q", parts[1])
-			}
-			if tt.wantBlocked {
+			if tt.nextPhase != "" {
 				assertSDDTaskResultHandoff(t, parts[0], tt.wantCode, tt.wantPhase, tt.wantSummary, tt.wantModel)
-				assertSDDTaskResultHandoff(t, parts[1], tt.wantCode, tt.wantPhase, tt.wantSummary, tt.wantModel)
+				assertSDDTaskResultHandoff(t, parts[1], tt.wantCode, tt.wantPhase, tt.nextPhase+" was not launched", tt.wantModel)
+				if !strings.Contains(parts[1], tt.wantPhase+" previously failed") || !strings.Contains(parts[1], "original failure remains terminal for this parent session") || !strings.Contains(parts[1], "Run `gentle-ai sdd-status") || !strings.Contains(parts[1], "exactly once, surface the prior failure") || !strings.Contains(parts[1], "start a new OpenCode session/conversation") {
+					t.Fatalf("blocked SDD launch does not name truthful recovery: %q", parts[1])
+				}
+				if parts[2] != "NO_ERROR" {
+					t.Fatalf("SDD failure leaked into a different parent session: %q", parts[2])
+				}
 			}
 			for _, leaked := range tt.forbid {
 				if strings.Contains(parts[0], leaked) || strings.Contains(parts[1], leaked) {
 					t.Fatalf("failure handoff leaked %q: %q", leaked, parts[:2])
 				}
 			}
-			if !tt.wantBlocked && parts[1] != "NOT_ATTEMPTED" {
-				t.Fatalf("unrelated agent unexpectedly entered SDD routing: %q", parts[1])
+			if tt.nextPhase == "" && (parts[1] != "NOT_ATTEMPTED" || parts[2] != "NOT_ATTEMPTED") {
+				t.Fatalf("unrelated agent unexpectedly entered SDD routing: %q", parts[1:3])
 			}
-			if parts[2] != "existing artifact" {
-				t.Fatalf("task-result handling mutated the existing artifact: %q", parts[2])
+			if parts[3] != "existing artifact" {
+				t.Fatalf("task-result handling mutated the existing artifact: %q", parts[3])
 			}
 		})
+	}
+}
+
+func TestReviewPluginDisposeClearsSDDSessionFailure(t *testing.T) {
+	parts := strings.Split(runReviewPluginScenario(t, "sdd-lifecycle", "unused"), "\n---\n")
+	if len(parts) != 4 {
+		t.Fatalf("SDD lifecycle outcomes = %q", parts)
+	}
+	assertSDDTaskResultHandoff(t, parts[0], "sdd_task_result_empty", "sdd-propose", sddEmptySummaryFragment, "opencode-go/deepseek-v4-flash")
+	assertSDDTaskResultHandoff(t, parts[1], "sdd_task_result_empty", "sdd-propose", "sdd-propose was not launched", "opencode-go/deepseek-v4-flash")
+	if parts[2] != "NO_ERROR" {
+		t.Fatalf("dispose retained a failed SDD session for its reused ID: %q", parts[2])
+	}
+	if parts[3] != "existing artifact" {
+		t.Fatalf("SDD lifecycle handling mutated the existing artifact: %q", parts[3])
 	}
 }
 
@@ -370,7 +406,7 @@ func assertSDDTaskResultHandoff(t *testing.T, message, code, phase, summary, mod
 	if !strings.Contains(handoff.Summary, summary) {
 		t.Fatalf("failure handoff summary = %q, want it to contain %q", handoff.Summary, summary)
 	}
-	if code == "sdd_task_result_empty" && !strings.Contains(handoff.Summary, sddEmptyCauseFragment) {
+	if code == "sdd_task_result_empty" && summary == sddEmptySummaryFragment && !strings.Contains(handoff.Summary, sddEmptyCauseFragment) {
 		t.Fatalf("empty-result summary does not name the likeliest cause class: %q", handoff.Summary)
 	}
 	if handoff.TaskModel != model {
@@ -383,22 +419,6 @@ func assertSDDTaskResultHandoff(t *testing.T, message, code, phase, summary, mod
 	}
 	if !strings.HasPrefix(handoff.Continuation, "gentle-ai sdd-status --cwd '") || !strings.HasSuffix(handoff.Continuation, "' --json") {
 		t.Fatalf("failure handoff names no runnable sdd-status continuation: %#v", handoff)
-	}
-}
-
-func TestReviewPluginDisposeClearsSDDSessionFailure(t *testing.T) {
-	parts := strings.Split(runReviewPluginScenario(t, "sdd-lifecycle", "unused"), "\n---\n")
-	if len(parts) != 4 {
-		t.Fatalf("SDD lifecycle outcomes = %q", parts)
-	}
-	if !strings.Contains(parts[0], "sdd_task_result_empty") || !strings.Contains(parts[1], "sdd_task_result_empty") {
-		t.Fatalf("SDD failure was not retained before dispose: %q", parts[:2])
-	}
-	if parts[2] != "NO_ERROR" {
-		t.Fatalf("dispose retained a failed SDD session for its reused ID: %q", parts[2])
-	}
-	if parts[3] != "existing artifact" {
-		t.Fatalf("SDD lifecycle handling mutated the existing artifact: %q", parts[3])
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #2629

---

## PR Type

- [x] `type:bug`: Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature`: New feature (non-breaking change that adds functionality)
- [ ] `type:docs`: Documentation only
- [ ] `type:refactor`: Code refactoring (no functional changes)
- [ ] `type:chore`: Build, CI, or tooling changes
- [ ] `type:breaking-change`: Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Preserve executable same-session blocking after an empty or malformed SDD task result.
- Distinguish the original failed phase from a later requested phase that was never launched.
- Give users an actionable recovery: inspect state once, surface the prior failure, then continue in a new OpenCode session after an explicit decision.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/plugins/review-result-artifacts.ts` | Builds typed failures from structured data and emits a truthful actionable handoff for blocked later phases. |
| `internal/assets/review_plugin_recovery_test.go` | Covers cross-phase blocking, other-session isolation, lifecycle cleanup, metadata sanitization, and artifact preservation. |
| `internal/assets/assets_test.go` | Pins the actionable blocked-failure helper in the plugin asset contract. |
| `bench/axis_sdd_task_result.go` | Drives a downstream SDD launch and proves hard blocking plus new-session recovery. |

---

## Test Plan

**Unit Tests**

- [x] `go test ./internal/assets -count=1`
- [x] Focused terminal and lifecycle tests
- [x] `go test ./... -count=1` passes in CI. Local execution was environment-limited in non-candidate Windows packages.

**Go Format**

- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check origin/main...HEAD`

**E2E Tests**

- [x] E2E passes in CI. `e2e/docker-test.sh` remains unavailable locally because Docker is not installed and WSL has no Linux distribution.

**Benchmark Validation**

- [x] Driven `tr01-sdd-empty-task-result`: 1 completed, 0 unsupported, 0 failed.

**Manual Validation**

- [x] Confirmed the original phase, code, model, and continuation remain bound to the actual failed task.
- [x] Confirmed the requested later phase is reported as not launched.
- [x] Confirmed a different parent session remains unaffected.

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | PASS | 157 changed lines, below the 400-line budget. |
| Check Issue Reference | PASS | Body contains `Closes #2629`. |
| Check Issue Has `status:approved` | PASS | #2629 was approved before implementation. |
| Check PR Has `type:*` Label | PASS | Exactly `type:bug` is applied. |
| Unit Tests | PASS | The full cross-platform suite passed in CI. |
| Go Format | PASS | Local and CI format checks passed. |
| E2E Tests | PASS | E2E passed in CI. |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Full `go test ./...` passes in CI
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E passes in CI
- [x] Benchmark validation completed
- [x] Documentation is not required; the changed behavior is covered by typed summaries, tests, and the driven journey
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Please focus on the ownership boundary: the plugin retains hard no-retry/no-advance enforcement, while the replacement handoff describes the earlier failure rather than claiming the requested phase ran. The wire schema, code, original phase, task model, and continuation remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or failed SDD task results with clearer terminal recovery guidance.
  * Prevented downstream SDD actions from running after a failed phase until explicit continuation.
  * Isolated failures to the affected session so unrelated sessions can continue normally.
  * Ensured retained failure state is cleared when a session is disposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->