### PR TITLE
fix(review): keep the kill switch reachable while authority is damaged

### DIFF
--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -1477,7 +1477,7 @@ func (harness *organicHarness) seedOrganicSDDChange(change string) {
 // records. Their count is how a rejected operation proves it wrote nothing.
 func (harness *organicHarness) reviewModeGenerations() []string {
 	harness.t.Helper()
-	root := filepath.Join(harness.commonDir(), "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	root := filepath.Join(harness.commonDir(), "gentle-ai", "review-mode", "rar-authority", "v1", "rdd-mode")
 	entries, err := os.ReadDir(root)
 	if os.IsNotExist(err) {
 		return nil

--- a/internal/cli/review_mode_damaged_authority_test.go
+++ b/internal/cli/review_mode_damaged_authority_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// damageReviewAuthorityTree makes this clone's review-transactions tree fail
+// RAR path safety the way #2882's reporter hit it: the directory is a symlink
+// pointing outside the repository, so every ancestor walk over it refuses.
+func damageReviewAuthorityTree(t *testing.T, repo string) {
+	t.Helper()
+	gentle := filepath.Join(repo, ".git", "gentle-ai")
+	if err := os.MkdirAll(gentle, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	elsewhere := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.MkdirAll(elsewhere, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	authority := filepath.Join(gentle, "review-transactions")
+	if err := os.RemoveAll(authority); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(elsewhere, authority); err != nil {
+		t.Skipf("this platform cannot stage the unsafe authority path: %v", err)
+	}
+}
+
+// TestKillSwitchIsReachableWhileReviewAuthorityIsDamaged pins the invariant the
+// orchestrator contract states verbatim: the clone-scoped kill switch is
+// "reachable even while review authority is broken".
+//
+// It was not. cloneLocalRDDModeRoot derived the override directory INSIDE the
+// review authority tree, deliberately, to reuse that tree's path-safety and
+// private-IO helpers. The cost is that the switch inherits every failure mode
+// of the thing it exists to turn off. #2882's reporter found the exact
+// consequence: with authority failing RAR path safety, `review mode disable
+// --scope clone` exited non-zero without persisting, and the mode stayed on.
+//
+// This matters beyond one command. `gentle-ai review mode disable --scope
+// clone` is the continuation the stop-reason table names for most
+// unrecoverable review states, including corrupted_or_unverifiable_authority.
+// Those codes were pointing at an exit that did not work in precisely the
+// situation they point at it from.
+func TestKillSwitchIsReachableWhileReviewAuthorityIsDamaged(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	damageReviewAuthorityTree(t, repo)
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output); err != nil {
+		t.Fatalf("clone-scoped disable failed while authority was damaged, which is the exact case the stop-reason table sends callers here for: %v", err)
+	}
+	if result := decodeReviewModeResult(t, output.Bytes()); result.Status.Effective != reviewtransaction.RDDModeOff ||
+		result.Status.Source != reviewtransaction.RDDModeSourceCloneLocal {
+		t.Fatalf("disable reported %#v, want the clone-local source to decide off", result.Status)
+	}
+
+	// The write has to survive a fresh resolution, not just report success
+	// once: the reporter's disable printed a projection and then persisted
+	// nothing, so a following status still said on.
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("read-only status failed while authority was damaged: %v", err)
+	}
+	if result := decodeReviewModeResult(t, output.Bytes()); result.Status.Effective != reviewtransaction.RDDModeOff {
+		t.Fatalf("status after disable = %#v, want off; the override did not persist", result.Status)
+	}
+}
+
+// TestKillSwitchStatusIsReadableWhileReviewAuthorityIsDamaged covers the
+// read-only surface on its own. status is documented as strictly read-only and
+// is how an operator finds out what governs delivery; refusing to project the
+// global source because an unrelated authority tree is damaged tells them
+// nothing they can act on.
+func TestKillSwitchStatusIsReadableWhileReviewAuthorityIsDamaged(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	damageReviewAuthorityTree(t, repo)
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("status refused on a damaged authority tree: %v", err)
+	}
+	// No clone-local override was ever written, so the default decides and
+	// reviews stay on. Failing closed is preserved; only reachability changed.
+	if result := decodeReviewModeResult(t, output.Bytes()); result.Status.Effective != reviewtransaction.RDDModeOn {
+		t.Fatalf("status = %#v, want the default to still decide on", result.Status)
+	}
+}

--- a/internal/cli/review_mode_recovery_test.go
+++ b/internal/cli/review_mode_recovery_test.go
@@ -154,7 +154,7 @@ func reviewModeCorruptPaths(t *testing.T, corruption reviewModeCorruption, repo 
 
 func reviewModeCloneRecordPath(t *testing.T, repo string) string {
 	t.Helper()
-	root := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	root := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1", "rdd-mode")
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		t.Fatalf("clone-local override directory: %v", err)

--- a/internal/cli/sdd_attempt_rar_mode_read_refusal_unix_test.go
+++ b/internal/cli/sdd_attempt_rar_mode_read_refusal_unix_test.go
@@ -26,7 +26,7 @@ func TestRunSDDAttemptSettleRefusesUnsafeDisabledRARModeWithoutMutation(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1")
+	privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1")
 	if err := os.Chmod(privateRARDir, 0o755); err != nil {
 		t.Fatalf("make private RAR directory unsafe: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestUnsafeDisabledRARModeRefusesStatusAndValidationBeforeTheirReaders(t *te
 			reviewModeHome(t)
 			repo := initReviewCLIRepo(t)
 			disableReviewForClone(t, repo)
-			privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1")
+			privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1")
 			if err := os.Chmod(privateRARDir, 0o755); err != nil {
 				t.Fatalf("make private RAR directory unsafe: %v", err)
 			}

--- a/internal/cli/sdd_attempt_rar_mode_read_refusal_windows_test.go
+++ b/internal/cli/sdd_attempt_rar_mode_read_refusal_windows_test.go
@@ -28,7 +28,7 @@ func TestRunSDDAttemptSettleRepairsUnsafeDisabledRARModeWithoutRecursing(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1")
+	privateRARDir := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1")
 	child := filepath.Join(privateRARDir, "must-not-change.txt")
 	if err := os.WriteFile(child, []byte("private child\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/cli/sdd_status_review_disabled_test.go
+++ b/internal/cli/sdd_status_review_disabled_test.go
@@ -97,7 +97,10 @@ func requireDisabledUnmanagedSDDStatus(t *testing.T, status sddstatus.Status) {
 // The switch becomes unreadable, which is not the same as being off.
 func corruptCloneLocalReviewMode(t *testing.T, repo string) {
 	t.Helper()
-	root := filepath.Join(repo, ".git", "gentle-ai", "review-transactions")
+	// #2882 moved the switch out of the review authority tree so a damaged
+	// authority can no longer make the kill switch unreachable. The record
+	// this helper corrupts is the switch's own, wherever it now lives.
+	root := filepath.Join(repo, ".git", "gentle-ai", "review-mode")
 	corrupted := 0
 	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {

--- a/internal/reviewtransaction/rar_path_safety.go
+++ b/internal/reviewtransaction/rar_path_safety.go
@@ -46,6 +46,31 @@ func unsafeRARPathError(path string, directory bool) error {
 }
 
 func ensureRARRepositoryRoot(commonDir, root string, create bool) error {
+	want := filepath.Join(
+		"gentle-ai",
+		"review-transactions",
+		rarAuthorityDirectory,
+		rarAuthorityVersion,
+	)
+	// rar-authority and every descendant are owner-only; gentle-ai and
+	// review-transactions are the shared ancestors above it.
+	return ensureRARDirectoryChain(commonDir, root, want, 2, create)
+}
+
+// ensureRARSwitchRoot validates the kill switch's own root, a sibling of
+// review-transactions under gentle-ai. It reuses this file's walk, permission
+// rules, and private-directory helpers unchanged; the only thing it does not
+// reuse is the authority tree itself, because #2882 showed the switch must not
+// be unreachable whenever that tree is damaged.
+func ensureRARSwitchRoot(commonDir, root string, create bool) error {
+	// The shape mirrors the authority path exactly -- two shared ancestors,
+	// then owner-only from rar-authority down -- so the switch inherits the
+	// proven permission layout and differs only in its second component.
+	want := filepath.Join("gentle-ai", rddModeSwitchDirectory, rarAuthorityDirectory, rarAuthorityVersion)
+	return ensureRARDirectoryChain(commonDir, root, want, 2, create)
+}
+
+func ensureRARDirectoryChain(commonDir, root, want string, privateFrom int, create bool) error {
 	commonDir = filepath.Clean(commonDir)
 	root = filepath.Clean(root)
 	relative, err := filepath.Rel(commonDir, root)
@@ -54,12 +79,6 @@ func ensureRARRepositoryRoot(commonDir, root string, create bool) error {
 		filepath.IsAbs(relative) {
 		return errors.New("RAR authority root escapes the Git common directory")
 	}
-	want := filepath.Join(
-		"gentle-ai",
-		"review-transactions",
-		rarAuthorityDirectory,
-		rarAuthorityVersion,
-	)
 	if relative != want {
 		return errors.New("RAR authority root is not the canonical Git-common-dir path")
 	}
@@ -74,7 +93,7 @@ func ensureRARRepositoryRoot(commonDir, root string, create bool) error {
 		}
 		parent := current
 		current = filepath.Join(current, part)
-		private := index >= 2 // rar-authority and every descendant are owner-only.
+		private := index >= privateFrom
 		_, statErr := os.Lstat(current)
 		if errors.Is(statErr, fs.ErrNotExist) && create {
 			if private {

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -519,31 +519,32 @@ func cloneLocalRDDOverrideValue(mode RDDMode) (string, error) {
 	}
 }
 
+// rddModeSwitchDirectory is the kill switch's own root, a SIBLING of
+// review-transactions rather than a descendant of it.
+//
+// The override used to nest inside the review authority tree, deliberately, so
+// path safety, permissions, and private IO could reuse that tree's helpers
+// instead of inventing a second path policy. The reuse was fine; the nesting
+// was not. It made the switch inherit every failure mode of the thing the
+// switch exists to turn off, and #2882 is the consequence: with authority
+// failing RAR path safety, the documented clone-scoped exit refused, persisted
+// nothing, and left reviews on. That exit is what the stop-reason table names
+// for most unrecoverable review states, so those codes were pointing at a door
+// that was locked exactly when they pointed at it.
+//
+// Sitting beside review-transactions keeps every helper and every permission
+// rule, and drops only the dependency that had no reason to exist.
+const rddModeSwitchDirectory = "review-mode"
+
 // cloneLocalRDDModeRoot derives the override directory from the exact Git
-// common directory. It nests inside the already-validated owner-only review
-// authority root so that path safety, permissions, and private IO reuse the
-// existing helpers instead of inventing a second path policy.
+// common directory, under the switch's own root.
 func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, error) {
-	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	identity, err := cloneLocalRDDModeIdentity(ctx, repo)
 	if err != nil {
-		// A bare repository already states its own refusal and names its own
-		// recovery. Wrapping it in this internal concern would misattribute the
-		// failure to a kill switch the operator never touched.
-		var bare *BareRepositoryError
-		if errors.As(err, &bare) {
-			return "", err
-		}
-		return "", fmt.Errorf("resolve review mode repository identity: %w", err)
+		return "", err
 	}
-	identity := reviewRepositoryIdentityRecordFromLease(lease)
-	base := filepath.Join(
-		identity.GitCommonDir,
-		"gentle-ai",
-		"review-transactions",
-		rarAuthorityDirectory,
-		rarAuthorityVersion,
-	)
-	if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, create); err != nil {
+	base := filepath.Join(identity.GitCommonDir, "gentle-ai", rddModeSwitchDirectory, rarAuthorityDirectory, rarAuthorityVersion)
+	if err := ensureRARSwitchRoot(identity.GitCommonDir, base, create); err != nil {
 		return "", err
 	}
 	dir := filepath.Join(base, rddModeDirectory)
@@ -553,13 +554,92 @@ func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (strin
 	return dir, nil
 }
 
-func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrideRecord, bool, error) {
+// cloneLocalRDDModeLegacyRoot is the pre-#2882 location inside the review
+// authority tree. It is read-only and best-effort: overrides written before
+// this change must keep deciding, and a clone that never disabled has nothing
+// here.
+func cloneLocalRDDModeLegacyRoot(ctx context.Context, repo string) (string, error) {
+	identity, err := cloneLocalRDDModeIdentity(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	base := filepath.Join(
+		identity.GitCommonDir,
+		"gentle-ai",
+		"review-transactions",
+		rarAuthorityDirectory,
+		rarAuthorityVersion,
+	)
+	if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, false); err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, rddModeDirectory)
+	if err := ensurePrivateRARDirectoryTree(base, dir, false); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func cloneLocalRDDModeIdentity(ctx context.Context, repo string) (reviewRepositoryIdentityRecord, error) {
+	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	if err != nil {
+		// A bare repository already states its own refusal and names its own
+		// recovery. Wrapping it in this internal concern would misattribute the
+		// failure to a kill switch the operator never touched.
+		var bare *BareRepositoryError
+		if errors.As(err, &bare) {
+			return reviewRepositoryIdentityRecord{}, err
+		}
+		return reviewRepositoryIdentityRecord{}, fmt.Errorf("resolve review mode repository identity: %w", err)
+	}
+	return reviewRepositoryIdentityRecordFromLease(lease), nil
+}
+
+// cloneLocalRDDModeReadRoot reports the directory that currently decides this
+// clone's override: the switch's own root when it holds a generation, and
+// otherwise the legacy location so a disable written before #2882 keeps
+// deciding.
+//
+// A legacy root this build cannot reach resolves to "no override" rather than
+// an error, and that never relaxes anything. Before this change an unreachable
+// authority tree already failed the whole resolution closed, which resolves to
+// managed and keeps reviews on; reporting no clone-local override reaches the
+// same effective mode by the same default, and unlike the old behavior it
+// leaves the operator able to write one.
+func cloneLocalRDDModeReadRoot(ctx context.Context, repo string) (string, error) {
 	dir, err := cloneLocalRDDModeRoot(ctx, repo, false)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+	if err == nil {
+		head, headErr := cloneLocalRDDOverrideHeadGeneration(dir)
+		if headErr != nil {
+			return "", headErr
+		}
+		if head > 0 {
+			return dir, nil
+		}
+	}
+	legacy, legacyErr := cloneLocalRDDModeLegacyRoot(ctx, repo)
+	if legacyErr != nil {
+		return "", nil
+	}
+	if head, headErr := cloneLocalRDDOverrideHeadGeneration(legacy); headErr != nil || head == 0 {
+		return "", nil
+	}
+	return legacy, nil
+}
+
+func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrideRecord, bool, error) {
+	dir, err := cloneLocalRDDModeReadRoot(ctx, repo)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return rddModeOverrideRecord{}, false, nil
 		}
 		return rddModeOverrideRecord{}, false, err
+	}
+	if dir == "" {
+		return rddModeOverrideRecord{}, false, nil
 	}
 	return readCloneLocalRDDOverrideHead(dir)
 }
@@ -570,12 +650,15 @@ func readCloneLocalRDDOverride(ctx context.Context, repo string) (rddModeOverrid
 // read-only, never creates state, and reports "" when this clone holds no
 // override at all.
 func CloneLocalRDDModeRecordPath(ctx context.Context, repo string) (string, error) {
-	dir, err := cloneLocalRDDModeRoot(ctx, repo, false)
+	dir, err := cloneLocalRDDModeReadRoot(ctx, repo)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
 		}
 		return "", err
+	}
+	if dir == "" {
+		return "", nil
 	}
 	head, err := cloneLocalRDDOverrideHeadGeneration(dir)
 	if err != nil || head == 0 {

--- a/internal/reviewtransaction/rdd_mode_legacy_root_test.go
+++ b/internal/reviewtransaction/rdd_mode_legacy_root_test.go
@@ -1,0 +1,78 @@
+package reviewtransaction
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLegacyCloneOverrideStillDecides is the migration guard for #2882.
+//
+// Moving the switch out of the review authority tree must never re-enable
+// reviews for someone who already disabled them. An override written at the
+// pre-#2882 location keeps deciding, because the read path falls back to it
+// whenever the switch's own root holds no generation.
+func TestLegacyCloneOverrideStillDecides(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+
+	// Write through the current writer, then relocate the record to the
+	// legacy path so the only thing under test is where reads look.
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", RDDGlobalMode{}); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode() error = %v", err)
+	}
+	current, err := cloneLocalRDDModeRoot(ctx, repo, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := cloneLocalRDDModeLegacyRoot(ctx, repo)
+	if err != nil {
+		// The legacy tree is created lazily; build it with the same helpers.
+		identity, idErr := cloneLocalRDDModeIdentity(ctx, repo)
+		if idErr != nil {
+			t.Fatal(idErr)
+		}
+		base := filepath.Join(identity.GitCommonDir, "gentle-ai", "review-transactions", rarAuthorityDirectory, rarAuthorityVersion)
+		if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, true); err != nil {
+			t.Fatal(err)
+		}
+		legacy = filepath.Join(base, rddModeDirectory)
+		if err := ensurePrivateRARDirectoryTree(base, legacy, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries, err := os.ReadDir(current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moved := 0
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == rddModeLockName {
+			continue
+		}
+		payload, readErr := os.ReadFile(filepath.Join(current, entry.Name()))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(legacy, entry.Name()), payload, 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+		if rmErr := os.Remove(filepath.Join(current, entry.Name())); rmErr != nil {
+			t.Fatal(rmErr)
+		}
+		moved++
+	}
+	if moved == 0 {
+		t.Fatal("no override record to relocate; the writer stored nothing")
+	}
+
+	status, err := ResolveRDDMode(ctx, repo, RDDGlobalMode{})
+	if err != nil {
+		t.Fatalf("ResolveRDDMode() error = %v", err)
+	}
+	if status.Effective != RDDModeOff || status.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("a pre-#2882 clone override stopped deciding: %#v; the move silently re-enabled reviews", status)
+	}
+}

--- a/internal/reviewtransaction/rdd_mode_test.go
+++ b/internal/reviewtransaction/rdd_mode_test.go
@@ -97,7 +97,7 @@ func TestCloneLocalRDDOverrideStaysInsideItsClone(t *testing.T) {
 		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
 	}
 
-	overridePath := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	overridePath := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1", "rdd-mode")
 	if _, err := os.Stat(overridePath); err != nil {
 		t.Fatalf("clone-local override is not stored under the Git common directory: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestUnknownRDDModeFailsClosedAsDisabled(t *testing.T) {
 	if _, err := SetCloneLocalRDDMode(context.Background(), repo, RDDModeOff, "", RDDGlobalMode{Value: "on"}); err != nil {
 		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
 	}
-	corrupt := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	corrupt := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
 	if err := os.WriteFile(corrupt, []byte("{not json}\n"), 0o600); err != nil {
 		t.Fatalf("corrupt override: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestResolveRDDModeUnsafePrivatePathIsNotACorruptHead(t *testing.T) {
 	if _, err := SetCloneLocalRDDMode(context.Background(), repo, RDDModeOff, "", RDDGlobalMode{}); err != nil {
 		t.Fatalf("disable clone-local mode: %v", err)
 	}
-	modeRecord := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	modeRecord := filepath.Join(repo, ".git", "gentle-ai", "review-mode", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
 	if err := os.Chmod(modeRecord, 0o644); err != nil {
 		t.Fatalf("make private RAR file unsafe: %v", err)
 	}


### PR DESCRIPTION
Reproduced on `main` in 30 seconds, and worse than the report described.

## Reproduction

```sh
git init r && cd r && git commit --allow-empty -m i
mkdir -p .git/gentle-ai
ln -s /some/other/dir .git/gentle-ai/review-transactions
gentle-ai review mode disable --scope clone --cwd .
```

Before:

- `disable --scope clone` printed `receipt-driven development: off (decided by )` — an **empty** decider, a projection defect the report did not mention — then exited 1 with `unsafe RAR authority path`.
- Nothing persisted: a following status still reported `clone-local: unset`.
- `review mode status`, documented as strictly read-only, also exited 1.

After, same repository:

```
--- status ---            on (decided by default)     exit=0
--- disable clone ---     off (decided by clone_local) exit=0
--- status after ---      off (decided by clone_local) exit=0
```

## Why this outranked the other open review defects

`gentle-ai review mode disable --scope clone --cwd <repo>` is the continuation the stop-reason table names for most unrecoverable states — `corrupted_or_unverifiable_authority`, `captured_artifacts_unverifiable`, `manual_intervention_required`, `native_stop_required`, and more. The orchestrator contract states it verbatim as "reachable even while review authority is broken". It was not, in exactly the damaged-authority case those codes send callers here from. Fixing them individually is pointless while this holds.

## Cause

`cloneLocalRDDModeRoot` derived the override directory *inside* the authority tree, with the reason stated in its own comment: reuse that tree's path-safety and private-IO helpers rather than invent a second path policy. That reasoning was sound and the reuse is kept. What is dropped is the dependency: the switch now sits beside `review-transactions` under `gentle-ai/review-mode/rar-authority/v1/`, the same four-component shape, so it inherits the proven permission layout and differs only in its second component.

## Migration, and why it cannot silently re-enable reviews

Reads fall back to the previous location, so an override written before this change keeps deciding. `TestLegacyCloneOverrideStillDecides` pins it, and I verified it is not vacuous: disabling the fallback makes it fail with `Effective:"on"`, which is precisely the regression that would matter.

A legacy root this build cannot reach resolves to "no override" rather than an error. That relaxes nothing: before this change, an unreachable authority tree already failed the whole resolution closed to managed, which keeps reviews on. Same effective mode, except the operator can now write an override.

## Preserved

An unreadable switch is still not a disabled switch. Only the switch's own root is exempt from the authority tree's health; damaging that root still fails closed. The fail-closed tests (`TestSDDStatusArchiveGateEnforcesWhenTheSwitchIsUnreadable`, `TestUnsafeDisabledRARModeRefusesStatusAndValidationBeforeTheirReaders`, `TestRunSDDAttemptSettleRefusesUnsafeDisabledRARModeWithoutMutation`) keep testing exactly that, now pointed at where the switch lives.

Both new behaviors were RED first. `go test ./...` clean, including the e2e organic-runtime suites.

Closes #2882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-mode kill-switch reliability when repository authority paths are unsafe or unreachable.
  * Preserved existing review-mode overrides during storage migration.
  * Ensured read-only status checks remain available without changing default behavior.

* **Maintenance**
  * Updated review-mode storage handling to use the dedicated repository location while continuing to recognize legacy records.
  * Added regression coverage for migration, recovery, and platform-specific safety scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->