### PR TITLE
fix(review): derive provider causal evidence at admission

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -969,10 +969,8 @@ func reviewArtifactModeSafeForOS(mode os.FileMode, directory bool, goos string) 
 // FrozenCandidateContext/reopen machinery, not rebuilt for v3 per the
 // coordinator's minimal-capture-primitive decision -- just enough to
 // confirm which lens/order was captured and under what subject hash. The
-// reviewer's own findings ARE captured and persisted (C-E, fix cycle 3,
-// newLineageCapturedFindings below) even though this response does not echo
-// them back; the response shape reports the CAPTURE binding, not the
-// admission consequence, which is decided at finalize.
+// the provider carrier is captured and persisted even though this response
+// does not echo it back; the response shape reports the capture binding.
 type ReviewFacadeCaptureResultNewLineageResult struct {
 	Operation     string `json:"operation"`
 	LineageID     string `json:"lineage_id"`
@@ -982,21 +980,13 @@ type ReviewFacadeCaptureResultNewLineageResult struct {
 	Preflight     bool   `json:"preflight,omitempty"`
 }
 
-// newLineageCapturedFindings converts the reviewer-contract wire shape
-// (facadeFinding, the SAME shape v2's own reviewer results use) into the
-// reviewtransaction admission shape (FindingEvidence, the SAME shape
-// --admission-findings already reads from a caller-supplied file) -- C-E,
-// Wave 5 fix cycle 3: capture-result validates and persists findings, and
-// finalize feeds them into the EXISTING AdmitCandidateCausalFindings, reused
-// rather than duplicated. ProofRefs (a list) joins into Proof (a single
-// string) with "; ", matching the single free-text Proof field
-// FindingEvidence has always carried for the --admission-findings channel.
-func newLineageCapturedFindings(findings []facadeFinding) []reviewtransaction.FindingEvidence {
-	converted := make([]reviewtransaction.FindingEvidence, len(findings))
+// newLineageProviderClaims converts reviewer findings into claims. The
+// provider derives classification from the frozen Git trees.
+func newLineageProviderClaims(findings []facadeFinding) []reviewtransaction.ProviderCausalEvidence {
+	converted := make([]reviewtransaction.ProviderCausalEvidence, len(findings))
 	for index, finding := range findings {
-		converted[index] = reviewtransaction.FindingEvidence{
-			FindingID: finding.ID, Severity: finding.Severity, Class: finding.EvidenceClass, Causality: finding.CausalDisposition,
-			Proof: strings.Join(finding.ProofRefs, "; "),
+		converted[index] = reviewtransaction.ProviderCausalEvidence{
+			FindingID: finding.ID, Location: finding.Location, ProofRefs: append([]string(nil), finding.ProofRefs...),
 		}
 	}
 	return converted
@@ -1053,7 +1043,11 @@ func runReviewFacadeCaptureResultNewLineage(
 	if result.Findings == nil || result.Evidence == nil {
 		return reviewPreflightError(errors.New("reviewer result requires explicit findings and evidence arrays"))
 	}
-	if err := reviewtransaction.ValidateNewLineageLensResult(authority, lens, order, result.SubjectHash, newLineageCapturedFindings(result.Findings)); err != nil {
+	if result.SubjectHash != wantSubject {
+		return reviewPreflightError(fmt.Errorf("reviewer result subject hash does not match the provider-owned authority; refresh the binding with `gentle-ai review capture-result --cwd <repo> --lineage %s --target <target> --lens %s --order %d --preflight`", lineage, lens, order))
+	}
+	claims := newLineageProviderClaims(result.Findings)
+	if _, err := reviewtransaction.DeriveProviderCausalCarrier(ctx, root, result.SubjectHash, authority.CandidateIdentity, claims); err != nil {
 		return reviewPreflightError(err)
 	}
 	if preflight {
@@ -1066,7 +1060,7 @@ func runReviewFacadeCaptureResultNewLineage(
 	if err != nil {
 		return err
 	}
-	if _, err := store.CaptureLensResult(ctx, record.Revision, lens, order, result.SubjectHash, newLineageCapturedFindings(result.Findings)); err != nil {
+	if _, err := store.CaptureLensResultWithProviderEvidenceAndInspection(ctx, record.Revision, lens, order, result.SubjectHash, result.Inspection, claims); err != nil {
 		return reviewPreflightError(err)
 	}
 	return encodeReviewJSON(stdout, ReviewFacadeCaptureResultNewLineageResult{

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -401,6 +401,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	nativeResult := reviewtransaction.LensResult{
 		Lens: canonicalReviewerResult.Lens, Findings: canonicalReviewerResult.Findings, Evidence: canonicalReviewerResult.Evidence,
 	}
+	var providerCarrier *reviewtransaction.ProviderCausalCarrier
 	// Derive verified candidate-causal IDs from the CANONICALIZED result, not
 	// the raw one: CanonicalCompactLensResult assigns a fallback ID
 	// (`<prefix>-NNN`) to any severe finding submitted without an explicit
@@ -413,13 +414,43 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	if err != nil {
 		return reviewPreflightError(fmt.Errorf("canonicalize reviewer result: %w", err))
 	}
-	candidateCausalIDs, err := verifiedCandidateCausalFindingIDs(ctx, root, state.InitialSnapshot, canonicalForCausality)
-	if err != nil {
-		return reviewPreflightError(err)
+	var candidateCausalIDs []string
+	if subject.Schema == reviewtransaction.ArtifactSubjectSchema {
+		candidate, deriveErr := reviewtransaction.FreezeCandidateIdentity(ctx, root, state.InitialSnapshot, state.PolicyHash)
+		if deriveErr != nil {
+			return reviewPreflightError(fmt.Errorf("derive compact provider candidate: %w", deriveErr))
+		}
+		claims, claimErr := newLineageProviderClaims(subject.Lens, result)
+		if claimErr != nil {
+			return reviewPreflightError(fmt.Errorf("canonicalize compact provider claims: %w", claimErr))
+		}
+		carrier, deriveErr := reviewtransaction.DeriveProviderCausalCarrier(ctx, root, subject.SubjectHash, candidate, claims)
+		if deriveErr != nil {
+			if errors.Is(deriveErr, reviewtransaction.ErrInvalidFindingLocation) {
+				for _, claim := range claims {
+					if claim.Location != "" {
+						return reviewPreflightError(reviewtransaction.NewArtifactLocationAdmissionError(claim.FindingID, claim.Location, deriveErr))
+					}
+				}
+			}
+			return reviewPreflightError(fmt.Errorf("derive compact provider carrier: %w", deriveErr))
+		}
+		binding := compactProviderArtifactBinding(subject, frozen, result.Inspection, candidate)
+		carrier, deriveErr = reviewtransaction.BindProviderCausalCarrier(carrier, binding)
+		if deriveErr != nil {
+			return reviewPreflightError(fmt.Errorf("bind compact provider carrier: %w", deriveErr))
+		}
+		providerCarrier = &carrier
+		candidateCausalIDs = providerCandidateCausalFindingIDs(carrier, canonicalForCausality)
+	} else {
+		candidateCausalIDs, err = verifiedCandidateCausalFindingIDs(ctx, root, state.InitialSnapshot, canonicalForCausality)
+		if err != nil {
+			return reviewPreflightError(err)
+		}
 	}
 	_, admission, err := reviewtransaction.AdmitArtifact(ctx, reviewtransaction.ArtifactAdmissionRequest{
 		ExpectedSubject: subject, FrozenContext: frozen, EchoedSubjectHash: result.SubjectHash,
-		Inspection: result.Inspection, Result: nativeResult, CandidateCausalFindingIDs: candidateCausalIDs,
+		Inspection: result.Inspection, Result: nativeResult, CandidateCausalFindingIDs: candidateCausalIDs, ProviderCausalCarrier: providerCarrier,
 		RawPayload: rawPayload, CanonicalPayload: canonicalResult,
 	})
 	if err != nil {
@@ -436,7 +467,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	_, err = store.CaptureAdmittedReviewerResult(ctx, reviewtransaction.CompactAdmittedReviewerResultRequest{
 		ExpectedRevision: record.Revision, TargetIdentity: *target, FrozenContext: frozen,
 		ArtifactSubject: subject, Inspection: result.Inspection, Result: nativeResult,
-		CandidateCausalFindingIDs: candidateCausalIDs, RawPayload: rawPayload,
+		CandidateCausalFindingIDs: candidateCausalIDs, ProviderCausalCarrier: providerCarrier, RawPayload: rawPayload,
 		PreparePublication: func(current reviewtransaction.CompactState) error {
 			return archiveQuarantinedReviewerArtifact(store.Dir, current, *order, path)
 		},
@@ -847,6 +878,7 @@ func decodeAdmittedReviewerResult(ctx context.Context, payload []byte, expected 
 		ExpectedSubject: expected, FrozenContext: frozen, EchoedSubjectHash: envelope.Result.SubjectHash,
 		Inspection: envelope.Result.Inspection, Result: native,
 		CandidateCausalFindingIDs: envelope.Admission.CandidateCausalFindingIDs,
+		ProviderCausalCarrier:     envelope.Result.Provider,
 		RawPayload:                canonical, CanonicalPayload: canonical,
 	})
 	if err != nil || revalidated.Decision != reviewtransaction.ArtifactAdmissionCompleted ||
@@ -854,6 +886,32 @@ func decodeAdmittedReviewerResult(ctx context.Context, payload []byte, expected 
 		return facadeReviewerResult{}, errors.New("captured reviewer result no longer satisfies its admission record")
 	}
 	return envelope.Result, nil
+}
+
+func compactProviderArtifactBinding(subject reviewtransaction.ArtifactSubject, frozen reviewtransaction.FrozenCandidateContext, inspection reviewtransaction.ArtifactInspection, candidate reviewtransaction.CandidateIdentity) reviewtransaction.NewLineageArtifactBinding {
+	return reviewtransaction.NewLineageArtifactBinding{
+		Subject: reviewtransaction.NewLineageArtifactSubject{
+			Schema: subject.Schema, SubjectHash: subject.SubjectHash, LineageID: subject.LineageID,
+			RepositoryID: candidate.RepositoryID, BaseTree: subject.BaseTree, CandidateTree: subject.CandidateTree,
+			ChangedPathManifestSHA256: subject.ChangedPathManifestSHA256, Lens: subject.Lens, SelectedOrder: subject.SelectedOrder,
+		},
+		FrozenPathManifest: append([]reviewtransaction.ChangedPathManifestEntry(nil), frozen.ChangedPathManifest...), Inspection: inspection,
+	}
+}
+
+func providerCandidateCausalFindingIDs(carrier reviewtransaction.ProviderCausalCarrier, result reviewtransaction.LensResult) []string {
+	severe := make(map[string]bool, len(result.Findings))
+	for _, finding := range result.Findings {
+		severe[finding.ID] = facadeSevere(finding.Severity)
+	}
+	ids := make([]string, 0, len(carrier.Findings))
+	for _, finding := range carrier.Findings {
+		if finding.Classification == reviewtransaction.ProviderCandidateCausal && severe[finding.FindingID] {
+			ids = append(ids, finding.FindingID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func verifiedCandidateCausalFindingIDs(ctx context.Context, repo string, snapshot reviewtransaction.Snapshot, result reviewtransaction.LensResult) ([]string, error) {
@@ -982,14 +1040,28 @@ type ReviewFacadeCaptureResultNewLineageResult struct {
 
 // newLineageProviderClaims converts reviewer findings into claims. The
 // provider derives classification from the frozen Git trees.
-func newLineageProviderClaims(findings []facadeFinding) []reviewtransaction.ProviderCausalEvidence {
-	converted := make([]reviewtransaction.ProviderCausalEvidence, len(findings))
-	for index, finding := range findings {
-		converted[index] = reviewtransaction.ProviderCausalEvidence{
-			FindingID: finding.ID, Location: finding.Location, ProofRefs: append([]string(nil), finding.ProofRefs...),
+func newLineageProviderClaims(lens string, result facadeReviewerResult) ([]reviewtransaction.ProviderCausalEvidence, error) {
+	findings := make([]reviewtransaction.Finding, len(result.Findings))
+	for index, finding := range result.Findings {
+		findings[index] = reviewtransaction.Finding{
+			ID: finding.ID, Lens: finding.Lens, Location: finding.Location, Severity: finding.Severity,
+			Claim: finding.Claim, ProofRefs: finding.ProofRefs, EvidenceClass: finding.EvidenceClass,
+			CausalDisposition: finding.CausalDisposition,
 		}
 	}
-	return converted
+	canonical, err := reviewtransaction.CanonicalCompactLensResult(reviewtransaction.LensResult{Lens: lens, Findings: findings, Evidence: result.Evidence})
+	if err != nil {
+		return nil, err
+	}
+	claims := make([]reviewtransaction.ProviderCausalEvidence, len(canonical.Findings))
+	for index, finding := range canonical.Findings {
+		raw := result.Findings[index]
+		claims[index] = reviewtransaction.ProviderCausalEvidence{
+			FindingID: finding.ID, Location: finding.Location, ProofRefs: append([]string(nil), finding.ProofRefs...),
+			CausalDisposition: finding.CausalDisposition, BaseProofRefs: append([]string(nil), raw.BaseProofRefs...), CandidateProofRefs: append([]string(nil), raw.CandidateProofRefs...),
+		}
+	}
+	return claims, nil
 }
 
 // runReviewFacadeCaptureResultNewLineage is C-A's CLI wiring for the minimal
@@ -1046,7 +1118,10 @@ func runReviewFacadeCaptureResultNewLineage(
 	if result.SubjectHash != wantSubject {
 		return reviewPreflightError(fmt.Errorf("reviewer result subject hash does not match the provider-owned authority; refresh the binding with `gentle-ai review capture-result --cwd <repo> --lineage %s --target <target> --lens %s --order %d --preflight`", lineage, lens, order))
 	}
-	claims := newLineageProviderClaims(result.Findings)
+	claims, err := newLineageProviderClaims(lens, result)
+	if err != nil {
+		return reviewPreflightError(fmt.Errorf("canonicalize provider claims: %w", err))
+	}
 	if _, err := reviewtransaction.DeriveProviderCausalCarrier(ctx, root, result.SubjectHash, authority.CandidateIdentity, claims); err != nil {
 		return reviewPreflightError(err)
 	}

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -99,6 +99,19 @@ func TestReviewCaptureResultStrictBindingReplayAndFinalize(t *testing.T) {
 	}
 }
 
+func TestNewLineageProviderClaimsCanonicalizesMissingIDsAndPreservesProofInputs(t *testing.T) {
+	claims, err := newLineageProviderClaims(reviewtransaction.LensReliability, facadeReviewerResult{
+		Findings: []facadeFinding{{Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "candidate regression", ProofRefs: []string{"tracked.txt:1"}, CausalDisposition: reviewtransaction.CausalIntroduced, BaseProofRefs: []string{"tracked.txt:1"}, CandidateProofRefs: []string{"tracked.txt:1"}}},
+		Evidence: []string{"reviewed"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claims) != 1 || claims[0].FindingID != "R3-001" || claims[0].CausalDisposition != reviewtransaction.CausalIntroduced || len(claims[0].BaseProofRefs) != 1 || len(claims[0].CandidateProofRefs) != 1 {
+		t.Fatalf("canonical provider claims = %#v", claims)
+	}
+}
+
 func TestReviewCaptureResultAdmitsOneJSONEnvelopeInsideProse(t *testing.T) {
 	repo, started, _, record := newArtifactReview(t, false)
 	payload := admittedReviewerPayloadForTest(t, repo, record, record.State.SelectedLenses[0], 0)
@@ -355,6 +368,43 @@ func TestReviewCaptureResultRejectsInvalidLocationWithActionableDiagnostic(t *te
 		admissionErr.Diagnostic.Location != "tracked.txt:1-2,3" ||
 		admissionErr.Diagnostic.Reason != "line_suffix_not_integer" {
 		t.Fatalf("capture diagnostic = %#v", admissionErr.Diagnostic)
+	}
+}
+
+func TestReviewCaptureResultPersistsProviderCarrierForV2CompactAdmission(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		disposition reviewtransaction.CausalDisposition
+		wantClass   reviewtransaction.ProviderCausalClassification
+	}{
+		{name: "canonical candidate causal", disposition: reviewtransaction.CausalIntroduced, wantClass: reviewtransaction.ProviderCandidateCausal},
+		{name: "behavior activated without differential proof", disposition: reviewtransaction.CausalBehaviorActivated, wantClass: reviewtransaction.ProviderUnknown},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, started, store, record := newArtifactReview(t, false)
+			result := admittedReviewerResultForTest(t, repo, record, record.State.SelectedLenses[0], 0)
+			result.Findings = []facadeFinding{{
+				Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "candidate finding", ProofRefs: []string{"tracked.txt:1"},
+				EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: tt.disposition,
+			}}
+			input := filepath.Join(t.TempDir(), "result.json")
+			writeReviewCLIJSON(t, input, result)
+			if err := RunReviewCaptureResult([]string{
+				"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+				"--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input,
+			}, io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			payload, err := os.ReadFile(filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir, "00-"+record.State.SelectedLenses[0]+".json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var envelope admittedReviewerResult
+			decodeStrictReviewJSON(t, payload, &envelope)
+			if envelope.Result.Provider == nil || len(envelope.Result.Provider.Findings) != 1 || envelope.Result.Provider.Findings[0].FindingID != "R3-001" || envelope.Result.Provider.Findings[0].Classification != tt.wantClass {
+				t.Fatalf("persisted provider carrier = %#v", envelope.Result.Provider)
+			}
+		})
 	}
 }
 

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -459,22 +459,25 @@ type ReviewRecoverResult struct {
 }
 
 type facadeFinding struct {
-	ID                string                              `json:"id,omitempty"`
-	Lens              string                              `json:"lens,omitempty"`
-	Location          string                              `json:"location,omitempty"`
-	Severity          string                              `json:"severity,omitempty"`
-	Claim             string                              `json:"claim,omitempty"`
-	ProofRefs         []string                            `json:"proof_refs,omitempty"`
-	EvidenceClass     reviewtransaction.EvidenceClass     `json:"evidence_class,omitempty"`
-	CausalDisposition reviewtransaction.CausalDisposition `json:"causal_disposition,omitempty"`
+	ID                 string                              `json:"id,omitempty"`
+	Lens               string                              `json:"lens,omitempty"`
+	Location           string                              `json:"location,omitempty"`
+	Severity           string                              `json:"severity,omitempty"`
+	Claim              string                              `json:"claim,omitempty"`
+	ProofRefs          []string                            `json:"proof_refs,omitempty"`
+	EvidenceClass      reviewtransaction.EvidenceClass     `json:"evidence_class,omitempty"`
+	CausalDisposition  reviewtransaction.CausalDisposition `json:"causal_disposition,omitempty"`
+	BaseProofRefs      []string                            `json:"base_proof_refs,omitempty"`
+	CandidateProofRefs []string                            `json:"candidate_proof_refs,omitempty"`
 }
 
 type facadeReviewerResult struct {
-	SubjectHash string                               `json:"subject_hash"`
-	Inspection  reviewtransaction.ArtifactInspection `json:"inspection"`
-	Lens        string                               `json:"lens,omitempty"`
-	Findings    []facadeFinding                      `json:"findings"`
-	Evidence    []string                             `json:"evidence"`
+	SubjectHash string                                   `json:"subject_hash"`
+	Inspection  reviewtransaction.ArtifactInspection     `json:"inspection"`
+	Lens        string                                   `json:"lens,omitempty"`
+	Findings    []facadeFinding                          `json:"findings"`
+	Evidence    []string                                 `json:"evidence"`
+	Provider    *reviewtransaction.ProviderCausalCarrier `json:"provider,omitempty"`
 }
 
 type facadeValidationCheck struct {

--- a/internal/cli/review_new_lineage_capture_test.go
+++ b/internal/cli/review_new_lineage_capture_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -78,7 +79,7 @@ func captureNewLineageLensResults(t *testing.T, repo, lineage string, lenses []s
 		}
 
 		inputPath := filepath.Join(t.TempDir(), lens+".json")
-		payload := `{"subject_hash":"` + preflight.SubjectHash + `","findings":[],"evidence":["reviewed"]}`
+		payload := `{"subject_hash":"` + preflight.SubjectHash + `","inspection":{"status":"completed","paths":["lib/` + lineage + `.go"]},"findings":[],"evidence":["reviewed"]}`
 		if err := os.WriteFile(inputPath, []byte(payload), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -118,7 +119,7 @@ func TestReviewFacadeCaptureResultNewLineage_InputPreflightDoesNotCapture(t *tes
 	}
 	gitBefore := runReviewCLIGit(t, repo, "status", "--porcelain=v1")
 	input := filepath.Join(t.TempDir(), "result.json")
-	if err := os.WriteFile(input, []byte(`{"subject_hash":"`+wantSubject+`","findings":[],"evidence":["reviewed"]}`), 0o600); err != nil {
+	if err := os.WriteFile(input, []byte(`{"subject_hash":"`+wantSubject+`","inspection":{"status":"completed","paths":["lib/`+lineage+`.go"]},"findings":[],"evidence":["reviewed"]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	args := []string{
@@ -156,6 +157,38 @@ func TestReviewFacadeCaptureResultNewLineage_InputPreflightDoesNotCapture(t *tes
 	after, found, err := reviewtransaction.DiscoverNewLineage(t.Context(), repo, lineage)
 	if err != nil || !found || len(after.Authority.CapturedResults) != 1 {
 		t.Fatalf("real capture did not persist normally: %#v, %t, %v", after, found, err)
+	}
+}
+
+func TestReviewFacadeCaptureResultNewLineage_InputPreflightRejectsForeignSubjectHash(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "new-lineage-foreign-subject-preflight"
+	started := startMediumTierNewLineage(t, repo, lineage)
+	lens := started.SelectedLenses[0]
+	before, found, err := reviewtransaction.DiscoverNewLineage(t.Context(), repo, lineage)
+	if err != nil || !found {
+		t.Fatalf("discover new-lineage authority: %#v, %t, %v", before, found, err)
+	}
+	wantSubject := reviewtransaction.NewLineageArtifactSubjectHash(before.Authority, lens, 0)
+	foreignSubject := "sha256:" + strings.Repeat("0", 64)
+	input := filepath.Join(t.TempDir(), "foreign-subject.json")
+	if err := os.WriteFile(input, []byte(`{"subject_hash":"`+foreignSubject+`","inspection":{"status":"completed","paths":["lib/`+lineage+`.go"]},"findings":[],"evidence":["reviewed"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	err = RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", "unused-for-new-lineage",
+		"--lens", lens, "--order", "0", "--input", input, "--preflight",
+	}, &output)
+	if err == nil || !strings.Contains(err.Error(), "subject hash") {
+		t.Fatalf("foreign subject hash preflight error = %v, want subject-hash binding refusal", err)
+	}
+	if got := output.Len(); got != 0 {
+		t.Fatalf("foreign subject hash preflight emitted %d bytes, want none", got)
+	}
+	if wantSubject == foreignSubject {
+		t.Fatal("test fixture accidentally used the provider-owned subject hash")
 	}
 }
 
@@ -228,13 +261,9 @@ func TestReviewFacadeCaptureResultNewLineage_MediumTierFinalizeAllowsAllFiveGate
 // reviewer-reported, deterministic, candidate-introduced BLOCKER never
 // reached AdmitCandidateCausalFindings, and finalize --captured-results
 // issued `approved` where the identical input escalates on the
-// --admission-findings channel. This test submits the identical BLOCKER
-// shape the verify report used (severity BLOCKER, evidence_class
-// deterministic, causal_disposition introduced) through the real capture
-// CLI and asserts finalize now escalates with the finding admitted -- the
-// SAME outcome (blocks) the v2/compact path reaches as correction_required
-// and the v3 --admission-findings channel already reached as escalated.
-func TestReviewFacadeCaptureResultNewLineage_CandidateCausalBlockerEscalates(t *testing.T) {
+// --admission-findings channel. S1 stops at capture: it must persist the
+// provider-derived carrier, while replay/finalize projection remains S2.
+func TestReviewFacadeCaptureResultNewLineage_PersistsCandidateCausalCarrier(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
 	const lineage = "candidate-causal-blocker-lineage"
@@ -254,17 +283,18 @@ func TestReviewFacadeCaptureResultNewLineage_CandidateCausalBlockerEscalates(t *
 	inputPath := filepath.Join(t.TempDir(), "blocker.json")
 	payload := `{
 		"subject_hash": "` + preflight.SubjectHash + `",
+		"inspection": {"status": "completed", "paths": ["lib/candidate-causal-blocker-lineage.go"]},
 		"findings": [{
 			"id": "R3-boom-div-zero",
 			"lens": "` + lens + `",
-			"location": "lib/boom.go:1",
+		"location": "lib/candidate-causal-blocker-lineage.go:1",
 			"severity": "BLOCKER",
 			"claim": "candidate introduces a division by zero",
-			"proof_refs": ["lib/boom.go:1"],
+			"proof_refs": ["lib/candidate-causal-blocker-lineage.go:1"],
 			"evidence_class": "deterministic",
 			"causal_disposition": "introduced"
 		}],
-		"evidence": ["reviewed lib/boom.go and confirmed the divide-by-zero"]
+		"evidence": ["reviewed lib/candidate-causal-blocker-lineage.go and confirmed the divide-by-zero"]
 	}`
 	if err := os.WriteFile(inputPath, []byte(payload), 0o644); err != nil {
 		t.Fatal(err)
@@ -277,17 +307,20 @@ func TestReviewFacadeCaptureResultNewLineage_CandidateCausalBlockerEscalates(t *
 		t.Fatalf("capture-result with a candidate-causal BLOCKER: %v\n%s", err, captureOut.String())
 	}
 
-	var finalizeOut bytes.Buffer
-	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--captured-results=true"}, &finalizeOut); err != nil {
-		t.Fatalf("finalize after capturing a candidate-causal BLOCKER: %v\n%s", err, finalizeOut.String())
+	store, err := reviewtransaction.NewLineageAuthorityStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatalf("open captured authority: %v", err)
 	}
-	var finalized ReviewFacadeFinalizeNewLineageResult
-	decodeStrictReviewJSON(t, finalizeOut.Bytes(), &finalized)
-	if finalized.State != reviewtransaction.NewLineageStateEscalated {
-		t.Fatalf("finalize after a captured candidate-causal BLOCKER = %q, want escalated (CRITICAL-E: a captured BLOCKER must not silently approve)", finalized.State)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("load captured authority: %v", err)
 	}
-	if len(finalized.AdmittedFindingIDs) != 1 || finalized.AdmittedFindingIDs[0] != "R3-boom-div-zero" {
-		t.Fatalf("admitted_finding_ids = %v, want exactly [R3-boom-div-zero]", finalized.AdmittedFindingIDs)
+	if len(record.Authority.CapturedResults) != 1 {
+		t.Fatalf("captured results = %d, want 1", len(record.Authority.CapturedResults))
+	}
+	findings := record.Authority.CapturedResults[0].Provider.Findings
+	if len(findings) != 1 || findings[0].FindingID != "R3-boom-div-zero" || findings[0].Classification != reviewtransaction.ProviderCandidateCausal {
+		t.Fatalf("persisted provider findings = %#v, want one candidate-causal finding", findings)
 	}
 }
 
@@ -317,17 +350,18 @@ func TestReviewFacadeCaptureResultNewLineage_NonCausalFindingDoesNotBlock(t *tes
 	inputPath := filepath.Join(t.TempDir(), "pre-existing.json")
 	payload := `{
 		"subject_hash": "` + preflight.SubjectHash + `",
+		"inspection": {"status": "completed", "paths": ["lib/non-causal-finding-lineage.go"]},
 		"findings": [{
 			"id": "pre-existing-finding",
 			"lens": "` + lens + `",
-			"location": "lib/legacy.go:1",
+		"location": "lib/non-causal-finding-lineage.go:1",
 			"severity": "WARNING",
 			"claim": "pre-existing issue, not introduced by this candidate",
-			"proof_refs": ["lib/legacy.go:1"],
+			"proof_refs": ["lib/non-causal-finding-lineage.go:1"],
 			"evidence_class": "deterministic",
 			"causal_disposition": "pre_existing"
 		}],
-		"evidence": ["reviewed lib/legacy.go"]
+		"evidence": ["reviewed lib/non-causal-finding-lineage.go"]
 	}`
 	if err := os.WriteFile(inputPath, []byte(payload), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -60,6 +60,7 @@ type ArtifactAdmissionRequest struct {
 	// causality the provider verified against repository-derived changed-line
 	// evidence before admission.
 	CandidateCausalFindingIDs []string
+	ProviderCausalCarrier     *ProviderCausalCarrier
 	RawPayload                []byte
 	CanonicalPayload          []byte
 }
@@ -348,6 +349,24 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 		}
 		return fail(ArtifactAdmissionIncomplete, err.Error())
 	}
+	if request.ProviderCausalCarrier != nil {
+		carrier := *request.ProviderCausalCarrier
+		if err := carrier.Validate(); err != nil || carrier.SubjectHash != request.ExpectedSubject.SubjectHash || carrier.CandidateIdentity.BaseTree != request.FrozenContext.BaseTree || carrier.CandidateIdentity.CandidateTree != request.FrozenContext.CandidateTree {
+			return fail(ArtifactAdmissionBindingMismatch, "provider causal carrier does not bind the frozen artifact")
+		}
+		findingIDs := make(map[string]bool, len(canonical.Findings))
+		for _, finding := range canonical.Findings {
+			findingIDs[finding.ID] = isSevereSeverity(finding.Severity)
+		}
+		for _, finding := range carrier.Findings {
+			if _, ok := findingIDs[finding.FindingID]; !ok {
+				return fail(ArtifactAdmissionBindingMismatch, "provider causal carrier finding is outside the canonical reviewer result")
+			}
+		}
+		if len(carrier.Findings) != len(canonical.Findings) {
+			return fail(ArtifactAdmissionBindingMismatch, "provider causal carrier does not cover the canonical reviewer result")
+		}
+	}
 	repository, cleanup, err := newFrozenRepositoryPathLookup(ctx, request.FrozenContext)
 	if err != nil {
 		return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup is unavailable")
@@ -409,6 +428,22 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 	verifiedIDs, err := canonicalStrings(request.CandidateCausalFindingIDs, "candidate-causal finding id")
 	if err != nil {
 		return fail(ArtifactAdmissionIncomplete, err.Error())
+	}
+	if request.ProviderCausalCarrier != nil {
+		wantCandidateCausalIDs = wantCandidateCausalIDs[:0]
+		severeFindingIDs := make(map[string]bool, len(canonical.Findings))
+		for _, finding := range canonical.Findings {
+			severeFindingIDs[finding.ID] = isSevereSeverity(finding.Severity)
+		}
+		for _, finding := range request.ProviderCausalCarrier.Findings {
+			if finding.Classification == ProviderCandidateCausal && severeFindingIDs[finding.FindingID] {
+				wantCandidateCausalIDs = append(wantCandidateCausalIDs, finding.FindingID)
+			}
+		}
+		wantCandidateCausalIDs, wantErr = canonicalStrings(wantCandidateCausalIDs, "candidate-causal finding id")
+		if wantErr != nil {
+			return fail(ArtifactAdmissionIncomplete, wantErr.Error())
+		}
 	}
 	// Both sides are canonicalized before comparing: a submission that names
 	// the same candidate-causal findings in a different order or with

--- a/internal/reviewtransaction/authority_store.go
+++ b/internal/reviewtransaction/authority_store.go
@@ -119,10 +119,11 @@ type NewLineageAuthority struct {
 // no reopen) -- only the findings themselves, fed into the existing
 // AdmitCandidateCausalFindings at finalize time.
 type NewLineageCapturedResult struct {
-	Lens        string            `json:"lens"`
-	Order       int               `json:"order"`
-	SubjectHash string            `json:"subject_hash"`
-	Findings    []FindingEvidence `json:"findings,omitempty"`
+	Lens        string                `json:"lens"`
+	Order       int                   `json:"order"`
+	SubjectHash string                `json:"subject_hash"`
+	Findings    []FindingEvidence     `json:"findings,omitempty"`
+	Provider    ProviderCausalCarrier `json:"provider,omitempty"`
 }
 
 // CapturedLensNames returns the plain lens-name list
@@ -222,6 +223,17 @@ func (authority NewLineageAuthority) Validate() error {
 		for _, finding := range captured.Findings {
 			if strings.TrimSpace(finding.FindingID) == "" {
 				return errors.New("new-lineage authority captured findings must carry a non-empty finding id") // refusal:by-design world-action: captured findings are only ever written by AuthorityStore.CaptureLensResult from an already-decoded reviewer result; a malformed entry here means in-process corruption, not something an operator command repairs
+			}
+		}
+		if captured.Provider.SubjectHash != "" {
+			if err := captured.Provider.Validate(); err != nil {
+				return fmt.Errorf("captured provider carrier: %w", err)
+			}
+			if captured.Provider.SubjectHash != captured.SubjectHash || captured.Provider.CandidateIdentity != authority.CandidateIdentity {
+				return errors.New("captured provider carrier subject does not match result") // refusal:by-design operator-knowledge: persisted carrier binding is contradictory
+			}
+			if err := captured.Provider.ArtifactBinding.Validate(authority, captured.Lens, captured.Order, captured.SubjectHash); err != nil {
+				return fmt.Errorf("captured provider artifact binding: %w", err)
 			}
 		}
 	}

--- a/internal/reviewtransaction/compact_result_reopen.go
+++ b/internal/reviewtransaction/compact_result_reopen.go
@@ -74,11 +74,12 @@ type compactAdmittedReviewerResult struct {
 }
 
 type compactProviderReviewerResult struct {
-	SubjectHash string             `json:"subject_hash"`
-	Inspection  ArtifactInspection `json:"inspection"`
-	Lens        string             `json:"lens,omitempty"`
-	Findings    []Finding          `json:"findings"`
-	Evidence    []string           `json:"evidence"`
+	SubjectHash string                 `json:"subject_hash"`
+	Inspection  ArtifactInspection     `json:"inspection"`
+	Lens        string                 `json:"lens,omitempty"`
+	Findings    []Finding              `json:"findings"`
+	Evidence    []string               `json:"evidence"`
+	Provider    *ProviderCausalCarrier `json:"provider,omitempty"`
 }
 
 // CompactReviewerResultSlot is one immutable reviewer-result publication slot.
@@ -413,6 +414,7 @@ func reAdmitCompactReviewerResult(ctx context.Context, envelope compactAdmittedR
 		Inspection:                provider.Inspection,
 		Result:                    LensResult{Lens: expected.Lens, Findings: provider.Findings, Evidence: provider.Evidence},
 		CandidateCausalFindingIDs: envelope.Admission.CandidateCausalFindingIDs,
+		ProviderCausalCarrier:     provider.Provider,
 		RawPayload:                canonicalPayload, CanonicalPayload: canonicalPayload,
 	})
 	if err != nil || admission.Decision != ArtifactAdmissionCompleted ||

--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -23,6 +23,7 @@ type CompactAdmittedReviewerResultRequest struct {
 	Inspection                ArtifactInspection
 	Result                    LensResult
 	CandidateCausalFindingIDs []string
+	ProviderCausalCarrier     *ProviderCausalCarrier
 	RawPayload                []byte
 	// PreparePublication performs caller-owned quarantine work under the authority lock.
 	PreparePublication func(CompactState) error
@@ -120,6 +121,9 @@ func (store CompactStore) CaptureAdmittedReviewerResult(
 	if err := ValidateArtifactSubject(request.ArtifactSubject); err != nil {
 		return LensResult{}, err
 	}
+	if request.ArtifactSubject.Schema == ArtifactSubjectSchema && request.ProviderCausalCarrier == nil {
+		return LensResult{}, errors.New("v2 compact reviewer capture requires a provider causal carrier")
+	}
 	if request.ArtifactSubject.AuthorityRevision != request.ExpectedRevision ||
 		request.Result.Lens != request.ArtifactSubject.Lens {
 		return LensResult{}, errors.New(
@@ -149,6 +153,7 @@ func (store CompactStore) CaptureAdmittedReviewerResult(
 		Lens:        request.ArtifactSubject.Lens,
 		Findings:    canonicalResult.Findings,
 		Evidence:    canonicalResult.Evidence,
+		Provider:    request.ProviderCausalCarrier,
 	}
 	canonicalPayload, err := json.Marshal(providerResult)
 	if err != nil {
@@ -199,6 +204,7 @@ func (store CompactStore) CaptureAdmittedReviewerResult(
 					Inspection:                canonicalInspection,
 					Result:                    canonicalResult,
 					CandidateCausalFindingIDs: request.CandidateCausalFindingIDs,
+					ProviderCausalCarrier:     request.ProviderCausalCarrier,
 					RawPayload:                request.RawPayload,
 					CanonicalPayload:          canonicalPayload,
 				},
@@ -243,7 +249,8 @@ func (store CompactStore) CaptureAdmittedReviewerResult(
 				ExpectedSubject: request.ArtifactSubject, FrozenContext: request.FrozenContext,
 				EchoedSubjectHash: request.ArtifactSubject.SubjectHash, Inspection: canonicalInspection,
 				Result: request.Result, CandidateCausalFindingIDs: request.CandidateCausalFindingIDs,
-				RawPayload: request.RawPayload, CanonicalPayload: canonicalPayload,
+				ProviderCausalCarrier: request.ProviderCausalCarrier,
+				RawPayload:            request.RawPayload, CanonicalPayload: canonicalPayload,
 			})
 			if admissionErr == nil {
 				replayed, found, replayErr := store.resolveAdmittedReviewerResult(

--- a/internal/reviewtransaction/new_lineage_capture.go
+++ b/internal/reviewtransaction/new_lineage_capture.go
@@ -30,8 +30,82 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 )
+
+type NewLineageArtifactSubject struct {
+	Schema                    string `json:"schema"`
+	SubjectHash               string `json:"subject_hash"`
+	LineageID                 string `json:"lineage_id"`
+	RepositoryID              string `json:"repository_id"`
+	BaseTree                  string `json:"base_tree"`
+	CandidateTree             string `json:"candidate_tree"`
+	ChangedPathManifestSHA256 string `json:"changed_path_manifest_sha256"`
+	Lens                      string `json:"lens"`
+	SelectedOrder             int    `json:"selected_order"`
+}
+
+type NewLineageArtifactBinding struct {
+	Subject            NewLineageArtifactSubject  `json:"subject"`
+	FrozenPathManifest []ChangedPathManifestEntry `json:"frozen_path_manifest"`
+	Inspection         ArtifactInspection         `json:"inspection"`
+}
+
+func (binding NewLineageArtifactBinding) Validate(authority NewLineageAuthority, lens string, order int, subjectHash string) error {
+	if binding.Subject.Schema != "gentle-ai.new-lineage-artifact-subject/v1" || binding.Subject.SubjectHash != subjectHash || binding.Subject.SubjectHash != NewLineageArtifactSubjectHash(authority, lens, order) || binding.Subject.LineageID != authority.LineageID || binding.Subject.BaseTree != authority.CandidateIdentity.BaseTree || binding.Subject.CandidateTree != authority.CandidateIdentity.CandidateTree || binding.Subject.Lens != lens || binding.Subject.SelectedOrder != order {
+		return errors.New("new-lineage artifact subject does not bind the frozen authority") // refusal:by-design operator-knowledge: capture must use the exact frozen subject
+	}
+	if binding.Inspection.Status != ArtifactInspectionCompleted {
+		return errors.New("new-lineage artifact inspection is not completed") // refusal:by-design operator-knowledge: incomplete provider inspection cannot be admitted
+	}
+	if err := ValidateChangedPathManifest(binding.FrozenPathManifest); err != nil {
+		return errors.New("new-lineage artifact frozen manifest is not canonical") // refusal:by-design operator-knowledge: provider coverage must bind the exact frozen path set
+	}
+	coverage, coverageErr := validateCompleteInspectionCoverage(binding.Inspection.Paths, binding.FrozenPathManifest)
+	if coverageErr != nil || coverage != nil {
+		return errors.New("new-lineage artifact inspection does not cover the frozen manifest") // refusal:by-design operator-knowledge: canonical inspection evidence is required
+	}
+	return nil
+}
+
+func NewLineageArtifactBindingForAuthority(ctx context.Context, repo string, authority NewLineageAuthority, lens string, order int, inspection ArtifactInspection) (NewLineageArtifactBinding, error) {
+	if order < 0 || order >= len(authority.SelectedLenses) || authority.SelectedLenses[order] != lens {
+		return NewLineageArtifactBinding{}, ErrNewLineageCaptureLensNotSelected
+	}
+	manifest, err := frozenNewLineagePathManifest(ctx, repo, authority.CandidateIdentity)
+	if err != nil {
+		return NewLineageArtifactBinding{}, err
+	}
+	binding := NewLineageArtifactBinding{Subject: NewLineageArtifactSubject{Schema: "gentle-ai.new-lineage-artifact-subject/v1", SubjectHash: NewLineageArtifactSubjectHash(authority, lens, order), LineageID: authority.LineageID, RepositoryID: authority.CandidateIdentity.RepositoryID, BaseTree: authority.CandidateIdentity.BaseTree, CandidateTree: authority.CandidateIdentity.CandidateTree, ChangedPathManifestSHA256: authority.CandidateIdentity.ChangedPathsModesDigest, Lens: lens, SelectedOrder: order}, FrozenPathManifest: manifest, Inspection: inspection}
+	return binding, binding.Validate(authority, lens, order, binding.Subject.SubjectHash)
+}
+
+func frozenNewLineagePathManifest(ctx context.Context, repo string, candidate CandidateIdentity) ([]ChangedPathManifestEntry, error) {
+	raw, err := runGit(ctx, repo, nil, nil, "diff", "--raw", "-z", "--no-renames", "--no-ext-diff", "--no-textconv", candidate.BaseTree, candidate.CandidateTree, "--")
+	if err != nil {
+		return nil, err
+	}
+	modes, err := parseRawDiffModes(raw)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(modes))
+	for path := range modes {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	manifest := make([]ChangedPathManifestEntry, 0, len(paths))
+	for _, path := range paths {
+		mode := modes[path]
+		entry := ChangedPathManifestEntry{Path: path, Status: mode.status, OldMode: mode.oldMode, NewMode: mode.newMode, Deleted: mode.status == CandidatePathDeleted, TypeChanged: mode.status == CandidatePathTypeChanged, ModeOnly: mode.status == CandidatePathModified && mode.oldObject == mode.newObject && mode.oldMode != mode.newMode}
+		if err := validateChangedPathManifestEntry(entry); err != nil {
+			return nil, err
+		}
+		manifest = append(manifest, entry)
+	}
+	return manifest, nil
+}
 
 // NewLineageArtifactSubjectHash is C-A's minimal provider-owned binding: it
 // proves a reviewer result was computed against THIS exact frozen authority
@@ -119,6 +193,47 @@ func (store AuthorityStore) CaptureLensResult(ctx context.Context, expectedRevis
 		next.CapturedResults = append(append([]NewLineageCapturedResult(nil), next.CapturedResults...), NewLineageCapturedResult{
 			Lens: lens, Order: order, SubjectHash: subjectHash, Findings: normalizedFindings,
 		})
+		return nil
+	}); err != nil {
+		return NewLineageRecord{}, err
+	}
+	return store.Load()
+}
+
+func (store AuthorityStore) CaptureLensResultWithProviderEvidenceAndInspection(ctx context.Context, expectedRevision, lens string, order int, subjectHash string, inspection ArtifactInspection, claims []ProviderCausalEvidence) (NewLineageRecord, error) {
+	record, err := store.Load()
+	if err != nil {
+		return NewLineageRecord{}, err
+	}
+	binding, err := NewLineageArtifactBindingForAuthority(ctx, store.repo, record.Authority, lens, order, inspection)
+	if err != nil {
+		return NewLineageRecord{}, err
+	}
+	carrier, err := DeriveProviderCausalCarrier(ctx, store.repo, subjectHash, record.Authority.CandidateIdentity, claims)
+	if err != nil {
+		return NewLineageRecord{}, err
+	}
+	if err := binding.Validate(record.Authority, lens, order, subjectHash); err != nil {
+		return NewLineageRecord{}, err
+	}
+	carrier.ArtifactBinding = binding
+	carrier.AggregateDigest = providerAggregateDigest(carrier)
+	if _, err := store.Mutate(ctx, expectedRevision, func(next *NewLineageAuthority) error {
+		if next.State != NewLineageStateReviewing && next.State != NewLineageStateValidating {
+			return fmt.Errorf("%w: lineage %q is %q", ErrNewLineageCaptureNotReviewable, next.LineageID, next.State)
+		}
+		if order < 0 || order >= len(next.SelectedLenses) || next.SelectedLenses[order] != lens || subjectHash != NewLineageArtifactSubjectHash(*next, lens, order) {
+			return ErrNewLineageCaptureSubjectMismatch
+		}
+		for _, existing := range next.CapturedResults {
+			if existing.Lens == lens {
+				if existing.SubjectHash == subjectHash && reflect.DeepEqual(existing.Provider, carrier) {
+					return nil
+				}
+				return fmt.Errorf("%w: lineage %q lens %q", ErrNewLineageCaptureConflict, next.LineageID, lens)
+			}
+		}
+		next.CapturedResults = append(next.CapturedResults, NewLineageCapturedResult{Lens: lens, Order: order, SubjectHash: subjectHash, Provider: carrier})
 		return nil
 	}); err != nil {
 		return NewLineageRecord{}, err

--- a/internal/reviewtransaction/new_lineage_capture_test.go
+++ b/internal/reviewtransaction/new_lineage_capture_test.go
@@ -289,3 +289,73 @@ func TestCaptureLensResult_RefusesSevereFindingMissingEvidenceOrCausality(t *tes
 		}
 	})
 }
+
+func TestCaptureLensResult_DerivesAndBindsProviderCarrier(t *testing.T) {
+	store, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	subject := NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0)
+	claims := []ProviderCausalEvidence{{
+		FindingID: "R3-002", Location: "tracked.txt:1",
+		ProofRefs: []string{"tracked.txt:1", " tracked.txt:1 "},
+	}, {
+		FindingID: "R3-001", Location: "tracked.txt:1",
+		ProofRefs: []string{"tracked.txt:1"},
+	}}
+	inspection := ArtifactInspection{Status: ArtifactInspectionCompleted, Paths: []string{}}
+
+	updated, err := store.CaptureLensResultWithProviderEvidenceAndInspection(
+		context.Background(), record.Revision, "review-reliability", 0, subject, inspection, claims,
+	)
+	if err != nil {
+		t.Fatalf("provider capture: %v", err)
+	}
+	if len(updated.Authority.CapturedResults) != 1 {
+		t.Fatalf("captured results = %#v", updated.Authority.CapturedResults)
+	}
+	carrier := updated.Authority.CapturedResults[0].Provider
+	if carrier.SubjectHash != subject || carrier.ArtifactBinding.Subject.SubjectHash != subject {
+		t.Fatalf("carrier binding = %#v, want subject %q", carrier, subject)
+	}
+	if len(carrier.Findings) != 2 || carrier.Findings[0].FindingID != "R3-001" || carrier.Findings[1].FindingID != "R3-002" {
+		t.Fatalf("carrier findings = %#v, want canonical finding order", carrier.Findings)
+	}
+	if carrier.Findings[0].Classification != ProviderUnknown || carrier.Findings[1].Classification != ProviderUnknown {
+		t.Fatalf("carrier classifications = %#v, want frozen-tree derived unknown", carrier.Findings)
+	}
+	if carrier.Findings[1].ProofRefs[0] != "tracked.txt:1" || carrier.Findings[1].EvidenceDigest == "" || carrier.AggregateDigest == "" {
+		t.Fatalf("carrier canonical evidence = %#v", carrier)
+	}
+	if err := carrier.Validate(); err != nil {
+		t.Fatalf("persisted carrier failed validation: %v", err)
+	}
+}
+
+func TestNewLineageArtifactBinding_InspectionExactlyCoversFrozenManifest(t *testing.T) {
+	_, record := newLineageCaptureFixtureStore(t, []string{"review-reliability"})
+	binding := NewLineageArtifactBinding{
+		Subject: NewLineageArtifactSubject{
+			Schema: "gentle-ai.new-lineage-artifact-subject/v1", SubjectHash: NewLineageArtifactSubjectHash(record.Authority, "review-reliability", 0),
+			LineageID: record.Authority.LineageID, BaseTree: record.Authority.CandidateIdentity.BaseTree, CandidateTree: record.Authority.CandidateIdentity.CandidateTree,
+			Lens: "review-reliability", SelectedOrder: 0,
+		},
+		FrozenPathManifest: []ChangedPathManifestEntry{{Path: "tracked.txt", Status: CandidatePathModified, OldMode: "100644", NewMode: "100644"}},
+	}
+
+	t.Run("accepted coverage is canonical and complete", func(t *testing.T) {
+		binding.Inspection = ArtifactInspection{Status: ArtifactInspectionCompleted, Paths: []string{"tracked.txt"}}
+		if err := binding.Validate(record.Authority, "review-reliability", 0, binding.Subject.SubjectHash); err != nil {
+			t.Fatalf("complete inspection was refused: %v", err)
+		}
+	})
+	t.Run("incomplete coverage is refused", func(t *testing.T) {
+		binding.Inspection = ArtifactInspection{Status: ArtifactInspectionCompleted, Paths: nil}
+		if err := binding.Validate(record.Authority, "review-reliability", 0, binding.Subject.SubjectHash); err == nil {
+			t.Fatal("completed inspection with a missing frozen path was accepted")
+		}
+	})
+	t.Run("foreign coverage is refused", func(t *testing.T) {
+		binding.Inspection = ArtifactInspection{Status: ArtifactInspectionCompleted, Paths: []string{"other.txt"}}
+		if err := binding.Validate(record.Authority, "review-reliability", 0, binding.Subject.SubjectHash); err == nil {
+			t.Fatal("completed inspection with a foreign path was accepted")
+		}
+	})
+}

--- a/internal/reviewtransaction/provider_causal_classification.go
+++ b/internal/reviewtransaction/provider_causal_classification.go
@@ -23,17 +23,22 @@ const (
 // ProviderCausalEvidence contains reviewer claims. Classification is ignored;
 // the frozen Git trees are the authority used to derive the carrier.
 type ProviderCausalEvidence struct {
-	FindingID string   `json:"finding_id"`
-	Location  string   `json:"location"`
-	ProofRefs []string `json:"proof_refs"`
+	FindingID          string            `json:"finding_id"`
+	Location           string            `json:"location"`
+	ProofRefs          []string          `json:"proof_refs"`
+	CausalDisposition  CausalDisposition `json:"causal_disposition,omitempty"`
+	BaseProofRefs      []string          `json:"base_proof_refs,omitempty"`
+	CandidateProofRefs []string          `json:"candidate_proof_refs,omitempty"`
 }
 
 type ProviderCausalFinding struct {
-	FindingID      string                       `json:"finding_id"`
-	Location       string                       `json:"location"`
-	ProofRefs      []string                     `json:"proof_refs"`
-	Classification ProviderCausalClassification `json:"classification"`
-	EvidenceDigest string                       `json:"evidence_digest"`
+	FindingID          string                       `json:"finding_id"`
+	Location           string                       `json:"location"`
+	ProofRefs          []string                     `json:"proof_refs"`
+	BaseProofRefs      []string                     `json:"base_proof_refs,omitempty"`
+	CandidateProofRefs []string                     `json:"candidate_proof_refs,omitempty"`
+	Classification     ProviderCausalClassification `json:"classification"`
+	EvidenceDigest     string                       `json:"evidence_digest"`
 }
 
 type ProviderCausalCarrier struct {
@@ -42,6 +47,11 @@ type ProviderCausalCarrier struct {
 	ArtifactBinding   NewLineageArtifactBinding `json:"artifact_binding"`
 	Findings          []ProviderCausalFinding   `json:"findings"`
 	AggregateDigest   string                    `json:"aggregate_digest"`
+}
+
+type frozenProofComparison struct {
+	Comparable bool
+	Differs    bool
 }
 
 func (carrier ProviderCausalCarrier) Validate() error {
@@ -53,15 +63,22 @@ func (carrier ProviderCausalCarrier) Validate() error {
 		if finding.FindingID == "" || seen[finding.FindingID] || i > 0 && finding.FindingID < carrier.Findings[i-1].FindingID {
 			return errors.New("provider causal carrier finding IDs are not canonical") // refusal:by-design operator-knowledge: canonical IDs are required before persistence
 		}
-		if finding.Location != strings.TrimSpace(finding.Location) || !canonicalProviderProofRefsOrdered(finding.ProofRefs) {
+		if finding.Location != strings.TrimSpace(finding.Location) || !canonicalProviderProofRefsOrdered(finding.ProofRefs) || !canonicalProviderProofRefsOrdered(finding.BaseProofRefs) || !canonicalProviderProofRefsOrdered(finding.CandidateProofRefs) {
 			return errors.New("provider causal carrier proof references are not canonical") // refusal:by-design operator-knowledge: proof order is part of persisted authority
+		}
+		if len(finding.BaseProofRefs) > 0 && !canonicalProviderProofRefsParseable(finding.BaseProofRefs) || len(finding.CandidateProofRefs) > 0 && !canonicalProviderProofRefsParseable(finding.CandidateProofRefs) {
+			return errors.New("provider causal carrier proof references are not parseable") // refusal:by-design operator-knowledge: persisted frozen proof locations must use the native location grammar
 		}
 		switch finding.Classification {
 		case ProviderCandidateCausal:
 			if len(finding.ProofRefs) == 0 || !canonicalProviderProofRefsParseable(finding.ProofRefs) {
 				return errors.New("candidate-causal provider finding requires proof references") // refusal:by-design operator-knowledge: candidate causality requires affirmative frozen proof
 			}
-		case ProviderProvenNonCandidate, ProviderUnknown:
+		case ProviderProvenNonCandidate:
+			if len(finding.BaseProofRefs) == 0 || len(finding.CandidateProofRefs) == 0 || !canonicalProviderProofRefsParseable(finding.BaseProofRefs) || !canonicalProviderProofRefsParseable(finding.CandidateProofRefs) {
+				return errors.New("proven-non-candidate provider finding requires base and candidate proof references") // refusal:by-design operator-knowledge: non-causality requires affirmative frozen proof on both sides
+			}
+		case ProviderUnknown:
 		default:
 			return errors.New("provider causal carrier classification is unsupported") // refusal:by-design operator-knowledge: the provider classification domain is closed
 		}
@@ -80,6 +97,9 @@ func (carrier ProviderCausalCarrier) Validate() error {
 }
 
 func canonicalProviderProofRefs(refs []string) []string {
+	if len(refs) == 0 {
+		return nil
+	}
 	seen := map[string]bool{}
 	result := make([]string, 0, len(refs))
 	for _, ref := range refs {
@@ -115,6 +135,8 @@ func canonicalProviderClaims(claims []ProviderCausalEvidence) ([]ProviderCausalE
 		result[i].FindingID = strings.TrimSpace(result[i].FindingID)
 		result[i].Location = strings.TrimSpace(result[i].Location)
 		result[i].ProofRefs = canonicalProviderProofRefs(result[i].ProofRefs)
+		result[i].BaseProofRefs = canonicalProviderProofRefs(result[i].BaseProofRefs)
+		result[i].CandidateProofRefs = canonicalProviderProofRefs(result[i].CandidateProofRefs)
 		if result[i].FindingID == "" {
 			return nil, errors.New("provider causal evidence requires a finding ID") // refusal:by-design operator-knowledge: provider evidence needs a stable canonical ID
 		}
@@ -136,10 +158,12 @@ func canonicalProviderClaims(claims []ProviderCausalEvidence) ([]ProviderCausalE
 
 func providerFindingDigest(f ProviderCausalFinding) string {
 	payload, _ := json.Marshal(struct {
-		ID, Location string
-		Proof        []string
-		Class        ProviderCausalClassification
-	}{f.FindingID, f.Location, f.ProofRefs, f.Classification})
+		ID, Location   string
+		Proof          []string
+		BaseProof      []string
+		CandidateProof []string
+		Class          ProviderCausalClassification
+	}{f.FindingID, f.Location, f.ProofRefs, f.BaseProofRefs, f.CandidateProofRefs, f.Classification})
 	sum := sha256.Sum256(append([]byte("gentle-ai.provider-causal-finding/v1\x00"), payload...))
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
@@ -169,16 +193,36 @@ func DeriveProviderCausalCarrier(ctx context.Context, repo, subjectHash string, 
 	carrier := ProviderCausalCarrier{SubjectHash: subjectHash, CandidateIdentity: candidate, Findings: make([]ProviderCausalFinding, 0, len(canonical))}
 	for _, claim := range canonical {
 		classification := ProviderUnknown
+		changed := false
 		if claim.Location != "" {
-			changed, err := frozenCandidateLineChanged(ctx, repo, candidate, claim.Location)
+			changed, err = frozenCandidateLineChanged(ctx, repo, candidate, claim.Location)
 			if err != nil {
 				return ProviderCausalCarrier{}, err
 			}
-			if changed && len(claim.ProofRefs) > 0 && canonicalProviderProofRefsHaveFrozenEvidence(ctx, repo, candidate, claim.ProofRefs) {
+		}
+		candidateProof := canonicalProviderProofRefsHaveFrozenEvidence(ctx, repo, candidate.CandidateTree, claim.CandidateProofRefs)
+		baseProof := canonicalProviderProofRefsHaveFrozenEvidence(ctx, repo, candidate.BaseTree, claim.BaseProofRefs)
+		comparison := frozenDifferentialProof(ctx, repo, candidate, claim.BaseProofRefs, claim.CandidateProofRefs)
+		switch claim.CausalDisposition {
+		case CausalBehaviorActivated:
+			// A changed location alone does not establish an activated behavior.
+			if changed && len(claim.ProofRefs) > 0 && canonicalProviderProofRefsHaveChangedFrozenEvidence(ctx, repo, candidate, claim.ProofRefs) && comparison.Comparable && comparison.Differs {
+				classification = ProviderCandidateCausal
+			}
+		case CausalPreExisting:
+			if baseProof && candidateProof && comparison.Comparable && !comparison.Differs {
+				classification = ProviderProvenNonCandidate
+			}
+		case CausalBaseOnly:
+			if baseProof && candidateProof && comparison.Comparable && comparison.Differs {
+				classification = ProviderProvenNonCandidate
+			}
+		default:
+			if changed && len(claim.ProofRefs) > 0 && canonicalProviderProofRefsHaveChangedFrozenEvidence(ctx, repo, candidate, claim.ProofRefs) {
 				classification = ProviderCandidateCausal
 			}
 		}
-		finding := ProviderCausalFinding{FindingID: claim.FindingID, Location: claim.Location, ProofRefs: claim.ProofRefs, Classification: classification}
+		finding := ProviderCausalFinding{FindingID: claim.FindingID, Location: claim.Location, ProofRefs: claim.ProofRefs, BaseProofRefs: claim.BaseProofRefs, CandidateProofRefs: claim.CandidateProofRefs, Classification: classification}
 		finding.EvidenceDigest = providerFindingDigest(finding)
 		carrier.Findings = append(carrier.Findings, finding)
 	}
@@ -186,7 +230,24 @@ func DeriveProviderCausalCarrier(ctx context.Context, repo, subjectHash string, 
 	return carrier, nil
 }
 
-func canonicalProviderProofRefsHaveFrozenEvidence(ctx context.Context, repo string, candidate CandidateIdentity, refs []string) bool {
+// BindProviderCausalCarrier attaches the exact provider artifact binding and
+// refreshes the content digests before persistence.
+func BindProviderCausalCarrier(carrier ProviderCausalCarrier, binding NewLineageArtifactBinding) (ProviderCausalCarrier, error) {
+	if carrier.SubjectHash == "" || binding.Subject.SubjectHash != carrier.SubjectHash {
+		return ProviderCausalCarrier{}, errors.New("provider causal carrier binding does not match its subject")
+	}
+	carrier.ArtifactBinding = binding
+	for index := range carrier.Findings {
+		carrier.Findings[index].EvidenceDigest = providerFindingDigest(carrier.Findings[index])
+	}
+	carrier.AggregateDigest = providerAggregateDigest(carrier)
+	if err := carrier.Validate(); err != nil {
+		return ProviderCausalCarrier{}, err
+	}
+	return carrier, nil
+}
+
+func canonicalProviderProofRefsHaveChangedFrozenEvidence(ctx context.Context, repo string, candidate CandidateIdentity, refs []string) bool {
 	if !canonicalProviderProofRefsParseable(refs) {
 		return false
 	}
@@ -197,6 +258,57 @@ func canonicalProviderProofRefsHaveFrozenEvidence(ctx context.Context, repo stri
 		}
 	}
 	return true
+}
+
+func canonicalProviderProofRefsHaveFrozenEvidence(ctx context.Context, repo, tree string, refs []string) bool {
+	if !canonicalProviderProofRefsParseable(refs) {
+		return false
+	}
+	for _, ref := range refs {
+		if !frozenTreeLocationEvidence(ctx, repo, tree, ref) {
+			return false
+		}
+	}
+	return true
+}
+
+func frozenTreeLocationEvidence(ctx context.Context, repo, tree, location string) bool {
+	parsed, err := parseFindingLocation(location)
+	if err != nil {
+		return false
+	}
+	content, err := runGit(ctx, repo, nil, nil, "cat-file", "blob", tree+":"+parsed.Path)
+	if err != nil {
+		return false
+	}
+	return len(strings.Split(string(content), "\n")) >= parsed.EndLine
+}
+
+func frozenDifferentialProof(ctx context.Context, repo string, candidate CandidateIdentity, baseRefs, candidateRefs []string) frozenProofComparison {
+	if len(baseRefs) == 0 || len(candidateRefs) == 0 || len(baseRefs) != len(candidateRefs) {
+		return frozenProofComparison{}
+	}
+	comparison := frozenProofComparison{Comparable: true}
+	for index, baseRef := range baseRefs {
+		candidateRef := candidateRefs[index]
+		base, baseErr := parseFindingLocation(baseRef)
+		current, candidateErr := parseFindingLocation(candidateRef)
+		if baseErr != nil || candidateErr != nil || base.Path != current.Path || base.StartLine != current.StartLine || base.EndLine != current.EndLine {
+			return frozenProofComparison{}
+		}
+		if !frozenTreeLocationEvidence(ctx, repo, candidate.BaseTree, baseRef) || !frozenTreeLocationEvidence(ctx, repo, candidate.CandidateTree, candidateRef) {
+			return frozenProofComparison{}
+		}
+		baseContent, baseErr := runGit(ctx, repo, nil, nil, "cat-file", "blob", candidate.BaseTree+":"+base.Path)
+		candidateContent, candidateErr := runGit(ctx, repo, nil, nil, "cat-file", "blob", candidate.CandidateTree+":"+current.Path)
+		if baseErr != nil || candidateErr != nil {
+			return frozenProofComparison{}
+		}
+		if string(baseContent) != string(candidateContent) {
+			comparison.Differs = true
+		}
+	}
+	return comparison
 }
 
 var providerHunk = regexp.MustCompile(`(?m)^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)

--- a/internal/reviewtransaction/provider_causal_classification.go
+++ b/internal/reviewtransaction/provider_causal_classification.go
@@ -1,0 +1,229 @@
+package reviewtransaction
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type ProviderCausalClassification string
+
+const (
+	ProviderCandidateCausal    ProviderCausalClassification = "candidate-causal"
+	ProviderProvenNonCandidate ProviderCausalClassification = "proven-non-candidate"
+	ProviderUnknown            ProviderCausalClassification = "unknown"
+)
+
+// ProviderCausalEvidence contains reviewer claims. Classification is ignored;
+// the frozen Git trees are the authority used to derive the carrier.
+type ProviderCausalEvidence struct {
+	FindingID string   `json:"finding_id"`
+	Location  string   `json:"location"`
+	ProofRefs []string `json:"proof_refs"`
+}
+
+type ProviderCausalFinding struct {
+	FindingID      string                       `json:"finding_id"`
+	Location       string                       `json:"location"`
+	ProofRefs      []string                     `json:"proof_refs"`
+	Classification ProviderCausalClassification `json:"classification"`
+	EvidenceDigest string                       `json:"evidence_digest"`
+}
+
+type ProviderCausalCarrier struct {
+	SubjectHash       string                    `json:"subject_hash"`
+	CandidateIdentity CandidateIdentity         `json:"candidate_identity"`
+	ArtifactBinding   NewLineageArtifactBinding `json:"artifact_binding"`
+	Findings          []ProviderCausalFinding   `json:"findings"`
+	AggregateDigest   string                    `json:"aggregate_digest"`
+}
+
+func (carrier ProviderCausalCarrier) Validate() error {
+	if !validSHA256(carrier.SubjectHash) || carrier.CandidateIdentity == (CandidateIdentity{}) {
+		return errors.New("provider causal carrier binding is incomplete") // refusal:by-design operator-knowledge: malformed provider authority requires fresh capture
+	}
+	seen := map[string]bool{}
+	for i, finding := range carrier.Findings {
+		if finding.FindingID == "" || seen[finding.FindingID] || i > 0 && finding.FindingID < carrier.Findings[i-1].FindingID {
+			return errors.New("provider causal carrier finding IDs are not canonical") // refusal:by-design operator-knowledge: canonical IDs are required before persistence
+		}
+		if finding.Location != strings.TrimSpace(finding.Location) || !canonicalProviderProofRefsOrdered(finding.ProofRefs) {
+			return errors.New("provider causal carrier proof references are not canonical") // refusal:by-design operator-knowledge: proof order is part of persisted authority
+		}
+		switch finding.Classification {
+		case ProviderCandidateCausal:
+			if len(finding.ProofRefs) == 0 || !canonicalProviderProofRefsParseable(finding.ProofRefs) {
+				return errors.New("candidate-causal provider finding requires proof references") // refusal:by-design operator-knowledge: candidate causality requires affirmative frozen proof
+			}
+		case ProviderProvenNonCandidate, ProviderUnknown:
+		default:
+			return errors.New("provider causal carrier classification is unsupported") // refusal:by-design operator-knowledge: the provider classification domain is closed
+		}
+		if finding.EvidenceDigest != providerFindingDigest(finding) {
+			return errors.New("provider causal finding digest does not match its content") // refusal:by-design operator-knowledge: persisted evidence integrity failed
+		}
+		seen[finding.FindingID] = true
+	}
+	if carrier.AggregateDigest != providerAggregateDigest(carrier) {
+		return errors.New("provider causal carrier digest does not match its content") // refusal:by-design operator-knowledge: persisted carrier integrity failed
+	}
+	if carrier.ArtifactBinding.Subject.SubjectHash != carrier.SubjectHash {
+		return errors.New("provider causal carrier artifact binding does not match its subject") // refusal:by-design operator-knowledge: capture binding is contradictory
+	}
+	return nil
+}
+
+func canonicalProviderProofRefs(refs []string) []string {
+	seen := map[string]bool{}
+	result := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref != "" && !seen[ref] {
+			seen[ref] = true
+			result = append(result, ref)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+func canonicalProviderProofRefsOrdered(refs []string) bool {
+	for i, ref := range refs {
+		if ref == "" || ref != strings.TrimSpace(ref) || i > 0 && refs[i-1] >= ref {
+			return false
+		}
+	}
+	return true
+}
+func canonicalProviderProofRefsParseable(refs []string) bool {
+	for _, ref := range refs {
+		if _, err := parseFindingLocation(ref); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalProviderClaims(claims []ProviderCausalEvidence) ([]ProviderCausalEvidence, error) {
+	result := append([]ProviderCausalEvidence(nil), claims...)
+	for i := range result {
+		result[i].FindingID = strings.TrimSpace(result[i].FindingID)
+		result[i].Location = strings.TrimSpace(result[i].Location)
+		result[i].ProofRefs = canonicalProviderProofRefs(result[i].ProofRefs)
+		if result[i].FindingID == "" {
+			return nil, errors.New("provider causal evidence requires a finding ID") // refusal:by-design operator-knowledge: provider evidence needs a stable canonical ID
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].FindingID != result[j].FindingID {
+			return result[i].FindingID < result[j].FindingID
+		}
+		return result[i].Location < result[j].Location
+	})
+	unique := result[:0]
+	for _, claim := range result {
+		if len(unique) == 0 || unique[len(unique)-1].FindingID != claim.FindingID {
+			unique = append(unique, claim)
+		}
+	}
+	return unique, nil
+}
+
+func providerFindingDigest(f ProviderCausalFinding) string {
+	payload, _ := json.Marshal(struct {
+		ID, Location string
+		Proof        []string
+		Class        ProviderCausalClassification
+	}{f.FindingID, f.Location, f.ProofRefs, f.Classification})
+	sum := sha256.Sum256(append([]byte("gentle-ai.provider-causal-finding/v1\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+func providerAggregateDigest(c ProviderCausalCarrier) string {
+	parts := make([]string, len(c.Findings))
+	for i, f := range c.Findings {
+		parts[i] = f.EvidenceDigest
+	}
+	payload, _ := json.Marshal(struct {
+		Subject   string
+		Candidate CandidateIdentity
+		Binding   NewLineageArtifactBinding
+		Findings  []string
+	}{c.SubjectHash, c.CandidateIdentity, c.ArtifactBinding, parts})
+	sum := sha256.Sum256(append([]byte("gentle-ai.provider-causal-carrier/v1\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func DeriveProviderCausalCarrier(ctx context.Context, repo, subjectHash string, candidate CandidateIdentity, claims []ProviderCausalEvidence) (ProviderCausalCarrier, error) {
+	if !validSHA256(subjectHash) || !validGitTree(candidate.BaseTree) || !validGitTree(candidate.CandidateTree) {
+		return ProviderCausalCarrier{}, errors.New("provider causal derivation requires a valid frozen candidate") // refusal:by-design operator-knowledge: capture cannot proceed without frozen trees
+	}
+	canonical, err := canonicalProviderClaims(claims)
+	if err != nil {
+		return ProviderCausalCarrier{}, err
+	}
+	carrier := ProviderCausalCarrier{SubjectHash: subjectHash, CandidateIdentity: candidate, Findings: make([]ProviderCausalFinding, 0, len(canonical))}
+	for _, claim := range canonical {
+		classification := ProviderUnknown
+		if claim.Location != "" {
+			changed, err := frozenCandidateLineChanged(ctx, repo, candidate, claim.Location)
+			if err != nil {
+				return ProviderCausalCarrier{}, err
+			}
+			if changed && len(claim.ProofRefs) > 0 && canonicalProviderProofRefsHaveFrozenEvidence(ctx, repo, candidate, claim.ProofRefs) {
+				classification = ProviderCandidateCausal
+			}
+		}
+		finding := ProviderCausalFinding{FindingID: claim.FindingID, Location: claim.Location, ProofRefs: claim.ProofRefs, Classification: classification}
+		finding.EvidenceDigest = providerFindingDigest(finding)
+		carrier.Findings = append(carrier.Findings, finding)
+	}
+	carrier.AggregateDigest = providerAggregateDigest(carrier)
+	return carrier, nil
+}
+
+func canonicalProviderProofRefsHaveFrozenEvidence(ctx context.Context, repo string, candidate CandidateIdentity, refs []string) bool {
+	if !canonicalProviderProofRefsParseable(refs) {
+		return false
+	}
+	for _, ref := range refs {
+		changed, err := frozenCandidateLineChanged(ctx, repo, candidate, ref)
+		if err != nil || !changed {
+			return false
+		}
+	}
+	return true
+}
+
+var providerHunk = regexp.MustCompile(`(?m)^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+func frozenCandidateLineChanged(ctx context.Context, repo string, candidate CandidateIdentity, location string) (bool, error) {
+	parsed, err := parseFindingLocation(location)
+	if err != nil {
+		return false, err
+	}
+	path := parsed.Path
+	output, err := runGit(ctx, repo, nil, nil, "diff", "--unified=0", "--no-renames", "--no-ext-diff", "--no-textconv", candidate.BaseTree, candidate.CandidateTree, "--", literalPathspec(path))
+	if err != nil {
+		return false, err
+	}
+	coveredThrough := parsed.StartLine
+	for _, match := range providerHunk.FindAllSubmatch(output, -1) {
+		start, _ := strconv.Atoi(string(match[1]))
+		count := 1
+		if len(match[2]) > 0 {
+			count, _ = strconv.Atoi(string(match[2]))
+		}
+		if count > 0 && start <= coveredThrough && start+count > coveredThrough {
+			coveredThrough = start + count
+			if coveredThrough > parsed.EndLine {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/internal/reviewtransaction/provider_causal_classification_test.go
+++ b/internal/reviewtransaction/provider_causal_classification_test.go
@@ -27,6 +27,13 @@ func TestDeriveProviderCausalCarrierRequiresAffirmativeProofTreeEvidence(t *test
 		{name: "affirmative changed line", claim: ProviderCausalEvidence{FindingID: "R3-affirmative", Location: "tracked.txt:1", ProofRefs: []string{"tracked.txt:1"}}, want: ProviderCandidateCausal},
 		{name: "proof references unchanged path", claim: ProviderCausalEvidence{FindingID: "R3-mismatched", Location: "tracked.txt:1", ProofRefs: []string{"other.txt:1"}}, want: ProviderUnknown},
 		{name: "range is not fully changed", claim: ProviderCausalEvidence{FindingID: "R3-partial-range", Location: "tracked.txt:1-2", ProofRefs: []string{"tracked.txt:1-2"}}, want: ProviderUnknown},
+		{name: "behavior activated without differential proof", claim: ProviderCausalEvidence{FindingID: "R3-behavior", Location: "tracked.txt:1", ProofRefs: []string{"tracked.txt:1"}, CausalDisposition: CausalBehaviorActivated}, want: ProviderUnknown},
+		{name: "behavior activated with differential proof", claim: ProviderCausalEvidence{FindingID: "R3-behavior-diff", Location: "tracked.txt:1", ProofRefs: []string{"tracked.txt:1"}, BaseProofRefs: []string{"tracked.txt:1"}, CandidateProofRefs: []string{"tracked.txt:1"}, CausalDisposition: CausalBehaviorActivated}, want: ProviderCandidateCausal},
+		{name: "pre-existing with affirmative both-tree proof", claim: ProviderCausalEvidence{FindingID: "R3-pre-existing", Location: "other.txt:1", ProofRefs: []string{"other.txt:1"}, BaseProofRefs: []string{"other.txt:1"}, CandidateProofRefs: []string{"other.txt:1"}, CausalDisposition: CausalPreExisting}, want: ProviderProvenNonCandidate},
+		{name: "base-only with changed paired proof", claim: ProviderCausalEvidence{FindingID: "R3-base-only", Location: "tracked.txt:1", ProofRefs: []string{"tracked.txt:1"}, BaseProofRefs: []string{"tracked.txt:1"}, CandidateProofRefs: []string{"tracked.txt:1"}, CausalDisposition: CausalBaseOnly}, want: ProviderProvenNonCandidate},
+		{name: "pre-existing with mismatched proof paths", claim: ProviderCausalEvidence{FindingID: "R3-mismatched-pair", Location: "other.txt:1", ProofRefs: []string{"other.txt:1"}, BaseProofRefs: []string{"other.txt:1"}, CandidateProofRefs: []string{"tracked.txt:1"}, CausalDisposition: CausalPreExisting}, want: ProviderUnknown},
+		{name: "pre-existing with missing proof", claim: ProviderCausalEvidence{FindingID: "R3-missing-proof", Location: "other.txt:1", ProofRefs: []string{"other.txt:1"}, BaseProofRefs: []string{"missing.txt:1"}, CandidateProofRefs: []string{"missing.txt:1"}, CausalDisposition: CausalPreExisting}, want: ProviderUnknown},
+		{name: "pre-existing with unpaired proof", claim: ProviderCausalEvidence{FindingID: "R3-unpaired-proof", Location: "other.txt:1", ProofRefs: []string{"other.txt:1"}, BaseProofRefs: []string{"other.txt:1"}, CandidateProofRefs: []string{}, CausalDisposition: CausalPreExisting}, want: ProviderUnknown},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			carrier, err := DeriveProviderCausalCarrier(context.Background(), repo, subject, candidate, []ProviderCausalEvidence{tt.claim})
@@ -35,6 +42,31 @@ func TestDeriveProviderCausalCarrierRequiresAffirmativeProofTreeEvidence(t *test
 			}
 			if got := carrier.Findings[0].Classification; got != tt.want {
 				t.Fatalf("classification = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProviderCausalCarrierRejectsMalformedFrozenProofReferences(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*ProviderCausalFinding)
+	}{
+		{name: "malformed base proof", mutate: func(finding *ProviderCausalFinding) { finding.BaseProofRefs = []string{"not-a-location"} }},
+		{name: "malformed candidate proof", mutate: func(finding *ProviderCausalFinding) { finding.CandidateProofRefs = []string{"not-a-location"} }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			finding := ProviderCausalFinding{
+				FindingID: "R3-001", BaseProofRefs: []string{"tracked.txt:1"}, CandidateProofRefs: []string{"tracked.txt:1"}, Classification: ProviderProvenNonCandidate,
+			}
+			tt.mutate(&finding)
+			finding.EvidenceDigest = providerFindingDigest(finding)
+			carrier := ProviderCausalCarrier{
+				SubjectHash: hash("a"), CandidateIdentity: CandidateIdentity{RepositoryID: "repo"}, Findings: []ProviderCausalFinding{finding},
+			}
+			carrier.AggregateDigest = providerAggregateDigest(carrier)
+			if err := carrier.Validate(); err == nil || !strings.Contains(err.Error(), "proof references are not parseable") {
+				t.Fatalf("Validate() error = %v, want malformed proof refusal", err)
 			}
 		})
 	}

--- a/internal/reviewtransaction/provider_causal_classification_test.go
+++ b/internal/reviewtransaction/provider_causal_classification_test.go
@@ -1,0 +1,41 @@
+package reviewtransaction
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestDeriveProviderCausalCarrierRequiresAffirmativeProofTreeEvidence(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nunchanged\n")
+	writeSnapshotFile(t, repo, "other.txt", "unchanged\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt", "other.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	baseTree := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\nunchanged\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	candidateTree := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	candidate := CandidateIdentity{RepositoryID: "repo", BaseTree: baseTree, CandidateTree: candidateTree, PolicyHash: "sha256:" + hash("policy")}
+	subject := hash("a")
+	for _, tt := range []struct {
+		name  string
+		claim ProviderCausalEvidence
+		want  ProviderCausalClassification
+	}{
+		{name: "affirmative changed line", claim: ProviderCausalEvidence{FindingID: "R3-affirmative", Location: "tracked.txt:1", ProofRefs: []string{"tracked.txt:1"}}, want: ProviderCandidateCausal},
+		{name: "proof references unchanged path", claim: ProviderCausalEvidence{FindingID: "R3-mismatched", Location: "tracked.txt:1", ProofRefs: []string{"other.txt:1"}}, want: ProviderUnknown},
+		{name: "range is not fully changed", claim: ProviderCausalEvidence{FindingID: "R3-partial-range", Location: "tracked.txt:1-2", ProofRefs: []string{"tracked.txt:1-2"}}, want: ProviderUnknown},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			carrier, err := DeriveProviderCausalCarrier(context.Background(), repo, subject, candidate, []ProviderCausalEvidence{tt.claim})
+			if err != nil {
+				t.Fatalf("DeriveProviderCausalCarrier: %v", err)
+			}
+			if got := carrier.Findings[0].Classification; got != tt.want {
+				t.Fatalf("classification = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1757

## PR Type
- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## Summary
- Derives provider-owned tri-state causal classifications from frozen evidence before compact and new-lineage admission.
- Canonicalizes finding IDs, binds candidate/base proof, and persists deterministic carrier and aggregate digests.
- Preserves historical/legacy semantics while requiring carriers for native v2 captures.

## Changes
| File / Area | What Changed |
|---|---|
| `internal/reviewtransaction` | Provider carrier derivation, affirmative proof validation, differential behavior evidence, binding and digest checks. |
| `internal/reviewtransaction/artifact_admission.go` | Provider carrier admission and canonical candidate-causal ID projection. |
| `internal/cli` | Compact and new-lineage capture wiring with canonical fallback IDs. |
| Tests | Tri-state, malformed proof, behavior-activated, compact admission, and canonical-ID coverage. |

## Test Plan
- [x] Focused `internal/reviewtransaction` tests pass.
- [x] Focused `internal/cli` tests pass.
- [x] `gofmt` and `git diff --check` pass.
- [ ] Full suite to run in CI.

## Chain Context
- Slice 1 of 3: provider carrier/admission.
- Slice 2 fork ref: `fix/1757-three-replay-finalize-v2`.
- Slice 3 fork ref: `fix/1757-three-receipts-gates-v2`.
- `size:exception` is required for this semantic slice under the maintainer-approved chain plan.

The two child PRs require upstream base refs materialized from the fork branches before they can be opened with clean stacked diffs.