### PR TITLE
fix(review): preserve recovery selector replay

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -13,6 +13,12 @@ import (
 // needs before it will emit next_transition.
 const reviewContract = "gentle-ai.review-integration/v1"
 
+type negotiatedArgument struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Token string `json:"token"`
+}
+
 // statusEnvelope is the subset of `review status --next-transition` this
 // benchmark reads. Unknown fields are ignored so older and newer envelopes
 // both parse.
@@ -34,14 +40,11 @@ type statusEnvelope struct {
 		ReasonCode string `json:"reason_code"`
 		Collect    struct {
 			Inputs []struct {
-				Name             string `json:"name"`
-				CaptureOperation string `json:"capture_operation"`
-				Arguments        []struct {
-					Name  string `json:"name"`
-					Value string `json:"value"`
-					Token string `json:"token"`
-				} `json:"arguments"`
-				ArtifactSubject struct {
+				Name              string               `json:"name"`
+				CaptureOperation  string               `json:"capture_operation"`
+				Arguments         []negotiatedArgument `json:"arguments"`
+				SelectorArguments []negotiatedArgument `json:"selector_arguments"`
+				ArtifactSubject   struct {
 					SubjectHash string `json:"subject_hash"`
 				} `json:"artifact_subject"`
 				ChangedPathManifest []struct {
@@ -50,13 +53,10 @@ type statusEnvelope struct {
 			} `json:"inputs"`
 		} `json:"collect"`
 		Execute struct {
-			Operation string `json:"operation"`
-			Command   string `json:"command"`
-			Arguments []struct {
-				Name  string `json:"name"`
-				Value string `json:"value"`
-				Token string `json:"token"`
-			} `json:"arguments"`
+			Operation         string               `json:"operation"`
+			Command           string               `json:"command"`
+			Arguments         []negotiatedArgument `json:"arguments"`
+			SelectorArguments []negotiatedArgument `json:"selector_arguments"`
 		} `json:"execute"`
 	} `json:"next_transition"`
 }
@@ -627,6 +627,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, reviewedSupersetJourneys()...)
 	journeys = append(journeys, stagedDeliveryJourneys()...)
 	journeys = append(journeys, managedAssetJourneys()...)
+	journeys = append(journeys, recoverySelectorReplayJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -44,6 +44,7 @@ func journeySources() []journeySource {
 		{"journeys_reviewed_superset.go", reviewedSupersetJourneys()},
 		{"journeys_staged_delivery.go", stagedDeliveryJourneys()},
 		{"journeys_managed_assets.go", managedAssetJourneys()},
+		{"journeys_recovery_selector_replay.go", recoverySelectorReplayJourneys()},
 	}
 }
 

--- a/bench/journeys_recovery_selector_replay.go
+++ b/bench/journeys_recovery_selector_replay.go
@@ -1,0 +1,43 @@
+package main
+
+import "fmt"
+
+func recoverySelectorReplayJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j86-recovery-authorization-preserves-selectors",
+			Title:  "Recovery authorization preserves the exact staged target through printed execution",
+			Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/1972",
+			Steps: []Step{
+				{Name: "fixture: linked worktree and remote", Fixture: linkedWorktreeWithRemote},
+				{Name: "fixture: commit base-diff candidate", Fixture: commitStagedRecoveryCandidate},
+				{Name: "start workspace-projected base-diff review", Requires: statusCapability, Composite: startStagedRecoveryReview},
+				{Name: "capture blocker on predecessor", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
+					return captureCorrectableFindingFor(r, stagedPredecessorSelectors(r.sandbox)...)
+				}},
+				{Name: "enter correction-required", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", stagedRecoveryLineage, "--captured-results=true")},
+				{Name: "forecast correction", Requires: finalizeCorrectionCapability, Args: productArgs("review", "finalize", "--lineage", stagedRecoveryLineage, "--correction-lines", "3")},
+				{Name: "fixture: exact staged correction", Fixture: stageExpandedCorrection},
+				{Name: "collect, replay, and execute exact selectors", Requires: recoverCapability, Composite: recoverStagedCorrection},
+			},
+		},
+	}
+}
+
+func startStagedRecoveryReview(r *journeyRun) error {
+	envelope, err := readStatusFor(r, "--lineage", stagedRecoveryLineage, "--base-ref", r.sandbox.Scratch["staged-recovery-base"])
+	if err != nil {
+		return err
+	}
+	if envelope.NextTransition.Kind != "execute" {
+		return fmt.Errorf("expected an execute review.start transition for the staged recovery base-diff candidate, got %q", envelope.NextTransition.Kind)
+	}
+	started, err := runPrintedTransition(r, envelope)
+	if err != nil {
+		return err
+	}
+	if started.ExitCode != 0 {
+		return fmt.Errorf("negotiated staged base-diff start failed: exit=%d stderr=%s", started.ExitCode, started.Stderr)
+	}
+	return nil
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -36,7 +36,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 			want[journey.ID] = true
 		}
 	}
-	// 85 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
+	// 88 since j76-claude-advisory-result-reaches-delivery (#2692, #2566),
 	// j77-capture-result-input-preflight-is-read-only (#2630 D2),
 	// j78-lens-finding-id-prefix-discovery (#1844), j79-consecutive-rescope-
 	// refuses-before-publication (#2830), and j80-rescope-authorized-evidence-
@@ -46,8 +46,9 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// j82 proves #2127's reviewed full candidate can publish an unpublished
 	// monotonic subset without reopening review.
 	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base
-	// while the advertised main ref remains a moving publication boundary. j87
-	// proves #2871's correction binds the immutable failure across a later interrupt;
+	// while the advertised main ref remains a moving publication boundary. j86
+	// proves #1972's recovery authorization collect preserves selectors through execute;
+	// j87 proves #2871's correction binds the immutable failure across a later interrupt;
 	// j88 proves #2843's unborn STATUS collects explicit untracked intent first;
 	// j89 proves #2758 never offers a workspace receipt for a different index;
 	// j93 proves #2822 classifies stale managed assets before START can persist.
