### PR TITLE
fix(review): name an occupied reviewer slot instead of a context failure

### DIFF
--- a/e2e/organicruntime/organic_lifecycle_hardening_test.go
+++ b/e2e/organicruntime/organic_lifecycle_hardening_test.go
@@ -1304,9 +1304,8 @@ func reviewDefectReportDirEntries(t *testing.T, harness *organicHarness) []strin
 // Phase 5: a genuine tool-fault terminal (the confirmed captured-final-
 // EVIDENCE byte conflict, tasks.md 3b.9) generates a template-shaped,
 // privacy-clean defect report named by its Tier C statement, while a
-// legitimate user-decision terminal (the reviewer-result byte conflict,
-// tasks.md 3b.7 -- a human must choose `review dispose-result` or `review
-// preserve-result`) generates none.
+// legitimate occupied reviewer-result slot generates none and directs the
+// caller to the authoritative STATUS continuation.
 func TestOrganicReviewDefectReportToolFaultVersusUserDecision(t *testing.T) {
 	t.Run("issue-organic-dx-phase5-tool-fault-report", func(t *testing.T) {
 		harness := newOrganicHarness(t)
@@ -1420,8 +1419,15 @@ func TestOrganicReviewDefectReportToolFaultVersusUserDecision(t *testing.T) {
 		if err == nil {
 			t.Fatal("conflicting reviewer result capture unexpectedly succeeded")
 		}
-		if !strings.Contains(stderr, "review dispose-result") || !strings.Contains(stderr, "review preserve-result") {
-			t.Fatalf("user-decision terminal did not name the deciding operations: %q", stderr)
+		for _, want := range []string{"reviewer_result_slot_occupied", "gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --next-transition", "authoritative continuation"} {
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("occupied-slot terminal did not name %q: %q", want, stderr)
+			}
+		}
+		for _, forbidden := range []string{"review dispose-result", "review preserve-result", "retry capture-result"} {
+			if strings.Contains(stderr, forbidden) {
+				t.Fatalf("occupied-slot terminal advertised %q: %q", forbidden, stderr)
+			}
 		}
 		if entries := reviewDefectReportDirEntries(t, harness); len(entries) != 0 {
 			t.Fatalf("user-decision terminal wrote a defect report, want none: %v", entries)

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -31,6 +31,21 @@ const (
 // stable identity so discoverability guidance can wrap them with %w.
 var reviewerResultSlotConflictError = errors.New("captured reviewer result already exists with different canonical bytes")
 
+const (
+	// reviewerResultSlotOccupiedCode names the one cause that is neither a
+	// transport failure nor a bad binding: the slot holds a different reviewer
+	// result already. Distinct from repository_context_capture_failed because
+	// that code's whole instruction is to retry the same binding, which cannot
+	// succeed while the slot is occupied.
+	reviewerResultSlotOccupiedCode = "reviewer_result_slot_occupied"
+	// reviewerResultSlotOccupiedAction names the decision the operator has to
+	// make. Both exits already existed; they were just unreachable behind an
+	// action telling the caller to retry instead.
+	reviewerResultSlotOccupiedAction = "a different reviewer result already occupies this slot, so retrying the same binding cannot succeed; " +
+		"decide between `review dispose-result` (discard the occupying result) and " +
+		"`review preserve-result` (keep it and quarantine this new submission)"
+)
+
 // errCapturedFinalEvidenceMissing has the historical explicit-selector error
 // text, but a distinct identity so lineage-only discovery can distinguish an
 // absent capture from an unsafe or invalid persisted capture.
@@ -442,8 +457,16 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		},
 	})
 	if err != nil {
+		// An occupied slot is a conflict about content, not a failure to reach
+		// the repository, and the two are not interchangeable to a caller.
+		// This branch used to build the message below and then wrap it in
+		// repository_context_capture_failed, whose action is "retry
+		// capture-result with the same exact binding" — precisely what fails
+		// again while the slot stays occupied. The exits it already knew about
+		// ended up buried inside a cause, under an action contradicting them,
+		// and #2411's rc.6 reporter followed that action and looped.
 		if strings.Contains(err.Error(), "different canonical bytes") {
-			err = fmt.Errorf("%w; a different reviewer result already occupies this slot — decide with `review dispose-result` (discard it) or `review preserve-result` (keep it and quarantine this new submission)", reviewerResultSlotConflictError)
+			return reviewOpaqueContextFailure(reviewerResultSlotOccupiedCode, reviewerResultSlotOccupiedAction)
 		}
 		if contextHandle != "" {
 			return reviewOpaqueContextCause("repository_context_capture_failed", "retry capture-result with the same exact binding or refresh status", err)

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -27,24 +27,17 @@ const (
 	reviewResultArtifactLimit      = 4 << 20
 )
 
-// reviewerResultSlotConflictError gives immutable publication conflicts a
-// stable identity so discoverability guidance can wrap them with %w.
-var reviewerResultSlotConflictError = errors.New("captured reviewer result already exists with different canonical bytes")
-
 const (
 	// reviewerResultSlotOccupiedCode names the one cause that is neither a
 	// transport failure nor a bad binding: the slot holds a different reviewer
-	// result already. Distinct from repository_context_capture_failed because
-	// that code's whole instruction is to retry the same binding, which cannot
-	// succeed while the slot is occupied.
-	reviewerResultSlotOccupiedCode = "reviewer_result_slot_occupied"
-	// reviewerResultSlotOccupiedAction names the decision the operator has to
-	// make. Both exits already existed; they were just unreachable behind an
-	// action telling the caller to retry instead.
-	reviewerResultSlotOccupiedAction = "a different reviewer result already occupies this slot, so retrying the same binding cannot succeed; " +
-		"decide between `review dispose-result` (discard the occupying result) and " +
-		"`review preserve-result` (keep it and quarantine this new submission)"
+	// result already.
+	reviewerResultSlotOccupiedCode   = "reviewer_result_slot_occupied"
+	reviewerResultSlotOccupiedAction = "refresh the negotiated STATUS transition with " + reviewNextTransitionRefreshCommandV21 + " and follow its authoritative continuation"
 )
+
+func reviewReviewerResultSlotOccupiedFailure() error {
+	return reviewPreflightError(fmt.Errorf("%s: a different reviewer result already occupies this immutable slot; %s: %w", reviewerResultSlotOccupiedCode, reviewerResultSlotOccupiedAction, reviewtransaction.ErrCapturedReviewerResultSlotConflict))
+}
 
 // errCapturedFinalEvidenceMissing has the historical explicit-selector error
 // text, but a distinct identity so lineage-only discovery can distinguish an
@@ -457,16 +450,8 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		},
 	})
 	if err != nil {
-		// An occupied slot is a conflict about content, not a failure to reach
-		// the repository, and the two are not interchangeable to a caller.
-		// This branch used to build the message below and then wrap it in
-		// repository_context_capture_failed, whose action is "retry
-		// capture-result with the same exact binding" — precisely what fails
-		// again while the slot stays occupied. The exits it already knew about
-		// ended up buried inside a cause, under an action contradicting them,
-		// and #2411's rc.6 reporter followed that action and looped.
-		if strings.Contains(err.Error(), "different canonical bytes") {
-			return reviewOpaqueContextFailure(reviewerResultSlotOccupiedCode, reviewerResultSlotOccupiedAction)
+		if errors.Is(err, reviewtransaction.ErrCapturedReviewerResultSlotConflict) {
+			return reviewReviewerResultSlotOccupiedFailure()
 		}
 		if contextHandle != "" {
 			return reviewOpaqueContextCause("repository_context_capture_failed", "retry capture-result with the same exact binding or refresh status", err)

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -78,12 +78,10 @@ func TestReviewCaptureResultStrictBindingReplayAndFinalize(t *testing.T) {
 	}
 	if err := RunReviewCaptureResult(validArgs, io.Discard); err == nil {
 		t.Fatal("mismatched replay accepted")
-	} else {
-		for _, want := range []string{"review dispose-result", "review preserve-result"} {
-			if !strings.Contains(err.Error(), want) {
-				t.Fatalf("reviewer result byte-conflict = %q, want it to name %q", err.Error(), want)
-			}
-		}
+	} else if !errors.Is(err, reviewtransaction.ErrCapturedReviewerResultSlotConflict) ||
+		!strings.Contains(err.Error(), reviewerResultSlotOccupiedCode) ||
+		!strings.Contains(err.Error(), reviewNextTransitionRefreshCommandV21) {
+		t.Fatalf("reviewer result byte-conflict = %q, want occupied-slot STATUS continuation", err.Error())
 	}
 	manifest := strings.TrimSpace(first.String())
 	for _, finalize := range [][]string{

--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -128,7 +128,7 @@ func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 				}
 			},
 			code: reviewerResultSlotOccupiedCode,
-			want: "review dispose-result",
+			want: reviewNextTransitionRefreshCommandV21,
 		},
 		{
 			name: "results-directory-unusable",

--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -106,10 +106,17 @@ func TestOpaqueRepositoryContextResolutionNamesDistinctCauses(t *testing.T) {
 // point reported as #2411: everything past admission answered with one
 // repository_context_capture_failed sentence, which is why a preflight that
 // cannot reach any of these paths appeared to "pass" while capture "failed".
+//
+// The property is that the causes are DISTINGUISHABLE, not that they share a
+// code. An occupied slot now carries its own, because #2411's rc.6 occurrence
+// showed the shared code's action ("retry the same exact binding") is the one
+// thing that cannot work while the slot is occupied. So the code is asserted
+// per case; a cause that stops being distinguishable still fails here.
 func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 	cases := []struct {
 		name    string
 		arrange func(t *testing.T, repo, lineage string, binding []string)
+		code    string
 		want    string
 	}{
 		{
@@ -120,7 +127,8 @@ func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 					t.Fatalf("first capture failed: %v", err)
 				}
 			},
-			want: "different canonical bytes",
+			code: reviewerResultSlotOccupiedCode,
+			want: "review dispose-result",
 		},
 		{
 			name: "results-directory-unusable",
@@ -130,6 +138,7 @@ func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
+			code: "repository_context_capture_failed",
 			want: opaqueNativeCause("not a directory", "unsafe RAR authority path"),
 		},
 	}
@@ -146,7 +155,7 @@ func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 				t.Fatal("capture succeeded despite an unusable authority store")
 			}
 			message := err.Error()
-			assertOpaqueFailureNamesCause(t, message, "repository_context_capture_failed", tt.want, repo)
+			assertOpaqueFailureNamesCause(t, message, tt.code, tt.want, repo)
 			messages[tt.name] = message
 		})
 	}

