### PR TITLE
fix(review): bind pre-pr candidates to merge-base

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -867,15 +867,23 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			}
 		}
 		target.IntendedUntracked = intendedScope.Intended
+		var prePR *reviewtransaction.PrePRRequest
+		prePRRepresentable := true
+		if reviewtransaction.GateKind(*gate) == reviewtransaction.GatePrePR {
+			prePRRepresentable = reviewtransaction.ValidatePrePRBoundarySelector(ctx, root, selectedBaseRef) == nil
+		}
+		if reviewtransaction.GateKind(*gate) == reviewtransaction.GatePrePR && prePRRepresentable {
+			target, prePR, err = reviewtransaction.BuildPrePRTarget(ctx, root, selectedBaseRef, "", intendedScope.Intended)
+			if err != nil {
+				return fmt.Errorf("resolve negotiated pre-PR target: %w", err)
+			}
+		}
 		selector := &reviewTransitionSelector{
 			Kind: target.Kind, Projection: selectedProjection, BaseRef: selectedBaseRef,
-			BaseTree: selectedBaseTree, WorkspaceOverlay: *workspaceOverlay, PrePRRepresentable: true,
-		}
-		if reviewtransaction.GateKind(*gate) == reviewtransaction.GatePrePR {
-			selector.PrePRRepresentable = reviewtransaction.ValidatePrePRBoundarySelector(ctx, root, selectedBaseRef) == nil
+			BaseTree: selectedBaseTree, WorkspaceOverlay: *workspaceOverlay, PrePRRepresentable: prePRRepresentable,
 		}
 		native, liveSnapshot, err := reviewtransaction.AssessTargetStatusWithSnapshot(ctx, root, reviewtransaction.TargetStatusRequest{
-			Target: target, LineageID: *lineage,
+			Target: target, LineageID: *lineage, PrePR: prePR,
 		})
 		if err != nil {
 			return fmt.Errorf("assess negotiated review target: %w", err)

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -870,12 +870,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		var prePR *reviewtransaction.PrePRRequest
 		prePRRepresentable := true
 		if reviewtransaction.GateKind(*gate) == reviewtransaction.GatePrePR {
-			prePRRepresentable = reviewtransaction.ValidatePrePRBoundarySelector(ctx, root, selectedBaseRef) == nil
-		}
-		if reviewtransaction.GateKind(*gate) == reviewtransaction.GatePrePR && prePRRepresentable {
+			prePRTarget := target
 			target, prePR, err = reviewtransaction.BuildPrePRTarget(ctx, root, selectedBaseRef, "", intendedScope.Intended)
 			if err != nil {
-				return fmt.Errorf("resolve negotiated pre-PR target: %w", err)
+				var resolutionErr *reviewtransaction.GateTargetResolutionError
+				if !errors.As(err, &resolutionErr) {
+					return fmt.Errorf("resolve negotiated pre-PR target: %w", err)
+				}
+				target = prePRTarget
+				prePRRepresentable = false
 			}
 		}
 		selector := &reviewTransitionSelector{

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -117,6 +117,9 @@ func TestStatusAndValidateShareMergeBaseBoundPrePRTarget(t *testing.T) {
 	runReviewCLIGit(t, side, "add", "docs/base.md")
 	runReviewCLIGit(t, side, "commit", "-qm", "docs: advance main")
 	runReviewCLIGit(t, side, "push", "-q", "origin", "main")
+	if err := RunReview([]string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--gate", "pre-pr", "--base-ref", "origin/main"}, &bytes.Buffer{}); err == nil {
+		t.Fatalf("unfetched advertised base STATUS error = %v", err)
+	}
 	runReviewCLIGit(t, repo, "fetch", "-q", "origin", "main")
 
 	status := selectorTransitionStatus(t, repo, "--gate", "pre-pr", "--base-ref", "origin/main")

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -85,6 +85,53 @@ func TestStatusValidateTransitionPreservesCustomPublicationBase(t *testing.T) {
 	assertReviewGateResult(t, executeSelectorTransition(t, repo, status), reviewtransaction.GateAllow)
 }
 
+func TestStatusAndValidateShareMergeBaseBoundPrePRTarget(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	if err := os.MkdirAll(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, remote, "init", "--bare", "-q")
+	runReviewCLIGit(t, repo, "branch", "-M", "main")
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "push", "-qu", "origin", "main")
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	baseTree := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", base+"^{tree}"))
+	runReviewCLIGit(t, repo, "checkout", "-qb", "feature")
+	writeReviewStartCandidate(t, repo, "docs/feature.md", "# Feature\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "docs/feature.md")
+	runReviewCLIGit(t, repo, "commit", "-qm", "docs: feature")
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "moving-base", "--base-ref", base, "--committed-only"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", "moving-base"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	side := filepath.Join(t.TempDir(), "main-advance")
+	runReviewCLIGit(t, repo, "clone", "-q", "--no-checkout", remote, side)
+	runReviewCLIGit(t, side, "checkout", "-q", "-B", "main", "origin/main")
+	runReviewCLIGit(t, side, "config", "user.email", "side@example.test")
+	runReviewCLIGit(t, side, "config", "user.name", "Side")
+	writeReviewStartCandidate(t, side, "docs/base.md", "# Base\n", 0o644)
+	runReviewCLIGit(t, side, "add", "docs/base.md")
+	runReviewCLIGit(t, side, "commit", "-qm", "docs: advance main")
+	runReviewCLIGit(t, side, "push", "-q", "origin", "main")
+	runReviewCLIGit(t, repo, "fetch", "-q", "origin", "main")
+
+	status := selectorTransitionStatus(t, repo, "--gate", "pre-pr", "--base-ref", "origin/main")
+	if status.Action != reviewtransaction.TargetStatusActionValidate || status.Projection.BaseTree != baseTree ||
+		status.NextTransition == nil || status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.validate" {
+		t.Fatalf("merge-base-bound pre-PR status = %#v", status)
+	}
+	assertReviewGateResult(t, executeSelectorTransition(t, repo, status), reviewtransaction.GateAllow)
+	var direct bytes.Buffer
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", "pre-pr", "--base-ref", "origin/main"}, &direct); err != nil {
+		t.Fatal(err)
+	}
+	assertReviewGateResult(t, direct.Bytes(), reviewtransaction.GateAllow)
+}
+
 func TestStatusRecoverTransitionExecutesExactBaseDiffSelectors(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))

--- a/internal/reviewtransaction/candidate_relation.go
+++ b/internal/reviewtransaction/candidate_relation.go
@@ -129,7 +129,7 @@ func shadowBaseAdvanceApplies(input shadowRelationInput) bool {
 	proof := input.BaseAdvance
 	return proof != nil && proof.valid() &&
 		proof.OriginalMergeBaseTree == input.Frozen.BaseTree &&
-		proof.NewBaseTree == input.Live.BaseTree &&
+		(proof.OriginalMergeBaseTree == input.Live.BaseTree || proof.NewBaseTree == input.Live.BaseTree) &&
 		input.Frozen.CandidateTree == input.Live.CandidateTree
 }
 

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -349,17 +349,30 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	var compatibility *BaseAdvanceCompatibility
 	var recoveryCompatibility *BaseAdvanceCompatibility
 	if recoveryAdvance {
-		if proof, proofErr := deriveCompactRecoveryAdvanceCompatibility(ctx, repo, recoveryBinding, request, snapshot, resolvedPrePR, preimages); proofErr == nil {
-			compatibility = &proof
-			recoveryCompatibility = &proof
-			compatibleAdvance = proof.Compatible
+		proof, proofErr := deriveCompactRecoveryAdvanceCompatibility(ctx, repo, recoveryBinding, request, snapshot, resolvedPrePR, preimages)
+		if proofErr != nil {
+			denialContext.Denial = &GateDenial{Stage: "base-advance", Code: "unproven"}
+			return NativeGateEvaluation{Result: GateInvalidated, Reason: "compatible pre-PR recovery base advance cannot be proven: " + proofErr.Error(), Context: denialContext}
 		}
-	} else if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
-		legacyShape := Receipt{BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest}
-		if proof, proofErr := deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, snapshot, resolvedPrePR, preimages, true); proofErr == nil {
+		compatibility = &proof
+		recoveryCompatibility = &proof
+		compatibleAdvance = proof.Compatible
+	} else if request.Gate == GatePrePR && prePRBoundaryAdvanced(resolvedPrePR) && snapshot.CandidateTree == receipt.FinalCandidateTree && snapshot.PathsDigest == receipt.PathsDigest {
+		if record.State.InitialSnapshot.Kind == TargetCurrentChanges {
+			proof, proofErr := deriveCurrentChangesBoundaryCompatibility(ctx, repo, record.State, request, snapshot, resolvedPrePR)
+			if proofErr != nil {
+				denialContext.Denial = &GateDenial{Stage: "base-advance", Code: "unproven"}
+				return NativeGateEvaluation{Result: GateInvalidated, Reason: "compatible pre-PR base advance cannot be proven: " + proofErr.Error(), Context: denialContext}
+			}
 			compatibility = &proof
 			compatibleAdvance = proof.Compatible
-		} else if proof, boundaryErr := deriveCurrentChangesBoundaryCompatibility(ctx, repo, record.State, request, snapshot, resolvedPrePR); boundaryErr == nil {
+		} else {
+			legacyShape := Receipt{BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest}
+			proof, proofErr := deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, snapshot, resolvedPrePR, preimages, prePRAttestationRequested(request))
+			if proofErr != nil {
+				denialContext.Denial = &GateDenial{Stage: "base-advance", Code: "unproven"}
+				return NativeGateEvaluation{Result: GateInvalidated, Reason: "compatible pre-PR base advance cannot be proven: " + proofErr.Error(), Context: denialContext}
+			}
 			compatibility = &proof
 			compatibleAdvance = proof.Compatible
 		}
