### PR TITLE
fix(review): preserve symbolic pre-push selectors

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -33,7 +33,7 @@ go vet ./...
 go test ./...
 ```
 
-The portable core contains 57 journeys. `j57` is deliberately excluded because
+The portable core contains 101 journeys. `j57` is deliberately excluded because
 it requires the product's `bench_fixture` seam; it is an explicit
 `source-coupled` axis, not a portable black-box measurement.
 

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -668,6 +668,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, managedAssetJourneys()...)
 	journeys = append(journeys, issue2906Journeys()...)
 	journeys = append(journeys, issue2138Journeys()...)
+	journeys = append(journeys, issue3092Journeys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -53,6 +53,7 @@ func journeySources() []journeySource {
 		{"journeys_managed_assets.go", managedAssetJourneys()},
 		{"journeys_issue2906.go", issue2906Journeys()},
 		{"journeys_issue_2138.go", issue2138Journeys()},
+		{"journeys_issue_3092.go", issue3092Journeys()},
 	}
 }
 

--- a/bench/journeys_issue_3092.go
+++ b/bench/journeys_issue_3092.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const issue3092Lineage = "issue-3092-fork-pre-push"
+
+var issue3092StartCapability = &Capability{
+	Verb:  []string{"review", "start"},
+	Flags: []string{"--cwd", "--lineage", "--base-ref", "--committed-only"},
+}
+
+func issue3092Journeys() []Journey {
+	return []Journey{{
+		ID:     "j103-pre-push-symbolic-fork-selector",
+		Title:  "Fork pre-push validation preserves an upstream review base separate from the origin tracking branch",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/3092",
+		Steps: []Step{
+			{Name: "fixture: fork remotes, tracking branch, and committed candidate", Fixture: issue3092ForkFixture},
+			{Name: "start committed-only review against upstream/main", Requires: issue3092StartCapability,
+				Args: productArgs("review", "start", "--lineage", issue3092Lineage, "--base-ref", "upstream/main", "--committed-only")},
+			{Name: "finalize the approved candidate", Requires: finalizeCapability,
+				Args: productArgs("review", "finalize", "--lineage", issue3092Lineage)},
+			{Name: "fixture: upstream advances after approval", Fixture: issue3092AdvanceUpstream},
+			{Name: "STATUS emits symbolic pre-push validation and preserves authority", Requires: statusCapability,
+				Composite: issue3092ValidateSymbolicSelector},
+			{Name: "invalid selectors remain denied without mutation", Requires: validateBaseRefCapability,
+				Composite: issue3092RejectInvalidSelectors},
+		},
+	}}
+}
+
+func issue3092ForkFixture(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	base, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	origin := filepath.Join(sandbox.Home, "origin.git")
+	upstream := filepath.Join(sandbox.Home, "upstream.git")
+	for _, remote := range []string{origin, upstream} {
+		if err := sandbox.git(sandbox.Home, "init", "--bare", "-q", remote); err != nil {
+			return err
+		}
+	}
+	for name, remote := range map[string]string{"origin": origin, "upstream": upstream} {
+		if err := sandbox.git(sandbox.Repo, "remote", "add", name, remote); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.git(sandbox.Repo, "push", "-q", "upstream", "HEAD:refs/heads/main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "--git-dir", upstream, "symbolic-ref", "HEAD", "refs/heads/main"); err != nil {
+		return err
+	}
+	parent := filepath.Join(sandbox.Root, "upstream-work")
+	if err := sandbox.git(sandbox.Root, "clone", "-q", upstream, parent); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "checkout", "-q", "-b", "feature", "upstream/main"); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "docs", "feature.md"), "# Feature\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "docs/feature.md"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "add feature"); err != nil {
+		return err
+	}
+	featureCommit, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["issue3092-feature-commit"] = featureCommit
+	for _, branch := range []string{"main", "feature"} {
+		if err := sandbox.git(sandbox.Repo, "push", "-q", "origin", base+":refs/heads/"+branch); err != nil {
+			return err
+		}
+	}
+	for _, setting := range [][2]string{{"branch.feature.remote", "origin"}, {"branch.feature.merge", "refs/heads/feature"}, {"branch.feature.pushRemote", "origin"}} {
+		if err := sandbox.git(sandbox.Repo, "config", setting[0], setting[1]); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.git(sandbox.Repo, "branch", "local-only", "HEAD"); err != nil {
+		return err
+	}
+	sandbox.Scratch["issue3092-upstream-work"] = parent
+	return nil
+}
+
+func issue3092AdvanceUpstream(sandbox *Sandbox) error {
+	parent := sandbox.Scratch["issue3092-upstream-work"]
+	for _, setting := range [][2]string{{"user.email", "bench@example.invalid"}, {"user.name", "Bench"}} {
+		if err := sandbox.git(parent, "config", setting[0], setting[1]); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.write(filepath.Join(parent, "docs", "upstream.md"), "# Upstream\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(parent, "add", "docs/upstream.md"); err != nil {
+		return err
+	}
+	if err := sandbox.git(parent, "commit", "-qm", "advance upstream base"); err != nil {
+		return err
+	}
+	if err := sandbox.git(parent, "push", "-q", "origin", "HEAD:refs/heads/main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "fetch", "-q", "upstream", "main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "reset", "-q", "--hard", "upstream/main"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "merge", "--no-ff", "--no-edit", sandbox.Scratch["issue3092-feature-commit"]); err != nil {
+		return err
+	}
+	raw, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "upstream/main")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["issue3092-raw-base"] = raw
+	return nil
+}
+
+func issue3092Status(r *journeyRun, selectors ...string) (statusEnvelope, string, error) {
+	args := append([]string{"review", "status", "--contract", reviewContract, "--next-transition"}, selectors...)
+	observation := r.run(productArgsFor(r, args...), false)
+	if observation.ExitCode != 0 {
+		return statusEnvelope{}, "", fmt.Errorf("STATUS exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	payload := strings.TrimSpace(observation.Stdout)
+	var status statusEnvelope
+	if err := json.Unmarshal([]byte(payload), &status); err != nil {
+		return status, "", fmt.Errorf("parse STATUS transition: %w", err)
+	}
+	return status, payload, nil
+}
+
+func issue3092Candidate(sandbox *Sandbox) (string, error) {
+	values := make([]string, 0, 3)
+	for _, args := range [][]string{{"rev-parse", "HEAD"}, {"status", "--porcelain"}, {"hash-object", filepath.Join(sandbox.Repo, "docs", "feature.md")}} {
+		value, err := gitOut(sandbox, sandbox.Repo, args...)
+		if err != nil {
+			return "", err
+		}
+		values = append(values, value)
+	}
+	return strings.Join(values, "\x00"), nil
+}
+
+func issue3092AssertUnchanged(r *journeyRun, authority, candidate string) error {
+	_, afterAuthority, err := issue3092Status(r, "--lineage", issue3092Lineage, "--gate", "pre-push", "--base-ref", "upstream/main", "--committed-only")
+	if err != nil {
+		return err
+	}
+	afterCandidate, err := issue3092Candidate(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if afterAuthority != authority || afterCandidate != candidate {
+		return fmt.Errorf("pre-push validation mutated authority or candidate: authority=%+v/%+v candidate=%+v/%+v", authority, afterAuthority, candidate, afterCandidate)
+	}
+	return nil
+}
+
+func issue3092ValidateSymbolicSelector(r *journeyRun) error {
+	selectors := []string{"--lineage", issue3092Lineage, "--gate", "pre-push", "--base-ref", "upstream/main", "--committed-only"}
+	status, authority, err := issue3092Status(r, selectors...)
+	if err != nil {
+		return err
+	}
+	if status.Authority.LineageID != issue3092Lineage || status.Authority.State != "approved" ||
+		status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.validate" ||
+		status.executeArgument("gate") != "pre-push" || status.executeArgument("base-ref") != "upstream/main" {
+		return fmt.Errorf("symbolic pre-push STATUS = authority=%+v transition=%+v", authority, status.NextTransition)
+	}
+	candidate, err := issue3092Candidate(r.sandbox)
+	if err != nil {
+		return err
+	}
+	observation, err := runPrintedTransition(r, status)
+	if err != nil {
+		return err
+	}
+	if err := requireGateForLineage(observation, issue3092Lineage, true); err != nil {
+		return err
+	}
+	return issue3092AssertUnchanged(r, authority, candidate)
+}
+
+func issue3092RejectInvalidSelectors(r *journeyRun) error {
+	_, authority, err := issue3092Status(r, "--lineage", issue3092Lineage, "--gate", "pre-push", "--base-ref", "upstream/main", "--committed-only")
+	if err != nil {
+		return err
+	}
+	candidate, err := issue3092Candidate(r.sandbox)
+	if err != nil {
+		return err
+	}
+	for _, selector := range []string{r.sandbox.Scratch["issue3092-raw-base"], "main", "upstream/missing", "local-only"} {
+		observation := r.run(productArgsFor(r, "review", "validate", "--lineage", issue3092Lineage, "--gate", "pre-push", "--base-ref", selector), false)
+		var gate waveGateResult
+		if observation.ExitCode == 0 || json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &gate) != nil || gate.Allowed || gate.Result == "allow" {
+			return fmt.Errorf("invalid selector %q was not denied: exit=%d stdout=%s stderr=%s", selector, observation.ExitCode, observation.Stdout, observation.Stderr)
+		}
+		if err := issue3092AssertUnchanged(r, authority, candidate); err != nil {
+			return fmt.Errorf("selector %q: %w", selector, err)
+		}
+	}
+	return nil
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -72,6 +72,8 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// SDD status surfaces and preserves the same routing state.
 	//
 	// j96 proves #2891 blocks an off-path sibling in a nested same-repository workspace.
+	// j103 proves #3092 preserves a symbolic upstream review base through pre-push
+	// while origin remains the independent tracking and push destination.
 	// Bump this deliberately when a journey is added OR removed, and name it
 	// here: the count exists so a journey cannot appear or vanish unnoticed.
 	//
@@ -88,8 +90,10 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// stop that must replace an otherwise unexecutable START transition. 99 ->
 	// 100: #2773 adds j102, which drives the immutable reviewer-context capacity
 	// terminal instead of accepting an impossible reviewer slot.
-	if got := len(seen); got != 100 {
-		t.Errorf("core journey count = %d, want 100", got)
+	// 100 -> 101: #3092 adds j103, which preserves a symbolic upstream review
+	// base through pre-push while origin remains the independent tracking remote.
+	if got := len(seen); got != 101 {
+		t.Errorf("core journey count = %d, want 101", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/review_pre_push_symbolic_selector_test.go
+++ b/internal/cli/review_pre_push_symbolic_selector_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+func TestPrePushValidationPreservesForkBaseSelectorAndRejectsInvalidSelectors(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	upstream := filepath.Join(t.TempDir(), "upstream.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, origin)
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, upstream)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", origin)
+	runReviewCLIGit(t, repo, "remote", "add", "upstream", upstream)
+
+	parent := filepath.Join(t.TempDir(), "upstream-work")
+	runReviewCLIGit(t, repo, "clone", "--no-local", upstream, parent)
+	runReviewCLIGit(t, parent, "config", "user.email", "test@example.com")
+	runReviewCLIGit(t, parent, "config", "user.name", "Test")
+	writeReviewStartCandidate(t, parent, "docs/base.md", "# Upstream base\n", 0o644)
+	runReviewCLIGit(t, parent, "commit", "-qm", "advance upstream base")
+	runReviewCLIGit(t, parent, "push", "-q", "origin", "HEAD:refs/heads/main")
+	runReviewCLIGit(t, repo, "fetch", "-q", "upstream", "main")
+
+	upstreamBase := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "upstream/main"))
+	runReviewCLIGit(t, repo, "checkout", "-q", "-B", "feature", upstreamBase)
+	writeReviewStartCandidate(t, repo, "docs/feature.md", "# Feature\n", 0o644)
+	runReviewCLIGit(t, repo, "commit", "-qm", "add feature")
+	runReviewCLIGit(t, repo, "--git-dir", origin, "update-ref", "refs/heads/feature", base)
+	runReviewCLIGit(t, repo, "config", "branch.feature.remote", "origin")
+	runReviewCLIGit(t, repo, "config", "branch.feature.merge", "refs/heads/feature")
+	runReviewCLIGit(t, repo, "config", "branch.feature.pushRemote", "origin")
+	runReviewCLIGit(t, repo, "--git-dir", origin, "update-ref", "refs/heads/main", base)
+
+	const lineage = "fork-symbolic-pre-push"
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{
+		"--cwd", repo, "--lineage", lineage, "--base-ref", "upstream/main", "--committed-only",
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateBefore, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptBefore, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateBefore, err := os.ReadFile(filepath.Join(repo, "docs", "feature.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status := selectorTransitionStatus(t, repo, "--lineage", lineage, "--gate", "pre-push", "--base-ref", "upstream/main")
+	if status.NextTransition == nil || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.validate" ||
+		selectorTransitionArguments(t, status)["base-ref"] != "upstream/main" {
+		t.Fatalf("symbolic pre-push STATUS = %#v", status.NextTransition)
+	}
+	assertReviewGateResult(t, executeSelectorTransition(t, repo, status), reviewtransaction.GateAllow)
+
+	rawBase := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "upstream/main"))
+	for _, test := range []struct {
+		name     string
+		selector string
+		want     string
+	}{
+		{name: "raw nontracking commit", selector: rawBase, want: "advertised tracking branch"},
+		{name: "ambiguous unqualified branch", selector: "main", want: "missing or ambiguous"},
+		{name: "unadvertised qualified branch", selector: "upstream/missing", want: "missing or ambiguous"},
+		{name: "local-only branch", selector: "local-only", want: "missing or ambiguous"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.selector == "local-only" {
+				runReviewCLIGit(t, repo, "branch", test.selector, "HEAD")
+			}
+			output.Reset()
+			err := RunReviewFacadeValidate([]string{
+				"--cwd", repo, "--lineage", lineage, "--gate", string(reviewtransaction.GatePrePush), "--base-ref", test.selector,
+			}, &output)
+			if err == nil || !strings.Contains(err.Error(), test.want) && !strings.Contains(output.String(), test.want) {
+				t.Fatalf("selector %q error=%v output=%s, want %q", test.selector, err, output.String(), test.want)
+			}
+			var result ReviewValidateResult
+			if decodeErr := json.Unmarshal(output.Bytes(), &result); decodeErr != nil {
+				t.Fatalf("decode denied selector %q: %v\n%s", test.selector, decodeErr, output.String())
+			}
+			if result.Allowed || result.Result == reviewtransaction.GateAllow {
+				t.Fatalf("selector %q was allowed: %#v", test.selector, result)
+			}
+			stateAfter, stateErr := os.ReadFile(store.StatePath())
+			receiptAfter, receiptErr := os.ReadFile(store.ReceiptPath())
+			candidateAfter, candidateErr := os.ReadFile(filepath.Join(repo, "docs", "feature.md"))
+			if stateErr != nil || receiptErr != nil || candidateErr != nil ||
+				!bytes.Equal(stateBefore, stateAfter) || !bytes.Equal(receiptBefore, receiptAfter) ||
+				!bytes.Equal(candidateBefore, candidateAfter) {
+				t.Fatalf("denied selector %q mutated candidate or authority: state=%v receipt=%v candidate=%v", test.selector, stateErr, receiptErr, candidateErr)
+			}
+		})
+	}
+}

--- a/internal/reviewtransaction/compact_gate_local_advance_test.go
+++ b/internal/reviewtransaction/compact_gate_local_advance_test.go
@@ -2,6 +2,7 @@ package reviewtransaction
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -57,5 +58,46 @@ func TestCompactLocalBaseAdvanceRejectsUnadvertisedExplicitParent(t *testing.T) 
 	})
 	if got.Result == GateAllow || !strings.Contains(got.Reason, "advertised tracking branch") {
 		t.Fatalf("unadvertised explicit local parent = %#v, want fail-closed tracking-boundary denial", got)
+	}
+}
+
+func TestCompactPrePushForkSelectorStaysSymbolicDuringBaseAdvanceProof(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	state, receipt := approvedCompactPrePRFixture(t, fixture)
+
+	// The feature branch publishes to origin/feature, while the reviewed base
+	// is advertised by a distinct upstream remote. Keep origin/feature behind
+	// HEAD so the raw-commit control has a different tracking boundary.
+	gitSnapshot(t, fixture.repo, "--git-dir", fixture.remote, "update-ref", "refs/heads/feature", fixture.originalBaseCommit)
+	gitSnapshot(t, fixture.repo, "config", "branch.feature.merge", "refs/heads/feature")
+	upstream := filepath.Join(t.TempDir(), "upstream.git")
+	gitSnapshot(t, fixture.repo, "clone", "--bare", fixture.remote, upstream)
+	gitSnapshot(t, fixture.repo, "remote", "add", "upstream", upstream)
+
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: state.LineageID, BaseRef: "upstream/main",
+	})
+	if got.Result != GateAllow || got.Context.BaseAdvance == nil || !got.Context.BaseAdvance.Compatible {
+		t.Fatalf("symbolic fork base = %#v, want allow with compatible base proof", got)
+	}
+
+	rawUpstream := trimGit(gitSnapshot(t, fixture.repo, "rev-parse", "main"))
+	raw := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: state.LineageID, BaseRef: rawUpstream,
+	})
+	if raw.Result == GateAllow || !strings.Contains(raw.Reason, "advertised tracking branch") {
+		t.Fatalf("raw nontracking base = %#v, want tracking-boundary denial", raw)
+	}
+
+	for _, selector := range []string{"upstream/missing", "main", "local-only"} {
+		if selector == "local-only" {
+			gitSnapshot(t, fixture.repo, "branch", selector, "HEAD")
+		}
+		denied := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+			Gate: GatePrePush, LineageID: state.LineageID, BaseRef: selector,
+		})
+		if denied.Result == GateAllow {
+			t.Fatalf("selector %q was accepted", selector)
+		}
 	}
 }

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -231,6 +231,11 @@ func reviewedBaseAdvanceHead(ctx context.Context, repo, reviewedTree, head strin
 
 func deriveExplicitBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, preimages gateArtifactPreimages) (BaseAdvanceCompatibility, error) {
 	selector := strings.TrimSpace(request.Target.BaseRef)
+	if request.Gate == GatePrePush && request.Push != nil && request.Push.Boundary.Source == PrePRBoundaryExplicit {
+		// Target.BaseRef is the resolved merge base; retain the caller's
+		// symbolic selector for the advertised-remote check.
+		selector = strings.TrimSpace(request.Push.Boundary.Selector)
+	}
 	if selector == "" {
 		return BaseAdvanceCompatibility{}, errors.New("compatible local base advance requires an explicit base ref") // refusal:by-design operator-knowledge: only the caller can choose the intended reviewed base
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3092

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Preserve an explicit symbolic remote/branch selector during the pre-push local base-advance proof while retaining raw SHA tracking-boundary denial.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/prepr.go` | Preserve explicit symbolic remote/branch selector identity during local base-advance proof; retain raw SHA tracking-boundary denial. |
| `internal/reviewtransaction` and `internal/cli` regressions | Cover transaction behavior and the public CLI boundary for symbolic pre-push selectors and negative controls. |
| `bench/journeys_issue_3092.go` | Add driven benchmark journey `j103-pre-push-symbolic-fork-selector`. |
| `bench/journeys.go`, `bench/README.md`, and journey registration/count tests | Register the journey and update corpus/count documentation. |