@@ -60,8 +61,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	//
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 87 {
-		t.Errorf("core journey count = %d, want 87", got)
+	if got := len(seen); got != 88 {
+		t.Errorf("core journey count = %d, want 88", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -77,9 +77,10 @@ type waveCorrectionStatus struct {
 		ReasonCode string `json:"reason_code"`
 		Collect    *struct {
 			Inputs []struct {
-				Name             string                    `json:"name"`
-				CaptureOperation string                    `json:"capture_operation"`
-				Submission       *waveSubmissionDescriptor `json:"submission"`
+				Name              string                    `json:"name"`
+				CaptureOperation  string                    `json:"capture_operation"`
+				SelectorArguments []negotiatedArgument      `json:"selector_arguments"`
+				Submission        *waveSubmissionDescriptor `json:"submission"`
 			} `json:"inputs"`
 		} `json:"collect"`
 		Execute *struct {
@@ -391,18 +392,32 @@ func recoverStagedCorrection(r *journeyRun) error {
 	if err := decodeWaveObservation(probeObservation, &probe, "staged recovery probe"); err != nil {
 		return err
 	}
-	if probe.Authority == nil || probe.Action != "recover" || probe.ActionDisposition != "scope_changed" || probe.NextTransition == nil || probe.NextTransition.Kind != "collect" {
+	if probe.Authority == nil || probe.Action != "recover" || probe.ActionDisposition != "scope_changed" || probe.NextTransition == nil || probe.NextTransition.Kind != "collect" || probe.NextTransition.Collect == nil || len(probe.NextTransition.Collect.Inputs) != 1 {
 		return fmt.Errorf("staged recovery was not negotiated: %+v", probe)
+	}
+	wantSelectors := "base-ref=" + r.sandbox.Scratch["staged-recovery-base"] + "\nprojection=staged\nworkspace-overlay=true"
+	if err := requireRecoverySelectorReplay("authorization collect", probe.NextTransition.Collect.Inputs[0].SelectorArguments, wantSelectors); err != nil {
+		return err
 	}
 	const actor, reason = "bench-maintainer", "authorize staged correction scope expansion"
 	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + stagedRecoveryLineage +
 		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
 		"\nsuccessor_lineage=" + stagedSuccessorLineage + "\nactor=" + actor + "\nreason=" + reason
-	authorized := append(selectors, "--recovery-successor-lineage", stagedSuccessorLineage, "--recovery-reason", reason,
+	authorized := []string{"--lineage", stagedRecoveryLineage}
+	for _, selector := range probe.NextTransition.Collect.Inputs[0].SelectorArguments {
+		if selector.Token != "" {
+			return fmt.Errorf("authorization collect tokenized selector %q", selector.Name)
+		}
+		authorized = append(authorized, "--"+selector.Name+"="+selector.Value)
+	}
+	authorized = append(authorized, "--recovery-successor-lineage", stagedSuccessorLineage, "--recovery-reason", reason,
 		"--recovery-actor", actor, "--recovery-authorization", authorization)
 	envelope, err := readStatusFor(r, authorized...)
 	if err != nil || envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
 		return fmt.Errorf("authorized staged recovery is not executable: %+v, %v", envelope.NextTransition, err)
+	}
+	if err := requireRecoverySelectorReplay("authorized execute", envelope.NextTransition.Execute.SelectorArguments, wantSelectors); err != nil {
+		return err
 	}
 	recovered, err := runPrintedTransition(r, envelope)
 	if err != nil {
@@ -416,6 +431,20 @@ func recoverStagedCorrection(r *journeyRun) error {
 	if err != nil || fresh.Authority.LineageID != stagedSuccessorLineage || fresh.Authority.State != "reviewing" ||
 		fresh.NextTransition.Kind != "collect" || strings.Join(fresh.paths(), "\x00") != "candidate.go\x00migration.sql" {
 		return fmt.Errorf("successor did not start a fresh exact-overlay review: %+v, %v", fresh, err)
+	}
+	return nil
+}
+
+func requireRecoverySelectorReplay(stage string, arguments []negotiatedArgument, want string) error {
+	values := make([]string, len(arguments))
+	for index, argument := range arguments {
+		if argument.Token != "" {
+			return fmt.Errorf("%s tokenized selector %q", stage, argument.Name)
+		}
+		values[index] = argument.Name + "=" + argument.Value
+	}
+	if got := strings.Join(values, "\n"); got != want {
+		return fmt.Errorf("%s selectors = %q, want %q", stage, got, want)
 	}
 	return nil
 }
@@ -1315,23 +1344,7 @@ func waveOneJourneys() []Journey {
 				// derived lineage name into the printed execute transition,
 				// so stagedRecoveryLineage still names the review every
 				// later step in this journey references.
-				{Name: "start workspace-projected base-diff review", Requires: statusCapability, Composite: func(r *journeyRun) error {
-					envelope, err := readStatusFor(r, "--lineage", stagedRecoveryLineage, "--base-ref", r.sandbox.Scratch["staged-recovery-base"])
-					if err != nil {
-						return err
-					}
-					if envelope.NextTransition.Kind != "execute" {
-						return fmt.Errorf("expected an execute review.start transition for the staged recovery base-diff candidate, got %q", envelope.NextTransition.Kind)
-					}
-					started, err := runPrintedTransition(r, envelope)
-					if err != nil {
-						return err
-					}
-					if started.ExitCode != 0 {
-						return fmt.Errorf("negotiated staged base-diff start failed: exit=%d stderr=%s", started.ExitCode, started.Stderr)
-					}
-					return nil
-				}},
+				{Name: "start workspace-projected base-diff review", Requires: statusCapability, Composite: startStagedRecoveryReview},
 				{Name: "capture blocker on predecessor", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
 					return captureCorrectableFindingFor(r, stagedPredecessorSelectors(r.sandbox)...)
 				}},

--- a/contracts/review-integration/v1/schemas/status-v2.schema.json
+++ b/contracts/review-integration/v1/schemas/status-v2.schema.json
@@ -152,6 +152,7 @@
       "properties": {
         "name": { "type": "string", "pattern": "^[a-z0-9_]+$" }, "schema": { "type": "string", "minLength": 1 }, "capture_operation": { "type": "string", "minLength": 1 },
         "arguments": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
         "artifact_subject": { "$ref": "artifact-subject.schema.json" },
         "candidate_diff": { "$ref": "start-v2.schema.json#/$defs/frozen_candidate_diff" },
         "changed_path_manifest": { "type": "array", "uniqueItems": true, "items": { "$ref": "start-v2.schema.json#/$defs/changed_path" } },

--- a/contracts/review-integration/v1/schemas/status-v2.schema.json
+++ b/contracts/review-integration/v1/schemas/status-v2.schema.json
@@ -114,6 +114,7 @@
       "type": "object", "additionalProperties": false, "required": ["name", "value"],
       "properties": { "name": { "type": "string", "pattern": "^[a-z0-9_-]+$" }, "value": { "type": "string", "minLength": 1 }, "token": { "type": "string", "minLength": 1 } }
     },
+    "selector_argument": { "$comment": "Normalized selector echo; token is forbidden because selector arguments are never argv.", "allOf": [{ "$ref": "#/$defs/transition_argument" }, { "not": { "required": ["token"] } }] },
     "executable_transition_argument": {
       "$comment": "One argv entry of an execute transition. Unlike preconditions and selector_arguments -- which are assertions and a normalized echo the product never tokenizes -- an execute argument is always literally executed, so its exact runnable token is required rather than optional.",
       "allOf": [{ "$ref": "#/$defs/transition_argument" }],
@@ -129,7 +130,7 @@
         "operation": { "enum": ["review.start", "review.finalize", "review.recover", "review.repair", "review.validate"] },
         "command": { "$comment": "The complete, literally runnable command line for this transition, e.g. \"gentle-ai review start --contract=... --target=...\". Operation alone is a dotted logical name; command is what a caller can paste. Argument words are the execute arguments' own tokens, in order, POSIX-shell-quoted only when a value would otherwise be word-split.", "type": "string", "minLength": 1, "pattern": "^gentle-ai review [a-z][a-z-]*" },
         "arguments": { "type": "array", "items": { "$ref": "#/$defs/executable_transition_argument" } },
-        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/selector_argument" } },
         "preconditions": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
         "binding": { "$ref": "#/$defs/transition_binding" },
         "artifacts": { "type": "array", "items": { "$ref": "#/$defs/transition_artifact" } }
@@ -152,7 +153,7 @@
       "properties": {
         "name": { "type": "string", "pattern": "^[a-z0-9_]+$" }, "schema": { "type": "string", "minLength": 1 }, "capture_operation": { "type": "string", "minLength": 1 },
         "arguments": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
-        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/selector_argument" } },
         "artifact_subject": { "$ref": "artifact-subject.schema.json" },
         "candidate_diff": { "$ref": "start-v2.schema.json#/$defs/frozen_candidate_diff" },
         "changed_path_manifest": { "type": "array", "uniqueItems": true, "items": { "$ref": "start-v2.schema.json#/$defs/changed_path" } },

--- a/contracts/review-integration/v1/schemas/status.schema.json
+++ b/contracts/review-integration/v1/schemas/status.schema.json
@@ -97,6 +97,7 @@
       "type": "object", "additionalProperties": false, "required": ["name", "value"],
       "properties": { "name": { "type": "string", "pattern": "^[a-z0-9_-]+$" }, "value": { "type": "string", "minLength": 1 }, "token": { "type": "string", "minLength": 1 } }
     },
+    "selector_argument": { "$comment": "Normalized selector echo; token is forbidden because selector arguments are never argv.", "allOf": [{ "$ref": "#/$defs/transition_argument" }, { "not": { "required": ["token"] } }] },
     "executable_transition_argument": {
       "$comment": "One argv entry of an execute transition. Unlike preconditions and selector_arguments -- which are assertions and a normalized echo the product never tokenizes -- an execute argument is always literally executed, so its exact runnable token is required rather than optional.",
       "allOf": [{ "$ref": "#/$defs/transition_argument" }],
@@ -112,7 +113,7 @@
         "operation": { "enum": ["review.start", "review.finalize", "review.recover", "review.validate"] },
         "command": { "$comment": "The complete, literally runnable command line for this transition, e.g. \"gentle-ai review start --contract=... --target=...\". Operation alone is a dotted logical name; command is what a caller can paste. Argument words are the execute arguments' own tokens, in order, POSIX-shell-quoted only when a value would otherwise be word-split.", "type": "string", "minLength": 1, "pattern": "^gentle-ai review [a-z][a-z-]*" },
         "arguments": { "type": "array", "items": { "$ref": "#/$defs/executable_transition_argument" } },
-        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/selector_argument" } },
         "preconditions": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
         "binding": { "$ref": "#/$defs/transition_binding" },
         "artifacts": { "type": "array", "items": { "$ref": "#/$defs/transition_artifact" } }
@@ -135,7 +136,7 @@
       "properties": {
         "name": { "type": "string", "pattern": "^[a-z0-9_]+$" }, "schema": { "type": "string", "minLength": 1 }, "capture_operation": { "type": "string", "minLength": 1 },
         "arguments": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
-        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/selector_argument" } },
         "validation_request": { "$ref": "targeted-validation-request.schema.json" }
       },
       "allOf": [

--- a/contracts/review-integration/v1/schemas/status.schema.json
+++ b/contracts/review-integration/v1/schemas/status.schema.json
@@ -135,6 +135,7 @@
       "properties": {
         "name": { "type": "string", "pattern": "^[a-z0-9_]+$" }, "schema": { "type": "string", "minLength": 1 }, "capture_operation": { "type": "string", "minLength": 1 },
         "arguments": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
         "validation_request": { "$ref": "targeted-validation-request.schema.json" }
       },
       "allOf": [

--- a/contracts/review-integration/v2/schemas/status-v4.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v4.schema.json
@@ -73,7 +73,7 @@
         "schema": {"type": "string", "minLength": 1},
         "capture_operation": {"type": "string", "minLength": 1},
         "arguments": {"type": "array", "minItems": 1, "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
-        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
+        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/selector_argument"}},
         "submission": {"$ref": "#/$defs/submission_descriptor"},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},

--- a/contracts/review-integration/v2/schemas/status-v4.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v4.schema.json
@@ -73,6 +73,7 @@
         "schema": {"type": "string", "minLength": 1},
         "capture_operation": {"type": "string", "minLength": 1},
         "arguments": {"type": "array", "minItems": 1, "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
+        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
         "submission": {"$ref": "#/$defs/submission_descriptor"},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},

--- a/contracts/review-integration/v2/schemas/status-v5.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v5.schema.json
@@ -73,7 +73,7 @@
         "schema": {"type": "string", "minLength": 1},
         "capture_operation": {"type": "string", "minLength": 1},
         "arguments": {"type": "array", "minItems": 1, "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
-        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
+        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/selector_argument"}},
         "submission": {"oneOf": [{"$ref": "#/$defs/submission_descriptor"}, {"$ref": "#/$defs/capture_evidence_submission_descriptor"}]},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},

--- a/contracts/review-integration/v2/schemas/status-v5.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v5.schema.json
@@ -73,6 +73,7 @@
         "schema": {"type": "string", "minLength": 1},
         "capture_operation": {"type": "string", "minLength": 1},
         "arguments": {"type": "array", "minItems": 1, "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
+        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
         "submission": {"oneOf": [{"$ref": "#/$defs/submission_descriptor"}, {"$ref": "#/$defs/capture_evidence_submission_descriptor"}]},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},

--- a/contracts/review-integration/v2/schemas/status.schema.json
+++ b/contracts/review-integration/v2/schemas/status.schema.json
@@ -63,6 +63,7 @@
           "type": "array", "minItems": 1,
           "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}
         },
+        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},
         "candidate_tree": {"$ref": "#/$defs/git_tree"},

--- a/contracts/review-integration/v2/schemas/status.schema.json
+++ b/contracts/review-integration/v2/schemas/status.schema.json
@@ -63,7 +63,7 @@
           "type": "array", "minItems": 1,
           "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}
         },
-        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
+        "selector_arguments": {"type": "array", "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/selector_argument"}},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},
         "candidate_tree": {"$ref": "#/$defs/git_tree"},

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1161,7 +1161,14 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	baseDiff := predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseDiff
 	overlay := predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseWorkspaceOverlay
 	explicitOverlayBase := overlay && base != "" && !*committedOnly
-	ordinaryScopeOverlay := *workspaceOverlay && overlay && base != "" && !*committedOnly && strings.TrimSpace(*projectionFlag) == string(reviewtransaction.ProjectionWorkspace)
+	projection := facadeProjection(predecessorRecord.State.InitialSnapshot.Projection)
+	if selected := strings.TrimSpace(*projectionFlag); selected != "" {
+		projection = reviewtransaction.Projection(selected)
+		if projection != reviewtransaction.ProjectionWorkspace && projection != reviewtransaction.ProjectionStaged {
+			return fmt.Errorf("unsupported review recovery projection %q", selected)
+		}
+	}
+	ordinaryScopeOverlay := *workspaceOverlay && overlay && base != "" && !*committedOnly && projection == reviewtransaction.ProjectionWorkspace
 	stagedScopeOverlay := *workspaceOverlay && !ordinaryScopeOverlay
 	if *releaseScope && (base != "" || *committedOnly || *workspaceOverlay) {
 		return errors.New("--release-scope cannot be combined with --base-ref, --committed-only, or --workspace-overlay")
@@ -1172,19 +1179,12 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	if *releaseScope && predecessorRecord.State.InitialSnapshot.Kind != reviewtransaction.TargetCurrentChanges {
 		return errors.New("--release-scope requires a current-changes predecessor")
 	}
-	if stagedScopeOverlay && (!(baseDiff || overlay && predecessorRecord.State.State == reviewtransaction.StateInvalidated && predecessorRecord.State.InitialSnapshot.Projection == reviewtransaction.ProjectionStaged) || base == "" || *committedOnly || strings.TrimSpace(*projectionFlag) != string(reviewtransaction.ProjectionStaged)) {
+	if stagedScopeOverlay && (!(baseDiff || overlay && predecessorRecord.State.State == reviewtransaction.StateInvalidated && predecessorRecord.State.InitialSnapshot.Projection == reviewtransaction.ProjectionStaged) || base == "" || *committedOnly || projection != reviewtransaction.ProjectionStaged) {
 		return errors.New("--workspace-overlay recovery requires a base-diff predecessor, --base-ref, and --projection staged without --committed-only")
 	}
 	if !*releaseScope && !stagedScopeOverlay &&
 		(*committedOnly != (base != "")) && !explicitOverlayBase {
 		return errors.New("base-diff recovery requires matching --base-ref and --committed-only")
-	}
-	projection := predecessorRecord.State.InitialSnapshot.Projection
-	if selected := strings.TrimSpace(*projectionFlag); selected != "" {
-		projection = reviewtransaction.Projection(selected)
-		if projection != reviewtransaction.ProjectionWorkspace && projection != reviewtransaction.ProjectionStaged {
-			return fmt.Errorf("unsupported review recovery projection %q", selected)
-		}
 	}
 	// Issue #2394: a recovery successor declares scope exactly the way a fresh
 	// START does, so it never re-sweeps the worktree either.

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1120,7 +1120,7 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus; large pure documentation always uses readability")
 	baseRef := flags.String("base-ref", "", "optional base revision for immutable base-to-HEAD review")
 	committedOnly := flags.Bool("committed-only", false, "acknowledge that --base-ref excludes dirty tracked changes")
-	workspaceOverlay := flags.Bool("workspace-overlay", false, "recover an approved base-diff into the exact staged index over --base-ref")
+	workspaceOverlay := flags.Bool("workspace-overlay", false, "replay the exact workspace-overlay recovery target over --base-ref")
 	releaseScope := flags.Bool("release-scope", false, "recover an approved current-changes review into the immutable HEAD first-parent release scope")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
@@ -1161,8 +1161,9 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	baseDiff := predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseDiff
 	overlay := predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseWorkspaceOverlay
 	explicitOverlayBase := overlay && base != "" && !*committedOnly
-	stagedScopeOverlay := *workspaceOverlay
-	if *releaseScope && (base != "" || *committedOnly || stagedScopeOverlay) {
+	ordinaryScopeOverlay := *workspaceOverlay && overlay && base != "" && !*committedOnly && strings.TrimSpace(*projectionFlag) == string(reviewtransaction.ProjectionWorkspace)
+	stagedScopeOverlay := *workspaceOverlay && !ordinaryScopeOverlay
+	if *releaseScope && (base != "" || *committedOnly || *workspaceOverlay) {
 		return errors.New("--release-scope cannot be combined with --base-ref, --committed-only, or --workspace-overlay")
 	}
 	if *releaseScope && reviewtransaction.RecoveryDisposition(*disposition) != reviewtransaction.RecoveryScopeChanged {

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -793,9 +793,10 @@ func (selector reviewTransitionSelector) recoveryArguments() ([]ReviewTransition
 	arguments := []ReviewTransitionArgument{}
 	switch target.Kind {
 	case reviewtransaction.TargetCurrentChanges:
-		if target.Projection == reviewtransaction.ProjectionStaged {
-			arguments = append(arguments, ReviewTransitionArgument{Name: "projection", Value: string(target.Projection)})
+		if target.Projection != reviewtransaction.ProjectionWorkspace && target.Projection != reviewtransaction.ProjectionStaged {
+			return nil, false
 		}
+		arguments = append(arguments, ReviewTransitionArgument{Name: "projection", Value: string(target.Projection)})
 	case reviewtransaction.TargetBaseDiff:
 		if target.BaseRef == "" || target.Projection != reviewtransaction.ProjectionWorkspace {
 			return nil, false

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -52,6 +52,7 @@ type ReviewTransitionInput struct {
 	Schema              string                                        `json:"schema"`
 	CaptureOperation    string                                        `json:"capture_operation"`
 	Arguments           []ReviewTransitionArgument                    `json:"arguments"`
+	SelectorArguments   *[]ReviewTransitionArgument                   `json:"selector_arguments,omitempty"`
 	Submission          *ReviewTransitionSubmission                   `json:"submission,omitempty"`
 	ArtifactSubject     *reviewtransaction.ArtifactSubject            `json:"artifact_subject,omitempty"`
 	CandidateDiff       *reviewtransaction.FrozenCandidateDiff        `json:"candidate_diff,omitempty"`
@@ -743,6 +744,7 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 		disposition = reviewtransaction.RecoveryInvalidated
 	}
 	var selectorArguments []ReviewTransitionArgument
+	var selectorReplay *[]ReviewTransitionArgument
 	// The core has already narrowed this to the evidence-bound,
 	// accounting-only edge. It is the only selector-free recovery.
 	if input.Selector != nil && !input.Selector.SelectorFreeAccountingOnlyRecovery {
@@ -766,18 +768,17 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 				CaptureOperation: "external.select_recovery_target", Arguments: reviewTargetArguments(status),
 			})
 		}
+		selectorReplay = reviewTransitionSelectorArguments(selectorArguments)
 	}
 	if input.recoveryAuthorized(binding) {
 		arguments := []ReviewTransitionArgument{{Name: "predecessor-lineage", Value: binding.LineageID}, {Name: "expected-predecessor-revision", Value: binding.Revision}, {Name: "successor-lineage", Value: input.Successor}, {Name: "disposition", Value: string(disposition)}, {Name: "reason", Value: input.Reason}, {Name: "actor", Value: input.Actor}, {Name: "maintainer-authorization", Value: input.Authorization}}
 		transition := reviewExecuteTransition("recovery_authorized", "review.recover", append(arguments, selectorArguments...), []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
-		if input.Selector != nil && !input.Selector.SelectorFreeAccountingOnlyRecovery {
-			transition.Execute.SelectorArguments = reviewTransitionSelectorArguments(selectorArguments)
-		}
+		transition.Execute.SelectorArguments = selectorReplay
 		return transition
 	}
 	return reviewCollectTransition("recovery_authorization_required", ReviewTransitionInput{
 		Name: "recovery_authorization", Schema: "gentle-ai.review-recovery-authorization/v1", CaptureOperation: "external.authorize_recovery",
-		Arguments: append(reviewBindingArguments(binding), ReviewTransitionArgument{Name: "disposition", Value: string(disposition)}),
+		Arguments: append(reviewBindingArguments(binding), ReviewTransitionArgument{Name: "disposition", Value: string(disposition)}), SelectorArguments: selectorReplay,
 	})
 }
 
@@ -805,14 +806,20 @@ func (selector reviewTransitionSelector) recoveryArguments() ([]ReviewTransition
 			return nil, false
 		}
 		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: target.BaseRef})
-		if target.Projection == reviewtransaction.ProjectionStaged {
+		switch target.Projection {
+		case reviewtransaction.ProjectionStaged:
 			arguments = append(arguments,
 				ReviewTransitionArgument{Name: "projection", Value: string(reviewtransaction.ProjectionStaged)},
 				ReviewTransitionArgument{Name: "workspace-overlay", Value: "true"},
 			)
-			return arguments, true
+		case reviewtransaction.ProjectionWorkspace:
+			arguments = append(arguments,
+				ReviewTransitionArgument{Name: "projection", Value: string(reviewtransaction.ProjectionWorkspace)},
+				ReviewTransitionArgument{Name: "workspace-overlay", Value: "true"},
+			)
+		default:
+			return nil, false
 		}
-		arguments = append(arguments, ReviewTransitionArgument{Name: "workspace-overlay", Value: "true"})
 	default:
 		return nil, false
 	}

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -799,7 +799,7 @@ func validateAgainstPublishedNextTransitionSchemaV5(t *testing.T, payload []byte
 // deliberately excluding the top-level schema's "projection" property so
 // compiling never touches projection.schema.json's RE2-incompatible
 // negative-lookahead regex (see the comment above the v1 wrapper).
-func validateAgainstPublishedStatusNextTransitionSchema(t *testing.T, version, schemaFile string, payload []byte) {
+func validateAgainstPublishedStatusNextTransitionSchema(t *testing.T, version, schemaFile string, payload []byte, reject ...bool) {
 	t.Helper()
 	root, err := filepath.Abs(filepath.Join("..", "..", "contracts", "review-integration"))
 	if err != nil {
@@ -870,8 +870,15 @@ func validateAgainstPublishedStatusNextTransitionSchema(t *testing.T, version, s
 	if err := json.Unmarshal(payload, &document); err != nil {
 		t.Fatal(err)
 	}
-	if err := schema.Validate(document); err != nil {
-		t.Fatalf("published next_transition schema (%s) rejected the emitted transition: %v", schemaFile, err)
+	validationErr := schema.Validate(document)
+	if len(reject) != 0 {
+		if validationErr == nil {
+			t.Fatalf("published next_transition schema (%s) accepted a tokenized selector", schemaFile)
+		}
+		return
+	}
+	if validationErr != nil {
+		t.Fatalf("published next_transition schema (%s) rejected the emitted transition: %v", schemaFile, validationErr)
 	}
 }
 

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -33,8 +33,8 @@ func TestReviewProviderArtifactV1ContractsArePinned(t *testing.T) {
 		"schemas/result-artifact.schema.json":    "91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6",
 		"schemas/start.schema.json":              "4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229",
 		"schemas/start-v2.schema.json":           "ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c",
-		"schemas/status.schema.json":             "250d2c646b8822b38eaefafd2bfdefa1134cc23a00e553a7201f33257573149a",
-		"schemas/status-v2.schema.json":          "dd9914b647a1d9edc4ecdcbed4f0c800b39ec290912d5c2a4cc6ba3098d5f21e",
+		"schemas/status.schema.json":             "c7eb1137a1b1e0bd400de807b8d3c12c46774227a20d4659347b2b05524926e3",
+		"schemas/status-v2.schema.json":          "08559976579b7f55ef5e2901cf6cb2411a82f9ac5675a04c203436dc7f467498",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -56,7 +56,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 		"fixtures/status.fixture.json":       "d5438578f2969f17635fecea94c7ef46d14c78fa668e50df48c4254254d5e935",
 		"schemas/capabilities.schema.json":   "7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248",
 		"schemas/consent.schema.json":        "b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858",
-		"schemas/status.schema.json":         "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+		"schemas/status.schema.json":         "662648111761b7ed8f9ce1bb1b3150ebfe60427032df956fd87872b472a67b06",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -80,7 +80,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		"fixtures/consent-v3.fixture.json":      "feb1dc7705f7da6490698ef48021bb7730de154ae23ec73d033d8d96fa996a21",
 		"schemas/capabilities-v2.1.schema.json": "9ede8ebbe3e169cf6ca4f4a6882c9c4e588a6d1073d8e22a155649cd41d38cd0",
 		"schemas/consent-v3.schema.json":        "80915f5f4f43a494826253d1e7251fc463989f41d2cf163a6a52a8b4328c023c",
-		"schemas/status.schema.json":            "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+		"schemas/status.schema.json":            "662648111761b7ed8f9ce1bb1b3150ebfe60427032df956fd87872b472a67b06",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -98,7 +98,7 @@ func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/status-v5.fixture.json": "1a6d002c9691c87e50687f8d5f3e59013e9229d93004028f746bfcda7947d5fc",
-		"schemas/status-v5.schema.json":   "32dd99042d11c06cc4dbc1f9f8396b5e32ea9ded7f2177a97b90398923d282b3",
+		"schemas/status-v5.schema.json":   "4df135f239ae495ac14656ff51622976d35d2cd2b0f49f1e0f2985e12fae177b",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -33,8 +33,8 @@ func TestReviewProviderArtifactV1ContractsArePinned(t *testing.T) {
 		"schemas/result-artifact.schema.json":    "91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6",
 		"schemas/start.schema.json":              "4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229",
 		"schemas/start-v2.schema.json":           "ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c",
-		"schemas/status.schema.json":             "c7eb1137a1b1e0bd400de807b8d3c12c46774227a20d4659347b2b05524926e3",
-		"schemas/status-v2.schema.json":          "08559976579b7f55ef5e2901cf6cb2411a82f9ac5675a04c203436dc7f467498",
+		"schemas/status.schema.json":             "02b536d95b3ddd96a322761b133ce9423b868439cd940f26133c03331722a635",
+		"schemas/status-v2.schema.json":          "f20af2fdab080222e1fe9455cd955b2a0e7ab90cde50cae7ed966ed6e39657c7",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -56,7 +56,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 		"fixtures/status.fixture.json":       "d5438578f2969f17635fecea94c7ef46d14c78fa668e50df48c4254254d5e935",
 		"schemas/capabilities.schema.json":   "7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248",
 		"schemas/consent.schema.json":        "b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858",
-		"schemas/status.schema.json":         "662648111761b7ed8f9ce1bb1b3150ebfe60427032df956fd87872b472a67b06",
+		"schemas/status.schema.json":         "3b7d8d5d04aeb2297e19d703e6c9e68548e82cb826bbee76c894596b773968ec",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -80,7 +80,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		"fixtures/consent-v3.fixture.json":      "feb1dc7705f7da6490698ef48021bb7730de154ae23ec73d033d8d96fa996a21",
 		"schemas/capabilities-v2.1.schema.json": "9ede8ebbe3e169cf6ca4f4a6882c9c4e588a6d1073d8e22a155649cd41d38cd0",
 		"schemas/consent-v3.schema.json":        "80915f5f4f43a494826253d1e7251fc463989f41d2cf163a6a52a8b4328c023c",
-		"schemas/status.schema.json":            "662648111761b7ed8f9ce1bb1b3150ebfe60427032df956fd87872b472a67b06",
+		"schemas/status.schema.json":            "3b7d8d5d04aeb2297e19d703e6c9e68548e82cb826bbee76c894596b773968ec",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -98,7 +98,7 @@ func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/status-v5.fixture.json": "1a6d002c9691c87e50687f8d5f3e59013e9229d93004028f746bfcda7947d5fc",
-		"schemas/status-v5.schema.json":   "4df135f239ae495ac14656ff51622976d35d2cd2b0f49f1e0f2985e12fae177b",
+		"schemas/status-v5.schema.json":   "a1527ef588dfef2469e29ac8e2b845500b628e91cb45473041377846f6a62118",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))

--- a/internal/cli/review_recovery_selector_replay_test.go
+++ b/internal/cli/review_recovery_selector_replay_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -11,13 +10,14 @@ import (
 
 func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.T) {
 	t.Parallel()
-
 	tests := []struct {
 		name     string
 		recovery reviewtransaction.Target
 		want     []ReviewTransitionArgument
 	}{
-		{name: "current changes", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace}, want: []ReviewTransitionArgument{}},
+		{name: "current workspace over staged predecessor", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace}, want: []ReviewTransitionArgument{{Name: "projection", Value: "workspace"}}},
+		{name: "current changes without projection", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges}},
+		{name: "current changes with invalid projection", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: "future"}},
 		{name: "staged projection", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionStaged}, want: []ReviewTransitionArgument{{Name: "projection", Value: "staged"}}},
 		{name: "base diff", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseDiff, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "main"}, want: []ReviewTransitionArgument{{Name: "base-ref", Value: "main"}, {Name: "committed-only", Value: "true"}}},
 		{name: "workspace overlay", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "main"}, want: []ReviewTransitionArgument{{Name: "base-ref", Value: "main"}, {Name: "projection", Value: "workspace"}, {Name: "workspace-overlay", Value: "true"}}},
@@ -26,16 +26,18 @@ func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.want == nil {
+				if _, representable := (reviewTransitionSelector{Recovery: &test.recovery}).recoveryArguments(); representable {
+					t.Fatalf("invalid recovery projection %q was representable", test.recovery.Projection)
+				}
+				return
+			}
 			status := recoverySelectorReplayStatus(t, test.recovery)
-			input := reviewNextTransitionInput{Selector: &reviewTransitionSelector{Recovery: &test.recovery}}
+			input := reviewNextTransitionInput{Selector: &reviewTransitionSelector{Projection: reviewtransaction.ProjectionStaged, Recovery: &test.recovery}}
 			collectedTransition := newReviewNextTransition(status, nil, nil, nil, nil, input)
 			collected := decodeRecoverySelectorReplayTransition(t, collectedTransition)
-			if collected.Kind != reviewNextTransitionCollect || collected.Collect == nil || len(collected.Collect.Inputs) != 1 {
-				t.Fatalf("recovery authorization transition = %#v, want one collect input", collected)
-			}
-			selectors := collected.Collect.Inputs[0].SelectorArguments
-			if selectors == nil || !reflect.DeepEqual(*selectors, test.want) {
-				t.Fatalf("recovery authorization selectors = %#v, want %#v", selectors, test.want)
+			if collected.Kind != reviewNextTransitionCollect || collected.Collect == nil || len(collected.Collect.Inputs) != 1 || collected.Collect.Inputs[0].SelectorArguments == nil || !reflect.DeepEqual(*collected.Collect.Inputs[0].SelectorArguments, test.want) {
+				t.Fatalf("recovery authorization transition = %#v, want selectors %#v", collected, test.want)
 			}
 			if test.name == "staged workspace overlay" {
 				validateRecoverySelectorReplaySchemas(t, collectedTransition)
@@ -56,18 +58,12 @@ func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.
 			input.Authorization = reviewTransitionRecoveryAuthorization(binding, successor, actor, reason)
 			authorizedTransition := newReviewNextTransition(status, nil, nil, nil, nil, input)
 			authorized := decodeRecoverySelectorReplayTransition(t, authorizedTransition)
-			if authorized.Kind != reviewNextTransitionExecute || authorized.Execute == nil {
-				t.Fatalf("authorized recovery transition = %#v, want execute", authorized)
-			}
-			if authorized.Execute.SelectorArguments == nil || !reflect.DeepEqual(*authorized.Execute.SelectorArguments, test.want) {
-				t.Fatalf("authorized recovery selectors = %#v, want %#v", authorized.Execute.SelectorArguments, test.want)
+			if authorized.Kind != reviewNextTransitionExecute || authorized.Execute == nil || authorized.Execute.SelectorArguments == nil || !reflect.DeepEqual(*authorized.Execute.SelectorArguments, test.want) {
+				t.Fatalf("authorized recovery transition = %#v, want execute selectors %#v", authorized, test.want)
 			}
 			arguments, err := reviewTransitionArgumentMap(authorized.Execute.Arguments)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if arguments["maintainer-authorization"] != input.Authorization {
-				t.Fatal("selector replay changed the canonical recovery authorization bytes")
+			if err != nil || arguments["maintainer-authorization"] != input.Authorization {
+				t.Fatalf("selector replay changed the canonical recovery authorization bytes: %v", err)
 			}
 			status.NextTransition = &authorizedTransition
 			if err := status.Validate(); err != nil {
@@ -119,19 +115,12 @@ func recoverySelectorReplayStatus(t *testing.T, recovery reviewtransaction.Targe
 
 func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTransition) {
 	t.Helper()
-	marshal := func(transition ReviewNextTransition) []byte {
-		payload, err := json.Marshal(transition)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return payload
-	}
-	payload := marshal(transition)
+	payload := []byte(mustReviewJSON(t, transition))
 	selector := &(*transition.Collect.Inputs[0].SelectorArguments)[0]
 	selector.Token = "--base-ref=main"
-	tokenized := marshal(transition)
+	tokenized := []byte(mustReviewJSON(t, transition))
 	selector.Token = ""
-	if string(marshal(transition)) != string(payload) {
+	if mustReviewJSON(t, transition) != string(payload) {
 		t.Fatal("tokenized fixture changed more than one selector argument")
 	}
 	for _, schema := range []struct{ version, file string }{
@@ -150,13 +139,7 @@ func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTr
 
 func decodeRecoverySelectorReplayTransition(t *testing.T, transition ReviewNextTransition) ReviewNextTransition {
 	t.Helper()
-	payload, err := json.Marshal(transition)
-	if err != nil {
-		t.Fatal(err)
-	}
 	var decoded ReviewNextTransition
-	if err := json.Unmarshal(payload, &decoded); err != nil {
-		t.Fatal(err)
-	}
+	decodeStrictReviewJSON(t, []byte(mustReviewJSON(t, transition)), &decoded)
 	return decoded
 }

--- a/internal/cli/review_recovery_selector_replay_test.go
+++ b/internal/cli/review_recovery_selector_replay_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"reflect"
@@ -10,20 +9,6 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
-
-type recoverySelectorReplayTransition struct {
-	Kind    string `json:"kind"`
-	Collect *struct {
-		Inputs []struct {
-			Arguments         []ReviewTransitionArgument  `json:"arguments"`
-			SelectorArguments *[]ReviewTransitionArgument `json:"selector_arguments,omitempty"`
-		} `json:"inputs"`
-	} `json:"collect,omitempty"`
-	Execute *struct {
-		Arguments         []ReviewTransitionArgument  `json:"arguments"`
-		SelectorArguments *[]ReviewTransitionArgument `json:"selector_arguments,omitempty"`
-	} `json:"execute,omitempty"`
-}
 
 func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.T) {
 	t.Parallel()
@@ -149,11 +134,21 @@ func recoverySelectorReplayStatus(t *testing.T, recovery reviewtransaction.Targe
 
 func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTransition) {
 	t.Helper()
-	payload, err := json.Marshal(transition)
-	if err != nil {
-		t.Fatal(err)
+	marshal := func(transition ReviewNextTransition) []byte {
+		payload, err := json.Marshal(transition)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return payload
 	}
-	tokenized := bytes.Replace(payload, []byte(`"value":"main"`), []byte(`"value":"main","token":"--base-ref=main"`), 1)
+	payload := marshal(transition)
+	selector := &(*transition.Collect.Inputs[0].SelectorArguments)[0]
+	selector.Token = "--base-ref=main"
+	tokenized := marshal(transition)
+	selector.Token = ""
+	if string(marshal(transition)) != string(payload) {
+		t.Fatal("tokenized fixture changed more than one selector argument")
+	}
 	for _, schema := range []struct{ version, file string }{
 		{version: "v1", file: "status.schema.json"},
 		{version: "v1", file: "status-v2.schema.json"},
@@ -168,13 +163,13 @@ func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTr
 	}
 }
 
-func decodeRecoverySelectorReplayTransition(t *testing.T, transition ReviewNextTransition) recoverySelectorReplayTransition {
+func decodeRecoverySelectorReplayTransition(t *testing.T, transition ReviewNextTransition) ReviewNextTransition {
 	t.Helper()
 	payload, err := json.Marshal(transition)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var decoded recoverySelectorReplayTransition
+	var decoded ReviewNextTransition
 	if err := json.Unmarshal(payload, &decoded); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/review_recovery_selector_replay_test.go
+++ b/internal/cli/review_recovery_selector_replay_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		recovery reviewtransaction.Target
@@ -35,7 +34,8 @@ func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.
 			status := recoverySelectorReplayStatus(t, test.recovery)
 			input := reviewNextTransitionInput{Selector: &reviewTransitionSelector{Projection: reviewtransaction.ProjectionStaged, Recovery: &test.recovery}}
 			collectedTransition := newReviewNextTransition(status, nil, nil, nil, nil, input)
-			collected := decodeRecoverySelectorReplayTransition(t, collectedTransition)
+			var collected ReviewNextTransition
+			decodeStrictReviewJSON(t, []byte(mustReviewJSON(t, collectedTransition)), &collected)
 			if collected.Kind != reviewNextTransitionCollect || collected.Collect == nil || len(collected.Collect.Inputs) != 1 || collected.Collect.Inputs[0].SelectorArguments == nil || !reflect.DeepEqual(*collected.Collect.Inputs[0].SelectorArguments, test.want) {
 				t.Fatalf("recovery authorization transition = %#v, want selectors %#v", collected, test.want)
 			}
@@ -57,7 +57,8 @@ func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.
 			input.Successor, input.Actor, input.Reason = successor, actor, reason
 			input.Authorization = reviewTransitionRecoveryAuthorization(binding, successor, actor, reason)
 			authorizedTransition := newReviewNextTransition(status, nil, nil, nil, nil, input)
-			authorized := decodeRecoverySelectorReplayTransition(t, authorizedTransition)
+			var authorized ReviewNextTransition
+			decodeStrictReviewJSON(t, []byte(mustReviewJSON(t, authorizedTransition)), &authorized)
 			if authorized.Kind != reviewNextTransitionExecute || authorized.Execute == nil || authorized.Execute.SelectorArguments == nil || !reflect.DeepEqual(*authorized.Execute.SelectorArguments, test.want) {
 				t.Fatalf("authorized recovery transition = %#v, want execute selectors %#v", authorized, test.want)
 			}
@@ -75,9 +76,8 @@ func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.
 
 func TestStatusAcceptsNormalizedOrdinaryWorkspaceOverlaySelectors(t *testing.T) {
 	repo := initReviewCLIRepo(t)
-	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
 	writeReviewStartCandidate(t, repo, "tracked.txt", "overlay\n", 0o644)
-	status := selectorTransitionStatus(t, repo, "--base-ref", base, "--projection", "workspace", "--workspace-overlay")
+	status := selectorTransitionStatus(t, repo, "--base-ref", strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD")), "--projection", "workspace", "--workspace-overlay")
 	if status.Projection.Kind != reviewtransaction.TargetBaseWorkspaceOverlay || status.Projection.Projection != reviewtransaction.ProjectionWorkspace {
 		t.Fatalf("normalized ordinary overlay selectors resolved %#v", status.Projection)
 	}
@@ -86,10 +86,6 @@ func TestStatusAcceptsNormalizedOrdinaryWorkspaceOverlaySelectors(t *testing.T) 
 func recoverySelectorReplayStatus(t *testing.T, recovery reviewtransaction.Target) ReviewTargetStatusResult {
 	t.Helper()
 	const changedLines = 20
-	budget, err := reviewtransaction.CorrectionBudget(changedLines)
-	if err != nil {
-		t.Fatal(err)
-	}
 	authorityTarget := "sha256:" + strings.Repeat("0", 64)
 	target := "sha256:" + strings.Repeat("1", 64)
 	return ReviewTargetStatusResult{
@@ -102,7 +98,7 @@ func recoverySelectorReplayStatus(t *testing.T, recovery reviewtransaction.Targe
 			Revision: "sha256:" + strings.Repeat("2", 64), State: reviewtransaction.StateInvalidated,
 		},
 		Receipt: ReviewTargetStatusReceipt{Status: ReviewReceiptExpectedMissing},
-		Frozen:  &ReviewTargetStatusFrozen{Tier: reviewtransaction.RiskMedium, OriginalChangedLines: changedLines, CorrectionBudget: budget},
+		Frozen:  &ReviewTargetStatusFrozen{Tier: reviewtransaction.RiskMedium, OriginalChangedLines: changedLines, CorrectionBudget: changedLines / 2},
 		Repair:  reviewtransaction.UnsupportedAuthorityRepairAssessment(),
 		Projection: ReviewTargetStatusProjection{
 			Schema: ReviewIntegrationProjectionSchema, Kind: recovery.Kind, Projection: recovery.Projection,
@@ -135,11 +131,4 @@ func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTr
 			validateAgainstPublishedStatusNextTransitionSchema(t, schema.version, schema.file, tokenized, true)
 		})
 	}
-}
-
-func decodeRecoverySelectorReplayTransition(t *testing.T, transition ReviewNextTransition) ReviewNextTransition {
-	t.Helper()
-	var decoded ReviewNextTransition
-	decodeStrictReviewJSON(t, []byte(mustReviewJSON(t, transition)), &decoded)
-	return decoded
 }

--- a/internal/cli/review_recovery_selector_replay_test.go
+++ b/internal/cli/review_recovery_selector_replay_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -85,20 +84,6 @@ func TestStatusAcceptsNormalizedOrdinaryWorkspaceOverlaySelectors(t *testing.T) 
 	status := selectorTransitionStatus(t, repo, "--base-ref", base, "--projection", "workspace", "--workspace-overlay")
 	if status.Projection.Kind != reviewtransaction.TargetBaseWorkspaceOverlay || status.Projection.Projection != reviewtransaction.ProjectionWorkspace {
 		t.Fatalf("normalized ordinary overlay selectors resolved %#v", status.Projection)
-	}
-}
-
-func TestReviewRecoverAcceptsNormalizedOrdinaryWorkspaceOverlaySelectors(t *testing.T) {
-	repo, predecessor := approvedWorkspaceOverlayRecoveryPredecessor(t, "selector-replay-recover-source")
-	writeReviewStartCandidate(t, repo, "new.txt", "expanded overlay\n", 0o644)
-	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^"))
-	err := RunReviewRecover([]string{
-		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
-		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "selector-replay-recover-successor",
-		"--disposition", "scope_changed", "--base-ref", base, "--projection", "workspace", "--workspace-overlay",
-	}, io.Discard)
-	if err != nil {
-		t.Fatalf("normalized ordinary overlay RECOVER: %v", err)
 	}
 }
 

--- a/internal/cli/review_recovery_selector_replay_test.go
+++ b/internal/cli/review_recovery_selector_replay_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"reflect"
@@ -152,6 +153,7 @@ func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTr
 	if err != nil {
 		t.Fatal(err)
 	}
+	tokenized := bytes.Replace(payload, []byte(`"value":"main"`), []byte(`"value":"main","token":"--base-ref=main"`), 1)
 	for _, schema := range []struct{ version, file string }{
 		{version: "v1", file: "status.schema.json"},
 		{version: "v1", file: "status-v2.schema.json"},
@@ -159,7 +161,10 @@ func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTr
 		{version: "v2", file: "status-v4.schema.json"},
 		{version: "v2", file: "status-v5.schema.json"},
 	} {
-		validateAgainstPublishedStatusNextTransitionSchema(t, schema.version, schema.file, payload)
+		t.Run(schema.version+"/"+schema.file, func(t *testing.T) {
+			validateAgainstPublishedStatusNextTransitionSchema(t, schema.version, schema.file, payload)
+			validateAgainstPublishedStatusNextTransitionSchema(t, schema.version, schema.file, tokenized, true)
+		})
 	}
 }
 

--- a/internal/cli/review_recovery_selector_replay_test.go
+++ b/internal/cli/review_recovery_selector_replay_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+type recoverySelectorReplayTransition struct {
+	Kind    string `json:"kind"`
+	Collect *struct {
+		Inputs []struct {
+			Arguments         []ReviewTransitionArgument  `json:"arguments"`
+			SelectorArguments *[]ReviewTransitionArgument `json:"selector_arguments,omitempty"`
+		} `json:"inputs"`
+	} `json:"collect,omitempty"`
+	Execute *struct {
+		Arguments         []ReviewTransitionArgument  `json:"arguments"`
+		SelectorArguments *[]ReviewTransitionArgument `json:"selector_arguments,omitempty"`
+	} `json:"execute,omitempty"`
+}
+
+func TestRecoveryAuthorizationCollectionPreservesNormalizedSelectors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		recovery reviewtransaction.Target
+		want     []ReviewTransitionArgument
+	}{
+		{name: "current changes", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace}, want: []ReviewTransitionArgument{}},
+		{name: "staged projection", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionStaged}, want: []ReviewTransitionArgument{{Name: "projection", Value: "staged"}}},
+		{name: "base diff", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseDiff, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "main"}, want: []ReviewTransitionArgument{{Name: "base-ref", Value: "main"}, {Name: "committed-only", Value: "true"}}},
+		{name: "workspace overlay", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "main"}, want: []ReviewTransitionArgument{{Name: "base-ref", Value: "main"}, {Name: "projection", Value: "workspace"}, {Name: "workspace-overlay", Value: "true"}}},
+		{name: "staged workspace overlay", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionStaged, BaseRef: "main"}, want: []ReviewTransitionArgument{{Name: "base-ref", Value: "main"}, {Name: "projection", Value: "staged"}, {Name: "workspace-overlay", Value: "true"}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := recoverySelectorReplayStatus(t, test.recovery)
+			input := reviewNextTransitionInput{Selector: &reviewTransitionSelector{Recovery: &test.recovery}}
+			collectedTransition := newReviewNextTransition(status, nil, nil, nil, nil, input)
+			collected := decodeRecoverySelectorReplayTransition(t, collectedTransition)
+			if collected.Kind != reviewNextTransitionCollect || collected.Collect == nil || len(collected.Collect.Inputs) != 1 {
+				t.Fatalf("recovery authorization transition = %#v, want one collect input", collected)
+			}
+			selectors := collected.Collect.Inputs[0].SelectorArguments
+			if selectors == nil || !reflect.DeepEqual(*selectors, test.want) {
+				t.Fatalf("recovery authorization selectors = %#v, want %#v", selectors, test.want)
+			}
+			if test.name == "staged workspace overlay" {
+				validateRecoverySelectorReplaySchemas(t, collectedTransition)
+			}
+			status.NextTransition = &collectedTransition
+			if err := status.Validate(); err != nil {
+				t.Fatalf("public STATUS rejected recovery authorization collect: %v", err)
+			}
+			for _, argument := range collected.Collect.Inputs[0].Arguments {
+				if argument.Name == "base-ref" || argument.Name == "committed-only" || argument.Name == "projection" || argument.Name == "workspace-overlay" {
+					t.Fatalf("selector %q leaked into canonical authorization arguments", argument.Name)
+				}
+			}
+
+			const successor, actor, reason = "selector-replay-successor", "maintainer", "authorize exact recovery target"
+			binding := reviewTransitionBinding(status.Authority, status.TargetIdentity)
+			input.Successor, input.Actor, input.Reason = successor, actor, reason
+			input.Authorization = reviewTransitionRecoveryAuthorization(binding, successor, actor, reason)
+			authorizedTransition := newReviewNextTransition(status, nil, nil, nil, nil, input)
+			authorized := decodeRecoverySelectorReplayTransition(t, authorizedTransition)
+			if authorized.Kind != reviewNextTransitionExecute || authorized.Execute == nil {
+				t.Fatalf("authorized recovery transition = %#v, want execute", authorized)
+			}
+			if authorized.Execute.SelectorArguments == nil || !reflect.DeepEqual(*authorized.Execute.SelectorArguments, test.want) {
+				t.Fatalf("authorized recovery selectors = %#v, want %#v", authorized.Execute.SelectorArguments, test.want)
+			}
+			arguments, err := reviewTransitionArgumentMap(authorized.Execute.Arguments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if arguments["maintainer-authorization"] != input.Authorization {
+				t.Fatal("selector replay changed the canonical recovery authorization bytes")
+			}
+			status.NextTransition = &authorizedTransition
+			if err := status.Validate(); err != nil {
+				t.Fatalf("public STATUS rejected authorized selector replay: %v", err)
+			}
+		})
+	}
+}
+
+func TestStatusAcceptsNormalizedOrdinaryWorkspaceOverlaySelectors(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "tracked.txt", "overlay\n", 0o644)
+	status := selectorTransitionStatus(t, repo, "--base-ref", base, "--projection", "workspace", "--workspace-overlay")
+	if status.Projection.Kind != reviewtransaction.TargetBaseWorkspaceOverlay || status.Projection.Projection != reviewtransaction.ProjectionWorkspace {
+		t.Fatalf("normalized ordinary overlay selectors resolved %#v", status.Projection)
+	}
+}
+
+func TestReviewRecoverAcceptsNormalizedOrdinaryWorkspaceOverlaySelectors(t *testing.T) {
+	repo, predecessor := approvedWorkspaceOverlayRecoveryPredecessor(t, "selector-replay-recover-source")
+	writeReviewStartCandidate(t, repo, "new.txt", "expanded overlay\n", 0o644)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^"))
+	err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "selector-replay-recover-successor",
+		"--disposition", "scope_changed", "--base-ref", base, "--projection", "workspace", "--workspace-overlay",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("normalized ordinary overlay RECOVER: %v", err)
+	}
+}
+
+func recoverySelectorReplayStatus(t *testing.T, recovery reviewtransaction.Target) ReviewTargetStatusResult {
+	t.Helper()
+	const changedLines = 20
+	budget, err := reviewtransaction.CorrectionBudget(changedLines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorityTarget := "sha256:" + strings.Repeat("0", 64)
+	target := "sha256:" + strings.Repeat("1", 64)
+	return ReviewTargetStatusResult{
+		Schema: ReviewIntegrationStatusSchemaV2, Contract: ReviewIntegrationContractV1, Operation: "review.status",
+		Applicability: reviewtransaction.TargetApplicabilityCurrent, Action: reviewtransaction.TargetStatusActionRecover,
+		ActionDisposition: reviewtransaction.RecoveryInvalidated, Replayability: reviewtransaction.ReplayabilityManualActionRequired,
+		TargetIdentity: target, AuthorityTargetIdentity: authorityTarget, Candidates: []string{},
+		Authority: &ReviewTargetStatusAuthority{
+			Version: reviewtransaction.AuthorityVersionCompact, LineageID: "selector-replay-source", Generation: 1,
+			Revision: "sha256:" + strings.Repeat("2", 64), State: reviewtransaction.StateInvalidated,
+		},
+		Receipt: ReviewTargetStatusReceipt{Status: ReviewReceiptExpectedMissing},
+		Frozen:  &ReviewTargetStatusFrozen{Tier: reviewtransaction.RiskMedium, OriginalChangedLines: changedLines, CorrectionBudget: budget},
+		Repair:  reviewtransaction.UnsupportedAuthorityRepairAssessment(),
+		Projection: ReviewTargetStatusProjection{
+			Schema: ReviewIntegrationProjectionSchema, Kind: recovery.Kind, Projection: recovery.Projection,
+			BaseTree: strings.Repeat("3", 40), InitialReviewTree: strings.Repeat("4", 40), CurrentCandidateTree: strings.Repeat("5", 40),
+			PathsDigest: "sha256:" + strings.Repeat("6", 64), Paths: []string{"candidate.go"}, IntendedUntracked: []string{},
+			IntendedUntrackedProof: "sha256:" + strings.Repeat("7", 64), InitialSnapshotIdentity: authorityTarget, CurrentSnapshotIdentity: target,
+		},
+	}
+}
+
+func validateRecoverySelectorReplaySchemas(t *testing.T, transition ReviewNextTransition) {
+	t.Helper()
+	payload, err := json.Marshal(transition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, schema := range []struct{ version, file string }{
+		{version: "v1", file: "status.schema.json"},
+		{version: "v1", file: "status-v2.schema.json"},
+		{version: "v2", file: "status.schema.json"},
+		{version: "v2", file: "status-v4.schema.json"},
+		{version: "v2", file: "status-v5.schema.json"},
+	} {
+		validateAgainstPublishedStatusNextTransitionSchema(t, schema.version, schema.file, payload)
+	}
+}
+
+func decodeRecoverySelectorReplayTransition(t *testing.T, transition ReviewNextTransition) recoverySelectorReplayTransition {
+	t.Helper()
+	payload, err := json.Marshal(transition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded recoverySelectorReplayTransition
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -673,15 +673,12 @@ func TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip(t *testing.T
 		t.Fatalf("current-changes recovery transition = %#v", status.NextTransition)
 	}
 	selectors := status.NextTransition.Execute.SelectorArguments
-	if selectors == nil || len(*selectors) != 0 {
-		t.Fatalf("current-changes selectors = %#v, want explicit empty selector contract", selectors)
+	if selectors == nil || len(*selectors) != 1 || (*selectors)[0].Name != "projection" || (*selectors)[0].Value != "workspace" {
+		t.Fatalf("current-changes selectors = %#v, want explicit workspace projection", selectors)
 	}
 	payload, err := json.Marshal(status)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if !bytes.Contains(payload, []byte(`"selector_arguments":[]`)) {
-		t.Fatalf("status JSON omitted explicit empty selectors: %s", payload)
 	}
 	var decoded ReviewTargetStatusResult
 	if err := json.Unmarshal(payload, &decoded); err != nil {
@@ -689,7 +686,7 @@ func TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip(t *testing.T
 	}
 	if decoded.NextTransition == nil || decoded.NextTransition.Execute == nil ||
 		decoded.NextTransition.Execute.SelectorArguments == nil ||
-		len(*decoded.NextTransition.Execute.SelectorArguments) != 0 {
+		!reflect.DeepEqual(*decoded.NextTransition.Execute.SelectorArguments, *selectors) {
 		t.Fatalf("round-tripped selectors = %#v", decoded.NextTransition)
 	}
 	if err := decoded.Validate(); err != nil {

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -692,6 +692,12 @@ func TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip(t *testing.T
 	if err := decoded.Validate(); err != nil {
 		t.Fatalf("round-tripped status validation: %v", err)
 	}
+	assertSelectorTransitionMutationRejected(t, decoded, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return removeSelectorTransitionArgument(arguments, "projection")
+	}, true)
+	assertSelectorTransitionMutationRejected(t, decoded, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "projection", "staged")
+	}, true)
 	before, _ := os.ReadFile(store.StatePath())
 	recoveredPayload := executeSelectorTransition(t, repo, decoded)
 	var recovered ReviewRecoverResult
@@ -865,14 +871,18 @@ func selectorTransitionCommandArguments(repo string, status ReviewTargetStatusRe
 	return args
 }
 
-func assertSelectorTransitionMutationRejected(t *testing.T, status ReviewTargetStatusResult, mutate func([]ReviewTransitionArgument) []ReviewTransitionArgument) {
+func assertSelectorTransitionMutationRejected(t *testing.T, status ReviewTargetStatusResult, mutate func([]ReviewTransitionArgument) []ReviewTransitionArgument, normalized ...bool) {
 	t.Helper()
 	invalid := status
 	transition := *status.NextTransition
 	execution := *status.NextTransition.Execute
 	execution.Arguments = mutate(append([]ReviewTransitionArgument(nil), execution.Arguments...))
+	if len(normalized) != 0 && execution.SelectorArguments != nil {
+		selectors := mutate(append([]ReviewTransitionArgument(nil), (*execution.SelectorArguments)...))
+		execution.SelectorArguments = &selectors
+	}
 	transition.Execute, invalid.NextTransition = &execution, &transition
-	if err := invalid.Validate(); err == nil {
+	if err := invalid.validateSelectorNextTransition(); len(normalized) != 0 && err == nil || len(normalized) == 0 && invalid.Validate() == nil {
 		t.Fatalf("status accepted invalid transition arguments: %#v", execution.Arguments)
 	}
 }

--- a/internal/cli/review_start_contract_test.go
+++ b/internal/cli/review_start_contract_test.go
@@ -361,8 +361,11 @@ func TestReviewRecoverAdoptsExplicitWorkspaceOverlayBase(t *testing.T) {
 	declaredBase := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
 	declaredBaseTree := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", declaredBase+"^{tree}"))
 	args := []string{"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID, "--expected-predecessor-revision", predecessor.Revision,
-		"--successor-lineage", "overlay-explicit-base-successor", "--disposition", "scope_changed", "--reason", "base advanced", "--actor", "maintainer", "--base-ref", declaredBase}
+		"--successor-lineage", "overlay-explicit-base-successor", "--disposition", "scope_changed", "--reason", "base advanced", "--actor", "maintainer", "--base-ref", declaredBase, "--workspace-overlay"}
 
+	if err := RunReviewRecover(append(args, "--projection", "staged"), io.Discard); err == nil {
+		t.Fatal("ordinary workspace-overlay predecessor accepted staged projection")
+	}
 	if err := RunReviewRecover(args, io.Discard); err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +378,7 @@ func TestReviewRecoverAdoptsExplicitWorkspaceOverlayBase(t *testing.T) {
 		t.Fatal(err)
 	}
 	snapshot := successor.State.InitialSnapshot
-	if snapshot.Kind != reviewtransaction.TargetBaseWorkspaceOverlay || snapshot.BaseTree != declaredBaseTree || snapshot.BaseTree == predecessor.State.InitialSnapshot.BaseTree || snapshot.Identity == predecessor.State.InitialSnapshot.Identity {
+	if snapshot.Kind != reviewtransaction.TargetBaseWorkspaceOverlay || facadeProjection(snapshot.Projection) != reviewtransaction.ProjectionWorkspace || snapshot.BaseTree != declaredBaseTree || snapshot.BaseTree == predecessor.State.InitialSnapshot.BaseTree || snapshot.Identity == predecessor.State.InitialSnapshot.Identity {
 		t.Fatalf("recovered overlay snapshot = %#v", snapshot)
 	}
 	assessment, err := reviewtransaction.AssessCompactGateTarget(context.Background(), repo, successor.State, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply})

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -883,8 +883,9 @@ func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
 			(!hasProjection || projection != string(reviewtransaction.ProjectionStaged) || !hasWorkspaceOverlay) {
 			return errors.New("staged workspace-overlay RECOVER transition lacks exact target selectors")
 		}
-		if result.Projection.Projection != reviewtransaction.ProjectionStaged && hasWorkspaceOverlay {
-			return errors.New("workspace-overlay RECOVER transition invented a staged selector")
+		if result.Projection.Projection == reviewtransaction.ProjectionWorkspace &&
+			(!hasProjection || projection != string(reviewtransaction.ProjectionWorkspace) || !hasWorkspaceOverlay) {
+			return errors.New("workspace-overlay RECOVER transition lacks exact target selectors") // refusal:by-design world-action: provider-generated recovery selectors require a code fix when they do not reproduce the selected target
 		}
 	default:
 		return errors.New("RECOVER transition target kind is unsupported")
@@ -1367,7 +1368,7 @@ func validateReviewTransitionExecution(execution ReviewTransitionExecution, argu
 			hasProjection && projection != string(reviewtransaction.ProjectionWorkspace) &&
 				projection != string(reviewtransaction.ProjectionStaged) ||
 			hasWorkspaceOverlay && (!hasBase || hasCommitted || !hasProjection ||
-				projection != string(reviewtransaction.ProjectionStaged) || workspaceOverlay != "true") {
+				projection != string(reviewtransaction.ProjectionStaged) && projection != string(reviewtransaction.ProjectionWorkspace) || workspaceOverlay != "true") {
 			return errors.New("review recover transition selectors are invalid")
 		}
 	}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -891,6 +891,7 @@ func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
 		return errors.New("RECOVER transition target kind is unsupported")
 	}
 	if result.Projection.Kind != reviewtransaction.TargetCurrentChanges && base == "" ||
+		result.Projection.Kind == reviewtransaction.TargetCurrentChanges && selectorsPresent && !hasProjection ||
 		hasProjection && projection != string(result.Projection.Projection) {
 		return errors.New("RECOVER transition selectors do not match the selected target")
 	}

--- a/internal/cli/review_transition_command_test.go
+++ b/internal/cli/review_transition_command_test.go
@@ -525,7 +525,7 @@ func TestReviewRecoverTransitionEmitsACommandThatRuns(t *testing.T) {
 		" --disposition=" + string(probe.ActionDisposition) +
 		" '--reason=" + reason + "'" +
 		" --actor=" + actor +
-		" '--maintainer-authorization=" + authorization + "'"
+		" '--maintainer-authorization=" + authorization + "' --projection=workspace"
 	if status.NextTransition.Execute.Command != want {
 		t.Fatalf("recover command = %q\nwant %q", status.NextTransition.Execute.Command, want)
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1972

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Preserve provider-normalized target selectors in recovery authorization collection and replay the same values into the authorized execute transition.
- Keep recovery authorization bytes and persisted state unchanged while making current, staged, base-diff, ordinary-overlay, and staged-overlay selectors explicit and valid.
- Add schema compatibility coverage and a driven public-boundary regression journey for #1972.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_next_transition.go` | Adds optional `selector_arguments` to recovery authorization collection and reuses one normalized selector set for collect and execute. |
| `internal/cli/review_facade.go`, `internal/cli/review_status_contract.go` | Accept and validate the canonical ordinary workspace-overlay tuple without weakening invalid-selector rejection. |
| `contracts/review-integration/**/status*.schema.json` | Adds the backward-compatible optional selector field to all five shipped status schemas. |
| `internal/cli/*selector_replay*_test.go` | Covers five selector shapes, canonical authorization stability, schema compatibility, public STATUS validation, direct RECOVER, and negative controls. |
| `bench/journeys_recovery_selector_replay.go`, `bench/journeys_wave1.go` | Adds driven journey `j86-recovery-authorization-preserves-selectors`, linked to #1972, which replays collected selectors and executes the printed recovery. |

---

## 🧪 Test Plan

- [x] Focused selector/schema/public-boundary tests pass.
- [x] `go test -count=1 ./internal/cli`
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `./scripts/deadcode-ratchet.sh` — no new unreachable functions
- [x] `cd bench && go test -count=1 ./... && go vet ./...`
- [x] Driven `j86-recovery-authorization-preserves-selectors` — `1 completed, 0 unsupported, 0 failed`
- [ ] Local `go test -count=1 ./...` reports three existing `internal/sddstatus` failures when the user-owned global RDD kill switch is off. The same failures reproduce on immutable base `564b0dfc`; CI will run the clean environment.
- [ ] Docker E2E suite was not run locally; CI owns those platform lanes.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 397 changed lines, within the 400-line budget |
| Check Issue Reference | ⏳ | `Closes #1972` |
| Check Issue Has `status:approved` | ⏳ | #1972 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` applied after PR inspection and user approval |
| Unit Tests | ⏳ | Focused and full affected package suites passed locally |
| Go Format | ⏳ | Checker passed locally |
| E2E Tests | ⏳ | CI-owned platform suites |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Full root unit suite passes locally — three inherited kill-switch failures reproduce on base
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally
- [x] Benchmark validation completed in driven mode
- [x] Wire schemas and public-boundary coverage were updated with the behavior
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- Delivery is `disabled/unmanaged`: the user-owned RDD kill switch remained off throughout implementation and publication; this PR claims no receipt approval.
- The change implements #1972's approved additive selector-replay scope. It does not restore generic sequential receipt composition, add replay-token persistence, or introduce a capture endpoint.
- CodeRabbit’s effective-projection finding was fixed in `6bfbf044`; omitted projection now inherits the predecessor before classification, validation, and successor construction.
- CodeRabbit’s tokenized-selector finding was fixed in `8d09949b`; all five collect schemas now use a token-free selector argument definition while generic transition token support remains unchanged.
- Independent verification first caught a false-green ordinary workspace-overlay case. The candidate was corrected so every selector shape now passes production STATUS validation and the journey replays the collected field rather than fixture-owned selectors.
- [x] Selector admission was challenged against current changes, staged, base diff, ordinary workspace overlay, and staged workspace overlay; incompatible tuples still fail closed.
- [x] No `guard:population` direction or claim changed, and `.guard-population-baseline.txt` is unchanged.
- [x] Passing declaration checks were not treated as semantic proof; focused public-boundary and driven-runtime evidence are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery transitions now preserve selector arguments during collection and execution.
  * Added support for ordinary workspace-overlay recovery with explicit workspace projection.
  * Added staged recovery flows with selector replay validation.

* **Bug Fixes**
  * Improved recovery mode detection and projection validation.
  * Prevented unsupported recovery projections from being silently defaulted.

* **Documentation**
  * Updated status schemas to support optional selector arguments and enforce selector-specific restrictions, including disallowing tokenized selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->