### PR TITLE
fix(bench): restore the journey count baseline to 95

### DIFF
--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -69,8 +69,14 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// j96 proves #2891 blocks an off-path sibling in a nested same-repository workspace.
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
-	if got := len(seen); got != 94 {
-		t.Errorf("core journey count = %d, want 94", got)
+	//
+	// 94 -> 95 because #3037 (j98) and #3038 (j99) each added one journey and
+	// each bumped 93 -> 94 against a main where the other had not landed. Both
+	// were green alone; merging both left 95 journeys under a baseline of 94
+	// and turned main red. The guard did exactly its job -- this is what a
+	// count catches that a per-PR suite cannot.
+	if got := len(seen); got != 95 {
+		t.Errorf("core journey count = %d, want 95", got)
 	}
 	for id, found := range want {
 		if !found {


### PR DESCRIPTION
`main` is red at `63c86110`:

```
journeys_sdd_test.go:73: core journey count = 95, want 94
```

#3037 (j98, #2696) and #3038 (j99, #2906) each added one journey and each bumped the baseline 93 -> 94 against a main where the other had not landed. Both were green alone; merging both left 95 under a baseline of 94. The comment block already names both journeys, so only the number was stale.

I merged both, and the integrated-main check I ran afterwards was `go test ./...` at the repository root — which does not run `bench`, because it is a separate module. That is the gap, and the commit message records it.

Verified: `cd bench && go test ./...` passes on this branch.

Closes #3063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the core journey count validation to reflect the addition of a newly registered journey.
  * Added clarification about the journey registration history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->