### PR TITLE
fix(sync): include Codex hooks in backup targets

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2102,6 +2102,11 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 				}
 			}
 			paths = append(paths, sddSubAgentPaths(targetDir, adapter)...)
+			if adapter.Agent() == model.AgentCodex {
+				// SDD installs the Codex skill-registry hook outside the skills
+				// directory, so it must share the component's backup contract.
+				paths = append(paths, filepath.Join(adapter.GlobalConfigDir(homeDir), "hooks.json"))
+			}
 		case model.ComponentSkills:
 			for _, skillID := range selectedSkillIDs(selection) {
 				if skills.IsSDDSkill(skillID) {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -512,6 +512,21 @@ func TestComponentPathsEngramCodexIncludesConfigTOML(t *testing.T) {
 	}
 }
 
+func TestComponentPathsSDDCodexIncludesHooksJSONOnlyForCodex(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentCodex, model.AgentClaudeCode})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentSDD)
+	codexHooks := filepath.Join(home, ".codex", "hooks.json")
+	if !containsPath(paths, codexHooks) {
+		t.Fatalf("componentPaths(sdd,codex) missing skill-registry hook %q\npaths=%v", codexHooks, paths)
+	}
+	claudeHooks := filepath.Join(home, ".claude", "hooks.json")
+	if containsPath(paths, claudeHooks) {
+		t.Fatalf("componentPaths(sdd,claude) declared unsupported hooks path %q\npaths=%v", claudeHooks, paths)
+	}
+}
+
 // TestComponentPathsPermissionsCodexContributesNoPaths pins that the
 // Permission component claims nothing under ~/.codex. gentle-ai does not write
 // Codex's permissions config — not a profile, and not the legacy cleanup that

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -3844,6 +3844,86 @@ func setSyncTestHome(t *testing.T, home string) {
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 }
 
