### PR TITLE
fix(review): migrate legacy clone mode authority

### DIFF
--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -128,6 +128,52 @@ func TestReviewModeCloneScopeEnableIsIdempotentWhenGlobalOn(t *testing.T) {
 	}
 }
 
+func TestReviewModeCloneScopeEnableMigratesLegacyRevision(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	ctx := context.Background()
+	disabled, err := reviewtransaction.SetCloneLocalRDDMode(ctx, repo, reviewtransaction.RDDModeOff, "", reviewtransaction.RDDGlobalMode{Value: "on"})
+	if err != nil {
+		t.Fatalf("seed clone-local override: %v", err)
+	}
+	current, err := reviewtransaction.CloneLocalRDDModeRecordPath(ctx, repo)
+	if err != nil {
+		t.Fatalf("current record path: %v", err)
+	}
+	legacyDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
+	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
+		t.Fatalf("create legacy directory: %v", err)
+	}
+	legacy := filepath.Join(legacyDir, filepath.Base(current))
+	legacyBytes, err := os.ReadFile(current)
+	if err != nil {
+		t.Fatalf("read current record: %v", err)
+	}
+	if err := os.Rename(current, legacy); err != nil {
+		t.Fatalf("relocate legacy record: %v", err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("legacy status: %v", err)
+	}
+	status := decodeReviewModeResult(t, output.Bytes()).Status
+	if status.Revision != disabled.Revision || status.CloneLocal != reviewtransaction.RDDModeOff {
+		t.Fatalf("legacy CLI status = %#v", status)
+	}
+	output.Reset()
+	if err := RunReviewMode([]string{"enable", "--cwd", repo, "--scope", "clone", "--expected-revision", status.Revision, "--json"}, &output); err != nil {
+		t.Fatalf("legacy CLI enable: %v", err)
+	}
+	migrated := decodeReviewModeResult(t, output.Bytes()).Status
+	if !migrated.Enabled() || migrated.Revision == "" || migrated.Revision == status.Revision {
+		t.Fatalf("migrated CLI status = %#v", migrated)
+	}
+	if after, err := os.ReadFile(legacy); err != nil || !bytes.Equal(after, legacyBytes) {
+		t.Fatalf("legacy CLI bytes changed: err=%v", err)
+	}
+}
+
 func TestReviewModeCloneScopeEnableRejectsGlobalOffWithoutLocalOverride(t *testing.T) {
 	home := reviewModeHome(t)
 	repo := initReviewCLIRepo(t)

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -290,6 +290,7 @@ func SetCloneLocalRDDMode(
 	defer func() { _ = lock.release() }()
 
 	head, present, err := readCloneLocalRDDOverrideHead(dir)
+	repairingCurrentHead := false
 	if err != nil {
 		// An unreadable head is precisely what this command exists to replace,
 		// so it must not be able to block its own repair -- that left the
@@ -309,6 +310,29 @@ func SetCloneLocalRDDMode(
 			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), generationErr
 		}
 		head, present = rddModeOverrideRecord{Generation: generation}, false
+		repairingCurrentHead = true
+	}
+	if !present && !repairingCurrentHead {
+		// Legacy records are immutable forensic evidence. A valid one may advance
+		// only by publishing its successor in the switch-owned authority root;
+		// a damaged legacy record must never be shadowed by a fresh root.
+		legacy, legacyErr := cloneLocalRDDModeLegacyRoot(ctx, repo)
+		if legacyErr == nil {
+			// Writers before the relocation lock this path. Taking current then
+			// legacy serializes either version without a lock-order cycle.
+			legacyLock, lockErr := acquireRARAuthorityLock(ctx, filepath.Join(legacy, rddModeLockName))
+			if lockErr != nil {
+				return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), lockErr
+			}
+			defer func() { _ = legacyLock.release() }()
+			legacyHead, legacyPresent, legacyHeadErr := readCloneLocalRDDOverrideHead(legacy)
+			if legacyHeadErr != nil {
+				return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), legacyHeadErr
+			}
+			if legacyPresent {
+				head, present = legacyHead, true
+			}
+		}
 	}
 	current := ""
 	if present {

--- a/internal/reviewtransaction/rdd_mode_legacy_root_test.go
+++ b/internal/reviewtransaction/rdd_mode_legacy_root_test.go
@@ -1,10 +1,14 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 // TestLegacyCloneOverrideStillDecides is the migration guard for #2882.
@@ -68,4 +72,249 @@ func TestLegacyCloneOverrideStillDecides(t *testing.T) {
 	if status.Effective != RDDModeOff || status.Source != RDDModeSourceCloneLocal {
 		t.Fatalf("a pre-#2882 clone override stopped deciding: %#v; the move silently re-enabled reviews", status)
 	}
+}
+
+func TestLegacyCloneOverrideMigratesExactRevision(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		legacy    RDDMode
+		requested RDDMode
+		wantMode  string
+		enabled   bool
+	}{
+		{name: "clear legacy off", legacy: RDDModeOff, requested: RDDModeUnset, wantMode: rddModeOverrideInherit, enabled: true},
+		{name: "disable legacy inherit", legacy: RDDModeUnset, requested: RDDModeOff, wantMode: string(RDDModeOff)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := initSnapshotRepo(t)
+			legacy, legacyPath, legacyBytes, current := legacyCloneOverrideForTest(t, ctx, repo, test.legacy)
+			global := RDDGlobalMode{Value: "on"}
+
+			status, err := ResolveRDDMode(ctx, repo, global)
+			if err != nil || status.Revision != legacy.Revision {
+				t.Fatalf("legacy status = %#v, %v", status, err)
+			}
+			if _, err := SetCloneLocalRDDMode(ctx, repo, test.requested, "stale", global); !errors.Is(err, ErrRDDModeRevisionMismatch) {
+				t.Fatalf("stale legacy revision error = %v, want ErrRDDModeRevisionMismatch", err)
+			}
+			if head, err := cloneLocalRDDOverrideHeadGeneration(current); err != nil || head != 0 {
+				t.Fatalf("stale revision published current generation %d, %v", head, err)
+			}
+
+			migrated, err := SetCloneLocalRDDMode(ctx, repo, test.requested, status.Revision, global)
+			if err != nil {
+				t.Fatalf("migrate legacy record: %v", err)
+			}
+			currentRecord, present, err := readCloneLocalRDDOverrideHead(current)
+			if err != nil || !present || currentRecord.Generation != legacy.Generation+1 ||
+				currentRecord.PreviousRevision != legacy.Revision || currentRecord.Mode != test.wantMode ||
+				currentRecord.Revision != migrated.Revision {
+				t.Fatalf("migrated current record = %#v, present=%v, err=%v", currentRecord, present, err)
+			}
+			if after, err := os.ReadFile(legacyPath); err != nil || !bytes.Equal(after, legacyBytes) {
+				t.Fatalf("legacy forensic bytes changed: err=%v before=%q after=%q", err, legacyBytes, after)
+			}
+			if path, err := CloneLocalRDDModeRecordPath(ctx, repo); err != nil || path != filepath.Join(current, rddModeGenerationName(currentRecord.Generation)) {
+				t.Fatalf("authoritative record path = %q, %v", path, err)
+			}
+			resolved, err := ResolveRDDMode(ctx, repo, global)
+			if err != nil || resolved.Revision != migrated.Revision || resolved.Enabled() != test.enabled {
+				t.Fatalf("post-migration status = %#v, %v", resolved, err)
+			}
+		})
+	}
+}
+
+func TestLegacyCloneOverridePreservesNoopAndGlobalOffTruthfulness(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	legacy, legacyPath, legacyBytes, current := legacyCloneOverrideForTest(t, ctx, repo, RDDModeOff)
+
+	status, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, legacy.Revision, RDDGlobalMode{Value: "on"})
+	if err != nil || status.Revision != legacy.Revision {
+		t.Fatalf("legacy no-op = %#v, %v", status, err)
+	}
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, "stale", RDDGlobalMode{Value: "off"}); !errors.Is(err, ErrRDDModeRevisionMismatch) {
+		t.Fatalf("stale revision before global-off error = %v, want ErrRDDModeRevisionMismatch", err)
+	}
+	status, err = SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, legacy.Revision, RDDGlobalMode{Value: "off"})
+	var disabled *RDDDisabledError
+	if !errors.As(err, &disabled) || disabled.Source != RDDModeSourceGlobal || status.Revision != legacy.Revision {
+		t.Fatalf("current revision under global-off = %#v, %v", status, err)
+	}
+	if head, err := cloneLocalRDDOverrideHeadGeneration(current); err != nil || head != 0 {
+		t.Fatalf("no-op/global-off published current generation %d, %v", head, err)
+	}
+	if after, err := os.ReadFile(legacyPath); err != nil || !bytes.Equal(after, legacyBytes) {
+		t.Fatalf("no-op/global-off changed legacy bytes: err=%v before=%q after=%q", err, legacyBytes, after)
+	}
+}
+
+func TestCorruptLegacyCloneOverrideFailsClosedWithoutMigration(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	_, legacyPath, _, current := legacyCloneOverrideForTest(t, ctx, repo, RDDModeOff)
+	corrupt := []byte("{not json}\n")
+	if err := os.WriteFile(legacyPath, corrupt, 0o600); err != nil {
+		t.Fatalf("corrupt legacy record: %v", err)
+	}
+
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, "", RDDGlobalMode{Value: "on"}); !errors.Is(err, ErrRDDModeCorrupt) {
+		t.Fatalf("corrupt legacy mutation error = %v, want ErrRDDModeCorrupt", err)
+	}
+	if head, err := cloneLocalRDDOverrideHeadGeneration(current); err != nil || head != 0 {
+		t.Fatalf("corrupt legacy migration published current generation %d, %v", head, err)
+	}
+	if after, err := os.ReadFile(legacyPath); err != nil || !bytes.Equal(after, corrupt) {
+		t.Fatalf("corrupt legacy bytes changed: err=%v before=%q after=%q", err, corrupt, after)
+	}
+}
+
+func TestCurrentOverrideWinsOverLegacyRecords(t *testing.T) {
+	ctx := context.Background()
+	for _, mode := range []string{string(RDDModeOff), rddModeOverrideInherit} {
+		t.Run(mode, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			legacy, legacyPath, legacyBytes, current := legacyCloneOverrideForTest(t, ctx, repo, RDDModeOff)
+			currentRecord := publishCurrentModeRecordForTest(t, current, legacy, mode)
+			currentPath := filepath.Join(current, rddModeGenerationName(currentRecord.Generation))
+			currentBytes, err := os.ReadFile(currentPath)
+			if err != nil {
+				t.Fatalf("read current record: %v", err)
+			}
+
+			status, err := ResolveRDDMode(ctx, repo, RDDGlobalMode{Value: "on"})
+			if err != nil || status.Revision != currentRecord.Revision {
+				t.Fatalf("current root was not authoritative: %#v, %v", status, err)
+			}
+			if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, legacy.Revision, RDDGlobalMode{Value: "on"}); !errors.Is(err, ErrRDDModeRevisionMismatch) {
+				t.Fatalf("legacy revision replaced current authority: %v", err)
+			}
+			if after, err := os.ReadFile(currentPath); err != nil || !bytes.Equal(after, currentBytes) {
+				t.Fatalf("stale legacy request changed current bytes: err=%v", err)
+			}
+			if after, err := os.ReadFile(legacyPath); err != nil || !bytes.Equal(after, legacyBytes) {
+				t.Fatalf("stale legacy request changed legacy bytes: err=%v", err)
+			}
+		})
+	}
+}
+
+func TestLegacyCloneOverrideConcurrentMigrationKeepsOneWinner(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	legacy, legacyPath, legacyBytes, current := legacyCloneOverrideForTest(t, ctx, repo, RDDModeOff)
+	var group sync.WaitGroup
+	var mutex sync.Mutex
+	winners := 0
+	for range 4 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, legacy.Revision, RDDGlobalMode{Value: "on"})
+			mutex.Lock()
+			defer mutex.Unlock()
+			if err == nil {
+				winners++
+				return
+			}
+			if !errors.Is(err, ErrRDDModeRevisionMismatch) {
+				t.Errorf("losing migration error = %v", err)
+			}
+		}()
+	}
+	group.Wait()
+	if winners != 1 {
+		t.Fatalf("concurrent legacy migrations = %d winners, want 1", winners)
+	}
+	currentRecord, present, err := readCloneLocalRDDOverrideHead(current)
+	if err != nil || !present || currentRecord.Generation != legacy.Generation+1 || currentRecord.PreviousRevision != legacy.Revision {
+		t.Fatalf("concurrent migration record = %#v, present=%v, err=%v", currentRecord, present, err)
+	}
+	if after, err := os.ReadFile(legacyPath); err != nil || !bytes.Equal(after, legacyBytes) {
+		t.Fatalf("concurrent migration changed legacy bytes: err=%v", err)
+	}
+}
+
+func legacyCloneOverrideForTest(t *testing.T, ctx context.Context, repo string, mode RDDMode) (rddModeOverrideRecord, string, []byte, string) {
+	t.Helper()
+	status, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", RDDGlobalMode{Value: "on"})
+	if err != nil {
+		t.Fatalf("seed current override: %v", err)
+	}
+	if mode == RDDModeUnset {
+		status, err = SetCloneLocalRDDMode(ctx, repo, mode, status.Revision, RDDGlobalMode{Value: "on"})
+		if err != nil {
+			t.Fatalf("seed current inherit override: %v", err)
+		}
+	}
+	current, err := cloneLocalRDDModeRoot(ctx, repo, false)
+	if err != nil {
+		t.Fatalf("current root: %v", err)
+	}
+	legacy, err := cloneLocalRDDModeLegacyRoot(ctx, repo)
+	if err != nil {
+		identity, identityErr := cloneLocalRDDModeIdentity(ctx, repo)
+		if identityErr != nil {
+			t.Fatal(identityErr)
+		}
+		base := filepath.Join(identity.GitCommonDir, "gentle-ai", "review-transactions", rarAuthorityDirectory, rarAuthorityVersion)
+		if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, true); err != nil {
+			t.Fatal(err)
+		}
+		legacy = filepath.Join(base, rddModeDirectory)
+		if err := ensurePrivateRARDirectoryTree(base, legacy, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(current)
+	if err != nil {
+		t.Fatalf("read current root: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == rddModeLockName {
+			continue
+		}
+		if _, ok := rddModeGenerationOf(entry.Name()); !ok {
+			continue
+		}
+		if err := os.Rename(filepath.Join(current, entry.Name()), filepath.Join(legacy, entry.Name())); err != nil {
+			t.Fatalf("relocate current record: %v", err)
+		}
+	}
+	record, present, err := readCloneLocalRDDOverrideHead(legacy)
+	if err != nil || !present || record.Revision != status.Revision {
+		t.Fatalf("legacy record = %#v, present=%v, err=%v", record, present, err)
+	}
+	legacyPath := filepath.Join(legacy, rddModeGenerationName(record.Generation))
+	payload, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("read legacy record: %v", err)
+	}
+	return record, legacyPath, payload, current
+}
+
+func publishCurrentModeRecordForTest(t *testing.T, current string, predecessor rddModeOverrideRecord, mode string) rddModeOverrideRecord {
+	t.Helper()
+	record := rddModeOverrideRecord{
+		Schema:           rddModeOverrideSchema,
+		Generation:       predecessor.Generation + 1,
+		PreviousRevision: predecessor.Revision,
+		Mode:             mode,
+		RecordedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	var err error
+	record.Revision, err = rddModeOverrideDigest(record)
+	if err != nil {
+		t.Fatalf("current record digest: %v", err)
+	}
+	payload, err := canonicalRDDModeOverridePayload(record)
+	if err != nil {
+		t.Fatalf("current record payload: %v", err)
+	}
+	if err := publishPrivateRARImmutable(filepath.Join(current, rddModeGenerationName(record.Generation)), payload); err != nil {
+		t.Fatalf("publish current record: %v", err)
+	}
+	return record
 }


### PR DESCRIPTION
## Linked Issue

Closes #3061

## PR Type

- [x] `type:bug` Bug fix

## Summary

- Migrates a valid legacy clone-local RDD mode record into the switch-owned authority root during its authorized CAS mutation.
- Preserves legacy bytes as read-only forensic evidence and makes the new root authoritative immediately.
- Preserves #2831 stale-before-global-off and no-op truthfulness.

## Changes

| File / Area | What Changed |
|---|---|
| `internal/reviewtransaction/rdd_mode.go` | Reads a valid legacy head under both authority locks and publishes its next generation only in the new root. |
| `internal/reviewtransaction/rdd_mode_legacy_root_test.go` | Covers migration, stale CAS, corrupt legacy failure, current-root precedence, no-op/global-off, concurrency, bytes, and generations. |
| `internal/cli/review_mode_test.go` | Proves status revision reaches clone enable through the public CLI boundary. |

## RED / GREEN Evidence

RED before production edit:
- Transaction migration using the revision returned by legacy status failed with `ErrRDDModeRevisionMismatch` because the new root head was empty.
- `RunReviewMode enable --scope clone --expected-revision <status revision>` failed identically.

GREEN:
- Valid legacy off and inherit records migrate to `generation + 1`, chaining `previous_revision` to the legacy revision.
- The legacy record bytes remain byte-identical; status and record-path selection move to the new root after success.
- Stale revisions fail before global-off; no-op and global-off publish nothing; corrupt readable legacy records fail closed; new root wins; four concurrent migrations elect one winner.

## Migration and Rollback

The writer takes the new-root lock, then the legacy lock only when the new root has no readable head. It rereads the legacy record, validates the expected revision, and immutably publishes the successor in the new root. It never writes, deletes, or reinterprets legacy bytes. Existing #2882 behavior remains: an unreachable unsafe legacy authority does not block the switch-owned recovery path.

Rollback: revert `07396e9c`; forensic legacy bytes were never changed.

## Test Plan

- [x] Focused transaction and CLI migration matrix, uncached
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] Refusal resolution ratchets
- [x] Benchmark journey: N/A. Core bench cannot truthfully construct the historical product-owned authority residue without writing internal storage; the public CLI boundary is covered directly.

## Contributor Checklist

- [x] Linked approved issue
- [x] Within 400 changed lines: 319 additions, 0 deletions
- [x] Exactly one type label
- [x] Conventional commit with no Co-Authored-By trailer
- [x] RDD clone-local remains disabled/unmanaged; no native review started

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clone-local review mode handling when settings exist in legacy storage.
  * Automatically migrates valid legacy settings while preserving revision accuracy and original data.
  * Prevents incorrect migrations for corrupt records and preserves global-off and no-op behavior.
  * Ensures current settings take precedence and concurrent migrations produce a single consistent result.

* **Tests**
  * Added coverage for legacy migration, corruption handling, precedence, revision tracking, and concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->