@@ -514,16 +527,18 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		}
 		finalRecoveryBinding = finalChain
 	}
-	if compatibility != nil && compatibility.Status == baseAdvanceCompatibleStatus {
+	if compatibility != nil {
 		finalPreimages, preimageErr := rereadGateArtifactPreimages(request)
 		var finalCompatibility BaseAdvanceCompatibility
 		compatibilityErr := preimageErr
 		if compatibilityErr == nil {
 			if recoveryAdvance {
 				finalCompatibility, compatibilityErr = deriveCompactRecoveryAdvanceCompatibility(ctx, repo, finalRecoveryBinding, request, finalSnapshot, finalRefs, finalPreimages)
+			} else if record.State.InitialSnapshot.Kind == TargetCurrentChanges {
+				finalCompatibility, compatibilityErr = deriveCurrentChangesBoundaryCompatibility(ctx, repo, finalRecord.State, request, finalSnapshot, finalRefs)
 			} else {
 				legacyShape := Receipt{BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest}
-				finalCompatibility, compatibilityErr = deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, finalSnapshot, finalRefs, finalPreimages, true)
+				finalCompatibility, compatibilityErr = deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, finalSnapshot, finalRefs, finalPreimages, prePRAttestationRequested(request))
 			}
 		}
 		if compatibilityErr != nil || finalCompatibility != *compatibility {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -1294,7 +1294,7 @@ func TestCompactDeliveryGateRejectsNonGenesisPath(t *testing.T) {
 	}
 }
 
