### PR TITLE
feat(tui): make model picker adaptive and add role guidance

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1248,6 +1248,17 @@ func (m Model) View() string {
 func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	keyStr := key.String()
 
+	// Guidance toggle (i or ?) — works on the phase list of both the main
+	// model picker and the profile-create picker reuse. Has no effect in
+	// the provider / model / effort sub-modes where role guidance does
+	// not apply.
+	if m.Screen == ScreenModelPicker ||
+		(m.Screen == ScreenProfileCreate && m.ProfileCreateStep == 1) {
+		if screens.ToggleModelPickerGuidance(&m.ModelPicker, keyStr) {
+			return m, nil
+		}
+	}
+
 	// When the model picker is in a sub-mode, delegate navigation there first.
 	if m.Screen == ScreenModelPicker && m.ModelPicker.Mode != screens.ModePhaseList {
 		handled, updated := screens.HandleModelPickerNav(keyStr, &m.ModelPicker, m.Selection.ModelAssignments)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -788,6 +788,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
+		m.ModelPicker.Resize(msg.Height)
 		m.clampAdvisoryScroll()
 		return m, nil
 	case TickMsg:

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -106,6 +106,12 @@ type ModelPickerState struct {
 	// keeps the cursor and scroll offsets inside the new window.
 	Height int
 
+	// GuidanceExpanded toggles the expanded contextual-role-guidance panel
+	// for the currently selected assignment row. Off by default — only a
+	// compact one-line purpose hint is rendered below the help line.
+	// ToggleModelPickerGuidance flips this flag on the "i" or "?" keys.
+	GuidanceExpanded bool
+
 	lmStudioURL       string
 	lmStudioConfig    opencode.ConfigProvider
 	lmStudioCatalog   opencode.Provider
@@ -999,8 +1005,37 @@ func renderPhaseList(
 		help = "j/k: navigate • enter: change model / confirm • backspace: clear • esc: back"
 	}
 	b.WriteString(styles.HelpStyle.Render(help))
+	b.WriteString("\n")
+
+	// Contextual role guidance for the currently selected row.
+	if role := selectedPhaseRow(state, cursor); role != "" {
+		if state.GuidanceExpanded {
+			b.WriteString(renderExpandedGuidance(role))
+		} else {
+			b.WriteString(renderCompactGuidance(role))
+		}
+	}
 
 	return b.String()
+}
+
+// selectedPhaseRow returns the agent role name for the cursor's row, or
+// the empty string for non-agent rows (the orchestrator row, the "Set all
+// phases" row, and the separator rows). Used to drive the contextual
+// guidance panel — only configurable agents carry guidance.
+func selectedPhaseRow(state ModelPickerState, cursor int) string {
+	rows := ModelPickerRows()
+	if state.ForProfile {
+		rows = ModelPickerRowsForProfile()
+	}
+	if cursor < 0 || cursor >= len(rows) {
+		return ""
+	}
+	row := rows[cursor]
+	if cursor <= 1 || IsModelPickerSeparatorRow(row) {
+		return ""
+	}
+	return row
 }
 
 func renderProviderSelect(state ModelPickerState) string {

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -26,8 +26,14 @@ const (
 	ModeEffortSelect                          // Sub-mode: pick a reasoning effort level
 )
 
-// maxVisibleItems is the maximum number of items shown in scrollable sub-lists.
+// maxVisibleItems is the fallback number of rows rendered in scrollable
+// sub-lists (provider, model, effort). It is used when the picker has no
+// known terminal height (tests, profile-create scaffolding) so behaviour
+// matches the pre-adaptive implementation.
 const maxVisibleItems = 10
+
+// maxVisiblePhaseRows is the fallback number of assignment rows rendered
+// on the phase-list screen. Same fallback contract as maxVisibleItems.
 const maxVisiblePhaseRows = 16
 
 var fetchDynamicModels = opencode.FetchDynamicModels
@@ -87,6 +93,18 @@ type ModelPickerState struct {
 	// When true, the row list still includes optional profile-scoped Judgment Day
 	// agents alongside SDD rows.
 	ForProfile bool
+
+	// Height is the current terminal height in rows. When > 0, renderers
+	// compute the visible list-row budget from the available space after
+	// subtracting fixed screen chrome (title, subtext, actions, help,
+	// warnings). When 0, renderers fall back to the fixed maxVisibleItems
+	// and maxVisiblePhaseRows budgets so tests and the profile-create
+	// scaffolding preserve their existing behaviour.
+	//
+	// The parent TUI syncs this field on every tea.WindowSizeMsg via
+	// (*ModelPickerState).Resize. ClampPickerViewport, exported below,
+	// keeps the cursor and scroll offsets inside the new window.
+	Height int
 
 	lmStudioURL       string
 	lmStudioConfig    opencode.ConfigProvider
@@ -207,6 +225,123 @@ func (state *ModelPickerState) refreshAvailableModels() {
 	}
 }
 
+// Resize updates the picker's height and clamps cursor / scroll offsets for
+// the currently visible lists. Call this from the parent TUI on every
+// tea.WindowSizeMsg so the picker reflects the new viewport without losing
+// the selected row or leaving stale scroll offsets behind.
+//
+// The phase list itself does not have a scroll offset (rows are static, so
+// the renderer computes the visible window directly from cursor + budget),
+// but the sub-lists (provider, model, effort) all carry explicit scroll
+// offsets that must be clamped after the budget changes.
+func (state *ModelPickerState) Resize(height int) {
+	state.Height = height
+
+	// Phase list: clamp SelectedPhaseIdx against the row count even though
+	// the renderer uses the caller-supplied cursor. The cursor is owned by
+	// the parent TUI; this guard only catches direct mutations of state.
+	rows := ModelPickerRows()
+	if state.ForProfile {
+		rows = ModelPickerRowsForProfile()
+	}
+	if state.SelectedPhaseIdx >= len(rows) {
+		state.SelectedPhaseIdx = len(rows) - 1
+	}
+	if state.SelectedPhaseIdx < 0 {
+		state.SelectedPhaseIdx = 0
+	}
+
+	// Provider list.
+	entries := ProviderEntries(*state)
+	ClampPickerScroll(&state.ProviderScroll, &state.ProviderCursor, len(entries), listBudget(height, providerSelectChromeLines(), maxVisibleItems))
+
+	// Model list (uses the current search filter).
+	models := FilteredModelEntries(*state)
+	ClampPickerScroll(&state.ModelScroll, &state.ModelCursor, len(models), listBudget(height, modelSelectChromeLines(), maxVisibleItems))
+
+	// Effort list (empty outside ModeEffortSelect, where the clamp is a no-op).
+	opts := effortOptionsFromLevels(state.SelectedModelEffortLevels)
+	ClampPickerScroll(&state.EffortScroll, &state.EffortCursor, len(opts), listBudget(height, effortSelectChromeLines(), maxVisibleItems))
+}
+
+// listBudget returns the number of list rows that fit in the available
+// terminal height after subtracting the given chrome. When stateHeight is
+// non-positive (no real terminal), the fallback is returned unchanged so
+// callers preserve the pre-adaptive fixed budgets.
+func listBudget(stateHeight, chrome, fallback int) int {
+	if stateHeight <= 0 {
+		return fallback
+	}
+	budget := stateHeight - chrome
+	if budget < fallback {
+		return fallback
+	}
+	return budget
+}
+
+// ClampPickerScroll keeps the cursor inside [scroll, scroll+budget) and the
+// scroll offset inside [0, max(0, items-budget)]. Call this whenever the
+// item count or viewport budget changes (resize, search filtering, mode
+// switch). All clamp logic happens in place on the supplied pointers.
+//
+// When items is empty the cursor is reset to 0 as well so that subsequent
+// re-population of the list (e.g. clearing a search query) starts the
+// cursor at the first entry instead of an out-of-bounds index.
+func ClampPickerScroll(scroll *int, cursor *int, items, budget int) {
+	if items <= 0 {
+		*scroll = 0
+		*cursor = 0
+		return
+	}
+	if *cursor >= items {
+		*cursor = items - 1
+	}
+	if *cursor < 0 {
+		*cursor = 0
+	}
+	if budget <= 0 {
+		budget = 1
+	}
+	if *cursor < *scroll {
+		*scroll = *cursor
+	} else if *cursor >= *scroll+budget {
+		*scroll = *cursor - budget + 1
+	}
+	maxScroll := items - budget
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if *scroll > maxScroll {
+		*scroll = maxScroll
+	}
+}
+
+// phaseListChromeLines returns the rows consumed by title, warnings,
+// actions, help, and inter-section blanks in renderPhaseList — everything
+// except the assignment rows themselves.
+func phaseListChromeLines(state ModelPickerState) int {
+	chrome := 8 // title + blank + subtext + blank + blank + actions + blank + help
+	if state.ConfigWarning != "" {
+		chrome += 2 // warning + blank
+	}
+	return chrome
+}
+
+// providerSelectChromeLines returns the chrome for renderProviderSelect.
+func providerSelectChromeLines() int {
+	return 4 // title + blank + blank + help
+}
+
+// modelSelectChromeLines returns the chrome for renderModelSelect.
+func modelSelectChromeLines() int {
+	return 6 // title + blank + search + blank + blank + help
+}
+
+// effortSelectChromeLines returns the chrome for renderEffortSelect.
+func effortSelectChromeLines() int {
+	return 4 // title + blank + blank + help
+}
+
 func appendConfigWarning(existing, warning string) string {
 	if existing == "" {
 		return warning
@@ -311,6 +446,8 @@ func handleProviderNav(key string, state *ModelPickerState) bool {
 		return false
 	}
 
+	budget := listBudget(state.Height, providerSelectChromeLines(), maxVisibleItems)
+
 	switch key {
 	case "up", "k":
 		if state.ProviderCursor > 0 {
@@ -323,8 +460,8 @@ func handleProviderNav(key string, state *ModelPickerState) bool {
 	case "down", "j":
 		if state.ProviderCursor < len(entries)-1 {
 			state.ProviderCursor++
-			if state.ProviderCursor >= state.ProviderScroll+maxVisibleItems {
-				state.ProviderScroll = state.ProviderCursor - maxVisibleItems + 1
+			if state.ProviderCursor >= state.ProviderScroll+budget {
+				state.ProviderScroll = state.ProviderCursor - budget + 1
 			}
 		}
 		return true
@@ -350,6 +487,7 @@ func handleModelNav(
 	assignments map[string]model.ModelAssignment,
 ) (bool, map[string]model.ModelAssignment) {
 	models := FilteredModelEntries(*state)
+	budget := listBudget(state.Height, modelSelectChromeLines(), maxVisibleItems)
 
 	switch key {
 	case "up", "k":
@@ -363,8 +501,8 @@ func handleModelNav(
 	case "down", "j":
 		if state.ModelCursor < len(models)-1 {
 			state.ModelCursor++
-			if state.ModelCursor >= state.ModelScroll+maxVisibleItems {
-				state.ModelScroll = state.ModelCursor - maxVisibleItems + 1
+			if state.ModelCursor >= state.ModelScroll+budget {
+				state.ModelScroll = state.ModelCursor - budget + 1
 			}
 		}
 		return true, assignments
@@ -638,6 +776,7 @@ func handleEffortNav(
 	assignments map[string]model.ModelAssignment,
 ) (ModelPickerState, map[string]model.ModelAssignment) {
 	opts := effortOptionsFromLevels(state.SelectedModelEffortLevels)
+	budget := listBudget(state.Height, effortSelectChromeLines(), maxVisibleItems)
 
 	switch key {
 	case "up", "k":
@@ -650,8 +789,8 @@ func handleEffortNav(
 	case "down", "j":
 		if state.EffortCursor < len(opts)-1 {
 			state.EffortCursor++
-			if state.EffortCursor >= state.EffortScroll+maxVisibleItems {
-				state.EffortScroll = state.EffortCursor - maxVisibleItems + 1
+			if state.EffortCursor >= state.EffortScroll+budget {
+				state.EffortScroll = state.EffortCursor - budget + 1
 			}
 		}
 	case "enter":
@@ -692,7 +831,10 @@ func renderEffortSelect(state ModelPickerState) string {
 
 	opts := effortOptionsFromLevels(state.SelectedModelEffortLevels)
 
-	end := state.EffortScroll + maxVisibleItems
+	budget := listBudget(state.Height, effortSelectChromeLines(), maxVisibleItems)
+	ClampPickerScroll(&state.EffortScroll, &state.EffortCursor, len(opts), budget)
+
+	end := state.EffortScroll + budget
 	if end > len(opts) {
 		end = len(opts)
 	}
@@ -786,10 +928,11 @@ func renderPhaseList(
 	} else {
 		rows = ModelPickerRows()
 	}
+	budget := listBudget(state.Height, phaseListChromeLines(state), maxVisiblePhaseRows)
 	start, end := 0, len(rows)
-	if len(rows) > maxVisiblePhaseRows {
-		start = max(0, min(cursor-maxVisiblePhaseRows+1, len(rows)-maxVisiblePhaseRows))
-		end = start + maxVisiblePhaseRows
+	if len(rows) > budget {
+		start = max(0, min(cursor-budget+1, len(rows)-budget))
+		end = start + budget
 	}
 	if start > 0 {
 		b.WriteString(styles.SubtextStyle.Render("  ↑ more assignments") + "\n")
@@ -868,7 +1011,10 @@ func renderProviderSelect(state ModelPickerState) string {
 
 	entries := ProviderEntries(state)
 
-	end := state.ProviderScroll + maxVisibleItems
+	budget := listBudget(state.Height, providerSelectChromeLines(), maxVisibleItems)
+	ClampPickerScroll(&state.ProviderScroll, &state.ProviderCursor, len(entries), budget)
+
+	end := state.ProviderScroll + budget
 	if end > len(entries) {
 		end = len(entries)
 	}
@@ -913,17 +1059,13 @@ func renderModelSelect(state ModelPickerState) string {
 	b.WriteString("\n\n")
 
 	models := FilteredModelEntries(state)
-	if state.ModelCursor >= len(models) && len(models) > 0 {
-		state.ModelCursor = len(models) - 1
-	}
-	if state.ModelScroll > state.ModelCursor {
-		state.ModelScroll = state.ModelCursor
-	}
+	budget := listBudget(state.Height, modelSelectChromeLines(), maxVisibleItems)
+	ClampPickerScroll(&state.ModelScroll, &state.ModelCursor, len(models), budget)
 
 	b.WriteString(styles.SubtextStyle.Render("Search: " + modelSearchDisplay(state.ModelSearch)))
 	b.WriteString("\n\n")
 
-	end := state.ModelScroll + maxVisibleItems
+	end := state.ModelScroll + budget
 	if end > len(models) {
 		end = len(models)
 	}

--- a/internal/tui/screens/model_picker_guidance.go
+++ b/internal/tui/screens/model_picker_guidance.go
@@ -1,0 +1,282 @@
+package screens
+
+import (
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/tui/styles"
+)
+
+// ModelSelectionGuidance describes the capabilities, reasoning range, and
+// tradeoffs a user should consider when assigning a model to a given SDD,
+// Judgment Day, or review role. Guidance is capability-based — it never
+// pins to specific model brands or transient model IDs, and reasoning-effort
+// guidance is kept separate from Fast / service-tier guidance.
+type ModelSelectionGuidance struct {
+	// Purpose is a one-line summary of what the role does.
+	Purpose string
+
+	// Priorities is a newline-separated list of capabilities to prefer
+	// when selecting a model for the role. Rendered as bullet points
+	// when the expanded guidance panel is visible.
+	Priorities string
+
+	// Reasoning is the suggested reasoning-effort range. Reasoning is
+	// separate from Fast mode — see FastMode below.
+	Reasoning string
+
+	// FastMode describes when to enable Fast / service-tier processing.
+	// Empty means Fast mode is not recommended for the role. Fast mode
+	// changes processing speed and pricing only; it does not replace
+	// the chosen reasoning effort.
+	FastMode string
+
+	// Tradeoffs lists quality / speed / cost / context considerations.
+	// Rendered only when the expanded guidance panel is visible.
+	Tradeoffs string
+}
+
+// modelSelectionGuidance maps every configurable agent role to capability-
+// based guidance. Roles not present in the map fall back to generic
+// implementation- or review-agent guidance (see guidanceFor).
+//
+// The guidance describes what to look for in a model, not which model to
+// pick, so the map stays valid as provider catalogs, pricing, and IDs
+// change. The Fast / service-tier note is intentionally separate from
+// the reasoning-effort note because the two settings control different
+// dimensions of model behaviour.
+var modelSelectionGuidance = map[string]ModelSelectionGuidance{
+	SDDOrchestratorPhase: {
+		Purpose:    "Coordinates agents, routes work, and maintains workflow state.",
+		Priorities: "Reliable instruction following\nTool and workflow coordination\nBalanced latency and reasoning",
+		Reasoning:  "Medium reasoning for normal orchestration.",
+		FastMode:   "Use when many small interactions add up to perceptible latency.",
+		Tradeoffs:  "Prefer stable JSON output; avoid expensive reasoning unless the workload demands it.",
+	},
+	"sdd-init": {
+		Purpose:    "Initializes SDD context, capabilities cache, and persistence.",
+		Priorities: "Reliable instruction following\nStable schema and config output",
+		Reasoning:  "Low to medium reasoning.",
+		Tradeoffs:  "Prefer cheaper models; boot is frequent and reasoning rarely helps.",
+	},
+	"sdd-explore": {
+		Purpose:    "Explores the problem space before committing to a proposal.",
+		Priorities: "Reasoning over ambiguous requirements\nMulti-source synthesis\nOutput that structures findings",
+		Reasoning:  "Medium to high reasoning.",
+		Tradeoffs:  "Quality of synthesis matters more than speed; sufficient context helps.",
+	},
+	"sdd-propose": {
+		Purpose:    "Drafts the change proposal (intent, scope, approach).",
+		Priorities: "Clarity of writing\nScope reasoning\nStructured proposal format",
+		Reasoning:  "Medium reasoning.",
+		Tradeoffs:  "Editorial quality matters; avoid hallucinating model IDs or external facts.",
+	},
+	"sdd-spec": {
+		Purpose:    "Writes the delta spec: requirements, scenarios, acceptance criteria.",
+		Priorities: "Precise requirements writing\nTestable scenarios\nGiven / When / Then discipline",
+		Reasoning:  "Medium to high reasoning.",
+		Tradeoffs:  "Spec correctness gates downstream work; long context helps related specs.",
+	},
+	"sdd-design": {
+		Purpose:    "Writes the technical design and architecture approach.",
+		Priorities: "Architectural reasoning\nTradeoff analysis\nDiagram and code-fence output",
+		Reasoning:  "High reasoning.",
+		Tradeoffs:  "Quality matters more than speed; strong context capacity helps multi-file designs.",
+	},
+	"sdd-tasks": {
+		Purpose:    "Breaks the change into implementation tasks with review-budget forecasting.",
+		Priorities: "Decomposition discipline\nWork-unit clarity\nRollback thinking",
+		Reasoning:  "Medium reasoning.",
+		Tradeoffs:  "Granularity matters — commits that read alone; avoid premature optimization.",
+	},
+	"sdd-apply": {
+		Purpose:    "Implements approved tasks and modifies project files.",
+		Priorities: "Strong coding and tool-use reliability\nSufficient context for specs, design, and tasks\nMedium or high reasoning for non-trivial changes",
+		Reasoning:  "Medium or high reasoning for non-trivial changes.",
+		FastMode:   "Use when lower latency justifies the additional cost.",
+		Tradeoffs:  "Code correctness matters more than cleverness; do not fight the design.",
+	},
+	"sdd-verify": {
+		Purpose:    "Executes tests and proves implementation matches specs, design, and tasks.",
+		Priorities: "Test discipline\nEvidence-based pass / fail\nCoverage of acceptance criteria",
+		Reasoning:  "Medium reasoning.",
+		Tradeoffs:  "Honesty about regressions matters; do not declare done without evidence.",
+	},
+	"sdd-archive": {
+		Purpose:    "Archives the change by syncing delta specs.",
+		Priorities: "Stable archive writes\nNo accidental spec deletion\nCheap and fast",
+		Reasoning:  "Low reasoning.",
+		Tradeoffs:  "Use a cheap model — verification already passed; latency-sensitive final step.",
+	},
+	"sdd-onboard": {
+		Purpose:    "Walks new users through the SDD workflow with skills.",
+		Priorities: "Friendly explanation\nContext-rich examples\nStable rendering of skill content",
+		Reasoning:  "Low to medium reasoning.",
+		Tradeoffs:  "Latency-sensitive (first impression); clarity over depth.",
+	},
+	"jd-judge-a": {
+		Purpose:    "Performs an independent adversarial review.",
+		Priorities: "Strong reasoning\nDefect detection\nEvidence analysis\nIndependence from the implementation model",
+		Reasoning:  "High reasoning effort.",
+		Tradeoffs:  "Prefer review quality over generation speed; diversity from the implementation model improves catch rate.",
+	},
+	"jd-judge-b": {
+		Purpose:    "Second independent adversarial reviewer (Judgment Day diversity).",
+		Priorities: "Defect detection from a different angle\nReasoning robustness\nIndependence from judge-a",
+		Reasoning:  "High reasoning effort.",
+		Tradeoffs:  "Pick a model that disagrees with judge-a often; cheap is fine if quality is comparable.",
+	},
+	"jd-fix-agent": {
+		Purpose:    "Applies judgment-day fixes after the review identifies defects.",
+		Priorities: "Targeted code edits\nTest discipline\nMinimal-scope changes",
+		Reasoning:  "Medium reasoning.",
+		Tradeoffs:  "Do not expand scope beyond the defect; reuse the implementation model's strengths where possible.",
+	},
+	"review-risk": {
+		Purpose:    "Native bounded-review lens: surfaces risk and integrity concerns.",
+		Priorities: "Reasoning depth\nDefect detection\nSpecific, actionable findings",
+		Reasoning:  "High reasoning effort.",
+		Tradeoffs:  "Prefer slower, careful review over speed; cite evidence.",
+	},
+	"review-readability": {
+		Purpose:    "Native bounded-review lens: surfaces readability and clarity issues.",
+		Priorities: "Editorial discipline\nStyle consistency\nConstructive framing",
+		Reasoning:  "Medium reasoning.",
+		Tradeoffs:  "Be specific; avoid taste-based feedback without evidence.",
+	},
+	"review-reliability": {
+		Purpose:    "Native bounded-review lens: surfaces reliability and correctness issues.",
+		Priorities: "Edge-case reasoning\nConcurrency and error-path coverage\nTest-evidence analysis",
+		Reasoning:  "High reasoning effort.",
+		Tradeoffs:  "Quality of evidence matters more than volume; cite specific failure modes.",
+	},
+	"review-resilience": {
+		Purpose:    "Native bounded-review lens: surfaces resilience and failure-handling issues.",
+		Priorities: "Failure-mode reasoning\nOperational thinking\nRecovery and rollback paths",
+		Reasoning:  "High reasoning effort.",
+		Tradeoffs:  "Focus on realistic failure modes; avoid paranoid edge cases that do not occur in production.",
+	},
+	"review-refuter": {
+		Purpose:    "Aggregates lens output and refutes weak claims before sign-off.",
+		Priorities: "Strong reasoning\nIndependent judgement\nDefensible verdict",
+		Reasoning:  "High reasoning effort.",
+		Tradeoffs:  "Adversarial role — do not soften findings; cite evidence.",
+	},
+}
+
+// guidanceFor returns the guidance entry for a given role. Unknown roles
+// fall back to a generic guidance that describes the implementation /
+// review responsibilities without claiming any specific SDD or JD phase.
+func guidanceFor(role string) ModelSelectionGuidance {
+	if g, ok := modelSelectionGuidance[role]; ok {
+		return g
+	}
+	if strings.HasPrefix(role, "jd-") {
+		return ModelSelectionGuidance{
+			Purpose:    "Judgment Day sub-agent that participates in adversarial review.",
+			Priorities: "Strong reasoning\nDefect detection\nIndependence from the implementation model",
+			Reasoning:  "High reasoning effort.",
+			Tradeoffs:  "Prefer review quality over generation speed.",
+		}
+	}
+	if strings.HasPrefix(role, "review-") {
+		return ModelSelectionGuidance{
+			Purpose:    "Native bounded-review sub-agent.",
+			Priorities: "Reasoning depth\nDefect detection\nSpecific, actionable findings",
+			Reasoning:  "Medium to high reasoning effort.",
+			Tradeoffs:  "Cite evidence; prefer careful review over speed.",
+		}
+	}
+	return ModelSelectionGuidance{
+		Purpose:    "SDD sub-agent that implements approved tasks.",
+		Priorities: "Coding and tool-use reliability\nSufficient context\nMedium reasoning for non-trivial work",
+		Reasoning:  "Medium reasoning.",
+		FastMode:   "Use when lower latency justifies the additional cost.",
+		Tradeoffs:  "Code correctness matters more than cleverness.",
+	}
+}
+
+// renderCompactGuidance renders the single-line summary shown by default
+// below the help line. The "i / ?" hint invites the user to expand the
+// full guidance panel.
+func renderCompactGuidance(role string) string {
+	g := guidanceFor(role)
+	if g.Purpose == "" {
+		return ""
+	}
+	return styles.SubtextStyle.Render("Role: "+role+" — "+g.Purpose) +
+		"\n" +
+		styles.HelpStyle.Render("i or ?: show full guidance") +
+		"\n"
+}
+
+// renderExpandedGuidance renders the multi-line capability panel. The
+// panel always ends with a hint that the user can collapse it again.
+func renderExpandedGuidance(role string) string {
+	g := guidanceFor(role)
+	if g.Purpose == "" {
+		return renderCompactGuidance(role)
+	}
+
+	var b strings.Builder
+	b.WriteString(styles.SubtextStyle.Render("Role: " + role))
+	b.WriteString("\n")
+	b.WriteString(styles.SelectedStyle.Render(g.Purpose))
+	b.WriteString("\n\n")
+
+	b.WriteString(styles.SubtextStyle.Render("Consider:"))
+	b.WriteString("\n")
+	for _, line := range strings.Split(g.Priorities, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		b.WriteString(styles.SubtextStyle.Render("  • " + line))
+		b.WriteString("\n")
+	}
+
+	if g.Reasoning != "" {
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("Reasoning: " + g.Reasoning))
+		b.WriteString("\n")
+	}
+
+	if g.FastMode != "" {
+		b.WriteString(styles.SubtextStyle.Render("Fast mode: " + g.FastMode))
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("Fast changes processing speed and pricing."))
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("It does not replace the selected reasoning effort."))
+		b.WriteString("\n")
+	}
+
+	if g.Tradeoffs != "" {
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("Tradeoffs:"))
+		b.WriteString("\n")
+		for _, line := range strings.Split(g.Tradeoffs, "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			b.WriteString(styles.SubtextStyle.Render("  - " + line))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("i or ?: hide guidance"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// ToggleModelPickerGuidance flips the GuidanceExpanded flag when the user
+// presses the i or ? key. Returns true if the key was handled so the
+// caller can short-circuit normal navigation.
+func ToggleModelPickerGuidance(state *ModelPickerState, key string) bool {
+	if state == nil {
+		return false
+	}
+	if key != "i" && key != "?" {
+		return false
+	}
+	state.GuidanceExpanded = !state.GuidanceExpanded
+	return true
+}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1608,3 +1608,168 @@ func TestModelPickerRowsForProfile(t *testing.T) {
 		}
 	}
 }
+
+// ─── Issue #2301: contextual role guidance for the phase list ───────────────
+
+// pickableAssignmentState returns a ModelPickerState populated with one
+// provider and one SDD-capable model so renderPhaseList can reach the row
+// rendering path. The state height is fixed so the chrome-aware budget
+// stays predictable across assertions.
+func pickableAssignmentState(t *testing.T, height int) ModelPickerState {
+	t.Helper()
+	return ModelPickerState{
+		Height:         height,
+		AvailableIDs:   []string{"openai"},
+		Providers:      map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels:      map[string][]opencode.Model{"openai": {{ID: "gpt-5", Name: "GPT-5"}}},
+		lmStudioURL:    "http://127.0.0.1:1234/v1",
+		lmStudioConfig: opencode.ConfigProvider{URL: "http://127.0.0.1:1234/v1"},
+	}
+}
+
+// rowIndexFor returns the index of role in ModelPickerRows(), or -1 if the
+// role is not present.
+func rowIndexFor(role string) int {
+	rows := ModelPickerRows()
+	for i, row := range rows {
+		if row == role {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestRenderPhaseList_CompactGuidanceForKnownRole verifies that selecting an
+// SDD agent row renders the compact guidance line — the agent purpose plus
+// the "i or ?: show full guidance" hint.
+//
+// Issue #2301 — contextual role guidance, compact presentation.
+func TestRenderPhaseList_CompactGuidanceForKnownRole(t *testing.T) {
+	state := pickableAssignmentState(t, 40)
+	cursor := rowIndexFor("sdd-apply")
+	if cursor < 0 {
+		t.Fatal("sdd-apply row missing from ModelPickerRows()")
+	}
+
+	output := RenderModelPicker(nil, state, cursor)
+	if !strings.Contains(output, "Role: sdd-apply") {
+		t.Errorf("compact guidance should name the role; got:\n%s", output)
+	}
+	if !strings.Contains(output, "i or ?: show full guidance") {
+		t.Errorf("compact guidance should hint at the toggle key; got:\n%s", output)
+	}
+	if !strings.Contains(output, "Implements approved tasks") {
+		t.Errorf("compact guidance should show the role purpose; got:\n%s", output)
+	}
+}
+
+// TestRenderPhaseList_ExpandedGuidanceForKnownRole verifies that toggling
+// GuidanceExpanded renders the multi-line capability panel for the selected
+// agent, including the Fast-mode note for roles where it applies.
+//
+// Issue #2301 — contextual role guidance, expanded presentation.
+func TestRenderPhaseList_ExpandedGuidanceForKnownRole(t *testing.T) {
+	state := pickableAssignmentState(t, 60)
+	state.GuidanceExpanded = true
+	cursor := rowIndexFor("sdd-apply")
+	if cursor < 0 {
+		t.Fatal("sdd-apply row missing from ModelPickerRows()")
+	}
+
+	output := RenderModelPicker(nil, state, cursor)
+	for _, want := range []string{
+		"Role: sdd-apply",
+		"Implements approved tasks",
+		"Consider:",
+		"Strong coding and tool-use reliability",
+		"Reasoning:",
+		"Fast mode:",
+		"It does not replace the selected reasoning effort",
+		"Tradeoffs:",
+		"i or ?: hide guidance",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expanded guidance missing %q; got:\n%s", want, output)
+		}
+	}
+}
+
+// TestRenderPhaseList_GuidanceForJDAndReviewRoles verifies that the guidance
+// renderers reach into the JD and review agent maps, not just the SDD ones.
+//
+// Issue #2301 — coverage across every configurable agent family.
+func TestRenderPhaseList_GuidanceForJDAndReviewRoles(t *testing.T) {
+	state := pickableAssignmentState(t, 60)
+	state.GuidanceExpanded = true
+
+	for _, role := range []string{"jd-judge-a", "review-refuter"} {
+		cursor := rowIndexFor(role)
+		if cursor < 0 {
+			t.Fatalf("%s row missing from ModelPickerRows()", role)
+		}
+		output := RenderModelPicker(nil, state, cursor)
+		if !strings.Contains(output, "Role: "+role) {
+			t.Errorf("%s: guidance header missing; got:\n%s", role, output)
+		}
+		if !strings.Contains(output, "Consider:") {
+			t.Errorf("%s: capability bullets missing; got:\n%s", role, output)
+		}
+	}
+}
+
+// TestRenderPhaseList_NoGuidanceForNonAgentRows verifies that the "Set all
+// phases", orchestrator, and separator rows stay clean of guidance text —
+// those rows do not correspond to a single configurable agent role.
+//
+// Issue #2301 — guidance only applies to configurable agent rows.
+func TestRenderPhaseList_NoGuidanceForNonAgentRows(t *testing.T) {
+	state := pickableAssignmentState(t, 60)
+	for cursor, label := range map[int]string{0: "orchestrator", 1: "set-all", SeparatorRowIdx(): "separator"} {
+		output := RenderModelPicker(nil, state, cursor)
+		if strings.Contains(output, "Role: ") {
+			t.Errorf("%s row should not render role guidance; got:\n%s", label, output)
+		}
+	}
+}
+
+// TestToggleModelPickerGuidance_FlipsFlagOnIAndQuestionMark verifies the
+// toggle contract — i and ? both flip GuidanceExpanded, and any other key
+// returns false so the caller falls through to normal navigation.
+//
+// Issue #2301 — guidance expansion toggle.
+func TestToggleModelPickerGuidance_FlipsFlagOnIAndQuestionMark(t *testing.T) {
+	for _, key := range []string{"i", "?"} {
+		state := &ModelPickerState{}
+		if !ToggleModelPickerGuidance(state, key) {
+			t.Errorf("toggle should handle %q", key)
+		}
+		if !state.GuidanceExpanded {
+			t.Errorf("toggle %q should set GuidanceExpanded = true", key)
+		}
+		if !ToggleModelPickerGuidance(state, key) {
+			t.Errorf("toggle should still handle %q on second press", key)
+		}
+		if state.GuidanceExpanded {
+			t.Errorf("toggle %q should flip GuidanceExpanded back to false", key)
+		}
+	}
+
+	state := &ModelPickerState{}
+	if ToggleModelPickerGuidance(state, "enter") {
+		t.Error("toggle should NOT handle 'enter'")
+	}
+	if ToggleModelPickerGuidance(state, "j") {
+		t.Error("toggle should NOT handle 'j'")
+	}
+	if state.GuidanceExpanded {
+		t.Error("non-toggle keys must leave GuidanceExpanded = false")
+	}
+}
+
+// TestToggleModelPickerGuidance_NilStateReturnsFalse ensures the helper
+// never panics if a caller forgets to guard the state pointer.
+func TestToggleModelPickerGuidance_NilStateReturnsFalse(t *testing.T) {
+	if ToggleModelPickerGuidance(nil, "i") {
+		t.Error("toggle should return false when state is nil")
+	}
+}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -64,6 +65,222 @@ func TestRenderModelPickerScrollsToReviewAgents(t *testing.T) {
 	if strings.Contains(output, "gentle-orchestrator") {
 		t.Fatalf("picker did not window rows around review cursor:\n%s", output)
 	}
+}
+
+// ─── Issue #2301: adaptive viewport for the assignment screen ─────────────
+
+// manyModels returns n synthetic models for viewport-budget tests.
+func manyModels(n int) []opencode.Model {
+	models := make([]opencode.Model, n)
+	for i := 0; i < n; i++ {
+		models[i] = opencode.Model{ID: "model-" + strconv.Itoa(i), Name: "Model " + strconv.Itoa(i)}
+	}
+	return models
+}
+
+// TestRenderModelPicker_AdaptiveTallTerminalHidesMoreIndicator verifies that a
+// tall terminal renders the full assignment matrix without "more assignments"
+// indicators and keeps every row reachable (orchestrator at the top, review
+// agents at the bottom).
+//
+// Issue #2301 — adaptive layout.
+func TestRenderModelPicker_AdaptiveTallTerminalHidesMoreIndicator(t *testing.T) {
+	state := ModelPickerState{
+		Height:         60,
+		AvailableIDs:   []string{"openai"},
+		Providers:      map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels:      map[string][]opencode.Model{"openai": manyModels(3)},
+		lmStudioURL:    "http://127.0.0.1:1234/v1",
+		lmStudioConfig: opencode.ConfigProvider{URL: "http://127.0.0.1:1234/v1"},
+	}
+	rows := ModelPickerRows()
+
+	for _, cursor := range []int{0, len(rows) - 1, len(rows) / 2} {
+		output := RenderModelPicker(nil, state, cursor)
+		if strings.Contains(output, "↑ more assignments") || strings.Contains(output, "↓ more assignments") {
+			t.Fatalf("cursor=%d: tall terminal should hide overflow indicators; got:\n%s", cursor, output)
+		}
+		if !strings.Contains(output, "gentle-orchestrator") {
+			t.Errorf("cursor=%d: orchestrator row missing in tall terminal; got:\n%s", cursor, output)
+		}
+		if !strings.Contains(output, "review-refuter") {
+			t.Errorf("cursor=%d: review-refuter row missing in tall terminal; got:\n%s", cursor, output)
+		}
+	}
+}
+
+// TestRenderModelPicker_AdaptiveShortTerminalShowsOverflowIndicator verifies
+// that a short terminal keeps the list bounded and surfaces a "more"
+// indicator so the user knows scrollable content exists.
+//
+// Issue #2301 — adaptive layout.
+func TestRenderModelPicker_AdaptiveShortTerminalShowsOverflowIndicator(t *testing.T) {
+	state := ModelPickerState{
+		Height:         18, // chrome 8 → budget 10 < 22 rows
+		AvailableIDs:   []string{"openai"},
+		Providers:      map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels:      map[string][]opencode.Model{"openai": manyModels(3)},
+		lmStudioURL:    "http://127.0.0.1:1234/v1",
+		lmStudioConfig: opencode.ConfigProvider{URL: "http://127.0.0.1:1234/v1"},
+	}
+
+	output := RenderModelPicker(nil, state, 0)
+	if !strings.Contains(output, "↓ more assignments") {
+		t.Fatalf("short terminal should show ↓ more assignments; got:\n%s", output)
+	}
+	// Help and Continue/Back chrome must still be present.
+	if !strings.Contains(output, "Continue") || !strings.Contains(output, "Back") {
+		t.Errorf("short terminal lost chrome controls; got:\n%s", output)
+	}
+}
+
+// TestResize_ClampsModelScrollWhenBudgetShrinks verifies that calling Resize
+// with a smaller terminal height keeps the cursor visible by adjusting the
+// scroll offset, instead of leaving the cursor off-screen.
+//
+// Issue #2301 — preserve the selected assignment after resize.
+func TestResize_ClampsModelScrollWhenBudgetShrinks(t *testing.T) {
+	state := ModelPickerState{
+		Height:           60, // large budget at start
+		Mode:             ModeModelSelect,
+		SelectedProvider: "openai",
+		Providers:        map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels:        map[string][]opencode.Model{"openai": manyModels(20)},
+		ModelCursor:      15,
+		ModelScroll:      0,
+	}
+
+	state.Resize(20) // shrinks: budget = 20-6 = 14, maxScroll = 20-14 = 6
+	if state.ModelScroll != 2 {
+		t.Errorf("ModelScroll after shrink = %d, want 2 (cursor 15, budget 14)", state.ModelScroll)
+	}
+	if state.ModelCursor != 15 {
+		t.Errorf("ModelCursor preserved = %d, want 15", state.ModelCursor)
+	}
+}
+
+// TestResize_ClampsModelScrollWhenBudgetGrows verifies that a larger terminal
+// does not leave stale scroll offsets that would hide the top of the list.
+//
+// Issue #2301 — preserve the selected assignment after resize.
+func TestResize_ClampsModelScrollWhenBudgetGrows(t *testing.T) {
+	state := ModelPickerState{
+		Height:           20,
+		Mode:             ModeModelSelect,
+		SelectedProvider: "openai",
+		Providers:        map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels:        map[string][]opencode.Model{"openai": manyModels(20)},
+		ModelCursor:      18,
+		ModelScroll:      5,
+	}
+
+	state.Resize(60) // grows: budget = 60-6 = 54, maxScroll = max(0, 20-54) = 0
+	if state.ModelScroll != 0 {
+		t.Errorf("ModelScroll after grow = %d, want 0", state.ModelScroll)
+	}
+	if state.ModelCursor != 18 {
+		t.Errorf("ModelCursor preserved = %d, want 18", state.ModelCursor)
+	}
+}
+
+// TestResize_ClampsModelCursorAfterSearchFilter exercises the second reason
+// to clamp: search filtering shrinks the visible list. The cursor and scroll
+// offset must move into a valid range so the next render does not panic or
+// hide every entry.
+//
+// Issue #2301 — search filtering safely clamps cursor and scroll state.
+func TestResize_ClampsModelCursorAfterSearchFilter(t *testing.T) {
+	state := ModelPickerState{
+		Height:           60,
+		Mode:             ModeModelSelect,
+		SelectedProvider: "openai",
+		Providers:        map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels: map[string][]opencode.Model{
+			"openai": {
+				{ID: "gpt-5", Name: "GPT-5"},
+				{ID: "gpt-5-mini", Name: "GPT-5 Mini"},
+				{ID: "gpt-4", Name: "GPT-4"},
+			},
+		},
+		ModelCursor: 2,
+		ModelScroll: 1,
+		ModelSearch: "no-match",
+	}
+
+	state.Resize(60)
+	if state.ModelCursor != 0 {
+		t.Errorf("ModelCursor after empty-filter clamp = %d, want 0", state.ModelCursor)
+	}
+	if state.ModelScroll != 0 {
+		t.Errorf("ModelScroll after empty-filter clamp = %d, want 0", state.ModelScroll)
+	}
+}
+
+// TestResize_ZeroHeightFallsBackToFixedBudgets verifies that Resize with a
+// non-positive height (the default for tests and profile-create scaffolding)
+// leaves the cursor and scroll offsets untouched and still exposes the
+// pre-adaptive fixed-budget behaviour.
+//
+// Issue #2301 — backward-compatibility for callers without a terminal height.
+func TestResize_ZeroHeightFallsBackToFixedBudgets(t *testing.T) {
+	state := ModelPickerState{
+		Height:           0,
+		Mode:             ModeModelSelect,
+		SelectedProvider: "openai",
+		Providers:        map[string]opencode.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+		SDDModels:        map[string][]opencode.Model{"openai": manyModels(20)},
+		ModelCursor:      5,
+		ModelScroll:      0,
+	}
+
+	state.Resize(0)
+	if state.ModelCursor != 5 || state.ModelScroll != 0 {
+		t.Errorf("zero-height Resize should not mutate cursor/scroll; got cursor=%d scroll=%d", state.ModelCursor, state.ModelScroll)
+	}
+
+	// RenderModelPicker with Height=0 still uses maxVisibleItems budget.
+	output := renderModelSelect(state)
+	if !strings.Contains(output, "Search: _") {
+		t.Errorf("zero-height render lost the search input; got:\n%s", output)
+	}
+}
+
+// TestClampPickerScroll_EdgeCases covers the clamp helper directly so the
+// resize and renderer paths can trust it under unusual inputs (empty list,
+// single item, budget=0).
+func TestClampPickerScroll_EdgeCases(t *testing.T) {
+	t.Run("empty items clamps cursor to zero", func(t *testing.T) {
+		scroll, cursor := 3, 7
+		ClampPickerScroll(&scroll, &cursor, 0, 5)
+		if scroll != 0 || cursor != 0 {
+			t.Errorf("empty items: got scroll=%d cursor=%d, want 0/0", scroll, cursor)
+		}
+	})
+
+	t.Run("cursor above scroll snaps down", func(t *testing.T) {
+		scroll, cursor := 10, 3
+		ClampPickerScroll(&scroll, &cursor, 20, 5)
+		if scroll != 3 || cursor != 3 {
+			t.Errorf("snap down: got scroll=%d cursor=%d, want 3/3", scroll, cursor)
+		}
+	})
+
+	t.Run("cursor below scroll+budget scrolls forward", func(t *testing.T) {
+		scroll, cursor := 0, 12
+		ClampPickerScroll(&scroll, &cursor, 20, 5)
+		if scroll != 8 || cursor != 12 {
+			t.Errorf("scroll forward: got scroll=%d cursor=%d, want 8/12", scroll, cursor)
+		}
+	})
+
+	t.Run("cursor above maxScroll clamps scroll", func(t *testing.T) {
+		scroll, cursor := 100, 18
+		ClampPickerScroll(&scroll, &cursor, 20, 5)
+		// maxScroll = max(0, 20-5) = 15
+		if scroll != 15 || cursor != 18 {
+			t.Errorf("max clamp: got scroll=%d cursor=%d, want 15/18", scroll, cursor)
+		}
+	})
 }
 
 func TestModelPickerRows_OrchestratorIsFirst(t *testing.T) {


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #2301

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

> Label application is queued under **Pending maintainer actions** — see below.

---

## 📝 Summary

Two related TUI improvements to the "Assign Models to SDD, JD & Review Agents" screen, addressing both halves of #2301:

1. **Adaptive viewport.** The picker now derives the visible list-row budget from the current terminal height instead of the fixed `maxVisibleItems = 10` and `maxVisiblePhaseRows = 16` constants. A tall terminal renders the full assignment matrix (orchestrator, 10 SDD phases, 3 JD agents, 5 review agents) without `more assignments` indicators; a short terminal keeps the list bounded and shows the indicator only when entries actually overflow. Resize clamps the cursor and scroll offsets so the selected row never disappears.
2. **Contextual role guidance.** A compact one-line summary appears below the help line by default; pressing `i` or `?` expands it into a multi-line panel that lists each agent's purpose, the capabilities to prioritize, the suggested reasoning-effort range, when to enable Fast mode, and the relevant quality / speed / cost / context tradeoffs. Fast-mode guidance is intentionally separate from reasoning-effort guidance.

The work ships as two work-unit commits (`02bd7d88` adaptive layout, `477b42d4` role guidance).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/screens/model_picker.go` | Added `Height` and `GuidanceExpanded` fields to `ModelPickerState`. New `Resize`, `listBudget`, `ClampPickerScroll`, and per-renderer `chromeLines` helpers. Refactored `renderPhaseList`, `renderProviderSelect`, `renderModelSelect`, `renderEffortSelect`, and their nav handlers to consume the dynamic budget. New `selectedPhaseRow` helper drives the guidance panel. |
| `internal/tui/screens/model_picker_guidance.go` | **New file.** `ModelSelectionGuidance` struct + `modelSelectionGuidance` map covering orchestrator, 10 SDD phases, 3 JD agents, and 5 review agents. Compact and expanded renderers. `ToggleModelPickerGuidance` exported for the parent TUI. |
| `internal/tui/model.go` | `tea.WindowSizeMsg` syncs `m.ModelPicker.Height` via `(*ModelPickerState).Resize`. `i` and `?` keys on the phase list toggle `GuidanceExpanded` via `screens.ToggleModelPickerGuidance`. |
| `internal/tui/screens/model_picker_test.go` | Tall-terminal / short-terminal / resize-clamp / search-filter / zero-height fallback / clamp-edge / compact-guidance / expanded-guidance / JD-and-review-guidance / non-agent-rows / toggle-contract / nil-state tests. |

Per `gh pr view --json` (4 changed files): **+872 / -19 = 891 changed lines**. This exceeds the 400-line cognitive-load budget — see **Pending maintainer actions**.

---

## 🧪 Test Plan

**Unit Tests**

```bash
go test ./internal/tui/... -count=1
```

Result on this branch:

```text
ok      github.com/gentleman-programming/gentle-ai/v2/internal/tui               5.429s
ok      github.com/gentleman-programming/gentle-ai/v2/internal/tui/screens      2.469s
?       github.com/gentleman-programming/gentle-ai/v2/internal/tui/styles       [no test files]
ok      github.com/gentleman-programming/gentle-ai/v2/internal/opencode         1.010s
ok      github.com/gentleman-programming/gentle-ai/v2/internal/model            0.783s
```

**Go Build / Vet / Format**

```bash
go build ./...      # clean
go vet ./...        # clean
go run ./internal/gofmtcheck   # clean
```

**E2E Tests** (Docker required)

`N/A` — this slice touches only the TUI rendering layer (no installation path, no runtime agent behaviour, no `gga` CLI surface). The Docker E2E suite exercises shell-script installers, not Bubble Tea screens. Confirmed by inspection of the changed files; no shell scripts or installer code paths were modified.

**Benchmark Validation** (`bench/`)

`N/A` — neither `bench/` nor any bench corpus / axis was touched. The slice is rendering-layer only.

**Manual sanity**

- Tall terminal (height 60): orchestrator row and `review-refuter` row both visible without any `more assignments` indicator.
- Short terminal (height 18): `↓ more assignments` appears, Continue / Back actions and help text remain present.
- Resize from 60 → 20: cursor preserved, scroll re-anchored so the selected row stays visible.
- Typing a search query that empties the list: cursor and scroll both reset to 0.

**Pre-existing failures**

None. Re-ran the full unit suite before pushing; all packages green. The repo's only pre-existing test quirks documented in `CONTRIBUTING.md` (Windows symlink privilege) are unrelated to this slice and were not triggered.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (`Closes #2301`)
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented *(see Pending maintainer actions)*
- [ ] I have added the appropriate `type:*` label to this PR *(see Pending maintainer actions)*
- [x] Unit tests pass (`go test ./internal/tui/... ./internal/opencode/... ./internal/model/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass *(not applicable — TUI rendering slice; documented above)*
- [x] Benchmark validation completed, or this change is not applicable to the benchmark *(documented above)*
- [x] I have updated documentation if necessary *(behaviour is opt-in via `i` / `?`; no README/docs changes needed)*
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Two work-unit commits so the change reads top-to-bottom:

1. `02bd7d88` — adaptive viewport (state field, `Resize`, dynamic budgets in renderers + nav handlers, chrome helpers, clamp tests).
2. `477b42d4` — role guidance (new `model_picker_guidance.go`, guidance rendering in `renderPhaseList`, `i` / `?` toggle wired through `model.go`).

**Chained follow-up plan (provider-specific pickers)**

If this slice lands clean, the adaptive pattern is small enough to port to `internal/tui/screens/claude_model_picker.go` (preset list and custom phase list) without touching the model picker refactor. A separate PR is queued for that work — it would also extend the `GuidanceExpanded` toggle if reviewers find the compact-line affordance useful there. `codex_model_picker.go` and `kiro_model_picker.go` are intentionally out of scope for this slice per the issue's reference to `internal/tui/screens/model_picker.go`.

**Production Go guard review**

Not applicable — the slice does not touch `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`. The renderer's value-receiver pattern preserves the existing behaviour for the profile-create scaffolding call site (`internal/tui/screens/profile_create.go`) because `Height == 0` falls back to the original fixed budgets.

---

## Pending maintainer actions

These are items the contributor cannot complete via `gh` (verified empirically: `gh pr edit --add-label` against the upstream repo returns GraphQL 403 `AddLabelsToLabelable`).

- **Apply `type:feature` label** *(reason: `gh pr edit --add-label type:feature` fails with GraphQL 403 — see PR Type section)*
- **Apply `size:exception` label** *(reason: this PR exceeds the 400 changed-line cognitive-load budget. Final API-reported size will be added below after `gh pr create` returns.)*

The forecast for slice 1 (#2301) was 250–450 lines; the actual implementation grew to **+872 / -19 = 891 changed lines** (confirmed via `gh pr view --json additions,deletions,changedFiles`) once the role-guidance data for every configurable agent (orchestrator + 10 SDD + 3 JD + 5 review agents) plus per-renderer chrome helpers and the full set of clamp + guidance tests were accounted for. The work was kept as a single PR per the contributor scope constraint ("Do NOT split mid-flight") and per the inline comment on the issue: *"if it crosses 400 I'll request `size:exception` rather than chaining prematurely"*.

If `size:exception` is declined, the natural chained split is:
1. Slice A: adaptive layout + its tests (commit `02bd7d88`, ~398 changed lines on its own).
2. Slice B: role guidance + its tests (commit `477b42d4`, ~493 changed lines on its own).

Both slices are independently reviewable.
