### PR TITLE
fix(doctor): honor the configured Engram MCP timeout and name a deadline

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -76,7 +76,7 @@ var (
 		return filepath.SplitList(os.Getenv("PATH"))
 	}
 	osExecutableDoctor = os.Executable
-	engramProbeStdioFn = engram.ProbeStdio
+	engramProbeStdioFn = engram.ProbeStdioWithTimeout
 	httpGetFn          = func(url string, timeout time.Duration) (int, error) {
 		resp, err := (&http.Client{Timeout: timeout}).Get(url) //nolint:noctx
 		if err != nil {
@@ -483,13 +483,28 @@ func checkEngramReachable(ctx context.Context, homeDir string, installedAgents [
 
 	sources := make([]string, 0, len(commands))
 	for _, command := range commands {
-		err := engramProbeStdioFn(ctx, command.Command, command.Args...)
+		err := engramProbeStdioFn(ctx, command.Timeout, command.Command, command.Args...)
 		switch {
 		case errors.Is(err, engram.ErrNotInstalled):
 			return CheckResult{
 				Name:   id,
 				Status: CheckStatusWarn,
 				Detail: "engram MCP not probed: persisted command in " + command.Source + " is not found on PATH (see the tool:engram check)",
+			}
+		// A deadline that elapsed is not evidence that the transport is
+		// broken, and #3068 showed what the old wording cost: the reporter's
+		// arguments were correct and their store answered in about five
+		// seconds, but they were told the handshake failed and sent to inspect
+		// the command and arguments, which the evidence did not implicate.
+		// Failing stays, because a probe that never answered is not a pass.
+		case errors.Is(err, context.DeadlineExceeded):
+			return CheckResult{
+				Name:   id,
+				Status: CheckStatusFail,
+				Detail: "engram MCP (stdio) did not answer within " + engram.StdioProbeDeadline(command.Timeout).String() +
+					" for persisted configuration " + command.Source,
+				Remedy: doctor.NewRemedy(doctor.RemedyInspectEngram,
+					"Raise the Engram MCP server's timeout in "+command.Source+" if the store is simply slow to start, or check whether the process is hanging"),
 			}
 		case err != nil:
 			return CheckResult{

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -76,7 +76,7 @@ var (
 		return filepath.SplitList(os.Getenv("PATH"))
 	}
 	osExecutableDoctor = os.Executable
-	engramProbeStdioFn = engram.ProbeStdioWithTimeout
+	engramProbeStdioFn = engram.ProbeStdio
 	httpGetFn          = func(url string, timeout time.Duration) (int, error) {
 		resp, err := (&http.Client{Timeout: timeout}).Get(url) //nolint:noctx
 		if err != nil {

--- a/internal/cli/doctor_engram_timeout_test.go
+++ b/internal/cli/doctor_engram_timeout_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestEngramDeadlineIsReportedAsADeadline is #3068's second half.
+//
+// A deadline that elapsed is not evidence that the transport is broken, but
+// the check reported `initialize handshake failed` and a remedy telling the
+// operator to check their Engram command and arguments. #3068's reporter had
+// correct arguments and a store that answered in about five seconds; they were
+// sent to inspect the one thing the evidence did not implicate, while
+// `Status: unhealthy` is what fail-closed consumers act on.
+//
+// Failing stays: a probe that did not answer within its budget is not a pass.
+// What changes is that the refusal describes what actually happened and points
+// at the timeout it exceeded.
+func TestEngramDeadlineIsReportedAsADeadline(t *testing.T) {
+	t.Setenv(engramHealthEnvVar, "")
+	setStdioProbeForTest(t, context.DeadlineExceeded)
+	homeDir, installedAgents := doctorStdioConfig(t)
+
+	got := checkEngramReachable(context.Background(), homeDir, installedAgents)
+
+	if got.Status != CheckStatusFail {
+		t.Fatalf("status = %s, want fail: a probe that never answered is not a pass", got.Status)
+	}
+	if strings.Contains(got.Detail, "handshake failed") {
+		t.Fatalf("a deadline is still reported as a failed handshake: %s", got.Detail)
+	}
+	if !strings.Contains(got.Detail, "did not answer within") {
+		t.Fatalf("detail does not say the probe ran out of time: %s", got.Detail)
+	}
+	if got.Remedy == nil {
+		t.Fatal("expected a remedy")
+	}
+	remedy := got.Remedy.Description
+	if strings.Contains(remedy, "command and arguments") {
+		t.Fatalf("remedy still sends the operator to inspect command and arguments, which a deadline does not implicate: %s", remedy)
+	}
+	if !strings.Contains(remedy, "timeout") {
+		t.Fatalf("remedy does not name the timeout the operator can raise: %s", remedy)
+	}
+}
+
+// TestEngramNonDeadlineFailureKeepsItsRemedy is the guard on the other side.
+// A handshake that genuinely answered wrong, or a process that exited, still
+// implicates the configured command, and that remedy must survive.
+func TestEngramNonDeadlineFailureKeepsItsRemedy(t *testing.T) {
+	t.Setenv(engramHealthEnvVar, "")
+	setStdioProbeForTest(t, errStdioProbeTest)
+	homeDir, installedAgents := doctorStdioConfig(t)
+
+	got := checkEngramReachable(context.Background(), homeDir, installedAgents)
+
+	if got.Status != CheckStatusFail {
+		t.Fatalf("status = %s, want fail", got.Status)
+	}
+	if !strings.Contains(got.Detail, "handshake failed") {
+		t.Fatalf("a real handshake failure lost its wording: %s", got.Detail)
+	}
+	if got.Remedy == nil || !strings.Contains(got.Remedy.Description, "command and arguments") {
+		t.Fatalf("a real handshake failure lost the remedy that does implicate the config: %#v", got.Remedy)
+	}
+}
+
+// errStdioProbeTest is an ordinary transport failure: the process answered
+// wrongly rather than not at all.
+var errStdioProbeTest = errProbeAnsweredWrong{}
+
+type errProbeAnsweredWrong struct{}
+
+func (errProbeAnsweredWrong) Error() string {
+	return "engram mcp exited without answering initialize"
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -378,7 +378,7 @@ func TestCheckStateJSON_OK(t *testing.T) {
 func setStdioProbeForTest(t *testing.T, err error) {
 	t.Helper()
 	orig := engramProbeStdioFn
-	engramProbeStdioFn = func(context.Context, string, ...string) error { return err }
+	engramProbeStdioFn = func(context.Context, time.Duration, string, ...string) error { return err }
 	t.Cleanup(func() { engramProbeStdioFn = orig })
 }
 
@@ -561,7 +561,7 @@ func TestCheckEngramReachable_StdioUsesPersistedConfiguration(t *testing.T) {
 	var gotCommand string
 	var gotArgs []string
 	orig := engramProbeStdioFn
-	engramProbeStdioFn = func(_ context.Context, command string, args ...string) error {
+	engramProbeStdioFn = func(_ context.Context, _ time.Duration, command string, args ...string) error {
 		gotCommand = command
 		gotArgs = args
 		return nil

--- a/internal/components/engram/healthprobe.go
+++ b/internal/components/engram/healthprobe.go
@@ -30,9 +30,61 @@ import (
 // tool:engram check.
 var ErrNotInstalled = errors.New("engram binary not found on PATH")
 
-// stdioProbeTimeout is the hard deadline for the whole stdio probe: spawning
-// the engram MCP process plus the initialize handshake round-trip.
-var stdioProbeTimeout = 5 * time.Second
+// stdioProbeTimeout is the DEFAULT deadline for the whole stdio probe:
+// spawning the engram MCP process plus the initialize handshake round-trip. A
+// timeout persisted in the agent's own MCP configuration overrides it.
+//
+// It was 5 seconds, and #3068 showed that is under the line rather than over
+// it: a healthy store's handshake ALONE measured 4.87 to 5.16 seconds, on top
+// of which this budget also pays process spawn. The reporter's check flapped,
+// passing and failing the same store in one session. The value below clears
+// the slowest measurement with real headroom, because a default that merely
+// beats it reproduces the same flap on a slower machine.
+var stdioProbeTimeout = 15 * time.Second
+
+// stdioProbeDeadline chooses between the operator's configured timeout and the
+// default. A configured value wins in both directions: asking for a tighter
+// bound is as legitimate as asking for a looser one, and silently applying a
+// floor would repeat the defect where a configured timeout changed nothing.
+// StdioProbeDeadline exposes the resolved deadline so a caller reporting a
+// timeout can name the exact budget that elapsed instead of a number the
+// operator has to guess at.
+func StdioProbeDeadline(configured time.Duration) time.Duration {
+	return stdioProbeDeadline(configured)
+}
+
+func stdioProbeDeadline(configured time.Duration) time.Duration {
+	if configured > 0 {
+		return configured
+	}
+	return stdioProbeTimeout
+}
+
+// stdioTimeoutFromConfig reads an MCP server's timeout. A bare number is
+// seconds, which is how the OpenCode MCP configuration expresses it and what
+// #3068's reporter set; a string is a Go duration.
+//
+// Anything unparseable, zero, or negative yields 0 and falls back to the
+// default rather than failing the read. A malformed timeout must not make an
+// otherwise valid Engram configuration unreadable: that consequence is worse
+// than the defect this fixes.
+func stdioTimeoutFromConfig(value any) time.Duration {
+	switch typed := value.(type) {
+	case float64:
+		if typed > 0 {
+			return time.Duration(typed * float64(time.Second))
+		}
+	case int:
+		if typed > 0 {
+			return time.Duration(typed) * time.Second
+		}
+	case string:
+		if parsed, err := time.ParseDuration(strings.TrimSpace(typed)); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return 0
+}
 
 // stdioHandshakeFn is a package-level seam over the real handshake (built on
 // the execCommandContext precedent) so internal/cli doctor tests can pin the
@@ -45,6 +97,12 @@ type StdioCommand struct {
 	Command string
 	Args    []string
 	Source  string
+
+	// Timeout is the deadline persisted alongside this command in the agent's
+	// own MCP configuration, or zero when it declares none. #3068: this used
+	// to be absent, so an operator who raised their MCP timeout saw no effect
+	// and reasonably concluded they had misconfigured something.
+	Timeout time.Duration
 }
 
 // ProbeStdio verifies the exact command and arguments persisted in an agent
@@ -53,7 +111,13 @@ type StdioCommand struct {
 // checked. Only a bare Engram command maps to ErrNotInstalled; a missing path
 // or custom command is a broken configured transport.
 func ProbeStdio(ctx context.Context, command string, args ...string) error {
-	err := stdioHandshakeFn(ctx, command, args...)
+	return ProbeStdioWithTimeout(ctx, 0, command, args...)
+}
+
+// ProbeStdioWithTimeout is ProbeStdio bounded by the configured deadline. A
+// zero timeout falls back to the package default.
+func ProbeStdioWithTimeout(ctx context.Context, timeout time.Duration, command string, args ...string) error {
+	err := stdioHandshakeFn(ctx, stdioProbeDeadline(timeout), command, args...)
 	if isBareEngramCommand(command) && errors.Is(err, exec.ErrNotFound) {
 		return ErrNotInstalled
 	}
@@ -74,8 +138,8 @@ func isBareEngramCommand(command string) bool {
 // handshake over the newline-delimited JSON-RPC stdio transport. A successful
 // probe proves only the bounded initialize exchange: it terminates the child,
 // drains all stdout already produced to EOF, and rejects any extra frame.
-func stdioHandshake(ctx context.Context, name string, args ...string) error {
-	probeCtx, cancel := context.WithTimeout(ctx, stdioProbeTimeout)
+func stdioHandshake(ctx context.Context, timeout time.Duration, name string, args ...string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := execCommandContext(context.Background(), name, args...)
@@ -453,6 +517,7 @@ func stdioCommandFromServer(server map[string]any) (StdioCommand, error) {
 	if !ok {
 		return StdioCommand{}, errors.New("command is required")
 	}
+	timeout := stdioTimeoutFromConfig(server["timeout"])
 
 	command, commandArgs, commandIsArray, err := splitCommand(commandValue)
 	if err != nil {
@@ -463,16 +528,16 @@ func stdioCommandFromServer(server map[string]any) (StdioCommand, error) {
 		return StdioCommand{}, errors.New("command array must not also define args")
 	}
 	if commandIsArray {
-		return StdioCommand{Command: command, Args: commandArgs}, nil
+		return StdioCommand{Command: command, Args: commandArgs, Timeout: timeout}, nil
 	}
 	if !hasArgs {
-		return StdioCommand{Command: command}, nil
+		return StdioCommand{Command: command, Timeout: timeout}, nil
 	}
 	args, err := stringSlice(argsValue)
 	if err != nil {
 		return StdioCommand{}, fmt.Errorf("args: %w", err)
 	}
-	return StdioCommand{Command: command, Args: args}, nil
+	return StdioCommand{Command: command, Args: args, Timeout: timeout}, nil
 }
 
 func splitCommand(value any) (string, []string, bool, error) {

--- a/internal/components/engram/healthprobe.go
+++ b/internal/components/engram/healthprobe.go
@@ -110,13 +110,9 @@ type StdioCommand struct {
 // doctor's PATH: an absolute command in the config must be the process that is
 // checked. Only a bare Engram command maps to ErrNotInstalled; a missing path
 // or custom command is a broken configured transport.
-func ProbeStdio(ctx context.Context, command string, args ...string) error {
-	return ProbeStdioWithTimeout(ctx, 0, command, args...)
-}
-
-// ProbeStdioWithTimeout is ProbeStdio bounded by the configured deadline. A
-// zero timeout falls back to the package default.
-func ProbeStdioWithTimeout(ctx context.Context, timeout time.Duration, command string, args ...string) error {
+// The timeout is the one persisted alongside the command in the agent's own
+// MCP configuration; zero falls back to the package default.
+func ProbeStdio(ctx context.Context, timeout time.Duration, command string, args ...string) error {
 	err := stdioHandshakeFn(ctx, stdioProbeDeadline(timeout), command, args...)
 	if isBareEngramCommand(command) && errors.Is(err, exec.ErrNotFound) {
 		return ErrNotInstalled

--- a/internal/components/engram/healthprobe_test.go
+++ b/internal/components/engram/healthprobe_test.go
@@ -595,7 +595,7 @@ func TestProbeStdio_NotInstalled(t *testing.T) {
 	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
-	if err := ProbeStdio(context.Background(), "engram", "mcp", "--tools=agent"); !errors.Is(err, ErrNotInstalled) {
+	if err := ProbeStdio(context.Background(), 0, "engram", "mcp", "--tools=agent"); !errors.Is(err, ErrNotInstalled) {
 		t.Fatalf("ProbeStdio() error = %v, want ErrNotInstalled", err)
 	}
 }
@@ -605,7 +605,7 @@ func TestProbeStdio_MissingAbsoluteConfiguredCommandFails(t *testing.T) {
 	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
-	err := ProbeStdio(context.Background(), "/configured/engram", "mcp", "--tools=agent")
+	err := ProbeStdio(context.Background(), 0, "/configured/engram", "mcp", "--tools=agent")
 	if !errors.Is(err, exec.ErrNotFound) {
 		t.Fatalf("ProbeStdio() error = %v, want missing configured command", err)
 	}
@@ -637,7 +637,7 @@ func TestProbeStdio_ClassifiesCommandNotFound(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ProbeStdio(context.Background(), tt.command, "mcp", "--tools=agent")
+			err := ProbeStdio(context.Background(), 0, tt.command, "mcp", "--tools=agent")
 			if tt.wantNotInstalled {
 				if !errors.Is(err, ErrNotInstalled) {
 					t.Fatalf("ProbeStdio() error = %v, want ErrNotInstalled", err)
@@ -665,7 +665,7 @@ func TestProbeStdio_UsesExactPersistedCommand(t *testing.T) {
 	}
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
-	if err := ProbeStdio(context.Background(), "/opt/gentle-engram/bin/engram", "mcp", "--tools=custom"); err != nil {
+	if err := ProbeStdio(context.Background(), 0, "/opt/gentle-engram/bin/engram", "mcp", "--tools=custom"); err != nil {
 		t.Fatalf("ProbeStdio() error = %v", err)
 	}
 	if gotName != "/opt/gentle-engram/bin/engram" {

--- a/internal/components/engram/healthprobe_test.go
+++ b/internal/components/engram/healthprobe_test.go
@@ -160,7 +160,7 @@ func TestStdioHandshake_TerminatesDescendantHoldingStdout(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		defer close(finished)
-		result <- stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+		result <- stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	}()
 
 	pid := waitForHelperPID(t, pidPath)
@@ -226,7 +226,7 @@ func TestStdioHandshake_TerminatesDescendantOnContextEnd(t *testing.T) {
 			finished := make(chan struct{})
 			go func() {
 				defer close(finished)
-				result <- stdioHandshake(ctx, "engram", "mcp", "--tools=agent")
+				result <- stdioHandshake(ctx, stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 			}()
 
 			pid := waitForHelperPID(t, pidPath)
@@ -390,7 +390,7 @@ func terminateTestProcess(pid int) {
 func TestStdioHandshake_Healthy(t *testing.T) {
 	setStdioHelperProcess(t, "healthy")
 
-	if err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent"); err != nil {
+	if err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent"); err != nil {
 		t.Fatalf("stdioHandshake() error = %v, want nil for a healthy MCP server", err)
 	}
 }
@@ -398,7 +398,7 @@ func TestStdioHandshake_Healthy(t *testing.T) {
 func TestStdioHandshake_RPCError(t *testing.T) {
 	setStdioHelperProcess(t, "rpc-error")
 
-	err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+	err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	if err == nil || !strings.Contains(err.Error(), "initialize returned error") {
 		t.Fatalf("stdioHandshake() error = %v, want initialize error", err)
 	}
@@ -422,7 +422,7 @@ func TestStdioHandshake_RejectsInvalidInitializeResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setStdioHelperProcess(t, tt.mode)
 
-			err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+			err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 			if err == nil || !strings.Contains(err.Error(), "initialize returned invalid result") {
 				t.Fatalf("stdioHandshake() error = %v, want invalid initialize result", err)
 			}
@@ -433,7 +433,7 @@ func TestStdioHandshake_RejectsInvalidInitializeResult(t *testing.T) {
 func TestStdioHandshake_EarlyExit(t *testing.T) {
 	setStdioHelperProcess(t, "early-exit")
 
-	err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+	err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	if err == nil || !strings.Contains(err.Error(), "exited without answering initialize") {
 		t.Fatalf("stdioHandshake() error = %v, want early-exit error", err)
 	}
@@ -442,7 +442,7 @@ func TestStdioHandshake_EarlyExit(t *testing.T) {
 func TestStdioHandshake_GarbageOutput(t *testing.T) {
 	setStdioHelperProcess(t, "garbage")
 
-	err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+	err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	if err == nil || !strings.Contains(err.Error(), "invalid MCP stdout") {
 		t.Fatalf("stdioHandshake() error = %v, want invalid stdout error", err)
 	}
@@ -467,7 +467,7 @@ func TestStdioHandshake_RejectsInvalidResponseEnvelope(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setStdioHelperProcess(t, tt.mode)
 
-			err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+			err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("stdioHandshake() error = %v, want %q", err, tt.want)
 			}
@@ -478,7 +478,7 @@ func TestStdioHandshake_RejectsInvalidResponseEnvelope(t *testing.T) {
 func TestStdioHandshake_TerminatesThenDrainsBufferedStdout(t *testing.T) {
 	setStdioHelperProcess(t, "trailing-stdout-after-healthy")
 
-	err := stdioHandshake(context.Background(), "engram", "mcp", "--tools=agent")
+	err := stdioHandshake(context.Background(), stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	if err == nil || !strings.Contains(err.Error(), "invalid MCP stdout") {
 		t.Fatalf("stdioHandshake() error = %v, want buffered trailing stdout error", err)
 	}
@@ -490,7 +490,7 @@ func TestStdioHandshake_PreservesEarlierDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	err := stdioHandshake(ctx, "engram", "mcp", "--tools=agent")
+	err := stdioHandshake(ctx, stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	if err != context.DeadlineExceeded {
 		t.Fatalf("stdioHandshake() error = %v, want earlier caller deadline", err)
 	}
@@ -505,7 +505,7 @@ func TestStdioHandshake_PreservesCallerCancellation(t *testing.T) {
 	defer timer.Stop()
 	defer cancel(nil)
 
-	err := stdioHandshake(ctx, "engram", "mcp", "--tools=agent")
+	err := stdioHandshake(ctx, stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 	if err != cause {
 		t.Fatalf("stdioHandshake() error = %v, want caller cancellation", err)
 	}
@@ -570,7 +570,7 @@ func TestStdioHandshake_TerminalOutcomes(t *testing.T) {
 				timer := time.AfterFunc(tt.cancelAfter, cancel)
 				defer timer.Stop()
 			}
-			err := stdioHandshake(ctx, "engram", "mcp", "--tools=agent")
+			err := stdioHandshake(ctx, stdioProbeTimeout, "engram", "mcp", "--tools=agent")
 			if tt.want != nil && err != tt.want {
 				t.Fatalf("stdioHandshake() error = %v, want %v", err, tt.want)
 			}
@@ -585,14 +585,14 @@ func TestStdioHandshake_TerminalOutcomes(t *testing.T) {
 }
 
 func TestStdioHandshake_MissingBinary(t *testing.T) {
-	if err := stdioHandshake(context.Background(), "gentle-ai-test-no-such-binary"); err == nil {
+	if err := stdioHandshake(context.Background(), stdioProbeTimeout, "gentle-ai-test-no-such-binary"); err == nil {
 		t.Fatal("stdioHandshake() expected error for a missing binary")
 	}
 }
 
 func TestProbeStdio_NotInstalled(t *testing.T) {
 	orig := stdioHandshakeFn
-	stdioHandshakeFn = func(context.Context, string, ...string) error { return exec.ErrNotFound }
+	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
 	if err := ProbeStdio(context.Background(), "engram", "mcp", "--tools=agent"); !errors.Is(err, ErrNotInstalled) {
@@ -602,7 +602,7 @@ func TestProbeStdio_NotInstalled(t *testing.T) {
 
 func TestProbeStdio_MissingAbsoluteConfiguredCommandFails(t *testing.T) {
 	orig := stdioHandshakeFn
-	stdioHandshakeFn = func(context.Context, string, ...string) error { return exec.ErrNotFound }
+	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
 	err := ProbeStdio(context.Background(), "/configured/engram", "mcp", "--tools=agent")
@@ -616,7 +616,7 @@ func TestProbeStdio_MissingAbsoluteConfiguredCommandFails(t *testing.T) {
 
 func TestProbeStdio_ClassifiesCommandNotFound(t *testing.T) {
 	orig := stdioHandshakeFn
-	stdioHandshakeFn = func(context.Context, string, ...string) error { return exec.ErrNotFound }
+	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
 	tests := []struct {
@@ -658,7 +658,7 @@ func TestProbeStdio_UsesExactPersistedCommand(t *testing.T) {
 	var gotName string
 	var gotArgs []string
 	orig := stdioHandshakeFn
-	stdioHandshakeFn = func(_ context.Context, name string, args ...string) error {
+	stdioHandshakeFn = func(_ context.Context, _ time.Duration, name string, args ...string) error {
 		gotName = name
 		gotArgs = args
 		return nil

--- a/internal/components/engram/healthprobe_timeout_test.go
+++ b/internal/components/engram/healthprobe_timeout_test.go
@@ -1,0 +1,91 @@
+package engram
+
+import (
+	"testing"
+	"time"
+)
+
+// TestConfiguredStdioTimeoutIsRead is #3068's first half.
+//
+// The probe's deadline was a fixed 5 seconds covering process spawn PLUS the
+// initialize handshake, and #3068's reporter measured a healthy store's
+// handshake alone at 4.87 to 5.16 seconds. The check therefore sat on top of
+// the line rather than under it and flapped: their report captured the same
+// store both passing and failing.
+//
+// They raised the OpenCode MCP timeout to 15 seconds, saw no change, and
+// reverted it. They were right that it did nothing: StdioCommand carried
+// Command, Args and Source, so a configured timeout had no wire to travel
+// down. It does now.
+func TestConfiguredStdioTimeoutIsRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		server map[string]any
+		want   time.Duration
+	}{
+		{name: "absent", server: map[string]any{"command": "engram"}, want: 0},
+		// A bare number is seconds: that is how the OpenCode MCP config
+		// expresses it, and it is what #3068's reporter set.
+		{name: "seconds as number", server: map[string]any{"command": "engram", "timeout": float64(15)}, want: 15 * time.Second},
+		{name: "seconds as integer", server: map[string]any{"command": "engram", "timeout": 20}, want: 20 * time.Second},
+		{name: "duration string", server: map[string]any{"command": "engram", "timeout": "12s"}, want: 12 * time.Second},
+		// Nonsense is ignored rather than fatal. A malformed timeout must not
+		// make an otherwise valid Engram configuration unreadable, because the
+		// consequence would be worse than the defect being fixed.
+		{name: "unparseable string", server: map[string]any{"command": "engram", "timeout": "soon"}, want: 0},
+		{name: "negative", server: map[string]any{"command": "engram", "timeout": -3}, want: 0},
+		{name: "zero", server: map[string]any{"command": "engram", "timeout": 0}, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, err := stdioCommandFromServer(tt.server)
+			if err != nil {
+				t.Fatalf("stdioCommandFromServer() error = %v", err)
+			}
+			if command.Timeout != tt.want {
+				t.Fatalf("Timeout = %v, want %v", command.Timeout, tt.want)
+			}
+		})
+	}
+}
+
+// TestStdioProbeDeadlineHonorsTheConfiguredTimeout proves the value reaches
+// the deadline instead of being parsed and dropped.
+func TestStdioProbeDeadlineHonorsTheConfiguredTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "unset falls back to the default", configured: 0, want: stdioProbeTimeout},
+		{name: "configured wins", configured: 15 * time.Second, want: 15 * time.Second},
+		// A configured timeout shorter than the default is still the operator's
+		// choice: they asked for a tighter bound and get one.
+		{name: "shorter than default is respected", configured: 2 * time.Second, want: 2 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stdioProbeDeadline(tt.configured); got != tt.want {
+				t.Fatalf("stdioProbeDeadline(%v) = %v, want %v", tt.configured, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDefaultStdioProbeTimeoutClearsAMeasuredHealthyHandshake pins the default
+// against the evidence rather than against taste.
+//
+// #3068 measured a healthy store at 4.87 to 5.16 seconds for the handshake
+// alone, on top of which the probe also pays process spawn. A default that
+// merely exceeds the measurement by a hair reproduces the same flap on a
+// slower machine, so it carries real headroom over the slowest observed value.
+func TestDefaultStdioProbeTimeoutClearsAMeasuredHealthyHandshake(t *testing.T) {
+	const slowestObservedHealthyHandshake = 5160 * time.Millisecond
+	if stdioProbeTimeout <= slowestObservedHealthyHandshake {
+		t.Fatalf("default probe timeout %v does not clear the healthy handshake #3068 measured (%v)", stdioProbeTimeout, slowestObservedHealthyHandshake)
+	}
+	if stdioProbeTimeout < 2*slowestObservedHealthyHandshake {
+		t.Fatalf("default probe timeout %v leaves less than 2x headroom over the slowest observed healthy handshake (%v); a slower machine reproduces #3068", stdioProbeTimeout, slowestObservedHealthyHandshake)
+	}
+}

--- a/internal/components/engram/healthprobe_windows_test.go
+++ b/internal/components/engram/healthprobe_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os/exec"
 	"testing"
+	"time"
 )
 
 func TestProbeStdio_MissingRelativeWindowsExecutableIsNotInstalled(t *testing.T) {
@@ -14,7 +15,7 @@ func TestProbeStdio_MissingRelativeWindowsExecutableIsNotInstalled(t *testing.T)
 	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
-	err := ProbeStdio(context.Background(), "engram.exe", "mcp", "--tools=agent")
+	err := ProbeStdio(context.Background(), 0, "engram.exe", "mcp", "--tools=agent")
 	if !errors.Is(err, ErrNotInstalled) {
 		t.Fatalf("ProbeStdio() error = %v, want ErrNotInstalled for missing relative engram.exe", err)
 	}

--- a/internal/components/engram/healthprobe_windows_test.go
+++ b/internal/components/engram/healthprobe_windows_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestProbeStdio_MissingRelativeWindowsExecutableIsNotInstalled(t *testing.T) {
 	orig := stdioHandshakeFn
-	stdioHandshakeFn = func(context.Context, string, ...string) error { return exec.ErrNotFound }
+	stdioHandshakeFn = func(context.Context, time.Duration, string, ...string) error { return exec.ErrNotFound }
 	t.Cleanup(func() { stdioHandshakeFn = orig })
 
 	err := ProbeStdio(context.Background(), "engram.exe", "mcp", "--tools=agent")


### PR DESCRIPTION
#3068, reported by @eduardoemb against `2.4.0-rc.6`, with measurements that made it diagnosable without a local reproduction.

## The number

```go
// stdioProbeTimeout is the hard deadline for the whole stdio probe: spawning
// the engram MCP process plus the initialize handshake round-trip.
var stdioProbeTimeout = 5 * time.Second
```

They measured the handshake **alone** at 4.87 to 5.16 seconds. That budget also pays process spawn, so a healthy store sat on top of the line. Their report captured the same store both passing and failing in one session: this was a flapping check, not a stable failure.

## Two things wrong beyond the number

**The configured timeout could not reach the probe.** `StdioCommand` carried `Command`, `Args` and `Source`, and nothing in the package read a timeout. The reporter raised their OpenCode MCP timeout to 15 seconds, saw no change, and reverted it — correctly, because there was no wire for it to travel down. It is read now: a number is seconds (how the OpenCode config expresses it), a string is a Go duration, and anything unparseable, zero or negative falls back to the default rather than making an otherwise valid Engram configuration unreadable.

**The verdict was wrong even when the timeout was right.** A deadline that elapsed does not implicate the command, yet the check said `initialize handshake failed` and the remedy was *Check the Engram MCP command and arguments*. Theirs were fine. They were sent to inspect the one thing the evidence excluded, while `Status: unhealthy` is what fail-closed consumers act on.

Before / after, for a deadline:

```
- engram MCP (stdio) initialize handshake failed for persisted configuration <path>: context deadline exceeded
-   Remedy: Check the Engram MCP command and arguments in <path>

+ engram MCP (stdio) did not answer within 15s for persisted configuration <path>
+   Remedy: Raise the Engram MCP server's timeout in <path> if the store is simply slow to start,
+           or check whether the process is hanging
```

It still **fails**. A probe that never answered is not a pass, and `TestEngramNonDeadlineFailureKeepsItsRemedy` pins that a real handshake failure keeps the wording and the remedy that does implicate the configuration.

## The default, pinned to evidence rather than taste

`TestDefaultStdioProbeTimeoutClearsAMeasuredHealthyHandshake` asserts the default clears the slowest healthy handshake #3068 measured **with at least 2x headroom**. Raising the constant to something that merely beats 5.16 seconds would move the edge, not remove it, and reproduce the same flap on a slower machine. That test fails if someone later trims the default back toward the measurement.

A configured timeout wins in both directions, including shorter than the default: asking for a tighter bound is as legitimate as asking for a looser one, and silently applying a floor would repeat the defect where a configured timeout changed nothing.

RED first for all of it. `go test ./...` and `cd bench && go test ./...` both green with the test cache cleared.

Closes #3068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Engram health checks now support configurable probe timeouts using seconds or duration values.
  - A 15-second default timeout is applied when no valid timeout is configured.
- **Bug Fixes**
  - Timeout-related failures now clearly report that the probe exceeded its deadline and suggest investigating slow or hung processes.
  - Non-timeout handshake failures retain their existing diagnostics and remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->