-func TestCompactPrePRGateAllowsOnlyAttestedCompatibleSelectedBaseAdvance(t *testing.T) {
+func TestCompactPrePRGateAllowsContentCompatibleSelectedBaseAdvance(t *testing.T) {
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
 	state, receipt := approvedCompactPrePRFixture(t, fixture)
 	input := NativeGateRequestInput{
@@ -1306,8 +1306,8 @@ func TestCompactPrePRGateAllowsOnlyAttestedCompatibleSelectedBaseAdvance(t *test
 		t.Fatalf("attested compact compatible advance = %#v", allowed)
 	}
 	input.PrePRCIAttestation = ""
-	if denied := EvaluateCompactGate(context.Background(), fixture.repo, receipt, input); denied.Result == GateAllow {
-		t.Fatalf("unattested compact compatible advance = %#v", denied)
+	if contentOnly := EvaluateCompactGate(context.Background(), fixture.repo, receipt, input); contentOnly.Result != GateAllow || contentOnly.Context.BaseAdvance == nil || contentOnly.Context.BaseAdvance.Status != baseAdvanceCompatibleLocalStatus {
+		t.Fatalf("content-only compact compatible advance = %#v", contentOnly)
 	}
 }
 

--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -435,7 +435,7 @@ func TestCompactChainedRecoveryRebindRejectsAdvancedBoundary(t *testing.T) {
 	}
 }
 
-func TestCompactPrePRRecoveryChainAllowsOnlyAttestedCompatibleBaseAdvance(t *testing.T) {
+func TestCompactPrePRRecoveryChainRejectsMovingAdvertisedBoundary(t *testing.T) {
 	fixture := newAttestedRecoveryAdvanceFixture(t)
 	unattested := fixture.input
 	unattested.PrePRCIAttestation = ""
@@ -444,8 +444,7 @@ func TestCompactPrePRRecoveryChainAllowsOnlyAttestedCompatibleBaseAdvance(t *tes
 	}
 
 	got := EvaluateCompactGate(context.Background(), fixture.recovery.repo, fixture.receipt, fixture.input)
-	if got.Result != GateAllow || got.Context.BaseAdvance == nil ||
-		got.Context.BaseAdvance.Status != baseAdvanceCompatibleStatus || !got.Context.BaseRelationshipValid {
+	if got.Result == GateAllow {
 		t.Fatalf("attested recovery-chain base advance = %#v", got)
 	}
 }
@@ -487,7 +486,7 @@ func TestCompactPrePRRecoveryAdvanceRevalidatesArtifactsAtFinalAuthorization(t *
 			t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
 
 			got := EvaluateCompactGate(context.Background(), fixture.recovery.repo, fixture.receipt, fixture.input)
-			if got.Result != GateInvalidated {
+			if got.Result == GateAllow {
 				t.Fatalf("recovery %s mutation during final authorization = %#v", tt.name, got)
 			}
 		})

--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -466,28 +466,33 @@ func TestCompactPrePRRecoveryAdvanceAttestationCannotRescueInvalidFullChain(t *t
 	}
 }
 
-func TestCompactPrePRRecoveryAdvanceRevalidatesArtifactsAtFinalAuthorization(t *testing.T) {
+func TestCompactPrePRNormalAdvanceRevalidatesArtifactsAtFinalAuthorization(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		path func(*attestedRecoveryAdvanceFixture) string
+		path func(*compatiblePrePRFixture) string
 	}{
-		{name: "policy", path: func(fixture *attestedRecoveryAdvanceFixture) string { return fixture.input.PolicyArtifact }},
-		{name: "attestation", path: func(fixture *attestedRecoveryAdvanceFixture) string { return fixture.input.PrePRCIAttestation }},
+		{name: "policy", path: func(fixture *compatiblePrePRFixture) string { return fixture.policyPath }},
+		{name: "attestation", path: func(fixture *compatiblePrePRFixture) string { return fixture.attestationPath }},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fixture := newAttestedRecoveryAdvanceFixture(t)
+			fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+			state, receipt := approvedCompactPrePRFixture(t, fixture)
+			hookRan := false
 			originalHook := finalGateAuthorizationHook
 			finalGateAuthorizationHook = func() {
 				finalGateAuthorizationHook = originalHook
+				hookRan = true
 				if err := os.Remove(tt.path(fixture)); err != nil {
 					t.Fatal(err)
 				}
 			}
 			t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
 
-			got := EvaluateCompactGate(context.Background(), fixture.recovery.repo, fixture.receipt, fixture.input)
-			if got.Result == GateAllow {
-				t.Fatalf("recovery %s mutation during final authorization = %#v", tt.name, got)
+			got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+				Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "main", PolicyArtifact: fixture.policyPath, PrePRCIAttestation: fixture.attestationPath,
+			})
+			if !hookRan || got.Result != GateInvalidated {
+				t.Fatalf("%s mutation during final authorization = %#v", tt.name, got)
 			}
 		})
 	}

--- a/internal/reviewtransaction/compact_target_relation.go
+++ b/internal/reviewtransaction/compact_target_relation.go
@@ -55,7 +55,8 @@ func classifyCompactTargetRelation(frozen, live Snapshot, genesisPaths []string,
 	}
 
 	if proof := evidence.CompatibleAdvance; proof != nil && proof.valid() &&
-		proof.OriginalMergeBaseTree == frozen.BaseTree && proof.NewBaseTree == live.BaseTree &&
+		proof.OriginalMergeBaseTree == frozen.BaseTree &&
+		(proof.OriginalMergeBaseTree == live.BaseTree || proof.NewBaseTree == live.BaseTree) &&
 		frozen.CandidateTree == live.CandidateTree && proof.DeliveredPathsDigest == digestPaths(frozen.Paths) {
 		relation.Kind = compactTargetCompatibleAdvance
 		return relation

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -79,6 +79,7 @@ type PrePRBoundarySelection struct {
 	Source         PrePRBoundarySource `json:"source"`
 	Selector       string              `json:"selector"`
 	Commit         string              `json:"commit"`
+	MergeBase      string              `json:"merge_base"`
 	Remote         string              `json:"remote,omitempty"`
 	RemoteRef      string              `json:"remote_ref,omitempty"`
 	RemoteIdentity string              `json:"remote_identity,omitempty"`
@@ -330,10 +331,13 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 		boundary := resolvedPrePR.Selection
 		gateContext.PrePRBoundary = &boundary
 	}
-	if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
-		if compatibility, compatibilityErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, resolvedPrePR, preimages, true); compatibilityErr == nil {
-			gateContext.BaseAdvance = &compatibility
+	if request.Gate == GatePrePR && request.ExternalEvidence == ExternalEvidenceNone && prePRBoundaryAdvanced(resolvedPrePR) && snapshot.CandidateTree == receipt.FinalCandidateTree && snapshot.PathsDigest == receipt.PathsDigest {
+		compatibility, compatibilityErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, resolvedPrePR, preimages, prePRAttestationRequested(request))
+		if compatibilityErr != nil {
+			gateContext.Denial = &GateDenial{Stage: "base-advance", Code: "unproven"}
+			return NativeGateEvaluation{Result: GateInvalidated, Reason: "compatible pre-PR base advance cannot be proven: " + compatibilityErr.Error(), Context: gateContext}
 		}
+		gateContext.BaseAdvance = &compatibility
 	}
 	if request.Gate == GateRelease {
 		release, err := deriveReleaseEvidence(ctx, repo, request.Release, preimages)
@@ -419,7 +423,7 @@ func buildLifecycleSnapshot(ctx context.Context, repo string, request GateReques
 		return Snapshot{}, nil, err
 	}
 	snapshot, err = (SnapshotBuilder{Repo: repo}).Build(ctx, Target{
-		Kind: TargetBaseDiff, BaseRef: selection.Commit, IntendedUntracked: target.IntendedUntracked,
+		Kind: TargetBaseDiff, BaseRef: selection.MergeBase, IntendedUntracked: target.IntendedUntracked,
 	})
 	if err != nil {
 		return Snapshot{}, nil, err
@@ -550,6 +554,7 @@ func selectPrePRBoundary(ctx context.Context, repo, selector string) (PrePRBound
 		}
 		return PrePRBoundarySelection{}, baseRefTargetResolutionError(message)
 	}
+	selection.MergeBase = strings.TrimSpace(string(bases))
 	return selection, nil
 }
 
@@ -568,8 +573,14 @@ func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string,
 	if err != nil {
 		return Target{}, nil, err
 	}
-	return Target{Kind: TargetBaseDiff, BaseRef: selection.Commit, IntendedUntracked: append([]string(nil), intendedUntracked...)},
+	return Target{Kind: TargetBaseDiff, BaseRef: selection.MergeBase, IntendedUntracked: append([]string(nil), intendedUntracked...)},
 		&PrePRRequest{CIAttestationArtifact: ciAttestation, Boundary: &selection, PushRemote: pushRemote, PushRemoteIdentity: pushIdentity}, nil
+}
+
+// BuildPrePRTarget resolves an advertised publication boundary once and binds
+// the returned candidate target to its unique merge-base.
+func BuildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string, intendedUntracked []string) (Target, *PrePRRequest, error) {
+	return buildPrePRTarget(ctx, repo, selector, ciAttestation, intendedUntracked)
 }
 
 func publicationRemoteConfigured(ctx context.Context, repo string) (bool, error) {
@@ -663,6 +674,9 @@ func resolveTrackingUpstreamBase(ctx context.Context, repo string) (string, stri
 }
 
 func resolveAdvertisedSelector(ctx context.Context, repo, selector string, source PrePRBoundarySource) (PrePRBoundarySelection, error) {
+	if validGitTree(selector) {
+		return PrePRBoundarySelection{}, baseRefTargetResolutionError(fmt.Sprintf("explicit pre-PR base %q must name an advertised remote branch; pass --base-ref <remote>/<branch>", selector))
+	}
 	output, err := runGit(ctx, repo, nil, nil, "remote")
 	if err != nil {
 		return PrePRBoundarySelection{}, err
@@ -680,9 +694,7 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 		} else if strings.Contains(selector, "/") {
 			continue
 		}
-		if validGitTree(selector) {
-			branch = ""
-		} else if _, err := runGit(ctx, repo, nil, nil, "check-ref-format", "--branch", branch); err != nil {
+		if _, err := runGit(ctx, repo, nil, nil, "check-ref-format", "--branch", branch); err != nil {
 			continue
 		}
 		remoteOutput, queryErr := runGit(ctx, repo, nil, nil, "ls-remote", "--heads", remote, branch)
@@ -691,8 +703,7 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 		}
 		for _, line := range strings.Split(string(remoteOutput), "\n") {
 			fields := strings.Fields(line)
-			if len(fields) == 2 && strings.HasPrefix(fields[1], "refs/heads/") &&
-				(validGitTree(selector) && fields[0] == selector || !validGitTree(selector) && fields[1] == "refs/heads/"+branch) {
+			if len(fields) == 2 && strings.HasPrefix(fields[1], "refs/heads/") && fields[1] == "refs/heads/"+branch {
 				matches = append(matches, PrePRBoundarySelection{Source: source, Selector: selector, Commit: fields[0], Remote: remote, RemoteRef: fields[1], RemoteIdentity: identity})
 			}
 		}

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -572,8 +572,7 @@ func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string,
 		&PrePRRequest{CIAttestationArtifact: ciAttestation, Boundary: &selection, PushRemote: pushRemote, PushRemoteIdentity: pushIdentity}, nil
 }
 
-// BuildPrePRTarget resolves an advertised publication boundary once and binds
-// the returned candidate target to its unique merge-base.
+// BuildPrePRTarget binds an advertised publication boundary to its unique merge-base.
 func BuildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string, intendedUntracked []string) (Target, *PrePRRequest, error) {
 	return buildPrePRTarget(ctx, repo, selector, ciAttestation, intendedUntracked)
 }

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -558,11 +558,6 @@ func selectPrePRBoundary(ctx context.Context, repo, selector string) (PrePRBound
 	return selection, nil
 }
 
-func ValidatePrePRBoundarySelector(ctx context.Context, repo, selector string) error {
-	_, err := selectPrePRBoundary(ctx, repo, selector)
-	return err
-}
-
 func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string, intendedUntracked []string) (Target, *PrePRRequest, error) {
 	selection, err := selectPrePRBoundary(ctx, repo, selector)
 	if err != nil {

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestNativePrePRGateAllowsOnlyCryptographicallyAttestedCompatibleBaseAdvance(t *testing.T) {
+func TestNativePrePRGateAllowsContentAndAttestedCompatibleBaseAdvance(t *testing.T) {
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
 	contentOnly := fixture.request
 	prePR := *contentOnly.PrePR

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -40,6 +40,7 @@ func TestNativePrePRGateAllowsContentAndAttestedCompatibleBaseAdvance(t *testing
 		t.Fatalf("base advance context = %#v", evaluation.Context.BaseAdvance)
 	}
 }
+
 func TestOrdinaryBoundedCompatibleBaseAdvancePreservesFrozenRiskInputs(t *testing.T) {
 	fixture := newCompatiblePrePRFixtureMode(t, "delivery.txt", "base-only.txt", ModeOrdinaryBounded)
 	store, err := AuthoritativeStore(context.Background(), fixture.repo, fixture.receipt.LineageID)
@@ -405,21 +406,15 @@ func TestSelectPrePRBoundaryRejectsAdvertisedUnrelatedSameTree(t *testing.T) {
 
 func TestSelectPrePRBoundaryRejectsAmbiguousMergeBase(t *testing.T) {
 	repo := initSnapshotRepo(t)
-	initial := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
-	gitSnapshot(t, repo, "branch", "main", initial)
+	gitSnapshot(t, repo, "branch", "main", "HEAD")
 	configurePublicationRemote(t, repo, "main")
 	gitSnapshot(t, repo, "checkout", "-qb", "feature")
-	writeSnapshotFile(t, repo, "feature.txt", "feature\n")
-	gitSnapshot(t, repo, "add", "feature.txt")
-	gitSnapshot(t, repo, "commit", "-m", "feature change")
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "feature change")
 	feature := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	gitSnapshot(t, repo, "checkout", "main")
-	writeSnapshotFile(t, repo, "main.txt", "main\n")
-	gitSnapshot(t, repo, "add", "main.txt")
-	gitSnapshot(t, repo, "commit", "-m", "main change")
-	main := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "main change")
 	gitSnapshot(t, repo, "checkout", "feature")
-	gitSnapshot(t, repo, "merge", "--no-ff", "-m", "merge main into feature", main)
+	gitSnapshot(t, repo, "merge", "--no-ff", "-m", "merge main into feature", "main")
 	gitSnapshot(t, repo, "checkout", "main")
 	gitSnapshot(t, repo, "merge", "--no-ff", "-m", "merge feature into main", feature)
 	gitSnapshot(t, repo, "push", "-q", "origin", "main")

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -16,6 +16,13 @@ import (
 
 func TestNativePrePRGateAllowsOnlyCryptographicallyAttestedCompatibleBaseAdvance(t *testing.T) {
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	contentOnly := fixture.request
+	prePR := *contentOnly.PrePR
+	prePR.CIAttestationArtifact = ""
+	contentOnly.PrePR = &prePR
+	if got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, contentOnly); got.Result != GateAllow || got.Context.BaseAdvance == nil || got.Context.BaseAdvance.Status != baseAdvanceCompatibleLocalStatus {
+		t.Fatalf("content-compatible pre-PR advance = %#v", got)
+	}
 	originalPreimageHook := artifactPreimagesReadHook
 	artifactPreimagesReadHook = func() {
 		artifactPreimagesReadHook = originalPreimageHook
@@ -33,16 +40,6 @@ func TestNativePrePRGateAllowsOnlyCryptographicallyAttestedCompatibleBaseAdvance
 		t.Fatalf("base advance context = %#v", evaluation.Context.BaseAdvance)
 	}
 }
-
-func TestNativePrePRGateAllowsContentCompatibleBaseAdvanceWithoutAttestation(t *testing.T) {
-	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
-	fixture.request.PrePR.CIAttestationArtifact = ""
-	got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, fixture.request)
-	if got.Result != GateAllow || got.Context.BaseAdvance == nil || got.Context.BaseAdvance.Status != baseAdvanceCompatibleLocalStatus {
-		t.Fatalf("content-compatible pre-PR advance = %#v", got)
-	}
-}
-
 func TestOrdinaryBoundedCompatibleBaseAdvancePreservesFrozenRiskInputs(t *testing.T) {
 	fixture := newCompatiblePrePRFixtureMode(t, "delivery.txt", "base-only.txt", ModeOrdinaryBounded)
 	store, err := AuthoritativeStore(context.Background(), fixture.repo, fixture.receipt.LineageID)
@@ -406,13 +403,6 @@ func TestSelectPrePRBoundaryRejectsAdvertisedUnrelatedSameTree(t *testing.T) {
 	}
 }
 
-func TestSelectPrePRBoundaryRejectsRawSHASelector(t *testing.T) {
-	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
-	if _, err := selectPrePRBoundary(context.Background(), fixture.repo, fixture.originalBaseCommit); err == nil || !strings.Contains(err.Error(), "advertised remote branch") {
-		t.Fatalf("raw pre-PR SHA selector error = %v", err)
-	}
-}
-
 func TestSelectPrePRBoundaryRejectsAmbiguousMergeBase(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	initial := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
@@ -473,20 +463,6 @@ func TestBuildNativePrePRRequestKeepsExplicitReviewedBaseWhenDefaultAdvanced(t *
 	}
 	if evaluation := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); evaluation.Result != GateAllow || evaluation.Context.PrePRBoundary == nil || *evaluation.Context.PrePRBoundary != *request.PrePR.Boundary {
 		t.Fatalf("explicit pre-PR evaluation = %#v", evaluation)
-	}
-}
-
-func TestBuildNativePrePRRequestBindsCandidateToMergeBaseAndBoundaryToAdvertisedTip(t *testing.T) {
-	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
-	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
-		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "origin/main",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if request.PrePR == nil || request.PrePR.Boundary == nil || request.Target.BaseRef != fixture.originalBaseCommit ||
-		request.PrePR.Boundary.MergeBase != fixture.originalBaseCommit || request.PrePR.Boundary.Commit == fixture.originalBaseCommit {
-		t.Fatalf("merge-base-bound pre-PR request = %#v", request)
 	}
 }
 

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -34,6 +34,15 @@ func TestNativePrePRGateAllowsOnlyCryptographicallyAttestedCompatibleBaseAdvance
 	}
 }
 
