### PR TITLE
fix(review): require staged status for pre-commit

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -619,6 +619,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, zeroDeltaJourneys()...)
 	journeys = append(journeys, localGateBaseAdvanceJourneys()...)
 	journeys = append(journeys, intendedUntrackedJourneys()...)
+	journeys = append(journeys, stagedDeliveryStatusJourneys()...)
 	journeys = append(journeys, captureResultDryRunJourneys()...)
 	journeys = append(journeys, findingIDPrefixJourneys()...)
 	journeys = append(journeys, rescopeWriteGuardJourneys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -36,6 +36,7 @@ func journeySources() []journeySource {
 		{"journeys_zero_delta.go", zeroDeltaJourneys()},
 		{"journeys_local_gate_advance.go", localGateBaseAdvanceJourneys()},
 		{"journeys_intended_untracked.go", intendedUntrackedJourneys()},
+		{"journeys_staged_delivery_status.go", stagedDeliveryStatusJourneys()},
 		{"journeys_capture_result_dry_run.go", captureResultDryRunJourneys()},
 		{"journeys_finding_id_prefix.go", findingIDPrefixJourneys()},
 		{"journeys_rescope_write_guard.go", rescopeWriteGuardJourneys()},

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -48,11 +48,12 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// j83 proves #2127's pre-PR path binds its candidate to the unique merge-base
 	// while the advertised main ref remains a moving publication boundary. j87
 	// proves #2871's correction binds the immutable failure across a later interrupt;
-	// j88 proves #2843's unborn STATUS collects explicit untracked intent first.
+	// j88 proves #2843's unborn STATUS collects explicit untracked intent first;
+	// j89 proves #2758's workspace receipt must stage exact paths before pre-commit STATUS validates.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 87 {
-		t.Errorf("core journey count = %d, want 87", got)
+	if got := len(seen); got != 88 {
+		t.Errorf("core journey count = %d, want 88", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/journeys_staged_delivery_status.go
+++ b/bench/journeys_staged_delivery_status.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+const approvedWorkspacePreCommitLineage = "j89-approved-workspace-precommit-staged-status"
+
+var stagedProjectionStatusCapability = &Capability{
+	Verb:  []string{"review", "status"},
+	Flags: []string{"--cwd", "--contract", "--agent", "--next-transition", "--lineage", "--projection"},
+}
+
+func unstagedPassiveWorkspaceReceiptCandidate(sandbox *Sandbox) error {
+	path := filepath.Join(sandbox.Repo, "README.md")
+	return sandbox.write(path, "# demo\n\nreviewed workspace receipt candidate for #2758.\n")
+}
+
+func stageApprovedWorkspaceReceiptPaths(sandbox *Sandbox) error {
+	return sandbox.git(sandbox.Repo, "add", "README.md")
+}
+
+func approvedWorkspaceStatusRequiresStagedDelivery(run *journeyRun) error {
+	status, err := readStatusForContract(run, reviewContractV2,
+		"--agent", "opencode", "--lineage", approvedWorkspacePreCommitLineage)
+	if err != nil {
+		return err
+	}
+	if status.NextTransition.Kind != "stop" || status.NextTransition.ReasonCode != "staged_delivery_candidate_required" ||
+		status.NextTransition.Execute.Operation != "" || len(status.NextTransition.Collect.Inputs) != 0 {
+		return fmt.Errorf("workspace STATUS transition = %+v, want stop/staged_delivery_candidate_required with no command", status.NextTransition)
+	}
+	return nil
+}
+
+func stagedStatusExecutesPreCommitValidation(run *journeyRun) error {
+	status, err := readStatusForContract(run, reviewContractV2,
+		"--agent", "opencode", "--lineage", approvedWorkspacePreCommitLineage, "--projection", "staged")
+	if err != nil {
+		return err
+	}
+	if status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.validate" {
+		return fmt.Errorf("staged STATUS transition = %+v, want executable review.validate", status.NextTransition)
+	}
+	observation, err := runPrintedTransition(run, status)
+	if err != nil {
+		return err
+	}
+	return requireGateForLineage(observation, approvedWorkspacePreCommitLineage, false)
+}
+
+func stagedDeliveryStatusJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j89-approved-workspace-receipt-requires-exact-staged-precommit-status",
+			Title:  "Approved workspace receipt: pre-commit STATUS stops until the exact reviewed paths are staged",
+			Source: "issue #2758: workspace receipt cannot authorize a different staged-index delivery candidate",
+			Steps: []Step{
+				{Name: "fixture: repository", Fixture: baseRepo},
+				{Name: "fixture: unstaged passive workspace candidate", Fixture: unstagedPassiveWorkspaceReceiptCandidate},
+				{Name: "review start freezes the workspace candidate", Requires: startNamedCapability,
+					Args: productArgs("review", "start", "--lineage", approvedWorkspacePreCommitLineage), After: rememberLineage},
+				{Name: "review finalize approves the workspace receipt", Requires: finalizeCapability,
+					Args: productArgs("review", "finalize", "--lineage", approvedWorkspacePreCommitLineage), After: rememberLineage},
+				{Name: "workspace STATUS refuses to hand out pre-commit validation", Requires: stagedProjectionStatusCapability,
+					Composite: approvedWorkspaceStatusRequiresStagedDelivery},
+				{Name: "fixture: stage the exact reviewed path", Fixture: stageApprovedWorkspaceReceiptPaths},
+				{Name: "staged STATUS prints validation and that validation allows", Requires: stagedProjectionStatusCapability,
+					Composite: stagedStatusExecutesPreCommitValidation},
+			},
+		},
+	}
+}

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -284,6 +284,9 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 			return reviewRecoveryCollection(status, binding, input)
 		}
 		if status.Receipt.Status == ReviewReceiptPresent {
+			if input.gate() == reviewtransaction.GatePreCommit && status.Projection.Projection != reviewtransaction.ProjectionStaged {
+				return reviewStopTransition("staged_delivery_candidate_required")
+			}
 			if input.Selector != nil && input.gate() == reviewtransaction.GatePrePR && !input.Selector.PrePRRepresentable {
 				// Root 7 (#2471): the caller supplied a raw commit SHA where
 				// pre-PR needs a symbolic ref. That is a missing input, not a
@@ -1013,6 +1016,8 @@ func reviewReasonDescription(reason string) string {
 		return "Verification evidence required prior to finalization"
 	case "delivery_gate_required":
 		return "Delivery gate selection required before validation"
+	case "staged_delivery_candidate_required":
+		return "Stage the exact reviewed paths and rerun status with staged projection before pre-commit validation"
 	case "staged_workspace_overlay_recovery_unavailable":
 		return "Staged workspace overlay recovery is unavailable"
 	case "corrupted_or_unverifiable_authority":

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -76,6 +76,70 @@ func TestValidatingEvidenceCollectionUnblocksFinalizeAndPreCommit(t *testing.T) 
 	}
 }
 
+func TestApprovedWorkspaceReceiptRequiresStagedStatusBeforePreCommitValidate(t *testing.T) {
+	repo, started, store, record, _ := capturedArtifact(t)
+	finalize := []string{"--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", started.LineageID, "--captured-results"}
+	var waiting bytes.Buffer
+	if err := RunReviewFacadeFinalize(finalize, &waiting); err != nil {
+		t.Fatal(err)
+	}
+	var validating ReviewIntegrationFinalizeResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, waiting.Bytes()).Result, &validating)
+	if validating.State != reviewtransaction.StateValidating || validating.NextTransition == nil || validating.NextTransition.Kind != reviewNextTransitionCollect {
+		t.Fatalf("captured-results finalize = %#v", validating.NextTransition)
+	}
+	evidence := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidence, []byte("verification passed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReview([]string{"capture-evidence", "--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--expected-revision", validating.StoreRevision, "--outcome", string(reviewtransaction.VerificationOutcomePassed), "--input", evidence}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	var approvedOutput bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", started.LineageID, "--captured-evidence"}, &approvedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var approved ReviewIntegrationFinalizeResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, approvedOutput.Bytes()).Result, &approved)
+	if approved.State != reviewtransaction.StateApproved {
+		t.Fatalf("captured-evidence finalize state = %q, want approved", approved.State)
+	}
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var workspaceStatus bytes.Buffer
+	if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", started.LineageID}, &workspaceStatus); err != nil {
+		t.Fatal(err)
+	}
+	var workspace ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, workspaceStatus.Bytes(), &workspace)
+	if workspace.Projection.Projection != reviewtransaction.ProjectionWorkspace || workspace.NextTransition == nil || workspace.NextTransition.Kind != reviewNextTransitionStop || workspace.NextTransition.ReasonCode != "staged_delivery_candidate_required" || workspace.NextTransition.Execute != nil || workspace.NextTransition.Collect != nil {
+		t.Fatalf("workspace STATUS transition = %#v", workspace.NextTransition)
+	}
+	if workspace.ValidationRequest != nil {
+		t.Fatalf("workspace STATUS exposed validation request: %#v", workspace.ValidationRequest)
+	}
+	if after, err := os.ReadFile(store.StatePath()); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("workspace STATUS mutated authority: %v", err)
+	}
+
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	var stagedStatus bytes.Buffer
+	if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", started.LineageID, "--projection", string(reviewtransaction.ProjectionStaged)}, &stagedStatus); err != nil {
+		t.Fatal(err)
+	}
+	var staged ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, stagedStatus.Bytes(), &staged)
+	if staged.Projection.Projection != reviewtransaction.ProjectionStaged || staged.NextTransition == nil || staged.NextTransition.Kind != reviewNextTransitionExecute || staged.NextTransition.Execute == nil || staged.NextTransition.Execute.Operation != "review.validate" {
+		t.Fatalf("staged STATUS transition = %#v", staged.NextTransition)
+	}
+	if err := RunReview([]string{"validate", "--cwd", repo, "--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePreCommit)}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("pre-commit after exact staged STATUS: %v", err)
+	}
+}
+
 func TestFinalizeNextTransitionBindsCorrectedCurrentSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -400,7 +464,12 @@ func TestReviewNextTransitionStateTable(t *testing.T) {
 		{"unchanged corrected authority", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateCorrectionRequired, reviewtransaction.TargetStatusActionStop, reviewtransaction.ReplayabilityManualActionRequired), nil, nil, reviewNextTransitionStop, ""},
 		{"validating", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateValidating, reviewtransaction.TargetStatusActionFinalize, reviewtransaction.ReplayabilityNotReplayable), nil, nil, reviewNextTransitionCollect, ""},
 		{"pending finalize journal", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateReviewing, reviewtransaction.TargetStatusActionReconcileFinalize, reviewtransaction.ReplayabilityStatusRequired), nil, nil, reviewNextTransitionStop, ""},
