### PR TITLE
feat(sdd): admit slice-scoped verify reports (scope + slice-id)

### DIFF
--- a/internal/cli/sdd_verify_validate.go
+++ b/internal/cli/sdd_verify_validate.go
@@ -28,6 +28,8 @@ type sddVerifyValidateFlagDefinition struct {
 
 var sddVerifyValidateFlagDefinitions = []sddVerifyValidateFlagDefinition{
 	{name: "input", value: "<path|->", usage: "Verify report path; use - to read stdin", kind: sddVerifyValidateStringFlag},
+	{name: "scope", value: "<whole|slice>", usage: "Verification scope: whole (default) binds to change totals; slice requires --slice-id and a slice-scope envelope", kind: sddVerifyValidateStringFlag},
+	{name: "slice-id", value: "<id>", usage: "Slice identifier when --scope=slice; must match slice_id in the verify result envelope", kind: sddVerifyValidateStringFlag},
 	{name: "requirements", value: "<n>", usage: "Authoritative nonnegative requirement total", kind: sddVerifyValidateIntFlag},
 	{name: "scenarios", value: "<n>", usage: "Authoritative nonnegative scenario total", kind: sddVerifyValidateIntFlag},
 }
@@ -44,6 +46,8 @@ func runSDDVerifyValidate(args []string, stdin io.Reader, stdout io.Writer) erro
 	flags := flag.NewFlagSet("sdd-verify-validate", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 	input := registerSDDVerifyValidateStringFlag(flags, "input", "")
+	scope := registerSDDVerifyValidateStringFlag(flags, "scope", "whole")
+	sliceID := registerSDDVerifyValidateStringFlag(flags, "slice-id", "")
 	requirements := registerSDDVerifyValidateIntFlag(flags, "requirements", -2)
 	scenarios := registerSDDVerifyValidateIntFlag(flags, "scenarios", -2)
 	if err := flags.Parse(args); err != nil {
@@ -54,6 +58,18 @@ func runSDDVerifyValidate(args []string, stdin io.Reader, stdout io.Writer) erro
 	}
 	if strings.TrimSpace(*input) == "" {
 		return errors.New("sdd-verify-validate requires --input")
+	}
+	switch *scope {
+	case "whole":
+		if strings.TrimSpace(*sliceID) != "" {
+			return errors.New("--slice-id is only valid with --scope=slice")
+		}
+	case "slice":
+		if strings.TrimSpace(*sliceID) == "" {
+			return errors.New("--scope=slice requires --slice-id")
+		}
+	default:
+		return fmt.Errorf("--scope must be one of: whole, slice (got %q)", *scope)
 	}
 	if *requirements == -2 {
 		return errors.New("sdd-verify-validate requires --requirements")
@@ -80,7 +96,13 @@ func runSDDVerifyValidate(args []string, stdin io.Reader, stdout io.Writer) erro
 	if len(payload) > maxVerifyReportBytes {
 		return fmt.Errorf("verify report exceeds %d-byte limit", maxVerifyReportBytes)
 	}
-	admission := sddstatus.ValidateVerifyReportAdmission(string(payload), sddstatus.SpecCounts{Requirements: *requirements, Scenarios: *scenarios})
+	specs := sddstatus.SpecCounts{Requirements: *requirements, Scenarios: *scenarios}
+	var admission sddstatus.VerifyReportAdmission
+	if *scope == "slice" {
+		admission = sddstatus.ValidateSliceVerifyReportAdmission(string(payload), specs, *sliceID)
+	} else {
+		admission = sddstatus.ValidateVerifyReportAdmission(string(payload), specs)
+	}
 	if !admission.Valid {
 		return fmt.Errorf("verify report admission denied: %s", admission.Reason)
 	}

--- a/internal/cli/sdd_verify_validate_test.go
+++ b/internal/cli/sdd_verify_validate_test.go
@@ -136,6 +136,82 @@ func TestRunSDDVerifyValidateRequiredFlagsRemainRequired(t *testing.T) {
 	}
 }
 
+func TestRunSDDVerifyValidateSliceScopeFlags(t *testing.T) {
+	sliceReport := strings.Replace(testSDDVerifyValidateTestReport(), "verdict: pass", "verdict: pass\nscope: slice\nslice_id: PR8b1-a", 1)
+	tests := []struct {
+		name      string
+		args      []string
+		input     string
+		wantErr   string
+		wantValid bool
+	}{
+		{
+			name:      "slice admission happy path",
+			args:      []string{"--input", "-", "--scope", "slice", "--slice-id", "PR8b1-a", "--requirements", "1", "--scenarios", "1"},
+			input:     sliceReport,
+			wantValid: true,
+		},
+		{
+			name:    "slice requires --slice-id",
+			args:    []string{"--input", "-", "--scope", "slice", "--requirements", "1", "--scenarios", "1"},
+			input:   sliceReport,
+			wantErr: "requires --slice-id",
+		},
+		{
+			name:    "slice-id without --scope=slice",
+			args:    []string{"--input", "-", "--slice-id", "PR8b1-a", "--requirements", "1", "--scenarios", "1"},
+			input:   sliceReport,
+			wantErr: "only valid with --scope=slice",
+		},
+		{
+			name:    "invalid scope value",
+			args:    []string{"--input", "-", "--scope", "weird", "--requirements", "1", "--scenarios", "1"},
+			input:   sliceReport,
+			wantErr: "--scope must be one of",
+		},
+		{
+			name:    "slice admission rejects mismatched slice_id",
+			args:    []string{"--input", "-", "--scope", "slice", "--slice-id", "PR9z9-x", "--requirements", "1", "--scenarios", "1"},
+			input:   sliceReport,
+			wantErr: "does not match",
+		},
+		{
+			name:    "slice admission rejects whole-change report",
+			args:    []string{"--input", "-", "--scope", "slice", "--slice-id", "PR8b1-a", "--requirements", "1", "--scenarios", "1"},
+			input:   testSDDVerifyValidateTestReport(),
+			wantErr: "scope: slice",
+		},
+		{
+			name:    "slice admission rejects slice with totals mismatch",
+			args:    []string{"--input", "-", "--scope", "slice", "--slice-id", "PR8b1-a", "--requirements", "2", "--scenarios", "3"},
+			input:   sliceReport,
+			wantErr: "actual requirement count",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := runSDDVerifyValidate(tt.args, strings.NewReader(tt.input), &output)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if !strings.Contains(output.String(), `"valid": true`) {
+				t.Fatalf("output = %s", output.String())
+			}
+		})
+	}
+}
+
+func testSDDVerifyValidateTestReport() string {
+	return "```yaml\nschema: gentle-ai.verify-result/v1\nevidence_revision: sha256:" + strings.Repeat("a", 64) + "\nverdict: pass\nblockers: 0\ncritical_findings: 0\nrequirements: 1/1\nscenarios: 1/1\ntest_command: go test ./...\ntest_exit_code: 0\ntest_output_hash: sha256:" + strings.Repeat("b", 64) + "\nbuild_command: go vet ./...\nbuild_exit_code: 0\nbuild_output_hash: sha256:" + strings.Repeat("c", 64) + "\n```"
+}
+
 type sddVerifyValidateReadSpy struct{ reads int }
 
 func (spy *sddVerifyValidateReadSpy) Read([]byte) (int, error) {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -36,6 +36,11 @@ var verifyReportAuthorityOnlyFields = []string{
 	"command_failed", "observed_authority_revision",
 }
 
+// verifyReportSliceFields are optional slice-scope metadata fields. They
+// extend the allowed envelope when present; absence is back-compat for
+// whole-change reports that never declared a scope.
+var verifyReportSliceFields = []string{"scope", "slice_id"}
+
 var verifyReportVerdicts = []string{"pass", "pass_with_warnings", "fail"}
 
 func VerifyReportValidationContract() VerifyReportContract {
@@ -82,6 +87,11 @@ type verifyReport struct {
 	Blockers, Critical, TestExit, BuildExit int
 	Requirements, Scenarios                 verifyCompletion
 	AuthorityOnly                           bool
+	// Scope and SliceID are optional slice-scope metadata. When the report
+	// declares scope=slice, SliceID carries the slice identity and the
+	// validator requires --slice-id CLI authority to match.
+	Scope   string
+	SliceID string
 }
 
 var sha256IdentityPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -151,11 +161,40 @@ func parseVerifyResult(text string, expected SpecCounts) verifyResultEvaluation 
 // ValidateVerifyReportAdmission validates exact report bytes before persistence.
 func ValidateVerifyReportAdmission(text string, expected SpecCounts) VerifyReportAdmission {
 	report, reason := parseVerifyReport(text)
-	result := VerifyReportAdmission{Reason: reason}
 	if reason != "" {
-		return result
+		return VerifyReportAdmission{Reason: reason}
 	}
-	result.Verdict, result.EvidenceRevision = report.Verdict, report.EvidenceRevision
+	return admitVerifyReport(report, expected)
+}
+
+// ValidateSliceVerifyReportAdmission validates a slice-scope report. The
+// report envelope must declare scope=slice and a non-empty slice_id that
+// matches the sliceID authority passed on the CLI. --requirements and
+// --scenarios on the CLI are interpreted as slice totals (not whole-change
+// counts). Slice admission is a pure validity check; callers must not
+// use the returned Valid=true to mark whole-change archive as complete.
+func ValidateSliceVerifyReportAdmission(text string, expected SpecCounts, sliceID string) VerifyReportAdmission {
+	report, reason := parseVerifyReport(text)
+	if reason != "" {
+		return VerifyReportAdmission{Reason: reason}
+	}
+	if report.Scope != "slice" {
+		return VerifyReportAdmission{Reason: "slice admission requires scope: slice in verify result envelope"}
+	}
+	if report.SliceID == "" {
+		return VerifyReportAdmission{Reason: "missing slice_id in verify result envelope"}
+	}
+	if report.SliceID != sliceID {
+		return VerifyReportAdmission{Reason: "slice_id in verify result envelope does not match the slice authority"}
+	}
+	return admitVerifyReport(report, expected)
+}
+
+// admitVerifyReport applies the per-verdict and totals rules to an already-
+// parsed report. Both whole-change and slice admission share this logic;
+// the difference between them lives in the metadata validation above.
+func admitVerifyReport(report verifyReport, expected SpecCounts) VerifyReportAdmission {
+	result := VerifyReportAdmission{Verdict: report.Verdict, EvidenceRevision: report.EvidenceRevision}
 	if expected.Requirements < 0 || expected.Scenarios < 0 {
 		result.Reason = "expected requirement and scenario counts must be nonnegative"
 		return result
@@ -193,12 +232,12 @@ func parseVerifyReport(text string) (verifyReport, string) {
 	if reason != "" {
 		return verifyReport{}, reason
 	}
-	allowed := make(map[string]bool, len(verifyReportRequiredFields)+len(verifyReportAuthorityOnlyFields))
-	for _, field := range append(append([]string{}, verifyReportRequiredFields...), verifyReportAuthorityOnlyFields...) {
+	allowed := make(map[string]bool, len(verifyReportRequiredFields)+len(verifyReportAuthorityOnlyFields)+len(verifyReportSliceFields))
+	for _, field := range append(append(append([]string{}, verifyReportRequiredFields...), verifyReportAuthorityOnlyFields...), verifyReportSliceFields...) {
 		allowed[field] = true
 	}
 	fields, reason := parseScalarFields(lines[1:end], allowed, "verify result")
-	report := verifyReport{Fields: fields}
+	report := verifyReport{Fields: fields, Scope: fields["scope"], SliceID: fields["slice_id"]}
 	if fields["schema"] == VerifyResultSchema && sha256IdentityPattern.MatchString(fields["evidence_revision"]) {
 		report.EvidenceRevision = fields["evidence_revision"]
 	}

--- a/internal/sddstatus/verification_test.go
+++ b/internal/sddstatus/verification_test.go
@@ -98,6 +98,53 @@ func TestValidateVerifyReportAdmission(t *testing.T) {
 	}
 }
 
+func TestValidateSliceVerifyReportAdmission(t *testing.T) {
+	validWhole := testVerifyEnvelope("pass", 0, 0, "2/2", "3/3", 0, 0)
+	sliceEnvelope := func(scope, sliceID string) string {
+		header := ""
+		if scope != "" {
+			header += "scope: " + scope + "\n"
+		}
+		if sliceID != "" {
+			header += "slice_id: " + sliceID + "\n"
+		}
+		if header == "" {
+			return validWhole
+		}
+		return strings.Replace(validWhole, "verdict: pass", "verdict: pass\n"+strings.TrimRight(header, "\n"), 1)
+	}
+	failingFailEnvelope := strings.Replace(testVerifyEnvelope("fail", 1, 0, "2/2", "3/3", 0, 0), "verdict: fail", "verdict: fail\nscope: slice\nslice_id: PR8b1-a", 1)
+	tests := []struct {
+		name, report, reason string
+		sliceID              string
+		valid                bool
+	}{
+		{"slice pass with matching id", sliceEnvelope("slice", "PR8b1-a"), "", "PR8b1-a", true},
+		{"slice fail with matching id", failingFailEnvelope, "", "PR8b1-a", true},
+		{"slice warning with matching id", strings.Replace(sliceEnvelope("slice", "PR8b1-a"), "verdict: pass", "verdict: pass_with_warnings", 1), "", "PR8b1-a", true},
+		{"missing scope", sliceEnvelope("", "PR8b1-a"), "scope: slice", "PR8b1-a", false},
+		{"whole scope under slice admission", sliceEnvelope("whole", "PR8b1-a"), "scope: slice", "PR8b1-a", false},
+		{"unknown scope value", sliceEnvelope("weird", "PR8b1-a"), "scope: slice", "PR8b1-a", false},
+		{"missing slice_id", sliceEnvelope("slice", ""), "missing slice_id", "PR8b1-a", false},
+		{"slice_id mismatch", sliceEnvelope("slice", "PR9z9-x"), "does not match", "PR8b1-a", false},
+		{"slice admission rejects count mismatch", sliceEnvelope("slice", "PR8b1-a"), "actual requirement count", "PR8b1-a", false},
+		{"slice admission rejects incomplete totals", strings.Replace(sliceEnvelope("slice", "PR8b1-a"), "requirements: 2/2", "requirements: 1/2", 1), "contradicts", "PR8b1-a", false},
+		{"slice admission admits incomplete fail", failingFailEnvelope, "", "PR8b1-a", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specs := SpecCounts{Requirements: 2, Scenarios: 3}
+			if tt.name == "slice admission rejects count mismatch" {
+				specs.Requirements = 3
+			}
+			got := ValidateSliceVerifyReportAdmission(tt.report, specs, tt.sliceID)
+			if got.Valid != tt.valid || (tt.reason != "" && !strings.Contains(got.Reason, tt.reason)) {
+				t.Fatalf("admission = %#v, want valid=%v reason containing %q", got, tt.valid, tt.reason)
+			}
+		})
+	}
+}
+
 func TestVerifyReportAuthorityOnlyFieldCountUsesContract(t *testing.T) {
 	partial := strings.TrimSuffix(testVerifyEnvelope("pass", 0, 0, "2/2", "3/3", 0, 0), "```") + "authority_only_failure: true\n```"
 	admission := ValidateVerifyReportAdmission(partial, SpecCounts{Requirements: 2, Scenarios: 3})


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #2268

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Adds explicit slice scope to `sdd-verify-validate` admission while preserving whole-change as the default. The report envelope gains two optional fields — `scope: slice` and `slice_id: <id>` — and the CLI gains two optional flags — `--scope (whole|slice, default whole)` and `--slice-id <id>` (required when `--scope=slice`).

This is a re-scoped, simplified take on the original PR #2917 (closed without merge). The original PR attempted to add obligation assignment + chain projection to the runtime ledger, but upstream PR #2921 (`fix(sdd): bind remediation settle to failed evidence`) removed the obligation-assignment fields from `BeginAttemptRequest` before #2917 landed, which made the data-model approach stale. This PR scopes the fix to what issue #2268 actually requests and ships in 198 lines (within the 400-line review budget).

**Slice admission rules**:

- `scope` must be exactly `slice` when admission is requested under `--scope=slice`; reports without `scope` metadata are admitted only under `--scope=whole` (backward compatible).
- `slice_id` must be non-empty and exactly equal to the `--slice-id` CLI authority.
- `--requirements` and `--scenarios` are interpreted as the slice's authoritative totals; `PASS` and `PASS_WITH_WARNINGS` require those slice totals to be complete (same per-verdict logic as whole-change admission).
- Incomplete `FAIL` reports are admitted under the existing contradiction rules.

**Caller-side note**: `ValidateSliceVerifyReportAdmission` is a pure validity check; callers must not use `Valid=true` to mark whole-change archive as complete. Slice admission persists only work-unit evidence; whole-change archive gating remains under the existing `resolveDependencies` path.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/verification.go` | Extracted shared `admitVerifyReport` helper. Added `verifyReportSliceFields` (`scope`, `slice_id`) as optional envelope fields. Added `ValidateSliceVerifyReportAdmission` that validates scope metadata + delegates to the shared helper. |
| `internal/sddstatus/verification_test.go` | Added `TestValidateSliceVerifyReportAdmission` with 11 sub-tests (happy path, missing scope, wrong scope, missing slice_id, slice_id mismatch, count mismatch, incomplete totals, incomplete fail admitted). |
| `internal/cli/sdd_verify_validate.go` | Added `--scope` flag (default `whole`, accepts `slice`) and `--slice-id` flag (default empty). Validates `--scope=slice` requires `--slice-id` and vice versa. Routes to `ValidateSliceVerifyReportAdmission` (slice) or `ValidateVerifyReportAdmission` (whole). |
| `internal/cli/sdd_verify_validate_test.go` | Added `TestRunSDDVerifyValidateSliceScopeFlags` with 7 sub-tests (CLI happy path, `--scope slice` requires `--slice-id`, `--slice-id` without `--scope=slice` rejected, invalid scope value rejected, slice_id mismatch, whole-change report under slice admission rejected, totals mismatch). |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/sddstatus/ ./internal/cli/ -count=1 -run 'TestValidateSliceVerifyReportAdmission|TestRunSDDVerifyValidateSliceScopeFlags|TestValidateVerifyReportAdmission|TestRunSDDVerifyValidate'
```

**Compact Acquisition + sddstatus regression** (already-green tests should stay green)
```bash
go test ./internal/sddstatus/ -count=1 -run 'TestCompact|TestParseVerifyResult|TestVerifyReportAuthorityOnlyFieldCount'
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Result: clean.

**Go Vet**
```bash
go vet ./internal/sddstatus/ ./internal/cli/
```
Result: clean.

**Build**
```bash
go build ./...
```
Result: clean.

**Full sddstatus + cli suites**
```bash
go test ./internal/sddstatus/ ./internal/cli/ -count=1
```
Result: all pass (targeted + existing). 5 pre-existing Windows-specific git-subprocess tests still hang under parallel load on Windows; not regressions from this PR (verified via `git stash` baseline at `3c6a6341`).

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending CI
- [x] Manually tested locally — slice CLI and validator paths verified locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 198 changed lines, within the 400-line review budget |
| Check Issue Reference | ⏳ | PR body contains `Closes #2268` |
| Check Issue Has `status:approved` | ⏳ | Issue #2268 has `status:approved` (verified before PR open) |
| Check PR Has `type:*` Label | ⏳ | `type:feature` requested via PR body; maintainer must apply (contributor cannot add GitHub labels) |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#2268 verified `status:approved` before PR open)
- [x] PR stays within 400 changed lines (198 lines, no `size:exception` needed)
- [x] I have added the appropriate `type:*` label to this PR (`type:feature` requested via PR body; contributor cannot apply GitHub labels)
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending CI
- [x] I have updated documentation if necessary (no doc changes needed; this PR is pure validator + CLI behavior)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- The `scope` and `slice_id` envelope fields are **optional**. Existing whole-change reports without those fields continue to work and are admitted under `--scope=whole` (backward compatible). The allowed-map in `parseVerifyReport` was extended with `verifyReportSliceFields`; the required-fields list was not.
- The per-verdict admission logic (PASS/PASS_WITH_WARNINGS requires all-green evidence, FAIL admits incompleteness, authority-only extension rules) is shared between whole-change and slice admission via the extracted `admitVerifyReport` helper — no logic duplication.
- Slice totals are interpreted from the CLI (`--requirements/--scenarios`); the validator does not parse the spec to count slice requirements/scenarios. The caller is responsible for supplying the correct slice totals. This is a deliberate choice: it keeps the validator pure and stateless, and the slice totals are part of the slice's "contract" that the slice maintainer knows.
- `ValidateSliceVerifyReportAdmission` returns the same `VerifyReportAdmission` shape as `ValidateVerifyReportAdmission`, so the CLI and any other caller only need to switch the validator function. The `Verdict` and `EvidenceRevision` fields are populated identically.

**Focus areas for review**:

1. The scope metadata validation order in `ValidateSliceVerifyReportAdmission` (scope → slice_id → slice_id match → totals) — the order matters for the reason messages.
2. The CLI flag cross-validation (`--scope slice` requires `--slice-id`, `--slice-id` requires `--scope slice`) — caught before file IO, so the user sees the error fast.
3. The slice admission's preservation of the existing authority-only extension behavior — `ValidateSliceVerifyReportAdmission` shares `admitVerifyReport` with the whole-change path, so authority-only rules apply identically.

Looking forward to your review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating verification reports for a specific slice.
  * Added scope and slice ID options to verification validation commands.
  * Verification reports can now include slice metadata.

* **Bug Fixes**
  * Added validation to prevent missing or mismatched slice IDs and invalid scope values.
  * Preserved existing whole-change report validation behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->