### PR TITLE
fix(sdd): bind remediation settle to failed evidence

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -108,8 +108,9 @@ type sddRuntimeStatus struct {
 }
 
 type sddCompactAttemptResult struct {
-	State string `json:"state"`
-	Token string `json:"token"`
+	State  string `json:"state"`
+	Reason string `json:"reason"`
+	Token  string `json:"token"`
 }
 
 // sddStatusV1 is the subset of `sdd-status --json` the kill-switch journeys read.
@@ -1006,7 +1007,10 @@ func sddBeginFailedUnmanagedVerification(r *journeyRun) error {
 }
 
 func sddUnmanagedAcquireCorrection(r *journeyRun) error {
-	observation := r.run(append([]string{"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "bench-unmanaged-acquire"}, sddUnmanagedObjective...), false)
+	observation := r.run(append([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", "bench-unmanaged-acquire", "--remediates-evidence-revision", sddFailedEvidence,
+	}, sddUnmanagedObjective...), false)
 	var result sddCompactAttemptResult
 	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
 		return fmt.Errorf("parse unmanaged correction acquire: %w (stderr: %s)", err, firstLine(observation.Stderr))
@@ -1030,6 +1034,12 @@ func sddUnmanagedSettle(r *journeyRun, requestID, failedEvidence string, wantSuc
 		return fmt.Errorf("parse unmanaged correction settle: %w (stderr: %s)", err, firstLine(observation.Stderr))
 	}
 	if wantSuccess && (observation.ExitCode != 0 || result.State != "complete") {
+		if result.State == "blocked" && result.Reason == "invalid_continuation" {
+			if err := proveActiveAttempt(r.sandbox, 2, sddFailedEvidence); err != nil {
+				return fmt.Errorf("invalid continuation did not leave the remediation attempt running: %w", err)
+			}
+			return fmt.Errorf("bounded unmanaged correction was blocked as invalid_continuation and left its remediation attempt running")
+		}
 		return fmt.Errorf("bounded unmanaged correction did not settle: %#v exit=%d", result, observation.ExitCode)
 	}
 	if !wantSuccess && result.State != "blocked" {

--- a/bench/journeys_sdd_chain.go
+++ b/bench/journeys_sdd_chain.go
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
 
 // journeys_sdd_chain.go pins #1974 slice 2 (#2565): the unmanaged-remediation
 // binding derives from the immutable attempt chain, so an audited reset
@@ -19,19 +23,27 @@ var sddChainVerifyObjective = []string{
 	"--max-attempts", "1", "--max-changed-lines", "20",
 }
 
+const sddChainInterruptedEvidence = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
 // sddChainFailedVerificationExhaustsBudget settles the admitted verification
 // failure and proves the runtime demands a maintainer decision.
 func sddChainFailedVerificationExhaustsBudget(r *journeyRun) error {
-	status, err := readRuntimeStatus(r)
-	if err != nil {
-		return err
+	acquire := r.run(append([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", "bench-chain-acquire-verification",
+	}, sddChainVerifyObjective...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(acquire.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse failed verification acquire: %w (stderr: %s)", err, firstLine(acquire.Stderr))
 	}
-	r.run(sddAttemptArgs(r, "begin", status.Revision, "bench-chain-begin-verification", sddChainVerifyObjective...), false)
-	if status, err = readRuntimeStatus(r); err != nil {
-		return err
+	if acquire.ExitCode != 0 || result.State != "proceed" || result.Token == "" {
+		return fmt.Errorf("failed verification acquire = %#v exit=%d", result, acquire.ExitCode)
 	}
-	r.run(sddAttemptArgs(r, "finish", status.Revision, "bench-chain-finish-verification",
-		append([]string{"--outcome", "failed", "--evidence-revision", sddFailedEvidence}, sddTerminalEvidence...)...), false)
+	r.run(append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--token", result.Token, "--request-id", "bench-chain-settle-verification",
+		"--outcome", "failed", "--evidence-revision", sddFailedEvidence,
+	}, sddTerminalEvidence...), false)
 	proved, err := proveRuntime(r.sandbox)
 	if err != nil {
 		return err
@@ -63,6 +75,76 @@ func sddChainAuditedReset(r *journeyRun) error {
 	return nil
 }
 
+// sddChainInterruptedAttempt records a later non-remediation interruption.
+// Its evidence becomes the live pointer, while the earlier failed verification
+// remains the immutable correction binding after the audited reset.
+func sddChainInterruptedAttempt(r *journeyRun) error {
+	acquire := r.run(append([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", "bench-chain-acquire-interruption",
+	}, sddUnmanagedObjective...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(acquire.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse interruption acquire: %w (stderr: %s)", err, firstLine(acquire.Stderr))
+	}
+	if acquire.ExitCode != 0 || result.State != "proceed" || result.Token == "" {
+		return fmt.Errorf("interruption acquire = %#v exit=%d", result, acquire.ExitCode)
+	}
+	r.run(append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--token", result.Token, "--request-id", "bench-chain-settle-interruption",
+		"--outcome", "interrupted", "--evidence-revision", sddChainInterruptedEvidence,
+	}, sddTerminalEvidence...), false)
+	status, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if status.ActiveAttempt != nil || len(status.Attempts) != 2 || status.Attempts[1].Outcome != "interrupted" ||
+		status.EvidenceRevision != sddChainInterruptedEvidence || status.NextAction != "begin" {
+		return fmt.Errorf("interrupted successor did not retain its distinct live evidence: %#v", status)
+	}
+	return nil
+}
+
+// sddChainCorrectionCompletes keeps the RED diagnostic load-bearing: before
+// #2871, compact settle compares the caller's failed evidence to the later
+// interruption's live pointer, blocks invalid_continuation, and leaves token 3
+// running. The chain-derived correction must instead settle atomically.
+func sddChainCorrectionCompletes(r *journeyRun) error {
+	token := r.sandbox.Scratch["unmanaged-token"]
+	observation := r.run(append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange, "--token", token,
+		"--request-id", "bench-chain-correct", "--outcome", "passed", "--evidence-revision", sddCorrectedEvidence,
+		"--remediates-evidence-revision", sddFailedEvidence,
+	}, sddTerminalEvidence...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse chain correction settle: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if result.State == "blocked" && result.Reason == "invalid_continuation" {
+		status, err := proveRuntime(r.sandbox)
+		if err != nil {
+			return err
+		}
+		if status.ActiveAttempt == nil || len(status.Attempts) != 3 || status.ActiveAttempt.Ordinal != 3 ||
+			status.EvidenceRevision != sddChainInterruptedEvidence {
+			return fmt.Errorf("invalid continuation did not leave the exact remediation attempt running: %#v", status)
+		}
+		return fmt.Errorf("bounded correction was blocked as invalid_continuation and left the exact live remediation attempt running")
+	}
+	if observation.ExitCode != 0 || result.State != "complete" {
+		return fmt.Errorf("chain correction settle = %#v exit=%d", result, observation.ExitCode)
+	}
+	status, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if len(status.Attempts) != 3 || status.ActiveAttempt != nil || status.Attempts[2].RemediatesEvidenceRevision != sddFailedEvidence {
+		return fmt.Errorf("chain correction did not settle against the immutable failed evidence: %#v", status)
+	}
+	return nil
+}
+
 // sddChainJourneys is the corpus slice this file registers.
 func sddChainJourneys() []Journey {
 	return []Journey{
@@ -88,6 +170,21 @@ func sddChainJourneys() []Journey {
 						}
 						return nil
 					})},
+			},
+		},
+		{
+			ID:     "j87-unmanaged-remediation-uses-chain-failed-evidence",
+			Title:  "A reset-authorized correction settles against its failed evidence, not a later interruption",
+			Source: "#2871: compact settle must match the immutable failed-evidence chain",
+			Steps: []Step{
+				{Name: "fixture: completed change with admitted failed verification", Fixture: sddPlanningArtifacts(sddFailedVerifyReport)},
+				{Name: "mode disable", Requires: modeCapability, Args: productArgs("review", "mode", "disable", "--json")},
+				{Name: "failed verification exhausts its objective budget", Requires: sddAttemptBeginCapability, Composite: sddChainFailedVerificationExhaustsBudget},
+				{Name: "audited reset records the maintainer decision", Requires: sddAttemptResetCapability, Composite: sddChainAuditedReset},
+				{Name: "later interruption records distinct live evidence", Requires: sddAttemptRemediationCapability, Composite: sddChainInterruptedAttempt},
+				{Name: "acquire the correction bound to the original failed evidence", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedAcquireCorrection},
+				{Name: "fixture: correction changes the candidate", Fixture: sddBoundedCorrection},
+				{Name: "settle the exact live remediation token against the failed evidence chain", Requires: sddAttemptRemediationCapability, Composite: sddChainCorrectionCompletes},
 			},
 		},
 	}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -46,11 +46,12 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// j82 proves #2127's reviewed full candidate can publish an unpublished
 	// monotonic subset without reopening review.
 	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base
-	// while the advertised main ref remains a moving publication boundary.
+	// while the advertised main ref remains a moving publication boundary. j87
+	// proves #2871's correction binds the immutable failure across a later interrupt.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 85 {
-		t.Errorf("core journey count = %d, want 85", got)
+	if got := len(seen); got != 86 {
+		t.Errorf("core journey count = %d, want 86", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -283,10 +283,7 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		ProcessEvidence: request.ProcessEvidence,
 	}
 	explicitSuccessor := request.SuccessorLineageID != ""
-	failedEvidence := status.EvidenceRevision
-	if failedEvidence == "" {
-		failedEvidence = request.RemediatesEvidenceRevision
-	}
+	failedEvidence, _ := runtimeChainFailedEvidence(status.Attempts)
 	if request.RemediatesEvidenceRevision != "" && failedEvidence != request.RemediatesEvidenceRevision {
 		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 	}

--- a/internal/sddstatus/runtime_compact_test.go
+++ b/internal/sddstatus/runtime_compact_test.go
@@ -178,11 +178,7 @@ func TestCompactAcquireForeignTokenStaysBlockedWithoutMutation(t *testing.T) {
 }
 
 func TestCompactSettlePreservesAtomicRemediationAndReplay(t *testing.T) {
-	legacyFixture := newRuntimeUnchangedBindingFixture(t, "compact-legacy-evidence")
-	write(t, filepath.Join(legacyFixture.store.Repo, "openspec", "changes", "compact-legacy-evidence", "tasks.md"), "- [x] 1.1 Done\n# candidate-changing remediation\n")
-	fixture := runtimeRemediationFixture{repo: legacyFixture.store.Repo, store: legacyFixture.store, predecessorBinding: legacyFixture.binding,
-		failedEvidence: runtimeTestHash('b'), active: legacyFixture.active,
-		successor: createRuntimeRecoverySuccessor(t, legacyFixture.store.Repo, legacyFixture.binding.Lineage, "compact-legacy-successor", true)}
+	fixture := newRuntimeRemediationFixture(t, true)
 	failNextCompactStoreSync(t, fixture.store)
 	before := countRuntimeRecords(t, fixture.store.Dir)
 	legacy := fixture.finishRequest("compact-remediation-settle")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2871

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Derive compact remediation settlement from the immutable failed-attempt chain instead of the mutable live evidence pointer.
- Add `j87` to prove a correction still settles after a later interrupted attempt records distinct live evidence.
- Replace the synthetic compact-settle fixture with the real failed-verification/remediation chain.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_compact.go` | Resolve remediation evidence from persisted attempts before validating continuation. |
| `internal/sddstatus/runtime_compact_test.go` | Exercise compact settlement with the real remediation fixture. |
| `bench/journeys_sdd*.go` | Add j87, its chain helpers, and the 86-journey corpus ratchet. |

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `cd bench && go vet ./... && go test ./... -count=1`
- [x] Driven j87: `1 completed, 0 unsupported, 0 failed`
- [x] Driven core corpus: `86 completed, 0 unsupported, 0 failed`
- [x] Driven transition axis: `97 completed, 0 unsupported, 0 failed` (11 transition journeys)
- [x] Base-product decoy: `0 completed, 0 unsupported, 1 failed` with `invalid_continuation` and the exact live remediation attempt still active
- [x] `./scripts/deadcode-ratchet.sh`
- [x] Docker E2E suite (CI)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (149 authored lines)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI passed
- [x] Benchmark validation completed
- [x] Documentation is not required for this internal correction
- [x] My commits follow Conventional Commits
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The existing `invalid_continuation` integrity guard remains in place. The corrected legitimate population is a reset-authorized remediation whose original failed evidence remains in the immutable attempt chain after a later non-remediation interruption moves the live evidence pointer. j87 challenges that population through the real CLI and runtime ledger. The guard contract did not change, so `.guard-population-baseline.txt` is intentionally unchanged.

Rollback is limited to commit `475f2e57` and the five files in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remediation settlement to consistently reference the original failed verification evidence.
  * Added validation for interrupted remediation attempts and invalid continuation states.
  * Improved handling of unmanaged corrections and provided more specific error reporting.
  * Ensured successful correction settlements remain properly linked to their verification chain.

* **Tests**
  * Added coverage for interrupted remediation, evidence transitions, and chain-bound correction settlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
