### PR TITLE
fix(review): quarantine retired compact snapshot identities

### DIFF
--- a/bench/axis_damaged_store.go
+++ b/bench/axis_damaged_store.go
@@ -426,6 +426,10 @@ type storeInspection struct {
 		LineageID string `json:"lineage_id"`
 		Problem   string `json:"problem"`
 	} `json:"entry_diagnostics"`
+	SanctionedExits []struct {
+		LineageID string `json:"successor_lineage_id"`
+		Operation string `json:"operation"`
+	} `json:"sanctioned_exits"`
 }
 
 // storeStatus is the subset of `review status` that says whether the store
@@ -1318,12 +1322,16 @@ func dispositionRepositoryBinding(sandbox *Sandbox) (string, error) {
 // (authority_disposition_plan.go) computes internally, mirroring how
 // reconcileArgs and abandonArgs above hand-render their own authorization
 // bindings rather than depending on an exported production helper.
-func dispositionAuthorization(binding, planDigest, inventoryRevision, actor, reason string) string {
+func dispositionAuthorization(binding, planDigest, inventoryRevision, actor, reason string, class ...string) string {
+	authorizationClass := contentMismatchedRecoveryAuthorizationClass
+	if len(class) == 1 {
+		authorizationClass = class[0]
+	}
 	return strings.Join([]string{
 		authorityDispositionAuthorizationSchema,
 		"schema=" + authorityDispositionPlanSchema,
 		"repository=" + binding,
-		"class=" + contentMismatchedRecoveryAuthorizationClass,
+		"class=" + authorizationClass,
 		"plan_digest=" + planDigest,
 		"inventory_revision=" + inventoryRevision,
 		"actor=" + actor,

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -628,6 +628,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, stagedDeliveryJourneys()...)
 	journeys = append(journeys, frozenLineageResumeJourneys()...)
 	journeys = append(journeys, issue1800Journeys()...)
+	journeys = append(journeys, issue2879Journeys()...)
 	journeys = append(journeys, managedAssetJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -45,6 +45,7 @@ func journeySources() []journeySource {
 		{"journeys_staged_delivery.go", stagedDeliveryJourneys()},
 		{"journeys_frozen_lineage_resume.go", frozenLineageResumeJourneys()},
 		{"journeys_issue1800.go", issue1800Journeys()},
+		{"journeys_issue2879.go", issue2879Journeys()},
 		{"journeys_managed_assets.go", managedAssetJourneys()},
 	}
 }

--- a/bench/journeys_issue2879.go
+++ b/bench/journeys_issue2879.go
@@ -31,7 +31,7 @@ func issue2879Journeys() []Journey {
 			{Name: "fixture: stage unrelated current target", Fixture: stageProse("", "issue2879-current")},
 			{Name: "fixture: replay exact released v2.2.4 authority bytes", Fixture: issue2879HistoricalFixture},
 			{Name: "unrelated malformed entry blocks historical preflight", Requires: repairPreflightCapability, Composite: issue2879Plan},
-			{Name: "inspect historical authority offers repair", Requires: repairPreflightCapability, Args: productArgs("review", "inspect-authority"), After: inspectionAssertion("historical inspection", requireIssue2879HistoricalInspection)},
+			{Name: "inspect historical authority offers repair", Requires: inspectAuthorityCapability, Args: productArgs("review", "inspect-authority"), After: inspectionAssertion("historical inspection", requireIssue2879HistoricalInspection)},
 			{Name: "preflight binds historical repair", Requires: repairPreflightCapability, Args: productArgs("review", "repair", "--preflight"), After: requireDispositionPlanEligible},
 			{Name: "forged and stale repair bindings refuse unchanged", Requires: repairDispositionExecuteCapability, Composite: issue2879Refuse},
 			{Name: "authorized repair quarantines exactly once", Requires: repairDispositionExecuteCapability, Composite: issue2879Execute},

--- a/bench/journeys_issue2879.go
+++ b/bench/journeys_issue2879.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const issue2879Lineage = "review-f8708016a901b4ff"
+const issue2879Digest = "sha256:7adf81305d031f928d9898c03be98d5e942132bfc98d209ee99f6fe3dd008259"
+const issue2879Class = "retired_compact_snapshot_identity"
+
+// GitHub v2.2.4 asset gentle-ai_2.2.4_linux_amd64.tar.gz SHA-256 a6de9f21999fad2b22fed87e267bbb222782505b7316457bcb9af5e5a2217809.
+// Its release binary created these exact bytes, SHA-256 issue2879Digest.
+//
+//go:embed testdata/issue2879/released-v2.2.4-review-state.json
+var issue2879ReleasedRecord []byte
+
+func issue2879Journeys() []Journey {
+	return []Journey{{
+		ID: "j92-released-compact-history-quarantines-without-compatibility", Title: "Released compact history is quarantined through the bound repair plan", Source: "issue #2879 D-2879",
+		Steps: []Step{
+			{Name: "fixture: repository", Fixture: baseRepo},
+			{Name: "enable review mode in the disposable clone", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--scope", "clone", "--json")},
+			{Name: "fixture: stage unrelated current target", Fixture: stageProse("", "issue2879-current")},
+			{Name: "fixture: replay exact released v2.2.4 authority bytes", Fixture: issue2879HistoricalFixture},
+			{Name: "inspect and preflight bind the historical record", Requires: repairPreflightCapability, Composite: issue2879Plan},
+			{Name: "forged and stale repair bindings refuse unchanged", Requires: repairDispositionExecuteCapability, Composite: issue2879Refuse},
+			{Name: "authorized repair quarantines exactly once", Requires: repairDispositionExecuteCapability, Composite: issue2879Execute},
+			{Name: "unrelated current target remains routable", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", "issue2879-current")},
+			{Name: "status remains readable after exact replay", Requires: statusCapability, Composite: issue2879Status},
+			{Name: "decoy impossible identity remains ineligible", Requires: repairPreflightCapability, Composite: issue2879Decoy},
+		},
+	}}
+}
+
+func issue2879HistoricalFixture(sandbox *Sandbox) error {
+	sum := sha256.Sum256(issue2879ReleasedRecord)
+	if "sha256:"+hex.EncodeToString(sum[:]) != issue2879Digest {
+		return errors.New("released fixture digest drifted")
+	}
+	path, err := storeStatePath(sandbox, issue2879Lineage)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, issue2879ReleasedRecord, 0o644)
+}
+
+func issue2879Plan(r *journeyRun) error {
+	path, err := storeStatePath(r.sandbox, issue2879Lineage)
+	raw, readErr := os.ReadFile(path)
+	if err != nil || readErr != nil || !bytes.Equal(raw, issue2879ReleasedRecord) {
+		return errors.New("released authority bytes changed")
+	}
+	inspection := r.run(productArgsFor(r, "review", "inspect-authority"), false)
+	var report storeInspection
+	if inspection.ExitCode != 0 || json.Unmarshal([]byte(inspection.Stdout), &report) != nil || len(report.EntryDiagnostics) != 1 ||
+		report.EntryDiagnostics[0].LineageID != issue2879Lineage || report.EntryDiagnostics[0].Problem != "outdated_compact_state" ||
+		len(report.SanctionedExits) != 1 || report.SanctionedExits[0].LineageID != issue2879Lineage || report.SanctionedExits[0].Operation != "review repair" {
+		return fmt.Errorf("historical inspection = %+v", report)
+	}
+	preflight := r.run(productArgsFor(r, "review", "repair", "--preflight"), false)
+	var result dispositionRepairResult
+	if preflight.ExitCode != 0 || json.Unmarshal([]byte(preflight.Stdout), &result) != nil || result.DispositionProviderInputs == nil {
+		return fmt.Errorf("historical preflight = %s", preflight.Stdout)
+	}
+	r.sandbox.Scratch["issue2879-plan"] = result.DispositionProviderInputs.PlanDigest
+	r.sandbox.Scratch["issue2879-inventory"] = result.DispositionProviderInputs.AuthorityInventoryRevision
+	return nil
+}
+
+func issue2879Args(sandbox *Sandbox, plan, inventory, reason, authorization string) []string {
+	return []string{"review", "repair", "--cwd", sandbox.Repo, "--plan-digest", plan, "--inventory-revision", inventory,
+		"--actor", "bench", "--reason", reason, "--authorization", authorization}
+}
+
+func issue2879Refuse(r *journeyRun) error {
+	path, err := storeStatePath(r.sandbox, issue2879Lineage)
+	base, baseErr := reviewTransactionsBase(r.sandbox)
+	before, readErr := os.ReadFile(path)
+	binding, bindErr := dispositionRepositoryBinding(r.sandbox)
+	if err != nil || baseErr != nil || readErr != nil || bindErr != nil {
+		return errors.New("prepare repair refusals")
+	}
+	plan, inventory, reason := r.sandbox.Scratch["issue2879-plan"], r.sandbox.Scratch["issue2879-inventory"], "quarantine released historical record"
+	for _, test := range []struct{ inventory, authorizationReason string }{{inventory, "forged authorization"}, {inventory + "0", reason}, {inventory, "stale authorization"}} {
+		authorization := dispositionAuthorization(binding, plan, test.inventory, "bench", test.authorizationReason, issue2879Class)
+		observation := r.run(issue2879Args(r.sandbox, plan, test.inventory, reason, authorization), false)
+		after, readErr := os.ReadFile(path)
+		if observation.ExitCode == 0 || readErr != nil || !bytes.Equal(before, after) {
+			return errors.New("refused repair changed active authority")
+		}
+		if _, err := os.Stat(filepath.Join(base, "quarantine")); !os.IsNotExist(err) {
+			return errors.New("refused repair created quarantine residue")
+		}
+	}
+	return nil
+}
+
+func issue2879Execute(r *journeyRun) error {
+	plan, inventory := r.sandbox.Scratch["issue2879-plan"], r.sandbox.Scratch["issue2879-inventory"]
+	binding, err := dispositionRepositoryBinding(r.sandbox)
+	if err != nil {
+		return err
+	}
+	reason := "quarantine released historical record"
+	args := issue2879Args(r.sandbox, plan, inventory, reason, dispositionAuthorization(binding, plan, inventory, "bench", reason, issue2879Class))
+	for attempt := 0; attempt < 2; attempt++ {
+		observation := r.run(args, false)
+		var result dispositionRepairResult
+		if observation.ExitCode != 0 || json.Unmarshal([]byte(observation.Stdout), &result) != nil || result.DispositionExecution == nil || result.DispositionExecution.Status != "committed" {
+			return fmt.Errorf("historical repair replay %d = %s", attempt, observation.Stdout)
+		}
+	}
+	path, err := storeStatePath(r.sandbox, issue2879Lineage)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return errors.New("historical authority remains active")
+	}
+	base, err := reviewTransactionsBase(r.sandbox)
+	if err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(filepath.Join(base, "quarantine"))
+	if err != nil || len(entries) != 1 {
+		return errors.New("historical quarantine missing")
+	}
+	residue, err := os.ReadFile(filepath.Join(base, "quarantine", entries[0].Name(), "residue", "review-state.json"))
+	if err != nil || !bytes.Equal(residue, issue2879ReleasedRecord) {
+		return errors.New("historical quarantine did not preserve original bytes")
+	}
+	if _, err := os.Stat(filepath.Join(base, "quarantine", entries[0].Name(), "residue", "review-receipt.json")); !os.IsNotExist(err) {
+		return errors.New("historical repair created a receipt")
+	}
+	return nil
+}
+
+func issue2879Status(r *journeyRun) error {
+	observation := r.run(productArgsFor(r, "review", "status"), false)
+	if observation.ExitCode != 0 || strings.Contains(observation.Stdout, issue2879Lineage) {
+		return fmt.Errorf("status after historical repair = %s", observation.Stdout)
+	}
+	return nil
+}
+
+func issue2879Decoy(r *journeyRun) error {
+	const lineage = "issue2879-impossible"
+	path, err := storeStatePath(r.sandbox, lineage)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil || os.WriteFile(path, issue2879ReleasedRecord, 0o644) != nil {
+		return errors.New("write checksum-valid decoy")
+	}
+	record, err := loadStoreRecord(path)
+	if err != nil || !setOrderedMember(record.state, "lineage_id", lineage) {
+		return errors.New("prepare impossible identity")
+	}
+	for _, key := range []string{"initial_snapshot", "current_snapshot"} {
+		snapshot, ok := orderedMember(record.state, key)
+		if !ok || !setOrderedMember(snapshot, "identity", "sha256:"+strings.Repeat("0", 64)) {
+			return errors.New("cannot forge impossible snapshot identity")
+		}
+	}
+	if _, err := record.save(); err != nil {
+		return err
+	}
+	if _, err := loadStoreRecord(path); err != nil {
+		return err
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	inspection := r.run(productArgsFor(r, "review", "inspect-authority"), false)
+	var report storeInspection
+	preflight := r.run(productArgsFor(r, "review", "repair", "--preflight"), false)
+	var result dispositionRepairResult
+	after, readErr := os.ReadFile(path)
+	if inspection.ExitCode != 0 || json.Unmarshal([]byte(inspection.Stdout), &report) != nil || len(report.EntryDiagnostics) != 1 || report.EntryDiagnostics[0].LineageID != lineage || report.EntryDiagnostics[0].Problem != "malformed_compact_state" ||
+		preflight.ExitCode != 0 || json.Unmarshal([]byte(preflight.Stdout), &result) != nil || result.DispositionProviderInputs != nil || readErr != nil || !bytes.Equal(before, after) {
+		return errors.New("impossible identity received historical treatment")
+	}
+	return nil
+}

--- a/bench/journeys_issue2879.go
+++ b/bench/journeys_issue2879.go
@@ -17,8 +17,7 @@ const issue2879Lineage = "review-f8708016a901b4ff"
 const issue2879Digest = "sha256:7adf81305d031f928d9898c03be98d5e942132bfc98d209ee99f6fe3dd008259"
 const issue2879Class = "retired_compact_snapshot_identity"
 
-// GitHub v2.2.4 asset gentle-ai_2.2.4_linux_amd64.tar.gz SHA-256 a6de9f21999fad2b22fed87e267bbb222782505b7316457bcb9af5e5a2217809.
-// Its release binary created these exact bytes, SHA-256 issue2879Digest.
+// The released v2.2.4 asset gentle-ai_2.2.4_linux_amd64.tar.gz (SHA-256 a6de9f21999fad2b22fed87e267bbb222782505b7316457bcb9af5e5a2217809) created these exact issue2879Digest bytes.
 //
 //go:embed testdata/issue2879/released-v2.2.4-review-state.json
 var issue2879ReleasedRecord []byte
@@ -31,11 +30,12 @@ func issue2879Journeys() []Journey {
 			{Name: "enable review mode in the disposable clone", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--scope", "clone", "--json")},
 			{Name: "fixture: stage unrelated current target", Fixture: stageProse("", "issue2879-current")},
 			{Name: "fixture: replay exact released v2.2.4 authority bytes", Fixture: issue2879HistoricalFixture},
-			{Name: "inspect and preflight bind the historical record", Requires: repairPreflightCapability, Composite: issue2879Plan},
+			{Name: "unrelated malformed entry blocks historical preflight", Requires: repairPreflightCapability, Composite: issue2879Plan},
+			{Name: "inspect historical authority offers repair", Requires: repairPreflightCapability, Args: productArgs("review", "inspect-authority"), After: inspectionAssertion("historical inspection", requireIssue2879HistoricalInspection)},
+			{Name: "preflight binds historical repair", Requires: repairPreflightCapability, Args: productArgs("review", "repair", "--preflight"), After: requireDispositionPlanEligible},
 			{Name: "forged and stale repair bindings refuse unchanged", Requires: repairDispositionExecuteCapability, Composite: issue2879Refuse},
 			{Name: "authorized repair quarantines exactly once", Requires: repairDispositionExecuteCapability, Composite: issue2879Execute},
 			{Name: "unrelated current target remains routable", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", "issue2879-current")},
-			{Name: "status remains readable after exact replay", Requires: statusCapability, Composite: issue2879Status},
 			{Name: "decoy impossible identity remains ineligible", Requires: repairPreflightCapability, Composite: issue2879Decoy},
 		},
 	}}
@@ -57,58 +57,66 @@ func issue2879HistoricalFixture(sandbox *Sandbox) error {
 }
 
 func issue2879Plan(r *journeyRun) error {
-	path, err := storeStatePath(r.sandbox, issue2879Lineage)
-	raw, readErr := os.ReadFile(path)
-	if err != nil || readErr != nil || !bytes.Equal(raw, issue2879ReleasedRecord) {
-		return errors.New("released authority bytes changed")
+	historicalPath, historicalPathErr := storeStatePath(r.sandbox, issue2879Lineage)
+	unrelatedPath, err := storeStatePath(r.sandbox, "z-unrelated")
+	if historicalPathErr != nil || err != nil || os.MkdirAll(filepath.Dir(unrelatedPath), 0o755) != nil || os.WriteFile(unrelatedPath, []byte("{\n"), 0o644) != nil {
+		return errors.New("prepare unrelated malformed authority")
 	}
-	inspection := r.run(productArgsFor(r, "review", "inspect-authority"), false)
-	var report storeInspection
-	if inspection.ExitCode != 0 || json.Unmarshal([]byte(inspection.Stdout), &report) != nil || len(report.EntryDiagnostics) != 1 ||
-		report.EntryDiagnostics[0].LineageID != issue2879Lineage || report.EntryDiagnostics[0].Problem != "outdated_compact_state" ||
-		len(report.SanctionedExits) != 1 || report.SanctionedExits[0].LineageID != issue2879Lineage || report.SanctionedExits[0].Operation != "review repair" {
-		return fmt.Errorf("historical inspection = %+v", report)
+	blockedInspection := r.run(productArgsFor(r, "review", "inspect-authority"), false)
+	blockedPreflight := r.run(productArgsFor(r, "review", "repair", "--preflight"), false)
+	var blockedReport storeInspection
+	var blockedResult dispositionRepairResult
+	afterHistorical, historicalErr := os.ReadFile(historicalPath)
+	afterMalformed, malformedErr := os.ReadFile(unrelatedPath)
+	if blockedInspection.ExitCode != 0 || json.Unmarshal([]byte(blockedInspection.Stdout), &blockedReport) != nil || len(blockedReport.EntryDiagnostics) != 2 ||
+		blockedReport.EntryDiagnostics[0].LineageID != issue2879Lineage || blockedReport.EntryDiagnostics[0].Problem != "outdated_compact_state" ||
+		blockedReport.EntryDiagnostics[1].LineageID != "z-unrelated" || blockedReport.EntryDiagnostics[1].Problem != "malformed_compact_state" ||
+		blockedPreflight.ExitCode != 0 || json.Unmarshal([]byte(blockedPreflight.Stdout), &blockedResult) != nil || blockedResult.DispositionProviderInputs != nil ||
+		historicalErr != nil || malformedErr != nil || !bytes.Equal(afterHistorical, issue2879ReleasedRecord) || !bytes.Equal(afterMalformed, []byte("{\n")) {
+		return errors.New("unrelated malformed authority produced a historical disposition plan")
 	}
-	preflight := r.run(productArgsFor(r, "review", "repair", "--preflight"), false)
-	var result dispositionRepairResult
-	if preflight.ExitCode != 0 || json.Unmarshal([]byte(preflight.Stdout), &result) != nil || result.DispositionProviderInputs == nil {
-		return fmt.Errorf("historical preflight = %s", preflight.Stdout)
+	if err := os.RemoveAll(filepath.Dir(unrelatedPath)); err != nil {
+		return err
 	}
-	r.sandbox.Scratch["issue2879-plan"] = result.DispositionProviderInputs.PlanDigest
-	r.sandbox.Scratch["issue2879-inventory"] = result.DispositionProviderInputs.AuthorityInventoryRevision
 	return nil
 }
-
+func requireIssue2879HistoricalInspection(report storeInspection) error {
+	if len(report.EntryDiagnostics) != 1 || report.EntryDiagnostics[0].LineageID != issue2879Lineage ||
+		report.EntryDiagnostics[0].Problem != "outdated_compact_state" || len(report.SanctionedExits) != 1 ||
+		report.SanctionedExits[0].LineageID != issue2879Lineage || report.SanctionedExits[0].Operation != "review repair" {
+		return fmt.Errorf("historical inspection = %+v", report)
+	}
+	return nil
+}
 func issue2879Args(sandbox *Sandbox, plan, inventory, reason, authorization string) []string {
 	return []string{"review", "repair", "--cwd", sandbox.Repo, "--plan-digest", plan, "--inventory-revision", inventory,
 		"--actor", "bench", "--reason", reason, "--authorization", authorization}
 }
-
 func issue2879Refuse(r *journeyRun) error {
 	path, err := storeStatePath(r.sandbox, issue2879Lineage)
+	before, err := os.ReadFile(path)
 	base, baseErr := reviewTransactionsBase(r.sandbox)
-	before, readErr := os.ReadFile(path)
 	binding, bindErr := dispositionRepositoryBinding(r.sandbox)
-	if err != nil || baseErr != nil || readErr != nil || bindErr != nil {
+	if err != nil || baseErr != nil || bindErr != nil {
 		return errors.New("prepare repair refusals")
 	}
-	plan, inventory, reason := r.sandbox.Scratch["issue2879-plan"], r.sandbox.Scratch["issue2879-inventory"], "quarantine released historical record"
+	plan, inventory, reason := r.sandbox.Scratch[scratchDispositionPlanDigest], r.sandbox.Scratch[scratchDispositionInventoryRevision], "quarantine released historical record"
 	for _, test := range []struct{ inventory, authorizationReason string }{{inventory, "forged authorization"}, {inventory + "0", reason}, {inventory, "stale authorization"}} {
 		authorization := dispositionAuthorization(binding, plan, test.inventory, "bench", test.authorizationReason, issue2879Class)
 		observation := r.run(issue2879Args(r.sandbox, plan, test.inventory, reason, authorization), false)
 		after, readErr := os.ReadFile(path)
 		if observation.ExitCode == 0 || readErr != nil || !bytes.Equal(before, after) {
-			return errors.New("refused repair changed active authority")
+			return fmt.Errorf("refused repair %q changed active authority", test.authorizationReason)
 		}
 		if _, err := os.Stat(filepath.Join(base, "quarantine")); !os.IsNotExist(err) {
-			return errors.New("refused repair created quarantine residue")
+			return fmt.Errorf("refused repair %q created quarantine residue", test.authorizationReason)
 		}
 	}
 	return nil
 }
 
 func issue2879Execute(r *journeyRun) error {
-	plan, inventory := r.sandbox.Scratch["issue2879-plan"], r.sandbox.Scratch["issue2879-inventory"]
+	plan, inventory := r.sandbox.Scratch[scratchDispositionPlanDigest], r.sandbox.Scratch[scratchDispositionInventoryRevision]
 	binding, err := dispositionRepositoryBinding(r.sandbox)
 	if err != nil {
 		return err
@@ -144,29 +152,22 @@ func issue2879Execute(r *journeyRun) error {
 	if _, err := os.Stat(filepath.Join(base, "quarantine", entries[0].Name(), "residue", "review-receipt.json")); !os.IsNotExist(err) {
 		return errors.New("historical repair created a receipt")
 	}
-	return nil
-}
-
-func issue2879Status(r *journeyRun) error {
-	observation := r.run(productArgsFor(r, "review", "status"), false)
-	if observation.ExitCode != 0 || strings.Contains(observation.Stdout, issue2879Lineage) {
-		return fmt.Errorf("status after historical repair = %s", observation.Stdout)
+	if status := r.run(productArgsFor(r, "review", "status"), false); status.ExitCode != 0 || strings.Contains(status.Stdout, issue2879Lineage) {
+		return fmt.Errorf("status after historical repair = %s", status.Stdout)
 	}
 	return nil
 }
-
 func issue2879Decoy(r *journeyRun) error {
-	const lineage = "issue2879-impossible"
-	path, err := storeStatePath(r.sandbox, lineage)
+	path, err := storeStatePath(r.sandbox, issue2879Lineage)
 	if err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil || os.WriteFile(path, issue2879ReleasedRecord, 0o644) != nil {
-		return errors.New("write checksum-valid decoy")
+		return errors.New("write checksum-valid historical decoy")
 	}
 	record, err := loadStoreRecord(path)
-	if err != nil || !setOrderedMember(record.state, "lineage_id", lineage) {
-		return errors.New("prepare impossible identity")
+	if err != nil {
+		return err
 	}
 	for _, key := range []string{"initial_snapshot", "current_snapshot"} {
 		snapshot, ok := orderedMember(record.state, key)
@@ -175,9 +176,6 @@ func issue2879Decoy(r *journeyRun) error {
 		}
 	}
 	if _, err := record.save(); err != nil {
-		return err
-	}
-	if _, err := loadStoreRecord(path); err != nil {
 		return err
 	}
 	before, err := os.ReadFile(path)
@@ -189,9 +187,9 @@ func issue2879Decoy(r *journeyRun) error {
 	preflight := r.run(productArgsFor(r, "review", "repair", "--preflight"), false)
 	var result dispositionRepairResult
 	after, readErr := os.ReadFile(path)
-	if inspection.ExitCode != 0 || json.Unmarshal([]byte(inspection.Stdout), &report) != nil || len(report.EntryDiagnostics) != 1 || report.EntryDiagnostics[0].LineageID != lineage || report.EntryDiagnostics[0].Problem != "malformed_compact_state" ||
+	if inspection.ExitCode != 0 || json.Unmarshal([]byte(inspection.Stdout), &report) != nil || len(report.EntryDiagnostics) != 1 || report.EntryDiagnostics[0].LineageID != issue2879Lineage || report.EntryDiagnostics[0].Problem != "malformed_compact_state" || len(report.SanctionedExits) != 0 ||
 		preflight.ExitCode != 0 || json.Unmarshal([]byte(preflight.Stdout), &result) != nil || result.DispositionProviderInputs != nil || readErr != nil || !bytes.Equal(before, after) {
-		return errors.New("impossible identity received historical treatment")
+		return errors.New("checksum-valid impossible identity received historical treatment")
 	}
 	return nil
 }

--- a/bench/journeys_issue2879.go
+++ b/bench/journeys_issue2879.go
@@ -93,11 +93,11 @@ func issue2879Args(sandbox *Sandbox, plan, inventory, reason, authorization stri
 		"--actor", "bench", "--reason", reason, "--authorization", authorization}
 }
 func issue2879Refuse(r *journeyRun) error {
-	path, err := storeStatePath(r.sandbox, issue2879Lineage)
-	before, err := os.ReadFile(path)
+	path, pathErr := storeStatePath(r.sandbox, issue2879Lineage)
+	before, readErr := os.ReadFile(path)
 	base, baseErr := reviewTransactionsBase(r.sandbox)
 	binding, bindErr := dispositionRepositoryBinding(r.sandbox)
-	if err != nil || baseErr != nil || bindErr != nil {
+	if pathErr != nil || readErr != nil || baseErr != nil || bindErr != nil {
 		return errors.New("prepare repair refusals")
 	}
 	plan, inventory, reason := r.sandbox.Scratch[scratchDispositionPlanDigest], r.sandbox.Scratch[scratchDispositionInventoryRevision], "quarantine released historical record"

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -49,7 +49,7 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// while the advertised main ref remains a moving publication boundary. j87
 	// proves #2871's correction binds the immutable failure across a later interrupt;
 	// j88 proves #2843's unborn STATUS collects explicit untracked intent first;
-	// j89 proves #2758 never offers a workspace receipt for a different index; j90 proves #2016 resumes an explicit frozen reviewing lineage after workspace drift; j91 proves #1800's pre-plan exit is audited abandon.
+	// j89 proves #2758 never offers a workspace receipt for a different index; j90 proves #2016 resumes an explicit frozen reviewing lineage after workspace drift; j91 proves #1800's pre-plan exit is audited abandon; j92 proves #2879 quarantines released historical bytes without compatibility loading.
 	// j93 proves #2822 classifies stale managed assets before START can persist.
 	// #1993 REMOVED two: j38 (the bound-passing-finish refusal routing to the
 	// review router) and j39 (the stranded-successor exit it named). Review
@@ -60,8 +60,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	//
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 89 {
-		t.Errorf("core journey count = %d, want 89", got)
+	if got := len(seen); got != 90 {
+		t.Errorf("core journey count = %d, want 90", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/bench/testdata/issue2879/released-v2.2.4-review-state.json
+++ b/bench/testdata/issue2879/released-v2.2.4-review-state.json
@@ -1,0 +1,55 @@
+{
+  "schema": "gentle-ai.review-state-record/v2",
+  "revision": "sha256:a3a11e21759e3c36b32f17ccb1d15995029226661e38b2ca9ba9bf79e676ceab",
+  "state": {
+    "schema": "gentle-ai.review-state/v2",
+    "lineage_id": "review-f8708016a901b4ff",
+    "generation": 1,
+    "state": "reviewing",
+    "initial_snapshot": {
+      "kind": "current-changes",
+      "base_tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+      "candidate_tree": "0b919d88a591bd39ee0b8e37efc92e5ab949dc31",
+      "paths_digest": "sha256:6b2d9e38101eb421286f943f259ed3c8a183106c8c75612e12db13b848bbec69",
+      "intended_untracked": [
+        "main.go"
+      ],
+      "intended_untracked_proof": "sha256:605b96e3f644cb6983ac789b3a54fc0f3a0383dfca832e33ad82b934cde199bb",
+      "paths": [
+        "main.go"
+      ],
+      "identity": "sha256:f8708016a901b4ffb8a3e000fca45ff07891ba851c480f562986e94d8007ced3"
+    },
+    "current_snapshot": {
+      "kind": "current-changes",
+      "base_tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+      "candidate_tree": "0b919d88a591bd39ee0b8e37efc92e5ab949dc31",
+      "paths_digest": "sha256:6b2d9e38101eb421286f943f259ed3c8a183106c8c75612e12db13b848bbec69",
+      "intended_untracked": [
+        "main.go"
+      ],
+      "intended_untracked_proof": "sha256:605b96e3f644cb6983ac789b3a54fc0f3a0383dfca832e33ad82b934cde199bb",
+      "paths": [
+        "main.go"
+      ],
+      "identity": "sha256:f8708016a901b4ffb8a3e000fca45ff07891ba851c480f562986e94d8007ced3"
+    },
+    "genesis_paths": [
+      "main.go"
+    ],
+    "policy_hash": "sha256:34fb63d7f29f8613cd4431382b1057398a4816f8a4c20fc34677fffc80a184f6",
+    "risk_level": "medium",
+    "selected_lenses": [
+      "review-reliability"
+    ],
+    "original_changed_lines": 3,
+    "correction_budget": 2,
+    "lens_results": [],
+    "findings": [],
+    "classifications": {},
+    "outcomes": {},
+    "fix_finding_ids": [],
+    "follow_ups": [],
+    "fix_delta_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  }
+}

--- a/internal/reviewtransaction/authority_disposition_execute.go
+++ b/internal/reviewtransaction/authority_disposition_execute.go
@@ -189,9 +189,11 @@ func lockedAuthorityDispositionMutation(ctx context.Context, maintenance *Mainte
 	// with a forged Authorization and it would commit every remaining
 	// closure member.
 	var records map[string]CompactRecord
+	var report CompactRecoveryInspectionReport
+	var freshRecords map[string]CompactRecord
 	validationInventoryRevision := plan.AuthorityInventoryRevision
 	if freshExecution {
-		report, freshRecords, err := loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
+		report, freshRecords, err = loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
 		if err != nil {
 			return CompactReclaimRecord{}, err
 		}
@@ -210,7 +212,7 @@ func lockedAuthorityDispositionMutation(ctx context.Context, maintenance *Mainte
 		if currentPlan.PlanDigest != plan.PlanDigest {
 			return CompactReclaimRecord{}, fmt.Errorf("%w: plan digest drifted under lock re-derivation (expected_revisions or authority_inventory_revision changed)", ErrConcurrentUpdate)
 		}
-		currentInventoryRevision, err := authorityInventoryRevision(records)
+		currentInventoryRevision, err := authorityInventoryRevision(records, report.historical)
 		if err != nil {
 			return CompactReclaimRecord{}, err
 		}
@@ -237,13 +239,20 @@ func lockedAuthorityDispositionMutation(ctx context.Context, maintenance *Mainte
 	// were not already loaded above (freshExecution == false skipped
 	// re-derivation), so load them once here, for CAS-all-N only.
 	if records == nil {
-		_, freshRecords, err := loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
+		report, freshRecords, err = loadCompactRecoveryRecordsUnderMaintenanceHold(ctx, root)
 		if err != nil {
 			return CompactReclaimRecord{}, err
 		}
 		records = freshRecords
 	}
 	for _, lineage := range plan.Closure {
+		expectedRevision, expectedFound := plan.ExpectedRevisions[lineage]
+		if historical, found := report.historical[lineage]; found {
+			if !expectedFound || historical.RawDigest != expectedRevision {
+				return CompactReclaimRecord{}, fmt.Errorf("%w: expected revision for closure member %q drifted", ErrConcurrentUpdate, lineage)
+			}
+			continue
+		}
 		targetRecord, found := records[lineage]
 		if !found {
 			// On a fresh execution a missing member is drift — nothing has
@@ -258,7 +267,6 @@ func lockedAuthorityDispositionMutation(ctx context.Context, maintenance *Mainte
 			}
 			continue
 		}
-		expectedRevision, expectedFound := plan.ExpectedRevisions[lineage]
 		if !expectedFound || targetRecord.Revision != expectedRevision {
 			return CompactReclaimRecord{}, fmt.Errorf("%w: expected revision for closure member %q drifted", ErrConcurrentUpdate, lineage)
 		}
@@ -442,7 +450,7 @@ func quarantineDirectoryLineageMatches(quarantineRoot, entryName, expectedLineag
 // "uncoordinated read for a caller that already holds the required
 // coordination" primitive, compact_store.go) instead of Load.
 func loadCompactRecoveryRecordsUnderMaintenanceHold(ctx context.Context, repo string) (CompactRecoveryInspectionReport, map[string]CompactRecord, error) {
-	report := CompactRecoveryInspectionReport{Complete: true, Valid: true, Edges: []CompactRecoveryEdgeInspection{}, EntryDiagnostics: []CompactRecoveryEntryDiagnostic{}}
+	report := CompactRecoveryInspectionReport{Complete: true, Valid: true, Edges: []CompactRecoveryEdgeInspection{}, EntryDiagnostics: []CompactRecoveryEntryDiagnostic{}, historical: map[string]historicalCompactForensicRecord{}}
 	base, root, err := reviewAuthorityRoot(ctx, repo)
 	if err != nil {
 		return report, nil, err
@@ -476,6 +484,11 @@ func loadCompactRecoveryRecordsUnderMaintenanceHold(ctx context.Context, repo st
 			lockPath: filepath.Join(versionRoot, "LOCK"), maintenanceLockPath: compactMaintenanceLockPath(base)}
 		record, loadErr := store.loadCompactRecordLocked()
 		if loadErr != nil {
+			if payload, err := os.ReadFile(store.StatePath()); err == nil {
+				if historical, ok := forensicHistoricalCompactRecord(payload, entry.Name()); ok {
+					report.historical[entry.Name()] = historical
+				}
+			}
 			report.EntryDiagnostics = append(report.EntryDiagnostics, CompactRecoveryEntryDiagnostic{
 				LineageID: entry.Name(), Problem: compactRecoveryEntryProblem(loadErr),
 			})

--- a/internal/reviewtransaction/authority_disposition_plan.go
+++ b/internal/reviewtransaction/authority_disposition_plan.go
@@ -111,7 +111,7 @@ func authorityDispositionSelectors(report CompactRecoveryInspectionReport, recor
 // obligation (a)). It refuses (no plan) unless the inspection that produced
 // selected closure carries no entry diagnostics and exactly one report edge
 // re-derives into the one closed content_mismatched_recovery_authorization
-// class.
+// class, except one forensic historical entry whose only diagnostic is outdated.
 func deriveAuthorityDispositionPlan(report CompactRecoveryInspectionReport, records map[string]CompactRecord, binding, actor, reason string, requested ...AuthorityDispositionSelector) (AuthorityDispositionPlan, error) {
 	if len(requested) > 1 {
 		return AuthorityDispositionPlan{}, fmt.Errorf("%w: multiple exact content-mismatch selectors supplied", errAuthorityDispositionPlanNotDerivable)
@@ -120,8 +120,12 @@ func deriveAuthorityDispositionPlan(report CompactRecoveryInspectionReport, reco
 	if err != nil {
 		return AuthorityDispositionPlan{}, err
 	}
-	if len(requested) == 0 && len(selectors) == 0 && len(report.historical) == 1 {
+	if len(requested) == 0 && len(selectors) == 0 && len(report.historical) == 1 && len(report.EntryDiagnostics) == 1 {
 		for lineage, historical := range report.historical {
+			diagnostic := report.EntryDiagnostics[0]
+			if diagnostic.LineageID != lineage || diagnostic.Problem != compactInspectionEntryOutdated {
+				break
+			}
 			inventory, err := authorityInventoryRevision(records, report.historical)
 			if err != nil {
 				return AuthorityDispositionPlan{}, err

--- a/internal/reviewtransaction/authority_disposition_plan.go
+++ b/internal/reviewtransaction/authority_disposition_plan.go
@@ -72,6 +72,8 @@ type AuthorityDispositionSelector struct {
 // — a dead end (design decision 2).
 const compactContentMismatchedRecoveryAuthorizationClass = "content_mismatched_recovery_authorization"
 
+const compactHistoricalSnapshotIdentityClass = "retired_compact_snapshot_identity"
+
 // errAuthorityDispositionPlanNotDerivable is returned, always wrapped with a
 // specific cause, whenever derivation refuses to produce a plan: an
 // unclassifiable shape, a mixed/ambiguous set of eligible edges, or a
@@ -118,6 +120,17 @@ func deriveAuthorityDispositionPlan(report CompactRecoveryInspectionReport, reco
 	if err != nil {
 		return AuthorityDispositionPlan{}, err
 	}
+	if len(requested) == 0 && len(selectors) == 0 && len(report.historical) == 1 {
+		for lineage, historical := range report.historical {
+			inventory, err := authorityInventoryRevision(records, report.historical)
+			if err != nil {
+				return AuthorityDispositionPlan{}, err
+			}
+			plan := AuthorityDispositionPlan{Schema: AuthorityDispositionPlanSchema, RepositoryBinding: binding, AuthorityInventoryRevision: inventory, AnomalyClass: compactHistoricalSnapshotIdentityClass, SeedSet: []string{lineage}, Closure: []string{lineage}, ExpectedRevisions: map[string]string{lineage: historical.RawDigest}, Actor: strings.TrimSpace(actor), Reason: strings.TrimSpace(reason)}
+			plan.PlanDigest, err = authorityDispositionPlanDigest(plan)
+			return plan, err
+		}
+	}
 	var selector *AuthorityDispositionSelector
 	if len(requested) == 1 {
 		if index := slices.Index(selectors, requested[0]); index >= 0 {
@@ -150,7 +163,7 @@ func deriveAuthorityDispositionPlan(report CompactRecoveryInspectionReport, reco
 		}
 		expectedRevisions[lineage] = record.Revision
 	}
-	inventoryRevision, err := authorityInventoryRevision(records)
+	inventoryRevision, err := authorityInventoryRevision(records, report.historical)
 	if err != nil {
 		return AuthorityDispositionPlan{}, err
 	}
@@ -251,10 +264,13 @@ func authorityDispositionClosure(report CompactRecoveryInspectionReport, seed st
 // including outside the closure. encoding/json sorts map keys, so this is
 // already deterministic (the same idiom classifiedAuthorityRepairDigest's own
 // doc comment relies on).
-func authorityInventoryRevision(records map[string]CompactRecord) (string, error) {
-	revisions := make(map[string]string, len(records))
+func authorityInventoryRevision(records map[string]CompactRecord, historical map[string]historicalCompactForensicRecord) (string, error) {
+	revisions := make(map[string]string, len(records)+len(historical))
 	for lineage, record := range records {
 		revisions[lineage] = record.Revision
+	}
+	for lineage, record := range historical {
+		revisions[lineage] = record.RawDigest
 	}
 	return classifiedAuthorityRepairDigest("gentle-ai.review-authority-inventory-revision/v1", revisions)
 }

--- a/internal/reviewtransaction/compact_inspect.go
+++ b/internal/reviewtransaction/compact_inspect.go
@@ -32,6 +32,7 @@ type CompactRecoveryInspectionReport struct {
 	Totals           CompactRecoveryInspectionTotals  `json:"totals"`
 	Edges            []CompactRecoveryEdgeInspection  `json:"edges"`
 	EntryDiagnostics []CompactRecoveryEntryDiagnostic `json:"entry_diagnostics"`
+	historical       map[string]historicalCompactForensicRecord
 }
 type CompactRecoveryInspectionTotals struct {
 	CompactEntries   int `json:"compact_entries"`
@@ -128,7 +129,7 @@ func InspectCompactRecoveryEdges(ctx context.Context, repo string) (CompactRecov
 // down one level with InspectCompactRecoveryEdges left as a thin wrapper: no
 // inspection semantics or JSON output changed by this extraction.
 var loadCompactRecoveryRecords = func(ctx context.Context, repo string) (CompactRecoveryInspectionReport, map[string]CompactRecord, error) {
-	report := CompactRecoveryInspectionReport{Complete: true, Valid: true, Edges: []CompactRecoveryEdgeInspection{}, EntryDiagnostics: []CompactRecoveryEntryDiagnostic{}}
+	report := CompactRecoveryInspectionReport{Complete: true, Valid: true, Edges: []CompactRecoveryEdgeInspection{}, EntryDiagnostics: []CompactRecoveryEntryDiagnostic{}, historical: map[string]historicalCompactForensicRecord{}}
 	base, root, err := reviewAuthorityRoot(ctx, repo)
 	if err != nil {
 		return report, nil, err
@@ -162,6 +163,11 @@ var loadCompactRecoveryRecords = func(ctx context.Context, repo string) (Compact
 			lockPath: filepath.Join(versionRoot, "LOCK"), maintenanceLockPath: compactMaintenanceLockPath(base)}
 		record, loadErr := store.Load()
 		if loadErr != nil {
+			if payload, err := os.ReadFile(store.StatePath()); err == nil {
+				if historical, ok := forensicHistoricalCompactRecord(payload, entry.Name()); ok {
+					report.historical[entry.Name()] = historical
+				}
+			}
 			report.EntryDiagnostics = append(report.EntryDiagnostics, CompactRecoveryEntryDiagnostic{
 				LineageID: entry.Name(), Problem: compactRecoveryEntryProblem(loadErr),
 			})
@@ -208,7 +214,11 @@ func SanctionedCompactRecoveryExits(ctx context.Context, repo string, report Com
 	// aborts the whole exit computation.
 	dispositionSeed := ""
 	if plan, planErr := deriveAuthorityDispositionPlanAtRepo(ctx, repo, "", ""); planErr == nil && admitClosureDisposition(plan) == nil {
-		dispositionSeed = plan.SeedSet[0]
+		if plan.AnomalyClass == compactHistoricalSnapshotIdentityClass {
+			exits = append(exits, CompactRecoverySanctionedExit{SuccessorLineageID: plan.SeedSet[0], Operation: CompactRecoveryEdgeExitRepair})
+		} else {
+			dispositionSeed = plan.SeedSet[0]
+		}
 	}
 	for _, edge := range report.Edges {
 		if err := ctx.Err(); err != nil {

--- a/internal/reviewtransaction/compact_scoped_walks_test.go
+++ b/internal/reviewtransaction/compact_scoped_walks_test.go
@@ -73,17 +73,22 @@ func outdateCompactSnapshotIdentity(t *testing.T, store CompactStore) {
 		t.Fatal(err)
 	}
 	outdated := payload
-	for _, snapshot := range []Snapshot{record.State.InitialSnapshot, record.State.CurrentSnapshot} {
-		retired := retiredSnapshotIdentity(snapshot)
+	for _, snapshot := range []*Snapshot{&record.State.InitialSnapshot, &record.State.CurrentSnapshot} {
+		retired := retiredSnapshotIdentity(*snapshot)
 		if retired == snapshot.Identity {
 			t.Fatalf("retired identity formula reproduced the current identity %q; the fixture would prove nothing", snapshot.Identity)
 		}
 		outdated = bytes.ReplaceAll(outdated, []byte(`"identity": "`+snapshot.Identity+`"`), []byte(`"identity": "`+retired+`"`))
+		snapshot.Identity = retired
 	}
 	if bytes.Equal(outdated, payload) {
 		t.Fatal("fixture did not contain the expected snapshot identity markers")
 	}
-	if err := os.WriteFile(store.StatePath(), outdated, 0o644); err != nil {
+	_, payload, err = makeCompactRecord(record.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	_, loadErr := store.Load()

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -2258,8 +2258,9 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		return CompactRecord{}, errors.New("invalid compact review state record")
 	}
 	if err := record.State.Validate(); err != nil {
+		_, historical := forensicHistoricalCompactRecord(payload, lineageID)
 		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
-			OutdatedIdentity: errors.Is(err, errCompactSnapshotIdentityMismatch) && retiredCompactSnapshotIdentities(record.State)}
+			OutdatedIdentity: historical}
 	}
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")
@@ -2319,10 +2320,6 @@ func retiredCompactSnapshotIdentity(snapshot Snapshot) string {
 		writeLengthPrefixed(hash, []byte(value))
 	}
 	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
-}
-
-func retiredCompactSnapshotIdentities(state CompactState) bool {
-	return state.InitialSnapshot.Identity == retiredCompactSnapshotIdentity(state.InitialSnapshot) && state.CurrentSnapshot.Identity == retiredCompactSnapshotIdentity(state.CurrentSnapshot)
 }
 
 // retiredCompactFieldError reports whether a strict decode failure names a

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -142,6 +142,9 @@ type CompactRecord struct {
 	HistoricalCompat bool `json:"-"`
 }
 
+// historicalCompactForensicRecord is raw-byte identity, never authority.
+type historicalCompactForensicRecord struct{ RawDigest string }
+
 type CompactStore struct {
 	Dir                 string
 	lineageID           string
@@ -2256,7 +2259,7 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 	}
 	if err := record.State.Validate(); err != nil {
 		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
-			OutdatedIdentity: errors.Is(err, errCompactSnapshotIdentityMismatch)}
+			OutdatedIdentity: errors.Is(err, errCompactSnapshotIdentityMismatch) && retiredCompactSnapshotIdentities(record.State)}
 	}
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")
@@ -2268,6 +2271,58 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		}
 	}
 	return record, nil
+}
+
+func forensicHistoricalCompactRecord(payload []byte, lineageID string) (historicalCompactForensicRecord, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var record CompactRecord
+	if err := decoder.Decode(&record); err != nil {
+		return historicalCompactForensicRecord{}, false
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF || record.Schema != compactRecordSchema || !validSHA256(record.Revision) || record.State.LineageID != lineageID {
+		return historicalCompactForensicRecord{}, false
+	}
+	want, _, err := makeCompactRecord(record.State)
+	if err != nil || want.Revision != record.Revision || !errors.Is(record.State.Validate(), errCompactSnapshotIdentityMismatch) {
+		return historicalCompactForensicRecord{}, false
+	}
+	state := record.State
+	for _, snapshot := range []*Snapshot{&state.InitialSnapshot, &state.CurrentSnapshot} {
+		if snapshot.Identity != retiredCompactSnapshotIdentity(*snapshot) {
+			return historicalCompactForensicRecord{}, false
+		}
+		snapshot.Identity = snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+	}
+	if state.Validate() != nil {
+		return historicalCompactForensicRecord{}, false
+	}
+	sum := sha256.Sum256(payload)
+	return historicalCompactForensicRecord{RawDigest: "sha256:" + hex.EncodeToString(sum[:])}, true
+}
+
+func retiredCompactSnapshotIdentity(snapshot Snapshot) string {
+	hash := sha256.New()
+	if snapshot.Kind == TargetBaseWorkspaceOverlay {
+		hash.Write([]byte("gentle-ai.review-snapshot/base-workspace-overlay/v1\x00"))
+	} else if snapshot.Projection == ProjectionStaged {
+		hash.Write([]byte("gentle-ai.review-snapshot/v2\x00"))
+	} else {
+		hash.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
+	}
+	values := []string{string(snapshot.Kind), snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof}
+	if snapshot.Projection == ProjectionStaged {
+		values = []string{string(snapshot.Kind), string(snapshot.Projection), snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof}
+	}
+	for _, value := range append(values, append(snapshot.IntendedUntracked, snapshot.LedgerIDs...)...) {
+		writeLengthPrefixed(hash, []byte(value))
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+func retiredCompactSnapshotIdentities(state CompactState) bool {
+	return state.InitialSnapshot.Identity == retiredCompactSnapshotIdentity(state.InitialSnapshot) && state.CurrentSnapshot.Identity == retiredCompactSnapshotIdentity(state.CurrentSnapshot)
 }
 
 // retiredCompactFieldError reports whether a strict decode failure names a


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2879

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Recognizes only exact checksum-valid retired compact-v2 snapshot identities as non-authoritative forensic repair inputs.
- Reuses the existing inventory-bound repair plan, authorization, CAS, and quarantine executor to preserve original bytes without restoring lifecycle or delivery validity.
- Adds released-v2.2.4 provenance and driven j92, including forged/stale refusals and an impossible-identity decoy.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_store.go` | Strictly recognizes exact retired formulas after checksum and lineage validation; records only the raw digest. |
| `internal/reviewtransaction/compact_inspect.go` | Keeps the record diagnostic/non-authoritative while exposing the existing repair exit. |
| `internal/reviewtransaction/authority_disposition_*.go` | Binds historical raw digest into inventory/plan/CAS and executes through existing audited quarantine. |
| `bench/journeys_issue2879.go` | Adds j92 GREEN, forged/stale/inventory decoys, one-time quarantine replay, unrelated routing, and impossible-identity refusal. |
| `bench/testdata/issue2879/` | Preserves exact raw authority bytes created by the official released v2.2.4 Linux binary. |
| Bench registry/count | Registers unique j92 and advances the core corpus from 89 to 90. |

---

## 🧪 Test Plan

**Candidate**
- Commit: `8c830b1087702e458920647926c7c57279a134b6`
- Tree: `b5a14e4b751ccd975551a635ce9303ace5d7a2fd`
- Review budget: 380 additions + 20 deletions = 400/400 lines
- Prior candidate correction: 116/194 lines, tightening checksum/lineage classification and exclusive diagnostic admission
- Fresh corrective slice: PR #2987, 6 lines, preserving fixture path/read errors independently after the original correction transaction
- Final fresh-candidate correction: 2/200 lines, binding the inspect step to `inspectAuthorityCapability`
- RDD: `disabled/unmanaged`; no receipt-review claim

**Released provenance**
- Asset: `gentle-ai_2.2.4_linux_amd64.tar.gz`
- GitHub release asset ID: `496975453`
- Archive SHA-256: `a6de9f21999fad2b22fed87e267bbb222782505b7316457bcb9af5e5a2217809`
- Released binary SHA-256: `4a6dd5d8804ab0d78439d22d931261eb02e2cababc3e228b2e3dd87196c1bb2a`
- Exact product-created fixture SHA-256: `7adf81305d031f928d9898c03be98d5e942132bfc98d209ee99f6fe3dd008259`
- Independent reproduction byte-compared the released output to the committed fixture.

**RED / GREEN / decoy**
- RED on exact base: `outdated_compact_state`, no sanctioned exit, zero eligible repair inputs.
- GREEN j92: authorized plan-bound quarantine, exact raw-byte preservation, no receipt, removal from active inventory, idempotent replay, readable status, unrelated current routing.
- Decoy: checksum-valid impossible/non-retired identity remains `malformed_compact_state`, receives no plan, and remains unchanged.
- Checksum-invalid retired-formula bytes remain malformed and ineligible.
- A recognized historical entry plus any unrelated malformed diagnostic produces no provider input and no mutation.
- Each j92 refusal preserves `storeStatePath` and fixture-read failures independently.

**Verification**
- `go test ./... -count=1`
- `go vet ./...`
- `go run ./internal/gofmtcheck`
- `./scripts/deadcode-ratchet.sh`
- Focused reviewtransaction/CLI/bench tests
- Driven j92, j90, and j91: each completed
- Core corpus: 90 completed, 0 unsupported, 0 failed
- Transition corpus: 11/11 completed
- Source-coupled tagged/untagged CI assertions passed

- [x] Unit tests pass
- [x] Go format passes
- [x] Local E2E is represented by real driven j92; hosted platform/Organic Runtime lanes remain required
- [x] Manually tested with exact released bytes and current binary

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 400/400 changed lines |
| Check Issue Reference | ⏳ | `Closes #2879` |
| Check Issue Has `status:approved` | ⏳ | #2879 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` |
| Unit Tests | ⏳ | Required |
| Go Format | ⏳ | Required |
| E2E Tests | ⏳ | Required hosted lanes |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [x] Go format passes
- [x] Real driven benchmark validation completed
- [x] Release provenance and raw fixture digest are documented
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

This is deliberately **not** PR #2897's compatibility-loader approach. Normal compact loading still fails, the record never regains authority, and no lifecycle, receipt, approval, or delivery surface recognizes it.

PR #2897 should close as superseded only after this replacement merges with j92 and hosted CI green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of records created with older snapshot formats.
  * Historical records can now be identified and repaired without altering their original content.
  * Added stronger validation for stale, forged, mismatched, or incomplete recovery authorizations.
  * Repeated authorized quarantine operations are now handled safely and consistently.
  * Improved classification and handling of malformed or impossible record identities.

* **Reliability**
  * Expanded validation coverage for recovery workflows, including historical records and related status behavior.
  * Improved handling of recovery operations after interrupted or previously completed actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->