### PR TITLE
fix(review): name authority written by a newer release

### DIFF
--- a/internal/cli/review_incident.go
+++ b/internal/cli/review_incident.go
@@ -180,8 +180,31 @@ func reviewRepositoryContextResolutionFailure(err error) error {
 	if reviewGitOwnershipRefusal(err) {
 		return reviewOpaqueContextFailure(reviewGitTrustRefusalCode, reviewGitTrustRefusalAction)
 	}
+	// Authority written by a newer release is not a stale context, and the
+	// generic instruction is actively wrong for it: refreshing a transition
+	// cannot make this binary parse those bytes. #2461's reporter followed
+	// that instruction across four reoffered reviewer slots and got an
+	// identical failure every time.
+	if errors.Is(err, reviewtransaction.ErrCompactAuthorityFromNewerRelease) {
+		return reviewOpaqueContextCause(reviewAuthorityNewerReleaseCode, reviewAuthorityNewerReleaseAction, err)
+	}
 	return reviewOpaqueContextCause("repository_context_unavailable", "refresh the exact native next_transition before retrying", err)
 }
+
+const (
+	// reviewAuthorityNewerReleaseCode is the typed code for "the authority
+	// exists and is intact, but this build predates the release that wrote
+	// it". It is deliberately distinct from repository_context_unavailable:
+	// that code's whole instruction is to refresh the transition, which is
+	// unreachable here.
+	reviewAuthorityNewerReleaseCode = "review_authority_newer_release"
+	// reviewAuthorityNewerReleaseAction names the only two things that
+	// resolve it, and the PATH shape, because a bare-name spawn from an
+	// editor plugin is how the stale binary gets invoked: the caller
+	// installed the newer build but an older one answers first.
+	reviewAuthorityNewerReleaseAction = "upgrade this gentle-ai, or invoke the newer build directly; " +
+		"an editor plugin resolves gentle-ai from PATH, so run `which -a gentle-ai` and make the newer build the one it finds first"
+)
 
 // reviewGitOwnershipRefusal reports whether err was caused by Git refusing a
 // repository for ownership reasons.

--- a/internal/cli/review_newer_authority_test.go
+++ b/internal/cli/review_newer_authority_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestNewerAuthorityIsNotReportedAsARefreshableContextFailure is #2461's
+// reproduced defect, at the boundary where the reporter met it.
+//
+// A v2.3.0 binary resolving a repository context whose authority rc.6 wrote
+// fails inside validateLiveReviewRepositoryContext's store.Load(). Every such
+// failure used to be classified as repository_context_unavailable with the
+// instruction "refresh the exact native next_transition before retrying". That
+// instruction is unreachable for this cause: the reading binary can never
+// parse those bytes, so no transition refresh changes the outcome. @heriobb04
+// followed it exactly, relaunched all four reoffered slots, and got an
+// identical failure each time.
+func TestNewerAuthorityIsNotReportedAsARefreshableContextFailure(t *testing.T) {
+	cause := fmt.Errorf("load compact authority: %w: json: unknown field %q",
+		reviewtransaction.ErrCompactAuthorityFromNewerRelease, "correction_budget_policy")
+
+	message := reviewRepositoryContextResolutionFailure(cause).Error()
+
+	if strings.Contains(message, "refresh the exact native next_transition") {
+		t.Fatalf("refusal still tells the caller to refresh a transition that cannot help: %q", message)
+	}
+	if strings.Contains(message, "repository_context_unavailable") {
+		t.Fatalf("refusal reuses the generic code, so this cause stays indistinguishable from a stale context: %q", message)
+	}
+	if !strings.Contains(message, reviewAuthorityNewerReleaseCode) {
+		t.Fatalf("refusal does not carry its own typed code: %q", message)
+	}
+	// The action has to name what actually resolves it, and the PATH shape
+	// because that is how the stale binary got invoked in the first place.
+	for _, want := range []string{"upgrade", "which -a gentle-ai"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("refusal does not name %q: %q", want, message)
+		}
+	}
+}
+
+// TestOrdinaryContextFailuresKeepTheirCode proves the new branch is narrow: an
+// unrelated resolution failure must still reach the caller as the generic
+// refreshable context refusal, which for most causes is the right advice.
+func TestOrdinaryContextFailuresKeepTheirCode(t *testing.T) {
+	message := reviewRepositoryContextResolutionFailure(
+		fmt.Errorf("review repository context is stale or has no live matching authority"),
+	).Error()
+
+	if !strings.Contains(message, "repository_context_unavailable") ||
+		!strings.Contains(message, "refresh the exact native next_transition") {
+		t.Fatalf("ordinary context failure lost its classification: %q", message)
+	}
+}

