### PR TITLE
fix(sdd): detect edit targets outside the roots inside one repository

### DIFF
--- a/contracts/sdd-integration/v1/fixtures/consent.fixture.json
+++ b/contracts/sdd-integration/v1/fixtures/consent.fixture.json
@@ -10,17 +10,17 @@
     "/workspace/service-b"
   ],
   "headline": "This change plans work outside its authorized edit roots.",
-  "reason": "the task plan targets repository roots that no edit authority covers, so apply stays blocked until a human decides.",
+  "reason": "the task plan targets paths that no edit authority covers, so apply stays blocked until a human decides.",
   "value": "Granting scopes edit authority to this change alone: the grant is recorded in the change's ledger, auditable, and dies with archive.",
   "evidence": [
-    "/workspace/service-a is a Git repository root outside the authorized edit roots",
-    "/workspace/service-b is a Git repository root outside the authorized edit roots"
+    "/workspace/service-a is outside the authorized edit roots",
+    "/workspace/service-b is outside the authorized edit roots"
   ],
   "choices": [
     {
       "answer": "granted",
       "label": "Grant this change edit authority over the named roots",
-      "effect": "This change's apply actor may edit the named repositories. The grant is per-change, audited (who, when, which roots), and dies with archive; nothing is granted to any other change.",
+      "effect": "This change's apply actor may edit the named roots. The grant is per-change, audited (who, when, which roots), and dies with archive; nothing is granted to any other change.",
       "invocation": "gentle-ai sdd-attempt grant --cwd \"/workspace/planning\" --change multi-repo-rollout --root \"/workspace/service-a\" --root \"/workspace/service-b\" --actor maintainer --reason edit-authority-consent-granted --request-id grant-ce874466367354a2 --change-instance sdd-b2f4c0a1d8e64953a7c15b9d3e0f2a68"
     },
     {
@@ -31,7 +31,7 @@
     }
   ],
   "off_path": {
-    "note": "To keep this change single-repository instead, edit its tasks.md so no work unit targets an unauthorized root, then re-enter through 'gentle-ai sdd-status multi-repo-rollout --cwd \"/workspace/planning\"'.",
+    "note": "To keep this change inside its current authority instead, edit its tasks.md so no work unit targets an unauthorized root, then re-enter through 'gentle-ai sdd-status multi-repo-rollout --cwd \"/workspace/planning\"'.",
     "command": "gentle-ai sdd-status multi-repo-rollout --cwd \"/workspace/planning\""
   }
 }

--- a/internal/sddstatus/consent_contract_test.go
+++ b/internal/sddstatus/consent_contract_test.go
@@ -31,7 +31,13 @@ var sddConsentDeclineInvocationShape = regexp.MustCompile(
 func TestSDDIntegrationConsentContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "sdd-integration", "v1")
 	want := map[string]string{
-		"fixtures/consent.fixture.json": "aecd0f4d3ae85527a33ebc708a7a49d7f9fda99b13ccabd1fbe9b89bbf2c41e9",
+		// #2891 widened detection to a second kind of unauthorized root: a
+		// directory inside the planning repository. The envelope's prose said
+		// "repository roots" and "is a Git repository root", which is a false
+		// statement of fact for that kind, so the wording moved to what is
+		// true of both. No field, choice, answer token, or invocation
+		// changed. Deliberate, not drift.
+		"fixtures/consent.fixture.json": "44a3b7d68f75981c9758650526819d9fc49399074d4740beb9d2efbf1620e2f6",
 		"schemas/consent.schema.json":   "249e415c09223e75983abf6c55caa0eea57bd3389c23115a123e09da2ce07efb",
 	}
 	for name, expected := range want {

--- a/internal/sddstatus/edit_authority.go
+++ b/internal/sddstatus/edit_authority.go
@@ -55,10 +55,28 @@ func detectUnauthorizedEditRoots(tasksText string, workspaceRoot string, allowed
 			}
 			resolved = resolveExistingPath(filepath.Clean(resolved))
 			target := gitRootOf(resolved)
-			if target == "" || target == planningGitRoot || withinAnyRoot(target, allowed) {
+			if target == "" {
 				continue
 			}
-			unauthorized[target] = true
+			if target != planningGitRoot {
+				if withinAnyRoot(target, allowed) {
+					continue
+				}
+				unauthorized[target] = true
+				continue
+			}
+			// Same repository, and #2891's case: the original derivation
+			// stopped here, treating "belongs to the planning repository" as
+			// proof of authorization. It is not. When the planning workspace
+			// is a nested subproject, a sibling directory shares the Git root
+			// while sitting outside every authorized edit root, so apply
+			// stayed ready for a plan the sdd-apply outside-root guard would
+			// refuse. The authorized unit inside one repository is the edit
+			// root, not the repository.
+			if withinAnyRoot(resolved, allowed) {
+				continue
+			}
+			unauthorized[containingDirectory(resolved)] = true
 		}
 	}
 
