### PR TITLE
test(review): preserve historical fixture path errors

### DIFF
--- a/bench/journeys_issue2879.go
+++ b/bench/journeys_issue2879.go
@@ -93,11 +93,11 @@ func issue2879Args(sandbox *Sandbox, plan, inventory, reason, authorization stri
 		"--actor", "bench", "--reason", reason, "--authorization", authorization}
 }
 func issue2879Refuse(r *journeyRun) error {
-	path, err := storeStatePath(r.sandbox, issue2879Lineage)
-	before, err := os.ReadFile(path)
+	path, pathErr := storeStatePath(r.sandbox, issue2879Lineage)
+	before, readErr := os.ReadFile(path)
 	base, baseErr := reviewTransactionsBase(r.sandbox)
 	binding, bindErr := dispositionRepositoryBinding(r.sandbox)
-	if err != nil || baseErr != nil || bindErr != nil {
+	if pathErr != nil || readErr != nil || baseErr != nil || bindErr != nil {
 		return errors.New("prepare repair refusals")
 	}
 	plan, inventory, reason := r.sandbox.Scratch[scratchDispositionPlanDigest], r.sandbox.Scratch[scratchDispositionInventoryRevision], "quarantine released historical record"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2879

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Fresh corrective slice after PR #2979 exhausted its one correction budget.
- Preserves `storeStatePath` and fixture-read failures independently in j92's refusal proof.
- Changes no product behavior or other historical-disposition evidence.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_issue2879.go` | Retains `pathErr` and `readErr` separately and checks both before using captured bytes. |

---

## 🧪 Test Plan

- Candidate: `9bad5e06`
- Budget: 3 additions + 3 deletions = 6/400 lines
- `go test ./... -count=1`
- Bench vet/tests
- Driven j92: 1 completed, 0 unsupported, 0 failed
- Driven j90: 1 completed, 0 unsupported, 0 failed
- gofmtcheck and `git diff --check`

- [x] Unit tests pass
- [x] Go format passes
- [x] Hosted E2E remains required
- [x] Real driven benchmark validation completed

---

## Chain Context

| Field | Value |
|-------|-------|
| Parent PR | #2979 |
| Base branch | `fix/2879-historical-compact-disposition` |
| Current slice | 📍 Preserve j92 fixture path errors |
| Starts at | #2979 corrected head `16520636` |
| Ends with | Path and read errors independently fail closed |
| Rollback | Revert this one six-line commit |

```text
main
 └── #2979 historical compact disposition
      └── 📍 this corrective slice
```

---

## ✅ Contributor Checklist

- [x] Linked to approved issue #2879
- [x] Within 400 changed lines
- [x] Exactly one `type:*` label will be applied
- [x] Tests and driven evidence pass
- [x] Conventional commit with no `Co-Authored-By`

---

## 💬 Notes for Reviewers

This is intentionally a separate slice: #2979's original candidate already used its one bounded correction. Merge this slice into the parent branch, then revalidate #2979's resulting fresh candidate before delivery to `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when reading state files, ensuring errors from both path resolution and file access are preserved and reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->