-		{"approved", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateApproved, reviewtransaction.TargetStatusActionValidate, reviewtransaction.ReplayabilityNotReplayable), nil, nil, reviewNextTransitionExecute, "review.validate"},
+		{"approved workspace pre-commit requires staged delivery", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateApproved, reviewtransaction.TargetStatusActionValidate, reviewtransaction.ReplayabilityNotReplayable), nil, nil, reviewNextTransitionStop, ""},
+		{"approved staged", func() ReviewTargetStatusResult {
+			s := status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateApproved, reviewtransaction.TargetStatusActionValidate, reviewtransaction.ReplayabilityNotReplayable)
+			s.Projection.Projection = reviewtransaction.ProjectionStaged
+			return s
+		}(), nil, nil, reviewNextTransitionExecute, "review.validate"},
 		{"invalidated", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateInvalidated, reviewtransaction.TargetStatusActionRecover, reviewtransaction.ReplayabilityManualActionRequired), nil, nil, reviewNextTransitionExecute, "review.recover"},
 		{"escalated unchanged", status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateEscalated, reviewtransaction.TargetStatusActionStop, reviewtransaction.ReplayabilityManualActionRequired), nil, nil, reviewNextTransitionStop, ""},
 		{"ambiguous", status(reviewtransaction.TargetApplicabilityAmbiguous, "", reviewtransaction.TargetStatusActionSelectLineage, reviewtransaction.ReplayabilityStatusRequired), nil, nil, reviewNextTransitionCollect, ""},
