### PR TITLE
test(review): preserve secure legacy CLI fixture

### DIFF
--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -140,18 +140,18 @@ func TestReviewModeCloneScopeEnableMigratesLegacyRevision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("current record path: %v", err)
 	}
-	legacyDir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "rar-authority", "v1", "rdd-mode")
-	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
-		t.Fatalf("create legacy directory: %v", err)
-	}
-	legacy := filepath.Join(legacyDir, filepath.Base(current))
 	legacyBytes, err := os.ReadFile(current)
 	if err != nil {
 		t.Fatalf("read current record: %v", err)
 	}
-	if err := os.Rename(current, legacy); err != nil {
-		t.Fatalf("relocate legacy record: %v", err)
+	legacyRoot := filepath.Join(repo, ".git", "gentle-ai", "review-transactions")
+	if err := os.Rename(filepath.Join(repo, ".git", "gentle-ai", "review-mode"), legacyRoot); err != nil {
+		t.Fatalf("relocate secure legacy fixture: %v", err)
 	}
+	if _, err := os.Lstat(filepath.Join(repo, ".git", "gentle-ai", "review-mode")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy fixture left a separately created private directory: %v", err)
+	}
+	legacy := filepath.Join(legacyRoot, "rar-authority", "v1", "rdd-mode", filepath.Base(current))
 
 	var output bytes.Buffer
 	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &output); err != nil {


### PR DESCRIPTION
## Linked Issue

Closes #3036

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Relocate the production-created `review-mode` fixture tree to the legacy authority path with same-filesystem `os.Rename`.
- Preserve the secure Windows owner-only DACL for every private fixture directory and its record.
- Keep a portable assertion that the fixture did not leave a separately created private legacy directory.

RED: Windows Full Suite run 31599941691, cli-r-a-m, failed only `TestReviewModeCloneScopeEnableMigratesLegacyRevision`: legacy resolution returned the intentional default/on fallback because an `os.MkdirAll` fixture directory lacked the protected owner-only DACL.

GREEN: focused CLI regression, full repository suite, vet, gofmt, deadcode, and refusal ratchet pass on this candidate. The existing Windows DACL contract is `TestRARPrivateOwnerRemainsTokenUserOnly`; Linux cannot prove a Windows security descriptor.

---

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/cli/review_mode_test.go` | Move the secure fixture tree into the legacy location instead of recreating the private legacy directory. |

---

## Test Plan

- [x] Focused: `go test ./internal/cli -count=1 -run "^TestReviewModeCloneScopeEnableMigratesLegacyRevision$"`
- [x] Full repository: `go test ./... -count=1`
- [x] Vet: `go vet ./...`
- [x] Go format: `go run ./internal/gofmtcheck`
- [x] Integrity: `git diff --check`
- [x] Deadcode: `scripts/deadcode-ratchet.sh`
- [x] Refusal: `go test ./internal/cli -count=1 -run "^TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign$"`
- [x] Manually exercised the affected fixture through its regression test.
- [ ] Windows GREEN remains external CI evidence: this Linux host cannot validate protected Windows owner-only DACLs.
- [x] E2E Docker is not applicable to this fixture-only correction; `go test ./...` includes the repository organic-runtime suite.
- [x] Benchmark validation is N/A: no benchmark corpus, CLI product flow, or lifecycle behavior changed.

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | 14 changed lines, below 400. |
| Check Issue Reference | Pending | `Closes #3036`. |
| Check Issue Has `status:approved` | Pending | #3036 is open and approved. |
| Check PR Has `type:*` Label | Pending | Exactly one `type:bug`. |
| Windows proof | External | The next Windows Full Suite `cli-r` shard on the merged main candidate proves the preserved DACL path. |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines.
- [x] I have added the appropriate `type:bug` label to this PR.
- [x] Unit tests pass.
- [x] Go format passes.
- [x] Benchmark validation is not applicable; no benchmark scope changed.
- [x] Documentation is unnecessary for a fixture-only correction.
- [x] My commit follows Conventional Commits.
- [x] My commit does not include `Co-Authored-By` trailers.

---

## Notes for Reviewers

Rollback: revert only `internal/cli/review_mode_test.go` in commit `01f3a5838c17cbe6504a8b49a44e9d6cb99ad666`; no production writer, path safety validation, migration logic, or product behavior changes.

Current-main CI 31602594362 is green at base `d3c2da05aa2da12d3e638d830ccaee8c2c525e5b`, but it is not evidence for this Windows-only descriptor defect. Windows Full Suite 31602594331 is running on that same base and is not rerun or awaited here.

This is a test-only Go change; the production guard-population checklist is not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated migration coverage to verify secure review-mode data is relocated correctly from the legacy path.
  * Added validation that the original directory is removed after relocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->