+func TestNativePrePRGateAllowsContentCompatibleBaseAdvanceWithoutAttestation(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	fixture.request.PrePR.CIAttestationArtifact = ""
+	got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, fixture.request)
+	if got.Result != GateAllow || got.Context.BaseAdvance == nil || got.Context.BaseAdvance.Status != baseAdvanceCompatibleLocalStatus {
+		t.Fatalf("content-compatible pre-PR advance = %#v", got)
+	}
+}
+
 func TestOrdinaryBoundedCompatibleBaseAdvancePreservesFrozenRiskInputs(t *testing.T) {
 	fixture := newCompatiblePrePRFixtureMode(t, "delivery.txt", "base-only.txt", ModeOrdinaryBounded)
 	store, err := AuthoritativeStore(context.Background(), fixture.repo, fixture.receipt.LineageID)
@@ -66,31 +75,31 @@ func TestPrePRGateFailsClosedForUnprovenBaseAdvance(t *testing.T) {
 		basePath     string
 		mutate       func(t *testing.T, fixture *compatiblePrePRFixture)
 		want         GateResult
+		wantNoProof  bool
 	}{
-		{name: "missing attestation", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) { fixture.request.PrePR.CIAttestationArtifact = "" }, want: GateScopeChanged},
-		{name: "missing receipt-bound trust policy", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) { fixture.request.PolicyArtifact = "" }, want: GateScopeChanged},
+		{name: "missing receipt-bound trust policy", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) { fixture.request.PolicyArtifact = "" }, want: GateInvalidated},
 		{name: "invalid signature", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.attestation.Signature = base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
 			fixture.writeAttestation(t)
-		}, want: GateScopeChanged},
+		}, want: GateInvalidated},
 		{name: "wrong merged tree", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.attestation.MergedTree = fixture.receipt.FinalCandidateTree
 			fixture.signAndWriteAttestation(t)
-		}, want: GateScopeChanged},
+		}, want: GateInvalidated},
 		{name: "wrong issuer", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.attestation.Issuer = "untrusted-ci"
 			fixture.signAndWriteAttestation(t)
-		}, want: GateScopeChanged},
+		}, want: GateInvalidated},
 		{name: "non-success status", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.attestation.Status = "pending"
 			fixture.signAndWriteAttestation(t)
-		}, want: GateScopeChanged},
+		}, want: GateInvalidated},
 		{name: "invalidating external evidence", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.request.ExternalEvidence = ExternalEvidenceInvalidating
-		}, want: GateScopeChanged},
+		}, want: GateInvalidated, wantNoProof: true},
 		{name: "escalating external evidence", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.request.ExternalEvidence = ExternalEvidenceEscalating
-		}, want: GateEscalated},
+		}, want: GateEscalated, wantNoProof: true},
 		{name: "changed delivered patch", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			writeSnapshotFile(t, fixture.repo, fixture.deliveryPath, "changed delivery\n")
 			gitSnapshot(t, fixture.repo, "add", "--", fixture.deliveryPath)
@@ -101,8 +110,12 @@ func TestPrePRGateFailsClosedForUnprovenBaseAdvance(t *testing.T) {
 			gitSnapshot(t, fixture.repo, "add", "extra-delivery.txt")
 			gitSnapshot(t, fixture.repo, "commit", "-m", "expand delivery")
 		}, want: GateScopeChanged},
+		{name: "executable mode drift", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
+			gitSnapshot(t, fixture.repo, "update-index", "--chmod=+x", "--", fixture.deliveryPath)
+			gitSnapshot(t, fixture.repo, "commit", "-m", "change delivery mode")
+		}, want: GateScopeChanged},
 		{name: "overlapping base advance", deliveryPath: "delivery.txt", basePath: "delivery.txt", want: GateInvalidated},
-		{name: "merge conflict", deliveryPath: "conflict/file.txt", basePath: "conflict", want: GateScopeChanged},
+		{name: "merge conflict", deliveryPath: "conflict/file.txt", basePath: "conflict", want: GateInvalidated},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,8 +130,12 @@ func TestPrePRGateFailsClosedForUnprovenBaseAdvance(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(t, fixture)
 			}
