### PR TITLE
fix(sdd): refuse a filesystem-root workspace instead of answering empty

### DIFF
--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1504,6 +1504,17 @@ func resolveWorkspaceRoot(options ResolveOptions) (string, error) {
 	if !info.IsDir() {
 		return "", fmt.Errorf("workspace root is not a directory: %s", root)
 	}
+	// A filesystem root is never a workspace, and answering as if it might be
+	// is worse than refusing (#2790). A failure continuation that resolved its
+	// working directory to the drive root used to get a successful, empty,
+	// entirely plausible status back, so the operator read "SDD lost my
+	// project" instead of "that command was pointed at the wrong directory".
+	//
+	// Nothing legitimate is rejected: no project lives at `/` or at `C:\`, so
+	// there is no false positive to weigh against the confusion this prevents.
+	if filepath.Dir(root) == root {
+		return "", fmt.Errorf("workspace root %q is a filesystem root, which never holds an SDD project: whatever produced this call passed the wrong --cwd. Rerun it against the project: `gentle-ai sdd-status --cwd \"<project-directory>\" --json`. If the change is Engram-backed, this dispatcher is blind to it and should not be called at all", root)
+	}
 	return root, nil
 }
 

--- a/internal/sddstatus/workspace_root_test.go
+++ b/internal/sddstatus/workspace_root_test.go
@@ -1,0 +1,71 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A filesystem root is never an SDD workspace, and answering as if it might be
+// is worse than refusing.
+//
+// #2790's Windows reporter had a failure continuation resolve its working
+// directory to the drive root. `sdd-status` did not refuse it. It reported a
+// successful, empty, entirely plausible status — `changeName: null`,
+// `artifactStore: openspec`, `planningHome.path: "/openspec"` — so the operator
+// read "SDD lost my project" instead of "that command was pointed at the wrong
+// directory". The Engram reporter on the same issue read the same empty answer
+// as their change having vanished.
+//
+// The emitted continuation is the plugin's defect and our contract already
+// forbids it. This is the other half, and it is ours: our binary produced that
+// answer. No project lives at `/` or at `C:\`, so refusing costs nothing and
+// there is no false positive to weigh.
+
+func TestResolveWorkspaceRootRefusesAFilesystemRoot(t *testing.T) {
+	root := filepath.VolumeName(mustAbs(t, string(filepath.Separator))) + string(filepath.Separator)
+
+	_, err := resolveWorkspaceRoot(ResolveOptions{CWD: root})
+	if err == nil {
+		t.Fatalf("resolveWorkspaceRoot(%q) succeeded; a filesystem root is never a workspace, and answering with an empty status reads as the project having vanished (#2790)", root)
+	}
+	// The operator has to learn what actually happened, which is that something
+	// handed this command the wrong directory.
+	for _, want := range []string{root, "--cwd"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("refusal does not name %q:\n%v", want, err)
+		}
+	}
+}
+
+func TestResolveWorkspaceRootRefusesAFilesystemRootAsExplicitWorkspace(t *testing.T) {
+	root := filepath.VolumeName(mustAbs(t, string(filepath.Separator))) + string(filepath.Separator)
+
+	if _, err := resolveWorkspaceRoot(ResolveOptions{WorkspaceRoot: root}); err == nil {
+		t.Fatal("an explicit workspace root pointing at the filesystem root was accepted")
+	}
+}
+
+// TestResolveWorkspaceRootStillAcceptsOrdinaryDirectories keeps the guard
+// narrow. It must reject exactly one shape, not "directories that look
+// unpromising": a temp dir with no openspec tree is a perfectly ordinary
+// starting point and every existing caller depends on it resolving.
+func TestResolveWorkspaceRootStillAcceptsOrdinaryDirectories(t *testing.T) {
+	dir := t.TempDir()
+	resolved, err := resolveWorkspaceRoot(ResolveOptions{CWD: dir})
+	if err != nil {
+		t.Fatalf("resolveWorkspaceRoot(%q) = %v, want an ordinary directory to resolve", dir, err)
+	}
+	if resolved != mustAbs(t, dir) {
+		t.Fatalf("resolved = %q, want %q", resolved, mustAbs(t, dir))
+	}
+}
+
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}


### PR DESCRIPTION
```
$ gentle-ai sdd-status --cwd / --json          # v2.4.0-rc.4
{ "changeName": null, "artifactStore": "openspec",
  "planningHome": { "mode": "repo-local", "path": "/openspec" }, ... }
```

A successful, empty, entirely plausible status. Nothing refused it.

## Why this matters more than it looks

This is the half of #2790 that lives in **this binary**.

Its Windows reporter had a typed phase-failure continuation resolve its working directory to the drive root. Because the command *answered* rather than refused, they read **"SDD lost my project"** instead of **"that command was pointed at the wrong directory"**. An Engram-backed reporter on the same issue read the same empty answer as their change having vanished.

An empty status and a wrong directory are indistinguishable to the operator. That is what turns a one-line mistake upstream into a report about SDD being broken.

## After

```
Error: resolve sdd status: workspace root "/" is a filesystem root, which never
holds an SDD project: whatever produced this call passed the wrong --cwd. Rerun
it against the project: `gentle-ai sdd-status --cwd "<project-directory>" --json`.
If the change is Engram-backed, this dispatcher is blind to it and should not be
called at all.
```

The last sentence is there because the Engram reporter's session should never have reached this command; our orchestrator contract already says so in all twelve variants.

## Scope

`resolveWorkspaceRoot` is the single resolution point for both `--cwd` and an explicit workspace root, so the guard lands once and covers both entry points.

It rejects exactly one shape: a path that is its own parent. No SDD project lives at `/` or at `C:\`, so there is no false positive to weigh. A third test pins that a temp directory with no `openspec/` tree still resolves, because "directories that look unpromising" is not the rule and every existing caller depends on it.

## Not in scope

**#2790 stays open.** The unscoped, OpenSpec-only continuation belongs to the plugin that constructs it, and our contract already forbids calling this dispatcher for an Engram store. This PR only stops the binary from answering a question it should refuse.

## Verification

TDD, both refusal tests RED first. `go test ./...` 66 packages exit 0 · bench module · 90 journeys exit 0 · deadcode ratchet clean · refusal ratchet satisfied by naming the runnable continuation rather than annotating the site.

Closes #3000
Refs #2790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented filesystem root directories from being used as workspace locations.
  * Added actionable error messages directing users to specify a project directory with `--cwd`.
  * Continued supporting ordinary directories without an existing OpenSpec tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->