--- a/internal/cli/review_slot_conflict_classification_test.go
+++ b/internal/cli/review_slot_conflict_classification_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestOccupiedSlotIsNotARepositoryContextFailure is #2411's rc.6 occurrence.
+//
+// A reviewer result already occupying the slot with different bytes is a
+// conflict about content, not a failure to reach the repository. The capture
+// path already knows that: it builds a message naming both runnable exits,
+// `review dispose-result` and `review preserve-result`. It then wraps that
+// message in `repository_context_capture_failed`, whose action is "retry
+// capture-result with the same exact binding or refresh status" — which is
+// exactly what fails again, because the slot is still occupied.
+//
+// So the good advice sits inside the cause while the action contradicts it,
+// and a consumer following the action loops. That is what @kar0loz reported on
+// `2.4.0-rc.6` after their reviewer result had already been persisted.
+func TestOccupiedSlotIsNotARepositoryContextFailure(t *testing.T) {
+	binding, _, _ := startedOpaqueCaptureBinding(t, "slot-conflict-classification")
+
+	first := admissibleOpaqueReviewerResult(t, binding, "first reviewer evidence")
+	if err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", first), io.Discard); err != nil {
+		t.Fatalf("first capture failed: %v", err)
+	}
+	second := admissibleOpaqueReviewerResult(t, binding, "second reviewer evidence")
+	err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", second), io.Discard)
+	if err == nil {
+		t.Fatal("a second reviewer result with different bytes was accepted into an occupied slot")
+	}
+	message := err.Error()
+
+	if strings.Contains(message, "repository_context_capture_failed") {
+		t.Fatalf("an occupied slot is still classified as a repository-context failure: %s", message)
+	}
+	if strings.Contains(message, "retry capture-result with the same exact binding") {
+		t.Fatalf("the action still tells the caller to retry the binding that will fail again: %s", message)
+	}
+	// The exits the code already knew about have to reach the surface rather
+	// than stay buried inside a wrapped cause.
+	for _, exit := range []string{"review dispose-result", "review preserve-result"} {
+		if !strings.Contains(message, exit) {
+			t.Fatalf("refusal does not name %q: %s", exit, message)
+		}
+	}
+}
+
+// TestGenuineRepositoryContextCaptureFailureKeepsItsCode is the guard on the
+// other side: a capture that really could not reach its repository context
+// keeps the code and the retry action, which for that cause is correct.
+func TestGenuineRepositoryContextCaptureFailureKeepsItsCode(t *testing.T) {
+	binding, _, repo := startedOpaqueCaptureBinding(t, "slot-conflict-control")
+	result := admissibleOpaqueReviewerResult(t, binding, "reviewer evidence")
+	blocked := filepath.Join(reviewCLICompactStoreDir(repo, "slot-conflict-control"), reviewtransaction.CompactReviewerResultsDir)
+	if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", result), io.Discard)
+	if err == nil {
+		t.Fatal("capture succeeded despite an unusable results directory")
+	}
+	if !strings.Contains(err.Error(), "repository_context_capture_failed") {
+		t.Fatalf("a real capture failure lost its code: %s", err.Error())
+	}
+}

