### PR TITLE
fix(opencode): name the binary conflict the reviewer plugin can see

### DIFF
--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -313,6 +313,41 @@ function gitTrustRefusal(cause: unknown): boolean {
   return new RegExp(`\\b${GIT_TRUST_REFUSAL_CODE}\\b`).test(errorMessage(cause))
 }
 
+// AUTHORITY_SKEW_SIGNATURE recognises the one failure that proves two
+// different gentle-ai builds are in play: a repository-context resolution that
+// died decoding a persisted authority field the answering binary has never
+// heard of. Persisted authority is decoded with DisallowUnknownFields, so any
+// release that adds a state field writes bytes an older build cannot read.
+//
+// Both codes are matched. `review_authority_newer_release` is what a build
+// carrying #3025 says; `repository_context_unavailable` is what every build
+// before it says, and that is the one that actually reaches users here --
+// the process that fails is the OLD binary, so the newer native wording is
+// precisely the text that cannot appear. The `unknown field` clause is
+// required alongside the code so an ordinary unavailable context is never
+// mistaken for a version conflict.
+const AUTHORITY_SKEW_SIGNATURE =
+  /\b(?:repository_context_unavailable|review_authority_newer_release)\b[\s\S]*\bunknown field\b/
+
+// AUTHORITY_SKEW_MESSAGE is authored here, never forwarded, for the same
+// reason GIT_TRUST_REFUSAL_MESSAGE is: native failure text can embed local
+// paths, and the raw cause names a field that means nothing to the operator.
+//
+// This plugin is shipped by `gentle-ai sync`, so it comes from the NEWER
+// build even when PATH resolves an older one. That makes it the only
+// component in this loop still able to describe the situation. It deliberately
+// claims no version comparison: it has no reference build to compare against,
+// and the fact the failure already proves is enough.
+const AUTHORITY_SKEW_MESSAGE =
+  "the gentle-ai this OpenCode process resolved is older than the build that wrote this review's authority, " +
+  "so it cannot read it. Two builds are involved and PATH order decides which one answers: run `which -a gentle-ai` " +
+  "and make the newer build the one resolved first, then refresh status and relaunch the reoffered reviewer slots. " +
+  "Refreshing the transition alone cannot help, because the binary answering will not change."
+
+function authorityVersionSkew(cause: unknown): boolean {
+  return AUTHORITY_SKEW_SIGNATURE.test(errorMessage(cause))
+}
+
 // lensContextRefusal forwards the provider's typed refusal code and this
 // plugin's own recovery text for it, or undefined when the failure is not a
 // typed lens-context refusal at all (a Git trust refusal, a missing binary, a
@@ -331,6 +366,10 @@ function lensContextRefusal(cause: unknown): string | undefined {
 // failures can quote reviewer payload fragments.
 function lensContextFailureMessage(cause: unknown): string {
   if (gitTrustRefusal(cause)) return GIT_TRUST_REFUSAL_MESSAGE
+  // Checked before the typed-refusal branch: the skew arrives wearing
+  // repository_context_unavailable, whose generic recovery text tells the
+  // caller to refresh a transition that cannot change which binary answers.
+  if (authorityVersionSkew(cause)) return AUTHORITY_SKEW_MESSAGE
   return lensContextRefusal(cause) ?? scrubbedCause(cause)
 }
 

--- a/internal/assets/review_plugin_recovery_test.go
+++ b/internal/assets/review_plugin_recovery_test.go
@@ -664,6 +664,58 @@ func TestReviewPluginSurfacesNativeGitTrustRefusal(t *testing.T) {
 	}
 }
 
