### PR TITLE
fix(review): resume frozen reviewing status

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -896,6 +896,14 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		result := newReviewTargetStatusResultForContract(native, *contract)
 		result.intendedUntracked = intendedScope
+		if native.Decision.FrozenReviewing {
+			// Explicit reviewing resume keeps the immutable scope that the reviewer
+			// artifacts bind, rather than asking live workspace drift to select one.
+			intendedScope = reviewIntendedUntrackedScope{
+				Intended: append([]string{}, native.Projection.IntendedUntracked...), Declared: true,
+			}
+			result.intendedUntracked = intendedScope
+		}
 		// STATUS renders the core's executable decision, never the raw spelling
 		// the CLI parsed.
 		selector.Kind, selector.Projection = result.decision.Selector.Kind, result.decision.Selector.Projection
@@ -1043,7 +1051,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			// superseded lineage still occupies the name this target derives, and
 			// a start naming nothing would answer blocked-scope-action at exit 0.
 			startLineage := strings.TrimSpace(*lineage)
-			if startLineage == "" && native.Applicability == reviewtransaction.TargetApplicabilityUnrelated {
+			if native.Applicability == reviewtransaction.TargetApplicabilityUnrelated && !reviewStartLineageAvailable(ctx, root, startLineage) {
 				startLineage = reviewAvailableStartLineage(ctx, root, native.TargetIdentity)
 			}
 			input := reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector, IntendedUntracked: intendedScope, RDDMode: result.rddMode, RDDModeResolved: result.rddModeResolved, PreCommitDeliveryAssessment: preCommitDeliveryAssessment}