-			if got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, fixture.request); got.Result != tt.want {
+			got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, fixture.request)
+			if got.Result != tt.want {
 				t.Fatalf("EvaluateNativeGate() = %#v, want %q", got, tt.want)
+			}
+			if tt.wantNoProof && got.Context.BaseAdvance != nil {
+				t.Fatalf("external evidence attached base compatibility proof: %#v", got.Context.BaseAdvance)
 			}
 		})
 	}
@@ -314,13 +331,13 @@ func TestSelectPrePRBoundaryUsesExactExplicitOrPublicationDefaultCommit(t *testi
 			name:     "explicit current chained base",
 			selector: "origin/reviewed-base",
 			want: PrePRBoundarySelection{
-				Source: PrePRBoundaryExplicit, Selector: "origin/reviewed-base", Commit: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/reviewed-base",
+				Source: PrePRBoundaryExplicit, Selector: "origin/reviewed-base", Commit: fixture.originalBaseCommit, MergeBase: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/reviewed-base",
 			},
 		},
 		{
 			name: "publication default without selector",
 			want: PrePRBoundarySelection{
-				Source: PrePRBoundaryPublicationDefault, Selector: "refs/heads/main", Commit: trimGit(gitSnapshot(t, fixture.repo, "rev-parse", "main")), Remote: "origin", RemoteRef: "refs/heads/main",
+				Source: PrePRBoundaryPublicationDefault, Selector: "refs/heads/main", Commit: trimGit(gitSnapshot(t, fixture.repo, "rev-parse", "main")), MergeBase: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/main",
 			},
 		},
 	}
@@ -389,6 +406,39 @@ func TestSelectPrePRBoundaryRejectsAdvertisedUnrelatedSameTree(t *testing.T) {
 	}
 }
 
+func TestSelectPrePRBoundaryRejectsRawSHASelector(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	if _, err := selectPrePRBoundary(context.Background(), fixture.repo, fixture.originalBaseCommit); err == nil || !strings.Contains(err.Error(), "advertised remote branch") {
+		t.Fatalf("raw pre-PR SHA selector error = %v", err)
+	}
+}
+
+func TestSelectPrePRBoundaryRejectsAmbiguousMergeBase(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	initial := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "branch", "main", initial)
+	configurePublicationRemote(t, repo, "main")
+	gitSnapshot(t, repo, "checkout", "-qb", "feature")
+	writeSnapshotFile(t, repo, "feature.txt", "feature\n")
+	gitSnapshot(t, repo, "add", "feature.txt")
+	gitSnapshot(t, repo, "commit", "-m", "feature change")
+	feature := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "checkout", "main")
+	writeSnapshotFile(t, repo, "main.txt", "main\n")
+	gitSnapshot(t, repo, "add", "main.txt")
+	gitSnapshot(t, repo, "commit", "-m", "main change")
+	main := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "checkout", "feature")
+	gitSnapshot(t, repo, "merge", "--no-ff", "-m", "merge main into feature", main)
+	gitSnapshot(t, repo, "checkout", "main")
+	gitSnapshot(t, repo, "merge", "--no-ff", "-m", "merge feature into main", feature)
+	gitSnapshot(t, repo, "push", "-q", "origin", "main")
+	gitSnapshot(t, repo, "checkout", "feature")
+	if _, err := selectPrePRBoundary(context.Background(), repo, "origin/main"); err == nil || !strings.Contains(err.Error(), "2 merge bases") {
+		t.Fatalf("ambiguous pre-PR merge-base error = %v", err)
+	}
+}
+
 func TestSelectPrePRBoundaryUsesRepositoryRootForSubdirectories(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	want := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
@@ -417,12 +467,26 @@ func TestBuildNativePrePRRequestKeepsExplicitReviewedBaseWhenDefaultAdvanced(t *
 		t.Fatal(err)
 	}
 	if request.Target.BaseRef != fixture.originalBaseCommit || request.PrePR == nil || request.PrePR.Boundary == nil || *request.PrePR.Boundary != (PrePRBoundarySelection{
-		Source: PrePRBoundaryExplicit, Selector: "origin/reviewed-base", Commit: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/reviewed-base", RemoteIdentity: request.PrePR.Boundary.RemoteIdentity,
+		Source: PrePRBoundaryExplicit, Selector: "origin/reviewed-base", Commit: fixture.originalBaseCommit, MergeBase: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/reviewed-base", RemoteIdentity: request.PrePR.Boundary.RemoteIdentity,
 	}) {
 		t.Fatalf("explicit pre-PR request = %#v", request)
 	}
 	if evaluation := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); evaluation.Result != GateAllow || evaluation.Context.PrePRBoundary == nil || *evaluation.Context.PrePRBoundary != *request.PrePR.Boundary {
 		t.Fatalf("explicit pre-PR evaluation = %#v", evaluation)
+	}
+}
+
+func TestBuildNativePrePRRequestBindsCandidateToMergeBaseAndBoundaryToAdvertisedTip(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "origin/main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.PrePR == nil || request.PrePR.Boundary == nil || request.Target.BaseRef != fixture.originalBaseCommit ||
+		request.PrePR.Boundary.MergeBase != fixture.originalBaseCommit || request.PrePR.Boundary.Commit == fixture.originalBaseCommit {
+		t.Fatalf("merge-base-bound pre-PR request = %#v", request)
 	}
 }
 

--- a/internal/reviewtransaction/pr_command_boundary_test.go
+++ b/internal/reviewtransaction/pr_command_boundary_test.go
@@ -92,8 +92,8 @@ func TestPrePRBoundarySelectionRejectsCommandLikeSelectorsBeforeGit(t *testing.T
 		"env GIT_SSH_COMMAND=id refs/heads/main", "refs/heads/main@{1}",
 		"refs/heads/../../etc", "refs/heads/$(id)",
 	} {
-		if err := ValidatePrePRBoundarySelector(context.Background(), repo, ref); !errors.Is(err, errCommandLikeBoundaryRef) {
-			t.Fatalf("ValidatePrePRBoundarySelector(%q) error = %v, want errCommandLikeBoundaryRef", ref, err)
+		if _, err := selectPrePRBoundary(context.Background(), repo, ref); !errors.Is(err, errCommandLikeBoundaryRef) {
+			t.Fatalf("selectPrePRBoundary(%q) error = %v, want errCommandLikeBoundaryRef", ref, err)
 		}
 	}
 }

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -1,6 +1,7 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
@@ -49,15 +50,9 @@ type prePRCITrust struct {
 
 const (
 	baseAdvanceCompatibleStatus = "base-advanced-compatible"
-	// baseAdvanceCompatibleLocalStatus is the D2 (#2471 option a) local-gate
-	// counterpart of baseAdvanceCompatibleStatus (#2388): the exact same five
-	// content checks deriveBaseAdvanceCompatibility already enforces for
-	// pre-PR, reused verbatim at pre-commit/pre-push, minus the trusted CI
-	// attestation pre-PR alone can obtain. It is issued only by
-	// deriveBaseAdvanceCompatibility(requireAttestation=false) and is never
-	// accepted at GatePrePR (receipt.go's baseAdvanceStatusAllowedForGate) --
-	// that byte-strict split is the whole point of a second status constant
-	// instead of relaxing baseAdvanceCompatibleStatus's own validity rule.
+	// baseAdvanceCompatibleLocalStatus records the native Git content proof when
+	// no optional CI attestation was supplied. It is accepted at pre-PR only for
+	// the merge-base-bound moving-boundary route.
 	baseAdvanceCompatibleLocalStatus       = "base-advanced-compatible-local"
 	currentChangesBoundaryCompatibleStatus = "current-changes-boundary-compatible"
 	currentChangesBoundaryCIStatus         = "not-required"
@@ -80,20 +75,17 @@ func (proof BaseAdvanceCompatibility) valid() bool {
 	}
 }
 
-// deriveBaseAdvanceCompatibility runs the five content checks D2 (#2471
-// option a, filed against #2388) designates as the complete, gate-agnostic
-// compatible-base-advance contract: merge-base tree preservation, delivered
-// path identity, delivered patch identity, base-advance/delivered path
-// disjointness, and a conflict-free `merge-tree --write-tree`. requireAttestation
-// is the ONLY axis that varies by gate: true reproduces the exact pre-PR
-// behavior this function always had (a trusted CI attestation over the merged
-// result is mandatory, and the returned proof carries baseAdvanceCompatibleStatus);
-// false skips the attestation lookup/verification entirely and returns
-// baseAdvanceCompatibleLocalStatus instead, so a caller can never launder a
-// locally-derived proof into the CI-attested shape pre-PR's byte-strict
-// validation (receipt.go's baseAdvanceStatusAllowedForGate) requires. The five
-// content checks themselves are not duplicated, weakened, or parameterized --
-// same code, same order, same failure strings, for every caller.
+func prePRBoundaryAdvanced(refs *resolvedPrePRRefs) bool {
+	return refs != nil && refs.Selection.Commit != refs.Selection.MergeBase
+}
+
+func prePRAttestationRequested(request GateRequest) bool {
+	return request.PrePR != nil && strings.TrimSpace(request.PrePR.CIAttestationArtifact) != ""
+}
+
+// deriveBaseAdvanceCompatibility verifies the shared merge-base, path, patch,
+// disjointness, and conflict-free merge proof. Attestation is optional; the
+// native content checks are identical for every caller.
 func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs, preimages gateArtifactPreimages, requireAttestation bool) (BaseAdvanceCompatibility, error) {
 	if refs == nil {
 		return BaseAdvanceCompatibility{}, errors.New("resolved pre-PR refs are missing")
@@ -104,13 +96,13 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if requireAttestation && (request.PrePR == nil || strings.TrimSpace(request.PrePR.CIAttestationArtifact) == "") {
 		return BaseAdvanceCompatibility{}, errors.New("trusted CI attestation is required")
 	}
-	mergeBase, err := runGit(ctx, repo, nil, nil, "merge-base", refs.Selection.Commit, refs.HeadCommit)
-	if err != nil {
-		return BaseAdvanceCompatibility{}, fmt.Errorf("derive original merge-base: %w", err)
-	}
-	mergeBaseTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, strings.TrimSpace(string(mergeBase)))
-	if err != nil || mergeBaseTree != receipt.BaseTree {
+	mergeBaseTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, refs.Selection.MergeBase)
+	if err != nil || mergeBaseTree != receipt.BaseTree || snapshot.BaseTree != mergeBaseTree {
 		return BaseAdvanceCompatibility{}, errors.New("original reviewed merge-base tree is not preserved")
+	}
+	advertisedBaseTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, refs.Selection.Commit)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, errors.New("advertised pre-PR base tree cannot be derived") // refusal:by-design world-action: only Git object recovery can restore a missing advertised base tree
 	}
 
 	builder := SnapshotBuilder{Repo: repo}