+// reviewPluginNativeSkewFailure is what an OLDER gentle-ai on the runtime
+// PATH emits when it is handed a repository context whose authority a NEWER
+// build wrote. The wording is the pre-#3025 one on purpose: the process that
+// fails here is the old binary, so #3025's improved native message is exactly
+// the text that cannot appear.
+const reviewPluginNativeSkewFailure = "repository_context_unavailable: provider-issued review repository context operation failed; " +
+	`cause: json: unknown field "correction_budget_policy"; refresh the exact native next_transition before retrying`
+
+// TestReviewPluginNamesTheBinaryConflictItCanSee is #3049.
+//
+// The plugin resolves the CLI by bare name, so whatever `gentle-ai` PATH finds
+// first services reviewer calls -- including a build older than the one that
+// wrote the authority. #3025 made that failure legible natively and cannot
+// help here: its code ships in the new binary while the failing process is the
+// old one, so the caller keeps getting "refresh the exact native
+// next_transition", follows it, and loops. #2461's reporter did exactly that
+// across four reoffered reviewer slots.
+//
+// This plugin ships from the NEW build even when PATH resolves an old binary,
+// which makes it the only component in the loop that can still tell the truth.
+// It does not compare versions -- it has no reference to compare against, and
+// inventing one would be a guess. It states the fact the failure proves: the
+// binary that answered cannot read this authority, two builds are involved,
+// and PATH order is what decides which one answers.
+func TestReviewPluginNamesTheBinaryConflictItCanSee(t *testing.T) {
+	message := runReviewPluginScenario(t, "before-valid", reviewPluginNativeSkewFailure)
+	if message == "NO_ERROR" {
+		t.Fatal("preflight did not fail despite an always-failing native binary")
+	}
+	if strings.Contains(message, "next_transition") {
+		t.Fatalf("plugin forwarded the advice that loops the caller: %s", message)
+	}
+	if !strings.Contains(message, "which -a gentle-ai") {
+		t.Fatalf("plugin names no way to find the conflicting binaries: %s", message)
+	}
+	// The whole point is that two builds are in play. A message that does not
+	// say so reads as a corrupt repository.
+	for _, want := range []string{"older", "PATH"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("plugin does not name the version conflict (%q missing): %s", want, message)
+		}
+	}
+	if !strings.Contains(message, "The reviewer was not launched") {
+		t.Fatalf("plugin lost its pre-launch exactly-once guarantee: %s", message)
+	}
+	// Native text can embed local paths, so this classification is authored
+	// here like the Git trust refusal is, never forwarded.
+	if strings.Contains(message, "correction_budget_policy") {
+		t.Fatalf("plugin forwarded raw native cause text: %s", message)
+	}
+}
+
 // TestReviewPluginKeepsGenericOpaqueFailureOpaque proves an unstructured
 // native preflight failure is scrubbed, not forwarded verbatim, since native
 // failures can embed local paths.


### PR DESCRIPTION
Partial fix for #3049: it stops the loop today without pinning the binary, which is the larger change.

## The trap this is in

`injectReviewerContext` spawns `gentle-ai` by bare name, so PATH decides which build services reviewer calls. When that build is older than the one that wrote the authority, it fails decoding a persisted field it has never heard of.

#3025 already made that failure legible **natively** — and it provably cannot help here. Its code lives in the new binary; the process that fails is the old one. Verified on `main`: authority written by `main`, read by `v2.3.0`, still emits the pre-#3025 wording, because the new code never runs.

```
repository_context_unavailable: ... cause: json: unknown field "correction_budget_policy";
refresh the exact native next_transition before retrying
```

Refreshing cannot change which binary answers, so a consumer following that advice loops. @heriobb04 did exactly that across four reoffered reviewer slots on #2461.

## Why the plugin is the right place

The plugin is shipped by `gentle-ai sync`, so it comes from the **newer** build even when PATH resolves an older one. In this failure it is the only component in the loop that is up to date, and therefore the only one that can still tell the truth.

Before / after, same native failure:

```
- review lens context failed for lens review-risk: ... repository_context_unavailable: ...
  cause: json: unknown field "correction_budget_policy"; refresh the exact native next_transition before retrying

+ the gentle-ai this OpenCode process resolved is older than the build that wrote this review's authority,
+ so it cannot read it. Two builds are involved and PATH order decides which one answers: run
+ `which -a gentle-ai` and make the newer build the one resolved first, then refresh status and relaunch
+ the reoffered reviewer slots. Refreshing the transition alone cannot help, because the binary answering
+ will not change.
```

## Deliberate limits

- **No version comparison.** The plugin has no reference build to compare against, and inventing one would be a guess. It states only what the failure already proves.
- **Conservative detection.** The signature requires `unknown field` *alongside* a repository-context code, so an ordinary unavailable context is never reclassified. `TestReviewPluginKeepsGenericOpaqueFailureOpaque` covers exactly that case and still passes unchanged.
- **Authored, not forwarded.** Same rule as `GIT_TRUST_REFUSAL_MESSAGE`: native text can embed local paths, and the raw cause names a field that means nothing to an operator. The test asserts `correction_budget_policy` never reaches the transcript.
- **This does not pin the binary.** Pinning needs the installer to record which build performed the sync so the plugin can invoke that exact path. #3049 stays open for it.

RED first, and `go test ./...` clean.

Closes #3057

Note: the plugin ships from `gentle-ai sync`, so this reaches a user only after they sync with the newer build.


Refs #3049 -- that issue stays open for the binary pin, which this does not do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery guidance when an older command-line binary causes a version mismatch.
  * Replaced misleading refresh instructions with clear steps to diagnose conflicting binaries on the system PATH.
  * Prevented repeated transition advice and avoided exposing low-level error details during these failures.

* **Tests**
  * Added regression coverage to verify the improved refusal and diagnostic guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