--- a/internal/reviewtransaction/compact_forward_authority_test.go
+++ b/internal/reviewtransaction/compact_forward_authority_test.go
@@ -1,0 +1,73 @@
+package reviewtransaction
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestAuthorityFromANewerReleaseIsNamedAsSuch covers #2461's rc.6 report.
+//
+// Persisted compact authority is decoded with DisallowUnknownFields. That is
+// correct for tamper resistance, but it makes authority non-forward-compatible
+// by construction: every release that adds a state field produces bytes an
+// older binary can never read. There is already a compatibility path for the
+// mirror case, retiredCompactFieldError, and none for this one, because the
+// binary that needs to change is the old one and it cannot be patched
+// retroactively.
+//
+// What CAN be fixed is the story the refusal tells. The reporter received
+// `json: unknown field "correction_budget_policy"` wrapped in "refresh the
+// exact native next_transition before retrying", followed that advice exactly,
+// and got an identical failure, because refreshing a transition cannot make an
+// older binary parse newer bytes. The refusal has to name the real situation
+// and the only action that resolves it.
+func TestAuthorityFromANewerReleaseIsNamedAsSuch(t *testing.T) {
+	// A record a later release wrote: valid in every way this build knows,
+	// plus one state field it has never heard of.
+	payload := []byte(`{
+		"schema": "` + compactRecordSchema + `",
+		"revision": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"state": {"lineage_id": "review-0123456789abcdef", "field_a_later_release_added": "floor_two"}
+	}`)
+
+	_, err := parseCompactRecord(payload, "review-0123456789abcdef")
+	if err == nil {
+		t.Fatal("parseCompactRecord accepted a field this build does not know; strict decoding is the tamper guard and must stay")
+	}
+	if !errors.Is(err, ErrCompactAuthorityFromNewerRelease) {
+		t.Fatalf("error = %v, want it to unwrap to ErrCompactAuthorityFromNewerRelease so callers can name the situation instead of guessing", err)
+	}
+
+	message := err.Error()
+	// The unknown field is the one piece of evidence that identifies which
+	// release wrote it, so it is preserved rather than swallowed.
+	if !strings.Contains(message, "field_a_later_release_added") {
+		t.Fatalf("refusal drops the field that identifies the writing release: %q", message)
+	}
+	for _, want := range []string{"newer", "upgrade"} {
+		if !strings.Contains(strings.ToLower(message), want) {
+			t.Fatalf("refusal does not name the situation or the action (%q missing): %q", want, message)
+		}
+	}
+}
+
+// TestRetiredFieldCompatibilityStillWins proves the new classification did not
+// capture the mirror case. A retired field must still take the tolerant
+// historical parse, because that authority IS readable and refusing it would
+// strand records this build is explicitly meant to keep loading.
+func TestRetiredFieldCompatibilityStillWins(t *testing.T) {
+	if len(compactRetiredStateFieldPaths) == 0 {
+		t.Skip("no retired compatibility fields to exercise")
+	}
+	var retired string
+	for path := range compactRetiredStateFieldPaths {
+		segments := strings.Split(path, ".")
+		retired = segments[len(segments)-1]
+		break
+	}
+	err := errors.New(`json: unknown field "` + retired + `"`)
+	if compactAuthorityFromNewerRelease(err) {
+		t.Fatalf("retired field %q was classified as authority from a newer release; it is the opposite case and has its own tolerant parse", retired)
+	}
+}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -2240,6 +2240,12 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 	var record CompactRecord
 	if strictErr := decoder.Decode(&record); strictErr != nil {
 		if !retiredCompactFieldError(strictErr) {
+			if compactAuthorityFromNewerRelease(strictErr) {
+				// The decoder error names the exact unknown field, which is
+				// the one piece of evidence identifying which release wrote
+				// this authority. It is preserved, not swallowed.
+				return CompactRecord{}, fmt.Errorf("%w: %v", ErrCompactAuthorityFromNewerRelease, strictErr)
+			}
 			return CompactRecord{}, strictErr
 		}
 		historical, historicalErr := parseHistoricalCompactRecord(payload)
@@ -2326,6 +2332,33 @@ func retiredCompactSnapshotIdentity(snapshot Snapshot) string {
 // retired compatibility field, so only genuine historical records pay the
 // tolerant second parse. The decoder error only carries the leaf field name;
 // the tolerant parse then enforces the exact nesting level of each path.
+// ErrCompactAuthorityFromNewerRelease marks persisted authority that carries a
+// state field this build has never heard of. Strict decoding is the tamper
+// guard and stays, which makes authority non-forward-compatible by
+// construction: every release adding a state field writes bytes an older
+// binary can never read. The binary that would need the fix is the old one, so
+// no compatibility path can exist here the way retiredCompactFieldError exists
+// for the mirror case.
+//
+// What this sentinel buys is an honest refusal. #2461's reporter got
+// `json: unknown field "correction_budget_policy"` wrapped in "refresh the
+// exact native next_transition before retrying", followed that exactly, and
+// hit an identical failure, because refreshing a transition cannot make an
+// older binary parse newer bytes. The message therefore names the only thing
+// that does resolve it: run a build at least as new as the writer.
+var ErrCompactAuthorityFromNewerRelease = errors.New(
+	"this compact review authority was written by a newer gentle-ai than the one reading it, which cannot parse it; " +
+		"upgrade the reading gentle-ai to at least the build that wrote this authority",
+)
+
+// compactAuthorityFromNewerRelease reports whether a strict-decode failure is
+// an unknown state field rather than a retired one. Retired fields are checked
+// first by the caller and take the tolerant historical parse, so reaching here
+// means the field belongs to a release this build predates.
+func compactAuthorityFromNewerRelease(err error) bool {
+	return strings.Contains(err.Error(), "unknown field") && !retiredCompactFieldError(err)
+}
+
 func retiredCompactFieldError(err error) bool {
 	message := err.Error()
 	if !strings.Contains(message, "unknown field") {


### PR DESCRIPTION
Root cause of @heriobb04's rc.6 reproduction on #2461, verified end to end.

## The skew is real and released

`correction_budget_policy` entered the persisted `CompactState` in `5da8557b`; `review lens-context` entered in `9383ffd4`, on a parallel branch. Both merged, leaving published versions that have the command but whose struct does not know the field:

| version | `review lens-context` | knows `correction_budget_policy` |
| --- | --- | --- |
| 2.2.4 | no | no |
| **2.3.0 (current stable)** | **yes** | **no** |
| **2.4.0-rc.1** | **yes** | **no** |
| rc.3 / rc.4 / rc.6 | yes | yes |

Reproduced by building both, starting a review with `main`, and running the exact `review lens-context` the OpenCode plugin runs with each binary. The 2.3.0 binary emits the reporter's string byte for byte.

## What this changes, and what it cannot

It cannot make old binaries read new authority, and it does not try: `DisallowUnknownFields` is the tamper guard. What it fixes is the refusal, which was actively misleading. Every resolution failure was `repository_context_unavailable`, whose whole instruction is "refresh the exact native next_transition before retrying". That cannot help here, and @heriobb04 followed it across all four reoffered slots for an identical failure each time.

Before:

```
repository_context_unavailable: ... cause: json: unknown field "correction_budget_policy"; refresh the exact native next_transition before retrying
```

After, from a built binary reading authority carrying a field it does not know:

```
review_authority_newer_release: ... cause: this compact review authority was written by a newer gentle-ai than
the one reading it, which cannot parse it; upgrade the reading gentle-ai to at least the build that wrote this
authority: json: unknown field "a_field_a_later_release_added"; upgrade this gentle-ai, or invoke the newer
build directly; an editor plugin resolves gentle-ai from PATH, so run `which -a gentle-ai` and make the newer
build the one it finds first
```

The unknown field name is preserved, not swallowed: it is the one piece of evidence identifying which release wrote the authority.

## Scope

- `TestRetiredFieldCompatibilityStillWins` pins that the mirror case is untouched. Retired fields still take the tolerant historical parse; classifying them here would strand records this build is meant to keep loading.
- `TestOrdinaryContextFailuresKeepTheirCode` pins that every other cause still gets `repository_context_unavailable`, for which refreshing the transition is the right advice.
- Both new behaviors were RED first.
- `go test ./...` clean, including the refusal-resolution ratchet.

## Follow-up, not in this PR

The plugin still resolves the CLI by bare name (`spawn("gentle-ai", args)` in `injectReviewerContext`), which is why a stale binary services calls for authority a newer one wrote. Pinning that invocation is the durable fix and is a separate change; this one makes the resulting failure legible for every client, not just OpenCode.

Closes #3029

Refs #2461 -- that issue stays open: it is about committed-diff 4R review and lens-binding rejection on 2.2.4, and neither is fixed here.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when repository records were created by a newer release.
  * Added upgrade guidance, including checking the active installation path, instead of suggesting an unnecessary refresh.
  * Preserved existing refresh guidance for ordinary repository-context failures.
  * Maintained compatibility with retired fields while clearly identifying unsupported newer fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
