### PR TITLE
fix(cli): preserve Windows CWD in consent follow-up

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2203,7 +2203,7 @@ func reviewConsentFollowUpBase(
 	parts := []string{
 		"gentle-ai review start",
 		"--contract " + contract,
-		"--cwd " + cwd,
+		"--cwd " + reviewTransitionShellWord(cwd),
 		"--target " + target,
 		"--projection " + string(projection),
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -2223,7 +2223,7 @@ func reviewConsentFollowUpBase(
 		parts = append(parts, "--workspace-overlay")
 	}
 	if policy != "" {
-		parts = append(parts, "--policy "+policy)
+		parts = append(parts, "--policy "+reviewTransitionShellWord(policy))
 	}
 	// The focus default never needs restating; only an explicit non-default
 	// focus changes what the answered start would select.
@@ -2231,7 +2231,7 @@ func reviewConsentFollowUpBase(
 		parts = append(parts, "--focus "+focus)
 	}
 	if trace != "" {
-		parts = append(parts, "--trace "+trace)
+		parts = append(parts, "--trace "+reviewTransitionShellWord(trace))
 	}
 	if locale != "" {
 		parts = append(parts, "--locale "+locale)

--- a/internal/cli/review_intended_untracked_test.go
+++ b/internal/cli/review_intended_untracked_test.go
@@ -232,3 +232,28 @@ func TestIntendedUntrackedConsentFollowUpPreservesSelectedScope(t *testing.T) {
 		t.Fatalf("consent START target = %s, selected status target = %s", negotiatedStartTarget(started), status.TargetIdentity)
 	}
 }
+
+func TestConsentFollowUpPrintedCwdRoundTripsWindowsNativePath(t *testing.T) {
+	const cwd = `C:\Users\reviewer\gentle-ai`
+	command := reviewConsentFollowUpBase(
+		cwd, "sha256:target", reviewtransaction.ProjectionWorkspace,
+		"windows-cwd-roundtrip", "", "", "reliability", "", false, false,
+		ReviewIntegrationContractV2, "", "", reviewIntendedUntrackedScope{},
+	)
+
+	words, err := SplitPrintedCommandWords(command)
+	if err != nil {
+		t.Fatalf("split printed consent follow-up: %v", err)
+	}
+	want := []string{
+		"gentle-ai", "review", "start",
+		"--contract", ReviewIntegrationContractV2,
+		"--cwd", cwd,
+		"--target", "sha256:target",
+		"--projection", string(reviewtransaction.ProjectionWorkspace),
+		"--lineage", "windows-cwd-roundtrip",
+	}
+	if !reflect.DeepEqual(words, want) {
+		t.Fatalf("printed consent follow-up words = %#v, want %#v\ncommand: %q", words, want, command)
+	}
+}

--- a/internal/cli/review_intended_untracked_test.go
+++ b/internal/cli/review_intended_untracked_test.go
@@ -233,27 +233,42 @@ func TestIntendedUntrackedConsentFollowUpPreservesSelectedScope(t *testing.T) {
 	}
 }
 
-func TestConsentFollowUpPrintedCwdRoundTripsWindowsNativePath(t *testing.T) {
-	const cwd = `C:\Users\reviewer\gentle-ai`
-	command := reviewConsentFollowUpBase(
-		cwd, "sha256:target", reviewtransaction.ProjectionWorkspace,
-		"windows-cwd-roundtrip", "", "", "reliability", "", false, false,
-		ReviewIntegrationContractV2, "", "", reviewIntendedUntrackedScope{},
-	)
+func TestConsentFollowUpPrintedPathFlagsRoundTripWindowsNativePaths(t *testing.T) {
+	for _, test := range []struct {
+		name, cwd, policy, trace string
+	}{
+		{name: "cwd", cwd: `C:\Users\reviewer\gentle ai`},
+		{name: "policy", cwd: "/repo", policy: `C:\Users\reviewer\policy files\review policy.json`},
+		{name: "trace", cwd: "/repo", trace: `C:\Users\reviewer\traces\operation trace.json`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := reviewConsentFollowUpBase(
+				test.cwd, "sha256:target", reviewtransaction.ProjectionWorkspace,
+				"windows-path-roundtrip", "", test.policy, "reliability", test.trace, false, false,
+				ReviewIntegrationContractV2, "", "", reviewIntendedUntrackedScope{},
+			)
 
-	words, err := SplitPrintedCommandWords(command)
-	if err != nil {
-		t.Fatalf("split printed consent follow-up: %v", err)
-	}
-	want := []string{
-		"gentle-ai", "review", "start",
-		"--contract", ReviewIntegrationContractV2,
-		"--cwd", cwd,
-		"--target", "sha256:target",
-		"--projection", string(reviewtransaction.ProjectionWorkspace),
-		"--lineage", "windows-cwd-roundtrip",
-	}
-	if !reflect.DeepEqual(words, want) {
-		t.Fatalf("printed consent follow-up words = %#v, want %#v\ncommand: %q", words, want, command)
+			words, err := SplitPrintedCommandWords(command)
+			if err != nil {
+				t.Fatalf("split printed consent follow-up: %v", err)
+			}
+			want := []string{
+				"gentle-ai", "review", "start",
+				"--contract", ReviewIntegrationContractV2,
+				"--cwd", test.cwd,
+				"--target", "sha256:target",
+				"--projection", string(reviewtransaction.ProjectionWorkspace),
+				"--lineage", "windows-path-roundtrip",
+			}
+			if test.policy != "" {
+				want = append(want, "--policy", test.policy)
+			}
+			if test.trace != "" {
+				want = append(want, "--trace", test.trace)
+			}
+			if !reflect.DeepEqual(words, want) {
+				t.Fatalf("printed consent follow-up words = %#v, want %#v\ncommand: %q", words, want, command)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #3033

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Quote the dynamic `--cwd`, `--policy`, and `--trace` path values in consent follow-up commands so each is emitted as one POSIX shell word.
- Add table-driven portable coverage proving exact Windows-native path round trips for all three path-bearing flags.

---

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/cli/review_facade.go` | Render consent follow-up CWD, policy, and trace paths through `reviewTransitionShellWord`. |
| `internal/cli/review_intended_untracked_test.go` | Table-test exact Windows-native CWD, policy, and trace parser round trips. |

---

## Test Plan

**Unit Tests**
```bash
go test ./internal/cli -run '^(TestConsentFollowUpPrintedPathFlagsRoundTripWindowsNativePaths|TestIntendedUntrackedConsentFollowUpPreservesSelectedScope)$' -count=1
go test ./internal/cli -count=1
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
git diff --check
```

**Runtime Evidence**

- [x] The original base was RED for the unquoted Windows-native CWD; the immutable PR head was RED for unquoted policy and trace paths, which lost backslashes and split at spaces.
- [x] The table-driven CWD, policy, and trace regression is GREEN after the rendering-boundary corrections.
- [ ] A real Windows runner was not executed locally; Windows runtime proof remains CI-owned.

**Benchmark Validation**

N/A: this change does not modify benchmark implementation, corpus, classifier, or a benchmark-claimed lifecycle flow.

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] Docker E2E suite was not run; the affected boundary is covered by the parser round-trip regression and the existing consent follow-up execution test.
- [x] Manually tested locally with the focused portable parser scenario.

---

## Candidate Identity

- Base: `main` at `1ebb8e204e696fe77ebe10a7a51a7286ef9c0c73` (tree `91170d192dab1f9b855c962c4fa4fec4cb28f05d`)
- Head: `fix/3033-windows-consent-cwd` at `5fbbfdd279322c5be754440148a77d2f112c886f` (tree `e6c86e12742cb9c0b1f217c33a47f8c0a9168a3b`)

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (43 additions, 3 deletions)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] Docker E2E tests were not run; see the Test Plan limitation.
- [x] Benchmark validation is not applicable; see the Test Plan.
- [x] Documentation is not required for this internal command-rendering bug fix.
- [x] My commit follows Conventional Commits format.
- [x] My commit does not include `Co-Authored-By` trailers.

---

## Notes for Reviewers

- No qualifying security, integrity, admission, repair, or governance guard was added or changed; `.guard-population-baseline.txt` is unchanged.
- Rollback boundary: revert `5fbbfdd2` to remove only the policy/trace completion correction; revert both path-rendering commits to restore the prior behavior entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of consent follow-up commands containing paths with spaces or special characters.
  * Windows-native paths now remain intact when used for working directory, policy, or trace options.

* **Tests**
  * Added regression coverage to verify reliable round-trip parsing of Windows paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->