### PR TITLE
fix(review): read captured reviewer slots atomically

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -676,27 +676,21 @@ func discoverCapturedReviewerArtifacts(ctx context.Context, repo, storeDir strin
 	}
 	artifacts := make([]ReviewTransitionArtifact, 0, len(state.SelectedLenses))
 	for order, lens := range state.SelectedLenses {
-		path := filepath.Join(storeDir, reviewtransaction.CompactReviewerResultsDir, fmt.Sprintf("%02d-%s.json", order, lens))
-		digest, err := os.ReadFile(path + ".sha256")
-		if errors.Is(err, os.ErrNotExist) {
+		slot, err := reviewtransaction.ReadCompactReviewerResultSlot(storeDir, order, lens)
+		if err != nil {
+			return nil, fmt.Errorf("read captured reviewer result %d: %w", order, err)
+		}
+		if !slot.Occupied {
 			continue
 		}
-		if err != nil {
-			return nil, fmt.Errorf("read captured reviewer result digest %d: %w", order, err)
-		}
-		digestValue := strings.TrimSpace(string(digest))
-		if reviewtransaction.ReviewerResultDigestIsQuarantined(state, order, digestValue) {
+		if reviewtransaction.ReviewerResultDigestIsQuarantined(state, order, slot.Digest) {
 			continue
 		}
 		artifact := reviewResultArtifact{
-			Schema: reviewResultArtifactSchema, Capability: reviewResultArtifactCapability, Path: path, SHA256: digestValue,
+			Schema: reviewResultArtifactSchema, Capability: reviewResultArtifactCapability, SHA256: slot.Digest,
 			LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Lens: lens, SelectedOrder: order,
 		}
-		payload, err := readVerifiedReviewerArtifact(artifact, storeDir, state)
-		if err != nil {
-			return nil, fmt.Errorf("verify captured reviewer result %d: %w", order, err)
-		}
-		_, subject, err := decodeBoundAdmittedReviewerResult(ctx, repo, payload, artifact.SHA256, state, revision, order, frozen)
+		_, subject, err := decodeBoundAdmittedReviewerResult(ctx, repo, slot.Payload, slot.Digest, state, revision, order, frozen)
 		if err != nil {
 			return nil, fmt.Errorf("verify captured reviewer admission %d: %w", order, err)
 		}

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -869,6 +869,72 @@ func capturedArtifact(t *testing.T) (string, ReviewFacadeStartResult, reviewtran
 	return repo, started, store, record, artifact
 }
 
+func TestReviewStatusClassifiesCapturedReviewerSlots(t *testing.T) {
+	tests := []struct {
+		name, wantKind, wantReason string
+		capture                    bool
+		mutate                     func(*testing.T, string)
+	}{
+		{"clean pending", "collect", "reviewer_results_required", false, nil},
+		{"complete", "execute", "captured_results_ready", true, nil},
+		{"missing payload", "stop", "captured_artifacts_unverifiable", true, func(t *testing.T, path string) {
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"missing digest sidecar", "stop", "captured_artifacts_unverifiable", true, func(t *testing.T, path string) {
+			if err := os.Remove(path + ".sha256"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"alternate names ignored", "collect", "reviewer_results_required", false, func(t *testing.T, path string) {
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path+".alternate", []byte("unrelated\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"unrelated entries ignored", "collect", "reviewer_results_required", false, func(t *testing.T, path string) {
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			for index := 0; index < 33; index++ {
+				if err := os.WriteFile(filepath.Join(filepath.Dir(path), fmt.Sprintf("unrelated-%02d", index)), []byte("x"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo, started, store, record := newArtifactReview(t, false)
+			path := filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir, fmt.Sprintf("00-%s.json", record.State.SelectedLenses[0]))
+			if test.capture {
+				input := filepath.Join(t.TempDir(), "result.json")
+				if err := os.WriteFile(input, admittedReviewerPayloadForTest(t, repo, record, record.State.SelectedLenses[0], 0), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input}, io.Discard); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.mutate != nil {
+				test.mutate(t, path)
+			}
+			var output bytes.Buffer
+			if err := RunReviewStatus([]string{"--cwd", repo, "--lineage", started.LineageID, "--contract", ReviewIntegrationContractV1, "--next-transition"}, &output); err != nil {
+				t.Fatal(err)
+			}
+			var status ReviewTargetStatusResult
+			decodeStrictReviewJSON(t, output.Bytes(), &status)
+			if status.NextTransition == nil || string(status.NextTransition.Kind) != test.wantKind || status.NextTransition.ReasonCode != test.wantReason {
+				t.Fatalf("slot status = %#v", status.NextTransition)
+			}
+		})
+	}
+}
+
 func capturedArtifacts(t *testing.T, high bool) (string, ReviewFacadeStartResult, reviewtransaction.CompactStore, reviewtransaction.CompactRecord, []reviewResultArtifact) {
 	t.Helper()
 	repo, started, store, record := newArtifactReview(t, high)

--- a/internal/reviewtransaction/compact_result_reopen.go
+++ b/internal/reviewtransaction/compact_result_reopen.go
@@ -81,6 +81,12 @@ type compactProviderReviewerResult struct {
 	Evidence    []string           `json:"evidence"`
 }
 
+type CompactReviewerResultSlot struct {
+	Occupied bool
+	Payload  []byte
+	Digest   string
+}
+
 // CompactResultReopenAuthorization derives the exact maintainer binding for
 // one reopen. authorizedLenses must already be canonical (selected order,
 // deduplicated); when a maintainer overrides admitted slots the binding names
@@ -442,6 +448,36 @@ func readCompactReviewerArtifact(path string) ([]byte, string, error) {
 		return nil, "", errors.New("reviewer artifact digest does not match its bytes")
 	}
 	return payload, digest, nil
+}
+
+var readCompactReviewerResultSlotFile = readPrivateCompactReviewerFile
+
+func ReadCompactReviewerResultSlot(storeDir string, order int, lens string) (CompactReviewerResultSlot, error) {
+	if order < 0 || (lens != LensRisk && lens != LensResilience && lens != LensReadability && lens != LensReliability) {
+		return CompactReviewerResultSlot{}, errors.New("reviewer result slot requires a selected order and lens") // refusal:by-design operator-knowledge: callers pass only the frozen selected order and lens
+	}
+	path := filepath.Join(storeDir, CompactReviewerResultsDir, fmt.Sprintf("%02d-%s.json", order, lens))
+	payload, payloadErr := readCompactReviewerResultSlotFile(path, compactReviewerResultSizeLimit)
+	digestPayload, digestErr := readCompactReviewerResultSlotFile(path+".sha256", 256)
+	payloadMissing := errors.Is(payloadErr, os.ErrNotExist)
+	digestMissing := errors.Is(digestErr, os.ErrNotExist)
+	if payloadErr != nil && !payloadMissing {
+		return CompactReviewerResultSlot{}, fmt.Errorf("read reviewer result payload: %w", payloadErr)
+	}
+	if digestErr != nil && !digestMissing {
+		return CompactReviewerResultSlot{}, fmt.Errorf("read reviewer result digest: %w", digestErr)
+	}
+	if payloadMissing && digestMissing {
+		return CompactReviewerResultSlot{}, nil
+	}
+	if payloadMissing || digestMissing {
+		return CompactReviewerResultSlot{}, errors.New("reviewer result slot is partially published") // refusal:by-design human-authority: an interrupted immutable slot requires maintainer inspection
+	}
+	digest := strings.TrimSpace(string(digestPayload))
+	if !validSHA256(digest) || compactPreservedPayloadDigest(payload) != digest {
+		return CompactReviewerResultSlot{}, errors.New("reviewer result digest does not match its bytes") // refusal:by-design human-authority: mismatched immutable evidence requires maintainer inspection
+	}
+	return CompactReviewerResultSlot{Occupied: true, Payload: append([]byte(nil), payload...), Digest: digest}, nil
 }
 
 func replayCompactResultReopen(record CompactRecord, request CompactResultReopenRequest) (CompactResultReopenRecord, bool) {

--- a/internal/reviewtransaction/compact_reviewer_capture_test.go
+++ b/internal/reviewtransaction/compact_reviewer_capture_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -244,6 +245,137 @@ func TestCompactStoreCaptureAdmittedReviewerResultPublishesDurableExactReplay(
 		record.State.State != StateReviewing {
 		t.Fatalf("capture mutated compact authority = %#v", record)
 	}
+}
+
+func TestReadCompactReviewerResultSlot(t *testing.T) {
+	t.Run("complete reads each canonical member once", func(t *testing.T) {
+		fixture := newCompactReviewerCaptureFixture(t, "read-complete")
+		if _, err := fixture.store.CaptureAdmittedReviewerResult(t.Context(), fixture.request); err != nil {
+			t.Fatal(err)
+		}
+		original := readCompactReviewerResultSlotFile
+		reads := map[string]int{}
+		readCompactReviewerResultSlotFile = func(path string, limit int64) ([]byte, error) {
+			reads[path]++
+			return original(path, limit)
+		}
+		t.Cleanup(func() { readCompactReviewerResultSlotFile = original })
+		slot, err := ReadCompactReviewerResultSlot(fixture.store.Dir, 0, LensReliability)
+		if err != nil || !slot.Occupied || reads[fixture.path] != 1 || reads[fixture.path+".sha256"] != 1 {
+			t.Fatalf("slot = %#v, reads = %#v, err = %v", slot, reads, err)
+		}
+		if slot.Digest != compactPreservedPayloadDigest(slot.Payload) {
+			t.Fatalf("slot digest = %q", slot.Digest)
+		}
+	})
+
+	t.Run("pending ignores alternate unrelated and wrong selected names", func(t *testing.T) {
+		fixture := newCompactReviewerCaptureFixture(t, "read-pending")
+		dir := filepath.Dir(fixture.path)
+		if _, err := createPrivateRARDirectory(dir); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fixture.path+".alternate", []byte("alternate\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for index := 0; index < 33; index++ {
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("unrelated-%02d", index)), []byte("x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, selected := range []struct {
+			order int
+			lens  string
+		}{{0, LensReliability}, {1, LensReliability}, {0, LensRisk}} {
+			slot, err := ReadCompactReviewerResultSlot(fixture.store.Dir, selected.order, selected.lens)
+			if err != nil || slot.Occupied {
+				t.Fatalf("slot %d/%s = %#v, %v", selected.order, selected.lens, slot, err)
+			}
+		}
+	})
+
+	t.Run("partial pairs fail closed", func(t *testing.T) {
+		for _, member := range []string{"payload", "digest"} {
+			t.Run(member, func(t *testing.T) {
+				fixture := newCompactReviewerCaptureFixture(t, "read-partial-"+member)
+				if _, err := fixture.store.CaptureAdmittedReviewerResult(t.Context(), fixture.request); err != nil {
+					t.Fatal(err)
+				}
+				path := fixture.path
+				if member == "digest" {
+					path += ".sha256"
+				}
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				slot, err := ReadCompactReviewerResultSlot(fixture.store.Dir, 0, LensReliability)
+				if err == nil || slot.Occupied || !strings.Contains(err.Error(), "partially published") {
+					t.Fatalf("partial slot = %#v, %v", slot, err)
+				}
+			})
+		}
+	})
+
+	t.Run("unsafe members and read failures fail closed", func(t *testing.T) {
+		for _, test := range []struct {
+			name string
+			make func(*testing.T, string)
+		}{
+			{"directory", func(t *testing.T, path string) {
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}},
+			{"symlink", func(t *testing.T, path string) {
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation requires optional Windows privileges")
+				}
+				target := filepath.Join(t.TempDir(), "target")
+				if err := os.WriteFile(target, []byte("outside\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			}},
+			{"hardlink", func(t *testing.T, path string) {
+				target := filepath.Join(t.TempDir(), "target")
+				if err := os.WriteFile(target, []byte("outside\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Link(target, path); err != nil {
+					t.Skipf("hardlink unavailable: %v", err)
+				}
+			}},
+			{"group readable", func(t *testing.T, path string) {
+				if runtime.GOOS == "windows" {
+					t.Skip("Windows ACLs do not map to Unix mode bits")
+				}
+				if err := os.WriteFile(path, []byte("unsafe\n"), 0o640); err != nil {
+					t.Fatal(err)
+				}
+			}},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				fixture := newCompactReviewerCaptureFixture(t, "read-unsafe-"+strings.ReplaceAll(test.name, " ", "-"))
+				if _, err := createPrivateRARDirectory(filepath.Dir(fixture.path)); err != nil {
+					t.Fatal(err)
+				}
+				test.make(t, fixture.path)
+				if _, err := ReadCompactReviewerResultSlot(fixture.store.Dir, 0, LensReliability); !errors.Is(err, errUnsafeRARAuthorityPath) {
+					t.Fatalf("unsafe slot error = %v", err)
+				}
+			})
+		}
+		fixture := newCompactReviewerCaptureFixture(t, "read-operational")
+		injected := errors.New("injected read failure")
+		original := readCompactReviewerResultSlotFile
+		readCompactReviewerResultSlotFile = func(string, int64) ([]byte, error) { return nil, injected }
+		t.Cleanup(func() { readCompactReviewerResultSlotFile = original })
+		if _, err := ReadCompactReviewerResultSlot(fixture.store.Dir, 0, LensReliability); !errors.Is(err, injected) {
+			t.Fatalf("operational slot error = %v", err)
+		}
+	})
 }
 
 func TestCompactStoreCaptureAdmittedReviewerResultNormalizesInspectionPathsBeforePersisting(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2016

This child targets the non-default feature tracker branch, so #2016 remains open until the completed tracker merges to `main`.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Read each exact canonical reviewer-result payload/digest pair once through the existing no-follow private-file boundary.
- Treat exact partial publication as corrupted authority instead of silently reoffering collection.
- Pass immutable verified bytes directly into STATUS admission without reopening either path.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_result_reopen.go` | Adds the canonical secure slot read and immutable payload/digest result. |
| `internal/reviewtransaction/compact_reviewer_capture_test.go` | Covers complete, pending, partial, unrelated, unsafe, and one-read behavior. |
| `internal/cli/review_artifact.go` | Consumes secure slot bytes directly during captured-artifact discovery. |
| `internal/cli/review_artifact_test.go` | Proves partial slots stop while clean pending and complete slots keep their routes. |

---

## 🧪 Test Plan

- [x] Focused transaction and CLI regressions pass
- [x] `go test ./... -count=1`
- [x] `go vet ./internal/cli ./internal/reviewtransaction`
- [x] `go run ./internal/gofmtcheck`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] Bench declarations and vet pass
- [x] Existing driven j77 passes: 1 completed, 0 unsupported, 0 failed
- [x] Windows amd64 and Darwin arm64 cross-compilation pass
- [ ] Native Windows/Darwin filesystem behavior is delegated to CI

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | #2016 frozen-lineage resume v2 |
| Tracker PR | Opens after slice 1 integrates into the tracker branch |
| Position | 1 of 3 |
| Base | `fix/2016-frozen-lineage-resume-v2` |
| Depends on | None |
| Follow-up | Slice 2: explicit frozen-lineage STATUS routing |
| Review budget | 256 / 400 lines |
| Starts at | `main@6b18f1fa` tracker baseline |
| Ends with | Canonical partial-slot classification and no-reopen STATUS discovery |

### Chain Overview

```text
main
 └── fix/2016-frozen-lineage-resume-v2 (tracker)
      └── 📍 slice 1: atomic reviewer slot reads
           └── slice 2: explicit frozen STATUS routing
                └── slice 3: j90 driven integration proof
```

### Scope

- Includes: canonical slot occupancy, fail-closed partial pairs, immutable secure reads, focused controls.
- Excludes: workspace-drift resume behavior, selector precedence, and j90.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit

---

## ✅ Contributor Checklist

- [x] Linked to approved issue #2016
- [x] Exactly one `type:*` label is applied
- [x] 256 changed lines, within the 400-line budget
- [x] Unit tests, formatting, deadcode, and benchmark declarations pass
- [x] Commit follows Conventional Commits
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Only exact canonical `(order, lens)` names participate in authority. Alternate and unrelated filenames are ignored, not scanned. Neither canonical member means pending, one member means corrupt partial publication, and both members are securely read exactly once before digest, schema, subject, and admission checks.

The returned payload is copied before it leaves the transaction layer. STATUS consumes those bytes directly, so there is no classification-to-reopen TOCTOU window.