@@ -132,6 +150,29 @@ func gitRootOf(path string) string {
 	}
 }
 
+// containingDirectory reports the directory an in-repository target belongs
+// to, so the refusal names the unit an operator would actually grant. A file
+// yields its parent rather than itself: granting a single file is not a root,
+// and granting the whole repository would be broader than the plan needs.
+func containingDirectory(path string) string {
+	if info, err := os.Lstat(path); err == nil && info.IsDir() {
+		return path
+	}
+	return filepath.Dir(path)
+}
+
+// editAuthorityRootEvidence states the one fact that decides the block, for
+// both kinds of unauthorized root.
+//
+// It used to say "is a Git repository root", which #2891 made false: the new
+// kind is a directory inside the planning repository. Re-deriving the kind
+// from the filesystem was the obvious fix and it is wrong -- task plans name
+// paths that do not exist yet, so the probe would mislabel exactly the roots
+// it cannot see. The honest line is the one that needs no probe.
+func editAuthorityRootEvidence(root string) string {
+	return fmt.Sprintf("%s is outside the authorized edit roots", root)
+}
+
 func withinAnyRoot(target string, roots []string) bool {
 	for _, root := range roots {
 		if target == root || strings.HasPrefix(target, root+string(filepath.Separator)) {
@@ -151,7 +192,7 @@ func editAuthorityBlockedReason(roots []string) string {
 		quoted = append(quoted, pathquote.Quote(root))
 	}
 	return fmt.Sprintf(
-		"blocked(edit_authority_missing): tasks.md targets repositories outside the authorized edit roots: %s; edit tasks.md so every work unit stays inside the authorized edit roots, or grant this change edit authority for those repositories",
+		"blocked(edit_authority_missing): tasks.md targets paths outside the authorized edit roots: %s; edit tasks.md so every work unit stays inside the authorized edit roots, or grant this change edit authority for those roots",
 		strings.Join(quoted, ", "),
 	)
 }

--- a/internal/sddstatus/edit_authority_consent.go
+++ b/internal/sddstatus/edit_authority_consent.go
@@ -95,7 +95,7 @@ func newEditAuthorityConsent(change, workspaceRoot string, missingRoots []string
 	statusInvocation := fmt.Sprintf("gentle-ai sdd-status %s --cwd %s", change, pathquote.Quote(workspaceRoot))
 	evidence := make([]string, 0, len(missingRoots))
 	for _, root := range missingRoots {
-		evidence = append(evidence, fmt.Sprintf("%s is a Git repository root outside the authorized edit roots", root))
+		evidence = append(evidence, editAuthorityRootEvidence(root))
 	}
 	var grant strings.Builder
 	fmt.Fprintf(&grant, "%s--cwd %s --change %s", sddConsentGrantInvocationPrefix, pathquote.Quote(workspaceRoot), change)
@@ -117,14 +117,14 @@ func newEditAuthorityConsent(change, workspaceRoot string, missingRoots []string
 		Change:       change,
 		MissingRoots: append([]string{}, missingRoots...),
 		Headline:     "This change plans work outside its authorized edit roots.",
-		Reason:       "the task plan targets repository roots that no edit authority covers, so apply stays blocked until a human decides.",
+		Reason:       "the task plan targets paths that no edit authority covers, so apply stays blocked until a human decides.",
 		Value:        "Granting scopes edit authority to this change alone: the grant is recorded in the change's ledger, auditable, and dies with archive.",
 		Evidence:     evidence,
 		Choices: []consentenvelope.Choice{
 			{
 				Answer:     sddConsentAnswerGranted,
 				Label:      "Grant this change edit authority over the named roots",
-				Effect:     "This change's apply actor may edit the named repositories. The grant is per-change, audited (who, when, which roots), and dies with archive; nothing is granted to any other change.",
+				Effect:     "This change's apply actor may edit the named roots. The grant is per-change, audited (who, when, which roots), and dies with archive; nothing is granted to any other change.",
 				Invocation: grant.String(),
 			},
 			{
@@ -135,7 +135,7 @@ func newEditAuthorityConsent(change, workspaceRoot string, missingRoots []string
 			},
 		},
 		OffPath: consentenvelope.OffPath{
-			Note:    fmt.Sprintf("To keep this change single-repository instead, edit its tasks.md so no work unit targets an unauthorized root, then re-enter through '%s'.", statusInvocation),
+			Note:    fmt.Sprintf("To keep this change inside its current authority instead, edit its tasks.md so no work unit targets an unauthorized root, then re-enter through '%s'.", statusInvocation),
 			Command: statusInvocation,
 		},
 	}

--- a/internal/sddstatus/edit_authority_in_repo_test.go
+++ b/internal/sddstatus/edit_authority_in_repo_test.go
@@ -1,0 +1,115 @@
+package sddstatus
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedNestedSubprojectRepo builds #2891's exact layout: ONE Git repository
+// whose planning workspace is a nested subproject, with a sibling service
+// directory next to it.
+//
+//	<repo>/.git
+//	<repo>/<subproject>/openspec/changes/<change>/...
+//	<repo>/<service-dir>/...
+func seedNestedSubprojectRepo(t *testing.T, tasks string) (repo string, planning string) {
+	t.Helper()
+	repo = initRuntimeLedgerRepo(t)
+	planning = filepath.Join(repo, "subproject")
+	service := filepath.Join(repo, "service")
+	for _, dir := range []string{planning, service} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(service, "handler.go"), []byte("package service\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedReadyChange(t, planning, "nested-change", tasks)
+	return repo, planning
+}
+
+// TestSiblingDirectoryInsideOneRepositoryBlocksApply is #2891.
+//
+// detectUnauthorizedEditRoots was written for the cross-repository case and
+// says so in its own comment: it flags a token only when the token "resolves
+// to a real Git repository different from the planning repository". That
+// treats "outside the workspace" and "a different repository" as the same
+// thing. They are not. When the planning workspace is a nested subproject,
+// a sibling directory is outside every authorized edit root while sharing the
+// planning repository's Git root, so `target == planningGitRoot` skipped it
+// and apply stayed ready for a plan sdd-apply's outside-root guard would
+// refuse.
+//
+// #2540's edit-authority chain does not cover this: its targets resolve to a
+// different Git root. Neither does #3001's filesystem-root guard.
+func TestSiblingDirectoryInsideOneRepositoryBlocksApply(t *testing.T) {
+	_, planning := seedNestedSubprojectRepo(t, strings.Join([]string{
+		"- [ ] 1.1 Add the claim check to `../service/handler.go`",
+		"",
+	}, "\n"))
+
+	status, err := Resolve(ResolveOptions{CWD: planning, ChangeName: "nested-change"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.ApplyState != ApplyBlocked {
+		t.Fatalf("applyState = %q, want blocked: the plan edits a directory outside every authorized edit root", status.ApplyState)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if !strings.Contains(reasons, "edit_authority_missing") {
+		t.Fatalf("blocked reasons do not name the missing edit authority: %v", status.BlockedReasons)
+	}
+	// The refusal has to name the directory the operator would grant, not the
+	// file and not the whole repository.
+	if !strings.Contains(reasons, filepath.Join(filepath.Dir(planning), "service")) {
+		t.Fatalf("blocked reason does not name the unauthorized directory: %v", status.BlockedReasons)
+	}
+	// Both exits stay stated verbatim; this issue widens what is detected, it
+	// does not change what the operator can do about it.
+	for _, exit := range []string{"edit tasks.md so every work unit stays inside the authorized edit roots", "grant this change edit authority"} {
+		if !strings.Contains(reasons, exit) {
+			t.Fatalf("blocked reason dropped the exit %q: %v", exit, status.BlockedReasons)
+		}
+	}
+}
+
+// TestNestedSubprojectTargetsInsideItsOwnWorkspaceStayReady is the
+// false-positive guard. Widening detection must not block the ordinary case:
+// a nested subproject editing its own files is entirely inside its authorized
+// root and has nothing to grant.
+func TestNestedSubprojectTargetsInsideItsOwnWorkspaceStayReady(t *testing.T) {
+	_, planning := seedNestedSubprojectRepo(t, strings.Join([]string{
+		"- [ ] 1.1 Update `internal/auth/login.go` with the new claim check",
+		"- [ ] 1.2 Run `go test ./...` and fix regressions",
+		"",
+	}, "\n"))
+
+	status, err := Resolve(ResolveOptions{CWD: planning, ChangeName: "nested-change"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ApplyState != ApplyReady || len(status.BlockedReasons) != 0 {
+		t.Fatalf("a subproject editing its own files lost readiness: applyState = %q blockedReasons = %v",
+			status.ApplyState, status.BlockedReasons)
+	}
+}
+
+// TestGrantedSiblingDirectoryRestoresReadiness proves the new detection plugs
+// into the SAME grant seam as the cross-repository case: an authorized root
+// covering the sibling makes the plan admissible, with no separate mechanism.
+func TestGrantedSiblingDirectoryRestoresReadiness(t *testing.T) {
+	repo, planning := seedNestedSubprojectRepo(t, strings.Join([]string{
+		"- [ ] 1.1 Add the claim check to `../service/handler.go`",
+		"",
+	}, "\n"))
+
+	tasks := "- [ ] 1.1 Add the claim check to `../service/handler.go`\n"
+	roots := detectUnauthorizedEditRoots(tasks, planning, []string{planning, filepath.Join(repo, "service")})
+	if len(roots) != 0 {
+		t.Fatalf("granting the sibling directory left it unauthorized: %v", roots)
+	}
+}


### PR DESCRIPTION
Reproduced on `main` before the change: one Git repository, planning workspace at `<repo>/subproject`, a task naming `` `../service/handler.go` ``.

```
applyState      : ready
blockedReasons  : []
allowedEditRoots: ["<repo>/subproject"]
```

Apply was admitted for a target outside every authorized edit root.

## Cause

`detectUnauthorizedEditRoots` was written for the cross-repository case and states the limit in its own comment: it flags a token only when it "resolves to a real Git repository different from the planning repository". That treats *outside the workspace* and *a different repository* as the same thing.

```go
target := gitRootOf(resolved)
if target == "" || target == planningGitRoot || withinAnyRoot(target, allowed) {
    continue                       // <- #2891 exits here
}
```

A sibling directory in a nested-subproject layout shares the planning Git root, so it was skipped. #2540's edit-authority chain does not cover it (its targets resolve to a different Git root) and neither does #3001's filesystem-root guard.

## Change

Detection now asks what the roots actually answer:

- target in **another** repository -> unit stays the Git root (unchanged);
- target in **the planning** repository -> unit is the containing directory, which is what an operator would grant and narrower than the whole repository.

After, same fixture:

```
applyState : blocked
reason     : blocked(edit_authority_missing): tasks.md targets paths outside the authorized edit roots:
             "<repo>/service"; edit tasks.md so every work unit stays inside the authorized edit roots,
             or grant this change edit authority for those roots
consent    : gentle-ai.sdd-integration.consent/v1
```

It plugs into the existing grant seam with no new mechanism: `TestGrantedSiblingDirectoryRestoresReadiness` shows an authorized root covering the sibling clears the block.

## False positives

The flat case is untouched by construction: when the workspace is the Git root, every in-repository path is already inside an authorized root. `TestSingleRepoTasksKeepStatusByteIdentical` still passes unchanged, and `TestNestedSubprojectTargetsInsideItsOwnWorkspaceStayReady` pins that a subproject editing its own files keeps readiness.

## A wording fix I did not plan, and the mistake behind it

The envelope said the roots were repository roots, which is false for the new kind. My first fix re-derived the kind by probing the filesystem, and the shipped fixture caught it: `/workspace/service-a` does not exist on disk, so the probe labelled two separate repositories as directories inside the planning repository. Task plans routinely name paths that do not exist yet, so the probe would mislabel exactly the roots it cannot see. The line now states the fact that holds for both and needs no probe.

Two pins moved deliberately and are documented in place: the consent fixture (regenerated from the builder itself, which is what its test requires) and its digest. No field, choice, answer token, or invocation changed.

`go test ./...` clean. Both new behaviors were RED first.

Closes #2891