### PR TITLE
fix(review): classify START parse errors as preflight

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -515,6 +515,44 @@ func rememberLineage(sandbox *Sandbox, observation Observation) error {
 	return nil
 }
 
+// assertNegotiatedStartUnknownFlagPreflight keeps the parser refusal inside a
+// composite because a direct step treats an unknown flag as unsupported before
+// its After assertion can inspect the negotiated envelope.
+func assertNegotiatedStartUnknownFlagPreflight(run *journeyRun) error {
+	observation := run.run(productArgsFor(run, "review", "start", "--contract", reviewContract, "--unknown-start-flag"), false)
+	if observation.ExitCode == 0 {
+		return errors.New("negotiated START accepted an unknown flag")
+	}
+
+	var failure struct {
+		Code            string `json:"code"`
+		Phase           string `json:"phase"`
+		MutationOutcome string `json:"mutation_outcome"`
+		RetrySafe       bool   `json:"retry_safe"`
+		Replayability   string `json:"replayability"`
+		NextAction      string `json:"next_action"`
+		Cause           string `json:"cause"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &failure); err != nil {
+		return fmt.Errorf("decode negotiated START unknown-flag envelope: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if failure.Code != "invalid_request" || failure.Phase != "preflight" ||
+		failure.MutationOutcome != "not_started" || !failure.RetrySafe ||
+		failure.Replayability != "not_replayable" || failure.NextAction != "correct_request" {
+		return fmt.Errorf("START unknown-flag failure = code=%q phase=%q mutation_outcome=%q retry_safe=%t replayability=%q next_action=%q", failure.Code, failure.Phase, failure.MutationOutcome, failure.RetrySafe, failure.Replayability, failure.NextAction)
+	}
+	if failure.Cause != "flag provided but not defined: -unknown-start-flag" {
+		return fmt.Errorf("START unknown-flag cause = %q", failure.Cause)
+	}
+	if _, err := os.Stat(filepath.Join(run.sandbox.Repo, ".git", "gentle-ai", "defect-reports")); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return errors.New("START unknown-flag refusal wrote a defect report")
+		}
+		return fmt.Errorf("inspect START unknown-flag defect reports: %w", err)
+	}
+	return nil
+}
+
 var startCapability = &Capability{Verb: []string{"review", "start"}, Flags: []string{"--cwd"}}
 
 // Capabilities declare only the flags the step actually uses. Over-declaring
@@ -759,6 +797,16 @@ func coreJourneys() []Journey {
 				{Name: "fixture: stage docs", Fixture: stageDocs("abandoned")},
 				{Name: "review start", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
 				{Name: "abandon a non-terminal lineage with its V2 binding", Requires: abandonCapability, Composite: abandonNonTerminalLineage},
+			},
+		},
+		{
+			ID:     "j85-negotiated-start-unknown-flag-is-preflight",
+			Title:  "Negotiated START unknown flag is a retry-safe preflight refusal",
+			Source: "#1956: argv parsing happens before START can mutate authority",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "fixture: stage docs", Fixture: stageDocs("unknown-flag")},
+				{Name: "negotiated START unknown flag is typed before native execution", Requires: startContractCapability, Composite: assertNegotiatedStartUnknownFlagPreflight},
 			},
 		},
 	}

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -828,7 +828,7 @@ func coreJourneys() []Journey {
 			},
 		},
 		{
-			ID:     "j85-negotiated-start-unknown-flag-is-preflight",
+			ID:     "j85-review-parse-refusals-are-preflight",
 			Title:  "START and FINALIZE parser refusals are preflight and non-mutating",
 			Source: "#1956: argv parsing happens before review authority can mutate",
 			Steps: []Step{

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -515,45 +515,73 @@ func rememberLineage(sandbox *Sandbox, observation Observation) error {
 	return nil
 }
 
-// assertNegotiatedStartUnknownFlagPreflight keeps the parser refusal inside a
-// composite because a direct step treats an unknown flag as unsupported before
-// its After assertion can inspect the negotiated envelope.
-func assertNegotiatedStartUnknownFlagPreflight(run *journeyRun) error {
-	observation := run.run(productArgsFor(run, "review", "start", "--contract", reviewContract, "--unknown-start-flag"), false)
-	if observation.ExitCode == 0 {
-		return errors.New("negotiated START accepted an unknown flag")
+// assertReviewParseRefusalsPreflight keeps parser refusals inside a composite
+// because a direct unknown-flag step is classified as unsupported before its
+// After assertion can inspect the negotiated envelope. The positive equals
+// forms remain covered by TestReviewBooleanFlagSpacedValueNamesTheEqualsForm
+// and core journey j02's --captured-results=true transition.
+func assertReviewParseRefusalsPreflight(run *journeyRun, operation, booleanFlag string) error {
+	cases := []struct {
+		name, cause string
+		args        []string
+		usage       bool
+	}{
+		{name: "unknown flag", args: []string{"--unknown-" + operation + "-flag"}, cause: "flag provided but not defined: -unknown-" + operation + "-flag", usage: true},
+		{name: "detached boolean", args: []string{"--" + booleanFlag, "true"}, cause: "boolean flag --" + booleanFlag + " takes --" + booleanFlag + " or --" + booleanFlag + "=true, not a separate value; got \"true\""},
 	}
-
-	var failure struct {
-		Code            string `json:"code"`
-		Phase           string `json:"phase"`
-		MutationOutcome string `json:"mutation_outcome"`
-		RetrySafe       bool   `json:"retry_safe"`
-		Replayability   string `json:"replayability"`
-		NextAction      string `json:"next_action"`
-		Cause           string `json:"cause"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &failure); err != nil {
-		return fmt.Errorf("decode negotiated START unknown-flag envelope: %w (stderr: %s)", err, firstLine(observation.Stderr))
-	}
-	if failure.Code != "invalid_request" || failure.Phase != "preflight" ||
-		failure.MutationOutcome != "not_started" || !failure.RetrySafe ||
-		failure.Replayability != "not_replayable" || failure.NextAction != "correct_request" {
-		return fmt.Errorf("START unknown-flag failure = code=%q phase=%q mutation_outcome=%q retry_safe=%t replayability=%q next_action=%q", failure.Code, failure.Phase, failure.MutationOutcome, failure.RetrySafe, failure.Replayability, failure.NextAction)
-	}
-	if failure.Cause != "flag provided but not defined: -unknown-start-flag" {
-		return fmt.Errorf("START unknown-flag cause = %q", failure.Cause)
-	}
-	if _, err := os.Stat(filepath.Join(run.sandbox.Repo, ".git", "gentle-ai", "defect-reports")); !errors.Is(err, os.ErrNotExist) {
-		if err == nil {
-			return errors.New("START unknown-flag refusal wrote a defect report")
+	for _, test := range cases {
+		for _, negotiated := range []bool{true, false} {
+			mode := "plain"
+			args := []string{"review", operation}
+			if negotiated {
+				mode = "negotiated"
+				args = append(args, "--contract", reviewContract)
+			}
+			observation := run.run(productArgsFor(run, append(args, test.args...)...), false)
+			if observation.ExitCode == 0 {
+				return fmt.Errorf("%s %s %s accepted a parser refusal", operation, test.name, mode)
+			}
+			if negotiated {
+				var failure struct {
+					Code            string `json:"code"`
+					Phase           string `json:"phase"`
+					MutationOutcome string `json:"mutation_outcome"`
+					RetrySafe       bool   `json:"retry_safe"`
+					Replayability   string `json:"replayability"`
+					NextAction      string `json:"next_action"`
+					Cause           string `json:"cause"`
+				}
+				if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &failure); err != nil {
+					return fmt.Errorf("decode %s %s %s envelope: %w (stderr: %s)", operation, test.name, mode, err, firstLine(observation.Stderr))
+				}
+				if failure.Code != "invalid_request" || failure.Phase != "preflight" ||
+					failure.MutationOutcome != "not_started" || !failure.RetrySafe ||
+					failure.Replayability != "not_replayable" || failure.NextAction != "correct_request" || failure.Cause != test.cause {
+					return fmt.Errorf("%s %s %s failure = code=%q phase=%q mutation_outcome=%q retry_safe=%t replayability=%q next_action=%q cause=%q", operation, test.name, mode, failure.Code, failure.Phase, failure.MutationOutcome, failure.RetrySafe, failure.Replayability, failure.NextAction, failure.Cause)
+				}
+			} else {
+				if got := strings.TrimSpace(observation.Stderr); got != "Error: "+test.cause {
+					return fmt.Errorf("%s %s plain diagnostic = %q, want %q", operation, test.name, got, "Error: "+test.cause)
+				}
+				usage := "Usage: gentle-ai review " + operation + " [flags]"
+				if got := strings.Contains(observation.Stdout, usage); got != test.usage {
+					return fmt.Errorf("%s %s plain usage %t, want %t", operation, test.name, got, test.usage)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(run.sandbox.Repo, ".git", "gentle-ai", "defect-reports")); !errors.Is(err, os.ErrNotExist) {
+				if err == nil {
+					return fmt.Errorf("%s %s %s refusal wrote a defect report", operation, test.name, mode)
+				}
+				return fmt.Errorf("inspect %s %s %s defect reports: %w", operation, test.name, mode, err)
+			}
 		}
-		return fmt.Errorf("inspect START unknown-flag defect reports: %w", err)
 	}
 	return nil
 }
 
 var startCapability = &Capability{Verb: []string{"review", "start"}, Flags: []string{"--cwd"}}
+var startParseRefusalCapability = &Capability{Verb: []string{"review", "start"}, Flags: []string{"--cwd", "--contract", "--committed-only"}}
+var finalizeParseRefusalCapability = &Capability{Verb: []string{"review", "finalize"}, Flags: []string{"--cwd", "--contract", "--captured-results"}}
 
 // Capabilities declare only the flags the step actually uses. Over-declaring
 // would report an older binary as `unsupported` for a step it can in fact run.
@@ -801,12 +829,14 @@ func coreJourneys() []Journey {
 		},
 		{
 			ID:     "j85-negotiated-start-unknown-flag-is-preflight",
-			Title:  "Negotiated START unknown flag is a retry-safe preflight refusal",
-			Source: "#1956: argv parsing happens before START can mutate authority",
+			Title:  "START and FINALIZE parser refusals are preflight and non-mutating",
+			Source: "#1956: argv parsing happens before review authority can mutate",
 			Steps: []Step{
 				{Name: "fixture: repo", Fixture: baseRepo},
-				{Name: "fixture: stage docs", Fixture: stageDocs("unknown-flag")},
-				{Name: "negotiated START unknown flag is typed before native execution", Requires: startContractCapability, Composite: assertNegotiatedStartUnknownFlagPreflight},
+				{Name: "START parser refusals preserve their preflight contract", Requires: startParseRefusalCapability, Composite: func(run *journeyRun) error { return assertReviewParseRefusalsPreflight(run, "start", "committed-only") }},
+				{Name: "FINALIZE parser refusals preserve their preflight contract", Requires: finalizeParseRefusalCapability, Composite: func(run *journeyRun) error {
+					return assertReviewParseRefusalsPreflight(run, "finalize", "captured-results")
+				}},
 			},
 		},
 	}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,7 +36,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 84 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 85 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -42,7 +42,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-
 	// only-retry (#2621).
 	// j81's RC-created repair fixture (#2839) follows the independently-owned
-	// #2621 journey. j85 proves #1956's START argv parse refusal is preflight.
+	// #2621 journey. j85 proves #1956's START and FINALIZE parser refusals are preflight.
 	// j82 proves #2127's reviewed full candidate can publish an unpublished
 	// monotonic subset without reopening review.
 	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -42,15 +42,15 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-
 	// only-retry (#2621).
 	// j81's RC-created repair fixture (#2839) follows the independently-owned
-	// #2621 journey.
+	// #2621 journey. j85 proves #1956's START argv parse refusal is preflight.
 	// j82 proves #2127's reviewed full candidate can publish an unpublished
 	// monotonic subset without reopening review.
 	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base
 	// while the advertised main ref remains a moving publication boundary.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 84 {
-		t.Errorf("core journey count = %d, want 84", got)
+	if got := len(seen); got != 85 {
+		t.Errorf("core journey count = %d, want 85", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -76,10 +76,10 @@ func parseReviewFlags(flags *flag.FlagSet, args []string) error {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
 		}
-		return err
+		return reviewPreflightError(err)
 	}
 	if hint := reviewBooleanFlagSpacedValueHint(flags, args); hint != "" {
-		return errors.New(hint)
+		return reviewPreflightError(errors.New(hint))
 	}
 	return nil
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1509,7 +1509,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	flags.Var(&intendedUntracked, "intended-untracked", "repo-relative untracked path to include; repeat for each path")
 	flags.Var(&expectedUntrackedInventory, "expected-untracked-inventory", "sha256 inventory digest from review status")
 	if err := parseReviewFlags(flags, args); err != nil {
-		return reviewPreflightError(err)
+		return err
 	}
 	if reviewHelpRequested(args) {
 		return nil
@@ -2343,7 +2343,7 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	var resultArtifactFiles repeatedString
 	flags.Var(&resultArtifactFiles, "result-artifact-file", "native reviewer artifact manifest regular file or - for stdin; repeat in selected-lens order")
 	if err := parseReviewFlags(flags, args); err != nil {
-		return reviewPreflightError(err)
+		return err
 	}
 	if reviewHelpRequested(args) {
 		return nil

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1509,7 +1509,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	flags.Var(&intendedUntracked, "intended-untracked", "repo-relative untracked path to include; repeat for each path")
 	flags.Var(&expectedUntrackedInventory, "expected-untracked-inventory", "sha256 inventory digest from review status")
 	if err := parseReviewFlags(flags, args); err != nil {
-		return err
+		return reviewPreflightError(err)
 	}
 	if reviewHelpRequested(args) {
 		return nil


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1956

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Classify every review flag-parse refusal once at the shared parser boundary, before any lifecycle operation can claim it ran.
- Delete redundant START and FINALIZE caller-local wrappers instead of adding another error type or classifier.
- Add one black-box bench journey covering the full #1956 matrix across both commands, both parser refusal kinds, and plain/negotiated modes.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review.go` | Route both non-help parser exits through the existing preflight classifier. |
| `internal/cli/review_facade.go` | Remove redundant START and FINALIZE parse wrappers. |
| `bench/journeys.go` | Add j85 with eight real-binary regression cells and truthful per-command capabilities. |
| `bench/journeys_sdd_test.go` | Ratchet and document the core journey count at 85. |

---

## 🧪 Test Plan

**Unit and format checks**

- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./... -count=1`
- [x] `cd bench && go vet ./... && go test ./... -count=1`

**Driven benchmark proof**

- RED/decoy: the unchanged candidate harness against a freshly rebuilt `e659f46b` binary fails with `operation_outcome_unknown`, `native_running`, and `mutation_outcome=unknown` on START.
- Focused GREEN: `1 completed, 0 unsupported, 0 failed`; j85 executes all 8 matrix commands.
- Full core GREEN: `85 completed, 0 unsupported, 0 failed` using locally built harness and product binaries with CI's invocation shape.
- Positive controls remain covered by `TestReviewBooleanFlagSpacedValueNamesTheEqualsForm` and j02's `--captured-results=true` flow.

**E2E**

- [x] Repository E2E workflows passed on candidate `120d9e97`.
- [x] Manually tested the real CLI envelopes, plain diagnostics, usage streams, and defect-report absence through the driven harness.

---

## 🤖 Automated Checks

The repository checks remain authoritative. Authored review size is 92 lines (`85 additions + 7 deletions`), below the 400-line budget.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Added exactly one `type:*` label
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E checks pass on candidate `120d9e97`
- [x] Benchmark validation completed in driven mode
- [x] Documentation is not required beyond the corrected journey-count contract
- [x] Commits follow Conventional Commits
- [x] Commits have no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Deletion-first result: production source is net zero (`3 additions + 3 deletions`). One parser-boundary classification replaces two caller-local mechanisms, so every review verb now inherits the same pre-execution truth without parallel state, flags, fallbacks, or compatibility paths.

- [x] No qualifying security, integrity, admission, repair, or governance guard was added or changed; this corrects pre-mutation failure classification.
- [x] No `guard:population` claim or baseline update applies.
