### PR TITLE
test(bench): prove moving pre-pr base binding

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -73,6 +73,15 @@ func (e statusEnvelope) argument(name string) string {
 	return ""
 }
 
+func (e statusEnvelope) executeArgument(name string) string {
+	for _, argument := range e.NextTransition.Execute.Arguments {
+		if argument.Name == name {
+			return argument.Value
+		}
+	}
+	return ""
+}
+
 func (e statusEnvelope) paths() []string {
 	if len(e.NextTransition.Collect.Inputs) == 0 {
 		return nil

--- a/bench/journeys_reviewed_superset.go
+++ b/bench/journeys_reviewed_superset.go
@@ -243,10 +243,10 @@ func advanceReviewedSupersetAdvertisedMain(sandbox *Sandbox) error {
 	if err := sandbox.git(sibling, "checkout", "-q", "-B", "main", "origin/main"); err != nil {
 		return err
 	}
-	if err := sandbox.git(sibling, "config", "user.email", "bench@example.test"); err != nil {
+	if err := sandbox.git(sibling, "config", "user.email", "bench@example.invalid"); err != nil {
 		return err
 	}
-	if err := sandbox.git(sibling, "config", "user.name", "Benchmark Fixture"); err != nil {
+	if err := sandbox.git(sibling, "config", "user.name", "Bench"); err != nil {
 		return err
 	}
 	if err := sandbox.write(filepath.Join(sibling, reviewedSupersetBaseAdvancePath), "# Disjoint base advance\n"); err != nil {
@@ -277,10 +277,17 @@ func advanceReviewedSupersetAdvertisedMain(sandbox *Sandbox) error {
 func requireReviewedSupersetPrePRAllow(sandbox *Sandbox, observation Observation) error {
 	var gate waveGateResult
 	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate); err != nil {
+		if observation.ExitCode != 0 {
+			return fmt.Errorf("moving-base pre-PR exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+		}
 		return fmt.Errorf("parse moving-base pre-PR result: %w (stderr: %s)", err, firstLine(observation.Stderr))
 	}
 	if !gate.Allowed || gate.Result != "allow" || gate.Context.LineageID != sandbox.Lineage {
-		return fmt.Errorf("moving advertised base pre-PR rejected: exit=%d result=%q allowed=%t gate=%+v", observation.ExitCode, gate.Result, gate.Allowed, gate)
+		stage, code := "", ""
+		if gate.Context.Denial != nil {
+			stage, code = gate.Context.Denial.Stage, gate.Context.Denial.Code
+		}
+		return fmt.Errorf("moving advertised base pre-PR rejected: exit=%d result=%q allowed=%t denial_stage=%q denial_code=%q gate=%+v", observation.ExitCode, gate.Result, gate.Allowed, stage, code, gate)
 	}
 	return nil
 }
@@ -292,8 +299,9 @@ func executeReviewedSupersetMovingBaseTransition(run *journeyRun) error {
 	if err != nil {
 		return err
 	}
-	if envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.validate" {
-		return fmt.Errorf("moving-base pre-PR transition = %+v, want review.validate execute", envelope.NextTransition)
+	if envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.validate" ||
+		envelope.executeArgument("gate") != "pre-pr" || envelope.executeArgument("base-ref") != "origin/main" {
+		return fmt.Errorf("moving-base pre-PR transition = %+v, want review.validate --gate pre-pr --base-ref origin/main", envelope.NextTransition)
 	}
 	observation, err := runPrintedTransition(run, envelope)
 	if err != nil {

--- a/bench/journeys_reviewed_superset.go
+++ b/bench/journeys_reviewed_superset.go
@@ -8,10 +8,12 @@ import (
 )
 
 const (
-	reviewedSupersetJourneyID = "j82-reviewed-superset-pre-push-allows-unpublished-subset"
-	reviewedSupersetLineage   = "reviewed-superset-pre-push"
-	reviewedSupersetPathA     = "docs/reviewed-a.md"
-	reviewedSupersetPathB     = "docs/reviewed-b.md"
+	reviewedSupersetJourneyID           = "j82-reviewed-superset-pre-push-allows-unpublished-subset"
+	reviewedSupersetMovingBaseJourneyID = "j83-pre-pr-moving-advertised-base-binds-merge-base"
+	reviewedSupersetLineage             = "reviewed-superset-pre-push"
+	reviewedSupersetPathA               = "docs/reviewed-a.md"
+	reviewedSupersetPathB               = "docs/reviewed-b.md"
+	reviewedSupersetBaseAdvancePath     = "docs/disjoint-base-advance.md"
 )
 
 var reviewedSupersetFinalizeCapability = &Capability{
@@ -43,6 +45,12 @@ type reviewedSupersetStatus struct {
 // main, and the committed candidate changes exactly A and B.
 func reviewedSupersetFixture(sandbox *Sandbox) error {
 	if err := baseRepoWithRemote(sandbox); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "branch", "-M", "main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "push", "-q", "-u", "origin", "main"); err != nil {
 		return err
 	}
 	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "-b", "feature"); err != nil {
@@ -230,6 +238,76 @@ func requireReviewedSupersetPrePushAllow(sandbox *Sandbox, observation Observati
 	return nil
 }
 
+// advanceReviewedSupersetAdvertisedMain moves the advertised publication
+// boundary from a sibling clone. The feature candidate remains untouched and
+// the new base path is intentionally disjoint from the reviewed paths.
+func advanceReviewedSupersetAdvertisedMain(sandbox *Sandbox) error {
+	sibling := filepath.Join(sandbox.Root, "main-advance")
+	if err := sandbox.git(sandbox.Root, "clone", "-q", "--no-checkout", sandbox.Remote, sibling); err != nil {
+		return err
+	}
+	if err := sandbox.git(sibling, "checkout", "-q", "-B", "main", "origin/main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sibling, "config", "user.email", "bench@example.test"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sibling, "config", "user.name", "Benchmark Fixture"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sibling, reviewedSupersetBaseAdvancePath), "# Disjoint base advance\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sibling, "add", "--", reviewedSupersetBaseAdvancePath); err != nil {
+		return err
+	}
+	if err := sandbox.git(sibling, "commit", "-qm", "docs: advance main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sibling, "push", "-q", "origin", "main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "fetch", "-q", "origin", "main"); err != nil {
+		return err
+	}
+	paths, err := gitOut(sandbox, sandbox.Repo, "diff", "--name-only", sandbox.Scratch["reviewed-superset-base"]+"..origin/main")
+	if err != nil {
+		return err
+	}
+	if paths != reviewedSupersetBaseAdvancePath {
+		return fmt.Errorf("advertised main paths = %q, want %q", paths, reviewedSupersetBaseAdvancePath)
+	}
+	return nil
+}
+
+func requireReviewedSupersetPrePRAllow(sandbox *Sandbox, observation Observation) error {
+	var gate waveGateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate); err != nil {
+		return fmt.Errorf("parse moving-base pre-PR result: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if !gate.Allowed || gate.Result != "allow" || gate.Context.LineageID != sandbox.Lineage {
+		return fmt.Errorf("moving advertised base pre-PR rejected: exit=%d result=%q allowed=%t gate=%+v", observation.ExitCode, gate.Result, gate.Allowed, gate)
+	}
+	return nil
+}
+
+// executeReviewedSupersetMovingBaseTransition executes the exact validate
+// command that negotiated STATUS prints after the advertised base advances.
+func executeReviewedSupersetMovingBaseTransition(run *journeyRun) error {
+	envelope, err := readStatusFor(run, "--gate", "pre-pr", "--base-ref", "origin/main")
+	if err != nil {
+		return err
+	}
+	if envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.validate" {
+		return fmt.Errorf("moving-base pre-PR transition = %+v, want review.validate execute", envelope.NextTransition)
+	}
+	observation, err := runPrintedTransition(run, envelope)
+	if err != nil {
+		return err
+	}
+	return requireReviewedSupersetPrePRAllow(run.sandbox, observation)
+}
+
 func reviewedSupersetJourneys() []Journey {
 	return []Journey{
 		{
@@ -243,6 +321,19 @@ func reviewedSupersetJourneys() []Journey {
 				{Name: "native status proves the approved receipt covers the exact full candidate and paths A and B", Requires: statusCapability, Composite: proveReviewedSupersetReceipt},
 				{Name: "fixture: publish only reviewed prefix A and prove B remains unpublished", Fixture: publishReviewedPrefix},
 				{Name: "pre-push allows the one-path unpublished subset B", Requires: validateCapability, Args: productArgs("review", "validate", "--gate", "pre-push"), After: requireReviewedSupersetPrePushAllow},
+			},
+		},
+		{
+			ID:     reviewedSupersetMovingBaseJourneyID,
+			Title:  "Approved feature receipt: pre-PR binds the merge-base after advertised main advances",
+			Source: "#2127 R2 ratified content proof: an advertised ref is a publication boundary, while the unique merge-base binds candidate comparison",
+			Steps: []Step{
+				{Name: "fixture: feature tracks origin and commits reviewed paths A and B", Fixture: reviewedSupersetFixture},
+				{Name: "negotiate and execute review start for the full feature candidate", Requires: statusCapability, Composite: startReviewedSupersetBaseDiff},
+				{Name: "review finalize the full feature candidate", Requires: reviewedSupersetFinalizeCapability, Args: productArgs("review", "finalize", "--lineage", reviewedSupersetLineage)},
+				{Name: "fixture: sibling clone advances advertised main on a disjoint path and feature fetches it", Fixture: advanceReviewedSupersetAdvertisedMain},
+				{Name: "negotiated pre-PR STATUS executes its exact printed validation for origin/main", Requires: statusCapability, Composite: executeReviewedSupersetMovingBaseTransition},
+				{Name: "unqualified pre-PR validation against origin/main allows the approved feature candidate", Requires: validateCapability, Args: productArgs("review", "validate", "--gate", "pre-pr", "--base-ref", "origin/main"), After: requireReviewedSupersetPrePRAllow},
 			},
 		},
 	}

--- a/bench/journeys_reviewed_superset.go
+++ b/bench/journeys_reviewed_superset.go
@@ -47,12 +47,6 @@ func reviewedSupersetFixture(sandbox *Sandbox) error {
 	if err := baseRepoWithRemote(sandbox); err != nil {
 		return err
 	}
-	if err := sandbox.git(sandbox.Repo, "branch", "-M", "main"); err != nil {
-		return err
-	}
-	if err := sandbox.git(sandbox.Repo, "push", "-q", "-u", "origin", "main"); err != nil {
-		return err
-	}
 	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "-b", "feature"); err != nil {
 		return err
 	}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,7 +36,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 83 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 84 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -45,10 +45,12 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// #2621 journey.
 	// j82 proves #2127's reviewed full candidate can publish an unpublished
 	// monotonic subset without reopening review.
+	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base
+	// while the advertised main ref remains a moving publication boundary.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 83 {
-		t.Errorf("core journey count = %d, want 83", got)
+	if got := len(seen); got != 84 {
+		t.Errorf("core journey count = %d, want 84", got)
 	}
 	for id, found := range want {
 		if !found {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2127

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add driven j83 for a reviewed feature candidate whose advertised main base advances on a disjoint path.
- Execute the exact negotiated STATUS validation transition and direct pre-PR validation.
- Ratchet the portable core journey corpus from 83 to 84.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_reviewed_superset.go` | Added the moving advertised-base fixture and j83 gate flow |
| `bench/journeys_sdd_test.go` | Ratcheted and documented the 84-journey core corpus |

---

## 🧪 Test Plan

- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./... -count=1`
- [x] Bench `go test ./... -count=1` and `go vet ./...`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] Full CI-shaped driven run: 84 completed, 0 unsupported, 0 failed
- [x] Final focused j83 run: 1 completed, 0 unsupported, 0 failed
- [ ] Docker E2E locally — not run; CI remains authoritative for the repository E2E job

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 118 / 400
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [ ] E2E tests pass — CI pending
- [x] Benchmark validation completed
- [x] Documentation is not required beyond the journey source and ratchet comment
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | #2127 moving pre-PR base |
| Tracker PR | Not needed |
| Position | 2 of 2 |
| Base | `fix/2127-pre-pr-merge-base-binding` |
| Depends on | PR #2876 |
| Follow-up | None |
| Review budget | 118 / 400 |
| Starts at | Product mechanism and unit controls from PR #2876 |
| Ends with | Black-box runtime proof and the 84-journey corpus ratchet |

### Chain Overview

```text
main
 └── #2876 merge-base binding and unit controls
      └── 📍 This PR: j83 driven journey and corpus ratchet
```

### Scope
- Includes: the driven moving-base flow and corpus declaration.
- Excludes: product authorization and STATUS routing, which remain isolated in PR #2876.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] The exact CI-shaped benchmark harness covers this unit

---

## 💬 Notes for Reviewers

j83 is the behavior-first acceptance proof: the old binary returns `review.start` after main advances; the corrected binary prints and executes `review.validate`, then direct pre-PR validation also allows.