### PR TITLE
test(review): prove audited abandon for preplan correction

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -627,6 +627,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, reviewedSupersetJourneys()...)
 	journeys = append(journeys, stagedDeliveryJourneys()...)
 	journeys = append(journeys, frozenLineageResumeJourneys()...)
+	journeys = append(journeys, issue1800Journeys()...)
 	journeys = append(journeys, managedAssetJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }

--- a/bench/journeys_frozen_lineage_resume.go
+++ b/bench/journeys_frozen_lineage_resume.go
@@ -75,7 +75,7 @@ func frozenAuthorityInventory(r *journeyRun) ([]byte, int, error) {
 		if entry.Type()&os.ModeSymlink != 0 {
 			return fmt.Errorf("authority inventory contains symlink %q", path)
 		}
-		if entry.IsDir() {
+		if entry.IsDir() || entry.Name() == "LOCK" {
 			return nil
 		}
 		payload, err := os.ReadFile(path)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -44,6 +44,7 @@ func journeySources() []journeySource {
 		{"journeys_reviewed_superset.go", reviewedSupersetJourneys()},
 		{"journeys_staged_delivery.go", stagedDeliveryJourneys()},
 		{"journeys_frozen_lineage_resume.go", frozenLineageResumeJourneys()},
+		{"journeys_issue1800.go", issue1800Journeys()},
 		{"journeys_managed_assets.go", managedAssetJourneys()},
 	}
 }

--- a/bench/journeys_issue1800.go
+++ b/bench/journeys_issue1800.go
@@ -49,14 +49,14 @@ func issue1800State(r *journeyRun) ([]byte, issue1800Authority, error) {
 	if err != nil {
 		return nil, issue1800Authority{}, err
 	}
-	bytes, err := os.ReadFile(filepath.Join(strings.TrimSpace(common), "gentle-ai", "review-transactions", "v2", issue1800Lineage, "review-state.json"))
+	stateBytes, err := os.ReadFile(filepath.Join(strings.TrimSpace(common), "gentle-ai", "review-transactions", "v2", issue1800Lineage, "review-state.json"))
 	var record struct {
 		State issue1800Authority `json:"state"`
 	}
 	if err == nil {
-		err = json.Unmarshal(bytes, &record)
+		err = json.Unmarshal(stateBytes, &record)
 	}
-	return bytes, record.State, err
+	return stateBytes, record.State, err
 }
 
 func issue1800Entry(r *journeyRun) (authorityEntry, error) {
@@ -82,7 +82,7 @@ func prepareIssue1800Authority(r *journeyRun) error {
 		state.CorrectionBudget <= 0 || state.ProposedCorrectionLines != nil ||
 		strings.Join(status.Projection.Paths, "\x00") != "candidate.go" ||
 		entry.Revision != status.Authority.Revision || entry.SnapshotIdentity != state.InitialSnapshot.Identity {
-		return fmt.Errorf("pre-plan authority = status:%+v state:%+v errors:%v/%v", status, state, err, stateErr)
+		return fmt.Errorf("pre-plan authority = status:%+v state:%+v errors:%v/%v/%v", status, state, err, stateErr, entryErr)
 	}
 	r.sandbox.Scratch["issue1800-budget"] = strconv.Itoa(state.CorrectionBudget)
 	r.sandbox.Scratch["issue1800-state"] = string(stateBytes)

--- a/bench/journeys_issue1800.go
+++ b/bench/journeys_issue1800.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const issue1800Lineage = "issue-1800-pre-plan-abandon"
+
+// issue1800Journeys proves D1800's narrow exit without turning a pre-plan edit
+// into a retrospective forecast, recovery, or delivery authorization.
+func issue1800Journeys() []Journey {
+	return []Journey{{
+		ID:     "j91-audited-abandon-preplan-over-budget-correction",
+		Title:  "Already-edited pre-plan correction abandons audibly and requires a fresh review",
+		Source: "issue #1800 D1800: exact audited abandon is the supported pre-forecast exit",
+		Steps: []Step{
+			{Name: "fixture: repository", Fixture: baseRepo},
+			{Name: "enable review mode in the disposable clone", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--scope", "clone", "--json")},
+			{Name: "fixture: stage candidate", Fixture: stageWaveCandidate},
+			{Name: "start product-created compact review", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", issue1800Lineage)},
+			{Name: "capture candidate finding", Requires: captureResultCapability, Composite: captureCorrectableFinding},
+			{Name: "finalize into correction-required", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", issue1800Lineage, "--captured-results=true"), After: requireReviewState("correction_required", issue1800Lineage)},
+			{Name: "freeze the pre-plan authority", Requires: statusCapability, Composite: prepareIssue1800Authority},
+			{Name: "fixture: edit the frozen path to budget plus one", Fixture: applyIssue1800PrePlanEdit},
+			{Name: "STATUS remains correction-plan-required", Requires: statusCapability, Composite: proveIssue1800PrePlanStatus},
+			{Name: "forged and stale bindings refuse without mutation", Requires: abandonCapability, Composite: rejectIssue1800AbandonDecoys},
+			{Name: "exact native abandon preserves audited provenance", Requires: abandonCapability, Composite: abandonIssue1800Authority},
+			{Name: "fresh review is required before delivery", Requires: validateCapability, Composite: proveIssue1800FreshReviewRequired},
+		},
+	}}
+}
+
+type issue1800Authority struct {
+	CorrectionBudget        int  `json:"correction_budget"`
+	ProposedCorrectionLines *int `json:"proposed_correction_lines"`
+	InitialSnapshot         struct {
+		Identity string `json:"identity"`
+	} `json:"initial_snapshot"`
+}
+
+func issue1800State(r *journeyRun) ([]byte, issue1800Authority, error) {
+	common, err := gitOut(r.sandbox, r.sandbox.Repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return nil, issue1800Authority{}, err
+	}
+	bytes, err := os.ReadFile(filepath.Join(strings.TrimSpace(common), "gentle-ai", "review-transactions", "v2", issue1800Lineage, "review-state.json"))
+	var record struct {
+		State issue1800Authority `json:"state"`
+	}
+	if err == nil {
+		err = json.Unmarshal(bytes, &record)
+	}
+	return bytes, record.State, err
+}
+
+func issue1800Entry(r *journeyRun) (authorityEntry, error) {
+	status, err := proveStoreStatus(r.sandbox)
+	if err != nil {
+		return authorityEntry{}, err
+	}
+	for _, entry := range status.Entries {
+		if entry.LineageID == issue1800Lineage {
+			return authorityEntry{LineageID: entry.LineageID, State: entry.State, Revision: entry.Revision, SnapshotIdentity: entry.SnapshotIdentity, DiscardedWork: entry.DiscardedWork}, nil
+		}
+	}
+	return authorityEntry{}, fmt.Errorf("native inventory omits %q", issue1800Lineage)
+}
+
+func prepareIssue1800Authority(r *journeyRun) error {
+	status, err := readCorrectionStatusForContract(r, issue1800Lineage, reviewContractV2)
+	stateBytes, state, stateErr := issue1800State(r)
+	entry, entryErr := issue1800Entry(r)
+	if err != nil || stateErr != nil || entryErr != nil || status.Authority == nil ||
+		status.Authority.State != "correction_required" || status.NextTransition == nil ||
+		status.NextTransition.Kind != "collect" || status.NextTransition.ReasonCode != "correction_plan_required" ||
+		state.CorrectionBudget <= 0 || state.ProposedCorrectionLines != nil ||
+		strings.Join(status.Projection.Paths, "\x00") != "candidate.go" ||
+		entry.Revision != status.Authority.Revision || entry.SnapshotIdentity != state.InitialSnapshot.Identity {
+		return fmt.Errorf("pre-plan authority = status:%+v state:%+v errors:%v/%v", status, state, err, stateErr)
+	}
+	r.sandbox.Scratch["issue1800-budget"] = strconv.Itoa(state.CorrectionBudget)
+	r.sandbox.Scratch["issue1800-state"] = string(stateBytes)
+	r.sandbox.Scratch["issue1800-lineage"] = entry.LineageID
+	r.sandbox.Scratch["issue1800-revision"] = entry.Revision
+	r.sandbox.Scratch["issue1800-snapshot"] = entry.SnapshotIdentity
+	return nil
+}
+
+func applyIssue1800PrePlanEdit(sandbox *Sandbox) error {
+	budget, err := strconv.Atoi(sandbox.Scratch["issue1800-budget"])
+	if err != nil || budget < 1 {
+		return fmt.Errorf("correction budget = %q, %v", sandbox.Scratch["issue1800-budget"], err)
+	}
+	source := "package candidate\n\n" + strings.Repeat("// pre-plan correction detail\n", budget-1) + "func value() int { return 2 }\n"
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "candidate.go"), source); err != nil {
+		return err
+	}
+	numstat, err := gitOut(sandbox, sandbox.Repo, "diff", "--numstat")
+	fields := strings.Fields(numstat)
+	if err != nil || len(fields) != 3 || fields[2] != "candidate.go" {
+		return fmt.Errorf("pre-plan correction numstat = %q, %v", numstat, err)
+	}
+	added, addErr := strconv.Atoi(fields[0])
+	removed, removeErr := strconv.Atoi(fields[1])
+	if addErr != nil || removeErr != nil || added+removed != budget+1 {
+		return fmt.Errorf("pre-plan correction lines = %d+%d, want %d: %v/%v", added, removed, budget+1, addErr, removeErr)
+	}
+	return nil
+}
+
+func proveIssue1800PrePlanStatus(r *journeyRun) error {
+	status, err := readCorrectionStatusForContract(r, issue1800Lineage, reviewContractV2)
+	stateBytes, state, stateErr := issue1800State(r)
+	entry, entryErr := issue1800Entry(r)
+	store, _, storeErr := frozenAuthorityInventory(r)
+	candidate, candidateErr := os.ReadFile(filepath.Join(r.sandbox.Repo, "candidate.go"))
+	if err != nil || stateErr != nil || entryErr != nil || storeErr != nil || candidateErr != nil || status.Authority == nil ||
+		status.Authority.State != "correction_required" || status.NextTransition == nil || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "correction_plan_required" || status.Receipt.Status != "expected_missing" ||
+		state.ProposedCorrectionLines != nil || !bytes.Equal(stateBytes, []byte(r.sandbox.Scratch["issue1800-state"])) ||
+		entry.Revision != r.sandbox.Scratch["issue1800-revision"] || strings.Join(status.Projection.Paths, "\x00") != "candidate.go" {
+		return fmt.Errorf("pre-plan STATUS = status:%+v state:%+v errors:%v/%v/%v/%v", status, state, err, stateErr, entryErr, storeErr)
+	}
+	r.sandbox.Scratch["issue1800-store"] = string(store)
+	r.sandbox.Scratch["issue1800-candidate"] = string(candidate)
+	return nil
+}
+
+func issue1800Unchanged(r *journeyRun) error {
+	state, _, stateErr := issue1800State(r)
+	store, _, storeErr := frozenAuthorityInventory(r)
+	candidate, candidateErr := os.ReadFile(filepath.Join(r.sandbox.Repo, "candidate.go"))
+	for _, check := range []struct {
+		name string
+		got  []byte
+		want []byte
+		err  error
+	}{
+		{"authority", state, []byte(r.sandbox.Scratch["issue1800-state"]), stateErr},
+		{"active authority inventory", store, []byte(r.sandbox.Scratch["issue1800-store"]), storeErr},
+		{"candidate source", candidate, []byte(r.sandbox.Scratch["issue1800-candidate"]), candidateErr},
+	} {
+		if check.err != nil || !bytes.Equal(check.got, check.want) {
+			return fmt.Errorf("%s changed after abandoned authorization: %v", check.name, check.err)
+		}
+	}
+	return nil
+}
+
+func rejectIssue1800AbandonDecoys(r *journeyRun) error {
+	entry, err := issue1800Entry(r)
+	args, argsErr := abandonArgs("issue1800-lineage", "issue1800-revision", "issue1800-snapshot", "")(r.sandbox)
+	if err != nil || argsErr != nil {
+		return fmt.Errorf("assemble native abandon authorization: %v %v", err, argsErr)
+	}
+	stale := entry.Revision[:len(entry.Revision)-1] + "0"
+	if stale == entry.Revision {
+		stale = entry.Revision[:len(entry.Revision)-1] + "1"
+	}
+	forged := append([]string{}, args...)
+	forged[len(forged)-1] = strings.Replace(forged[len(forged)-1], "actor=bench", "actor=forged", 1)
+	staleArgs := append([]string{}, args...)
+	staleArgs[7] = stale
+	staleArgs[len(staleArgs)-1] = renderAbandonAuthorization(authorityEntry{LineageID: entry.LineageID, Revision: stale, SnapshotIdentity: entry.SnapshotIdentity, DiscardedWork: entry.DiscardedWork}, "bench", "operator_disposition")
+	for _, decoy := range []struct {
+		name string
+		args []string
+	}{{"forged", forged}, {"stale", staleArgs}} {
+		if observation := r.run(decoy.args, false); observation.ExitCode == 0 || strings.Contains(observation.Stdout, "quarantine_path") {
+			return fmt.Errorf("%s abandon authorization succeeded", decoy.name)
+		}
+		if err := issue1800Unchanged(r); err != nil {
+			return fmt.Errorf("%s decoy: %w", decoy.name, err)
+		}
+	}
+	return nil
+}
+
+func abandonIssue1800Authority(r *journeyRun) error {
+	entry, err := issue1800Entry(r)
+	args, argsErr := abandonArgs("issue1800-lineage", "issue1800-revision", "issue1800-snapshot", "")(r.sandbox)
+	if err != nil || argsErr != nil {
+		return fmt.Errorf("assemble exact abandon authorization: %v %v", err, argsErr)
+	}
+	observation := r.run(args, false)
+	var result struct {
+		Operation string `json:"operation"`
+		Record    struct {
+			LineageID      string `json:"lineage_id"`
+			Reason         string `json:"reason"`
+			Actor          string `json:"actor"`
+			QuarantinePath string `json:"quarantine_path"`
+			Abandonment    struct {
+				Schema           string                 `json:"schema"`
+				LineageID        string                 `json:"lineage_id"`
+				Revision         string                 `json:"revision"`
+				SnapshotIdentity string                 `json:"snapshot_identity"`
+				DiscardedWork    authorityDiscardedWork `json:"discarded_work"`
+			} `json:"abandonment"`
+		} `json:"record"`
+	}
+	if observation.ExitCode != 0 || json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result) != nil ||
+		result.Operation != "review/abandon" || result.Record.LineageID != entry.LineageID || result.Record.Reason != "operator_disposition" || result.Record.Actor != "bench" ||
+		result.Record.QuarantinePath == "" || result.Record.Abandonment.Schema != "gentle-ai.review-abandon-authorization/v2" ||
+		result.Record.Abandonment.LineageID != entry.LineageID || result.Record.Abandonment.Revision != entry.Revision || result.Record.Abandonment.SnapshotIdentity != entry.SnapshotIdentity ||
+		strings.Join(result.Record.Abandonment.DiscardedWork.CapturedLensResults, "\x00") != strings.Join(entry.DiscardedWork.CapturedLensResults, "\x00") ||
+		result.Record.Abandonment.DiscardedWork.FindingsPresent != entry.DiscardedWork.FindingsPresent || result.Record.Abandonment.DiscardedWork.EvidenceRecordsPresent != entry.DiscardedWork.EvidenceRecordsPresent {
+		return fmt.Errorf("exact abandon result = exit %d record=%+v", observation.ExitCode, result)
+	}
+	moved, moveErr := os.ReadFile(filepath.Join(result.Record.QuarantinePath, "residue", "review-state.json"))
+	candidate, candidateErr := os.ReadFile(filepath.Join(r.sandbox.Repo, "candidate.go"))
+	if moveErr != nil || candidateErr != nil || !bytes.Equal(moved, []byte(r.sandbox.Scratch["issue1800-state"])) || !bytes.Equal(candidate, []byte(r.sandbox.Scratch["issue1800-candidate"])) {
+		return fmt.Errorf("abandon did not preserve quarantined authority or candidate bytes: %v/%v", moveErr, candidateErr)
+	}
+	active, activeErr := proveStoreStatus(r.sandbox)
+	if activeErr != nil {
+		return activeErr
+	}
+	for _, entry := range active.Entries {
+		if entry.LineageID == issue1800Lineage {
+			return fmt.Errorf("abandoned authority remains active")
+		}
+	}
+	return nil
+}
+
+func proveIssue1800FreshReviewRequired(r *journeyRun) error {
+	status, err := readCorrectionStatusForContract(r, "", reviewContractV2)
+	gate := r.run([]string{"review", "validate", "--cwd", r.sandbox.Repo, "--gate", "post-apply"}, false)
+	if err != nil || status.Receipt.Status != "not_applicable" || status.Authority != nil || status.NextTransition == nil ||
+		status.NextTransition.Kind != "execute" || status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.start" || gate.ExitCode == 0 {
+		return fmt.Errorf("post-abandon status=%+v gate=%d", status, gate.ExitCode)
+	}
+	return nil
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -49,7 +49,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// while the advertised main ref remains a moving publication boundary. j87
 	// proves #2871's correction binds the immutable failure across a later interrupt;
 	// j88 proves #2843's unborn STATUS collects explicit untracked intent first;
-	// j89 proves #2758 never offers a workspace receipt for a different index; j90 proves #2016 resumes an explicit frozen reviewing lineage after workspace drift;
+	// j89 proves #2758 never offers a workspace receipt for a different index; j90 proves #2016 resumes an explicit frozen reviewing lineage after workspace drift; j91 proves #1800's pre-plan exit is audited abandon.
 	// j93 proves #2822 classifies stale managed assets before START can persist.
 	// #1993 REMOVED two: j38 (the bound-passing-finish refusal routing to the
 	// review router) and j39 (the stranded-successor exit it named). Review
@@ -60,8 +60,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	//
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 88 {
-		t.Errorf("core journey count = %d, want 88", got)
+	if got := len(seen); got != 89 {
+		t.Errorf("core journey count = %d, want 89", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -234,6 +234,26 @@ Classified execution persists a route-specific assessment digest, authorization-
 
 Before any correction edit, `correction_plan_required` carries a strict `gentle-ai.review-correction-plan-request/v1` object. Its provider-derived hash binds the current lineage, authority revision, frozen target, correction budget, canonical `fix_finding_ids`, and each accepted finding's location, claim, proof references, classification evidence, evidence class, and causal disposition. The same request is re-derived at the post-forecast revision and retained on `corrected_candidate_unavailable`; reading it does not consume an attempt or correction budget. Consumers plan and edit only from this accepted set, never from raw reviewer output.
 
+### Already-edited pre-plan correction
+
+At `correction_plan_required`, do not submit a retrospective forecast. Read the lineage row from `gentle-ai review status --cwd <repo>`, then run `review abandon` with `operator_disposition`, a maintainer actor, and this exact LF-only V2 binding (no trailing newline):
+
+```text
+gentle-ai.review-abandon-authorization/v2
+lineage=<entries[].lineage_id>
+revision=<entries[].revision>
+snapshot_identity=<entries[].snapshot_identity>
+reason=operator_disposition
+captured_lens_results=<entries[].discarded_work.captured_lens_results comma-joined>
+findings_present=<entries[].discarded_work.findings_present>
+evidence_records_present=<entries[].discarded_work.evidence_records_present>
+actor=<actor>
+```
+
+Run `gentle-ai review abandon --cwd <repo> --lineage <lineage> --expected-revision <revision> --reason operator_disposition --actor <actor> --maintainer-authorization <binding>`.
+
+The audit record quarantines authority and provenance; it creates no receipt and preserves candidate bytes. With RDD enabled, delivery stays denied until a fresh review. This applies only before a forecast or validator result, not post-forecast failed-validator or broader-scope cases.
+
 After a correction forecast and an actual candidate change, STATUS first collects candidate-bound repository/full-suite verification evidence. A `verification_failed` record leaves the correction transaction open: no attempt, changed-line charge, or budget is consumed, and a changed candidate receives a distinct immutable evidence directory without replacing the failed bytes. A `procedural_tooling_failed` record executes a terminal escalation before any retry eligibility is considered. Only `passed` repository evidence unlocks `targeted_validation` with a strict `gentle-ai.review-targeted-validation-request/v1` object.
 
 Execute the targeted request unchanged. Its provider-derived hash binds the lineage, expected authority revision, original target, exact frozen finding IDs, projection, corrected candidate tree and identity, and the exact canonical correction-path subset plus its digest. FINALIZE accepts the correction through one atomic state transition only when the targeted validation and passed repository record bind the same authority revision, candidate identity, paths, and ledger IDs. If the candidate did not materially change, no targeted-validation request is issued and routing stops with `corrected_candidate_unavailable`; consumers must not invent a validator request or another correction forecast. An ordinary lineage admits exactly one changed-target correction attempt, even when its measured delta is zero. It never admits a zero-edit correction or second fix transition.

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -244,11 +244,13 @@ lineage=<entries[].lineage_id>
 revision=<entries[].revision>
 snapshot_identity=<entries[].snapshot_identity>
 reason=operator_disposition
-captured_lens_results=<entries[].discarded_work.captured_lens_results comma-joined>
+captured_lens_results=<entries[].discarded_work.captured_lens_results comma-joined in the listed order>
 findings_present=<entries[].discarded_work.findings_present>
 evidence_records_present=<entries[].discarded_work.evidence_records_present>
 actor=<actor>
 ```
+
+Copy every array item verbatim in its listed order, then join them with a single `,` and no added whitespace. The native inventory uses lexicographic captured reviewer-result artifact filename order; do not re-sort or derive a different lens order.
 
 Run `gentle-ai review abandon --cwd <repo> --lineage <lineage> --expected-revision <revision> --reason operator_disposition --actor <actor> --maintainer-authorization <binding>`.
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1800

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Proves D1800 through driven j91 using real product-created compact authority and native CLI transitions.
- Documents audited `review abandon --operator-disposition` as the safe pre-forecast exit for an already-edited over-budget correction.
- Adds no product state, schema, verb, flag, fallback, recovery path, or compatibility behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_issue1800.go` | Adds j91 with forged/stale authorization decoys, exact quarantine proof, byte preservation, fresh-review routing, and delivery denial. |
| `bench/journeys*.go` | Registers j91, preserves ID-source ownership, advances the core corpus to 89, and excludes transient released `LOCK` metadata from authority byte snapshots. |
| `docs/review-integration.md` | Publishes the exact LF-only V2 authorization and operator procedure, including explicit out-of-scope cases. |

---

## 🧪 Test Plan

**Candidate**
- Commit: `f0411796e7c23cfc8428ffdef34808eed00a3a7b`
- Tree: `a3d71cfdffba4ffa5c0f3336b0742c3640bbb2c8`
- Review budget: 269 additions + 4 deletions = 273/400 lines
- One bounded correction: 12/136 lines, clarifying canonical binding order and diagnostics
- RDD: `disabled/unmanaged`; no receipt-review claim

**Unit and static checks**
```bash
go test ./... -count=1
go vet ./...
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
```

**CI-shaped benchmark proof**
- j91: 1 completed, 0 unsupported, 0 failed
- j90 regression: 1 completed, 0 unsupported, 0 failed
- Core corpus: 89 completed, 0 unsupported, 0 failed
- Transition corpus: 11/11 completed; CI predicate true
- Source-coupled untagged: j57 unsupported exactly once; CI predicate true
- Source-coupled `bench_fixture`: j57 completed exactly once; CI predicate true

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E is N/A locally because this changes bench evidence and docs only; hosted CI remains required
- [x] Manually tested locally through the real driven harness

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 273/400 changed lines |
| Check Issue Reference | ⏳ | `Closes #1800` |
| Check Issue Has `status:approved` | ⏳ | #1800 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` |
| Unit Tests | ⏳ | Required |
| Go Format | ⏳ | Required |
| E2E Tests | ⏳ | Required hosted lanes |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E is N/A locally for evidence/docs-only scope; hosted CI remains required
- [x] Benchmark validation completed with real driven execution
- [x] Documentation is updated
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

This closes only the already-edited **pre-forecast** correction shape ratified by D1800. Post-forecast failed-validator and later broader-scope cases remain separate roots.

The one shared helper change excludes only the released root `v2/LOCK` metadata from byte snapshots. Authoritative compact artifacts remain compared byte-for-byte, and driven j90 stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for safely abandoning an edited candidate when correction planning is required.
  - Abandonment preserves candidate content, quarantines related authority and provenance, and prevents delivery until a fresh review is completed.
  - Added validation to reject forged, stale, or incorrect abandon authorizations without changing state.

- **Documentation**
  - Documented the required authorization, command sequence, and review steps for this workflow.
  - Clarified that the procedure applies before forecast or validator results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->