### PR TITLE
fix(sdd): close Engram-backed changes with their archive report

### DIFF
--- a/internal/sddstatus/engram_archived_test.go
+++ b/internal/sddstatus/engram_archived_test.go
@@ -1,0 +1,74 @@
+package sddstatus
+
+import (
+	"slices"
+	"testing"
+)
+
+// An Engram-backed change is never closed, so every change that ever persisted
+// an artifact is reported active forever. Measured on a real store: 30 for one
+// project, including seven `rdd-root-simplification-wave*` archived weeks ago.
+//
+// The two stores archive differently and only one leaves a trace the resolver
+// reads. OpenSpec moves the directory into `openspec/changes/archive/`, so
+// "active" is what remains. Engram moves nothing — `sdd-archive/SKILL.md` says
+// "there are no openspec/ directories to move. The archive report in Engram
+// serves as the audit trail" — and `engramTitlePattern` does not recognize
+// `archive-report`. The one artifact that proves a change is finished is the
+// one the resolver ignores.
+//
+// `state` is not a substitute. Its documented schema carries phase, artifacts,
+// tasks_progress and last_updated with no terminal value, and in the measured
+// store 1 change out of 62 had one at all.
+
+func engramArtifact(project, title string) engramObservation {
+	return engramObservation{Project: project, Title: title}
+}
+
+func TestCollectEngramChangesExcludesArchivedChanges(t *testing.T) {
+	observations := []engramObservation{
+		engramArtifact("demo", "sdd/in-flight/proposal"),
+		engramArtifact("demo", "sdd/in-flight/tasks"),
+		engramArtifact("demo", "sdd/wave-one/proposal"),
+		engramArtifact("demo", "sdd/wave-one/tasks"),
+		engramArtifact("demo", "sdd/wave-one/verify-report"),
+		engramArtifact("demo", "sdd/wave-one/archive-report"),
+	}
+
+	changes := collectEngramChanges(observations, "demo")
+	if slices.Contains(changes, "wave-one") {
+		t.Fatalf("collectEngramChanges = %v; a change with an archive report is finished and must not be offered as active (#3008)", changes)
+	}
+	if !slices.Contains(changes, "in-flight") {
+		t.Fatalf("collectEngramChanges = %v, want the unarchived change still listed", changes)
+	}
+}
+
+// TestArchivedEngramChangeStillResolvesWhenNamed keeps the exclusion scoped to
+// discovery. Asking "which changes are in flight" and asking "show me this
+// change" are different questions, and an archived change must still answer the
+// second one — its artifacts are the audit trail.
+func TestArchivedEngramChangeStillResolvesWhenNamed(t *testing.T) {
+	observations := []engramObservation{
+		engramArtifact("demo", "sdd/wave-one/proposal"),
+		engramArtifact("demo", "sdd/wave-one/tasks"),
+		engramArtifact("demo", "sdd/wave-one/archive-report"),
+	}
+
+	artifacts := engramArtifactsForChange(observations, "demo", "wave-one")
+	if len(artifacts) == 0 {
+		t.Fatal("an archived change resolved no artifacts when named explicitly; excluding it from discovery must not erase it")
+	}
+}
+
+// TestArchiveReportAloneDoesNotCreateAChange guards the other direction: a
+// change known only by its archive report is finished by definition and was
+// never active, so it must not appear because the pattern learned a new title.
+func TestArchiveReportAloneDoesNotCreateAChange(t *testing.T) {
+	changes := collectEngramChanges([]engramObservation{
+		engramArtifact("demo", "sdd/only-archived/archive-report"),
+	}, "demo")
+	if len(changes) != 0 {
+		t.Fatalf("collectEngramChanges = %v, want none", changes)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1254,22 +1254,48 @@ func projectFromGitConfig(content string) string {
 	return ""
 }
 
-var engramTitlePattern = regexp.MustCompile(`^sdd/([^/]+)/(proposal|spec|design|tasks|apply-progress|verify-report|review/(?:transaction|policy|ledger|receipt|chain-bundle|gate-context)|state)$`)
+var engramTitlePattern = regexp.MustCompile(`^sdd/([^/]+)/(proposal|spec|design|tasks|apply-progress|verify-report|review/(?:transaction|policy|ledger|receipt|chain-bundle|gate-context)|state|archive-report)$`)
 
 func collectEngramChanges(observations []engramObservation, project string) []string {
+	// An Engram-backed change has no directory to move, so nothing about the
+	// store itself says a change is finished. OpenSpec derives "active" from
+	// what stays out of openspec/changes/archive/; Engram has no equivalent, so
+	// before this every change that ever persisted an artifact was reported
+	// active forever — thirty of them on one real project, seven of those
+	// archived weeks earlier (#3008).
+	//
+	// The archive phase already writes sdd/{change}/archive-report and calls it
+	// the audit trail. That report is the closure signal; it was simply not in
+	// the title pattern, so the one artifact proving a change is done was the
+	// one this never read.
+	archived := map[string]bool{}
 	seen := map[string]bool{}
 	for _, observation := range observations {
 		if !engramObservationMatchesProject(observation, project) {
 			continue
 		}
 		matches := engramTitlePattern.FindStringSubmatch(strings.TrimSpace(observation.Title))
-		if len(matches) != 3 || matches[2] == "state" {
+		if len(matches) != 3 {
 			continue
 		}
-		seen[matches[1]] = true
+		switch matches[2] {
+		case "archive-report":
+			archived[matches[1]] = true
+		case "state":
+			// Progress metadata, not evidence that work exists.
+		default:
+			seen[matches[1]] = true
+		}
 	}
 	changes := make([]string, 0, len(seen))
 	for change := range seen {
+		// Excluded from DISCOVERY only. Naming an archived change still
+		// resolves it through engramArtifactsForChange, because "which changes
+		// are in flight" and "show me this change" are different questions and
+		// the artifacts remain the audit trail.
+		if archived[change] {
+			continue
+		}
 		changes = append(changes, change)
 	}
 	sort.Strings(changes)


### PR DESCRIPTION
An Engram-backed change was never closed. Measured against a real store, 62 SDD changes across four projects:

| Project | Reported active |
|---|---|
| gentle-ai | **30** |
| engram | 15 |
| gentle-pi | 9 |
| gentleman-ai-installer | 8 |

The 30 include `rdd-root-simplification-wave0` through `wave6`, archived weeks ago.

## Why

The two stores archive differently, and only one leaves a trace the resolver reads.

**OpenSpec** moves the directory into `openspec/changes/archive/`, so active is what remains. **Engram** moves nothing, and `sdd-archive/SKILL.md` says so directly:

> there are no `openspec/` directories to move. The archive report in Engram serves as the audit trail.

Archive already writes `sdd/{change}/archive-report`. It was simply not in the title pattern:

```
^sdd/([^/]+)/(proposal|spec|design|tasks|apply-progress|verify-report|review/(?:…)|state)$
```

**The one artifact that proves a change is finished was the one the resolver never read.**

`state` is not a substitute: its documented schema carries `phase`, `artifacts`, `tasks_progress` and `last_updated` with no terminal value, and in the measured store exactly **1 of 62** changes had a `state` observation at all.

## What changes

`archive-report` joins the pattern, and a change that has one is excluded from discovery.

**Scoped to discovery on purpose.** Naming an archived change still resolves it through `engramArtifactsForChange`, because *"which changes are in flight"* and *"show me this change"* are different questions and its artifacts remain the audit trail. A test pins each direction, plus a third for a change known only by its archive report, which was finished by definition and never active.

## Why this matters beyond the count

In a hybrid session the ambiguity list would have grown from the OpenSpec candidates to those plus thirty closed ones. That is why the adjacent fix — consulting Engram in the ambiguous branch — was **not** made first: enumerating more would have made the answer worse, not better. Closure had to come first.

## Not in scope

Historical changes that never produced an archive report stay listed. Closing them is a cleanup or migration, not something this can infer without guessing by date.

The unscoped failure continuation is #2790 and remains open; it belongs to the plugin that constructs it.

## Verification

TDD, RED first. `go test ./...` 66 packages exit 0 · bench module · 90 journeys exit 0 · deadcode ratchet clean.

Closes #3008
Refs #2790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archived changes are now excluded from active change listings.
  - Changes containing only an archive report are no longer discovered as active.
  - Explicitly requested archived changes can still be resolved using their retained artifacts.
  - State metadata alone no longer causes a change to appear active.

- **Tests**
  - Added coverage for archived-change discovery and resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->