### PR TITLE
fix(review): collect unborn untracked selection

### DIFF
--- a/bench/journeys_intended_untracked.go
+++ b/bench/journeys_intended_untracked.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 )
 
 var intendedUntrackedStatusCapability = &Capability{
 	Verb:  []string{"review", "status"},
 	Flags: []string{"--cwd", "--contract", "--next-transition", "--untracked-scope", "--intended-untracked", "--expected-untracked-inventory"},
+}
+
+var unbornIntendedUntrackedStatusCapability = &Capability{
+	Verb:  []string{"review", "status"},
+	Flags: []string{"--cwd", "--contract", "--agent", "--next-transition"},
 }
 
 func mixedIntendedUntrackedCandidate(sandbox *Sandbox) error {
@@ -63,6 +71,61 @@ func selectIntendedUntrackedAndRunPrintedStart(r *journeyRun) error {
 	return nil
 }
 
+func unbornUntrackedExecutableCandidate(sandbox *Sandbox) error {
+	if err := os.MkdirAll(sandbox.Repo, 0o755); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "init", "-b", "main", "-q"); err != nil {
+		return err
+	}
+	path := filepath.Join(sandbox.Repo, "scripts", "unborn-candidate.sh")
+	if err := sandbox.write(path, "#!/bin/sh\necho candidate\n"); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o755)
+}
+
+func unbornUntrackedStatusCollectsSelection(r *journeyRun) error {
+	observation := r.run(productArgsFor(r,
+		"review", "status", "--cwd", r.sandbox.Repo, "--contract", reviewContractV2,
+		"--agent", "opencode", "--next-transition"), false)
+	if observation.ExitCode != 0 {
+		return fmt.Errorf("unborn STATUS exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	var status struct {
+		Authority      *json.RawMessage `json:"authority"`
+		NextTransition struct {
+			Kind       string `json:"kind"`
+			ReasonCode string `json:"reason_code"`
+			Collect    struct {
+				Inputs []struct {
+					Arguments []struct {
+						Name  string `json:"name"`
+						Value string `json:"value"`
+					} `json:"arguments"`
+				} `json:"inputs"`
+			} `json:"collect"`
+		} `json:"next_transition"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &status); err != nil {
+		return fmt.Errorf("parse unborn STATUS: %w", err)
+	}
+	if status.Authority != nil || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "intended_untracked_selection_required" || len(status.NextTransition.Collect.Inputs) != 1 {
+		return fmt.Errorf("unborn STATUS = %+v", status)
+	}
+	values := map[string]string{}
+	for _, argument := range status.NextTransition.Collect.Inputs[0].Arguments {
+		values[argument.Name] = argument.Value
+	}
+	var paths []string
+	if err := json.Unmarshal([]byte(values["eligible_paths_json"]), &paths); err != nil || !slices.Equal(paths, []string{"scripts/unborn-candidate.sh"}) ||
+		!strings.HasPrefix(values["expected_untracked_inventory"], "sha256:") {
+		return fmt.Errorf("unborn selection inventory = paths %v digest %q: %v", paths, values["expected_untracked_inventory"], err)
+	}
+	return nil
+}
+
 func intendedUntrackedJourneys() []Journey {
 	return []Journey{
 		{
@@ -73,6 +136,16 @@ func intendedUntrackedJourneys() []Journey {
 				{Name: "fixture: repository", Fixture: baseRepo},
 				{Name: "fixture: mixed tracked and intended/unrelated untracked files", Fixture: mixedIntendedUntrackedCandidate},
 				{Name: "STATUS collects selection and printed START freezes only chosen paths", Requires: intendedUntrackedStatusCapability, Composite: selectIntendedUntrackedAndRunPrintedStart},
+			},
+		},
+		{
+			ID:     "j88-unborn-status-collects-untracked-selection",
+			Title:  "Unborn repository: STATUS collects explicit untracked selection before snapshot assessment",
+			Source: "issue #2843: an unselected executable candidate must collect inventory-bound intent, never return generic retry or create authority",
+			Steps: []Step{
+				{Name: "fixture: unborn repository with one untracked executable candidate", Fixture: unbornUntrackedExecutableCandidate},
+				{Name: "mode enable", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--json")},
+				{Name: "v2 OpenCode STATUS collects the inventory-bound untracked selection", Requires: unbornIntendedUntrackedStatusCapability, Composite: unbornUntrackedStatusCollectsSelection},
 			},
 		},
 	}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -47,11 +47,12 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// monotonic subset without reopening review.
 	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base
 	// while the advertised main ref remains a moving publication boundary. j87
-	// proves #2871's correction binds the immutable failure across a later interrupt.
+	// proves #2871's correction binds the immutable failure across a later interrupt;
+	// j88 proves #2843's unborn STATUS collects explicit untracked intent first.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 86 {
-		t.Errorf("core journey count = %d, want 86", got)
+	if got := len(seen); got != 87 {
+		t.Errorf("core journey count = %d, want 87", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/review_intended_untracked_test.go
+++ b/internal/cli/review_intended_untracked_test.go
@@ -96,6 +96,34 @@ func TestIntendedUntrackedPreflightRequiresExplicitIntentBeforeAuthority(t *test
 	assertNoUntrackedSelectionAuthority(t, repo)
 }
 
+func TestNegotiatedStatusUnbornUntrackedRequiresSelectionBeforeSnapshot(t *testing.T) {
+	reviewModeHome(t)
+	repo := initUnbornReviewCLIRepo(t)
+	if err := RunReviewMode([]string{"enable", "--cwd", repo, "--scope", "global"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	const path = "scripts/unborn-candidate.sh"
+	writeUndeclaredWorkspaceFile(t, repo, path, "#!/bin/sh\necho candidate\n", 0o755)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "opencode", "--next-transition",
+	}, &output); err != nil {
+		t.Fatalf("unborn negotiated STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	digest, inventory := intendedUntrackedSelection(t, status)
+	if digest == "" || !reflect.DeepEqual(inventory, []string{path}) {
+		t.Fatalf("selection inventory = digest %q paths %v, want only %q", digest, inventory, path)
+	}
+	if status.Authority != nil {
+		t.Fatalf("selection STATUS created authority: %#v", status.Authority)
+	}
+	assertNoUntrackedSelectionAuthority(t, repo)
+}
+
 func TestIntendedUntrackedSelectionUsesCanonicalPathsAndPrintedStart(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	writeUndeclaredWorkspaceFile(t, repo, "docs/chosen, file.md", "# Chosen\n", 0o644)

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1163,7 +1163,7 @@ func (builder *SnapshotBuilder) buildCurrentChanges(ctx context.Context, intende
 		return "", "", "", err
 	}
 	candidateTree := strings.TrimSpace(string(candidateOutput))
-	if unborn && candidateTree == baseTree {
+	if unborn && projection == ProjectionStaged && candidateTree == baseTree {
 		return "", "", "", errors.New("unborn repository has no staged changes; stage the review candidate with git add")
 	}
 	if allowStagedIntended && projection != ProjectionStaged {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2843

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Let an enabled unborn workspace STATUS reach the existing explicit-untracked selection transition instead of generic retry.
- Preserve staged direct-START refusals and `stop/rdd_disabled` precedence.
- Add driven journey `j88` for the real unborn, untracked, unselected operator flow.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | Keep the empty-unborn refusal scoped to staged projection, allowing workspace STATUS assessment. |
| `internal/cli/review_intended_untracked_test.go` | Prove enabled unborn STATUS collects exact inventory-bound selection without authority. |
| `bench/journeys_intended_untracked.go` | Add j88 using an explicitly enabled sandbox and real v2/OpenCode STATUS. |
| `bench/journeys_sdd_test.go` | Ratchet the core corpus from 86 to 87 journeys. |

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `cd bench && go vet ./... && go test ./... -count=1`
- [x] Enabled j88: `1 completed, 0 unsupported, 0 failed`
- [x] Full core corpus: `87 completed, 0 unsupported, 0 failed`
- [x] Transition axis: `98 completed, 0 unsupported, 0 failed` (11 transition journeys)
- [x] Exact pre-fix decoy: `0 completed, 0 unsupported, 1 failed` with generic `operation_failed` / `next_action=retry`
- [x] Disabled control: `stop/rdd_disabled`, no selection collection, no authority
- [x] `./scripts/deadcode-ratchet.sh` and refusal/stop invariants
- [x] Docker E2E suite (CI)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (110 authored lines)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI passed
- [x] Benchmark validation completed
- [x] Documentation is not required for this internal correction
- [x] My commits follow Conventional Commits
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The qualifying empty-unborn guard remains fail-closed for staged projection, which is the direct START population requiring a staged candidate. Workspace STATUS is the legitimate population added here because it must first collect explicit untracked intent. Independent validation also caught and removed an earlier attempt that displaced `stop/rdd_disabled`; the final candidate leaves that contract unchanged. `.guard-population-baseline.txt` is unchanged because no guard origin or refusal vocabulary was added.

Rollback is limited to commit `7de3dbbc` and the four files in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reviewing intended untracked files in repositories without an initial commit.
  * Status results now identify eligible untracked files and provide their inventory digest before snapshot creation.
  * Workspace reviews can proceed when the working tree matches the empty base state.

* **Bug Fixes**
  * Corrected handling of empty candidates across staged and workspace review modes.

* **Tests**
  * Added regression coverage for unborn repository status and intended-untracked selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
