### PR TITLE
fix(sdd): detect flat root spec artifacts

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -610,6 +610,7 @@ func Journeys() []Journey {
 	journeys := append(coreJourneys(), edgeJourneys()...)
 	journeys = append(journeys, sddJourneys()...)
 	journeys = append(journeys, issue2891Journeys()...)
+	journeys = append(journeys, issue2696Journeys()...)
 	journeys = append(journeys, sddChainJourneys()...)
 	journeys = append(journeys, captureEvidenceDescriptorJourneys()...)
 	journeys = append(journeys, scopeChangedFixtureJourneys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -26,6 +26,7 @@ func journeySources() []journeySource {
 		{"journeys_edge.go", edgeJourneys()},
 		{"journeys_sdd.go", sddJourneys()},
 		{"journeys_issue_2891.go", issue2891Journeys()},
+		{"journeys_issue2696.go", issue2696Journeys()},
 		{"journeys_sdd_chain.go", sddChainJourneys()},
 		{"journeys_handoff.go", handoffJourneys()},
 		{"journeys_capture_evidence_v5.go", captureEvidenceDescriptorJourneys()},

--- a/bench/journeys_issue2696.go
+++ b/bench/journeys_issue2696.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+type issue2696Status struct {
+	ArtifactPaths struct {
+		Specs []string `json:"specs"`
+	} `json:"artifactPaths"`
+	Artifacts    map[string]string `json:"artifacts"`
+	Dependencies struct {
+		Specs string `json:"specs"`
+		Apply string `json:"apply"`
+	} `json:"dependencies"`
+	NextRecommended string   `json:"nextRecommended"`
+	BlockedReasons  []string `json:"blockedReasons"`
+}
+
+var sddContinueCapability = &Capability{
+	Verb:  []string{"sdd-continue"},
+	Probe: []string{"sdd-continue", "--json"},
+}
+
+func issue2696Journeys() []Journey {
+	return []Journey{{
+		ID:     "j98-sdd-flat-root-spec-is-discovered",
+		Title:  "Flat-root spec is discovered consistently by status and continue",
+		Source: "issue #2696: approved flat-root spec.md artifact discovery contract",
+		Steps: []Step{
+			{Name: "fixture: committed change with a flat root spec", Fixture: issue2696FlatSpecFixture},
+			{Name: "sdd-status reports the flat spec", Requires: sddStatusCapability,
+				Args: productArgs("sdd-status", sddChange, "--json"), After: issue2696StatusAssertion("sdd-status")},
+			{Name: "sdd-continue reports the same state", Requires: sddContinueCapability,
+				Args: productArgs("sdd-continue", sddChange, "--json"), After: issue2696StatusAssertion("sdd-continue")},
+		},
+	}}
+}
+
+func issue2696FlatSpecFixture(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	root := sddChangeRoot(sandbox)
+	files := []struct {
+		name    string
+		content string
+	}{
+		{name: "proposal.md", content: "# Flat spec change\n"},
+		{name: "spec.md", content: "### Requirement: flat spec\n#### Scenario: present\n\n- **WHEN** status runs\n- **THEN** the root spec is detected\n"},
+		{name: "design.md", content: "# Design\n"},
+		{name: "tasks.md", content: "- [ ] 1.1 Work\n"},
+	}
+	for _, file := range files {
+		if err := sandbox.write(filepath.Join(root, file.name), file.content); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "openspec"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "commit", "-qm", "flat root spec fixture")
+}
+
+func issue2696StatusAssertion(command string) func(*Sandbox, Observation) error {
+	return func(sandbox *Sandbox, observation Observation) error {
+		var status issue2696Status
+		if err := json.Unmarshal([]byte(observation.Stdout), &status); err != nil {
+			return fmt.Errorf("parse %s JSON: %w", command, err)
+		}
+		expectedSpec := filepath.Join(sddChangeRoot(sandbox), "spec.md")
+		if len(status.ArtifactPaths.Specs) != 1 || status.ArtifactPaths.Specs[0] != expectedSpec {
+			return fmt.Errorf("%s artifactPaths.specs = %v, want [%s]", command, status.ArtifactPaths.Specs, expectedSpec)
+		}
+		if status.Artifacts["specs"] != "done" {
+			return fmt.Errorf("%s artifacts.specs = %q, want done", command, status.Artifacts["specs"])
+		}
+		if status.Dependencies.Specs != "all_done" || status.Dependencies.Apply != "ready" {
+			return fmt.Errorf("%s dependencies = %#v, want specs all_done/apply ready", command, status.Dependencies)
+		}
+		if status.NextRecommended != "apply" || len(status.BlockedReasons) != 0 {
+			return fmt.Errorf("%s routing = next %q blocked %v, want apply and no blockers", command, status.NextRecommended, status.BlockedReasons)
+		}
+		fingerprint := fmt.Sprintf("%v|%s|%s|%s|%v", status.ArtifactPaths.Specs, status.Artifacts["specs"], status.Dependencies.Specs, status.NextRecommended, status.BlockedReasons)
+		if previous := sandbox.Scratch["issue-2696-status"]; previous != "" && previous != fingerprint {
+			return fmt.Errorf("%s state differs from the earlier public command: %q != %q", command, fingerprint, previous)
+		}
+		sandbox.Scratch["issue-2696-status"] = fingerprint
+		return nil
+	}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -62,12 +62,14 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// both journeys had no subject left. j37 survives, rewritten to prove the
 	// opposite of what it used to: the bound passing finish now CLOSES over a
 	// corrected candidate and keeps the binding recorded.
+	// j98 proves #2696 discovers a committed flat-root spec through both public
+	// SDD status surfaces and preserves the same routing state.
 	//
 	// j96 proves #2891 blocks an off-path sibling in a nested same-repository workspace.
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 93 {
-		t.Errorf("core journey count = %d, want 93", got)
+	if got := len(seen); got != 94 {
+		t.Errorf("core journey count = %d, want 94", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/sdd_status_test.go
+++ b/internal/cli/sdd_status_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -63,6 +64,49 @@ func TestRunSDDStatusPrintsJSONWithInstructions(t *testing.T) {
 	}
 	if status.NextRecommended != "apply" {
 		t.Fatalf("NextRecommended = %q, want apply", status.NextRecommended)
+	}
+}
+
+func TestRunSDDStatusAndContinueReportFlatSpecConsistently(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := filepath.Join(root, "openspec", "changes", "flat-spec")
+	writeSDDStatusFile(t, filepath.Join(changeRoot, "proposal.md"), "# Proposal\n")
+	writeSDDStatusFile(t, filepath.Join(changeRoot, "spec.md"), "### Requirement: flat\n#### Scenario: present\n")
+	writeSDDStatusFile(t, filepath.Join(changeRoot, "design.md"), "# Design\n")
+	writeSDDStatusFile(t, filepath.Join(changeRoot, "tasks.md"), "- [ ] 1.1 Work\n")
+
+	tests := []struct {
+		name string
+		run  func([]string, io.Writer) error
+	}{
+		{name: "sdd-status", run: RunSDDStatus},
+		{name: "sdd-continue", run: RunSDDContinue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			if err := tt.run([]string{"flat-spec", "--cwd", root, "--json"}, &stdout); err != nil {
+				t.Fatalf("command error = %v", err)
+			}
+
+			var status sddstatus.Status
+			if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+				t.Fatalf("JSON decode error = %v\n%s", err, stdout.String())
+			}
+			wantSpec := filepath.Join(changeRoot, "spec.md")
+			if !reflect.DeepEqual(status.ArtifactPaths.Specs, []string{wantSpec}) {
+				t.Fatalf("ArtifactPaths.Specs = %v, want [%s]", status.ArtifactPaths.Specs, wantSpec)
+			}
+			if status.Artifacts["specs"] != sddstatus.ArtifactDone {
+				t.Fatalf("Artifacts[specs] = %q, want done", status.Artifacts["specs"])
+			}
+			if status.Dependencies.Specs != sddstatus.DependencyAllDone || status.Dependencies.Apply != sddstatus.DependencyReady {
+				t.Fatalf("dependencies = %#v, want specs all_done and apply ready", status.Dependencies)
+			}
+			if status.NextRecommended != "apply" {
+				t.Fatalf("NextRecommended = %q, want apply", status.NextRecommended)
+			}
+		})
 	}
 }
 

--- a/internal/sddstatus/flat_spec_test.go
+++ b/internal/sddstatus/flat_spec_test.go
@@ -1,0 +1,108 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveSpecDiscoveryPrecedenceAndFallback(t *testing.T) {
+	flatSpec := "### Requirement: flat\n#### Scenario: present\n"
+	emptyFlat := ""
+	tests := []struct {
+		name           string
+		nested         string
+		flat           *string
+		wantPaths      []string
+		wantArtifact   ArtifactState
+		wantDependency DependencyState
+		wantNext       string
+	}{
+		{
+			name:           "nested only",
+			nested:         "### Requirement: nested\n#### Scenario: present\n",
+			wantPaths:      []string{"specs/auth/spec.md"},
+			wantArtifact:   ArtifactDone,
+			wantDependency: DependencyAllDone,
+			wantNext:       "apply",
+		},
+		{
+			name:           "flat only",
+			flat:           &flatSpec,
+			wantPaths:      []string{"spec.md"},
+			wantArtifact:   ArtifactDone,
+			wantDependency: DependencyAllDone,
+			wantNext:       "apply",
+		},
+		{
+			name:           "both present keeps nested authoritative",
+			nested:         "### Requirement: nested\n#### Scenario: present\n",
+			flat:           &flatSpec,
+			wantPaths:      []string{"specs/auth/spec.md"},
+			wantArtifact:   ArtifactDone,
+			wantDependency: DependencyAllDone,
+			wantNext:       "apply",
+		},
+		{
+			name:           "empty flat is not an artifact",
+			flat:           &emptyFlat,
+			wantPaths:      []string{},
+			wantArtifact:   ArtifactMissing,
+			wantDependency: DependencyBlocked,
+			wantNext:       "spec",
+		},
+		{
+			name:           "neither present",
+			wantPaths:      []string{},
+			wantArtifact:   ArtifactMissing,
+			wantDependency: DependencyBlocked,
+			wantNext:       "spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := filepath.Join(root, "openspec", "changes", "flat-spec")
+			write(t, filepath.Join(changeRoot, "proposal.md"), "# Proposal\n")
+			write(t, filepath.Join(changeRoot, "design.md"), "# Design\n")
+			write(t, filepath.Join(changeRoot, "tasks.md"), "- [ ] 1.1 Work\n")
+			if tt.nested != "" {
+				write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), tt.nested)
+			}
+			if tt.flat != nil {
+				write(t, filepath.Join(changeRoot, "spec.md"), *tt.flat)
+			}
+
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "flat-spec"})
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+
+			wantPaths := make([]string, 0, len(tt.wantPaths))
+			for _, path := range tt.wantPaths {
+				wantPaths = append(wantPaths, filepath.Join(changeRoot, path))
+			}
+			if !reflect.DeepEqual(status.ArtifactPaths.Specs, wantPaths) {
+				t.Fatalf("ArtifactPaths.Specs = %v, want %v", status.ArtifactPaths.Specs, wantPaths)
+			}
+			if status.Artifacts["specs"] != tt.wantArtifact {
+				t.Fatalf("Artifacts[specs] = %q, want %q", status.Artifacts["specs"], tt.wantArtifact)
+			}
+			if status.Dependencies.Specs != tt.wantDependency {
+				t.Fatalf("Dependencies.Specs = %q, want %q", status.Dependencies.Specs, tt.wantDependency)
+			}
+			if status.NextRecommended != tt.wantNext {
+				t.Fatalf("NextRecommended = %q, want %q", status.NextRecommended, tt.wantNext)
+			}
+		})
+	}
+}
+
+func TestPlanningSpecInstructionsDescribeBothLayouts(t *testing.T) {
+	instructions := strings.Join(planningInstructionsForPhase(Status{}, PhaseSpec), "\n")
+	if !strings.Contains(instructions, "Create spec.md or specs/<domain>/spec.md with requirements and scenarios.") {
+		t.Fatalf("spec planning instructions = %q, want both spec layouts", instructions)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1655,6 +1655,12 @@ func resolveArtifactPaths(changeRoot string) (ArtifactPaths, error) {
 	if err != nil {
 		return ArtifactPaths{}, err
 	}
+	if len(specFiles) == 0 {
+		flatSpec := filepath.Join(changeRoot, "spec.md")
+		if hasContent(flatSpec) {
+			specFiles = []string{flatSpec}
+		}
+	}
 	paths.Specs = specFiles
 	return paths, nil
 }
@@ -1893,7 +1899,7 @@ func artifactBlockedReasons(artifacts map[string]ArtifactState, taskProgress Tas
 		reasons.expectedPlanning = append(reasons.expectedPlanning, "proposal.md is missing or partial.")
 	}
 	if artifacts["specs"] != ArtifactDone {
-		reasons.expectedPlanning = append(reasons.expectedPlanning, "specs/**/spec.md is missing or partial.")
+		reasons.expectedPlanning = append(reasons.expectedPlanning, "spec.md or specs/**/spec.md is missing or partial.")
 	}
 	if artifacts["design"] != ArtifactDone {
 		reasons.expectedPlanning = append(reasons.expectedPlanning, "design.md is missing or partial.")
@@ -2202,7 +2208,7 @@ func planningInstructionsForPhase(status Status, phase Phase) []string {
 		return []string{
 			fmt.Sprintf("Change: %s", change),
 			"Read proposal.md before writing specs.",
-			"Create specs/<domain>/spec.md with requirements and scenarios.",
+			"Create spec.md or specs/<domain>/spec.md with requirements and scenarios.",
 		}
 	case PhaseDesign:
 		return []string{

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -255,7 +255,7 @@ func TestResolveStatusJSONUsesEmptyBlockedReasonsArray(t *testing.T) {
 func TestBlockerReasonsForRoute(t *testing.T) {
 	expected := []string{
 		"proposal.md is missing or partial.",
-		"specs/**/spec.md is missing or partial.",
+		"spec.md or specs/**/spec.md is missing or partial.",
 		"design.md is missing or partial.",
 		"tasks.md is missing or partial.",
 	}


### PR DESCRIPTION
<!-- Every PR must be linked to an approved issue. -->

## 🔗 Linked Issue

Closes #2696

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Detect a non-empty flat `openspec/changes/<change>/spec.md` when no nested specs exist.
- Preserve nested `specs/**/spec.md` precedence and consistent `sdd-status`/`sdd-continue` routing.
- Add focused coverage and the public/runtime `j98-sdd-flat-root-spec-is-discovered` benchmark journey.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | Add the non-empty flat-root spec fallback and update accurate planning guidance. |
| `internal/sddstatus`, `internal/cli` tests | Cover nested, flat, precedence, empty, absent, and public-command behavior. |
| `bench/` | Add the issue-linked public/runtime j98 journey and preserve corpus registration/count checks. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/sddstatus -run '^(TestResolveSpecDiscoveryPrecedenceAndFallback|TestPlanningSpecInstructionsDescribeBothLayouts|TestBlockerReasonsForRoute|TestResolveArtifactStatesAndTaskProgress|TestResolveNextRecommendedPlanningRouting|TestResolveIncludesInstructionsWhenRequested|TestRenderMarkdownIncludesFencedJSON|TestRenderDispatcherMarkdownIncludesRoutingContext|TestRenderDispatcherMarkdownIncludesBlockedReasonsSeparately|TestRenderNativePhasePromptIncludesAuthorityInstructionsJSONAndBlockedGuidance)$' -count=1
go test ./internal/cli -run '^(TestRunSDDStatusAndContinueOmitExpectedPlanningBlockers|TestRunSDDStatusAndContinueReportFlatSpecConsistently|TestRunSDDStatusPrintsJSONWithInstructions|TestRunSDDContinuePrintsDispatcherMarkdownWithInstructions|TestRunSDDContinuePrintsJSONWithInstructionsByDefault)$' -count=1
go test ./... -run '^$' -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```text
Not run locally; Docker E2E coverage remains a CI check.
```

**Benchmark Validation**
```bash
(cd bench && go test ./...)
(cd bench && go vet ./...)
gentle-ai-bench run --binary <built-gentle-ai> --only j98-sdd-flat-root-spec-is-discovered
```

Results: focused tests, root compile check, format check, benchmark tests/vet, and the exact j98 journey passed. The j98 journey completed with 1 completed, 0 unsupported, and 0 failed.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 265 authored changed lines. |
| Check Issue Reference | ⏳ | Linked issue reference is present. |
| Check Issue Has `status:approved` | ⏳ | Linked issue approval is required. |
| Check PR Has `type:*` Label | ⏳ | Label intentionally not added yet. |
| Unit Tests | ⏳ | Focused tests and root compile check passed locally. |
| Go Format | ⏳ | Format check passed locally. |
| E2E Tests | ⏳ | CI Docker coverage. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR (intentionally deferred)
- [x] Focused unit tests and root compile check pass
- [x] Go format passes
- [ ] E2E tests pass locally (CI Docker coverage)
- [x] Public/runtime benchmark validation completed with j98
- [x] Documentation update is not needed for this bounded behavior fix
- [x] Commit follows Conventional Commits format
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

- Nested specs remain authoritative when present; the flat file is only a fallback when non-empty and no nested spec files exist.
- Main benchmark entries and the issue-linked j98 journey are registered independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering specifications stored at the repository root as `spec.md`.
  * Nested specifications remain supported and take precedence when available.
  * Status and continuation guidance now recognize both specification layouts.

* **Bug Fixes**
  * Improved consistency between status and continuation results for flat-layout specifications.
  * Corrected artifact paths, completion state, dependency status, and next-step recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->