### PR TITLE
fix(reviewtransaction): retry transient Windows sharing violation on repository-context readback

### DIFF
--- a/internal/reviewtransaction/repository_locator.go
+++ b/internal/reviewtransaction/repository_locator.go
@@ -531,7 +531,7 @@ func readReviewRepositoryContext(path string) ([]byte, error) {
 	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || !privateLocatorFileModeSafe(info.Mode()) {
 		return nil, errors.New("review repository context is not a private regular file")
 	}
-	file, err := os.Open(path)
+	file, err := openReviewRepositoryContextFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reviewtransaction/repository_locator_open.go
+++ b/internal/reviewtransaction/repository_locator_open.go
@@ -1,0 +1,70 @@
+package reviewtransaction
+
+import (
+	"os"
+	"time"
+)
+
+// sharingViolationBackoffs is the bounded retry schedule for the transient
+// Windows sharing-violation recovery on the final-file open of an immutable
+// repository-context record. Five backoffs: 5/10/20/40/80 ms — 155 ms total
+// sleep. The first attempt is free; the schedule is consumed only on
+// ERROR_SHARING_VIOLATION. Every other open error fails immediately so
+// non-sharing failures are not masked by a silent retry.
+var sharingViolationBackoffs = []time.Duration{
+	5 * time.Millisecond,
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+	40 * time.Millisecond,
+	80 * time.Millisecond,
+}
+
+// openReviewRepositoryContextFile opens the immutable repository-context
+// record at path, delegating to the platform-specific openReviewRepositoryContextFile
+// implementation. On Windows the open tolerates a brief ERROR_SHARING_VIOLATION
+// window that can surface after concurrent publication (the kernel may still
+// hold the destination open for a short sharing-violation window after
+// MoveFileEx). On non-Windows platforms this is a direct passthrough to
+// os.Open; the transient sharing-violation retry applies only to Windows.
+//
+// Retry scope is limited to the final-file open. The Lstat, mode, file.Stat,
+// io.ReadAll, and decode checks that follow retain their existing
+// immediate-failure semantics — sharing-violation retry does not extend
+// to read or decode failures.
+func openReviewRepositoryContextFile(path string) (*os.File, error) {
+	return openReviewRepositoryContextFileWith(path, os.Open, sharingViolationBackoffs, time.Sleep, isTransientSharingViolation)
+}
+
+// openReviewRepositoryContextFileWith is the testable form: the production
+// openReviewRepositoryContextFile delegates to it with the real os.Open and
+// time.Sleep; the tests inject a fake opener, a no-op sleeper, and a
+// configurable isTransient predicate. Separating the retry loop from the
+// platform-specific isTransient check lets the test drive the full retry
+// schedule on any platform without needing to manufacture a real
+// ERROR_SHARING_VIOLATION.
+func openReviewRepositoryContextFileWith(
+	path string,
+	open func(string) (*os.File, error),
+	backoffs []time.Duration,
+	sleep func(time.Duration),
+	isTransient func(error) bool,
+) (*os.File, error) {
+	file, err := open(path)
+	if err == nil {
+		return file, nil
+	}
+	if !isTransient(err) {
+		return nil, err
+	}
+	for _, backoff := range backoffs {
+		sleep(backoff)
+		file, err = open(path)
+		if err == nil {
+			return file, nil
+		}
+		if !isTransient(err) {
+			return nil, err
+		}
+	}
+	return nil, err
+}

--- a/internal/reviewtransaction/repository_locator_open_test.go
+++ b/internal/reviewtransaction/repository_locator_open_test.go
@@ -1,0 +1,236 @@
+package reviewtransaction
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestOpenReviewRepositoryContextFileRetriesTransientSharingViolation proves
+// the final-file open tolerates a brief transient sharing-violation window
+// by retrying the open up to the bounded schedule, then succeeding on a
+// subsequent attempt. The test drives the retry loop with a fake opener and
+// a no-op sleeper, so it is portable across platforms: the isTransient
+// predicate is injected and reports true for the synthesized sharing
+// violation regardless of OS.
+func TestOpenReviewRepositoryContextFileRetriesTransientSharingViolation(t *testing.T) {
+	transient := errors.New("transient sharing violation")
+	other := errors.New("non-transient failure")
+	calls := atomic.Int32{}
+	attempts := make([]error, 0, 6)
+	var open func(string) (*os.File, error)
+	open = func(string) (*os.File, error) {
+		call := calls.Add(1)
+		switch call {
+		case 1, 2, 3, 4:
+			attempts = append(attempts, transient)
+			return nil, transient
+		case 5:
+			attempts = append(attempts, nil)
+			return os.NewFile(uintptr(call)+0xC0FFEE, "synthetic"), nil
+		default:
+			attempts = append(attempts, other)
+			return nil, other
+		}
+	}
+	slept := []time.Duration{}
+	sleep := func(d time.Duration) { slept = append(slept, d) }
+	isTransient := func(err error) bool { return errors.Is(err, transient) }
+	backoffs := []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond, 80 * time.Millisecond}
+
+	file, err := openReviewRepositoryContextFileWith("/synthetic/path", open, backoffs, sleep, isTransient)
+	if err != nil {
+		t.Fatalf("retry on transient sharing violation: %v", err)
+	}
+	if file == nil {
+		t.Fatal("retry returned a nil file handle on success")
+	}
+	_ = file.Close()
+	if got := calls.Load(); got != 5 {
+		t.Fatalf("open calls = %d, want 5 (1 initial + 4 retries before success)", got)
+	}
+	wantBackoffs := []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond}
+	if len(slept) != len(wantBackoffs) {
+		t.Fatalf("slept %d backoffs, want %d", len(slept), len(wantBackoffs))
+	}
+	for i, d := range slept {
+		if d != wantBackoffs[i] {
+			t.Fatalf("backoff[%d] = %v, want %v", i, d, wantBackoffs[i])
+		}
+	}
+	for i, err := range attempts[:len(attempts)-1] {
+		if !errors.Is(err, transient) {
+			t.Fatalf("attempt[%d] error = %v, want transient sharing violation", i, err)
+		}
+	}
+	if attempts[len(attempts)-1] != nil {
+		t.Fatalf("final attempt error = %v, want nil", attempts[len(attempts)-1])
+	}
+}
+
+// TestOpenReviewRepositoryContextFileFailsImmediatelyOnNonTransientError
+// proves the retry loop does not engage for any error that is not the
+// transient sharing violation. A non-transient failure on the first attempt
+// must surface verbatim with no backoff and no additional open call.
+func TestOpenReviewRepositoryContextFileFailsImmediatelyOnNonTransientError(t *testing.T) {
+	transient := errors.New("transient sharing violation")
+	other := errors.New("non-transient failure")
+	calls := atomic.Int32{}
+	open := func(string) (*os.File, error) {
+		calls.Add(1)
+		return nil, other
+	}
+	slept := []time.Duration{}
+	sleep := func(d time.Duration) { slept = append(slept, d) }
+	isTransient := func(err error) bool { return errors.Is(err, transient) }
+	backoffs := sharingViolationBackoffs
+
+	file, err := openReviewRepositoryContextFileWith("/synthetic/path", open, backoffs, sleep, isTransient)
+	if file != nil {
+		_ = file.Close()
+		t.Fatal("non-transient failure returned a file handle")
+	}
+	if !errors.Is(err, other) {
+		t.Fatalf("err = %v, want %v", err, other)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("open calls = %d, want 1 (no retry on non-transient)", got)
+	}
+	if len(slept) != 0 {
+		t.Fatalf("slept %d backoffs on non-transient failure, want 0", len(slept))
+	}
+}
+
+// TestOpenReviewRepositoryContextFileBoundedRetryOnPersistentSharingViolation
+// proves the retry budget is bounded. When the open keeps returning the
+// transient sharing violation past the schedule, the helper exhausts the
+// five backoffs (5/10/20/40/80 ms = 155 ms total) and surfaces the last
+// transient error verbatim. No further retries, no infinite loop.
+func TestOpenReviewRepositoryContextFileBoundedRetryOnPersistentSharingViolation(t *testing.T) {
+	transient := errors.New("transient sharing violation")
+	calls := atomic.Int32{}
+	open := func(string) (*os.File, error) {
+		calls.Add(1)
+		return nil, transient
+	}
+	var slept []time.Duration
+	sleep := func(d time.Duration) { slept = append(slept, d) }
+	isTransient := func(err error) bool { return errors.Is(err, transient) }
+	backoffs := sharingViolationBackoffs
+
+	file, err := openReviewRepositoryContextFileWith("/synthetic/path", open, backoffs, sleep, isTransient)
+	if file != nil {
+		_ = file.Close()
+		t.Fatal("bounded retry returned a file handle on persistent failure")
+	}
+	if !errors.Is(err, transient) {
+		t.Fatalf("err = %v, want %v", err, transient)
+	}
+	if want := int32(1 + len(backoffs)); calls.Load() != want {
+		t.Fatalf("open calls = %d, want %d (1 initial + 5 backoffs)", calls.Load(), want)
+	}
+	if len(slept) != len(backoffs) {
+		t.Fatalf("slept %d backoffs, want %d", len(slept), len(backoffs))
+	}
+	var total time.Duration
+	for i, d := range slept {
+		if d != backoffs[i] {
+			t.Fatalf("backoff[%d] = %v, want %v", i, d, backoffs[i])
+		}
+		total += d
+	}
+	if total != 155*time.Millisecond {
+		t.Fatalf("total backoff sleep = %v, want 155ms", total)
+	}
+}
+
+// TestOpenReviewRepositoryContextFileProductionScheduleMatchesIssueBounded
+// proves the production sharingViolationBackoffs schedule sums to exactly
+// 155 ms with five backoffs in the 5/10/20/40/80 ms shape. The issue pins
+// these numbers; if any future change loosens the bound, this guard fails.
+func TestOpenReviewRepositoryContextFileProductionScheduleMatchesIssueBounded(t *testing.T) {
+	if want := 5; len(sharingViolationBackoffs) != want {
+		t.Fatalf("len(sharingViolationBackoffs) = %d, want %d", len(sharingViolationBackoffs), want)
+	}
+	want := []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond, 80 * time.Millisecond}
+	var total time.Duration
+	for i, d := range sharingViolationBackoffs {
+		if d != want[i] {
+			t.Fatalf("sharingViolationBackoffs[%d] = %v, want %v", i, d, want[i])
+		}
+		total += d
+	}
+	if total != 155*time.Millisecond {
+		t.Fatalf("total sharing-violation backoff = %v, want 155ms", total)
+	}
+}
+
+// TestOpenReviewRepositoryContextFileSwitchesBetweenTransientAndNonTransient
+// proves the retry loop surfaces a non-transient error verbatim as soon as
+// the open returns one, even if the prior attempts returned the transient
+// sharing violation. The retry engages only while every attempt is the
+// transient error; a different error halts the loop immediately.
+func TestOpenReviewRepositoryContextFileSwitchesBetweenTransientAndNonTransient(t *testing.T) {
+	transient := errors.New("transient sharing violation")
+	other := errors.New("non-transient failure mid-retry")
+	calls := atomic.Int32{}
+	open := func(string) (*os.File, error) {
+		switch calls.Add(1) {
+		case 1, 2:
+			return nil, transient
+		case 3:
+			return nil, other
+		default:
+			return nil, fmt.Errorf("unexpected call %d", calls.Load())
+		}
+	}
+	var slept []time.Duration
+	sleep := func(d time.Duration) { slept = append(slept, d) }
+	isTransient := func(err error) bool { return errors.Is(err, transient) }
+	backoffs := []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond, 80 * time.Millisecond}
+
+	file, err := openReviewRepositoryContextFileWith("/synthetic/path", open, backoffs, sleep, isTransient)
+	if file != nil {
+		_ = file.Close()
+		t.Fatal("non-transient mid-retry returned a file handle")
+	}
+	if !errors.Is(err, other) {
+		t.Fatalf("err = %v, want %v", err, other)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("open calls = %d, want 3 (1 initial + 2 transient retries, halted on non-transient)", got)
+	}
+	if len(slept) != 2 {
+		t.Fatalf("slept %d backoffs before non-transient halt, want 2", len(slept))
+	}
+}
+
+// TestOpenReviewRepositoryContextFileRealPathSuccess proves the production
+// openReviewRepositoryContextFile succeeds against a real, non-flaky path on
+// every supported platform. This is the smoke test: if the helper is
+// mis-wired (for example if it returns the file from os.Open without going
+// through the helper, or if the build-tag shim is broken), the test catches
+// the regression on the native open path.
+func TestOpenReviewRepositoryContextFileRealPathSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "real-record")
+	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := openReviewRepositoryContextFile(path)
+	if err != nil {
+		t.Fatalf("real-path open: %v", err)
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stat.Size() != int64(len("payload")) {
+		t.Fatalf("stat.Size() = %d, want %d", stat.Size(), len("payload"))
+	}
+}

