### PR TITLE
fix(review): include --consent relay in negotiated start guidance command

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -170,7 +170,7 @@ func reviewNegotiatedStartCommand(snapshot reviewtransaction.Snapshot, runtimeAg
 	if identity == "" {
 		identity = reviewUndeclaredRuntimeIdentitySlot
 	}
-	command := fmt.Sprintf("gentle-ai review start --contract %s --agent %s --target %s --projection %s",
+	command := fmt.Sprintf("gentle-ai review start --contract %s --agent %s --target %s --projection %s --consent relay",
 		ReviewIntegrationContractV2, identity, snapshot.Identity, facadeProjection(snapshot.Projection))
 	switch snapshot.Kind {
 	case reviewtransaction.TargetBaseDiff:


### PR DESCRIPTION
## Summary

reviewNegotiatedStartCommand builds the v2 guidance command for users whose non-negotiated base-diff start is refused and redirected to the negotiated route. The command omitted `--consent relay`, so the consent envelope was never emitted and the review fell through to the non-interactive console path, which prints "this session has no terminal to answer on" and creates the review without asking.

The transition command (reviewStartArguments in review\_next\_transition.go:592) already includes `--consent relay` for v2 contracts. This fix aligns the guidance command.

## Root cause

`reviewNegotiatedStartCommand` in `internal/cli/review\_facade.go:168` builds the exact negotiated `review start` invocation shown in error messages. For v2 contracts, it omitted `--consent relay` in its Sprintf format string. When a user copies this command, the consent mode remains empty, hitting the fall-through console path in `authorizeReviewStart` (review\_mode.go:669) instead of the relay path (review\_mode.go:654).

## Fix

Added ` --consent relay` to the Sprintf format string at line 173.

## Test Plan

Benchmark validation: N/A (no change to review-lifecycle, gate, recovery, delivery, or benchmark code).

```
go build ./...
go vet ./internal/cli/
go test ./internal/cli/ -run "TestNegotiatedStartCommand|TestDirectReviewStartRefusal|TestNegotiatedV2FreshStatus|TestStatusStartTransition|consent|Relay|Consent"
```

All tests pass, including:

- TestNegotiatedStartCommandEchoesTheCallersOwnRuntime
- TestDirectReviewStartRefusalInventsNoRuntimeIdentity
- TestNegotiatedV2FreshStatusIncludesExactConsentRelay
- TestStatusStartTransitionPreservesFrozenTarget (symbolic base movement)
- TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
- Full consent and relay test suite

Closes #2870

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Negotiated review continuation commands now include the required relay consent option, enabling the command to proceed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->