### PR TITLE
fix(review): allow invalidated current recovery

### DIFF
--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -747,7 +747,8 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 				CaptureOperation: "external.select_recovery_target", Arguments: reviewTargetArguments(status),
 			})
 		}
-		if status.TargetIdentity == reviewAuthorityTargetIdentity(status) {
+		if status.TargetIdentity == reviewAuthorityTargetIdentity(status) &&
+			(disposition != reviewtransaction.RecoveryInvalidated || input.Selector.Recovery.Kind != reviewtransaction.TargetCurrentChanges) {
 			return reviewStopTransition("recovery_scope_unchanged")
 		}
 		var representable bool

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -607,6 +607,41 @@ func TestNewReviewNextTransitionEscalatedRouting(t *testing.T) {
 	})
 }
 
+func TestReviewRecoveryCollectionSameTargetSelectorGuard(t *testing.T) {
+	t.Parallel()
+
+	target := "sha256:" + strings.Repeat("b", 64)
+	status := ReviewTargetStatusResult{
+		Applicability:  reviewtransaction.TargetApplicabilityCurrent,
+		Action:         reviewtransaction.TargetStatusActionRecover,
+		Replayability:  reviewtransaction.ReplayabilityManualActionRequired,
+		Authority:      &ReviewTargetStatusAuthority{LineageID: "same-target-selector", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateInvalidated},
+		TargetIdentity: target, AuthorityTargetIdentity: target,
+		ActionDisposition: reviewtransaction.RecoveryInvalidated,
+		Frozen:            &ReviewTargetStatusFrozen{Tier: reviewtransaction.RiskMedium},
+		Projection:        ReviewTargetStatusProjection{Projection: reviewtransaction.ProjectionWorkspace},
+	}
+	for _, tt := range []struct {
+		name       string
+		recovery   reviewtransaction.Target
+		wantKind   string
+		wantReason string
+	}{
+		{name: "invalidated current changes collects authorization", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges}, wantKind: reviewNextTransitionCollect, wantReason: "recovery_authorization_required"},
+		{name: "unchanged base diff stops", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseDiff}, wantKind: reviewNextTransitionStop, wantReason: "recovery_scope_unchanged"},
+		{name: "unchanged workspace overlay stops", recovery: reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay}, wantKind: reviewNextTransitionStop, wantReason: "recovery_scope_unchanged"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newReviewNextTransition(status, nil, nil, nil, nil, reviewNextTransitionInput{
+				Selector: &reviewTransitionSelector{Recovery: &tt.recovery},
+			})
+			if got.Kind != tt.wantKind || got.ReasonCode != tt.wantReason {
+				t.Fatalf("same-target recovery transition = %#v", got)
+			}
+		})
+	}
+}
+
 // TestReviewNextTransitionExecuteArgumentValidatesAgainstPublishedSchema is
 // the RED-first proof for the 1745 follow-up: the "token" field 1745 added to
 // ReviewTransitionArgument for execution arguments must be admissible under

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -708,6 +708,53 @@ func TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip(t *testing.T
 	}
 }
 
+func TestStatusCollectsInvalidatedSameTargetCurrentChangesRecoveryAuthorization(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-current-invalidated"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewInvalidate([]string{
+		"--cwd", repo, "--lineage", started.LineageID, "--expected-revision", record.Revision,
+		"--reason", "replace invalidated current-changes review",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	record, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, _ := os.ReadFile(store.StatePath())
+	storesBefore, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+
+	status := selectorTransitionStatus(t, repo, "--lineage", started.LineageID)
+	if status.Action != reviewtransaction.TargetStatusActionRecover ||
+		status.ActionDisposition != reviewtransaction.RecoveryInvalidated ||
+		status.TargetIdentity != reviewAuthorityTargetIdentity(status) {
+		t.Fatalf("invalidated current-changes status = %#v", status)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "recovery_authorization_required" {
+		t.Fatalf("invalidated same-target current-changes transition = %#v", status.NextTransition)
+	}
+	after, _ := os.ReadFile(store.StatePath())
+	storesAfter, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if !bytes.Equal(before, after) || len(storesAfter) != len(storesBefore) {
+		t.Fatalf("invalidated same-target STATUS mutated authority: stores before=%d after=%d", len(storesBefore), len(storesAfter))
+	}
+}
+
 func TestStatusStopsUnrepresentableRecoveryWithoutMutation(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1984

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Allows invalidated same-target current-changes recovery to continue to the existing recovery authorization collection.
- Preserves `recovery_scope_unchanged` for unchanged base-diff and workspace-overlay selector recovery.
- Adds regressions proving STATUS does not mutate authority while collecting recovery authorization.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_next_transition.go` | Narrows the same-target selector stop so invalidated current-changes recovery can proceed. |
| `internal/cli/review_next_transition_test.go` | Covers the selector guard matrix for current-changes, base-diff, and workspace-overlay recovery. |
| `internal/cli/review_selector_transition_test.go` | Adds end-to-end STATUS coverage for invalidated same-target current-changes authorization collection without authority mutation. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/cli -run 'TestStatusCollectsInvalidatedSameTargetCurrentChangesRecoveryAuthorization|TestReviewRecoveryCollectionSameTargetSelectorGuard|TestStatusStopsUnchangedBaseDiffRecoveryWithoutSuccessor|TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip'
go test -count=1 ./internal/cli -run 'Recovery|Selector|NextTransition|Invalidated'
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
N/A, focused CLI transition/regression coverage for this narrow recovery routing fix.
```

**Benchmark Validation**

N/A, this change is covered by focused native CLI transition tests and does not alter the benchmark corpus or journey runner.

- [x] Unit tests pass (`go test ./internal/cli ...` focused runs above)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Native review evidence:
- Review lineage: `review-c1abcea0f5ac35e7`
- Receipt: `sha256:8e4e7132562330257f63594c7ac3ece5682608b23399a9d79c564b9753207c0d`
- `gentle-ai review validate --lineage=review-c1abcea0f5ac35e7 --gate=pre-push` allowed.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./internal/cli ...` focused runs above)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The production guard remains narrow: same-target selector recovery still stops for base-diff and workspace-overlay, while invalidated current-changes reaches authorization because the candidate is intentionally unchanged.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected recovery handling for invalidated reviews targeting the current changes.
  * These reviews now correctly request recovery authorization when the target remains unchanged.
  * Other unchanged-target recovery scenarios continue to stop with an appropriate scope error.

* **Tests**
  * Added regression coverage for recovery routing, authorization collection, and preservation of existing review state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->