---

## 🧪 Test Plan

**Unit and focused regressions**

- PASS: full `go test ./... -count=1`
- PASS: focused CLI and `reviewtransaction` test suites

**Static checks and builds**

- PASS: `go vet ./...` from the repository root and `bench/`
- PASS: product and benchmark builds
- PASS: `go run ./internal/gofmtcheck`
- PASS: `git diff --check`

**Benchmark Validation**

- PASS: `go test ./... -count=1` from `bench/`
- PASS: driven `j103-pre-push-symbolic-fork-selector` completed with supported execution and zero failures

**E2E Tests** (Docker required)

```bash
cd e2e && ./docker-test.sh
```

Docker E2E was not run locally. The affected public/runtime boundary was exercised through the driven benchmark and public CLI regression; CI is responsible for repository E2E.

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Not run locally; CI will run repository E2E.
- [x] Manually tested locally through the public CLI regression and driven benchmark

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | PASS locally | 400 changed lines: 397 additions and 3 deletions |
| Check Issue Reference | PASS | Body contains `Closes #3092` |
| Check Issue Has `status:approved` | PASS | Issue #3092 is approved |
| Check PR Has `type:*` Label | NOT APPLIED | No GitHub label was added during publication; the body classification checkbox is selected only |
| Unit Tests | PASS locally | Full and focused suites passed as listed above |
| Go Format | PASS locally | `internal/gofmtcheck` passed |
| E2E Tests | NOT RUN LOCALLY | Docker E2E is delegated to CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — intentionally not added; label mutation requires separate approval
- [x] Unit tests pass (`go test ./... -count=1` and focused CLI/`reviewtransaction` suites)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Not run locally
- [x] Benchmark validation completed
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This changes production code in `internal/reviewtransaction`. The legitimate population is fork workflows where `upstream/main` is the reviewed base while `origin/feature` remains the tracking/push destination. Negative controls cover raw nontracking SHA, ambiguous branch, missing qualified branch, and local-only branch. `.guard-population-baseline.txt` is unchanged because this preserves selector identity rather than adding a new qualifying declared guard.

- [ ] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pre-push reviews now preserve symbolic fork base selectors, such as `upstream/main`, throughout review and validation.
  - Validation correctly accepts valid tracking selectors and rejects raw hashes, ambiguous references, missing references, local-only branches, and non-tracking selectors without altering review state.
  - Added coverage for fork-based pre-push workflows, including upstream advancement and committed-only reviews.

- **Documentation**
  - Updated the portable benchmark journey count from 57 to 101.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->