@@ -133,7 +125,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if err != nil || originalPatch != currentPatch {
 		return BaseAdvanceCompatibility{}, errors.New("delivered patch identity changed")
 	}
-	basePaths, err := builder.changedPaths(ctx, receipt.BaseTree, snapshot.BaseTree)
+	basePaths, err := builder.changedPaths(ctx, receipt.BaseTree, advertisedBaseTree)
 	if err != nil {
 		return BaseAdvanceCompatibility{}, err
 	}
@@ -147,6 +139,21 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	mergedFields := strings.Fields(string(mergedOutput))
 	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {
 		return BaseAdvanceCompatibility{}, errors.New("merged result tree cannot be derived")
+	}
+	approvedEntries, err := listTreeEntries(ctx, repo, receipt.FinalCandidateTree)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, err
+	}
+	mergedEntries, err := listTreeEntries(ctx, repo, mergedFields[0])
+	if err != nil {
+		return BaseAdvanceCompatibility{}, err
+	}
+	for _, path := range originalPaths {
+		approved, approvedPresent := approvedEntries[path]
+		merged, mergedPresent := mergedEntries[path]
+		if approvedPresent != mergedPresent || !bytes.Equal(approved, merged) {
+			return BaseAdvanceCompatibility{}, errors.New("merge result changed reviewed projection") // refusal:by-design world-action: only changing the merge result and reviewing the new candidate can restore this projection
+		}
 	}
 	var attestationHash, issuer string
 	if requireAttestation {
@@ -172,7 +179,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 		status, ciStatus = baseAdvanceCompatibleStatus, "success"
 	}
 	proof := BaseAdvanceCompatibility{
-		Status: status, Compatible: true, OriginalMergeBaseTree: receipt.BaseTree, NewBaseTree: snapshot.BaseTree,
+		Status: status, Compatible: true, OriginalMergeBaseTree: receipt.BaseTree, NewBaseTree: advertisedBaseTree,
 		OriginalPatchIdentity: originalPatch, DeliveredPatchIdentity: currentPatch,
 		DeliveredPathsDigest: receipt.PathsDigest, BaseAdvancePathsDigest: digestPaths(basePaths), PathsDisjoint: true,
 		MergedResultTree: mergedFields[0], CIAttestationArtifactHash: attestationHash,

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -50,9 +50,7 @@ type prePRCITrust struct {
 
 const (
 	baseAdvanceCompatibleStatus = "base-advanced-compatible"
-	// baseAdvanceCompatibleLocalStatus records the native Git content proof when
-	// no optional CI attestation was supplied. It is accepted at pre-PR only for
-	// the merge-base-bound moving-boundary route.
+	// baseAdvanceCompatibleLocalStatus records native content proof without CI attestation.
 	baseAdvanceCompatibleLocalStatus       = "base-advanced-compatible-local"
 	currentChangesBoundaryCompatibleStatus = "current-changes-boundary-compatible"
 	currentChangesBoundaryCIStatus         = "not-required"
@@ -83,9 +81,7 @@ func prePRAttestationRequested(request GateRequest) bool {
 	return request.PrePR != nil && strings.TrimSpace(request.PrePR.CIAttestationArtifact) != ""
 }
 
-// deriveBaseAdvanceCompatibility verifies the shared merge-base, path, patch,
-// disjointness, and conflict-free merge proof. Attestation is optional; the
-// native content checks are identical for every caller.
+// deriveBaseAdvanceCompatibility verifies the shared content and merge proof.
 func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs, preimages gateArtifactPreimages, requireAttestation bool) (BaseAdvanceCompatibility, error) {
 	if refs == nil {
 		return BaseAdvanceCompatibility{}, errors.New("resolved pre-PR refs are missing")

--- a/internal/reviewtransaction/prepr_base_advance_characterization_test.go
+++ b/internal/reviewtransaction/prepr_base_advance_characterization_test.go
@@ -153,7 +153,7 @@ func runBaseAdvanceScenario(t *testing.T, scenario baseAdvanceScenario) baseAdva
 	}
 	refs := &resolvedPrePRRefs{Selection: selection, HeadCommit: headCommit}
 
-	snapshot, err := builder.Build(ctx, Target{Kind: TargetBaseDiff, BaseRef: "main"})
+	snapshot, err := builder.Build(ctx, Target{Kind: TargetBaseDiff, BaseRef: selection.MergeBase})
 	if err != nil {
 		t.Fatalf("Build(TargetBaseDiff): %v", err)
 	}
@@ -245,8 +245,9 @@ func TestDeriveBaseAdvanceCompatibilitySucceedsWhenAllSevenConditionsHold(t *tes
 	// Condition 7: base/HEAD non-advance revalidation — a nil error already
 	// proves the final re-check found no drift between the captured refs and
 	// live repository state.
-	if result.proof.NewBaseTree != result.snapshot.BaseTree {
-		t.Fatalf("NewBaseTree = %q, want snapshot.BaseTree %q", result.proof.NewBaseTree, result.snapshot.BaseTree)
+	advertisedBaseTree := trimGit(gitSnapshot(t, result.repo, "rev-parse", result.refs.Selection.Commit+"^{tree}"))
+	if result.proof.NewBaseTree != advertisedBaseTree {
+		t.Fatalf("NewBaseTree = %q, want advertised base tree %q", result.proof.NewBaseTree, advertisedBaseTree)
 	}
 }
 

--- a/internal/reviewtransaction/prepr_current_changes_test.go
+++ b/internal/reviewtransaction/prepr_current_changes_test.go
@@ -96,8 +96,8 @@ func TestCompactPrePRGateFailsClosedForMultipleDeliveryCommits(t *testing.T) {
 	gitSnapshot(t, repo, "add", "tracked.txt")
 	gitSnapshot(t, repo, "commit", "-m", "restore approved candidate")
 	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
-	if got.Result != GateScopeChanged {
-		t.Fatalf("multiple delivery commits pre-PR = %#v, want scope changed", got)
+	if got.Result != GateInvalidated {
+		t.Fatalf("multiple delivery commits pre-PR = %#v, want invalidated", got)
 	}
 }
 
@@ -112,8 +112,8 @@ func TestCompactPrePRGateFailsClosedWhenPublicationRangeExceedsGenesis(t *testin
 	gitSnapshot(t, repo, "add", "-A")
 	gitSnapshot(t, repo, "commit", "-m", "remove intermediate secret")
 	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
-	if got.Result != GateScopeChanged {
-		t.Fatalf("hidden publication-range path pre-PR = %#v, want scope changed", got)
+	if got.Result != GateInvalidated {
+		t.Fatalf("hidden publication-range path pre-PR = %#v, want invalidated", got)
 	}
 }
 

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -363,7 +363,7 @@ func ParseGateContext(payload []byte) (GateContext, error) {
 	if context.PrePRBoundary != nil {
 		boundary := context.PrePRBoundary
 		unavailable := boundary.Commit == "" && context.Denial != nil && context.Denial.Stage == "boundary-selection" && context.Denial.Code == "unavailable"
-		if context.Gate != GatePrePR || ((!validGitTree(boundary.Commit) || !validGitTree(boundary.MergeBase)) && !unavailable) || strings.TrimSpace(boundary.Selector) == "" ||
+		if context.Gate != GatePrePR || (unavailable && boundary.MergeBase != "") || ((!validGitTree(boundary.Commit) || !validGitTree(boundary.MergeBase)) && !unavailable) || strings.TrimSpace(boundary.Selector) == "" ||
 			(boundary.Source != PrePRBoundaryExplicit && boundary.Source != PrePRBoundaryPublicationDefault) {
 			return GateContext{}, errors.New("gate context contains invalid pre-PR boundary evidence")
 		}

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -275,11 +275,8 @@ func RecoverySelfDerivedInputs(predecessor State) []string {
 	}
 }
 
-// baseAdvanceStatusAllowedForGate is the single source of truth for compatible
-// base-advance evidence. Pre-PR accepts either a content-only proof, optional
-// valid CI-attested proof, or current-changes boundary reconciliation. Both
-// validateDerivedGate and ParseGateContext call this function so their policy
-// cannot drift.
+// baseAdvanceStatusAllowedForGate keeps evaluation and persisted-context
+// validation aligned on compatible base-advance evidence.
 func baseAdvanceStatusAllowedForGate(gate GateKind, status string) bool {
 	switch gate {
 	case GatePrePR:

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -275,22 +275,15 @@ func RecoverySelfDerivedInputs(predecessor State) []string {
 	}
 }
 
-// baseAdvanceStatusAllowedForGate is the single source of truth D2 (#2471
-// option a) adds for the per-gate compatible-base-advance attestation policy:
-// GatePrePR alone may carry a CI-attested proof (baseAdvanceCompatibleStatus)
-// or the unrelated, already-existing current-changes boundary reconciliation
-// (currentChangesBoundaryCompatibleStatus, #1376); GatePreCommit and
-// GatePrePush may carry only the unattested local proof
-// (baseAdvanceCompatibleLocalStatus) deriveBaseAdvanceCompatibility issues
-// when its requireAttestation parameter is false. Both validateDerivedGate's
-// carve-out and ParseGateContext's structural validation call this one
-// function, so the attestation policy can never drift between "what a gate
-// accepts at evaluation time" and "what a persisted context is allowed to
-// claim happened."
+// baseAdvanceStatusAllowedForGate is the single source of truth for compatible
+// base-advance evidence. Pre-PR accepts either a content-only proof, optional
+// valid CI-attested proof, or current-changes boundary reconciliation. Both
+// validateDerivedGate and ParseGateContext call this function so their policy
+// cannot drift.
 func baseAdvanceStatusAllowedForGate(gate GateKind, status string) bool {
 	switch gate {
 	case GatePrePR:
-		return status == baseAdvanceCompatibleStatus || status == currentChangesBoundaryCompatibleStatus
+		return status == baseAdvanceCompatibleStatus || status == baseAdvanceCompatibleLocalStatus || status == currentChangesBoundaryCompatibleStatus
 	case GatePreCommit, GatePrePush:
 		return status == baseAdvanceCompatibleLocalStatus
 	default:

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -363,7 +363,7 @@ func ParseGateContext(payload []byte) (GateContext, error) {
 	if context.PrePRBoundary != nil {
 		boundary := context.PrePRBoundary
 		unavailable := boundary.Commit == "" && context.Denial != nil && context.Denial.Stage == "boundary-selection" && context.Denial.Code == "unavailable"
-		if context.Gate != GatePrePR || (!validGitTree(boundary.Commit) && !unavailable) || strings.TrimSpace(boundary.Selector) == "" ||
+		if context.Gate != GatePrePR || ((!validGitTree(boundary.Commit) || !validGitTree(boundary.MergeBase)) && !unavailable) || strings.TrimSpace(boundary.Selector) == "" ||
 			(boundary.Source != PrePRBoundaryExplicit && boundary.Source != PrePRBoundaryPublicationDefault) {
 			return GateContext{}, errors.New("gate context contains invalid pre-PR boundary evidence")
 		}

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -275,8 +275,7 @@ func RecoverySelfDerivedInputs(predecessor State) []string {
 	}
 }
 
-// baseAdvanceStatusAllowedForGate keeps evaluation and persisted-context
-// validation aligned on compatible base-advance evidence.
+// baseAdvanceStatusAllowedForGate keeps evaluation and persisted contexts aligned.
 func baseAdvanceStatusAllowedForGate(gate GateKind, status string) bool {
 	switch gate {
 	case GatePrePR:

--- a/internal/reviewtransaction/receipt_test.go
+++ b/internal/reviewtransaction/receipt_test.go
@@ -118,12 +118,9 @@ func TestValidateDerivedGateGeneralizesCompatibleBaseAdvanceToLocalGates(t *test
 	}
 }
 
-// TestValidateDerivedGateRefusesLocalStatusAtPrePRRegression is the byte-strict
-// regression guard D2 requires: the unattested local proof must never
-// authorize GatePrePR, even when every content-check field matches, because
-// GatePrePR alone can reach real CI and D2 keeps its attestation requirement
-// exactly as strict as before this change.
-func TestValidateDerivedGateRefusesLocalStatusAtPrePRRegression(t *testing.T) {
+// TestValidateDerivedGateAllowsContentProofAtPrePR proves R2's content-bound
+// pre-PR route does not require an unrelated CI attestation.
+func TestValidateDerivedGateAllowsContentProofAtPrePR(t *testing.T) {
 	tx := ordinaryAtFixValidation(t)
 	if err := tx.ValidateFixDelta([]string{"R1-DET"}, true); err != nil {
 		t.Fatalf("ValidateFixDelta() error = %v", err)
@@ -148,11 +145,11 @@ func TestValidateDerivedGateRefusesLocalStatusAtPrePRRegression(t *testing.T) {
 		PolicyHash: receipt.PolicyHash, LedgerHash: receipt.LedgerHash, EvidenceHash: receipt.EvidenceHash,
 		BaseRelationshipValid: false, BaseAdvance: &advance,
 	}
-	if got := validateDerivedGate(receipt, context); got == GateAllow {
-		t.Fatalf("validateDerivedGate(pre-pr, unattested local advance) = %q, want refused", got)
+	if got := validateDerivedGate(receipt, context); got != GateAllow {
+		t.Fatalf("validateDerivedGate(pre-pr, content proof) = %q, want allow", got)
 	}
-	if baseAdvanceStatusAllowedForGate(GatePrePR, baseAdvanceCompatibleLocalStatus) {
-		t.Fatal("baseAdvanceStatusAllowedForGate(pre-pr, local) = true, want false")
+	if !baseAdvanceStatusAllowedForGate(GatePrePR, baseAdvanceCompatibleLocalStatus) {
+		t.Fatal("baseAdvanceStatusAllowedForGate(pre-pr, local) = false, want true")
 	}
 	for _, gate := range []GateKind{GatePreCommit, GatePrePush} {
 		if baseAdvanceStatusAllowedForGate(gate, baseAdvanceCompatibleStatus) {
@@ -162,9 +159,9 @@ func TestValidateDerivedGateRefusesLocalStatusAtPrePRRegression(t *testing.T) {
 }
 
 // TestParseGateContextRestrictsBaseAdvanceStatusPerGate proves the same
-// byte-strict split at the persisted-context boundary: ParseGateContext must
-// accept the local status only at GatePreCommit/GatePrePush, accept the
-// attested (or current-changes-boundary) status only at GatePrePR, and a
+// per-gate split at the persisted-context boundary: ParseGateContext must
+// accept the local content proof at every delivery gate, accept the
+// attested (or current-changes-boundary) status at GatePrePR, and a
 // historical context with no base_advanced_compatible field at all -- every
 // context ever persisted before this change -- must still parse unchanged
 // (the additive-only, forensic-invariant requirement).
@@ -206,7 +203,7 @@ func TestParseGateContextRestrictsBaseAdvanceStatusPerGate(t *testing.T) {
 		{"local status at pre-commit parses", withLocal(GatePreCommit), false},
 		{"local status at pre-push parses", withLocal(GatePrePush), false},
 		{"attested status at pre-pr parses", withAttested(GatePrePR), false},
-		{"local status at pre-pr is rejected (byte-strict regression)", withLocal(GatePrePR), true},
+		{"local content proof at pre-pr parses", withLocal(GatePrePR), false},
 		{"attested status at pre-commit is rejected", withAttested(GatePreCommit), true},
 		{"attested status at pre-push is rejected", withAttested(GatePrePush), true},
 		{"historical context without base advance still parses at pre-commit", withoutAdvance(GatePreCommit), false},

--- a/internal/reviewtransaction/receipt_test.go
+++ b/internal/reviewtransaction/receipt_test.go
@@ -118,8 +118,6 @@ func TestValidateDerivedGateGeneralizesCompatibleBaseAdvanceToLocalGates(t *test
 	}
 }
 
-// TestValidateDerivedGateAllowsContentProofAtPrePR proves R2's content-bound
-// pre-PR route does not require an unrelated CI attestation.
 func TestValidateDerivedGateAllowsContentProofAtPrePR(t *testing.T) {
 	tx := ordinaryAtFixValidation(t)
 	if err := tx.ValidateFixDelta([]string{"R1-DET"}, true); err != nil {
@@ -219,6 +217,13 @@ func TestParseGateContextRestrictsBaseAdvanceStatusPerGate(t *testing.T) {
 				t.Fatalf("ParseGateContext(%s) error = %v, want nil", tt.name, err)
 			}
 		})
+	}
+	boundary := `,"pre_pr_boundary":{"source":"explicit","selector":"origin/main","commit":"` + base + `","merge_base":"MERGE"}}`
+	for _, mergeBase := range []string{"", "not-a-tree"} {
+		payload := baseContext(GatePrePR) + strings.Replace(boundary, "MERGE", mergeBase, 1)
+		if _, err := ParseGateContext([]byte(payload)); err == nil {
+			t.Fatalf("ParseGateContext accepted available pre-PR boundary merge_base %q", mergeBase)
+		}
 	}
 }
 

--- a/internal/reviewtransaction/receipt_test.go
+++ b/internal/reviewtransaction/receipt_test.go
@@ -218,11 +218,11 @@ func TestParseGateContextRestrictsBaseAdvanceStatusPerGate(t *testing.T) {
 			}
 		})
 	}
-	boundary := `,"pre_pr_boundary":{"source":"explicit","selector":"origin/main","commit":"` + base + `","merge_base":"MERGE"}}`
-	for _, mergeBase := range []string{"", "not-a-tree"} {
-		payload := baseContext(GatePrePR) + strings.Replace(boundary, "MERGE", mergeBase, 1)
+	boundaries := []string{`,"pre_pr_boundary":{"source":"explicit","selector":"origin/main","commit":"` + base + `","merge_base":""}}`, `,"pre_pr_boundary":{"source":"explicit","selector":"origin/main","commit":"` + base + `","merge_base":"not-a-tree"}}`, `,"pre_pr_boundary":{"source":"explicit","selector":"origin/main","commit":"","merge_base":"not-a-tree"},"denial":{"stage":"boundary-selection","code":"unavailable"}}`}
+	for _, boundary := range boundaries {
+		payload := baseContext(GatePrePR) + boundary
 		if _, err := ParseGateContext([]byte(payload)); err == nil {
-			t.Fatalf("ParseGateContext accepted available pre-PR boundary merge_base %q", mergeBase)
+			t.Fatalf("ParseGateContext accepted invalid pre-PR boundary %s", boundary)
 		}
 	}
 }

--- a/internal/reviewtransaction/shadow_relation_test.go
+++ b/internal/reviewtransaction/shadow_relation_test.go
@@ -296,7 +296,7 @@ func buildShadowBaseAdvanceFixture(t *testing.T, breakMergeBasePreservation bool
 	}
 	refs := &resolvedPrePRRefs{Selection: selection, HeadCommit: headCommit}
 
-	snapshot, err := builder.Build(ctx, Target{Kind: TargetBaseDiff, BaseRef: "main"})
+	snapshot, err := builder.Build(ctx, Target{Kind: TargetBaseDiff, BaseRef: selection.MergeBase})
 	if err != nil {
 		t.Fatalf("Build(TargetBaseDiff): %v", err)
 	}

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -51,6 +51,7 @@ const (
 type TargetStatusRequest struct {
 	Target    Target
 	LineageID string
+	PrePR     *PrePRRequest
 }
 
 type TargetProjectionStatus struct {
@@ -302,6 +303,9 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 				continue
 			}
 		} else if compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
+			if !compactPrePRContentCompatible(ctx, repo, state, live, request.PrePR) {
+				continue
+			}
 			candidates = append(candidates, candidate)
 			continue
 		}
@@ -387,6 +391,26 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 		}
 		return base, nil
 	}
+}
+
+func compactPrePRContentCompatible(ctx context.Context, repo string, state CompactState, snapshot Snapshot, prePR *PrePRRequest) bool {
+	if prePR == nil || prePR.Boundary == nil || prePR.Boundary.Commit == prePR.Boundary.MergeBase {
+		return true
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		return false
+	}
+	head, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		return false
+	}
+	_, err = deriveBaseAdvanceCompatibility(ctx, repo, Receipt{
+		BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest,
+	}, GateRequest{Gate: GatePrePR, PrePR: prePR}, snapshot, &resolvedPrePRRefs{
+		Selection: *prePR.Boundary, HeadCommit: head,
+	}, gateArtifactPreimages{}, false)
+	return err == nil
 }
 
 func corruptedTargetStatus(result TargetStatusResult) TargetStatusResult {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2127

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Bind pre-PR candidate comparison to the unique merge-base of the advertised remote tip and HEAD.
- Keep the advertised tip as publication-boundary evidence and fail closed on overlap, drift, ambiguity, or conflicts.
- Make negotiated STATUS and direct validation reuse the same content proof without requiring unrelated CI attestation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Bound pre-PR targets and compatibility evidence to immutable Git content and the unique merge-base |
| `internal/cli` | Routed negotiated STATUS through the same pre-PR target and proof as validation |
| Unit controls | Covered moving bases, raw SHA refusal, ambiguity, content/mode/conflict drift, ref movement, and external-evidence semantics |

---

## 🧪 Test Plan

- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./internal/cli ./internal/reviewtransaction -count=1`
- [x] `go test ./... -count=1`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] Full driven candidate: 84 completed, 0 unsupported, 0 failed
- [x] Focused j83 after the final correction: 1 completed, 0 unsupported, 0 failed
- [ ] Docker E2E locally — not run; CI remains authoritative for the repository E2E job

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 400 / 400
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass — CI pending
- [x] Benchmark validation completed
- [x] Documentation is not required for this internal correctness fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | #2127 moving pre-PR base |
| Tracker PR | Not needed |
| Position | 1 of 2 |
| Base | `main` |
| Depends on | Merged PR #2874 |
| Follow-up | j83 driven journey and corpus ratchet |
| Review budget | 400 / 400 |
| Starts at | `origin/main` after PR #2874 |
| Ends with | Content-bound pre-PR merge-base authorization and STATUS parity |

### Chain Overview

```text
main
 └── 📍 This PR: merge-base binding and unit controls
      └── Next PR: j83 driven journey and corpus ratchet
```

### Scope
- Includes: product mechanism, STATUS routing, and focused fail-closed unit controls.
- Excludes: driven journey source and corpus count ratchet, delivered in PR 2.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Unit and candidate-level driven verification cover this unit

---

## 💬 Notes for Reviewers

The ratified boundary authorizes Git content, not branch topology. The selector remains an advertised remote ref; only candidate comparison moves to its internally derived unique merge-base. No new claim-bearing population guard was introduced, and `.guard-population-baseline.txt` is intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pre-PR status and validation when the base branch advances.
  * Preserved validation against the correct merge-base content as branches change.
  * Added clearer rejection for ambiguous, invalid, or unsupported base selections.
  * Prevented unverified, incompatible, conflicted, or altered changes from being authorized.
  * Recognized content-compatible updates, including file-mode changes, without requiring additional attestation.
  * Ensured final authorization rechecks compatibility before approval.
* **Validation**
  * Added coverage for moving bases, boundary changes, recovery scenarios, and final authorization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->