--- a/internal/cli/review_frozen_status_test.go
+++ b/internal/cli/review_frozen_status_test.go
@@ -1,0 +1,260 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+func TestExplicitFrozenReviewingStatusResumesPendingCandidateAfterDrift(t *testing.T) {
+	for _, targetKind := range []reviewtransaction.TargetKind{
+		reviewtransaction.TargetCurrentChanges,
+		reviewtransaction.TargetBaseDiff,
+		reviewtransaction.TargetBaseWorkspaceOverlay,
+	} {
+		t.Run(string(targetKind), func(t *testing.T) {
+			repo, _, record := frozenReviewingStatusFixture(t, targetKind, nil)
+			inventory := readLegacyAuthorityTree(t, reviewCLIAuthorityRoot(t, repo))
+			before := frozenCollectEnvelope(t, explicitFrozenReviewingStatus(t, repo, record.State.LineageID))
+			writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'live drift'\n", 0o644)
+			writeUndeclaredWorkspaceFile(t, repo, "live-untracked.txt", "live drift\n", 0o644)
+
+			status := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
+			if err := status.Validate(); err != nil {
+				t.Fatal(err)
+			}
+			if status.Applicability != reviewtransaction.TargetApplicabilityCurrent || status.Authority == nil ||
+				status.Authority.LineageID != record.State.LineageID || status.Authority.Revision != record.Revision ||
+				status.TargetIdentity != record.State.InitialSnapshot.Identity ||
+				status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+				status.NextTransition.ReasonCode != "reviewer_results_required" {
+				t.Fatalf("explicit frozen status = %#v", status)
+			}
+			if status.Projection.Kind != record.State.InitialSnapshot.Kind ||
+				status.Projection.BaseTree != record.State.InitialSnapshot.BaseTree ||
+				status.Projection.InitialReviewTree != record.State.InitialSnapshot.CandidateTree ||
+				status.Projection.CurrentCandidateTree != record.State.InitialSnapshot.CandidateTree ||
+				status.Projection.PathsDigest != record.State.InitialSnapshot.PathsDigest ||
+				!reflect.DeepEqual(status.Projection.Paths, record.State.InitialSnapshot.Paths) ||
+				!reflect.DeepEqual(status.Projection.IntendedUntracked, record.State.InitialSnapshot.IntendedUntracked) ||
+				status.Projection.IntendedUntrackedProof != record.State.InitialSnapshot.IntendedUntrackedProof {
+				t.Fatalf("frozen projection = %#v, authority = %#v", status.Projection, record.State.InitialSnapshot)
+			}
+			input := status.NextTransition.Collect.Inputs[0]
+			frozen, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).FrozenCandidateContext(t.Context(), record.State.InitialSnapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantSubject, err := reviewtransaction.NewArtifactSubject(record.State, record.Revision, frozen, record.State.SelectedLenses[0], 0, "")
+			if err != nil || input.ArtifactSubject == nil || !reflect.DeepEqual(*input.ArtifactSubject, wantSubject) {
+				t.Fatalf("capture binding = %#v, want %#v, err = %v", input, wantSubject, err)
+			}
+			if !bytes.Equal(before, frozenCollectEnvelope(t, status)) {
+				t.Fatalf("frozen collect envelope changed after drift")
+			}
+			if after := readLegacyAuthorityTree(t, reviewCLIAuthorityRoot(t, repo)); !reflect.DeepEqual(inventory, after) {
+				t.Fatalf("status changed authority inventory: before=%#v after=%#v", inventory, after)
+			}
+		})
+	}
+}
+
+func TestExplicitFrozenReviewingStatusUsesFrozenUntrackedScope(t *testing.T) {
+	repo, _, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, []string{"frozen-untracked.txt"})
+	writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'live drift'\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, "live-untracked.txt", "live drift\n", 0o644)
+
+	selectorless := explicitFrozenReviewingStatus(t, repo, "")
+	status := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
+	if selectorless.NextTransition == nil || selectorless.NextTransition.ReasonCode != "intended_untracked_selection_required" {
+		t.Fatalf("selectorless mixed workspace status = %#v", selectorless)
+	}
+	if !reflect.DeepEqual(status.Projection.IntendedUntracked, []string{"frozen-untracked.txt"}) ||
+		status.NextTransition == nil || status.NextTransition.ReasonCode != "reviewer_results_required" {
+		t.Fatalf("explicit frozen untracked status = %#v", status)
+	}
+}
+
+func TestExplicitFrozenReviewingStatusRejectsPartialSlotsAndStaleStartLineages(t *testing.T) {
+	t.Run("partial canonical slot fails closed", func(t *testing.T) {
+		repo, store, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, nil)
+		captureFrozenReviewerResults(t, repo, record, 1)
+		path := filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir, "00-"+record.State.SelectedLenses[0]+".json.sha256")
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'live drift'\n", 0o644)
+		status := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
+		if status.Applicability != reviewtransaction.TargetApplicabilityCorrupted || status.NextTransition == nil ||
+			status.NextTransition.Kind == reviewNextTransitionCollect {
+			t.Fatalf("partial frozen slot status = %#v", status)
+		}
+	})
+
+	t.Run("occupied slots and stale selector start fresh", func(t *testing.T) {
+		repo, _, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, nil)
+		captureFrozenReviewerResults(t, repo, record, len(record.State.SelectedLenses))
+		writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'live drift'\n", 0o644)
+		stale := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
+		if stale.Applicability != reviewtransaction.TargetApplicabilityUnrelated || stale.NextTransition == nil ||
+			stale.NextTransition.Execute == nil || stale.NextTransition.Execute.Operation != "review.start" ||
+			stale.NextTransition.Execute.Binding.LineageID == record.State.LineageID {
+			t.Fatalf("occupied stale status = %#v", stale)
+		}
+		fresh := explicitFrozenReviewingStatus(t, repo, "requested-new-lineage")
+		if fresh.NextTransition == nil || fresh.NextTransition.Execute == nil ||
+			fresh.NextTransition.Execute.Binding.LineageID != "requested-new-lineage" {
+			t.Fatalf("unknown requested lineage = %#v", fresh)
+		}
+	})
+
+	t.Run("stale legacy selector is not reused", func(t *testing.T) {
+		reviewModeHome(t)
+		repo := initReviewCLIRepo(t)
+		writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'legacy'\n", 0o644)
+		addPristineLegacyAuthority(t, repo, "stale-legacy-lineage")
+		writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'live drift'\n", 0o644)
+		status := explicitFrozenReviewingStatus(t, repo, "stale-legacy-lineage")
+		if status.NextTransition == nil || status.NextTransition.Execute == nil || status.NextTransition.Execute.Binding.LineageID == "stale-legacy-lineage" {
+			t.Fatalf("stale legacy start status = %#v", status)
+		}
+	})
+}
+
+func frozenReviewingStatusFixture(t *testing.T, kind reviewtransaction.TargetKind, intended []string) (string, reviewtransaction.CompactStore, reviewtransaction.CompactRecord) {
+	t.Helper()
+	if kind == reviewtransaction.TargetBaseWorkspaceOverlay {
+		return frozenStagedReviewingStatusFixture(t)
+	}
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'frozen'\n", 0o644)
+	target := reviewtransaction.Target{Kind: kind, IntendedUntracked: append([]string{}, intended...)}
+	for _, path := range intended {
+		writeUndeclaredWorkspaceFile(t, repo, path, "frozen intended\n", 0o644)
+	}
+	switch kind {
+	case reviewtransaction.TargetBaseDiff:
+		runReviewCLIGit(t, repo, "add", "service-token.ts")
+		runReviewCLIGit(t, repo, "commit", "-qm", "frozen base diff")
+		target.BaseRef = base
+	case reviewtransaction.TargetBaseWorkspaceOverlay:
+		runReviewCLIGit(t, repo, "add", "service-token.ts")
+		target.BaseRef, target.Projection = base, reviewtransaction.ProjectionStaged
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.BuildStoredSnapshot(t.Context(), target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(t.Context(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lenses := []string{}
+	if risk == reviewtransaction.RiskMedium {
+		lenses = []string{reviewtransaction.LensReliability}
+	} else if risk == reviewtransaction.RiskHigh {
+		lenses = []string{reviewtransaction.LensRisk, reviewtransaction.LensResilience, reviewtransaction.LensReadability, reviewtransaction.LensReliability}
+	}
+	if len(lenses) == 0 {
+		t.Fatalf("fixture must select reviewer lenses: risk=%q lines=%d", risk, lines)
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "frozen-status-" + strings.ReplaceAll(string(kind), "_", "-"), Mode: reviewtransaction.ModeOrdinaryBounded,
+		Generation: 1, Snapshot: snapshot, PolicyHash: "sha256:" + strings.Repeat("1", 64), RiskLevel: risk,
+		SelectedLenses: lenses, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := reviewtransaction.StartCompactAuthority(t.Context(), repo, reviewtransaction.CompactStartRequest{State: state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, store, started.Record
+}
+
+func frozenStagedReviewingStatusFixture(t *testing.T) (string, reviewtransaction.CompactStore, reviewtransaction.CompactRecord) {
+	t.Helper()
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "docs/candidate.md", "# Candidate\n", 0o644)
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed base candidate")
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "frozen-staged-root", "--base-ref", base, "--committed-only"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", "frozen-staged-root"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'frozen'\n", 0o644)
+	probe := selectorTransitionStatus(t, repo, "--lineage", "frozen-staged-root", "--base-ref", base, "--projection", "staged", "--workspace-overlay")
+	const successor, actor, reason = "frozen-staged-reviewing", "maintainer", "include staged token"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=frozen-staged-root\npredecessor_revision=" + probe.Authority.Revision +
+		"\ntarget_identity=" + probe.TargetIdentity + "\nsuccessor_lineage=" + successor + "\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo, "--lineage", "frozen-staged-root", "--base-ref", base, "--projection", "staged", "--workspace-overlay",
+		"--recovery-successor-lineage", successor, "--recovery-reason", reason, "--recovery-actor", actor, "--recovery-authorization", authorization)
+	executeSelectorTransition(t, repo, status)
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, successor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, store, record
+}
+
+func explicitFrozenReviewingStatus(t *testing.T, repo, lineage string) ReviewTargetStatusResult {
+	t.Helper()
+	var output bytes.Buffer
+	args := []string{"status", "--contract", ReviewIntegrationContractV2, "--next-transition", "--cwd", repo}
+	if lineage != "" {
+		args = append(args, "--lineage", lineage)
+	}
+	if err := RunReview(args, &output); err != nil {
+		t.Fatalf("frozen STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	return status
+}
+
+func frozenCollectEnvelope(t *testing.T, status ReviewTargetStatusResult) []byte {
+	t.Helper()
+	payload, err := json.Marshal([]any{status.Authority, status.Frozen, status.TargetIdentity,
+		status.AuthorityTargetIdentity, status.Projection, status.NextTransition})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func captureFrozenReviewerResults(t *testing.T, repo string, record reviewtransaction.CompactRecord, count int) {
+	t.Helper()
+	for order, lens := range record.State.SelectedLenses[:count] {
+		input := filepath.Join(t.TempDir(), lens+".json")
+		if err := os.WriteFile(input, admittedReviewerPayloadForTest(t, repo, record, lens, order), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", record.State.LineageID,
+			"--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", strconv.Itoa(order), "--input", input}, &bytes.Buffer{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/cli/review_start_lineage.go
+++ b/internal/cli/review_start_lineage.go
@@ -70,10 +70,20 @@ func reviewAvailableStartLineage(ctx context.Context, root, targetIdentity strin
 // not load is still taken, and a store that cannot be resolved at all answers
 // taken rather than inviting a start that would collide.
 func reviewStartLineageAvailable(ctx context.Context, root, lineage string) bool {
+	if lineage == "" {
+		return false
+	}
 	store, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, lineage)
 	if err != nil {
 		return false
 	}
-	_, loadErr := store.Load()
+	if _, loadErr := store.Load(); !errors.Is(loadErr, os.ErrNotExist) {
+		return false
+	}
+	legacy, err := reviewtransaction.AuthoritativeStore(ctx, root, lineage)
+	if err != nil {
+		return false
+	}
+	_, loadErr := legacy.LoadChain()
 	return errors.Is(loadErr, os.ErrNotExist)
 }

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -78,6 +78,7 @@ type TargetStatusDecision struct {
 	Selector                           Target
 	RecoverySelector                   *Target
 	SelectorFreeAccountingOnlyRecovery bool
+	FrozenReviewing                    bool
 }
 
 type TargetStatusResult struct {
@@ -105,6 +106,7 @@ type TargetStatusResult struct {
 	authorityTargetKind                TargetKind
 	authorityProjection                Projection
 	selectorFreeAccountingOnlyRecovery bool
+	frozenReviewing                    bool
 }
 
 type targetStatusCandidate struct {
@@ -119,6 +121,7 @@ type targetStatusCandidate struct {
 	receiptReplayable  bool
 	pendingFinalize    bool
 	correctionRecovery bool
+	frozenReviewing    bool
 	// selectorFreeAccountingOnlyRecovery is carried from the eligibility
 	// predicate so projection never guesses it from snapshot identity domains.
 	selectorFreeAccountingOnlyRecovery bool
@@ -231,6 +234,18 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			continue
 		}
 		state := candidate.compact.State
+		if request.LineageID != "" && request.Target.Kind == TargetCurrentChanges && request.Target.Projection != ProjectionStaged &&
+			!compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
+			eligible, eligibilityErr := explicitReviewingCompactCandidate(ctx, repo, candidate)
+			if eligibilityErr != nil {
+				return targetStatusFailure(base, eligibilityErr)
+			}
+			if eligible {
+				candidate.frozenReviewing = true
+				candidates = append(candidates, candidate)
+				continue
+			}
+		}
 		if state.State == StateInvalidated && state.InitialSnapshot.Kind == TargetBaseWorkspaceOverlay &&
 			state.InitialSnapshot.Projection == ProjectionStaged && live.Kind == TargetBaseWorkspaceOverlay &&
 			live.Projection == ProjectionStaged && state.InitialSnapshot.BaseTree == live.BaseTree &&
@@ -422,6 +437,47 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 	}
 }
 
+// explicitReviewingCompactCandidate admits a drifted reviewing authority only
+// after its immutable review inputs and every canonical result slot are safe.
+func explicitReviewingCompactCandidate(ctx context.Context, repo string, candidate targetStatusCandidate) (bool, error) {
+	if candidate.compact == nil {
+		return false, nil
+	}
+	state := candidate.compact.State
+	if state.State != StateReviewing || candidate.pendingFinalize || len(state.SelectedLenses) == 0 {
+		return false, nil
+	}
+	superseded, err := CompactLineageSuperseded(ctx, repo, state.LineageID)
+	if err != nil || superseded {
+		return false, err
+	}
+	store, err := CompactAuthoritativeStore(ctx, repo, state.LineageID)
+	if err != nil {
+		return false, err
+	}
+	pending := false
+	for order, lens := range state.SelectedLenses {
+		slot, err := ReadCompactReviewerResultSlot(store.Dir, order, lens)
+		if err != nil {
+			return false, err
+		}
+		pending = pending || !slot.Occupied
+	}
+	if !pending {
+		return false, nil
+	}
+	frozen, err := (SnapshotBuilder{Repo: repo}).FrozenCandidateContext(ctx, state.InitialSnapshot)
+	if err != nil {
+		return false, err
+	}
+	for order, lens := range state.SelectedLenses {
+		if _, err := NewArtifactSubject(state, candidate.compact.Revision, frozen, lens, order, ""); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
 func compactLocalBaseAdvanceCompatibility(ctx context.Context, repo string, state CompactState, target Target, live Snapshot) *BaseAdvanceCompatibility {
 	if state.CurrentSnapshot.Kind != TargetBaseDiff || state.Recovery != nil || target.Kind != TargetBaseDiff || strings.TrimSpace(target.BaseRef) == "" {
 		return nil
@@ -473,6 +529,11 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 	if candidate.compact != nil {
 		record := *candidate.compact
 		state := record.State
+		if candidate.frozenReviewing {
+			result.TargetIdentity = state.InitialSnapshot.Identity
+			result.Projection = targetProjectionFromSnapshot(state.InitialSnapshot)
+			result.frozenReviewing = true
+		}
 		result.State, result.Generation, result.Revision = state.State, state.Generation, record.Revision
 		result.AuthorityTargetIdentity = state.CurrentSnapshot.Identity
 		result.authorityTargetKind, result.authorityProjection = state.InitialSnapshot.Kind, state.InitialSnapshot.Projection
@@ -542,7 +603,7 @@ func projectTargetStatusDecision(result TargetStatusResult) TargetStatusResult {
 	}
 	decision := TargetStatusDecision{
 		CandidateRelation: result.Applicability, SemanticTransition: result.Action,
-		TargetIdentity: result.TargetIdentity, Selector: selector,
+		TargetIdentity: result.TargetIdentity, Selector: selector, FrozenReviewing: result.frozenReviewing,
 	}
 	if result.Action != TargetStatusActionRecover {
 		result.Decision = decision

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -1282,6 +1282,7 @@ func TestAssessTargetStatusPropagatesOperationalAuthorityFailures(t *testing.T) 
 
 	t.Run("git exit 73", func(t *testing.T) {
 		repo := targetStatusOperationalFailureFixture(t, "status-git-exit")
+		writeSnapshotFile(t, repo, "tracked.txt", "drifted candidate\n")
 		originalCommand := gitCommandContext
 		t.Cleanup(func() { gitCommandContext = originalCommand })
 		t.Setenv("GENTLE_AI_TARGET_STATUS_GIT_HELPER", "exit73")
@@ -1291,7 +1292,9 @@ func TestAssessTargetStatusPropagatesOperationalAuthorityFailures(t *testing.T) 
 			}
 			return originalCommand(ctx, name, args...)
 		}
-		got, err := AssessTargetStatus(context.Background(), repo, targetStatusCurrentChangesRequest())
+		request := targetStatusCurrentChangesRequest()
+		request.LineageID = "status-git-exit"
+		got, err := AssessTargetStatus(context.Background(), repo, request)
 		var commandErr *GitCommandError
 		if !errors.As(err, &commandErr) || commandErr.ExitCode != 73 || got.Applicability == TargetApplicabilityCorrupted {
 			t.Fatalf("Git exit status = %#v, error = %T %v", got, err, err)
@@ -1384,6 +1387,49 @@ func TestAssessTargetStatusPropagatesOperationalAuthorityFailures(t *testing.T) 
 		var pathErr *os.PathError
 		if !errors.As(err, &pathErr) || errors.Is(err, os.ErrNotExist) || got.Applicability == TargetApplicabilityCorrupted {
 			t.Fatalf("filesystem status = %#v, error = %T %v", got, err, err)
+		}
+	})
+}
+
+func TestExplicitReviewingStatusRejectsSemanticAndIneligibleFrozenCandidates(t *testing.T) {
+	t.Run("semantic frozen evidence", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+		store := storeCompactStartAuthority(t, repo, newCompactTestState(t, repo, "frozen-semantic"))
+		record, _ := store.Load()
+		record.State.InitialSnapshot.Paths = []string{"missing.txt"}
+		eligible, err := explicitReviewingCompactCandidate(context.Background(), repo, targetStatusCandidate{compact: &record})
+		status, statusErr := targetStatusFailure(TargetStatusResult{}, err)
+		if eligible || statusErr != nil || status.Applicability != TargetApplicabilityCorrupted || status.Action != TargetStatusActionRepairAuthority {
+			t.Fatalf("semantic frozen evidence = eligible %v status %#v error %v", eligible, status, statusErr)
+		}
+	})
+
+	t.Run("non-reviewing selected lineage", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+		store := storeCompactStartAuthority(t, repo, newCompactTestState(t, repo, "frozen-not-reviewing"))
+		record, _ := store.Load()
+		record.State.State = StateInvalidated
+		if eligible, err := explicitReviewingCompactCandidate(context.Background(), repo, targetStatusCandidate{compact: &record}); eligible || err != nil {
+			t.Fatalf("non-reviewing candidate = eligible %v error %v", eligible, err)
+		}
+	})
+
+	t.Run("superseded selected lineage", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+		predecessor, store, _ := approvedCompactRevisionFixture(t, repo, "frozen-superseded")
+		record, _ := store.Load()
+		writeSnapshotFile(t, repo, "tracked.txt", "drifted candidate\n")
+		successor := newCompactTestState(t, repo, "frozen-superseded-next")
+		successor.Generation = predecessor.Generation + 1
+		if _, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor, Disposition: RecoveryScopeChanged, Reason: "supersede frozen review", Actor: "maintainer"}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: predecessor.LineageID})
+		if err != nil || got.Applicability != TargetApplicabilityUnrelated || got.Action != TargetStatusActionStart {
+			t.Fatalf("superseded frozen status = %#v, %v", got, err)
 		}
 	})
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2016

This child targets the previous non-default chain branch, so #2016 remains open until tracker PR #2963 merges to `main`.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Resume an explicitly selected compact reviewing lineage from its immutable pending reviewer slot after live workspace drift.
- Preserve frozen intended-untracked scope and full collection bindings without mutating authority or creating another budget.
- Keep selectorless STATUS live-oriented and prevent stale compact/legacy lineage injection into fresh START.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/target_status.go` | Adds narrowly gated frozen-reviewing selection using parent canonical slot reads. |
| `internal/cli/review_facade.go` | Projects frozen intended scope and preserves the existing collection transition. |
| `internal/cli/review_start_lineage.go` | Distinguishes occupied compact/legacy names from legitimate unknown requested lineages. |
| Focused transaction/CLI tests | Cover drift, exact bindings, inventory immutability, fail-closed evidence, and lineage controls. |

---

## 🧪 Test Plan

- [x] Focused CLI and transaction controls
- [x] Exact-parent decoy RED for current, base-diff, and staged-overlay drift
- [x] `go test ./... -count=1`
- [x] Changed-package vet, gofmtcheck, and deadcode ratchet
- [x] Bench declaration suite
- [x] Driven j86 and j77 compatibility
- [ ] j90 full lifecycle proof (slice 3)
- [ ] Native platform lanes delegated to CI

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | #2016 frozen-lineage resume v2 |
| Tracker PR | #2963 |
| Position | 2 of 3 |
| Base | `fix/2016-slot-state-foundation-v2` |
| Depends on | #2962 |
| Follow-up | Slice 3: j90 driven integration proof |
| Review budget | 393 / 400 lines |
| Starts at | Atomic canonical slot-read foundation `f9683b24` |
| Ends with | Explicit frozen pending-slot STATUS routing and focused contract proof |

### Chain Overview

```text
main
 └── #2963 tracker
      └── ✅ #2962 atomic reviewer-slot reads
           └── 📍 slice 2 explicit frozen STATUS routing
                └── slice 3 j90 driven proof
```

### Scope

- Includes: explicit frozen selection, secure pending-slot admission, intended-scope precedence, fresh-lineage protection, focused tests.
- Excludes: j90 registration and final combined delivery proof.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit

---

## ✅ Contributor Checklist

- [x] Linked to approved issue #2016
- [x] Exactly one `type:*` label is applied
- [x] 393 changed lines, within the 400-line budget
- [x] Full root verification and focused runtime compatibility pass
- [x] Commit follows Conventional Commits
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Frozen precedence is deliberately narrow: explicit selector, drifted live target, compact `StateReviewing`, unsuperseded authority, no pending finalize, and at least one canonical pending slot. Partial or unsafe artifacts fail closed. Fully occupied slots retain their previous routing.

STATUS returns existing native collection bindings and leaves the full authority store byte-identical. It does not create a state, recovery edge, budget, receipt, or compatibility path.