@@ -465,8 +534,12 @@ func TestReviewTransitionArgumentToken(t *testing.T) {
 			wantTokens: map[string]string{"lineage": "--lineage=review-token", "captured_results": "--captured-results=true"},
 		},
 		{
-			name:       "approved receipt gate token",
-			status:     status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateApproved, reviewtransaction.TargetStatusActionValidate, reviewtransaction.ReplayabilityNotReplayable),
+			name: "approved receipt gate token",
+			status: func() ReviewTargetStatusResult {
+				s := status(reviewtransaction.TargetApplicabilityCurrent, reviewtransaction.StateApproved, reviewtransaction.TargetStatusActionValidate, reviewtransaction.ReplayabilityNotReplayable)
+				s.Projection.Projection = reviewtransaction.ProjectionStaged
+				return s
+			}(),
 			wantTokens: map[string]string{"lineage": "--lineage=review-token", "gate": "--gate=pre-commit"},
 		},
 		{


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2758

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Maintenance/tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Stops negotiated pre-commit STATUS from handing out `review.validate` for an approved workspace receipt unless STATUS is run against the staged projection.
- Adds `staged_delivery_candidate_required` so the operator stages the exact reviewed paths and re-runs STATUS with `--projection staged`.
- Adds unit coverage and driven bench journey j89 for the ratified #2758 flow.

---

## 📂 Changes

| File / Area | What Changed |
|---|---|
| `internal/cli/review_next_transition.go` | Adds the pre-commit staged-projection guard before `approved_receipt_ready`. |
| `internal/cli/review_next_transition_test.go` | Proves workspace STATUS stops read-only, exact staged STATUS emits validation, and pre-commit validation allows. |
| `bench/journeys_staged_delivery_status.go` | Adds j89 black-box journey for approved workspace receipt staging before pre-commit validation. |
| `bench/journeys.go`, `bench/journeys_id_collision_test.go`, `bench/journeys_sdd_test.go` | Registers j89 and bumps the pinned journey count. |

Changed-line budget: 167 authored changed lines, under 400. No chain or `size:exception` needed.

---

## 🧪 Test Plan

- [x] `go test -count=1 ./internal/cli -run 'TestApprovedWorkspaceReceiptRequiresStagedStatusBeforePreCommitValidate|TestValidatingEvidenceCollectionUnblocksFinalizeAndPreCommit|TestReviewNextTransitionStateTable|TestReviewTransitionArgumentToken|TestReviewStatusValidateRejectsMalformedForecast'`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`
- [x] `(cd bench && go test -count=1 ./...)`
- [x] `go build -trimpath -o /var/folders/sk/69y6zvfs0317p8dgxq6br1tc0000gn/T/opencode/gentle-ai-2758 ./cmd/gentle-ai`
- [x] `(cd bench && go build -o /var/folders/sk/69y6zvfs0317p8dgxq6br1tc0000gn/T/opencode/gentle-ai-bench-2758 .)`
- [x] Driven j89: `gentle-ai-bench run --binary /var/folders/sk/69y6zvfs0317p8dgxq6br1tc0000gn/T/opencode/gentle-ai-2758 --only j89-approved-workspace-receipt-requires-exact-staged-precommit-status` → `1 completed, 0 unsupported, 0 failed`
- [x] Native review: `review-fac97ed35a9fc3dc`, one reliability lens, approved receipt.
- [x] Native gates: `gentle-ai review validate --lineage=review-fac97ed35a9fc3dc --gate=pre-commit` and `--gate=pre-push` both allowed.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is applied — pending maintainer/triager permission, `type:bug` intended
- [x] Relevant unit tests pass
- [x] Go format passes
- [x] Benchmark validation completed in driven mode
- [x] Documentation is not required for this narrow negotiated-status contract correction
- [x] Commit follows Conventional Commits format
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The change intentionally does not auto-stage, create recovery state, mutate authority, or weaken validation. It only prevents STATUS from advertising a pre-commit validation command for the wrong projection. The successful path is explicit: stage the exact reviewed paths, re-query STATUS with `--projection staged`, then execute the returned validation.

I cannot apply labels with my current contributor permissions, so the PR will need exactly one `type:*` label, `type:bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staged-delivery workflow coverage for approved workspace receipts.
  * Added validation to confirm reviewed files are staged before delivery can proceed.

* **Bug Fixes**
  * Approved receipts now clearly indicate when staged delivery is required before pre-commit validation.
  * Improved status handling so workspace and staged projections follow the correct validation path.

* **Tests**
  * Expanded workflow coverage for staged delivery, status transitions, and receipt validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->