### PR TITLE
fix(cli): parse consent relay follow-ups

### DIFF
--- a/internal/cli/review_consent_relay_test.go
+++ b/internal/cli/review_consent_relay_test.go
@@ -46,11 +46,90 @@ func decodeConsentQuestion(t *testing.T, payload []byte) ReviewIntegrationConsen
 // literally runnable rather than merely descriptive.
 func invocationArgs(t *testing.T, invocation string) []string {
 	t.Helper()
-	fields := strings.Fields(invocation)
-	if len(fields) < 3 || fields[0] != "gentle-ai" || fields[1] != "review" || fields[2] != "start" {
+	words, err := SplitPrintedCommandWords(invocation)
+	if err != nil {
+		t.Fatalf("parse consent invocation: %v", err)
+	}
+	if len(words) < 3 || words[0] != "gentle-ai" || words[1] != "review" || words[2] != "start" {
 		t.Fatalf("consent invocation is not a runnable gentle-ai review start command: %q", invocation)
 	}
-	return fields[2:]
+	return words[2:]
+}
+
+func normalizeConsentFixtureCWD(t *testing.T, payload []byte, root string) []byte {
+	t.Helper()
+	var envelope struct {
+		Choices []struct {
+			Invocation string `json:"invocation"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("decode consent fixture: %v", err)
+	}
+
+	normalized := append([]byte(nil), payload...)
+	for _, choice := range envelope.Choices {
+		args := invocationArgs(t, choice.Invocation)
+		cwd := -1
+		for index, arg := range args {
+			if arg != "--cwd" {
+				continue
+			}
+			if cwd >= 0 {
+				t.Fatalf("consent invocation repeats --cwd: %q", choice.Invocation)
+			}
+			cwd = index
+		}
+		if cwd < 0 || cwd+1 >= len(args) || args[cwd+1] != root {
+			t.Fatalf("consent invocation CWD = %q, want %q: %q", args, root, choice.Invocation)
+		}
+		args[cwd+1] = "/repo"
+
+		words := append([]string{"gentle-ai", "review"}, args...)
+		for index, word := range words {
+			words[index] = reviewTransitionShellWord(word)
+		}
+		normalizedInvocation := strings.Join(words, " ")
+		encodedInvocation, err := json.Marshal(choice.Invocation)
+		if err != nil {
+			t.Fatalf("encode consent invocation: %v", err)
+		}
+		encodedNormalizedInvocation, err := json.Marshal(normalizedInvocation)
+		if err != nil {
+			t.Fatalf("encode normalized consent invocation: %v", err)
+		}
+		if next := bytes.ReplaceAll(normalized, encodedInvocation, encodedNormalizedInvocation); bytes.Equal(next, normalized) {
+			t.Fatalf("consent invocation not found in fixture payload: %q", choice.Invocation)
+		} else {
+			normalized = next
+		}
+	}
+	return normalized
+}
+
+func TestInvocationArgsParsesQuotedWindowsConsentFollowUp(t *testing.T) {
+	root := `C:\Users\Jane Doe\repo`
+	invocation := "gentle-ai review start --cwd '" + root + "' --contract " + ReviewIntegrationContractV1
+
+	want := []string{"start", "--cwd", root, "--contract", ReviewIntegrationContractV1}
+	if got := invocationArgs(t, invocation); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("invocation args = %#v, want %#v", got, want)
+	}
+}
+
+func TestConsentFixtureNormalizationStripsRenderedWindowsCWDQuoting(t *testing.T) {
+	root := `C:\Users\Jane Doe\repo`
+	payload, err := json.Marshal(ReviewIntegrationConsentResult{Choices: []ReviewIntegrationConsentChoice{{
+		Invocation: "gentle-ai review start --cwd '" + root + "' --contract " + ReviewIntegrationContractV1,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	normalized := normalizeConsentFixtureCWD(t, payload, root)
+	if !bytes.Contains(normalized, []byte("--cwd /repo")) || bytes.Contains(normalized, []byte("--cwd '/repo'")) {
+		t.Fatalf("normalized fixture CWD = %s, want canonical --cwd /repo", normalized)
+	}
 }
 
 func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion(t *testing.T) {
@@ -443,11 +522,7 @@ func TestConsentQuestionMatchesVersionedFixture(t *testing.T) {
 			if err := question.Validate(); err != nil {
 				t.Fatal(err)
 			}
-			encodedRoot, err := json.Marshal(root)
-			if err != nil {
-				t.Fatalf("encode fixture repository root: %v", err)
-			}
-			normalized := bytes.ReplaceAll(output.Bytes(), encodedRoot[1:len(encodedRoot)-1], []byte("/repo"))
+			normalized := normalizeConsentFixtureCWD(t, output.Bytes(), root)
 			fixturePath := filepath.Join("..", "..", "contracts", "review-integration", tt.fixture)
 			if os.Getenv("GENTLE_AI_CONSENT_FIXTURE_UPDATE") == "1" {
 				if err := os.WriteFile(fixturePath, normalized, 0o644); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3033

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Parse rendered consent follow-ups with `SplitPrintedCommandWords` instead of whitespace splitting.
- Normalize fixture CWD values as parsed argv, then render the canonical `/repo` value.
- Add portable RED coverage for quoted Windows paths; production files and versioned fixtures are unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_consent_relay_test.go` | Corrected relay test consumers and added Windows path parser/fixture regressions. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/cli -count=1
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
git diff --check
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```
Blocked locally before builds: Docker socket access is denied at `/var/run/docker.sock`.

**Benchmark Validation**
N/A: this is a test-only CLI consumer correction; it does not change review lifecycle, delivery, recovery, or the bench corpus.

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - blocked by local Docker socket permissions
- [x] Manually tested locally: both new portable regressions were RED before the correction and GREEN after it.

**Windows evidence and requirement**

- Main Windows Full Suite run `31513772401` was RED before this correction: the stale relay/decline consumers received malformed `C::` roots, while fixture normalization retained rendered CWD quotes.
- Local GREEN covers the eight relay/decline/fixture consumers, `TestConsentFollowUpPrintedPathFlagsRoundTripWindowsNativePaths`, and `TestIntendedUntrackedConsentFollowUpPreservesSelectedScope`.
- Windows CI must pass before merge.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | Candidate is 91 changed lines. |
| Check Issue Reference | Pending | `Closes #3033` is present. |
| Check Issue Has `status:approved` | Pending | #3033 is approved. |
| Check PR Has `type:*` Label | Pending | Exactly one `type:bug` label is applied. |
| Unit Tests | Pending | CI will rerun uncached tests. |
| Go Format | Pending | CI will rerun the formatter check. |
| Windows Full Suite | Required | Must pass before merge. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (91 additions plus deletions)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - blocked by local Docker socket permissions
- [x] Benchmark validation is not applicable to this test-consumer-only correction
- [x] Documentation is not needed; production behavior is unchanged
- [x] My commit follows Conventional Commits
- [x] My commit does not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- RDD mode is clone-local off, so this correction is `disabled/unmanaged`; no review was started.
- Rollback boundary: revert commit `361ebbbe`; it removes only `internal/cli/review_consent_relay_test.go` parser/normalization coverage and leaves production code and versioned fixtures untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent invocation handling for shell-quoted arguments, including Windows paths containing spaces.
  * Standardized consent fixture formatting and working-directory handling for more reliable comparisons.
* **Tests**
  * Added coverage for quoted Windows consent commands and normalized fixture output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->