--- a/internal/reviewtransaction/repository_locator_open_unix.go
+++ b/internal/reviewtransaction/repository_locator_open_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package reviewtransaction
+
+// isTransientSharingViolation reports whether err is a transient sharing
+// violation. On non-Windows platforms no syscall returns the equivalent of
+// ERROR_SHARING_VIOLATION from os.Open, so the predicate always reports
+// false and the retry loop never engages. The retry machinery remains in
+// the cross-platform file so the production open path and the test path use
+// the same code; the only thing that varies between platforms is whether
+// isTransientSharingViolation ever returns true.
+func isTransientSharingViolation(err error) bool {
+	return false
+}

--- a/internal/reviewtransaction/repository_locator_open_windows.go
+++ b/internal/reviewtransaction/repository_locator_open_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package reviewtransaction
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isTransientSharingViolation reports whether err is the Windows
+// ERROR_SHARING_VIOLATION returned by the final-file open of an immutable
+// repository-context record. The locker is outside the process: publishers
+// close temporary handles before MoveFileEx, but the kernel can still hold
+// the destination open for a brief sharing-violation window after the rename,
+// so the open must be tolerant of that transient state.
+func isTransientSharingViolation(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3046

---

## 🏷️ PR Type

- [ ] `type:bug` — pending maintainer (see `## Pending maintainer actions`)

---

## 📝 Summary

The final-file open in `readReviewRepositoryContext` can surface a transient Windows `ERROR_SHARING_VIOLATION` after concurrent publication: publishers close temporary handles before `MoveFileEx`, but the kernel can still hold the destination open for a short sharing-violation window after the rename. The locker is outside the process and not under our control, so the readback path must be tolerant of that window.

This PR wraps the open with a bounded retry that engages only on `ERROR_SHARING_VIOLATION`, with five short backoffs (5/10/20/40/80 ms = 155 ms total). Every other open error fails immediately. The `Lstat`, mode, `file.Stat`, `io.ReadAll`, and decode checks that follow the open retain their existing immediate-failure semantics.

The retry is platform-scoped via `//go:build` tags: the helper and retry loop live in a cross-platform file, while `isTransientSharingViolation` is a Windows-specific check on `golang.org/x/sys/windows.ERROR_SHARING_VIOLATION`. On non-Windows platforms the predicate returns `false` and the open is a direct `os.Open` passthrough.

---

## 📂 Changes

| File | What Changed | Lines |
|------|--------------|-------|
| `internal/reviewtransaction/repository_locator_open.go` | NEW. Cross-platform retry helper. `openReviewRepositoryContextFile` delegates to `openReviewRepositoryContextFileWith`, which takes the open function, backoff schedule, sleep function, and `isTransient` predicate as parameters. `sharingViolationBackoffs` pins the 5/10/20/40/80 ms = 155 ms schedule. | +70 / -0 |
| `internal/reviewtransaction/repository_locator_open_windows.go` | NEW. `//go:build windows`. `isTransientSharingViolation` returns `errors.Is(err, windows.ERROR_SHARING_VIOLATION)`. | +19 / -0 |
| `internal/reviewtransaction/repository_locator_open_unix.go` | NEW. `//go:build !windows`. `isTransientSharingViolation` returns `false` so the retry loop never engages on POSIX. | +14 / -0 |
| `internal/reviewtransaction/repository_locator.go` | `readReviewRepositoryContext` calls `openReviewRepositoryContextFile(path)` instead of `os.Open(path)`. Every other step (`Lstat`, mode check, `file.Stat`, `io.ReadAll`, decode) is unchanged. | +1 / -1 |
| `internal/reviewtransaction/repository_locator_open_test.go` | NEW. Six tests, all on the portable retry machinery. (1) Success on attempt 5 with all four prior attempts returning the transient sharing violation, backoffs match 5/10/20/40 ms. (2) Non-transient error on attempt 1 returns immediately with no sleep and no extra open calls. (3) Persistent sharing violation exhausts the five backoffs (5/10/20/40/80 ms = 155 ms total) and surfaces the last transient error verbatim. (4) Production `sharingViolationBackoffs` schedule matches the 5/10/20/40/80 ms shape and sums to exactly 155 ms (issue-pinned). (5) Retry halts immediately when the open returns a non-transient error mid-schedule. (6) Real-path success against a real file on every platform (smoke test for the build-tag wiring). | +236 / -0 |

Totals: **+340 / -1 across 5 files**, under the 400-line review budget.

---

## 🧪 Test Plan

**Local commands run on Windows (Go 1.26.1):**

```bash
go build ./...
# exit 0

go vet ./...
# exit 0

go run ./internal/gofmtcheck
# exit 0

go test -count=1 -timeout 60s -run "TestOpenReviewRepositoryContextFile" -v ./internal/reviewtransaction/...
# 6/6 PASS

go test -count=1 -timeout 60s -run "TestReviewRepositoryContext" -v ./internal/reviewtransaction/...
# 11/11 PASS (9 PASS + 2 SKIP: POSIX-only fixtures)
```

**New tests (6) — all on the retry machinery:**

- `TestOpenReviewRepositoryContextFileRetriesTransientSharingViolation` — first 4 attempts return the transient sharing violation, attempt 5 succeeds. Verifies call count (5), backoff schedule (5/10/20/40 ms), and final attempt error (nil).
- `TestOpenReviewRepositoryContextFileFailsImmediatelyOnNonTransientError` — non-transient error on attempt 1 returns verbatim, no sleep, no retry.
- `TestOpenReviewRepositoryContextFileBoundedRetryOnPersistentSharingViolation` — every attempt returns the transient sharing violation. Verifies call count (1 + 5 = 6), backoff schedule (5/10/20/40/80 ms), total sleep (155 ms), and final error.
- `TestOpenReviewRepositoryContextFileProductionScheduleMatchesIssueBounded` — guard against future loosening. `sharingViolationBackoffs` has exactly 5 entries (5/10/20/40/80 ms) and sums to 155 ms.
- `TestOpenReviewRepositoryContextFileSwitchesBetweenTransientAndNonTransient` — first 2 attempts transient, attempt 3 non-transient. Verifies the loop halts immediately on the non-transient error with no further attempts.
- `TestOpenReviewRepositoryContextFileRealPathSuccess` — smoke test that the build-tag wiring works on every platform. Opens a real file through the helper, asserts size matches.

**Existing tests that exercise the readback path (regression check):**

- `TestReviewRepositoryContextPublishesOpaquePrivateBinding` — PASS
- `TestReviewRepositoryContextRejectsTamperedExpiredAndWrongBindings` — PASS
- `TestReviewRepositoryContextRejectsUnsafeStorageAndDoesNotTraverseAboveHome` — PASS
- `TestReviewRepositoryContextRejectsMissingMalformedOversizedAndTerminalRecords` — PASS
- `TestReviewRepositoryContextPublicationConvergesAndRejectsUnsafeEntries` — PASS (the regression test from the issue)
- `TestReviewRepositoryContextPublicationSyncFailureIsRetrySafe` — PASS
- `TestReviewRepositoryContextDistinguishesLinkedWorktreesAndRejectsCommonDirMismatch` — PASS
- `TestReviewRepositoryContextHonorsCancellationAndHashesWindowsPaths` — PASS

Two tests skipped on Windows by design (`TestReviewRepositoryContextRejectsSymlinkedProviderDirectory`, `TestReviewRepositoryContextRejectsBroadProviderDirectoryWithoutChmod`) — both gate on POSIX-only permission semantics.

---

## ✅ Contributor Checklist

- [x] PR linked to issue #3046 (`status:approved`)
- [x] All retry constraints from the issue honored: 5 backoffs, 5/10/20/40/80 ms, 155 ms total, `ERROR_SHARING_VIOLATION` only, every other error fails immediately
- [x] 6 new tests PASS, 11/11 existing readback tests PASS
- [x] `go vet ./internal/reviewtransaction/...` clean
- [x] `go build ./...` clean
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Conventional Commits format (`fix(reviewtransaction): retry transient Windows sharing violation on repository-context readback`)
- [x] No `Co-Authored-By` trailers
- [x] Branch name matches regex `fix/3046-windows-sharing-violation-retry`
- [x] `339 lines added / 1 deleted` (under 400-line review budget, no `size:exception` needed)
- [ ] `type:bug` label applied — pending maintainer

---

## 💬 Notes for Reviewers

**Why a build-tag split instead of a single runtime check.** The retry machinery is in `repository_locator_open.go` (cross-platform), while the only platform-specific bit is the `isTransientSharingViolation` predicate, defined in `repository_locator_open_windows.go` and `repository_locator_open_unix.go`. The test file then drives the retry loop with an injected `isTransient` predicate, so the full retry schedule is verifiable on any platform without needing to manufacture a real `ERROR_SHARING_VIOLATION`.

**Why `isTransientSharingViolation` returns `false` on non-Windows rather than panicking or compiling away.** The cross-platform file's `openReviewRepositoryContextFileWith` is the single source of truth for the retry shape; on POSIX the predicate simply never fires, which is the same end-state as a no-op. No syscall-specific code leaks into the cross-platform build, and the production behavior is identical to `os.Open` on Linux/macOS.

**Why the test injects the open function and sleep function as parameters.** The production `openReviewRepositoryContextFile` calls `openReviewRepositoryContextFileWith(path, os.Open, sharingViolationBackoffs, time.Sleep, isTransientSharingViolation)`. The test substitutes a fake opener (so it can synthesize the transient error and assert the retry shape) and a no-op sleeper (so the test runs in <1 ms instead of 155 ms). This is the same package-level-injection pattern the codebase already uses for `syncReviewDirectory` (see `internal/reviewtransaction/store.go:27`).

**Why no production mutex or publisher serialization.** The locker is outside the process: it is the Windows kernel holding the destination file open for a brief window after `MoveFileEx`. Bounded retry is the only surface that can recover a transient kernel-state window. Serializing publication would add a global lock on the happy path for an issue that is 1 in 239 on the Windows Full Suite, which is a worse tradeoff than 155 ms of backoff on a single failing attempt.

**Why the test file is not gated by `//go:build windows`.** The retry loop is a portable concern. The test injects an `isTransient` predicate and a fake opener, so the full retry schedule (call count, backoff shape, total sleep, halt-on-non-transient) is verifiable on any platform. The Windows-only check lives in `repository_locator_open_windows.go` and is exercised end-to-end by the test that asserts the production wiring is correct (`TestOpenReviewRepositoryContextFileRealPathSuccess`).

---

## Pending maintainer actions

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:bug` label applied to this PR — pending Alan (verified `gh pr edit --add-label type:bug` returns 403 `AddLabelsToLabelable` for `ardelperal`)
- [ ] Fork workflow approval — `action_required` runs on first-time forks; once approved, all subsequent runs auto-approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening repository context files on Windows by retrying temporary file-sharing conflicts.
  * Stops retrying promptly for non-transient errors and preserves existing validation behavior.
  * Maintains direct file-opening behavior on non-Windows platforms.

* **Tests**
  * Added coverage for retry timing, retry limits, changing error conditions, platform behavior, and successful file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->