### PR TITLE
test(cli): render the native not-exist cause from the running installation

### DIFF
--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -66,7 +67,7 @@ func TestOpaqueRepositoryContextResolutionNamesDistinctCauses(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			want: opaqueNativeCause("no such file or directory", "The system cannot find the file specified."),
+			want: nativeNotExistCause(t),
 		},
 		{
 			name: "authority-record-unparsable",
@@ -186,7 +187,7 @@ func TestOpaqueRepositoryContextCauseIsScrubbed(t *testing.T) {
 	if strings.Contains(message, repo) || strings.Contains(message, lineage+"/review-state.json") {
 		t.Fatalf("forwarded cause leaked an absolute path: %s", message)
 	}
-	if !strings.Contains(message, opaqueNativeCause("no such file or directory", "The system cannot find the file specified.")) {
+	if !strings.Contains(message, nativeNotExistCause(t)) {
 		t.Fatalf("scrubbing removed the cause along with the path: %s", message)
 	}
 	if scrubbed := reviewScrubDefectReportField(message); scrubbed != message {
@@ -207,6 +208,40 @@ func assertOpaqueFailureNamesCause(t *testing.T, message, code, wantCause, repo 
 	}
 }
 
+// nativeNotExistCause asks THIS installation how it renders a missing file,
+// instead of pinning the sentence a US English installation renders. What the
+// assertion needs is that the forwarded cause survives scrubbing, and the
+// condition behind it -- ERROR_FILE_NOT_FOUND, the errno the removed authority
+// record leaves behind -- does not vary. The sentence does: syscall.Errno.Error
+// asks FormatMessage for US English first and falls back to the installation's
+// own message resources when that lookup fails, so an installation carrying no
+// English resources renders the same errno in its own language. Pinning the
+// text asserted the machine, not the contract.
+func nativeNotExistCause(t *testing.T) string {
+	t.Helper()
+	// The parent directory must exist. A missing parent is a different
+	// condition (ERROR_PATH_NOT_FOUND on Windows) and renders a different
+	// sentence, which would silently weaken every assertion built on this.
+	_, err := os.Open(filepath.Join(t.TempDir(), "absent-authority-record.json"))
+	if err == nil {
+		t.Fatal("opening an absent file succeeded, so this platform cannot render the cause under test")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("probe reported something other than a missing file, so its sentence is not the one under test: %v", err)
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("probe error carries no separable cause to render: %v", err)
+	}
+	return pathErr.Err.Error()
+}
+
+// opaqueNativeCause still serves one call site, and its two arms are safe for
+// different reasons. The Windows arm expects "unsafe RAR authority path",
+// which gentle-ai produces itself. The Unix arm does pin an errno text, "not
+// a directory", and is safe because Go renders errno 20 from its own
+// compile-time table rather than from the installation. Neither arm reaches
+// FormatMessage, which is what the replaced assertions depended on.
 func opaqueNativeCause(unix, windows string) string {
 	if runtime.GOOS == "windows" {
 		return windows


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2854

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Two assertions in `internal/cli/review_opaque_typed_cause_test.go` compared against the sentence a US English Windows renders for a missing file. Windows builds that sentence from the installation's own message resources: `syscall.Errno.Error` asks `FormatMessage` for US English first and falls back to the installation default when that lookup fails, so an installation carrying no English resources renders the same errno in its own language and both tests fail there.

The condition under test does not vary. Both scenarios remove the compact state file, so the cause is always `ERROR_FILE_NOT_FOUND`. The fix asks the running installation how it renders that errno instead of pinning one language's text, which keeps the assertion on the forwarded, scrubbed cause.

No production code changes. One test file, +37 / -2.

### Rebase note

This branch was rebuilt on `26d7ceed` and now carries a single commit. It previously carried a second commit against `internal/cli/review_facade_finalize_new_lineage_test.go`; that file was removed by `0ed9225f` (`refactor(review)!: close on the last causal event`), and the issue it addressed was closed as obsolete under the same refactor. That work is not adapted here and is not part of this PR's scope.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_opaque_typed_cause_test.go` | New `nativeNotExistCause(t)` helper renders the not-exist cause from the running installation and replaces the two pinned English literals. The parent directory comes from `t.TempDir()` on purpose: a missing parent reports `ERROR_PATH_NOT_FOUND`, a different condition with a different sentence. |

The remaining `opaqueNativeCause` call site is deliberately untouched, and it is worth being exact about why, since this PR is about pinned errno text. Its Windows arm expects `unsafe RAR authority path`, produced by `errors.New` at `internal/reviewtransaction/rar_path_safety.go:19`, so that half is Gentle AI's own string. Its Unix arm does still pin an errno text, `not a directory`. That one is safe for a different reason: Go renders errno 20 from its own compile-time table in `zerrors_linux_amd64.go` and `zerrors_darwin_{amd64,arm64}.go`, not from the installation, so it does not vary the way the Windows sentence does. Neither arm reaches `FormatMessage`, which is the mechanism both fixed assertions depended on.

---

## 🧪 Test Plan

Re-measured on the rebuilt branch against `26d7ceed`. Windows 10.0.26200, `windows/amd64`, go1.26.2, Spanish-language installation — the configuration that reproduces #2854. Evidence from the previous branch is historical and is not carried forward as proof.

**The two tests on this branch**

```bash
go test ./internal/cli/ -run 'TestOpaqueRepositoryContext' -count=1
# ok  github.com/gentleman-programming/gentle-ai/v2/internal/cli  19.078s
```

`TestOpaqueRepositoryContextResolutionNamesDistinctCauses/authority-record-absent` and `TestOpaqueRepositoryContextCauseIsScrubbed` both pass. Two subtests of the same parent skip with `PATH shim requires a POSIX shell`, unrelated to this change.

**The same file at `26d7ceed`, same machine, same command — both fail**

```
--- FAIL: TestOpaqueRepositoryContextResolutionNamesDistinctCauses/authority-record-absent
    failure does not name its own cause "The system cannot find the file specified.":
    ... cause: open <redacted> El sistema no puede encontrar el archivo especificado.
--- FAIL: TestOpaqueRepositoryContextCauseIsScrubbed
    scrubbing removed the cause along with the path: ...
```

That is the defect, reproduced on current `main`.

**The assertion is not vacuous**

Making `nativeNotExistCause` return a deliberately wrong string fails both tests with the same shape, so the assertion still carries the condition it names:

```
failure does not name its own cause "COUNTERFACTUAL-BOGUS-CAUSE": ...
```

The mutation was reverted; only the helper is in this PR.

**Format and vet**

```bash
gofmt -l internal/cli/                # no output
go vet ./internal/cli/                # no output, exit 0
go run ./internal/gofmtcheck          # no output, exit 0
```

**Not measured on the rebuilt branch, and I would rather say so than imply it**

The whole-package `go test ./internal/cli/` run and the repository-wide `go test ./...` were not repeated after the rebase; only the focused tests above were. Linux and macOS were not run. On those platforms `nativeNotExistCause` returns the same text the deleted literal contained — Go maps errno 2 from its own table, not from the operating system — but that is reading source, not running it. An English-language Windows installation was not run either.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

Three boxes are deliberately left unticked, with reasons rather than silence:

- **`type:*` label** — this account has no triage permission and cannot apply it. The linked issue already carries `type:bug`, applied by the maintainer who approved this work.
- **`go test ./...`** — only the focused tests were re-run after the rebase. The package-wide and repository-wide runs are unmeasured from here and are stated as such in the Test Plan.
- **E2E** — not run. Nothing under `e2e/` or `bench/` is touched, no production symbol is added and no lifecycle command is altered, but not-applicable is a judgement and the box records that it was not executed.

**Benchmark validation: not applicable.** `bench/` is a separate Go module and this change touches no path inside it, adds no production symbol, and alters no lifecycle command, so there is no axis for it to move.

---

## 💬 Notes for Reviewers

`git diff --name-only` returns one `_test.go` path and nothing else. The template's guard-population checklist does not apply: no production Go changed in `internal/cli`, `internal/reviewtransaction` or `internal/sddstatus`, and `.guard-population-baseline.txt` is untouched.

The single decision worth your attention is whether asking the running installation for the rendered errno is the assertion you want, or whether you would rather the test not depend on the rendered sentence at all. The condition — `ERROR_FILE_NOT_FOUND` behind a removed state file — is what the test is really about, and the helper is the narrowest way I found to assert it without pinning a language.
