### PR TITLE
feat(runtimecertification): add the runtime oracle evaluator (slice 1 of 2)

### DIFF
--- a/internal/runtimecertification/certification.go
+++ b/internal/runtimecertification/certification.go
@@ -1,0 +1,255 @@
+// Package runtimecertification evaluates runtime oracle evidence without
+// launching external providers or treating rendered files as proof.
+package runtimecertification
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+)
+
+type SchemaVersion string
+
+const SchemaV1 SchemaVersion = "gentle-ai.runtime-certification/v1"
+
+type State string
+
+const (
+	StateDeclared         State = "declared"
+	StateWritten          State = "written"
+	StateCertifiedCurrent State = "certified_current"
+	StateStale            State = "stale"
+	StateRevoked          State = "revoked"
+	StateInconclusive     State = "inconclusive"
+	StateFailed           State = "failed"
+)
+
+type EvidenceKind string
+
+const (
+	EvidenceDeclared EvidenceKind = "declared"
+	EvidenceWritten  EvidenceKind = "written"
+	EvidenceOracle   EvidenceKind = "oracle"
+)
+
+type OracleStatus string
+
+const (
+	OracleStatusPass         OracleStatus = "pass"
+	OracleStatusFail         OracleStatus = "fail"
+	OracleStatusInconclusive OracleStatus = "inconclusive"
+)
+
+const (
+	ClientOpenCode           = "opencode"
+	OracleOpenCodeDebugAgent = "opencode.debug-agent/v1"
+	CapabilityResolvedAgent  = "opencode.agent-config.resolved/v1"
+)
+
+type Tuple struct {
+	ClientName              string   `json:"client_name"`
+	ClientVersion           string   `json:"client_version"`
+	ClientVersionRange      string   `json:"client_version_range"`
+	BinarySHA256            string   `json:"binary_sha256"`
+	OS                      string   `json:"os"`
+	Arch                    string   `json:"arch"`
+	Capability              string   `json:"capability_id"`
+	Subject                 string   `json:"subject"`
+	OracleID                string   `json:"oracle_id"`
+	CommandDigest           string   `json:"command_digest"`
+	InputDigests            []string `json:"input_digests"`
+	EvidenceBoundaryDigests []string `json:"evidence_boundary_digests"`
+}
+
+type Record struct {
+	SchemaVersion SchemaVersion `json:"schema"`
+	EvidenceKind  EvidenceKind  `json:"evidence_kind"`
+	Tuple
+	Limitations  []string     `json:"limitations,omitempty"`
+	ExpiresAt    time.Time    `json:"expires_at"`
+	OracleResult OracleResult `json:"oracle_result,omitempty"`
+}
+
+type OracleResult struct {
+	Status  OracleStatus    `json:"status"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+type Revocation struct {
+	OracleID      string
+	ClientName    string
+	ClientVersion string
+	BinarySHA256  string
+}
+
+type Evaluation struct {
+	State  State
+	Detail string
+}
+
+type Policy struct {
+	Expected    Tuple
+	Now         time.Time
+	Revocations []Revocation
+}
+
+func Evaluate(record Record, policy Policy) Evaluation {
+	if record.SchemaVersion != SchemaV1 {
+		return Evaluation{State: StateFailed, Detail: "unsupported runtime certification schema"}
+	}
+	if record.EvidenceKind == EvidenceDeclared {
+		return Evaluation{State: StateDeclared, Detail: "declared evidence is not runtime certification"}
+	}
+	if record.EvidenceKind == EvidenceWritten {
+		return Evaluation{State: StateWritten, Detail: "written evidence is not runtime certification"}
+	}
+	if record.EvidenceKind != EvidenceOracle {
+		return Evaluation{State: StateFailed, Detail: "unknown evidence kind"}
+	}
+	if err := validateOracleEvidenceBoundary(record); err != nil {
+		return Evaluation{State: StateFailed, Detail: err.Error()}
+	}
+	if !matchesTuple(record, policy.Expected) {
+		return Evaluation{State: StateStale, Detail: "runtime certification tuple does not apply to the current identity"}
+	}
+	if isRevoked(record, policy.Revocations) {
+		return Evaluation{State: StateRevoked, Detail: "runtime certification tuple was revoked"}
+	}
+	if expired(record.ExpiresAt, policy.Now) {
+		return Evaluation{State: StateStale, Detail: "runtime certification expired for the current identity"}
+	}
+
+	switch record.OracleResult.Status {
+	case OracleStatusPass:
+		if err := validateOraclePayload(record.OracleID, record.Subject, record.OracleResult.Payload); err != nil {
+			return Evaluation{State: StateFailed, Detail: err.Error()}
+		}
+		return Evaluation{State: StateCertifiedCurrent, Detail: "runtime oracle passed for current identity"}
+	case OracleStatusInconclusive:
+		return Evaluation{State: StateInconclusive, Detail: "runtime oracle was inconclusive"}
+	case OracleStatusFail:
+		return Evaluation{State: StateFailed, Detail: "runtime oracle failed"}
+	default:
+		return Evaluation{State: StateFailed, Detail: "runtime oracle result is missing or invalid"}
+	}
+}
+
+func OpenCodeDebugAgentTuple(version, binarySHA256, goos, arch, subject string, inputDigests []string) Tuple {
+	return Tuple{
+		ClientName:              ClientOpenCode,
+		ClientVersion:           version,
+		ClientVersionRange:      version,
+		BinarySHA256:            binarySHA256,
+		OS:                      goos,
+		Arch:                    arch,
+		Capability:              CapabilityResolvedAgent,
+		Subject:                 subject,
+		OracleID:                OracleOpenCodeDebugAgent,
+		CommandDigest:           CommandDigest("opencode", "debug", "agent", subject),
+		InputDigests:            append([]string(nil), inputDigests...),
+		EvidenceBoundaryDigests: append([]string(nil), inputDigests...),
+	}
+}
+
+func CommandDigest(command ...string) string {
+	payload, _ := json.Marshal(command)
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func matchesTuple(record Record, expected Tuple) bool {
+	return record.ClientName == expected.ClientName &&
+		record.ClientVersion == expected.ClientVersion &&
+		record.ClientVersionRange == expected.ClientVersionRange &&
+		record.BinarySHA256 == expected.BinarySHA256 &&
+		record.OS == expected.OS &&
+		record.Arch == expected.Arch &&
+		record.Capability == expected.Capability &&
+		record.Subject == expected.Subject &&
+		record.OracleID == expected.OracleID &&
+		record.CommandDigest == expected.CommandDigest &&
+		slices.Equal(record.InputDigests, expected.InputDigests) &&
+		slices.Equal(record.EvidenceBoundaryDigests, expected.EvidenceBoundaryDigests)
+}
+
+func validateOracleEvidenceBoundary(record Record) error {
+	for name, value := range map[string]string{
+		"client_name": record.ClientName, "client_version": record.ClientVersion, "client_version_range": record.ClientVersionRange,
+		"binary_sha256": record.BinarySHA256, "os": record.OS, "arch": record.Arch, "capability_id": record.Capability,
+		"subject": record.Subject, "oracle_id": record.OracleID, "command_digest": record.CommandDigest,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("runtime certification missing %s", name)
+		}
+	}
+	if !hasUsableDigest(record.InputDigests) {
+		return errors.New("runtime certification missing input digests")
+	}
+	if !hasUsableDigest(record.EvidenceBoundaryDigests) {
+		return errors.New("runtime certification missing evidence boundary digests")
+	}
+	return nil
+}
+
+func hasUsableDigest(digests []string) bool {
+	for _, digest := range digests {
+		if strings.TrimSpace(digest) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func expired(expiresAt time.Time, now time.Time) bool {
+	if expiresAt.IsZero() {
+		return true
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return !expiresAt.After(now)
+}
+
+func isRevoked(record Record, revocations []Revocation) bool {
+	for _, revocation := range revocations {
+		if revocation.OracleID != "" && revocation.OracleID != record.OracleID {
+			continue
+		}
+		if revocation.ClientName != "" && revocation.ClientName != record.ClientName {
+			continue
+		}
+		if revocation.ClientVersion != "" && revocation.ClientVersion != record.ClientVersion {
+			continue
+		}
+		if revocation.BinarySHA256 != "" && revocation.BinarySHA256 != record.BinarySHA256 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func validateOraclePayload(oracleID, subject string, payload json.RawMessage) error {
+	if oracleID != OracleOpenCodeDebugAgent {
+		return errors.New("unsupported runtime oracle")
+	}
+	var agent map[string]any
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	if err := decoder.Decode(&agent); err != nil {
+		return fmt.Errorf("opencode debug-agent oracle payload is invalid: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("opencode debug-agent oracle payload contains trailing data")
+	}
+	name, _ := agent["name"].(string)
+	if strings.TrimSpace(name) != subject {
+		return errors.New("opencode debug-agent oracle payload does not match subject")
+	}
+	return nil
+}

--- a/internal/runtimecertification/certification_test.go
+++ b/internal/runtimecertification/certification_test.go
@@ -1,0 +1,68 @@
+package runtimecertification
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEvaluateOpenCodeDebugAgentCertification(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	expected := OpenCodeDebugAgentTuple("1.18.5", "sha256:binary", "darwin", "arm64", "gentle-orchestrator", []string{"sha256:agent"})
+	base := recordFor(expected, now.Add(time.Hour), OracleStatusPass, `{"name":"gentle-orchestrator"}`)
+
+	tests := map[string]struct {
+		record Record
+		policy Policy
+		want   State
+	}{
+		"matching pass certifies current identity":      {base, Policy{Expected: expected, Now: now}, StateCertifiedCurrent},
+		"written evidence remains lower evidence":       {withEvidenceKind(base, EvidenceWritten), Policy{Expected: expected, Now: now}, StateWritten},
+		"version range mismatch is stale":               {withClientVersionRange(base, "1.18.x"), Policy{Expected: expected, Now: now}, StateStale},
+		"missing input digest fails closed":             {withInputDigests(base, nil), Policy{Expected: expected, Now: now}, StateFailed},
+		"blank input digest fails closed":               {withInputDigests(base, []string{" \t "}), Policy{Expected: expected, Now: now}, StateFailed},
+		"missing evidence boundary digest fails closed": {withEvidenceBoundaryDigests(base, nil), Policy{Expected: expected, Now: now}, StateFailed},
+		"blank evidence boundary digest fails closed":   {withEvidenceBoundaryDigests(base, []string{"\n"}), Policy{Expected: expected, Now: now}, StateFailed},
+		"expired record has explicit stale detail":      {recordFor(expected, now, OracleStatusPass, `{"name":"gentle-orchestrator"}`), Policy{Expected: expected, Now: now}, StateStale},
+		"revoked oracle fails closed":                   {base, Policy{Expected: expected, Now: now, Revocations: []Revocation{{OracleID: OracleOpenCodeDebugAgent}}}, StateRevoked},
+		"revoked expired oracle returns revoked":        {recordFor(expected, now, OracleStatusPass, `{"name":"gentle-orchestrator"}`), Policy{Expected: expected, Now: now, Revocations: []Revocation{{OracleID: OracleOpenCodeDebugAgent}}}, StateRevoked},
+		"inconclusive oracle is not pass":               {recordFor(expected, now.Add(time.Hour), OracleStatusInconclusive, `{"name":"gentle-orchestrator"}`), Policy{Expected: expected, Now: now}, StateInconclusive},
+		"malformed oracle JSON is failed":               {recordFor(expected, now.Add(time.Hour), OracleStatusPass, `{`), Policy{Expected: expected, Now: now}, StateFailed},
+		"subject mismatch is failed":                    {recordFor(expected, now.Add(time.Hour), OracleStatusPass, `{"name":"other"}`), Policy{Expected: expected, Now: now}, StateFailed},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Evaluate(tt.record, tt.policy)
+			if got.State != tt.want {
+				t.Fatalf("state = %s, want %s; detail: %s", got.State, tt.want, got.Detail)
+			}
+			if name == "expired record has explicit stale detail" && got.Detail != "runtime certification expired for the current identity" {
+				t.Fatalf("detail = %q", got.Detail)
+			}
+		})
+	}
+}
+
+func recordFor(tuple Tuple, expiresAt time.Time, status OracleStatus, payload string) Record {
+	tuple.InputDigests = append([]string(nil), tuple.InputDigests...)
+	tuple.EvidenceBoundaryDigests = append([]string(nil), tuple.EvidenceBoundaryDigests...)
+	return Record{SchemaVersion: SchemaV1, EvidenceKind: EvidenceOracle, Tuple: tuple, Limitations: []string{"loaded evidence only"}, ExpiresAt: expiresAt, OracleResult: OracleResult{Status: status, Payload: json.RawMessage(payload)}}
+}
+
+func withEvidenceKind(record Record, kind EvidenceKind) Record {
+	record.EvidenceKind = kind
+	return record
+}
+func withClientVersionRange(record Record, versionRange string) Record {
+	record.ClientVersionRange = versionRange
+	return record
+}
+func withInputDigests(record Record, digests []string) Record {
+	record.InputDigests = digests
+	return record
+}
+func withEvidenceBoundaryDigests(record Record, digests []string) Record {
+	record.EvidenceBoundaryDigests = digests
+	return record
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Part of #1873 (closed by slice 2 of this chain)

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Adds the provider-neutral runtime oracle evaluator: it decides whether oracle evidence certifies the current identity, without launching external providers or treating a rendered file as proof.

- Declared and written evidence stay strictly below certified evidence.
- A complete tuple plus non-empty input and evidence-boundary digests are required; a payload whose subject does not match the record is rejected.
- Expiry, revocation, and identity drift each resolve to their own state instead of one opaque failure.

This slice is the library and its unit tests. Nothing imports it yet.

## 🔗 Chain Context

This PR was 422 lines and failed the 400-line cognitive budget. Rather than ask for `size:exception` on a non-urgent feature, it is now split by dependency direction.

```
📍 slice 1  feat(runtimecertification): the evaluator      323 lines  ← this PR
   slice 2  feat(doctor): surface it as a doctor check      99 lines
```

- **Start:** no prior dependency, applies to `main`.
- **End:** a tested evaluator with no callers.
- **Follow-up:** slice 2 wires it into doctor and closes #1873. Branch is ready at `jjeg1979:feat/1873-runtimecertification-doctor`; I will open it once this merges. It is not open yet because GitHub cannot use a fork branch as a PR base, so opening it now against `main` would show a 422-line diff and re-break the same budget the split exists to respect.
- **Out of scope:** registering the check in the doctor run list. Both slices leave the code unreachable, which is why slice 2 carries baseline entries.

## 🧮 Deadcode baseline

Worth flagging because it looks inverted at first glance: **this slice changes no baseline entries, and slice 2 adds all twelve** — including the nine that belong to files in *this* PR.

`scripts/deadcode-ratchet.sh` measures reachability from `./cmd/gentle-ai`. A package nothing imports is never analyzed, so the evaluator alone sits outside that graph entirely and the ratchet reports nothing. Slice 2's import is what pulls both packages in, and neither has a caller yet. The growth is real and belongs to the slice that creates the edge, not the slice that adds the code.

## ✅ Validation

- [x] `go build ./...`
- [x] `go vet ./internal/runtimecertification/`
- [x] `go test ./internal/runtimecertification/` — pass
- [x] `gofmt -l internal/runtimecertification/` — clean
- [x] `scripts/deadcode-ratchet.sh` — `no new unreachable functions`

## 📌 Maintainer action

Still needs exactly one `type:*` label (`type:feature`); this account cannot set labels. That was the other CI failure alongside the budget, and it is the only one left.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime certification support for validating schemas, evidence, identities, digests, expiration, revocations, and oracle results.
  * Added certification evaluation states and policy handling.
  * Added OpenCode debug-agent certification data with command digest generation.

* **Bug Fixes**
  * Added validation for malformed certification data, version mismatches, missing digests, expired records, revoked evidence, and subject mismatches.

* **Tests**
  * Added coverage for successful and rejected certification scenarios, including evidence-level and oracle-status variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->