### PR TITLE
fix(review): handle Git merge-tree capability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ An issue **without** that label is usually waiting on information (`status:needs
 
 - Go 1.25.10+
 - Docker (for E2E tests)
-- Git
+- Git 2.38+
 
 ### Clone and Build
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,6 +32,7 @@
 
 ### All platforms
 
+- Git 2.38+.
 - Go 1.25.10+ (for building from source).
 - Node.js 18+ and npm: `gentle-ai install` checks these as required prerequisites on every platform and prints a warning with a distro-specific install hint (see above) if either is missing — regardless of which agents/components you select. It does not install them for you, and it does not install agent runtimes either: if a selected agent isn't detected, `gentle-ai install` refuses and prints the exact `npm install -g` (or equivalent) command for you to run yourself. Node.js/npm are strictly required if you select the CodeGraph community tool, which gentle-ai does install via `npm install -g`.
 - Pi installed and available as `pi` on `PATH` if you select the Pi agent.

--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -507,6 +507,7 @@ type attestedRecoveryAdvanceFixture struct {
 
 func newAttestedRecoveryAdvanceFixture(t *testing.T) *attestedRecoveryAdvanceFixture {
 	t.Helper()
+	requireMergeTreeWriteTree(t)
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -1019,6 +1019,7 @@ func newCompatiblePrePRFixture(t *testing.T, deliveryPath, basePath string) *com
 
 func newCompatiblePrePRFixtureMode(t *testing.T, deliveryPath, basePath string, mode Mode) *compatiblePrePRFixture {
 	t.Helper()
+	requireMergeTreeWriteTree(t)
 	repo := initSnapshotRepo(t)
 	baseCommit := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	gitSnapshot(t, repo, "branch", "main", baseCommit)

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -142,7 +142,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	}
 	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, reviewedHead)
 	if err != nil {
-		return BaseAdvanceCompatibility{}, errors.New("merge against new base is not conflict-free")
+		return BaseAdvanceCompatibility{}, fmt.Errorf("merge against new base is not conflict-free: %w", err)
 	}
 	mergedFields := strings.Fields(string(mergedOutput))
 	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {
@@ -334,7 +334,7 @@ func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string,
 	}
 	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)
 	if err != nil {
-		return BaseAdvanceCompatibility{}, errors.New("merge against the advanced boundary is not conflict-free")
+		return BaseAdvanceCompatibility{}, fmt.Errorf("merge against the advanced boundary is not conflict-free: %w", err)
 	}
 	mergedFields := strings.Fields(string(mergedOutput))
 	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {

--- a/internal/reviewtransaction/prepr_base_advance_characterization_test.go
+++ b/internal/reviewtransaction/prepr_base_advance_characterization_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -97,6 +98,7 @@ type baseAdvanceScenarioResult struct {
 // conditions unless one of the scenario hooks perturbs exactly one of them.
 func runBaseAdvanceScenario(t *testing.T, scenario baseAdvanceScenario) baseAdvanceScenarioResult {
 	t.Helper()
+	requireMergeTreeWriteTree(t)
 	ctx := context.Background()
 
 	deliveryPath := scenario.deliveryPath
@@ -284,6 +286,7 @@ func TestDeriveBaseAdvanceCompatibilityFailsClosedOnSingleConditionViolation(t *
 		condition  string
 		scenario   baseAdvanceScenario
 		wantErrSub string
+		wantGitErr bool
 	}{
 		{
 			name:      "merge-base tree not preserved",
@@ -337,6 +340,7 @@ func TestDeriveBaseAdvanceCompatibilityFailsClosedOnSingleConditionViolation(t *
 				basePath:     "conflict",
 			},
 			wantErrSub: "merge against new base is not conflict-free",
+			wantGitErr: true,
 		},
 		{
 			name:      "CI attestation issuer does not match the receipt-bound trust root",
@@ -365,6 +369,10 @@ func TestDeriveBaseAdvanceCompatibilityFailsClosedOnSingleConditionViolation(t *
 			}
 			if !strings.Contains(result.err.Error(), tt.wantErrSub) {
 				t.Fatalf("condition %s: error = %q, want substring %q", tt.condition, result.err.Error(), tt.wantErrSub)
+			}
+			var gitErr *GitCommandError
+			if errors.As(result.err, &gitErr) != tt.wantGitErr {
+				t.Fatalf("condition %s: GitCommandError presence = %v, want %v", tt.condition, gitErr != nil, tt.wantGitErr)
 			}
 			if (result.proof != BaseAdvanceCompatibility{}) {
 				t.Fatalf("condition %s: proof = %#v, want zero value on failure", tt.condition, result.proof)

--- a/internal/reviewtransaction/shadow_relation_test.go
+++ b/internal/reviewtransaction/shadow_relation_test.go
@@ -253,6 +253,7 @@ func TestShadowRelateAmendmentBDegradesContractionOnExcludedFinding(t *testing.T
 // deriveBaseAdvanceCompatibility fails closed on that one condition.
 func buildShadowBaseAdvanceFixture(t *testing.T, breakMergeBasePreservation bool) (string, Receipt, GateRequest, Snapshot, *resolvedPrePRRefs, gateArtifactPreimages) {
 	t.Helper()
+	requireMergeTreeWriteTree(t)
 	ctx := context.Background()
 	repo := initSnapshotRepo(t)
 	baseCommit := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -22,6 +22,9 @@ var (
 	snapshotRepoTemplateOnce sync.Once
 	snapshotRepoTemplateDir  string
 	snapshotRepoTemplateErr  error
+	mergeTreeProbeOnce       sync.Once
+	mergeTreeWriteTree       bool
+	mergeTreeProbeErr        error
 )
 
 func TestMain(m *testing.M) {
@@ -1856,6 +1859,58 @@ func requireSnapshotGit(t *testing.T) {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("uses real git commands")
+	}
+}
+
+func requireMergeTreeWriteTree(t *testing.T) {
+	t.Helper()
+	requireSnapshotGit(t)
+	mergeTreeProbeOnce.Do(func() {
+		output, err := exec.Command("git", "merge-tree", "-h").CombinedOutput()
+		mergeTreeWriteTree, mergeTreeProbeErr = classifyMergeTreeWriteTreeProbe(output, err)
+	})
+	if mergeTreeProbeErr != nil {
+		t.Fatalf("probe git merge-tree --write-tree capability: %v", mergeTreeProbeErr)
+	}
+	if !mergeTreeWriteTree {
+		t.Skip("git does not support merge-tree --write-tree (needs Git 2.38+)")
+	}
+}
+
+func classifyMergeTreeWriteTreeProbe(output []byte, err error) (bool, error) {
+	validHelp := bytes.Contains(output, []byte("git merge-tree"))
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 129 || !validHelp {
+			return false, fmt.Errorf("git merge-tree -h: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+	}
+	if !validHelp {
+		return false, fmt.Errorf("git merge-tree -h returned unrecognized help output: %q", strings.TrimSpace(string(output)))
+	}
+	return bytes.Contains(output, []byte("--write-tree")), nil
+}
+
+func TestClassifyMergeTreeWriteTreeProbe(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		err       error
+		want      bool
+		wantError bool
+	}{
+		{name: "supported", output: "usage: git merge-tree [--write-tree] <branch1> <branch2>", want: true},
+		{name: "unsupported", output: "usage: git merge-tree <base-tree> <branch1> <branch2>"},
+		{name: "unexpected command failure", output: "fatal: cannot execute", err: errors.New("exec failed"), wantError: true},
+		{name: "unrecognized successful output", output: "unexpected", wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := classifyMergeTreeWriteTreeProbe([]byte(tt.output), tt.err)
+			if got != tt.want || (err != nil) != tt.wantError {
+				t.Fatalf("classifyMergeTreeWriteTreeProbe() = (%v, %v), want (%v, error=%v)", got, err, tt.want, tt.wantError)
+			}
+		})
 	}
 }
 

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -1896,6 +1896,7 @@ func TestClassifyMergeTreeWriteTreeProbe(t *testing.T) {
 		name      string
 		output    string
 		err       error
+		exitCode  string
 		want      bool
 		wantError bool
 	}{
@@ -1903,14 +1904,32 @@ func TestClassifyMergeTreeWriteTreeProbe(t *testing.T) {
 		{name: "unsupported", output: "usage: git merge-tree <base-tree> <branch1> <branch2>"},
 		{name: "unexpected command failure", output: "fatal: cannot execute", err: errors.New("exec failed"), wantError: true},
 		{name: "unrecognized successful output", output: "unexpected", wantError: true},
+		{name: "supported help exit", output: "usage: git merge-tree [--write-tree] <branch1> <branch2>", exitCode: "129", want: true},
+		{name: "unsupported help exit", output: "usage: git merge-tree <base-tree> <branch1> <branch2>", exitCode: "129"},
+		{name: "unexpected help exit", output: "usage: git merge-tree [--write-tree] <branch1> <branch2>", exitCode: "23", wantError: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := classifyMergeTreeWriteTreeProbe([]byte(tt.output), tt.err)
+			err := tt.err
+			if tt.exitCode != "" {
+				cmd := exec.Command(os.Args[0], "-test.run=^TestMergeTreeProbeExitHelper$")
+				cmd.Env = append(os.Environ(), "GENTLE_AI_TEST_MERGE_TREE_EXIT="+tt.exitCode)
+				err = cmd.Run()
+			}
+			got, err := classifyMergeTreeWriteTreeProbe([]byte(tt.output), err)
 			if got != tt.want || (err != nil) != tt.wantError {
 				t.Fatalf("classifyMergeTreeWriteTreeProbe() = (%v, %v), want (%v, error=%v)", got, err, tt.want, tt.wantError)
 			}
 		})
+	}
+}
+
+func TestMergeTreeProbeExitHelper(t *testing.T) {
+	switch os.Getenv("GENTLE_AI_TEST_MERGE_TREE_EXIT") {
+	case "129":
+		os.Exit(129)
+	case "23":
+		os.Exit(23)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2051

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Preserve the underlying `GitCommandError` when `merge-tree --write-tree` fails.
- Skip capability-dependent tests only when Git genuinely lacks `--write-tree`; unexpected probe failures remain test failures.
- Document Git 2.38+ as a prerequisite.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/prepr.go` | Wrap both merge-tree failures while preserving their typed cause. |
| `internal/reviewtransaction/*_test.go` | Add the capability probe, guard dependent fixtures, and assert typed error preservation. |
| `CONTRIBUTING.md`, `docs/quickstart.md` | Document the Git 2.38+ requirement. |

---

## 🧪 Test Plan

- [x] Unit tests pass: `go test ./...`
- [x] Go format passes: `go run ./internal/gofmtcheck`
- [x] E2E tests pass: `DOCKER_BUILDKIT=1 ./e2e/docker-test.sh` — Ubuntu, Arch, and Fedora; 79 passed, 0 failed, 2 opt-in skipped per platform.
- [x] Manually tested locally through the real Git capability probe and merge-conflict characterization.
- [x] Benchmark validation: from `bench/`, `go build ./...`, `go vet ./...`, and `go test ./...`.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E tests pass
- [x] Benchmark validation completed
- [x] Documentation was updated
- [x] Commits follow Conventional Commits format
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This change does not add or relax an authorization, admission, repair, integrity, or governance guard. The new helper gates only tests on an external Git capability, and `.guard-population-baseline.txt` is intentionally unchanged. Unexpected probe/setup failures fail rather than skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated setup and contributor guidance to require Git 2.38 or newer on all platforms.

- **Bug Fixes**
  - Improved merge-conflict error reporting by preserving underlying Git error details, making failures easier to diagnose.

- **Tests**
  - Added compatibility checks for required merge-tree functionality.
  - Relevant tests now skip automatically when the installed Git version lacks support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->