### PR TITLE
fix(sdd): cumulative apply-progress cannot satisfy remediation parser

### DIFF
--- a/internal/sddstatus/remediation_test.go
+++ b/internal/sddstatus/remediation_test.go
@@ -35,6 +35,112 @@ func TestParseRemediationResultRequiresExactTransactionBinding(t *testing.T) {
 	}
 }
 
+func TestParseRemediationResultCompletesFromCumulativeApplyProgress(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	prior := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 1}
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		"- [x] design",
+		"- [x] spec",
+		"",
+		remediationResultEvidenceWithBinding("sha256:"+strings.Repeat("c", 64), prior),
+		"",
+		"## Remediation fix batch 2",
+		"",
+		"```sh",
+		"go test ./internal/sddstatus",
+		"```",
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); !got.Complete {
+		t.Fatal("terminal remediation pair appended to cumulative apply-progress must complete remediation")
+	}
+}
+
+func TestParseRemediationResultRejectsSameIdentityDuplicateInCumulativeProgress(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	pair := remediationResultEvidenceWithBinding(revision, binding)
+	artifact := strings.Join([]string{"# Apply Progress", "", pair, "", "## retry", "", pair, ""}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); got.Complete {
+		t.Fatal("duplicate same-identity remediation pair must be rejected as ambiguous")
+	}
+}
+
+func TestParseRemediationResultRequiresTerminalPairToCarryRequestedIdentity(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	newer := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 3}
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+		"## Newer remediation fix batch 3",
+		"",
+		remediationResultEvidenceWithBinding("sha256:"+strings.Repeat("e", 64), newer),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); got.Complete {
+		t.Fatal("a matching pair that is not terminal must not complete remediation")
+	}
+}
+
+func TestParseRemediationResultRejectsBlockquotedSameIdentityDuplicate(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	pair := remediationResultEvidenceWithBinding(revision, binding)
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		quoteAsBlockquote(pair),
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); got.Complete {
+		t.Fatal("blockquoted duplicate remediation claim matching the current identity must be rejected")
+	}
+}
+
+func TestParseRemediationResultRejectsLegacyJSONResultSameIdentityDuplicate(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	legacy := map[string]any{
+		"schema":                   "gentle-ai.remediation-result/v1",
+		"status":                   "complete",
+		"failed_evidence_revision": revision,
+		"lineage_id":               binding.LineageID,
+		"generation":               binding.Generation,
+		"fix_batch":                binding.FixBatch,
+	}
+	raw, _ := json.Marshal(legacy)
+	legacyEnvelope := "```json\n" + string(raw) + "\n```"
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		legacyEnvelope,
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); got.Complete {
+		t.Fatal("legacy JSON-result duplicate claim matching the current identity must be rejected")
+	}
+}
+
+func quoteAsBlockquote(text string) string {
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		lines[index] = "> " + line
+	}
+	return strings.Join(lines, "\n")
+}
+
 func remediationEnvelope(revision string) string {
 	return strings.Join([]string{
 		"```yaml",

--- a/internal/sddstatus/remediation_test.go
+++ b/internal/sddstatus/remediation_test.go
@@ -133,6 +133,22 @@ func TestParseRemediationResultRejectsLegacyJSONResultSameIdentityDuplicate(t *t
 	}
 }
 
+func TestParseRemediationResultSkipsInlineFenceProse(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		"```yaml is inline fence prose, not a block opener",
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); !got.Complete {
+		t.Fatal("inline fence prose at line start must not swallow the terminal remediation pair")
+	}
+}
+
 func quoteAsBlockquote(text string) string {
 	lines := strings.Split(text, "\n")
 	for index, line := range lines {

--- a/internal/sddstatus/remediation_test.go
+++ b/internal/sddstatus/remediation_test.go
@@ -149,6 +149,60 @@ func TestParseRemediationResultSkipsInlineFenceProse(t *testing.T) {
 	}
 }
 
+func TestParseRemediationResultSkipsLongerBacktickFences(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	pair := remediationResultEvidenceWithBinding(revision, binding)
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		"````example",
+		pair,
+		"````",
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); !got.Complete {
+		t.Fatal("a longer-backtick fence must hide its example contents from the remediation scan")
+	}
+}
+
+func TestParseRemediationResultSkipsUnclosedLongerBacktickFence(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	pair := remediationResultEvidenceWithBinding(revision, binding)
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		"````example",
+		pair,
+		// no closing fence: a malformed document must fail closed, never
+		// fabricate a remediation claim from fence contents.
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); got.Complete {
+		t.Fatal("an unclosed longer-backtick fence must fail closed instead of parsing its contents")
+	}
+}
+
+func TestParseRemediationResultRejectsNestedBlockquotedSameIdentityDuplicate(t *testing.T) {
+	revision := "sha256:" + strings.Repeat("d", 64)
+	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
+	pair := remediationResultEvidenceWithBinding(revision, binding)
+	artifact := strings.Join([]string{
+		"# Apply Progress",
+		"",
+		quoteAsBlockquote(quoteAsBlockquote(pair)),
+		"",
+		remediationResultEvidenceWithBinding(revision, binding),
+		"",
+	}, "\n")
+	if got := parseRemediationResult(artifact, revision, binding); got.Complete {
+		t.Fatal("nested-blockquoted duplicate remediation claim matching the current identity must be rejected")
+	}
+}
+
 func quoteAsBlockquote(text string) string {
 	lines := strings.Split(text, "\n")
 	for index, line := range lines {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -381,9 +381,12 @@ type remediationRollbackEvidence struct {
 }
 
 // remediationClaim is one identity assertion found while scanning cumulative
-// apply-progress: a strict remediation result envelope, optionally completed by
-// an adjacent JSON evidence fence. Complete pairs carry EndLine set to the end
-// of their evidence fence so the terminal pair is unambiguous.
+// apply-progress: a strict remediation result envelope optionally completed by
+// an adjacent JSON evidence fence. Complete reports that the pair fully
+// validated against the requested revision and binding. Complete pairs carry
+// EndLine set to the end of their evidence fence so the terminal pair is
+// unambiguous, while claim-only and rejected pairs keep the EndLine of their
+// result envelope so a later assertion always outranks an earlier one.
 type remediationClaim struct {
 	Revision   string
 	LineageID  string
@@ -491,14 +494,14 @@ func scanRemediationClaims(lines []string, expectedRevision string, binding *Rem
 				claims = append(claims, claim)
 			}
 			index = end
-		case strings.HasPrefix(marker, "```"):
+		case isFenceOpener(marker):
 			// Unrelated closed fence: skip it so its content is never scanned
 			// as remediation claims.
-			if end, ok := fenceEnd(lines, index+1); !ok {
+			end, ok := fenceEnd(lines, index+1)
+			if !ok {
 				return claims
-			} else {
-				index = end
 			}
+			index = end
 		}
 	}
 	return claims
@@ -511,6 +514,19 @@ func fenceEnd(lines []string, start int) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// isFenceOpener reports whether a stripped line opens a fenced block rather
+// than carrying an inline code span. Only a bare opener (a fence marker
+// followed at most by a language token) consumes a block; prose that merely
+// starts with a fence marker must be scanned line by line so the terminal
+// remediation pair inside it is never skipped.
+func isFenceOpener(marker string) bool {
+	if !strings.HasPrefix(marker, "```") {
+		return false
+	}
+	rest := strings.TrimPrefix(marker, "```")
+	return !strings.ContainsAny(rest, "` ")
 }
 
 func stripBlockquote(line string) string {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -455,7 +455,7 @@ func scanRemediationClaims(lines []string, expectedRevision string, binding *Rem
 		marker := stripBlockquote(lines[index])
 		switch {
 		case marker == "```yaml":
-			end, ok := fenceEnd(lines, index+1)
+			end, ok := fenceEnd(lines, index+1, 3)
 			if !ok {
 				return claims
 			}
@@ -471,7 +471,7 @@ func scanRemediationClaims(lines []string, expectedRevision string, binding *Rem
 				evidenceStart++
 			}
 			if evidenceStart < len(lines) && stripBlockquote(lines[evidenceStart]) == "```json" {
-				if evidenceEnd, ok := fenceEnd(lines, evidenceStart+1); ok {
+				if evidenceEnd, ok := fenceEnd(lines, evidenceStart+1, 3); ok {
 					evaluation, valid := validateRemediationPair(body, stripBlockquoteLines(lines[evidenceStart:evidenceEnd+1]), expectedRevision, binding)
 					claim.Complete = valid && evaluation.Complete
 					if claim.Complete {
@@ -485,7 +485,7 @@ func scanRemediationClaims(lines []string, expectedRevision string, binding *Rem
 			claims = append(claims, claim)
 			index = end
 		case marker == "```json":
-			end, ok := fenceEnd(lines, index+1)
+			end, ok := fenceEnd(lines, index+1, 3)
 			if !ok {
 				return claims
 			}
@@ -496,8 +496,11 @@ func scanRemediationClaims(lines []string, expectedRevision string, binding *Rem
 			index = end
 		case isFenceOpener(marker):
 			// Unrelated closed fence: skip it so its content is never scanned
-			// as remediation claims.
-			end, ok := fenceEnd(lines, index+1)
+			// as remediation claims. The closer must match the opener length,
+			// so a longer backtick fence never parses its nested triple-backtick
+			// pairs as claims.
+			runLength, _ := fenceRunLength(marker)
+			end, ok := fenceEnd(lines, index+1, runLength)
 			if !ok {
 				return claims
 			}
@@ -507,26 +510,39 @@ func scanRemediationClaims(lines []string, expectedRevision string, binding *Rem
 	return claims
 }
 
-func fenceEnd(lines []string, start int) (int, bool) {
+// fenceEnd locates the bare closing fence whose backtick run length equals
+// closeLen, starting at line start. A longer or shorter run never closes the
+// block, so four-backtick fences do not consume triple-backtick remediation
+// pairs inside them and vice versa.
+func fenceEnd(lines []string, start int, closeLen int) (int, bool) {
 	for index := start; index < len(lines); index++ {
-		if stripBlockquote(lines[index]) == "```" {
+		marker := stripBlockquote(lines[index])
+		if run, rest := fenceRunLength(marker); run == closeLen && rest == "" {
 			return index, true
 		}
 	}
 	return 0, false
 }
 
-// isFenceOpener reports whether a stripped line opens a fenced block rather
-// than carrying an inline code span. Only a bare opener (a fence marker
-// followed at most by a language token) consumes a block; prose that merely
-// starts with a fence marker must be scanned line by line so the terminal
-// remediation pair inside it is never skipped.
-func isFenceOpener(marker string) bool {
-	if !strings.HasPrefix(marker, "```") {
-		return false
+// fenceRunLength reports the length of the leading backtick run on a stripped
+// line and the remainder after that run.
+func fenceRunLength(marker string) (int, string) {
+	run := 0
+	for run < len(marker) && marker[run] == '`' {
+		run++
 	}
-	rest := strings.TrimPrefix(marker, "```")
-	return !strings.ContainsAny(rest, "` ")
+	return run, marker[run:]
+}
+
+// isFenceOpener reports whether a stripped line opens a fenced block rather
+// than carrying an inline code span. Any fence run of three or more backticks
+// followed at most by a language token consumes a block, so longer backtick
+// fences hide their contents; prose that merely starts with a fence marker
+// must be scanned line by line so the terminal remediation pair inside it is
+// never skipped.
+func isFenceOpener(marker string) bool {
+	run, rest := fenceRunLength(marker)
+	return run >= 3 && !strings.ContainsAny(rest, "` ")
 }
 
 func stripBlockquote(line string) string {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -380,77 +380,278 @@ type remediationRollbackEvidence struct {
 	Evidence string `json:"evidence"`
 }
 
+// remediationClaim is one identity assertion found while scanning cumulative
+// apply-progress: a strict remediation result envelope, optionally completed by
+// an adjacent JSON evidence fence. Complete pairs carry EndLine set to the end
+// of their evidence fence so the terminal pair is unambiguous.
+type remediationClaim struct {
+	Revision   string
+	LineageID  string
+	Generation int
+	FixBatch   int
+	Complete   bool
+	EndLine    int
+}
+
+// remediationResultFields is the scalar field vocabulary shared by the
+// remediation result claim and pair validators.
+var remediationResultFields = map[string]bool{
+	"schema": true, "status": true, "failed_evidence_revision": true,
+	"focused_tests": true, "runtime_harness": true, "rollback_boundary": true,
+	"lineage_id": true, "generation": true, "fix_batch": true,
+}
+
 func parseRemediationResult(text, expectedRevision string, bindings ...RemediationBinding) remediationResultEvaluation {
-	lines, end, reason := parseLeadingEnvelope(text)
-	if reason != "" {
+	if len(bindings) > 1 {
 		return remediationResultEvaluation{}
 	}
-	allowed := map[string]bool{
-		"schema": true, "status": true, "failed_evidence_revision": true,
-		"focused_tests": true, "runtime_harness": true, "rollback_boundary": true,
-		"lineage_id": true, "generation": true, "fix_batch": true,
+	var binding *RemediationBinding
+	if len(bindings) == 1 {
+		binding = &bindings[0]
 	}
-	fields, reason := parseScalarFields(lines[1:end], allowed, "remediation result")
-	if reason != "" {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	claims := scanRemediationClaims(strings.Split(text, "\n"), expectedRevision, binding)
+	var terminal *remediationClaim
+	for index := range claims {
+		if terminal == nil || claims[index].EndLine > terminal.EndLine {
+			terminal = &claims[index]
+		}
+	}
+	var matched *remediationClaim
+	matches := 0
+	for index := range claims {
+		if remediationClaimMatches(claims[index], expectedRevision, binding) {
+			matches++
+			matched = &claims[index]
+		}
+	}
+	if matches != 1 || matched == nil || !matched.Complete || terminal == nil || matched.EndLine != terminal.EndLine {
 		return remediationResultEvaluation{}
+	}
+	return remediationResultEvaluation{Complete: true, EvidenceRevision: expectedRevision}
+}
+
+func remediationClaimMatches(claim remediationClaim, expectedRevision string, binding *RemediationBinding) bool {
+	if claim.Revision != expectedRevision {
+		return false
+	}
+	if binding != nil && (claim.LineageID != binding.LineageID || claim.Generation != binding.Generation || claim.FixBatch != binding.FixBatch) {
+		return false
+	}
+	return true
+}
+
+// scanRemediationClaims walks a cumulative apply-progress document and returns
+// every remediation identity claim it can locate, in document order. Earlier
+// remediation history with a different identity is kept as a claim so a later
+// duplicate of the current identity is recognized as ambiguous. Unrelated
+// closed fences, plain prose, and inline fence markers are skipped.
+func scanRemediationClaims(lines []string, expectedRevision string, binding *RemediationBinding) []remediationClaim {
+	var claims []remediationClaim
+	for index := 0; index < len(lines); index++ {
+		marker := stripBlockquote(lines[index])
+		switch {
+		case marker == "```yaml":
+			end, ok := fenceEnd(lines, index+1)
+			if !ok {
+				return claims
+			}
+			body := stripBlockquoteLines(lines[index+1 : end])
+			claim, ok := parseRemediationResultClaim(body)
+			if !ok {
+				index = end
+				continue
+			}
+			claim.EndLine = end
+			evidenceStart := end + 1
+			for evidenceStart < len(lines) && strings.TrimSpace(lines[evidenceStart]) == "" {
+				evidenceStart++
+			}
+			if evidenceStart < len(lines) && stripBlockquote(lines[evidenceStart]) == "```json" {
+				if evidenceEnd, ok := fenceEnd(lines, evidenceStart+1); ok {
+					evaluation, valid := validateRemediationPair(body, stripBlockquoteLines(lines[evidenceStart:evidenceEnd+1]), expectedRevision, binding)
+					claim.Complete = valid && evaluation.Complete
+					if claim.Complete {
+						claim.EndLine = evidenceEnd
+						index = evidenceEnd
+						claims = append(claims, claim)
+						continue
+					}
+				}
+			}
+			claims = append(claims, claim)
+			index = end
+		case marker == "```json":
+			end, ok := fenceEnd(lines, index+1)
+			if !ok {
+				return claims
+			}
+			if claim, ok := parseLegacyRemediationResultClaim(stripBlockquoteLines(lines[index+1 : end])); ok {
+				claim.EndLine = end
+				claims = append(claims, claim)
+			}
+			index = end
+		case strings.HasPrefix(marker, "```"):
+			// Unrelated closed fence: skip it so its content is never scanned
+			// as remediation claims.
+			if end, ok := fenceEnd(lines, index+1); !ok {
+				return claims
+			} else {
+				index = end
+			}
+		}
+	}
+	return claims
+}
+
+func fenceEnd(lines []string, start int) (int, bool) {
+	for index := start; index < len(lines); index++ {
+		if stripBlockquote(lines[index]) == "```" {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func stripBlockquote(line string) string {
+	trimmed := strings.TrimSpace(line)
+	for strings.HasPrefix(trimmed, ">") {
+		rest := strings.TrimSpace(strings.TrimPrefix(trimmed, ">"))
+		if rest == trimmed {
+			break
+		}
+		trimmed = rest
+	}
+	return trimmed
+}
+
+func stripBlockquoteLines(lines []string) []string {
+	stripped := make([]string, len(lines))
+	for index, line := range lines {
+		stripped[index] = stripBlockquote(line)
+	}
+	return stripped
+}
+
+// parseRemediationResultClaim extracts only the identity an envelope asserts.
+// Full semantic validation stays in validateRemediationPair.
+func parseRemediationResultClaim(lines []string) (remediationClaim, bool) {
+	fields, reason := parseScalarFields(lines, remediationResultFields, "remediation result")
+	if reason != "" || fields["schema"] != RemediationResultSchema || fields["status"] != "complete" {
+		return remediationClaim{}, false
+	}
+	claim := remediationClaim{Revision: fields["failed_evidence_revision"]}
+	claim.LineageID = fields["lineage_id"]
+	if generation, ok := parseNonnegativeInt(fields["generation"]); ok {
+		claim.Generation = generation
+	}
+	if fixBatch, ok := parseNonnegativeInt(fields["fix_batch"]); ok {
+		claim.FixBatch = fixBatch
+	}
+	return claim, true
+}
+
+// parseLegacyRemediationResultClaim recognizes an older JSON-encoded
+// remediation result envelope. It only asserts identity; like parseRemediationResultClaim,
+// it exists so a same-identity claim in that historical form is rejected as an
+// ambiguous duplicate instead of being silently ignored.
+func parseLegacyRemediationResultClaim(lines []string) (remediationClaim, bool) {
+	text := strings.TrimSpace(strings.Join(lines, "\n"))
+	var fields map[string]any
+	if !strings.HasPrefix(text, "{") || json.Unmarshal([]byte(text), &fields) != nil {
+		return remediationClaim{}, false
+	}
+	if fields["schema"] != RemediationResultSchema || fields["status"] != "complete" {
+		return remediationClaim{}, false
+	}
+	claim := remediationClaim{Revision: jsonString(fields["failed_evidence_revision"])}
+	claim.LineageID = jsonString(fields["lineage_id"])
+	if generation, ok := jsonInt(fields["generation"]); ok {
+		claim.Generation = generation
+	}
+	if fixBatch, ok := jsonInt(fields["fix_batch"]); ok {
+		claim.FixBatch = fixBatch
+	}
+	return claim, true
+}
+
+func jsonString(value any) string {
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return ""
+}
+
+func jsonInt(value any) (int, bool) {
+	switch number := value.(type) {
+	case float64:
+		return int(number), true
+	case int:
+		return number, true
+	}
+	return 0, false
+}
+
+// validateRemediationPair runs the strict remediation result and evidence
+// semantic validation over one extracted envelope pair. It is the unchanged
+// authoritative validator: the scanner only isolates the exact slices.
+func validateRemediationPair(resultBody, evidenceBody []string, expectedRevision string, binding *RemediationBinding) (remediationResultEvaluation, bool) {
+	fields, reason := parseScalarFields(resultBody, remediationResultFields, "remediation result")
+	if reason != "" {
+		return remediationResultEvaluation{}, false
 	}
 	revision := fields["failed_evidence_revision"]
 	evaluation := remediationResultEvaluation{EvidenceRevision: revision}
 	if fields["schema"] != RemediationResultSchema || fields["status"] != "complete" || revision != expectedRevision {
-		return evaluation
+		return evaluation, false
 	}
-	if len(bindings) > 1 {
-		return evaluation
-	}
-	if len(bindings) == 1 {
-		binding := bindings[0]
+	if binding != nil {
 		generation, generationOK := parseNonnegativeInt(fields["generation"])
 		fixBatch, fixBatchOK := parseNonnegativeInt(fields["fix_batch"])
 		if fields["lineage_id"] != binding.LineageID || !generationOK || generation != binding.Generation || !fixBatchOK || fixBatch != binding.FixBatch {
-			return evaluation
+			return evaluation, false
 		}
 	}
 	if fields["focused_tests"] != "passed" || fields["rollback_boundary"] != "recorded" {
-		return evaluation
+		return evaluation, false
 	}
 	if fields["runtime_harness"] != "passed" && fields["runtime_harness"] != "not_applicable" {
-		return evaluation
+		return evaluation, false
 	}
-	evidence, ok := parseRemediationEvidence(lines[end+1:])
+	evidence, ok := parseRemediationEvidence(evidenceBody)
 	if !ok || evidence.FailedEvidenceRevision != expectedRevision || len(evidence.Commands) == 0 {
-		return evaluation
+		return evaluation, false
 	}
-	if len(bindings) == 1 {
-		binding := bindings[0]
+	if binding != nil {
 		if evidence.LineageID != binding.LineageID || evidence.Generation != binding.Generation || evidence.FixBatch != binding.FixBatch {
-			return evaluation
+			return evaluation, false
 		}
 	}
 	for _, command := range evidence.Commands {
 		if command.ExitCode != 0 || !isConcreteEvidence(command.Command) || !isConcreteEvidence(command.Result) {
-			return evaluation
+			return evaluation, false
 		}
 	}
 	if evidence.RuntimeHarness.Status != fields["runtime_harness"] {
-		return evaluation
+		return evaluation, false
 	}
 	switch evidence.RuntimeHarness.Status {
 	case "passed":
 		if !isConcreteEvidence(evidence.RuntimeHarness.Command) || !isConcreteEvidence(evidence.RuntimeHarness.Result) || strings.TrimSpace(evidence.RuntimeHarness.NAReason) != "" {
-			return evaluation
+			return evaluation, false
 		}
 	case "not_applicable":
 		if evidence.RuntimeHarness.Command != "" || evidence.RuntimeHarness.Result != "" || !isConcreteNAReason(evidence.RuntimeHarness.NAReason) {
-			return evaluation
+			return evaluation, false
 		}
 	default:
-		return evaluation
+		return evaluation, false
 	}
 	if !isConcreteEvidence(evidence.Rollback.Boundary) || !isConcreteEvidence(evidence.Rollback.Evidence) {
-		return evaluation
+		return evaluation, false
 	}
 	evaluation.Complete = true
-	return evaluation
+	return evaluation, true
 }
 
 func parseRemediationEvidence(lines []string) (remediationEvidence, bool) {


### PR DESCRIPTION
## Summary

Closes #1767

`parseRemediationResult` required the first non-empty line of the artifact to be a fenced YAML envelope, and `parseRemediationEvidence` required its JSON fence to consume all remaining content. A cumulative `apply-progress.md` — as required by the shipped `sdd-apply` skill — therefore could never complete remediation: `nextRecommended` stayed `remediate` forever, and the only parser-accepted file shape destroyed prior implementation evidence.

This PR keeps the strict result/evidence semantic validators authoritative and unchanged, and replaces the leading-envelope requirement with a terminal pair locator over cumulative Markdown:

- locates ONE terminal strict YAML-result/JSON-evidence pair matching the requested failed revision + lineage + generation + fix batch;
- allows earlier complete remediation history only when its full identity differs;
- rejects an earlier duplicate claim matching the current identity in any form — YAML, legacy JSON-result, blockquoted, and nested-blockquoted;
- skips unrelated closed fences and inline fence prose.

## Tests

- `go test ./internal/sddstatus/ -run TestParseRemediationResult`: 7/7 pass (2 pre-existing + 5 new).
- New coverage: cumulative happy path (legal history + terminal pair), same-identity duplicate, non-terminal matching pair, blockquoted duplicate, legacy JSON-result duplicate.
- `go test ./...`: the only failures are identical on clean `main` — `TestReviewOfferDeclineNeverBlocksArchiveAtTheProjectionLevel`, `TestReviewOfferPresentAndArchiveReadyForAGenuinelyMissingReceipt`, `TestRuntimeDisabledUnmanagedRemediationConsumesTheOnlyRemainingAttempt`. Cause verified: this machine has RDD review mode disabled globally (`gentle-ai review mode status` reports `off (decided by global)`), which those review-offer tests depend on. Pre-existing, unrelated to this change.
- Benchmark validation (driven mode, CI parity from `.github/workflows/ci.yml`):
  - `bench/` harness built with `go build`; declarations `go vet ./... && go test ./...` pass.
  - Product binary `go build -trimpath ./cmd/gentle-ai`.
  - Core portable: 9 required journeys completed exactly once (j51, j52, j53, j54, j55, j56, j58, j81, j75).
  - `--axis transition`: 11/11 journeys completed (tr01–tr11).
  - Source-coupled j57: `unsupported` untagged, `completed` with `-tags bench_fixture`.
- E2E (Docker): CI-executed; local run not part of this parser-only change's surface (Docker is available locally and a local run can be provided on request).

## Commit

`fix(sdd): accept cumulative apply-progress in remediation parser` — conventional commit, single work unit (code + tests together).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remediation-result parsing across cumulative progress updates.
  - Added support for YAML claims with adjacent JSON evidence, including blockquoted and legacy formats.
  - Ignores unrelated fenced content and inline prose.
  - Rejects duplicate, ambiguous, unrelated, or non-terminal matching evidence.
  - Validates remediation identity and completion status more reliably.
  - Fails closed when evidence fences are incomplete or malformed.

- **Tests**
  - Added coverage for terminal completion, identity validation, duplicate detection, cumulative updates, and multiple evidence formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->