### PR TITLE
fix(review): avoid guessing recovery runtime identity

### DIFF
--- a/bench/axis_compatibility.go
+++ b/bench/axis_compatibility.go
@@ -37,6 +37,7 @@ func init() {
 			"cw01 pins the issue #2447 fix: a direct `review start --base-ref ... --committed-only` over a candidate large enough to select a reviewer lens now refuses before creating any lineage, naming the negotiated form. Before the fix (verified by running this exact journey against a pre-fix binary) it exited 0, created a lineage, and no reviewer lens could ever complete it -- the trap the issue reports. The journey also proves the refusal is idempotent (repeating the identical call produces byte-identical output), which is this benchmark's only black-box way to show nothing was persisted on the first attempt.",
 			"cw02 pins a sibling surface of the same shape: the hyphenated `review-start` (note: no space) v1-compatibility verb, registered in internal/app/app.go alongside `review start`. It has refused unconditionally since before this axis existed. It belongs here because an axis about direct/legacy start surfaces that omitted the one already-closed door would be an incomplete map of exactly the territory #2447 is about.",
 			"cw03 proves the surface #2447's fix deliberately leaves open still completes a review end to end: `review capture-result --cwd` (review-ledger-contract.md: \"Capture follows the native transition; opaque handles are cwd-independent and legacy bindings need --cwd\") drives a negotiated-started review through capture, finalize and a gate WITHOUT ever supplying --repository-context. This is the direct/manual capture path the execution contract still names as supported, and #2447's maintainer decision explicitly kept it: closing direct START does not close direct capture/finalize.",
+			"cw04 reproduces issue #2885 at the public direct-route boundary, extracts the exact unbound recovery command from the refusal, and executes it without an agent guess or transport-admission failure.",
 			"Surveyed from internal/app/app.go and excluded from this slice, with reasons: `review-resume`, `review-bundle-export`, `review-bundle-import`, and `review-validate` operate over authority the core corpus's ordinary lifecycle journeys already create and exercise through their own verbs -- they are not START-shaped, so they carry none of #2447's specific gap (a route that CREATES a lineage nothing can complete). `review-step` is structurally identical to cw02's already-closed shape (a permanent read-only refusal naming the compact verb) and would duplicate it rather than add coverage. The retired `--result` finalize flag no longer exists in the flag set at all (internal/cli/review_facade.go), so it is not a surface a caller can reach and is not a corpus member.",
 		},
 		Journeys: compatibilityJourneys,
