### PR TITLE
fix(review): refuse a nonexistent --lineage selector in pure review status

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -33,10 +33,11 @@ const reviewContractRequiredForActionEligibilityReason = "--action-eligibility a
 
 // reviewStatusTargetSelectorsRequireContractReason is the sibling of
 // reviewContractRequiredForActionEligibilityReason above: it names the same
-// exact contract value for the other set of --contract-gated review status
-// flags (target selectors such as --lineage, --base-ref, --base-tree,
+// exact accepted contract values for the other set of --contract-gated review
+// status flags (target selectors such as --lineage, --base-ref, --base-tree,
 // --workspace-overlay, --projection, --gate, and the recovery selectors).
-const reviewStatusTargetSelectorsRequireContractReason = "review status target selectors require --contract " + ReviewIntegrationContractV1
+const reviewStatusTargetSelectorsRequireContractReason = "review status target selectors require --contract " +
+	ReviewIntegrationContractV1 + " or " + ReviewIntegrationContractV2
 
 // reviewStartTargetRequiresContractReason is the sibling of
 // reviewContractRequiredForActionEligibilityReason above, naming the same
@@ -759,7 +760,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 	runtimeAgent := flags.String("agent", "", "generated active runtime identity for negotiated lifecycle routing")
 	actionEligibility := flags.Bool("action-eligibility", false, "include optional machine-readable review action eligibility in negotiated output")
 	nextTransition := flags.Bool("next-transition", false, "include the optional canonical native next transition in negotiated output")
-	lineage := flags.String("lineage", "", "optional explicit lineage selector for negotiated target status")
+	lineage := flags.String("lineage", "", "optional explicit lineage selector for negotiated target status; target selectors require --contract")
 	projection := flags.String("projection", string(reviewtransaction.ProjectionWorkspace), "negotiated target projection: workspace or staged")
 	baseRef := flags.String("base-ref", "", "optional negotiated immutable base-to-HEAD target")
 	baseTree := flags.String("base-tree", "", "optional negotiated resolved immutable overlay base tree")