+func TestSyncBackupManifestIncludesCodexHooksJSON(t *testing.T) {
+	home := t.TempDir()
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	mustWriteFile(t, hooksPath, []byte("{\"hooks\":{\"SessionStart\":[]}}\n"))
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentCodex},
+		Components: []model.ComponentID{model.ComponentSDD},
+	}
+	targets, err := syncBackupTargets(home, "", selection, resolveAdapters(selection.Agents))
+	if err != nil {
+		t.Fatalf("syncBackupTargets() error = %v", err)
+	}
+	if !containsPath(targets, hooksPath) {
+		t.Fatalf("sync backup targets missing %q\ntargets=%v", hooksPath, targets)
+	}
+
+	manifest, err := backup.NewSnapshotter().Create(filepath.Join(home, "snapshot"), targets)
+	if err != nil {
+		t.Fatalf("Snapshotter.Create() error = %v", err)
+	}
+	for _, entry := range manifest.Entries {
+		if entry.OriginalPath == hooksPath {
+			if !entry.Existed {
+				t.Fatalf("hooks.json manifest entry marked absent: %#v", entry)
+			}
+			return
+		}
+	}
+	t.Fatalf("snapshot manifest omitted %q: %#v", hooksPath, manifest.Entries)
+}
+
+func TestSyncCodexGentlemanConvergesWithHooksJSON(t *testing.T) {
+	home := t.TempDir()
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentCodex},
+		Components: []model.ComponentID{model.ComponentPersona, model.ComponentSDD},
+		Persona:    model.PersonaGentleman,
+		SDDMode:    model.SDDModeSingle,
+		CodexCarrilModelAssignments: map[string]string{
+			"sdd-strong": "gpt-5.5",
+			"sdd-mid":    "gpt-5.5",
+			"sdd-cheap":  "gpt-5.4-mini",
+		},
+	}
+	run := func() (int, []string) {
+		rt, err := newSyncRuntime(home, selection)
+		if err != nil {
+			t.Fatalf("newSyncRuntime() error = %v", err)
+		}
+		plan := rt.stagePlan()
+		before, err := snapshotSyncFiles(rt.managedPaths)
+		if err != nil {
+			t.Fatalf("snapshotSyncFiles() error = %v", err)
+		}
+		execution := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(plan)
+		if execution.Err != nil {
+			t.Fatalf("sync stage plan error = %v", execution.Err)
+		}
+		changed, err := changedSyncFiles(rt.changedFiles, before)
+		if err != nil {
+			t.Fatalf("changedSyncFiles() error = %v", err)
+		}
+		return len(changed), changed
+	}
+	firstFiles, _ := run()
+	if firstFiles == 0 {
+		t.Fatal("first sync reported no managed changes")
+	}
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	firstHooks := readTextFile(t, hooksPath)
+
+	secondFiles, changed := run()
+	if secondFiles != 0 || len(changed) != 0 {
+		t.Fatalf("second sync changed %d files: %v; want no changes", secondFiles, changed)
+	}
+	if got := readTextFile(t, hooksPath); got != firstHooks {
+		t.Fatalf("hooks.json changed between converged syncs")
+	}
+}
+
 // TestBuildSyncSelectionDoesNotHardcodePersona verifies that BuildSyncSelection
 // leaves Persona empty so RunSync can resolve it from state.
 func TestBuildSyncSelectionDoesNotHardcodePersona(t *testing.T) {
@@ -5218,7 +5298,7 @@ func TestSyncBackupTargetsIncludeRoutingGuidancePathsWithoutAnyComponent(t *test
 func TestSyncBackupTargetsContainNoDuplicatePaths(t *testing.T) {
 	home := t.TempDir()
 	selection := model.Selection{
-		Agents:     []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKimi},
+		Agents:     []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKimi, model.AgentCodex},
 		Components: []model.ComponentID{model.ComponentSDD, model.ComponentEngram, model.ComponentPersona},
 		SDDMode:    model.SDDModeSingle,
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2067

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Include Codex `hooks.json` in the SDD managed-path contract used by sync snapshots and backups.
- Make a converged Gentleman Codex sync report zero changed files.
- Add regression coverage for backup inclusion, Codex-only scope, duplicate targets, and repeated-sync idempotency.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go` | Adds Codex `hooks.json` to SDD component paths. |
| `internal/cli/run_component_paths_test.go` | Proves the hook path is Codex-specific. |
| `internal/cli/sync_test.go` | Proves backup coverage and repeated-sync convergence. |

---

## 🧪 Test Plan

- [x] `TMPDIR=/private/tmp go test ./internal/cli -count=1 -timeout 20m`
- [x] `go test ./internal/components/sdd/... ./internal/components/skills/... -count=1 -timeout 20m`
- [x] `go vet ./internal/cli ./internal/components/sdd/... ./internal/components/skills/...`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`
- [x] Manually exercised the sync stage-plan harness through the regression test.
- [ ] Docker E2E was not run locally; CI owns that lane.
- [x] Benchmark validation is N/A because this does not change review lifecycle, gates, recovery, delivery, or benchmark semantics.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 102 authored changed lines, within budget |
| Check Issue Reference | ⏳ | `Closes #2067` |
| Check Issue Has `status:approved` | ⏳ | #2067 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` will be applied |
| Unit Tests | ⏳ | Focused and affected-package suites passed locally |
| Go Format | ⏳ | Passed locally |
| E2E Tests | ⏳ | CI-owned platform lanes |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Affected unit tests pass
- [x] Go format passes
- [ ] E2E tests pass, delegated to CI
- [x] Benchmark validation is not applicable
- [x] Documentation is not required for this internal correctness fix
- [x] My commit follows Conventional Commits format
- [x] My commit does not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The residual current-main defect was narrower than the original report: nested skill assets are already enumerated, while Codex `hooks.json` remained outside the shared snapshot and backup target list. The fix extends that existing contract rather than weakening baseline-less changed-file detection.

RDD delivery is `disabled/unmanaged`; no receipt approval is claimed. This change does not add or modify a qualifying security, integrity, admission, repair, or governance guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex backups now include the global `~/.codex/hooks.json` configuration file.
  * Codex synchronization now consistently preserves hooks configuration across repeated runs.
  * Prevented unsupported Claude Code hooks paths from being included in SDD component paths.
  * Improved handling of duplicate backup paths across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->