### PR TITLE
test(cli): remove low-risk lifecycle stopwatch

### DIFF
--- a/internal/cli/review_low_risk_lifecycle_test.go
+++ b/internal/cli/review_low_risk_lifecycle_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
@@ -25,7 +24,6 @@ func TestOrdinaryMarkdownLowRiskLifecycleNeedsNoExternalEvidence(t *testing.T) {
 	}
 	writeReviewStartCandidate(t, repo, "docs/ordinary-guide.md", strings.Join(lines, "\n")+"\n", 0o644)
 
-	startedAt := time.Now()
 	var startOutput bytes.Buffer
 	if err := RunReview(boundNegotiatedStartArgs(t, []string{
 		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
@@ -137,9 +135,6 @@ func TestOrdinaryMarkdownLowRiskLifecycleNeedsNoExternalEvidence(t *testing.T) {
 		if strings.Contains(name, "model") || strings.Contains(name, "evidence") || strings.Contains(name, "result") {
 			t.Fatalf("native low-risk lifecycle created external model/evidence artifact %q", name)
 		}
-	}
-	if elapsed := time.Since(startedAt); elapsed > 10*time.Second {
-		t.Fatalf("warm low-risk lifecycle took %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #3089

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Removes the non-contract 10-second stopwatch from the low-risk lifecycle test.
- Retains the lifecycle's start, finalize, authority, evidence, receipt, gate, replay, and artifact assertions.
- Makes no production, workflow, fixture, or timing-threshold changes.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_low_risk_lifecycle_test.go` | Removed `time` import, start timestamp, and final elapsed-time assertion. |

---

## Test Plan

**Local evidence**

- [x] Focused semantic lifecycle test, uncached and repeated: `go test ./internal/cli -run '^TestOrdinaryMarkdownLowRiskLifecycleNeedsNoExternalEvidence$' -count=10`
- [x] Relevant CI selector mirrored locally: `go test ./internal/cli -count=1 -timeout=30m -run '^Test[D-Q]'` (414 selected tests)
- [x] Full module suite, uncached: `go test ./... -count=1`
- [x] Format and diff checks: `go run ./internal/gofmtcheck`, `gofmt -d internal/cli/review_low_risk_lifecycle_test.go`, and `git diff --check`
- [x] Benchmark validation N/A: this test-only correction changes no benchmark implementation, journey corpus, classifier, review lifecycle, gate, recovery, or delivery behavior.

**Preserved RED evidence**

- Windows Full Suite `cli-d-q` run [31552868687](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31552868687) failed only at the removed final stopwatch after semantic lifecycle completion: `10.93167s`.
- Windows Full Suite `cli-d-q` run [31552958409](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/31552958409) failed under the same condition: `10.7827683s`.

**Windows proof plan**

- CI-owned: run `TestOrdinaryMarkdownLowRiskLifecycleNeedsNoExternalEvidence` on Windows with `-count=100`, then execute the Windows Full Suite `cli-d-q` shard and final full-suite gate. This Linux worktree cannot provide Windows runner evidence.

**Rollback**

- Revert commit `c632cba4` to restore only the removed stopwatch. Reintroducing a timing assertion requires a documented user-visible latency SLO and deterministic isolated measurement boundary.

---

## Automated Checks

CodeRabbit is excluded from this PR. No reruns requested.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests are not applicable: no production behavior, workflow, or fixture changes
- [x] Benchmark validation is not applicable; rationale is in the Test Plan
- [x] Documentation updates are not needed because behavior is unchanged
- [x] My commit follows Conventional Commits format
- [x] My commit does not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The five-line deletion removes only an ambient Windows-load measurement. All semantic lifecycle assertions remain in place. Independent validation is ready; Windows proof remains CI-owned.