--- a/internal/cli/review_slot_conflict_classification_test.go
+++ b/internal/cli/review_slot_conflict_classification_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,45 +12,113 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
-// TestOccupiedSlotIsNotARepositoryContextFailure is #2411's rc.6 occurrence.
-//
-// A reviewer result already occupying the slot with different bytes is a
-// conflict about content, not a failure to reach the repository. The capture
-// path already knows that: it builds a message naming both runnable exits,
-// `review dispose-result` and `review preserve-result`. It then wraps that
-// message in `repository_context_capture_failed`, whose action is "retry
-// capture-result with the same exact binding or refresh status" — which is
-// exactly what fails again, because the slot is still occupied.
-//
-// So the good advice sits inside the cause while the action contradicts it,
-// and a consumer following the action loops. That is what @kar0loz reported on
-// `2.4.0-rc.6` after their reviewer result had already been persisted.
-func TestOccupiedSlotIsNotARepositoryContextFailure(t *testing.T) {
-	binding, _, _ := startedOpaqueCaptureBinding(t, "slot-conflict-classification")
+func TestOccupiedSlotUsesStatusContinuationForOpaqueCapture(t *testing.T) {
+	const lineage = "slot-conflict-classification"
+	binding, _, repo := startedOpaqueCaptureBinding(t, lineage)
 
 	first := admissibleOpaqueReviewerResult(t, binding, "first reviewer evidence")
-	if err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", first), io.Discard); err != nil {
+	var captured, replayed bytes.Buffer
+	if err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", first), &captured); err != nil {
 		t.Fatalf("first capture failed: %v", err)
 	}
+	path := filepath.Join(reviewCLICompactStoreDir(repo, lineage), reviewtransaction.CompactReviewerResultsDir, "00-review-reliability.json")
+	beforeArtifact, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest, err := os.ReadFile(path + ".sha256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", first), &replayed); err != nil || captured.String() != replayed.String() {
+		t.Fatalf("exact replay = %q, %v; want %q, nil", replayed.String(), err, captured.String())
+	}
 	second := admissibleOpaqueReviewerResult(t, binding, "second reviewer evidence")
