### PR TITLE
fix(sdd): make the exhausted-budget grant executable as returned

### DIFF
--- a/internal/sddstatus/budget_consent.go
+++ b/internal/sddstatus/budget_consent.go
@@ -1,6 +1,8 @@
 package sddstatus
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -114,8 +116,9 @@ func BudgetConsentEnvelope(in BudgetConsentInput) (BudgetConsentResult, error) {
 				Label:  "Open a fresh budget and keep going",
 				Effect: "Resets this objective to a fresh bounded budget. Every attempt already recorded stays in the immutable chain, nothing is erased, and no verification, review or receipt is fabricated.",
 				Invocation: fmt.Sprintf(
-					"gentle-ai sdd-attempt reset --cwd %s --change %s --expected-revision %q --request-id \"<unique-request-id>\" --reason %q --actor \"<actor>\"",
-					pathquote.Quote(in.Repo), in.Change, in.Revision, sddBudgetConsentReason(in)),
+					"gentle-ai sdd-attempt reset --cwd %s --change %s --expected-revision %q --request-id %s --reason %q --actor %s",
+					pathquote.Quote(in.Repo), in.Change, in.Revision,
+					sddBudgetConsentResetRequestID(in), sddBudgetConsentReason(in), sddRuntimeAuditActor),
 			},
 			{
 				Answer: sddBudgetConsentDeclined,
@@ -140,6 +143,34 @@ func BudgetConsentEnvelope(in BudgetConsentInput) (BudgetConsentResult, error) {
 		Headline: core.Headline, Reason: core.Reason, Value: core.Value,
 		Evidence: core.Evidence, Choices: core.Choices, OffPath: core.OffPath,
 	}, nil
+}
+
+// sddRuntimeAuditActor is the actor the runtime records for a reset it
+// materialized itself.
+//
+// The actor field is audit metadata, not authenticated human authority:
+// nothing downstream treats it as proof of who decided. #2959 emitted a
+// literal "<actor>" here, which forced the caller either to invent a value
+// inside a provider-owned command the relay contract forbids rewriting, or to
+// stop. A transparent fixed literal is honest about what the field is and
+// keeps the invocation executable exactly as returned. The human decision
+// itself is recorded by --reason, which still says a maintainer authorized it.
+const sddRuntimeAuditActor = "gentle-ai-runtime"
+
+// sddBudgetConsentResetRequestID derives the reset's request ID from the exact
+// objective it resets: the change, the expected revision, and the operation.
+//
+// Deterministic rather than random, because the relay contract permits
+// executing the returned command exactly once and a retry after an ambiguous
+// outcome must be the SAME request, not a second budget. Bound to the expected
+// revision, because a grant captured before authority moved must not be
+// replayable onto the new state; --expected-revision already fails CAS there,
+// and a distinct ID keeps the audit trail from claiming the stale decision was
+// the current one. Hashed rather than composed from the change name, so the
+// result satisfies runtimeRequestIDPattern for every change name that exists.
+func sddBudgetConsentResetRequestID(in BudgetConsentInput) string {
+	sum := sha256.Sum256([]byte("gentle-ai.sdd-budget-consent-reset/v1\x00" + in.Change + "\x00" + in.Revision))
+	return "reset-" + hex.EncodeToString(sum[:16])
 }
 
 func sddBudgetConsentReason(in BudgetConsentInput) string {

--- a/internal/sddstatus/budget_consent_invocation_test.go
+++ b/internal/sddstatus/budget_consent_invocation_test.go
@@ -1,0 +1,197 @@
+package sddstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func budgetConsentFixture() BudgetConsentInput {
+	return BudgetConsentInput{
+		Repo:     "/workspace/repo",
+		Change:   "harden-login",
+		Revision: "sha256:" + strings.Repeat("a", 64),
+
+		MaxAttempts: 1, CumulativeAttempts: 1,
+		MaxChangedLines: 400, CumulativeLines: 12,
+	}
+}
+
+// grantInvocationFlag pulls one flag value out of the granted invocation the
+// same way a relaying orchestrator would: by reading the exact string, not by
+// re-deriving it from the input.
+func grantInvocationFlag(t *testing.T, invocation, flag string) string {
+	t.Helper()
+	fields := strings.Fields(invocation)
+	for index, field := range fields {
+		if field == flag && index+1 < len(fields) {
+			return strings.Trim(fields[index+1], `"`)
+		}
+	}
+	t.Fatalf("granted invocation carries no %s: %s", flag, invocation)
+	return ""
+}
+
+func grantInvocation(t *testing.T, in BudgetConsentInput) string {
+	t.Helper()
+	envelope, err := BudgetConsentEnvelope(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, choice := range envelope.Choices {
+		if choice.Answer == sddBudgetConsentGranted {
+			return choice.Invocation
+		}
+	}
+	t.Fatal("envelope carries no granted choice")
+	return ""
+}
+
+// TestGrantedResetInvocationIsExecutableAsReturned is #3045, which #2959
+// introduced: I shipped the exhausted-budget question with literal
+// "<unique-request-id>" and "<actor>" inside the granted invocation.
+//
+// The relay contract requires executing the provider-owned invocation exactly
+// as returned, and forbids the orchestrator from rewriting it. So the one
+// command a granted answer produces was rejected by this project's own CLI
+// before any ledger mutation, and the consumer landed back in
+// decision_required with the same revision and the same envelope. A consent
+// question whose granted answer cannot be carried out is not a question.
+func TestGrantedResetInvocationIsExecutableAsReturned(t *testing.T) {
+	invocation := grantInvocation(t, budgetConsentFixture())
+
+	for _, placeholder := range []string{"<unique-request-id>", "<actor>", "<", ">"} {
+		if strings.Contains(invocation, placeholder) {
+			t.Fatalf("granted invocation still carries the placeholder %q, so executing it verbatim fails input validation: %s", placeholder, invocation)
+		}
+	}
+
+	requestID := grantInvocationFlag(t, invocation, "--request-id")
+	if !runtimeRequestIDPattern.MatchString(requestID) {
+		t.Fatalf("granted --request-id %q is not a canonical lowercase identifier, which is the exact refusal #3045 reported", requestID)
+	}
+	// The actor is audit metadata, not authenticated human authority, so it is
+	// a transparent fixed runtime literal rather than a value the orchestrator
+	// would have to invent. Ratified on the issue.
+	if actor := grantInvocationFlag(t, invocation, "--actor"); actor != sddRuntimeAuditActor {
+		t.Fatalf("granted --actor = %q, want the fixed runtime audit actor %q", actor, sddRuntimeAuditActor)
+	}
+}
+
+// TestGrantedResetRequestIDIsDeterministicAndBound pins replay. The same
+// objective at the same revision must produce the same request ID, so
+// executing the returned command twice is idempotent rather than opening two
+// budgets; a different revision must produce a different one, so a stale
+// granted command cannot be replayed onto moved authority. CAS on
+// --expected-revision is the enforcement; a distinct ID keeps the audit trail
+// honest about which decision it was.
+func TestGrantedResetRequestIDIsDeterministicAndBound(t *testing.T) {
+	base := budgetConsentFixture()
+	first := grantInvocationFlag(t, grantInvocation(t, base), "--request-id")
+	again := grantInvocationFlag(t, grantInvocation(t, base), "--request-id")
+	if first != again {
+		t.Fatalf("request id is not deterministic: %q then %q; replaying the returned command would open a second budget", first, again)
+	}
+
+	moved := base
+	moved.Revision = "sha256:" + strings.Repeat("b", 64)
+	if drifted := grantInvocationFlag(t, grantInvocation(t, moved), "--request-id"); drifted == first {
+		t.Fatalf("request id %q does not change with the expected revision, so a stale grant is indistinguishable from a current one", drifted)
+	}
+
+	other := base
+	other.Change = "harden-billing"
+	if elsewhere := grantInvocationFlag(t, grantInvocation(t, other), "--request-id"); elsewhere == first {
+		t.Fatalf("request id %q is shared across changes, so it is not bound to this objective", elsewhere)
+	}
+}
+
+// TestDeclineInvocationStaysReadOnly guards the half that was never broken:
+// declining re-enters native status and mutates nothing. It is pinned here
+// because the fix touches the same envelope.
+func TestDeclineInvocationStaysReadOnly(t *testing.T) {
+	envelope, err := BudgetConsentEnvelope(budgetConsentFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, choice := range envelope.Choices {
+		if choice.Answer != sddBudgetConsentDeclined {
+			continue
+		}
+		if !strings.HasPrefix(choice.Invocation, "gentle-ai sdd-attempt status ") {
+			t.Fatalf("decline no longer re-enters through read-only status: %s", choice.Invocation)
+		}
+		if strings.Contains(choice.Invocation, "reset") || strings.Contains(choice.Invocation, "<") {
+			t.Fatalf("decline invocation gained a mutation or a placeholder: %s", choice.Invocation)
+		}
+		return
+	}
+	t.Fatal("envelope carries no declined choice")
+}
+
+// TestStaleGrantFailsCASWithoutMutation completes #3045's closure coverage.
+//
+// The deterministic request ID makes an exact replay idempotent, which is what
+// the relay contract needs. The other half is that a grant captured BEFORE
+// authority drifted must not apply afterwards: that grant names an earlier
+// expected revision and carries a different ID, so it is a different decision
+// about a state that no longer exists. --expected-revision is the enforcement;
+// this pins that it actually refuses, and that the ledger is untouched when it
+// does.
+func TestStaleGrantFailsCASWithoutMutation(t *testing.T) {
+	ctx := context.Background()
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "stale-grant")
+	store.ReviewDisabled = true
+
+	appendRuntimeLedgerFile(t, repo, "work\n")
+	begun, err := store.Begin(ctx, BeginAttemptRequest{
+		RequestID: "s-begin", WorkUnit: "u", EvidenceGoal: "g",
+		MaxAttempts: 1, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exhausted, err := store.Finish(ctx, FinishAttemptRequest{
+		ExpectedRevision: begun.Revision, RequestID: "s-finish", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "failed",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "clean", ProcessEvidence: "none",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The grant the envelope would hand out at this revision.
+	captured := sddBudgetConsentResetRequestID(BudgetConsentInput{
+		Repo: repo, Change: "stale-grant", Revision: exhausted.Revision,
+	})
+
+	// Authority drifts for an unrelated reason: some other reset lands first.
+	drifted, err := store.Reset(ctx, ResetObjectiveRequest{
+		ExpectedRevision: exhausted.Revision, RequestID: "someone-else",
+		Reason: "another decision reached the ledger first", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drifted.Revision == exhausted.Revision {
+		t.Fatal("fixture did not drift the revision, so the stale case is not staged")
+	}
+
+	// The captured grant, executed verbatim, against the moved authority.
+	_, staleErr := store.Reset(ctx, ResetObjectiveRequest{
+		ExpectedRevision: exhausted.Revision, RequestID: captured,
+		Reason: "maintainer authorized a fresh budget for this objective", Actor: sddRuntimeAuditActor,
+	})
+	if staleErr == nil {
+		t.Fatal("a grant captured before the drift applied afterwards; it names a revision that no longer exists")
+	}
+
+	after, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Revision != drifted.Revision {
+		t.Fatalf("refused stale grant still moved the ledger: %q -> %q", drifted.Revision, after.Revision)
+	}
+}


### PR DESCRIPTION
#3045, which #2959 introduced. Mine to fix.

## The defect

The granted choice of the exhausted-budget consent envelope carried literal placeholders:

```
gentle-ai sdd-attempt reset ... --request-id "<unique-request-id>" ... --actor "<actor>"
```

The relay contract requires executing the provider-owned invocation exactly as returned and forbids the orchestrator from rewriting it. So the one command a granted answer produced failed this project's own input validation before touching the ledger:

```
Error: sdd-attempt reset: request_id must be a canonical lowercase identifier
```

The consumer went back to `decision_required` with the same revision and the same envelope. A consent question whose granted answer cannot be carried out is not a question.

## The fix, per the design ratified on the issue

- **Request ID** derived from the objective it resets: change + expected revision + operation, hashed so the result satisfies `runtimeRequestIDPattern` for any change name. Deterministic, because the contract permits executing the command exactly once and a retry after an ambiguous outcome must be the *same* request rather than a second budget. Bound to the expected revision, so a grant captured before authority moved is a different request about a state that no longer exists.
- **Actor** is the fixed literal `gentle-ai-runtime`. The field is audit metadata, not authenticated human authority; the human decision is what `--reason` records, and it still says a maintainer authorized it.
- No schema version, no orchestrator synthesis, decline untouched.

## Verified against the real CLI

Building the envelope and never running it is exactly how #2959 shipped this, so the builder tests are not the evidence — these are. Real repo, budget exhausted through `acquire` + `settle --outcome interrupted`, envelope read from scoped `sdd-attempt status`:

```
GRANTED -> gentle-ai sdd-attempt reset --cwd "…" --change ch \
  --expected-revision "sha256:b040385f…" --request-id reset-a2753364962953bf7203cc14147534c6 \
  --reason "maintainer authorized a fresh budget after attempts that never ran the work" \
  --actor gentle-ai-runtime
```

| check | result |
| --- | --- |
| grant executed verbatim | reset applied, `decision_required: false`, `next_action: begin` |
| immutable chain | `cumulative 0 / lifetime 1` — the spent attempt is still on the chain |
| exact replay | idempotent, same revision returned, no second budget |
| stale grant after unrelated drift | refused, ledger revision unchanged |

The stale case could not be staged through the CLI (nothing else reachable at `decision_required` moved the revision in my sandbox), so it is pinned at the store level in `TestStaleGrantFailsCASWithoutMutation`, which drifts authority with an unrelated reset and then executes the captured grant.

All four behaviors were RED first. `go test ./...` clean.

Closes #3045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Budget reset requests now use valid, deterministic request IDs tied to the relevant change and revision.
  * Approved reset actions now execute with the correct audit identity instead of placeholder values.
  * Declined requests remain read-only.
  * Stale approvals are rejected without modifying budget records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->