### PR TITLE
test(sdd): decoy proving delivery refuses an unreviewed candidate

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -1208,6 +1208,34 @@ func sddBoundPassingFinishCloses(r *journeyRun) error {
 	return nil
 }
 
+// sddDriftAfterApproval moves the candidate AFTER the review approved and bound
+// it, which is the exact state the removed #2956 gate used to intercept: bytes
+// the approved review never saw, about to be settled as passed.
+func sddDriftAfterApproval(sandbox *Sandbox) error {
+	return sandbox.write(filepath.Join(sandbox.Repo, "docs", "attempt.md"),
+		"# attempt\n\nplain prose, no executable content.\nbytes the approved review never saw.\n")
+}
+
+// sddDecoyUnreviewedCandidateIsRefusedAtDelivery is the decoy for #2956.
+//
+// Removing the bound-passing-finish gate rested on one argument: the delivery
+// gates re-derive their verdict from the candidate actually being delivered, so
+// an unreviewed candidate is still refused there, after SDD finishes. That is a
+// claim about a NEGATIVE. gateVerdict's 35-cell table already proves the
+// `changed` relation denies; what it cannot prove is REACHABILITY — that a
+// candidate settled past the removed gate actually arrives at that denial
+// instead of taking a branch where no receipt is evaluated at all.
+//
+// So this plants exactly what the removed guard caught, drift after approval,
+// and measures the live gate. If it ever allows, the justification for removing
+// that gate was wrong and this is where it says so.
+func sddDecoyUnreviewedCandidateIsRefusedAtDelivery(r *journeyRun) error {
+	if provePostApplyAllows(r.sandbox) {
+		return errors.New("the post-apply gate ALLOWS a candidate the approved review never saw; #2956 removed the ledger-side guard on the argument that delivery still refuses this, and it does not")
+	}
+	return nil
+}
+
 func sddBlockedLeafFinish(r *journeyRun) error {
 	if err := proveLeafTopology(r.sandbox, r.sandbox.Scratch["bound"]); err != nil {
 		return err
@@ -1689,7 +1717,10 @@ func sddJourneys() []Journey {
 				{Name: "review start on the corrected candidate", Requires: startCapability, Args: productArgs("review", "start"), After: rememberLineage},
 				{Name: "review finalize", Requires: finalizeCapability, Args: productArgs("review", "finalize"), After: rememberLineage},
 				{Name: "bind the approved review to the change", Requires: bindSDDCapability, Composite: sddBindApprovedReview},
+				{Name: "fixture: the candidate drifts AFTER the review approved it", Fixture: sddDriftAfterApproval},
 				{Name: "the plain passing finish closes over the changed candidate, and keeps the binding", Requires: sddAttemptFinishCapability, Composite: sddBoundPassingFinishCloses},
+				{Name: "decoy: delivery still refuses the unreviewed candidate", Composite: sddDecoyUnreviewedCandidateIsRefusedAtDelivery},
+				{Name: "decoy: delivery still refuses the unreviewed candidate", Composite: sddDecoyUnreviewedCandidateIsRefusedAtDelivery},
 			},
 		},
 		{


### PR DESCRIPTION
#2956 removed the ledger-side gate that refused a passing implementation attempt whose candidate had drifted from the approved review binding. The justification was a claim about a **negative**:

> The delivery gates re-derive their verdict from the candidate actually being delivered, so an unreviewed candidate is still refused there, after SDD finishes.

That shipped in `v2.4.0-rc.6` verified in unit tests and unproven end to end. The release notes name it as the one thing to watch. This closes that gap.

## What was already proven, and what was not

`gateVerdict`'s 35-cell total-function test pins `ShadowRelationChanged → GateInvalidated` with reason `candidate_changed`, for every gate. **That is the verdict.**

What no test covered is **reachability**: that a candidate settled past the removed gate actually *arrives* at that verdict, rather than taking a branch where no receipt is evaluated at all. The removed gate used to intercept this state earlier, so nothing ever exercised what happens once it does not.

A claim about a negative needs a decoy: plant exactly what the removed guard caught, and measure that the remaining path refuses.

## The decoy

`j37` already builds the fixture, so it gains two steps: drift the candidate **after** the review approved and bound it, then measure the live `post-apply` gate.

```go
if provePostApplyAllows(r.sandbox) {
    return errors.New("the post-apply gate ALLOWS a candidate the approved review never saw; " +
        "#2956 removed the ledger-side guard on the argument that delivery still refuses this, and it does not")
}
```

## The first version was vacuous, and the RED check caught it

Worth recording, because it is the whole reason to do the inversion.

The first attempt asserted the gate on j37 as it stood. j37 runs `review start` **after** the correction, so the review approves the *corrected* candidate and the gate legitimately allows. Inverting it passed, which meant the original would have failed for a reason that had nothing to do with #2956. A decoy pointed at the wrong state proves nothing and would have read as a real regression.

The drift has to happen after approval, which is the state the removed gate actually guarded.

## RED capability

Inverting the corrected decoy fails the journey:

```
journeys: 0 completed, 0 unsupported, 1 failed
```

Restored, it passes. A guard that has never been seen red is not a guard.

## Verification

`go test ./...` exit 0 · bench module ok · **90 journeys, 0 not completed**.

Closes #3012
Refs #2956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for candidate changes after review approval.
  * Verified that approved attempts retain their review association and complete successfully.
  * Added checks ensuring delivery is blocked for candidates that have not been reviewed.
  * Added duplicate delivery-gate validation to strengthen journey coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->