@@ -887,6 +888,13 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		native, liveSnapshot, err := reviewtransaction.AssessTargetStatusWithSnapshot(ctx, root, reviewtransaction.TargetStatusRequest{
 			Target: target, LineageID: *lineage, PrePR: prePR,
+			// Issue #1997: a pure status query with an explicit --lineage
+			// selector must fail when that lineage does not exist, instead of
+			// returning the same fresh-target envelope as selector-free status
+			// and exiting 0. A negotiated --next-transition legitimately names
+			// a proposed lineage that has not been created yet (the start
+			// consent flow), so only the pure query demands existence.
+			RequireLineageExists: strings.TrimSpace(*lineage) != "" && !*nextTransition,
 		})
 		if err != nil {
 			return fmt.Errorf("assess negotiated review target: %w", err)

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -451,10 +451,10 @@ func reviewLineageNotFoundContinuation(cwd, contract string) string {
 // sentence that points at the `cause` field, which carries the full command
 // under its own 4000-byte bound; the cwd is never truncated, because a
 // truncated path makes the advertised command unusable. A continuation that
-// itself contains a newline cannot be represented in the single-line envelope
-// at all: no command is printed, the message names the selector-free exit, and
-// the envelope stays valid (fail closed rather than advertise an unrunnable
-// line).
+// itself cannot fit the single-line envelope at all -- an embedded newline, or
+// one longer than the bounded cause field itself -- prints no command, the
+// message names the selector-free exit, and the envelope stays valid (fail
+// closed rather than advertise an unrunnable line).
 func reviewLineageNotFoundMessage(continuation string) (message string, cause string) {
 	const (
 		prefix    = "The requested review lineage does not exist; run `"
@@ -462,7 +462,11 @@ func reviewLineageNotFoundMessage(continuation string) (message string, cause st
 		degraded  = "The requested review lineage does not exist; the cause names the runnable next command."
 		noCommand = "The requested review lineage does not exist; run review status without --lineage to list stored reviews."
 	)
-	if strings.ContainsAny(continuation, "\r\n") {
+	// A continuation that cannot be represented in the single-line envelope at
+	// all -- embedded newline, or longer than the bounded cause field itself --
+	// names the selector-free exit instead of advertising a line that would
+	// make the refusal envelope invalid (fail closed).
+	if strings.ContainsAny(continuation, "\r\n") || len([]rune(continuation)) > reviewIntegrationFailureCauseLimit {
 		return noCommand, ""
 	}
 	if len(prefix)+len(continuation)+len(suffix) <= 240 {

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -975,6 +975,26 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		}
 		return failure
 	}
+	var lineageNotFound *reviewtransaction.ReviewLineageNotFoundError
+	if errors.As(runErr, &lineageNotFound) {
+		failure.Phase = "pre_native"
+		failure.Code = "lineage_not_found"
+		failure.Message = "The requested review lineage does not exist; run `gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v1 --lineage <id>` (or v2) to see where this review actually is."
+		failure.MutationOutcome = ReviewMutationNotStarted
+		failure.AuthorityApplicability = "not_evaluated"
+		failure.RetrySafe = true
+		failure.Replayability = reviewtransaction.ReplayabilityNotReplayable
+		failure.LineageID = lineageNotFound.LineageID
+		failure.RequiredInputs = []string{}
+		// The refusal continuation from issue #1997 asks the operator to see
+		// where a review actually is with `review status --lineage <id>`. A
+		// corrected selector is the exact way back in, so status is the next
+		// runnable action; a blind retry of the same nonexistent selector
+		// would never create the lineage and must not be advertised.
+		failure.NextAction = "review.status"
+		failure.Cause = reviewIntegrationFailureCause(runErr)
+		return failure
+	}
 	if operation == "review.capabilities" || operation == "review.status" || operation == "review.validate" {
 		failure.Phase = "pre_native"
 		failure.Code = "operation_failed"

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -420,6 +420,21 @@ func newReviewIntegrationPreflightFailure(operation, code, message string) Revie
 	}
 }
 
+// reviewLineageNotFoundContinuation renders the operator-runnable continuation
+// for the lineage_not_found refusal. It deliberately carries NO --lineage: the
+// refused selector is exactly what failed, so re-running it would dead-end in
+// the same refusal. A selector-free `review status` lists every stored entry
+// (including the one the caller asked about) and exits 0, so it is the honest
+// next runnable command. cwd and contract are the real values derived from the
+// original invocation; when cwd cannot be derived it is simply omitted rather
+// than replaced with a placeholder that misleads the caller.
+func reviewLineageNotFoundContinuation(cwd, contract string) string {
+	if cwd == "" {
+		return "gentle-ai review status --contract " + contract
+	}
+	return "gentle-ai review status --cwd " + cwd + " --contract " + contract
+}
+
 func newReviewIntegrationFailure(operation string, args []string, runErr error) ReviewIntegrationFailure {
 	failure := ReviewIntegrationFailure{
 		Schema: ReviewIntegrationFailureSchema, Contract: ReviewIntegrationContractV1, Operation: operation,
@@ -979,18 +994,27 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 	if errors.As(runErr, &lineageNotFound) {
 		failure.Phase = "pre_native"
 		failure.Code = "lineage_not_found"
-		failure.Message = "The requested review lineage does not exist; run `gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v1 --lineage <id>` (or v2) to see where this review actually is."
+		// The refusal continuation from issue #1997 must run verbatim and exit
+		// 0. Re-issuing `review status --lineage <id>` with the SAME nonexistent
+		// selector would loop straight back into this refusal, so the printed
+		// command carries the real --cwd and negotiated --contract (never a
+		// placeholder) and NO --lineage: a selector-free status lists the stored
+		// entries, including the lineage the operator was asking about.
+		cwd := ""
+		if values, valid := safeReviewIntegrationArguments(operation, args); valid && values["cwd"] != "" {
+			cwd = values["cwd"]
+		}
+		contract := ReviewIntegrationContractV1
+		if provided, value, missing := reviewIntegrationContractArgument(args); provided && !missing && value != "" {
+			contract = value
+		}
+		failure.Message = "The requested review lineage does not exist; run `" + reviewLineageNotFoundContinuation(cwd, contract) + "` to see where the review is."
 		failure.MutationOutcome = ReviewMutationNotStarted
 		failure.AuthorityApplicability = "not_evaluated"
 		failure.RetrySafe = true
 		failure.Replayability = reviewtransaction.ReplayabilityNotReplayable
 		failure.LineageID = lineageNotFound.LineageID
 		failure.RequiredInputs = []string{}
-		// The refusal continuation from issue #1997 asks the operator to see
-		// where a review actually is with `review status --lineage <id>`. A
-		// corrected selector is the exact way back in, so status is the next
-		// runnable action; a blind retry of the same nonexistent selector
-		// would never create the lineage and must not be advertised.
 		failure.NextAction = "review.status"
 		failure.Cause = reviewIntegrationFailureCause(runErr)
 		return failure

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -428,11 +428,47 @@ func newReviewIntegrationPreflightFailure(operation, code, message string) Revie
 // next runnable command. cwd and contract are the real values derived from the
 // original invocation; when cwd cannot be derived it is simply omitted rather
 // than replaced with a placeholder that misleads the caller.
+//
+// Both dynamic values are rendered through reviewTransitionShellWord so the
+// printed line stays executable when pasted: a cwd with spaces, quotes, shell
+// metacharacters, or newlines must survive POSIX word splitting and must never
+// introduce extra commands. This is the same quoting every other printed
+// continuation in the review contract uses, so SplitPrintedCommandWords (the
+// inverse grammar) can re-derive the exact argv.
 func reviewLineageNotFoundContinuation(cwd, contract string) string {
-	if cwd == "" {
-		return "gentle-ai review status --contract " + contract
+	quoted := "gentle-ai review status"
+	if cwd != "" {
+		quoted += " --cwd " + reviewTransitionShellWord(cwd)
 	}
-	return "gentle-ai review status --cwd " + cwd + " --contract " + contract
+	return quoted + " --contract " + reviewTransitionShellWord(contract)
+}
+
+// reviewLineageNotFoundMessage bounds the lineage_not_found failure sentence to
+// the published 240-byte message limit while keeping the refusal continuation
+// complete and executable. A short cwd keeps the command inside the message
+// (the common, human-visible path). When a deep or hostile cwd would push the
+// full command past the limit, the message degrades to a fixed, bounded
+// sentence that points at the `cause` field, which carries the full command
+// under its own 4000-byte bound; the cwd is never truncated, because a
+// truncated path makes the advertised command unusable. A continuation that
+// itself contains a newline cannot be represented in the single-line envelope
+// at all: no command is printed, the message names the selector-free exit, and
+// the envelope stays valid (fail closed rather than advertise an unrunnable
+// line).
+func reviewLineageNotFoundMessage(continuation string) (message string, cause string) {
+	const (
+		prefix    = "The requested review lineage does not exist; run `"
+		suffix    = "` to see where the review is."
+		degraded  = "The requested review lineage does not exist; the cause names the runnable next command."
+		noCommand = "The requested review lineage does not exist; run review status without --lineage to list stored reviews."
+	)
+	if strings.ContainsAny(continuation, "\r\n") {
+		return noCommand, ""
+	}
+	if len(prefix)+len(continuation)+len(suffix) <= 240 {
+		return prefix + continuation + suffix, ""
+	}
+	return degraded, continuation
 }
 
 func newReviewIntegrationFailure(operation string, args []string, runErr error) ReviewIntegrationFailure {
@@ -1008,7 +1044,16 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		if provided, value, missing := reviewIntegrationContractArgument(args); provided && !missing && value != "" {
 			contract = value
 		}
-		failure.Message = "The requested review lineage does not exist; run `" + reviewLineageNotFoundContinuation(cwd, contract) + "` to see where the review is."
+		message, continuation := reviewLineageNotFoundMessage(reviewLineageNotFoundContinuation(cwd, contract))
+		failure.Message = message
+		if continuation != "" {
+			// A deep or hostile cwd pushed the runnable command out of the
+			// 240-byte message; the full, executable continuation travels in
+			// the bounded `cause` field instead. It is never truncated.
+			failure.Cause = continuation
+		} else {
+			failure.Cause = reviewIntegrationFailureCause(runErr)
+		}
 		failure.MutationOutcome = ReviewMutationNotStarted
 		failure.AuthorityApplicability = "not_evaluated"
 		failure.RetrySafe = true
@@ -1016,7 +1061,6 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		failure.LineageID = lineageNotFound.LineageID
 		failure.RequiredInputs = []string{}
 		failure.NextAction = "review.status"
-		failure.Cause = reviewIntegrationFailureCause(runErr)
 		return failure
 	}
 	if operation == "review.capabilities" || operation == "review.status" || operation == "review.validate" {

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -484,6 +484,26 @@ func TestLineageNotFoundContinuationDegradesForDeepCwd(t *testing.T) {
 	if err := (ReviewIntegrationFailure{Message: message, Cause: cause}).messageCauseBound(); err != nil {
 		t.Fatalf("newline cwd envelope fields invalid: %v", err)
 	}
+
+	// A cwd deep enough that the full continuation would exceed the bounded
+	// cause field (4000 runes) must fail closed just like the newline case:
+	// no command is printed, the message names the selector-free exit, and the
+	// envelope stays valid -- never a truncated continuation.
+	huge := "/" + strings.Repeat("very/deep/workspace/segment/", 200) + "repo"
+	line = reviewLineageNotFoundContinuation(huge, ReviewIntegrationContractV1)
+	if len([]rune(line)) <= reviewIntegrationFailureCauseLimit {
+		t.Fatalf("test cwd not big enough: continuation is %d runes", len([]rune(line)))
+	}
+	message, cause = reviewLineageNotFoundMessage(line)
+	if strings.Contains(message, "`") || cause != "" {
+		t.Fatalf("huge cwd must fail closed with no command: message=%q cause=%q", message, cause)
+	}
+	if len(message) > 240 {
+		t.Fatalf("huge-degraded message exceeds 240 bytes: %d", len(message))
+	}
+	if err := (ReviewIntegrationFailure{Message: message, Cause: cause}).messageCauseBound(); err != nil {
+		t.Fatalf("huge cwd envelope fields invalid: %v", err)
+	}
 }
 
 // messageCauseBound is the subset of ReviewIntegrationFailure.Validate that

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -244,6 +244,19 @@ func TestReviewStatusContractRequirementNamesAllAcceptedContracts(t *testing.T) 
 	}
 }
 
+// TestReviewStatusSelectorsRequirementNamesAllAcceptedContracts pins the
+// sibling refusal for review status target selectors (--lineage, --base-ref,
+// --base-tree, --projection, --gate, and the recovery selectors): it must
+// name every contract the negotiated surface accepts, not just v1, so an
+// operator rerunning with either v1 or v2 knows the runnable form.
+func TestReviewStatusSelectorsRequirementNamesAllAcceptedContracts(t *testing.T) {
+	var output bytes.Buffer
+	err := RunReview([]string{"status", "--lineage", "review-ffffffffffffffff"}, &output)
+	if err == nil || err.Error() != "review status target selectors require --contract gentle-ai.review-integration/v1 or gentle-ai.review-integration/v2" {
+		t.Fatalf("unnegotiated target-selector refusal = %q, want both accepted contracts", err)
+	}
+}
+
 func TestV4StatusRemainsReadableAlongsideV5(t *testing.T) {
 	status := ReviewTargetStatusResult{
 		Schema:        ReviewIntegrationStatusSchemaV4,
@@ -271,6 +284,61 @@ func TestV4StatusRemainsReadableAlongsideV5(t *testing.T) {
 	}
 	if err := status.Validate(); err != nil {
 		t.Fatalf("v4 STATUS must remain readable: %v", err)
+	}
+}
+
+// TestNegotiatedStatusRejectsNonexistentLineageSelector pins issue #1997: an
+// explicit --lineage selector that names no stored authority must fail loudly
+// instead of returning the same fresh-target envelope as selector-free status.
+// Before the fix, every one of these commands produced the same byte-identical
+// output and exited 0, so the refusal continuation "see where this review
+// actually is with `review status --lineage <id>`" could never be answered.
+func TestNegotiatedStatusRejectsNonexistentLineageSelector(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate behavior\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+
+	tests := []struct {
+		name    string
+		lineage string
+		wantErr bool
+	}{
+		{name: "existing lineage succeeds", lineage: started.LineageID},
+		{name: "well-formed nonexistent lineage refused", lineage: "review-ffffffffffffffff", wantErr: true},
+		{name: "kebab-shaped junk refused", lineage: "not-even-a-lineage-shape", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", test.lineage}, &output)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("status --lineage %q accepted: %s", test.lineage, output.String())
+				}
+				failure := decodeReviewIntegrationFailure(t, output.Bytes())
+				if failure.Code != "lineage_not_found" {
+					t.Fatalf("status --lineage %q code = %q; want lineage_not_found", test.lineage, failure.Code)
+				}
+				if !strings.Contains(failure.Cause, `review lineage "`+test.lineage+`" does not exist`) {
+					t.Fatalf("status --lineage %q cause = %q; want does-not-exist reason", test.lineage, failure.Cause)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("status --lineage %q error: %v", test.lineage, err)
+			}
+			var status ReviewTargetStatusResult
+			decoder := json.NewDecoder(bytes.NewReader(output.Bytes()))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&status); err != nil {
+				t.Fatalf("decode status: %v", err)
+			}
+			if err := status.Validate(); err != nil {
+				t.Fatalf("status invalid: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -400,6 +400,107 @@ func TestLineageNotFoundContinuationRunsVerbatim(t *testing.T) {
 	}
 }
 
+// TestLineageNotFoundContinuationQuotesHostileCwd pins Major 1: the printed
+// continuation must survive POSIX word splitting even when cwd contains spaces,
+// quotes, or shell metacharacters. The full line rendered from a hostile cwd
+// round-trips through SplitPrintedCommandWords (the same inverse grammar the
+// product uses for every printed continuation) back into the exact argv the
+// refusal intended, and the envelope stays valid.
+func TestLineageNotFoundContinuationQuotesHostileCwd(t *testing.T) {
+	hostile := []string{
+		"/tmp/gitlab runner/path with spaces",  // spaces
+		"/tmp/o'brien/quote in path",           // embedded single quote
+		"/tmp/semi;colon && dollar $HOME",      // shell metacharacters
+		"/tmp/$(whoami)/`touchtmp/x` backtick", // command substitution
+		"relative/path without leading slash",  // no cwd derivation issues
+	}
+	for _, cwd := range hostile {
+		t.Run("cwd="+strings.ReplaceAll(strings.ReplaceAll(cwd, "/", "_"), " ", ""), func(t *testing.T) {
+			line := reviewLineageNotFoundContinuation(cwd, ReviewIntegrationContractV1)
+			if strings.Contains(line, "\n") || strings.Contains(line, "\r") {
+				t.Fatalf("rendered continuation contains a newline: %q", line)
+			}
+			words, err := SplitPrintedCommandWords(line)
+			if err != nil {
+				t.Fatalf("printed continuation does not survive POSIX splitting: %v (%q)", err, line)
+			}
+			want := []string{"gentle-ai", "review", "status", "--cwd", cwd, "--contract", ReviewIntegrationContractV1}
+			if !reflect.DeepEqual(words, want) {
+				t.Fatalf("split continuation = %#v, want %#v\nline: %q", words, want, line)
+			}
+			message, cause := reviewLineageNotFoundMessage(line)
+			if err := (ReviewIntegrationFailure{Message: message, Cause: cause}).messageCauseBound(); err != nil {
+				t.Fatalf("hostile cwd envelope fields invalid: %v", err)
+			}
+		})
+	}
+}
+
+// TestLineageNotFoundContinuationDegradesForDeepCwd pins Major 2: a cwd longer
+// than the ~88-byte message budget must not be truncated and must not produce
+// an invalid envelope. The message degrades to a bounded sentence and the full,
+// executable continuation travels in `cause` (4000-byte bound). A continuation
+// that cannot be represented in the single-line envelope at all (embedded
+// newline) fails closed with no printed command.
+func TestLineageNotFoundContinuationDegradesForDeepCwd(t *testing.T) {
+	deep := "/" + strings.Repeat("very/deep/workspace/", 24) + "repo"
+	if len(deep) <= 100 {
+		t.Fatalf("test cwd not deep enough: %d bytes", len(deep))
+	}
+	line := reviewLineageNotFoundContinuation(deep, ReviewIntegrationContractV1)
+	message, cause := reviewLineageNotFoundMessage(line)
+	if strings.Contains(message, "`") {
+		t.Fatalf("degraded message still embeds a command: %q", message)
+	}
+	if len(message) > 240 {
+		t.Fatalf("degraded message exceeds 240 bytes: %d (%q)", len(message), message)
+	}
+	if cause == "" {
+		t.Fatalf("deep cwd dropped the continuation instead of moving it to cause")
+	}
+	if !strings.Contains(cause, deep) {
+		t.Fatalf("cause truncated the cwd: %q", cause)
+	}
+	words, err := SplitPrintedCommandWords(cause)
+	if err != nil {
+		t.Fatalf("cause continuation does not survive POSIX splitting: %v (%q)", err, cause)
+	}
+	if !reflect.DeepEqual(words, []string{"gentle-ai", "review", "status", "--cwd", deep, "--contract", ReviewIntegrationContractV1}) {
+		t.Fatalf("cause split = %#v, want full cwd argv (never truncated)", words)
+	}
+	if err := (ReviewIntegrationFailure{Message: message, Cause: cause}).messageCauseBound(); err != nil {
+		t.Fatalf("deep cwd envelope fields invalid: %v", err)
+	}
+
+	newlineCwd := "/tmp/line\nbreak"
+	line = reviewLineageNotFoundContinuation(newlineCwd, ReviewIntegrationContractV1)
+	message, cause = reviewLineageNotFoundMessage(line)
+	if strings.Contains(message, "`") || cause != "" {
+		t.Fatalf("newline cwd must fail closed with no command: message=%q cause=%q", message, cause)
+	}
+	if len(message) > 240 {
+		t.Fatalf("newline-degraded message exceeds 240 bytes: %d", len(message))
+	}
+	if err := (ReviewIntegrationFailure{Message: message, Cause: cause}).messageCauseBound(); err != nil {
+		t.Fatalf("newline cwd envelope fields invalid: %v", err)
+	}
+}
+
+// messageCauseBound is the subset of ReviewIntegrationFailure.Validate that
+// governs the message/cause pair alone, so the hostile-cwd and deep-cwd tests
+// can prove envelope validity without constructing a full failure.
+func (failure ReviewIntegrationFailure) messageCauseBound() error {
+	if strings.TrimSpace(failure.Message) != failure.Message ||
+		failure.Message == "" || len(failure.Message) > 240 || strings.ContainsAny(failure.Message, "\r\n") {
+		return errors.New("invalid negotiated review failure message")
+	}
+	if failure.Cause != "" && (strings.ContainsAny(failure.Cause, "\r\n") ||
+		len([]rune(failure.Cause)) > reviewIntegrationFailureCauseLimit) {
+		return errors.New("invalid negotiated review failure cause")
+	}
+	return nil
+}
+
 // reviewFailureContinuation extracts the backtick-quoted command a failure
 // Message tells the operator to run.
 func reviewFailureContinuation(t *testing.T, message string) string {
@@ -420,7 +521,11 @@ func reviewContinuationArgs(t *testing.T, continuation string) []string {
 	if !strings.HasPrefix(continuation, prefix) {
 		t.Fatalf("continuation does not start with %q: %q", prefix, continuation)
 	}
-	return strings.Fields(strings.TrimPrefix(continuation, prefix))
+	words, err := SplitPrintedCommandWords(strings.TrimPrefix(continuation, prefix))
+	if err != nil {
+		t.Fatalf("continuation does not survive POSIX splitting: %v (%q)", err, continuation)
+	}
+	return words
 }
 
 func TestNegotiatedPendingFinalizeStatusMatchesPublishedSchema(t *testing.T) {

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -342,6 +342,87 @@ func TestNegotiatedStatusRejectsNonexistentLineageSelector(t *testing.T) {
 	}
 }
 
+// TestLineageNotFoundContinuationRunsVerbatim pins issue #1997's refusal
+// continuation: the Message printed by a lineage_not_found failure must be a
+// runnable command that exits 0 and carries the real --cwd and negotiated
+// --contract, never placeholders and never --lineage. Re-issuing
+// `review status --lineage <id>` with the SAME nonexistent selector would loop
+// straight back into this refusal, so the printed command must be
+// selector-free: a plain status lists every stored entry, including the one
+// the operator was asking about.
+func TestLineageNotFoundContinuationRunsVerbatim(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate behavior\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	startFacadeReview(t, repo)
+
+	for _, contract := range []string{ReviewIntegrationContractV1, ReviewIntegrationContractV2} {
+		t.Run(contract, func(t *testing.T) {
+			var output bytes.Buffer
+			err := RunReview([]string{"status", "--contract", contract, "--cwd", repo, "--lineage", "review-ffffffffffffffff"}, &output)
+			if err == nil {
+				t.Fatalf("status --lineage accepted: %s", output.String())
+			}
+			failure := decodeReviewIntegrationFailure(t, output.Bytes())
+			if failure.Code != "lineage_not_found" {
+				t.Fatalf("failure code = %q; want lineage_not_found", failure.Code)
+			}
+			continuation := reviewFailureContinuation(t, failure.Message)
+			if strings.Contains(continuation, "--lineage") {
+				t.Fatalf("continuation re-issues the refused selector: %q", continuation)
+			}
+			if strings.Contains(continuation, "<repo>") || strings.Contains(continuation, "<id>") {
+				t.Fatalf("continuation carries a placeholder: %q", continuation)
+			}
+			if !strings.Contains(continuation, "--cwd "+repo) {
+				t.Fatalf("continuation does not carry the real cwd %q: %q", repo, continuation)
+			}
+			if !strings.Contains(continuation, "--contract "+contract) {
+				t.Fatalf("continuation does not carry the negotiated contract %q: %q", contract, continuation)
+			}
+
+			args := reviewContinuationArgs(t, continuation)
+			var rerun bytes.Buffer
+			if err := RunReview(args, &rerun); err != nil {
+				t.Fatalf("continuation %q failed: %v\n%s", continuation, err, rerun.String())
+			}
+			var status ReviewTargetStatusResult
+			decoder := json.NewDecoder(bytes.NewReader(rerun.Bytes()))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&status); err != nil {
+				t.Fatalf("decode continuation status: %v\n%s", err, rerun.String())
+			}
+			if err := status.Validate(); err != nil {
+				t.Fatalf("continuation status invalid: %v\n%s", err, rerun.String())
+			}
+		})
+	}
+}
+
+// reviewFailureContinuation extracts the backtick-quoted command a failure
+// Message tells the operator to run.
+func reviewFailureContinuation(t *testing.T, message string) string {
+	t.Helper()
+	start := strings.IndexByte(message, '`')
+	end := strings.LastIndexByte(message, '`')
+	if start < 0 || end <= start {
+		t.Fatalf("failure message has no backtick continuation: %q", message)
+	}
+	return message[start+1 : end]
+}
+
+// reviewContinuationArgs converts a printed `gentle-ai review ...` continuation
+// into the argv shape RunReview expects, so the test executes it verbatim.
+func reviewContinuationArgs(t *testing.T, continuation string) []string {
+	t.Helper()
+	const prefix = "gentle-ai review "
+	if !strings.HasPrefix(continuation, prefix) {
+		t.Fatalf("continuation does not start with %q: %q", prefix, continuation)
+	}
+	return strings.Fields(strings.TrimPrefix(continuation, prefix))
+}
+
 func TestNegotiatedPendingFinalizeStatusMatchesPublishedSchema(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -52,6 +52,15 @@ type TargetStatusRequest struct {
 	Target    Target
 	LineageID string
 	PrePR     *PrePRRequest
+
+	// RequireLineageExists makes an explicit lineage selector a hard refusal
+	// when it names no stored authority. It is opt-in because --lineage is
+	// legitimately used in two ways: a pure status query ("where is THIS
+	// review?") must fail when the lineage does not exist (issue #1997), while
+	// a negotiated next-transition may name a proposed lineage that has not
+	// been created yet and must keep routing to the start consent flow. Only
+	// the pure-query CLI surface sets this; the core stays conservative.
+	RequireLineageExists bool
 }
 
 type TargetProjectionStatus struct {
@@ -129,6 +138,22 @@ type targetStatusCandidate struct {
 	finalVerificationRetry *FinalVerificationRetryEligibility
 }
 
+// ReviewLineageNotFoundError identifies an explicit lineage selector that names
+// no stored review authority in the repository. It is deliberately narrower
+// than "the lineage does not govern the live target": a lineage that exists but
+// does not govern remains a legitimate recovery or scope-changed outcome, and
+// only this typed absence is a hard refusal.
+type ReviewLineageNotFoundError struct {
+	LineageID string
+}
+
+// Error implements error with a message that names the exact missing lineage
+// so a caller or operator can reproduce the same explicit selector instead of
+// guessing which identifier failed to resolve.
+func (e *ReviewLineageNotFoundError) Error() string {
+	return fmt.Sprintf("review lineage %q does not exist in this repository's review authority", e.LineageID)
+}
+
 // AssessTargetStatus classifies the selected live Git projection against
 // validated authority. It only reads Git objects and authority bytes.
 func AssessTargetStatus(ctx context.Context, repo string, request TargetStatusRequest) (TargetStatusResult, error) {
@@ -144,6 +169,21 @@ func AssessTargetStatusWithSnapshot(ctx context.Context, repo string, request Ta
 		request.LineageID = strings.TrimSpace(request.LineageID)
 		if err := validateLineageID(request.LineageID); err != nil {
 			return TargetStatusResult{}, Snapshot{}, err
+		}
+		if request.RequireLineageExists {
+			// The opt-in veto (see RequireLineageExists) makes a pure query's
+			// explicit selector a hard refusal when it names no stored
+			// authority, instead of falling through the empty candidate set
+			// into the same fresh-target envelope as selector-free discovery
+			// and exiting 0 (issue #1997: review status --lineage silently
+			// ignored).
+			exists, existsErr := targetStatusLineageExists(ctx, repo, request.LineageID)
+			if existsErr != nil {
+				return TargetStatusResult{}, Snapshot{}, existsErr
+			}
+			if !exists {
+				return TargetStatusResult{}, Snapshot{}, &ReviewLineageNotFoundError{LineageID: request.LineageID}
+			}
 		}
 	}
 	live, err := (SnapshotBuilder{Repo: repo}).BuildStoredSnapshot(ctx, request.Target)

--- a/internal/reviewtransaction/target_status_lineage_existence_test.go
+++ b/internal/reviewtransaction/target_status_lineage_existence_test.go
@@ -1,0 +1,133 @@
+package reviewtransaction
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestExplicitStatusLineageMustExist proves that an explicit --lineage selector
+// names authority that actually exists in the repository. Issue #1997: a
+// well-formed but nonexistent lineage fell through the empty candidate set into
+// the same fresh-target envelope as selector-free discovery and exited 0, so
+// `review status --lineage <id>` could never answer the question its own
+// refusal continuation asked. The same veto must hold for every authority
+// format the existence check can discover: compact, legacy, and v3.
+func TestExplicitStatusLineageMustExist(t *testing.T) {
+	formats := []struct {
+		name string
+		seed func(t *testing.T, repo, lineage string)
+	}{
+		{
+			name: "compact authority",
+			seed: func(t *testing.T, repo, lineage string) {
+				state := newCompactTestState(t, repo, lineage)
+				if _, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: state}); err != nil {
+					t.Fatalf("start compact authority: %v", err)
+				}
+			},
+		},
+		{
+			name: "legacy authority",
+			seed: func(t *testing.T, repo, lineage string) {
+				requireSnapshotGit(t)
+				head := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+				snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetExactRevision, Revision: head})
+				if err != nil {
+					t.Fatal(err)
+				}
+				storeLegacyReviewingStatus(t, repo, lineage, snapshot)
+			},
+		},
+		{
+			name: "v3 authority",
+			seed: func(t *testing.T, repo, lineage string) {
+				store, err := NewLineageAuthorityStore(context.Background(), repo, lineage)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := store.Mutate(context.Background(), "", func(next *NewLineageAuthority) error {
+					*next = fixtureNewLineageAuthority(lineage, NewLineageStateReviewing)
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, format := range formats {
+		format := format
+		t.Run(format.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+			lineage := "existing-review-lineage"
+			format.seed(t, repo, lineage)
+
+			tests := []struct {
+				name     string
+				lineage  string
+				wantErr  bool
+				wantText string
+			}{
+				{
+					name:    "existing lineage is honored",
+					lineage: lineage,
+					wantErr: false,
+				},
+				{
+					name:     "well-formed nonexistent lineage refused",
+					lineage:  "review-ffffffffffffffff",
+					wantErr:  true,
+					wantText: `review lineage "review-ffffffffffffffff" does not exist`,
+				},
+				{
+					name:     "kebab-shaped junk refused",
+					lineage:  "not-even-a-lineage-shape",
+					wantErr:  true,
+					wantText: `review lineage "not-even-a-lineage-shape" does not exist`,
+				},
+			}
+			for _, tt := range tests {
+				tt := tt
+				t.Run(tt.name, func(t *testing.T) {
+					_, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+						Target:    Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}},
+						LineageID: tt.lineage,
+						// The pure status surface sets the opt-in existence
+						// demand; a negotiated next-transition must keep
+						// accepting a proposed lineage that has not been
+						// created yet.
+						RequireLineageExists: true,
+					})
+					if tt.wantErr {
+						if err == nil {
+							t.Fatalf("AssessTargetStatus(%q) = nil; want error", tt.lineage)
+						}
+						if !strings.Contains(err.Error(), tt.wantText) {
+							t.Fatalf("AssessTargetStatus(%q) error = %q; want substring %q", tt.lineage, err, tt.wantText)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatalf("AssessTargetStatus(%q) error: %v", tt.lineage, err)
+					}
+				})
+			}
+		})
+	}
+
+	// Shape validation runs before existence discovery, so it is independent
+	// of which authority format (if any) is stored.
+	t.Run("malformed shape still refused by shape validation", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+		_, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+			Target:               Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}},
+			LineageID:            "Not-Valid/Lineage",
+			RequireLineageExists: true,
+		})
+		if err == nil || !strings.Contains(err.Error(), "lineage_id must be") {
+			t.Fatalf("AssessTargetStatus(malformed) error = %v; want shape-validation refusal", err)
+		}
+	})
+}

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -39,6 +39,45 @@ func loadTargetStatusAuthorityView(ctx context.Context, repo string, request Tar
 	return targetStatusAuthorityView{compact: compact, legacy: legacy}, nil
 }
 
+// targetStatusLineageExists reports whether an explicit lineage selector names
+// authority present in this repository, without classifying or governing the
+// live target. Existence is the only question it answers: a lineage that
+// exists but does not govern the live target remains a legitimate recovery or
+// scope-changed outcome and is never refused here.
+func targetStatusLineageExists(ctx context.Context, repo, lineageID string) (bool, error) {
+	compactStores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return false, err
+	}
+	for _, store := range compactStores {
+		if store.lineageID == lineageID {
+			return true, nil
+		}
+	}
+	legacyStores, err := DiscoverAuthoritativeStores(ctx, repo)
+	if err != nil {
+		return false, err
+	}
+	for _, store := range legacyStores {
+		if store.lineageID == lineageID {
+			return true, nil
+		}
+	}
+	// v3 (new-lineage) authority is a real store in the same common-dir root
+	// even though the status classification layer does not yet surface it as a
+	// candidate. Existence is a different question from classification: a v3
+	// record means the lineage is NOT the phantom #1997 describes, so it must
+	// pass the veto and keep its frozen downstream classification.
+	_, found, discoverErr := DiscoverNewLineage(ctx, repo, lineageID)
+	if discoverErr != nil {
+		return false, discoverErr
+	}
+	if found {
+		return true, nil
+	}
+	return false, nil
+}
+
 func loadCompactTargetStatusCandidates(ctx context.Context, repo, lineageID string) (map[string]targetStatusCandidate, error) {
 	stores, err := DiscoverCompactStores(ctx, repo)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1997

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- `review status --lineage <id>` was a silent no-op: a well-formed but nonexistent lineage selector fell through the empty candidate set into the same fresh-target envelope as selector-free discovery, exited 0, and the refusal continuation `review status --lineage <id>` could never be answered.
- A pure status query with an explicit `--lineage` selector now refuses a lineage that names no stored authority with a typed `lineage_not_found` failure and a corrected-selector continuation.
- The refusal is opt-in (`RequireLineageExists`), so negotiated `--next-transition` routing keeps accepting a proposed lineage that has not been created yet (the start-consent flow), and selector-free discovery is unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Set `RequireLineageExists` for a pure status query (explicit `--lineage` without `--next-transition`) |
| `internal/cli/review_operation_contract.go` | Map `ReviewLineageNotFoundError` to a `lineage_not_found` failure envelope before the generic `operation_failed` fallback |
| `internal/cli/review_status_contract_test.go` | New `TestNegotiatedStatusRejectsNonexistentLineageSelector` pinning the #1997 regression |
| `internal/reviewtransaction/target_status.go` | Add opt-in `RequireLineageExists` request field, typed `ReviewLineageNotFoundError`, and the existence veto |
| `internal/reviewtransaction/target_status_lineage_existence_test.go` | New `TestExplicitStatusLineageMustExist` covering existing, nonexistent, and malformed selectors |
| `internal/reviewtransaction/target_status_projection.go` | Add `targetStatusLineageExists` checking compact, legacy, and v3 (new-lineage) authority stores |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/cli/ ./internal/reviewtransaction/
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — this change touches the review status/authority query path, not the benchmark, journey corpus, or classifier.

- [x] Unit tests pass (`go test ./internal/cli/ ./internal/reviewtransaction/` — both packages green, including the two new regression tests)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally (Docker not exercised for this change)
- [x] Manually tested locally: `gentle-ai review status --lineage <nonexistent>` now fails with `lineage_not_found` instead of exiting 0

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR stays within 400 changed lines (248 insertions) |
| Check Issue Reference | ⏳ | Body contains `Closes #1997` |
| Check Issue Has `status:approved` | ⏳ | Issue #1997 has `status:approved` |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label (`type:bug`) |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./internal/cli/ ./internal/reviewtransaction/`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (review status/authority query path; not benchmark-adjacent)
- [x] I have updated documentation if necessary (none needed — behavior now matches the documented continuation)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is my first contribution to gentle-ai; feedback welcome.

The key design decision: the existence veto is **opt-in** on `TargetStatusRequest` because `--lineage` legitimately has two meanings. A pure query must fail on a phantom lineage (the #1997 bug), but a negotiated `--next-transition` names a proposed lineage that has not been created yet (the start consent flow) and must keep routing. The `targetStatusLineageExists` helper also checks v3 new-lineage authority via `DiscoverNewLineage` so a real v3 record passes the veto and keeps its frozen downstream classification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Negotiated review status now supports integration contract versions 1 and 2.
  * Explicitly selected lineages must exist before status is reported, except proposed lineages queried for their next transition.
  * Missing lineages now provide structured, retry-safe responses with the lineage ID and a ready-to-run next action.
  * Continuation commands remain safe and bounded, even with unusual working-directory paths.
  * Existing lineages continue to return validated status results, including non-governing lineages.
* **Documentation**
  * Clarified that lineage selectors require a contract selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->