### PR TITLE
fix(opencode): record synced reviewer runtime

### DIFF
--- a/internal/cli/install_state_lock_test.go
+++ b/internal/cli/install_state_lock_test.go
@@ -16,7 +16,7 @@ func TestPersistSyncManagedAssetStateReReadsLatestStateAfterLockContention(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := persistSyncManagedAssetState(home, model.Selection{}, "sha256:current-writer"); err == nil || !strings.Contains(err.Error(), "acquire install state lock") {
+	if err := persistSyncManagedAssetState(home, model.Selection{}, "sha256:current-writer", nil); err == nil || !strings.Contains(err.Error(), "acquire install state lock") {
 		t.Fatalf("contended sync state persistence error = %v", err)
 	}
 	if err := state.Write(home, state.InstallState{Persona: "concurrent"}); err != nil {
@@ -25,11 +25,12 @@ func TestPersistSyncManagedAssetStateReReadsLatestStateAfterLockContention(t *te
 	if err := held.Release(); err != nil {
 		t.Fatal(err)
 	}
-	if err := persistSyncManagedAssetState(home, model.Selection{CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph}}, "sha256:current-writer"); err != nil {
+	provenance := &state.OpenCodeRuntimeProvenance{Executable: "/opt/gentle ai/gentle-ai", SHA256: "sha256:current-runtime", Version: "gentle-ai current"}
+	if err := persistSyncManagedAssetState(home, model.Selection{CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph}}, "sha256:current-writer", provenance); err != nil {
 		t.Fatal(err)
 	}
 	got, err := state.Read(home)
-	if err != nil || got.Persona != "concurrent" || got.ManagedAssetDigest != "sha256:current-writer" || !got.CommunityToolsConfigured || len(got.CommunityTools) != 1 || got.CommunityTools[0] != string(model.CommunityToolCodeGraph) {
+	if err != nil || got.Persona != "concurrent" || got.ManagedAssetDigest != "sha256:current-writer" || got.OpenCodeRuntimeProvenance == nil || *got.OpenCodeRuntimeProvenance != *provenance || !got.CommunityToolsConfigured || len(got.CommunityTools) != 1 || got.CommunityTools[0] != string(model.CommunityToolCodeGraph) {
 		t.Fatalf("persisted sync state = %#v, err = %v", got, err)
 	}
 }
@@ -42,7 +43,7 @@ func TestPersistSyncManagedAssetStateRefusesCorruptLatestState(t *testing.T) {
 	if err := os.WriteFile(state.Path(home), []byte("{not valid json\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := persistSyncManagedAssetState(home, model.Selection{}, "sha256:current-writer"); err == nil || !strings.Contains(err.Error(), "run `gentle-ai install`") {
+	if err := persistSyncManagedAssetState(home, model.Selection{}, "sha256:current-writer", nil); err == nil || !strings.Contains(err.Error(), "run `gentle-ai install`") {
 		t.Fatalf("corrupt sync state persistence error = %v", err)
 	}
 }

--- a/internal/cli/opencode_runtime_provenance.go
+++ b/internal/cli/opencode_runtime_provenance.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+)
+
+var currentExecutable = os.Executable
+
+// captureOpenCodeRuntimeProvenance binds managed reviewer assets to the exact
+// process that wrote them. The plugin verifies this record before it can ask
+// native Go to read review authority.
+func captureOpenCodeRuntimeProvenance() (*state.OpenCodeRuntimeProvenance, error) {
+	executable, err := currentExecutable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current gentle-ai executable: %w", err)
+	}
+	executable, err = filepath.Abs(executable)
+	if err != nil {
+		return nil, fmt.Errorf("make current gentle-ai executable path absolute: %w", err)
+	}
+	info, err := os.Stat(executable)
+	if err != nil {
+		return nil, fmt.Errorf("inspect current gentle-ai executable %q: %w", executable, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("current gentle-ai executable %q is not a regular file", executable)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		return nil, fmt.Errorf("current gentle-ai executable %q is not executable", executable)
+	}
+	file, err := os.Open(executable)
+	if err != nil {
+		return nil, fmt.Errorf("open current gentle-ai executable %q: %w", executable, err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return nil, fmt.Errorf("hash current gentle-ai executable %q: %w", executable, err)
+	}
+	return &state.OpenCodeRuntimeProvenance{
+		Executable: executable,
+		SHA256:     "sha256:" + hex.EncodeToString(hash.Sum(nil)),
+		Version:    "gentle-ai " + AppVersion,
+	}, nil
+}
+
+func hasOpenCodeReviewerPlugin(agentIDs []model.AgentID) bool {
+	for _, agentID := range agentIDs {
+		if agentID == model.AgentOpenCode {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/opencode_runtime_provenance_test.go
+++ b/internal/cli/opencode_runtime_provenance_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+)
+
+func TestRunSyncRecordsOpenCodeRuntimeProvenanceWhenReviewPluginIsCurrent(t *testing.T) {
+	home := t.TempDir()
+	plugin := filepath.Join(home, ".config", "opencode", "plugins", "review-result-artifacts.ts")
+	if err := os.MkdirAll(filepath.Dir(plugin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantPlugin := []byte(assets.MustRead("opencode/plugins/review-result-artifacts.ts"))
+	if err := os.WriteFile(plugin, wantPlugin, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"opencode"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RunSyncWithSelection(home, model.Selection{Agents: []model.AgentID{model.AgentOpenCode}}); err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	gotPlugin, err := os.ReadFile(plugin)
+	if err != nil || string(gotPlugin) != string(wantPlugin) {
+		t.Fatalf("managed plugin changed while already current: %q, %v", gotPlugin, err)
+	}
+	encoded, err := os.ReadFile(state.Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted struct {
+		OpenCodeRuntimeProvenance struct {
+			Executable string `json:"executable"`
+			SHA256     string `json:"sha256"`
+			Version    string `json:"version"`
+		} `json:"opencode_runtime_provenance"`
+	}
+	if err := json.Unmarshal(encoded, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(persisted.OpenCodeRuntimeProvenance.Executable) ||
+		!strings.HasPrefix(persisted.OpenCodeRuntimeProvenance.SHA256, "sha256:") ||
+		persisted.OpenCodeRuntimeProvenance.Version == "" {
+		t.Fatalf("sync did not record a complete exact runtime pin: %#v", persisted.OpenCodeRuntimeProvenance)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -162,6 +162,13 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 				"will be written to each selected agent's global config directory and will affect ALL workspaces for those agents on this machine.\n"+
 				"To install only into the current workspace, rerun with --scope=workspace.\n\n")
 	}
+	var openCodeRuntime *state.OpenCodeRuntimeProvenance
+	if hasOpenCodeReviewerPlugin(input.Selection.Agents) {
+		openCodeRuntime, err = captureOpenCodeRuntimeProvenance()
+		if err != nil {
+			return result, fmt.Errorf("capture OpenCode reviewer runtime provenance: %w", err)
+		}
+	}
 
 	runtime, err := newInstallRuntime(homeDir, input.Scope, input.Channel, input.Selection, resolved, profile)
 	if err != nil {
@@ -226,6 +233,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		CodexPhaseModelAssignments:  input.Selection.CodexPhaseModelAssignments,
 		ModelAssignments:            modelAssignmentsToState(input.Selection.ModelAssignments),
 		Persona:                     string(input.Selection.Persona),
+		OpenCodeRuntimeProvenance:   openCodeRuntime,
 	}
 	newState.SetSelection(input.Selection)
 	writer, err := managedAssetDigest()
@@ -300,6 +308,10 @@ func mergeExplicitAgentInstallState(homeDir string, newState state.InstallState,
 	}
 	if newState.CodexPhaseModelAssignments != nil {
 		merged.CodexPhaseModelAssignments = newState.CodexPhaseModelAssignments
+	}
+	if newState.OpenCodeRuntimeProvenance != nil {
+		provenance := *newState.OpenCodeRuntimeProvenance
+		merged.OpenCodeRuntimeProvenance = &provenance
 	}
 	if merged.SelectionConfigured {
 		if len(flags.Components) > 0 {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -445,14 +445,15 @@ func DiscoverAgents(homeDir string) []model.AgentID {
 // It reuses backup/rollback infrastructure but only calls inject functions —
 // no agentInstallStep, no engram setup, no persona.
 type syncRuntime struct {
-	homeDir      string
-	workspaceDir string
-	selection    model.Selection
-	agentIDs     []model.AgentID
-	backupRoot   string
-	state        *runtimeState
-	managedPaths []string
-	changedFiles []string // accumulates candidate paths reported by component injectors
+	homeDir         string
+	workspaceDir    string
+	selection       model.Selection
+	agentIDs        []model.AgentID
+	backupRoot      string
+	state           *runtimeState
+	managedPaths    []string
+	changedFiles    []string // accumulates candidate paths reported by component injectors
+	openCodeRuntime *state.OpenCodeRuntimeProvenance
 }
 
 func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, error) {
@@ -464,14 +465,22 @@ func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, er
 		return nil, err
 	}
 
-	return &syncRuntime{
+	runtime := &syncRuntime{
 		homeDir:      homeDir,
 		workspaceDir: workspaceDir,
 		selection:    selection,
 		agentIDs:     selection.Agents,
 		backupRoot:   backupRoot,
 		state:        &runtimeState{compatibilityTransaction: compatibilityTransaction},
-	}, nil
+	}
+	if hasOpenCodeReviewerPlugin(selection.Agents) {
+		provenance, err := captureOpenCodeRuntimeProvenance()
+		if err != nil {
+			return nil, fmt.Errorf("capture OpenCode reviewer runtime provenance: %w", err)
+		}
+		runtime.openCodeRuntime = provenance
+	}
+	return runtime, nil
 }
 
 func (r *syncRuntime) stagePlan() pipeline.StagePlan {
@@ -1587,14 +1596,14 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	if err != nil {
 		return result, fmt.Errorf("derive managed asset writer identity: %w", err)
 	}
-	if err := persistSyncManagedAssetState(homeDir, selection, writer); err != nil {
+	if err := persistSyncManagedAssetState(homeDir, selection, writer, rt.openCodeRuntime); err != nil {
 		return result, err
 	}
 
 	return result, nil
 }
 
-func persistSyncManagedAssetState(homeDir string, selection model.Selection, writer string) error {
+func persistSyncManagedAssetState(homeDir string, selection model.Selection, writer string, runtimeProvenance *state.OpenCodeRuntimeProvenance) error {
 	return withInstallStateLock(homeDir, func() error {
 		latest, err := state.Read(homeDir)
 		if errors.Is(err, os.ErrNotExist) {
@@ -1608,6 +1617,11 @@ func persistSyncManagedAssetState(homeDir string, selection model.Selection, wri
 		shouldWrite := false
 		if latest.ManagedAssetDigest != writer {
 			latest.ManagedAssetDigest = writer
+			shouldWrite = true
+		}
+		if runtimeProvenance != nil && (latest.OpenCodeRuntimeProvenance == nil || *latest.OpenCodeRuntimeProvenance != *runtimeProvenance) {
+			provenance := *runtimeProvenance
+			latest.OpenCodeRuntimeProvenance = &provenance
 			shouldWrite = true
 		}
 		if !latest.CommunityToolsConfigured && selection.CommunityTools != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,16 +37,26 @@ type ClaudePhaseAssignmentState struct {
 	Effort string `json:"effort,omitempty"`
 }
 
+// OpenCodeRuntimeProvenance identifies the exact gentle-ai binary that wrote
+// managed OpenCode reviewer assets. The temporary plugin adapter uses it only
+// to launch that binary; native Go remains the review authority owner.
+type OpenCodeRuntimeProvenance struct {
+	Executable string `json:"executable"`
+	SHA256     string `json:"sha256"`
+	Version    string `json:"version"`
+}
+
 // InstallState holds the persisted user selections from the last install run.
 type InstallState struct {
-	InstalledAgents     []string            `json:"installed_agents"`
-	ManagedAssetDigest  string              `json:"managed_asset_digest,omitempty"`
-	SelectionConfigured bool                `json:"selection_configured,omitempty"`
-	Components          []model.ComponentID `json:"components,omitempty"`
-	Skills              []model.SkillID     `json:"skills,omitempty"`
-	Preset              model.PresetID      `json:"preset,omitempty"`
-	SDDMode             model.SDDModeID     `json:"sdd_mode,omitempty"`
-	StrictTDD           bool                `json:"strict_tdd,omitempty"`
+	InstalledAgents           []string                   `json:"installed_agents"`
+	ManagedAssetDigest        string                     `json:"managed_asset_digest,omitempty"`
+	OpenCodeRuntimeProvenance *OpenCodeRuntimeProvenance `json:"opencode_runtime_provenance,omitempty"`
+	SelectionConfigured       bool                       `json:"selection_configured,omitempty"`
+	Components                []model.ComponentID        `json:"components,omitempty"`
+	Skills                    []model.SkillID            `json:"skills,omitempty"`
+	Preset                    model.PresetID             `json:"preset,omitempty"`
+	SDDMode                   model.SDDModeID            `json:"sdd_mode,omitempty"`
+	StrictTDD                 bool                       `json:"strict_tdd,omitempty"`
 	// CommunityTools records optional tools explicitly selected in the Gentle AI
 	// installer. Configured distinguishes a completed empty selection from legacy
 	// state files that predate persistence of this choice.
@@ -218,6 +228,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 	return InstallState{
 		InstalledAgents:             merged,
 		ManagedAssetDigest:          existing.ManagedAssetDigest,
+		OpenCodeRuntimeProvenance:   existing.OpenCodeRuntimeProvenance,
 		SelectionConfigured:         existing.SelectionConfigured,
 		Components:                  existing.Components,
 		Skills:                      existing.Skills,


### PR DESCRIPTION
## Linked Issue

Closes #3049

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Maintenance/tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Records the sync/install writer executable as an absolute path with SHA-256 and version.
- Refreshes that provenance under the existing install-state lock even when plugin bytes are unchanged.
- Does not yet enforce the pin; child 2 consumes this record.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/state`, `internal/cli` | Persist exact OpenCode reviewer runtime provenance during sync and install. |
| `internal/cli/*_test.go` | Prove unchanged-plugin refresh and lock-preserving state updates. |

---

## Test Plan

- [x] `go test ./internal/cli ./internal/state -count=1`
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `GOOS=windows GOARCH=amd64 go test -c ./internal/cli ./internal/state`
- [x] `git diff --check`
- [x] Plugin transpilation: `bun build --target bun --external @opencode-ai/plugin ...`
- [x] Organic runtime: N/A. This record-only slice has no enforcement boundary; child 2 supplies the runtime proof.
- [x] Benchmark validation: N/A. No bench or review semantics changed.

---

## Contributor Checklist

- [x] Linked approved issue #3049
- [x] Added exactly one `type:bug` label
- [x] Stayed within 204 / 400 changed lines
- [x] Ran focused and full Go tests
- [x] Ran Go format validation
- [x] Ran applicable E2E/runtime validation
- [x] Docs are not required for an internal temporary provenance record
- [x] Conventional commit; no `Co-Authored-By` trailer

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | `3049-pin-opencode-runtime` |
| Tracker PR | Pending initial child integration |
| Position | 1 of 2 |
| Base | `feat/3049-pin-opencode-runtime` |
| Depends on | None |
| Follow-up | `fix/3049-pin-opencode-plugin-runtime` |
| Review budget | 204 / 400 |
| Starts at | `origin/main@df1c44c` |
| Ends with | Sync/install durably record the exact OpenCode reviewer runtime. |

### Chain Overview

```text
main
  └── tracker PR: pending initial child integration
       └── 📍 child 1: record runtime provenance
            └── child 2: enforce exact plugin runtime
```

### Scope

- Includes: state schema, executable hash/version capture, sync/install persistence, lock behavior tests.
- Excludes: plugin enforcement, PATH refusal, receipt/gate runtime tests.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit

## Rollback

Revert this child from the tracker branch to stop recording temporary provenance. It changes no review authority or plugin launch behavior alone.

## Notes for Reviewers

Tracker PR: pending initial child integration. The temporary record is deleted by the future native cutover tracked in #3071.