@@ -213,7 +214,7 @@ func compatAssertNoRepositoryContext(_ *Sandbox, observation Observation) error 
 // ---------------------------------------------------------------------------
 
 func compatibilityJourneys() []Journey {
-	return []Journey{
+	journeys := []Journey{
 		{
 			ID:     "cw01-direct-start-refuses-uncompletable-base-diff",
 			Title:  "Direct `review start --base-ref ... --committed-only` over a real candidate refuses up front and names the negotiated exit",
@@ -257,4 +258,5 @@ func compatibilityJourneys() []Journey {
 			},
 		},
 	}
+	return append(journeys, compatibilityRuntimeIdentityJourneys()...)
 }

--- a/bench/axis_compatibility_runtime_identity.go
+++ b/bench/axis_compatibility_runtime_identity.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func compatExecuteUnboundRecovery(r *journeyRun) error {
+	refused := r.run(compatDirectBaseDiffStartArgs(r.sandbox), false)
+	if err := compatAssertNamedRefusal(refused, "unbound direct base-diff start"); err != nil {
+		return err
+	}
+
+	combined := refused.Stdout + "\n" + refused.Stderr
+	const marker = "`gentle-ai review start "
+	start := strings.Index(combined, marker)
+	if start < 0 {
+		return fmt.Errorf("direct refusal named no backtick-delimited review start command: %q", combined)
+	}
+	tail := combined[start+1:]
+	end := strings.IndexByte(tail, '`')
+	if end < 0 {
+		return fmt.Errorf("direct refusal did not close its recovery command: %q", combined)
+	}
+	command := tail[:end]
+	if strings.Contains(command, "--agent") || strings.Contains(command, "<your-runtime-identity>") {
+		return fmt.Errorf("unbound recovery guessed a runtime identity: %q", command)
+	}
+	args, err := printedCommandArguments(command)
+	if err != nil {
+		return err
+	}
+	recovered := r.run(args, false)
+	if recovered.ExitCode != 0 {
+		return fmt.Errorf("exact printed recovery command failed: exit=%d stdout=%q stderr=%q", recovered.ExitCode, recovered.Stdout, recovered.Stderr)
+	}
+	if strings.Contains(recovered.Stdout+recovered.Stderr, "review_transport_capability_unsupported") {
+		return fmt.Errorf("unbound recovery reached transport admission: stdout=%q stderr=%q", recovered.Stdout, recovered.Stderr)
+	}
+	return nil
+}
+
+func compatibilityRuntimeIdentityJourneys() []Journey {
+	return []Journey{{
+		ID:     "cw04-unbound-recovery-executes-without-agent-guess",
+		Title:  "An unbound direct-route refusal emits and executes a negotiated recovery without an agent guess",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/2885",
+		Steps: []Step{
+			{Name: "fixture: base commit, feature branch, committed candidate", Fixture: compatBaseDiffCandidate},
+			{Name: "extract and execute the exact unbound recovery without transport admission", Requires: startCapability, Composite: compatExecuteUnboundRecovery},
+		},
+	}}
+}

--- a/bench/axis_compatibility_test.go
+++ b/bench/axis_compatibility_test.go
@@ -45,9 +45,13 @@ func TestCompatibilityAxisDeclaresItselfAndItsJourneys(t *testing.T) {
 			"cw01-direct-start-refuses-uncompletable-base-diff":       true,
 			"cw02-hyphenated-review-start-always-refuses":             true,
 			"cw03-negotiated-start-then-direct-cwd-capture-completes": true,
+			"cw04-unbound-recovery-executes-without-agent-guess":      true,
 		}
 		for _, journey := range journeys {
 			delete(want, journey.ID)
+			if journey.ID == "cw04-unbound-recovery-executes-without-agent-guess" && journey.Source != "https://github.com/Gentleman-Programming/gentle-ai/issues/2885" {
+				t.Fatalf("cw04 source = %q", journey.Source)
+			}
 		}
 		if len(want) != 0 {
 			t.Fatalf("expected compatibility journeys not found: %v", want)

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -143,12 +143,8 @@ const ReviewStartConsentDeclinedThisCandidate = "declined_this_candidate"
 // and the fix is to name the base to compare against, not to redo the work.
 const reviewStartEmptyCandidateHint = "the candidate has no pending changes; already-committed work can be reviewed by rerunning review start with --base-ref <commit> naming the base to compare against"
 
-// reviewUndeclaredRuntimeIdentitySlot is what the printed continuation carries
-// when no runtime declared itself. The direct route refuses `--agent` outright
-// ("review start --agent requires a negotiated --contract"), so on that path
-// the caller's identity is genuinely unknown, and a slot is the only honest
-// thing to print: naming a concrete runtime there would be this CLI asserting
-// an identity on the caller's behalf.
+// reviewUndeclaredRuntimeIdentitySlot marks the optional agent segment in Tier C
+// narration until bindNarrationRuntimeIdentity either binds or removes it.
 const reviewUndeclaredRuntimeIdentitySlot = "<your-runtime-identity>"
 
 // reviewNegotiatedStartCommand builds the exact negotiated `review start`
@@ -167,11 +163,11 @@ const reviewUndeclaredRuntimeIdentitySlot = "<your-runtime-identity>"
 // correct outcome for this build.
 func reviewNegotiatedStartCommand(snapshot reviewtransaction.Snapshot, runtimeAgent string) string {
 	identity := strings.TrimSpace(runtimeAgent)
-	if identity == "" {
-		identity = reviewUndeclaredRuntimeIdentitySlot
+	command := fmt.Sprintf("gentle-ai review start --contract %s", ReviewIntegrationContractV2)
+	if identity != "" {
+		command += " --agent " + identity
 	}
-	command := fmt.Sprintf("gentle-ai review start --contract %s --agent %s --target %s --projection %s",
-		ReviewIntegrationContractV2, identity, snapshot.Identity, facadeProjection(snapshot.Projection))
+	command += fmt.Sprintf(" --target %s --projection %s", snapshot.Identity, facadeProjection(snapshot.Projection))
 	switch snapshot.Kind {
 	case reviewtransaction.TargetBaseDiff:
 		command += " --base-ref " + snapshot.BaseTree + " --committed-only"

--- a/internal/cli/review_narration.go
+++ b/internal/cli/review_narration.go
@@ -293,13 +293,12 @@ func reviewNarrateForecast(forecast ReviewForecast) {
 // registry is a package-level map with no caller context, so the statements
 // carry a slot rather than a constant: a narration that told every runtime to
 // rerun as `claude-code` would invite a Codex or OpenCode reader to declare a
-// false identity and pass the transport admission check under Claude Code's
-// capability profile (issue #2440). An undeclared caller keeps the slot, which
-// asks the reader to name themselves instead of naming them wrongly.
+// false identity and pass the transport admission check under another runtime's
+// capability profile. An undeclared caller omits the entire optional segment.
 func bindNarrationRuntimeIdentity(statement string, runtimeAgent model.AgentID) string {
 	identity := strings.TrimSpace(string(runtimeAgent))
 	if identity == "" {
-		return statement
+		return strings.ReplaceAll(statement, " --agent "+reviewUndeclaredRuntimeIdentitySlot, "")
 	}
 	return strings.ReplaceAll(statement, reviewUndeclaredRuntimeIdentitySlot, identity)
 }

--- a/internal/cli/review_start_evidence_test.go
+++ b/internal/cli/review_start_evidence_test.go
@@ -299,9 +299,8 @@ func TestReviewFacadeStartLensesRequiredHintsNegotiatedContract(t *testing.T) {
 		t.Fatalf("service-token start lenses_required = %v, selected_lenses = %v, want lenses selected", started.LensesRequired, started.SelectedLenses)
 	}
 	// The direct route refuses --agent, so this caller never declared a
-	// runtime and the hint must not declare one for it (issue #2440): it
-	// carries the fill-in slot the reader replaces with their own identity.
-	wantCommand := fmt.Sprintf("gentle-ai review start --contract %s --agent %s --target %s --projection %s", ReviewIntegrationContractV2, reviewUndeclaredRuntimeIdentitySlot, started.TargetIdentity, started.Projection)
+	// runtime and the hint must omit the complete agent segment (issue #2885).
+	wantCommand := fmt.Sprintf("gentle-ai review start --contract %s --target %s --projection %s", ReviewIntegrationContractV2, started.TargetIdentity, started.Projection)
 	if !strings.Contains(started.Hint, wantCommand) {
 		t.Fatalf("lenses-required start hint = %q, want it to contain %q", started.Hint, wantCommand)
 	}

--- a/internal/cli/review_start_runtime_identity_test.go
+++ b/internal/cli/review_start_runtime_identity_test.go
@@ -126,10 +126,9 @@ func TestDirectRouteStillRefusesADeclaredRuntime(t *testing.T) {
 
 // TestNegotiatedStartCommandEchoesTheCallersOwnRuntime pins the builder every
 // printed continuation goes through. The negotiated hint sites pass the
-// caller's declared identity, and today only claude-code clears the transport
-// gate, so a constant and an echo are observationally identical on this build.
-// That is exactly why the property needs its own test: the moment a second
-// runtime becomes eligible, a constant would start lying again.
+// caller's declared identity. Every runtime with immutable transport must be
+// echoed exactly; a fixed identity would lie for the rest of the supported
+// set, which is why this property has its own test.
 func TestNegotiatedStartCommandEchoesTheCallersOwnRuntime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/review_start_runtime_identity_test.go
+++ b/internal/cli/review_start_runtime_identity_test.go
@@ -50,16 +50,14 @@ func initLensSelectingReviewCLIRepo(t *testing.T) (repo, baseRef string) {
 }
 
 // TestDirectReviewStartRefusalInventsNoRuntimeIdentity is the RED-first proof
-// for the compiled half of issue #2440, reproduced against the real CLI.
+// for issue #2885, reproduced against the real CLI.
 //
 // The direct route refuses `--agent` outright ("review start --agent requires
 // a negotiated --contract", verified by execution below), so on this path no
 // runtime has declared itself and the CLI does not know who is calling. It
-// nonetheless printed an exact runnable continuation carrying a constant
-// `--agent claude-code`, at the exact moment a reader is most likely to copy
-// the command verbatim. A Codex or OpenCode caller who did so declared a false
-// identity and passed the transport admission check in
-// review_transport_capability.go under Claude Code's capability profile.
+// must therefore omit --agent entirely. The test runs the exact printed command
+// from the repository where it was emitted so executability is proved without
+// filling a placeholder or guessing a transport identity.
 func TestDirectReviewStartRefusalInventsNoRuntimeIdentity(t *testing.T) {
 	repo, baseRef := initLensSelectingReviewCLIRepo(t)
 
@@ -77,18 +75,26 @@ func TestDirectReviewStartRefusalInventsNoRuntimeIdentity(t *testing.T) {
 		t.Fatalf("did not reach the direct-route refusal that names a continuation: %s", message)
 	}
 
-	identities := compiledRuntimeIdentities()
-	named := reviewPrintedIdentityRegexp.FindAllStringSubmatch(message, -1)
-	if len(named) == 0 {
-		t.Fatalf("printed continuation names no --agent binding at all: %s", message)
+	opening := strings.Index(message, "`gentle-ai review start ")
+	if opening < 0 {
+		t.Fatalf("refusal has no negotiated start command: %s", message)
 	}
-	for _, match := range named {
-		if identities[match[1]] {
-			t.Errorf("printed continuation tells an undeclared caller to declare %q; copying this command verbatim passes a false identity to the review transport gate: %s", match[1], message)
-		}
+	closing := strings.IndexByte(message[opening+1:], '`')
+	if closing < 0 {
+		t.Fatalf("refusal command has no closing backtick: %s", message)
 	}
-	if !strings.Contains(message, "--agent "+reviewUndeclaredRuntimeIdentitySlot) {
-		t.Errorf("printed continuation does not leave the runtime identity to be filled in: %s", message)
+	command := message[opening+1 : opening+1+closing]
+	words := reviewShellWords(t, command)
+	if strings.Contains(command, "--agent") || strings.Contains(command, reviewUndeclaredRuntimeIdentitySlot) {
+		t.Fatalf("unbound recovery command guesses a runtime identity: %s", command)
+	}
+	if len(words) < 3 || words[0] != "gentle-ai" || words[1] != "review" || words[2] != "start" {
+		t.Fatalf("recovery command = %#v, want gentle-ai review start", words)
+	}
+	t.Chdir(repo)
+	var recovered bytes.Buffer
+	if err := RunReview(words[2:], &recovered); err != nil {
+		t.Fatalf("exact unbound recovery command is not executable: %v\n%s", err, recovered.String())
 	}
 }
 
@@ -131,25 +137,45 @@ func TestNegotiatedStartCommandEchoesTheCallersOwnRuntime(t *testing.T) {
 		Identity:   "sha256:0000000000000000000000000000000000000000000000000000000000000000",
 		Projection: reviewtransaction.ProjectionWorkspace,
 	}
-	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentCodex, model.AgentOpenCode, model.AgentKilocode} {
+	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
 		t.Run(string(agent), func(t *testing.T) {
 			command := reviewNegotiatedStartCommand(snapshot, string(agent))
-			if !strings.Contains(command, "--agent "+string(agent)+" ") {
-				t.Errorf("negotiated start command does not name the caller %q: %s", agent, command)
-			}
-			for other := range compiledRuntimeIdentities() {
-				if other == string(agent) {
-					continue
-				}
-				if strings.Contains(command, "--agent "+other+" ") {
-					t.Errorf("negotiated start command for %q names %q instead: %s", agent, other, command)
-				}
+			if strings.Count(command, "--agent ") != 1 || !strings.Contains(command, "--agent "+string(agent)+" ") {
+				t.Errorf("negotiated start command does not contain exactly one exact caller identity %q: %s", agent, command)
 			}
 		})
 	}
 
-	if slot := reviewNegotiatedStartCommand(snapshot, "   "); !strings.Contains(slot, "--agent "+reviewUndeclaredRuntimeIdentitySlot+" ") {
-		t.Errorf("a blank runtime identity did not fall back to the fill-in slot: %s", slot)
+	if unbound := reviewNegotiatedStartCommand(snapshot, "   "); strings.Contains(unbound, "--agent") || strings.Contains(unbound, reviewUndeclaredRuntimeIdentitySlot) {
+		t.Errorf("a blank runtime identity emitted an agent segment: %s", unbound)
+	}
+}
+
+func TestTierCRecoveryNarrationBindsOnlyDeclaredRuntimeIdentity(t *testing.T) {
+	t.Parallel()
+
+	for _, reason := range []string{"corrected_candidate_unavailable", "correction_repository_verification_failed"} {
+		statement, ok := reviewStopReasonStatement(reason)
+		if !ok {
+			t.Fatalf("Tier C reason %q has no narration", reason)
+		}
+		for _, runtime := range []model.AgentID{"", model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
+			t.Run(reason+"/"+string(runtime), func(t *testing.T) {
+				rendered := bindNarrationRuntimeIdentity(statement, runtime)
+				if strings.Contains(rendered, reviewUndeclaredRuntimeIdentitySlot) {
+					t.Fatalf("Tier C narration retained the runtime placeholder: %s", rendered)
+				}
+				if runtime == "" {
+					if strings.Contains(rendered, "--agent") {
+						t.Fatalf("unbound Tier C narration emitted an agent segment: %s", rendered)
+					}
+					return
+				}
+				if strings.Count(rendered, "--agent "+string(runtime)) != 1 {
+					t.Fatalf("bound Tier C narration does not contain one exact runtime identity: %s", rendered)
+				}
+			})
+		}
 	}
 }
 
@@ -353,59 +379,15 @@ func compiledRuntimeIdentityExpression(expression ast.Expr, identities map[strin
 	return "", false
 }
 
-// substituteReplayRuntimeIdentity prepares a printed continuation for verbatim
-// replay by supplying the one token the CLI could not know: the caller's own
-// runtime identity.
-//
-// This is the honest resolution of a real tension between two contracts. Issue
-// #2447 requires every refusal to name a command that actually runs. Issue
-// #2440 requires that no printed command assert an identity the CLI never
-// learned from the caller, because the direct route refuses `--agent` and a
-// reader who copies a constant declares a false runtime to the transport gate.
-// Both cannot hold in one fixed string, so the printed command leaves exactly
-// one slot and this helper fills it the way a human would. The replay still
-// proves everything #2447 cares about: the helper fails if ANY other token is
-// a fill-in slot, so a hint that quietly stopped resolving the frozen selector
-// would be caught here, not excused.
-func substituteReplayRuntimeIdentity(t *testing.T, arguments []string, caller model.AgentID) []string {
-	t.Helper()
-
-	substituted := make([]string, len(arguments))
-	filled := false
-	for index, argument := range arguments {
-		if argument == reviewUndeclaredRuntimeIdentitySlot {
-			substituted[index] = string(caller)
-			filled = true
-			continue
-		}
-		if strings.HasPrefix(argument, "<") && strings.HasSuffix(argument, ">") {
-			t.Fatalf("printed command leaves %q unresolved; only the caller's own runtime identity may need filling in", argument)
-		}
-		substituted[index] = argument
-	}
-	if !filled {
-		t.Fatalf("printed command carried no runtime-identity slot to fill: %v", arguments)
-	}
-	return substituted
-}
-
-// withoutReplayRuntimeIdentity exercises the manual compatibility route while
-// retaining every frozen selector emitted by a direct-route continuation.
+// withoutReplayRuntimeIdentity verifies that an unbound continuation is already
+// executable while retaining every frozen selector the direct route emitted.
 func withoutReplayRuntimeIdentity(t *testing.T, arguments []string) []string {
 	t.Helper()
 
-	without := make([]string, 0, len(arguments)-2)
-	removed := false
-	for index := 0; index < len(arguments); index++ {
-		if arguments[index] == "--agent" && index+1 < len(arguments) && arguments[index+1] == reviewUndeclaredRuntimeIdentitySlot {
-			removed = true
-			index++
-			continue
+	for _, argument := range arguments {
+		if argument == "--agent" || strings.Contains(argument, reviewUndeclaredRuntimeIdentitySlot) {
+			t.Fatalf("unbound printed command contains a runtime identity segment: %v", arguments)
 		}
-		without = append(without, arguments[index])
 	}
-	if !removed {
-		t.Fatalf("printed command carried no removable runtime-identity slot: %v", arguments)
-	}
-	return without
+	return append([]string(nil), arguments...)
 }

--- a/internal/cli/review_transport_capability_test.go
+++ b/internal/cli/review_transport_capability_test.go
@@ -71,6 +71,7 @@ func TestUnsupportedImmutableReviewTransportStopsBeforeRepositoryOrAuthority(t *
 		{name: "Kilo", runtime: string(model.AgentKilocode), startCode: reviewImmutableTransportUnsupportedCode},
 		{name: "Pi", runtime: string(model.AgentPi), startCode: reviewTransportCapabilityUnsupportedCode},
 		{name: "unknown", runtime: "unknown-runtime", startCode: reviewTransportCapabilityUnsupportedCode},
+		{name: "logical orchestrator role", runtime: "gentle-orchestrator", startCode: reviewTransportCapabilityUnsupportedCode},
 		// OpenCode used to stand here, refused for lacking its host isolation
 		// controls. The shared advisory transport (rdd-advisory-transport
 		// SKILL.md) retired that requirement: OpenCode's output is advisory
@@ -140,6 +141,9 @@ func TestUnsupportedImmutableReviewTransportStopsBeforeRepositoryOrAuthority(t *
 	for _, args := range [][]string{
 		{"status", "--contract", ReviewIntegrationContractV2, "--agent", string(model.AgentKilocode), "--next-transition", "--cwd", repo},
 		{"start", "--contract", ReviewIntegrationContractV2, "--agent", string(model.AgentPi), "--target", target, "--projection", "workspace", "--cwd", repo},
+		{"start", "--contract", ReviewIntegrationContractV2, "--agent", "unknown-runtime", "--target", target, "--projection", "workspace", "--cwd", repo},
+		{"start", "--contract", ReviewIntegrationContractV2, "--agent", "gentle-orchestrator", "--target", target, "--projection", "workspace", "--cwd", repo},
+		{"start", "--contract", ReviewIntegrationContractV2, "--agent", string(model.AgentClaudeCode), "--agent", string(model.AgentClaudeCode), "--target", target, "--projection", "workspace", "--cwd", repo},
 	} {
 		if err := RunReview(args, &bytes.Buffer{}); err == nil {
 			t.Fatalf("unsupported invocation succeeded: %v", args)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2885

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Stop printed unbound recovery commands from inventing a free-form runtime identity.
- Preserve the exact runtime for bound `claude-code`, `opencode`, and `codex` recoveries while keeping explicit unsupported identities fail-closed.
- Add a replayable black-box benchmark journey for the original issue scenario.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go`, `internal/cli/review_narration.go` | Omit the optional `--agent` segment when no runtime is bound and bind it only for declared runtimes. |
| `internal/cli/*runtime_identity*_test.go`, `internal/cli/review_transport_capability_test.go` | Cover executable unbound recovery, exact bound identities, narration, and fail-closed negative controls. |
| `bench/axis_compatibility_runtime_identity.go` | Add driven journey `cw04-unbound-recovery-executes-without-agent-guess` linked to #2885. |

---

## 🧪 Test Plan

- [x] Unit tests pass: `go test -count=1 ./...`
- [x] Static analysis passes: `go vet ./...`
- [x] Go format checker passes: `go run ./internal/gofmtcheck`
- [x] Bench declarations pass: `cd bench && go test -count=1 ./...`
- [x] Driven benchmark passes: `cw04-unbound-recovery-executes-without-agent-guess` — `1 completed, 0 unsupported, 0 failed`
- [x] Manually exercised the exact emitted unbound recovery command through the driven harness.
- [x] CI E2E coverage passes on Ubuntu, Windows, Arch, and Fedora.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 233 changed lines, within the 400-line budget |
| Check Issue Reference | ✅ | `Closes #2885` |
| Check Issue Has `status:approved` | ✅ | #2885 is approved |
| Check PR Has `type:*` Label | ✅ | Exactly one label: `type:bug` |
| Unit Tests | ✅ | Full root and bench suites passed |
| Go Format | ✅ | Checker passed |
| E2E Tests | ✅ | Required CI matrix passed |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test -count=1 ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Required E2E checks pass in CI
- [x] Benchmark validation completed in driven mode
- [x] Documentation was not required for this narrowly scoped recovery correction
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- This implements the [narrowed maintainer direction](https://github.com/Gentleman-Programming/gentle-ai/issues/2885#issuecomment-5233912067): omit the entire `--agent` segment when recovery is unbound, preserve the exact declared runtime when bound, and keep explicit invalid identities fail-closed before mutation.
- Receipt-driven development was disabled for the final comment-only update. The current delivery status is `disabled/unmanaged`, not receipt-approved.
- [x] Explicit unsupported runtime identities still fail before repository or authority access; the unbound manual route remains a distinct compatibility path.
- [x] No `guard:population` direction or claim changed.
- [x] `.guard-population-baseline.txt` is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery commands no longer include unusable placeholder runtime identities.
  * Unbound recovery commands can now be executed directly as printed.
  * Declared runtime identities are included only when required and supported.
  * Improved validation for unknown, unsupported, duplicate, and logical runtime identities.

* **Tests**
  * Added coverage for recovery command execution and runtime identity handling across supported scenarios.
  * Added compatibility coverage for unbound recovery workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