-	err := RunReviewCaptureResult(append(append([]string{}, binding...), "--input", second), io.Discard)
+	err = RunReviewCaptureResult(append(append([]string{}, binding...), "--input", second), io.Discard)
 	if err == nil {
 		t.Fatal("a second reviewer result with different bytes was accepted into an occupied slot")
 	}
-	message := err.Error()
+	if !errors.Is(err, reviewtransaction.ErrCapturedReviewerResultSlotConflict) {
+		t.Fatalf("occupied slot error = %v, want ErrCapturedReviewerResultSlotConflict", err)
+	}
+	assertOccupiedReviewerSlotStatusContinuation(t, err, repo, lineage)
+	assertReviewerSlotUnchanged(t, path, beforeArtifact, beforeDigest)
+}
 
-	if strings.Contains(message, "repository_context_capture_failed") {
-		t.Fatalf("an occupied slot is still classified as a repository-context failure: %s", message)
+func TestOccupiedSlotUsesStatusContinuationForDirectCapture(t *testing.T) {
+	repo, started, store, record := newArtifactReview(t, false)
+	input := filepath.Join(t.TempDir(), "reviewer-result.json")
+	args := []string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input}
+	if err := os.WriteFile(input, admittedReviewerPayloadForTest(t, repo, record, record.State.SelectedLenses[0], 0), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	if strings.Contains(message, "retry capture-result with the same exact binding") {
-		t.Fatalf("the action still tells the caller to retry the binding that will fail again: %s", message)
+	var captured, replayed bytes.Buffer
+	if err := RunReviewCaptureResult(args, &captured); err != nil {
+		t.Fatalf("first capture failed: %v", err)
 	}
-	// The exits the code already knew about have to reach the surface rather
-	// than stay buried inside a wrapped cause.
-	for _, exit := range []string{"review dispose-result", "review preserve-result"} {
-		if !strings.Contains(message, exit) {
-			t.Fatalf("refusal does not name %q: %s", exit, message)
+	path := filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir, "00-"+record.State.SelectedLenses[0]+".json")
+	beforeArtifact, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest, err := os.ReadFile(path + ".sha256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult(args, &replayed); err != nil || captured.String() != replayed.String() {
+		t.Fatalf("exact replay = %q, %v; want %q, nil", replayed.String(), err, captured.String())
+	}
+	if err := os.WriteFile(input, admittedReviewerPayloadForTest(t, repo, record, record.State.SelectedLenses[0], 0, "different reviewer evidence"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = RunReviewCaptureResult(args, io.Discard)
+	if err == nil {
+		t.Fatal("a second reviewer result with different bytes was accepted into an occupied slot")
+	}
+	if !errors.Is(err, reviewtransaction.ErrCapturedReviewerResultSlotConflict) {
+		t.Fatalf("occupied slot error = %v, want ErrCapturedReviewerResultSlotConflict", err)
+	}
+	assertOccupiedReviewerSlotStatusContinuation(t, err, repo, started.LineageID)
+	assertReviewerSlotUnchanged(t, path, beforeArtifact, beforeDigest)
+}
+
+func assertOccupiedReviewerSlotStatusContinuation(t *testing.T, err error, repo, lineage string) {
+	t.Helper()
+	message := err.Error()
+	if !strings.Contains(message, "reviewer_result_slot_occupied") {
+		t.Fatalf("occupied slot lost its generic code: %s", message)
+	}
+	for _, forbidden := range []string{"repository_context_capture_failed", "retry", "review capture-result", "review dispose-result", "review preserve-result"} {
+		if strings.Contains(message, forbidden) {
+			t.Fatalf("occupied slot advertises %q instead of STATUS continuation: %s", forbidden, message)
 		}
+	}
+	if !strings.Contains(message, reviewNextTransitionRefreshCommandV21) || !strings.Contains(message, "authoritative continuation") {
+		t.Fatalf("occupied slot does not advertise the STATUS continuation: %s", message)
+	}
+	var statusOutput bytes.Buffer
+	if statusErr := RunReviewStatus([]string{"--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2, "--next-transition"}, &statusOutput); statusErr != nil {
+		t.Fatalf("STATUS after occupied slot: %v", statusErr)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute || status.NextTransition.ReasonCode != "captured_results_ready" {
+		t.Fatalf("STATUS continuation = %#v", status.NextTransition)
+	}
+}
+
+func assertReviewerSlotUnchanged(t *testing.T, path string, beforeArtifact, beforeDigest []byte) {
+	t.Helper()
+	afterArtifact, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterDigest, err := os.ReadFile(path + ".sha256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeArtifact, afterArtifact) || !bytes.Equal(beforeDigest, afterDigest) {
+		t.Fatal("conflicting capture overwrote the occupied reviewer slot")
 	}
 }
 
@@ -69,5 +139,8 @@ func TestGenuineRepositoryContextCaptureFailureKeepsItsCode(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "repository_context_capture_failed") {
 		t.Fatalf("a real capture failure lost its code: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "retry capture-result with the same exact binding or refresh status") {
+		t.Fatalf("a real capture failure lost its retry action: %s", err.Error())
 	}
 }

--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -13,6 +13,10 @@ import (
 	"reflect"
 )
 
+// ErrCapturedReviewerResultSlotConflict reports an immutable reviewer result
+// slot occupied by different canonical bytes.
+var ErrCapturedReviewerResultSlotConflict = errors.New("captured reviewer result slot conflicts with different canonical bytes") // refusal:by-design world-action: transaction-layer capture cannot alter an immutable occupied slot
+
 // CompactAdmittedReviewerResultRequest contains one provider-observed reviewer
 // result and the exact native authority preimages that result must bind.
 type CompactAdmittedReviewerResultRequest struct {
@@ -362,9 +366,7 @@ func requireCompactReviewerSlotCompatible(
 		return err
 	}
 	if !bytes.Equal(existing, payload) {
-		return errors.New(
-			"captured reviewer result already exists with different canonical bytes",
-		)
+		return fmt.Errorf("%w: existing bytes differ from the requested payload", ErrCapturedReviewerResultSlotConflict)
 	}
 	return nil
 }

--- a/internal/reviewtransaction/compact_reviewer_capture_test.go
+++ b/internal/reviewtransaction/compact_reviewer_capture_test.go
@@ -420,7 +420,11 @@ func TestCompactStoreCaptureAdmittedReviewerResultNormalizesInspectionPathsBefor
 		t.Fatal(err)
 	}
 	conflicting.RawPayload = append(raw, '\n')
-	if _, err := fixture.store.CaptureAdmittedReviewerResult(t.Context(), conflicting); err == nil || !strings.Contains(err.Error(), "different canonical bytes") {
+	beforeDigest, err := os.ReadFile(fixture.path + ".sha256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.store.CaptureAdmittedReviewerResult(t.Context(), conflicting); !errors.Is(err, ErrCapturedReviewerResultSlotConflict) {
 		t.Fatalf("conflicting provider payload error = %v", err)
 	}
 	afterConflict, err := os.ReadFile(fixture.path)
@@ -429,6 +433,13 @@ func TestCompactStoreCaptureAdmittedReviewerResultNormalizesInspectionPathsBefor
 	}
 	if !bytes.Equal(afterConflict, persisted) {
 		t.Fatal("conflicting provider payload changed the persisted result")
+	}
+	afterDigest, err := os.ReadFile(fixture.path + ".sha256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(afterDigest, beforeDigest) {
+		t.Fatal("conflicting provider payload changed the persisted digest")
 	}
 }
 
@@ -905,10 +916,7 @@ func TestCompactStoreCaptureAdmittedReviewerResultSerializesConcurrentReplayAndC
 			switch {
 			case err == nil:
 				successes++
-			case strings.Contains(
-				err.Error(),
-				"different canonical bytes",
-			):
+			case errors.Is(err, ErrCapturedReviewerResultSlotConflict):
 				conflicts++
 			default:
 				t.Fatalf("concurrent conflict error = %v", err)


### PR DESCRIPTION
Closes #3103. Refs #2411: the DrvFS `EXDEV` publication root and Windows `binding_mismatch` variant remain out of scope.

## Summary

- Move the immutable reviewer-result slot-conflict sentinel to `internal/reviewtransaction` and classify it with `errors.Is`.
- Return `reviewer_result_slot_occupied` for both opaque and direct `--cwd` capture routes, without calling it a repository-context failure.
- Direct the caller to negotiated STATUS and its authoritative continuation. `dispose-result` cannot free an occupied slot and `preserve-result` remains forensic only, so neither is advertised as a resolution.
- Preserve exact replay, refuse different bytes without changing the first artifact or digest, and retain genuine `repository_context_capture_failed` retry behavior.

## Tests

- [x] RED: old opaque and direct routes returned false retry/dispose/preserve advice.
- [x] Focused transaction, CLI, and organic runtime controls pass.
- [x] `go test ./... -count=1`
- [x] `scripts/deadcode-ratchet.sh`
- [x] Refusal-resolution ratchet
- [x] Benchmark validation N/A: no bench corpus or driven runtime behavior changed.

## Review Notes

- Full PR delta: 203 additions + 26 deletions = 229 lines, below 400.
- No artifact/schema/authority mutation and no overwrite capability added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of conflicting reviewer-result submissions.
  - Conflicts now report a clear occupied-slot status and direct users to refresh status for the authoritative next step.
  - Existing reviewer results and their integrity data are preserved when conflicting content is submitted.
  - Exact replays continue to succeed without creating duplicate results.
  - Genuine repository-context capture failures retain their existing retry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->