### PR TITLE
fix(review): classify stale managed assets before start

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -626,6 +626,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, consecutiveRescopeRepairJourneys()...)
 	journeys = append(journeys, reviewedSupersetJourneys()...)
 	journeys = append(journeys, stagedDeliveryJourneys()...)
+	journeys = append(journeys, managedAssetJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -43,6 +43,7 @@ func journeySources() []journeySource {
 		{"journeys_consecutive_rescope_repair.go", consecutiveRescopeRepairJourneys()},
 		{"journeys_reviewed_superset.go", reviewedSupersetJourneys()},
 		{"journeys_staged_delivery.go", stagedDeliveryJourneys()},
+		{"journeys_managed_assets.go", managedAssetJourneys()},
 	}
 }
 

--- a/bench/journeys_managed_assets.go
+++ b/bench/journeys_managed_assets.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// historicalManagedAssetStateSHA256 pins the exact state bytes emitted by
+	// `gentle-ai sync --agents opencode` from predecessor 8c2cbd80.
+	historicalManagedAssetStateSHA256 = "6c337347a4c94055f321b6e4aef7fa6ee96f4ca0159e2e8d99e385557120a329"
+	managedAssetRemediation           = "managed reviewer assets are outdated; run `gentle-ai sync`"
+)
+
+//go:embed testdata/managed-assets/state-8c2cbd80.json
+var historicalManagedAssetState []byte
+
+var managedAssetsStartCapability = &Capability{
+	Verb:  []string{"review", "start"},
+	Flags: []string{"--cwd", "--contract", "--target", "--projection", "--agent", "--consent"},
+}
+
+// staleManagedAssetState copies the exact predecessor product artifact without
+// decoding or changing it, reproducing the cross-version stale-asset state.
+func staleManagedAssetState(sandbox *Sandbox) error {
+	if got := fmt.Sprintf("%x", sha256.Sum256(historicalManagedAssetState)); got != historicalManagedAssetStateSHA256 {
+		return fmt.Errorf("historical managed asset state SHA-256 = %s, want %s", got, historicalManagedAssetStateSHA256)
+	}
+	path := filepath.Join(sandbox.Home, ".gentle-ai", "state.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, historicalManagedAssetState, 0o644); err != nil {
+		return err
+	}
+	copied, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(copied, historicalManagedAssetState) {
+		return fmt.Errorf("historical managed asset state copy differs from its fixture")
+	}
+	return nil
+}
+
+func staleManagedAssetsStartIsNotUnknown(r *journeyRun) error {
+	status, err := readStatusForContract(r, reviewContractV2, "--agent", "opencode")
+	if err != nil {
+		return err
+	}
+	if status.NextTransition.Kind != "execute" || status.NextTransition.ReasonCode != "fresh_target_ready" ||
+		status.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("stale managed assets initial STATUS = %+v", status.NextTransition)
+	}
+
+	start, err := runPrintedTransition(r, status)
+	if err != nil {
+		return err
+	}
+	if start.ExitCode == 0 {
+		return fmt.Errorf("stale managed assets START succeeded: %s", start.Stdout)
+	}
+	var failure struct {
+		Operation       string `json:"operation"`
+		Phase           string `json:"phase"`
+		Code            string `json:"code"`
+		MutationOutcome string `json:"mutation_outcome"`
+		NextAction      string `json:"next_action"`
+		Cause           string `json:"cause"`
+	}
+	if err := json.Unmarshal([]byte(start.Stdout), &failure); err != nil {
+		return fmt.Errorf("parse stale managed assets START failure: %w (stderr: %s)", err, firstLine(start.Stderr))
+	}
+	if failure.Operation != "review.start" || failure.Phase != "preflight" || failure.Code != "managed_assets_outdated" ||
+		failure.MutationOutcome != "not_started" || failure.NextAction != "stop" || failure.Cause != managedAssetRemediation {
+		return fmt.Errorf("stale managed assets START failure = %#v", failure)
+	}
+
+	inspection, err := proveInspection(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if !inspection.Complete || !inspection.Valid || inspection.Totals.CompactEntries != 0 || inspection.Totals.LoadedEntries != 0 || inspection.Totals.Edges != 0 {
+		return fmt.Errorf("stale managed assets START created authority: %+v", inspection)
+	}
+
+	reconciled, err := readStatusForContract(r, reviewContractV2, "--agent", "opencode")
+	if err != nil {
+		return err
+	}
+	if reconciled.NextTransition.Kind != "execute" || reconciled.NextTransition.ReasonCode != "fresh_target_ready" ||
+		reconciled.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("stale managed assets reconciliation STATUS = %+v", reconciled.NextTransition)
+	}
+	return nil
+}
+
+func managedAssetJourneys() []Journey {
+	return []Journey{
+		{
+			ID:     "j93-stale-managed-assets-start-is-not-unknown",
+			Title:  "Stale managed assets: v2 OpenCode START stops before authority and STATUS remains usable",
+			Source: "issue #2822: a stale product-created managed-asset digest refuses before START can mutate; negotiated output must not claim native execution",
+			Steps: []Step{
+				{Name: "fixture: repository", Fixture: baseRepo},
+				{Name: "fixture: staged prose candidate", Fixture: stageDocs("stale-managed-assets")},
+				{Name: "fixture: predecessor managed asset digest", Fixture: staleManagedAssetState},
+				{Name: "v2 OpenCode START is typed not-started and reconciliation stays usable", Requires: managedAssetsStartCapability, Composite: staleManagedAssetsStartIsNotUnknown},
+			},
+		},
+	}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -49,11 +49,12 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// while the advertised main ref remains a moving publication boundary. j87
 	// proves #2871's correction binds the immutable failure across a later interrupt;
 	// j88 proves #2843's unborn STATUS collects explicit untracked intent first;
-	// j89 proves #2758 never offers a workspace receipt for a different index.
+	// j89 proves #2758 never offers a workspace receipt for a different index;
+	// j93 proves #2822 classifies stale managed assets before START can persist.
 	// Bump this deliberately when a journey is added, and name it here: the
 	// count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 88 {
-		t.Errorf("core journey count = %d, want 88", got)
+	if got := len(seen); got != 89 {
+		t.Errorf("core journey count = %d, want 89", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/testdata/managed-assets/state-8c2cbd80.json
+++ b/bench/testdata/managed-assets/state-8c2cbd80.json
@@ -1,0 +1,4 @@
+{
+  "installed_agents": null,
+  "managed_asset_digest": "sha256:3e5f8b412c5b7a851deefbda82763e7a2d7b4967bad3967cc730652d8d778751"
+}

--- a/internal/cli/review_asset_provenance_test.go
+++ b/internal/cli/review_asset_provenance_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
@@ -139,6 +140,61 @@ func TestManagedReviewerAssetProvenanceRefusesOnlyRecordedSkew(t *testing.T) {
 		staleManagedReviewerAssets(t, home)
 		requireManagedAssetProvenanceError(t, authorizeManagedReviewerAssets(), managedAssetProvenanceRefusal)
 	})
+}
+
+func TestNegotiatedReviewStartClassifiesStaleManagedAssetsBeforeAuthority(t *testing.T) {
+	home, repo := reviewModeHome(t), initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/stale-assets.md", "# Candidate\n", 0o644)
+	staleManagedReviewerAssets(t, home)
+
+	var output bytes.Buffer
+	err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--agent", "opencode", "--consent", "granted",
+	}), &output)
+	if err == nil {
+		t.Fatalf("stale managed assets START succeeded: %s", output.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Operation != "review.start" || failure.Phase != "preflight" ||
+		failure.Code != "managed_assets_outdated" || failure.MutationOutcome != ReviewMutationNotStarted ||
+		failure.NextAction != "stop" {
+		t.Fatalf("stale managed assets failure = %#v", failure)
+	}
+	if failure.Cause != managedAssetProvenanceRefusal {
+		t.Fatalf("stale managed assets cause = %q, want %q", failure.Cause, managedAssetProvenanceRefusal)
+	}
+	if err := failure.Validate(); err != nil {
+		t.Fatalf("stale managed assets failure does not satisfy its published contract: %v", err)
+	}
+}
+
+func TestNegotiatedReviewStartWithCurrentManagedAssetsStillStarts(t *testing.T) {
+	home, repo := reviewModeHome(t), initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/current-assets.md", "# Candidate\n", 0o644)
+	digest, err := managedAssetDigest()
+	requireManagedAssetProvenanceNoError(t, err)
+	requireManagedAssetProvenanceNoError(t, state.Write(home, state.InstallState{ManagedAssetDigest: digest}))
+
+	var output bytes.Buffer
+	err = RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--agent", "opencode", "--consent", "granted",
+	}), &output)
+	if err != nil {
+		t.Fatalf("current managed assets START refused: %v\n%s", err, output.String())
+	}
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	if err := started.Validate(); err != nil || started.LineageID == "" {
+		t.Fatalf("current managed assets START = %#v, validate = %v", started, err)
+	}
+}
+
+func TestManagedAssetsPreflightDoesNotClassifyUnrelatedRuntimeRefusal(t *testing.T) {
+	failure := newReviewIntegrationFailure("review.start", nil, errors.New("unrelated runtime refusal"))
+	if failure.Code != "operation_outcome_unknown" || failure.Phase != "native_running" ||
+		failure.MutationOutcome != ReviewMutationUnknown || failure.NextAction != "review.status" ||
+		!strings.Contains(failure.Cause, "unrelated runtime refusal") {
+		t.Fatalf("unrelated runtime failure = %#v", failure)
+	}
 }
 
 // TestManagedAssetDigestIsStableAndAssetBound proves the digest is a property

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -642,7 +642,7 @@ func authorizeReviewStart(ctx context.Context, repo string, assessment reviewtra
 		return reviewModeUnreadable(ctx, repo, global, err)
 	}
 	if err := authorizeManagedReviewerAssets(); err != nil {
-		return err
+		return reviewPreflightRefusal(reviewPreflightManagedAssetsReason, err)
 	}
 	if assessment.Level == reviewtransaction.RiskLow {
 		// Tier 0 is silent structural readback. Asking here would reintroduce

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -265,6 +265,16 @@ var reviewPreflightUntrackedScopeReason = reviewPreflightReason{
 	NextAction: "stop",
 }
 
+// reviewPreflightManagedAssetsReason classifies a START that is refused before
+// any authority can be created because this binary's managed reviewer assets
+// differ from the recorded installation state. The exact sync remediation stays
+// in the cause because it is the existing operator-facing source of truth.
+var reviewPreflightManagedAssetsReason = reviewPreflightReason{
+	Code:       "managed_assets_outdated",
+	Message:    "Managed reviewer assets are outdated; synchronize them before starting review.",
+	NextAction: "stop",
+}
+
 // reviewPreflightDirectRouteUncompletableReason classifies a direct
 // (non-negotiated) `review start` that would select at least one lens.
 // Issue #2447: the direct route's own response type cannot carry


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2822

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Classify stale managed reviewer assets as the truthful `managed_assets_outdated` preflight refusal instead of an unknown native outcome.
- Preserve the executable `gentle-ai sync` remediation while proving START creates no authority and STATUS remains usable.
- Add driven journey j93 using byte-identical state produced by predecessor `8c2cbd80`, with a pinned SHA-256 and exact-base decoy.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_mode.go` | Routes the managed-assets guard through the existing typed preflight boundary. |
| `internal/cli/review_operation_contract.go` | Adds public reason `managed_assets_outdated` with `next_action: stop`. |
| `internal/cli/review_asset_provenance_test.go` | Covers stale/current assets and unrelated refusal classification. |
| `bench/journeys_managed_assets.go` | Adds j93 end-to-end START, zero-authority, and STATUS recovery proof. |
| `bench/testdata/managed-assets/state-8c2cbd80.json` | Pins exact predecessor-generated state bytes for the cross-version fixture. |
| `bench/journeys*.go` | Registers j93 and updates the core corpus invariant to 89 journeys. |

---

## 🧪 Test Plan

- [x] Root unit tests pass: `go test ./... -count=1`
- [x] Go format passes: `go run ./internal/gofmtcheck`
- [x] Bench module passes: `cd bench && go vet ./... && go test ./... -count=1`
- [x] Driven j93 passes: 1 completed, 0 unsupported, 0 failed
- [x] Exact-base decoy fails on the former `operation_outcome_unknown` behavior
- [x] CI core invocation passes: 89 completed, 0 unsupported, 0 failed
- [x] CI transition invocation passes: 100 completed, 0 unsupported, 0 failed, including 11 transition journeys
- [x] Manually exercised the real negotiated START and authority inspection through j93
- [ ] Docker, Windows, and Darwin E2E are delegated to required CI and were not run locally

---

## 🤖 Automated Checks

Required CI remains authoritative for Docker Linux E2E, Windows, and Darwin coverage.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #2822 with `status:approved`
- [x] PR stays within 400 changed lines (198 total)
- [x] Exactly one `type:*` label is applied: `type:bug`
- [x] Unit tests pass
- [x] Go format passes
- [x] Benchmark validation completed
- [x] Documentation impact assessed; the existing runnable remediation remains unchanged and the typed wire contract is covered by tests
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The managed-assets admission guard itself is unchanged. Its legitimate population is an installation state written by older embedded managed assets; j93 uses byte-identical output from predecessor `8c2cbd80` and pins SHA-256 `6c337347a4c94055f321b6e4aef7fa6ee96f4ca0159e2e8d99e385557120a329`. This PR changes only the negotiated classification at the existing guard boundary, so `.guard-population-baseline.txt` does not change.

Please focus on the ordering guarantee: `authorizeReviewStart` returns this typed refusal before review-core persistence, so `mutation_outcome: not_started` remains truthful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review start now clearly reports when managed reviewer assets are outdated.
  * Outdated assets are detected before changes are made, with actionable remediation guidance.
  * Current assets continue to allow review startup, while unrelated startup failures retain their original classification.

* **Tests**
  * Added coverage for managed-asset validation, state preservation, and review preflight behavior.
  * Expanded journey coverage to include managed-asset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->