### PR TITLE
feat(review): bind effect intents to compact authority

### DIFF
--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -178,11 +178,11 @@ type CompactStore struct {
 }
 
 type CompactEffectIntent struct {
-	Class             string `json:"class"`
-	Destination       string `json:"destination"`
-	PayloadHash       string `json:"payload_hash"`
-	AuthorityRevision string `json:"authority_revision"`
-	EventID           string `json:"event_id"`
+	Class           string `json:"class"`
+	Destination     string `json:"destination"`
+	PayloadHash     string `json:"payload_hash"`
+	BindingRevision string `json:"binding_revision"`
+	EventID         string `json:"event_id"`
 }
 
 type CompactStartAction string
@@ -2271,14 +2271,19 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 	if err != nil {
 		return CompactRecord{}, nil, err
 	}
-	revision := ""
+	bindingRevision := compactStateRevision(statePayload)
+	revision := bindingRevision
 	if len(intents) == 0 {
-		sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
-		revision = "sha256:" + hex.EncodeToString(sum[:])
 	} else {
-		semantic := make([]CompactEffectIntent, len(intents))
+		semantic := make([]struct {
+			Class       string `json:"class"`
+			Destination string `json:"destination"`
+			PayloadHash string `json:"payload_hash"`
+		}, len(intents))
 		for index, intent := range intents {
-			semantic[index] = CompactEffectIntent{Class: intent.Class, Destination: intent.Destination, PayloadHash: intent.PayloadHash}
+			semantic[index].Class = intent.Class
+			semantic[index].Destination = intent.Destination
+			semantic[index].PayloadHash = intent.PayloadHash
 		}
 		semanticPayload, marshalErr := json.Marshal(semantic)
 		if marshalErr != nil {
@@ -2287,12 +2292,12 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 		sum := sha256.Sum256(bytes.Join([][]byte{[]byte("gentle-ai.review-state-effects/v1\x00"), statePayload, semanticPayload}, []byte{0}))
 		revision = "sha256:" + hex.EncodeToString(sum[:])
 		for index := range intents {
-			if intents[index].AuthorityRevision == "" {
-				intents[index].AuthorityRevision = revision
-			} else if intents[index].AuthorityRevision != revision {
-				return CompactRecord{}, nil, errors.New("invalid compact required effect authority") // refusal:by-design operator-knowledge: caller-supplied authority cannot override the enclosing record revision
+			if intents[index].BindingRevision == "" {
+				intents[index].BindingRevision = bindingRevision
+			} else if intents[index].BindingRevision != bindingRevision {
+				return CompactRecord{}, nil, errors.New("invalid compact required effect binding") // refusal:by-design operator-knowledge: caller-supplied binding cannot override the enclosing state identity
 			}
-			eventPayload, _ := json.Marshal([]string{intents[index].AuthorityRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
+			eventPayload, _ := json.Marshal([]string{state.LineageID, intents[index].BindingRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
 			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
 			wantEventID := "sha256:" + hex.EncodeToString(eventSum[:])
 			if intents[index].EventID == "" {
@@ -2309,6 +2314,11 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 		return CompactRecord{}, nil, err
 	}
 	return record, append(payload, '\n'), nil
+}
+
+func compactStateRevision(statePayload []byte) string {
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // CompactRevisionForState derives the exact content-addressed revision without

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -2400,7 +2400,10 @@ func validateCompactEffectIntents(record CompactRecord) error {
 		return nil
 	}
 	want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
-	if err != nil || want.Revision != record.Revision || !reflect.DeepEqual(want.EffectIntents, record.EffectIntents) {
+	if err != nil {
+		return fmt.Errorf("invalid compact required effect identity: %w", err)
+	}
+	if want.Revision != record.Revision || !reflect.DeepEqual(want.EffectIntents, record.EffectIntents) {
 		// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
 		return errors.New("invalid compact required effect identity")
 	}
@@ -2773,7 +2776,7 @@ func (store CompactStore) installTransportRecordLocked(ctx context.Context, reco
 	if err := validateCompactTransportDelivery(ctx, store.repo, record.State); err != nil {
 		return err
 	}
-	want, payload, err := makeCompactRecord(record.State)
+	want, payload, err := makeCompactRecordWithIntents(record.State, record.EffectIntents)
 	if err != nil || want.Revision != record.Revision {
 		return errors.New("imported compact record checksum changed")
 	}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -2253,6 +2253,11 @@ func makeCompactRecord(state CompactState) (CompactRecord, []byte, error) {
 
 func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectIntent) (CompactRecord, []byte, error) {
 	intents = append([]CompactEffectIntent(nil), intents...)
+	for _, intent := range intents {
+		if !validCompactEffectIntentFields(intent) {
+			return CompactRecord{}, nil, errors.New("invalid compact required effect intent") // refusal:by-design operator-knowledge: callers must supply a closed, persistable effect intent
+		}
+	}
 	sort.Slice(intents, func(i, j int) bool {
 		if intents[i].Class != intents[j].Class {
 			return intents[i].Class < intents[j].Class
@@ -2379,7 +2384,7 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 
 func validateCompactEffectIntents(record CompactRecord) error {
 	for index, intent := range record.EffectIntents {
-		if (intent.Class != "repository_context" && intent.Class != "requested_trace") || strings.TrimSpace(intent.Destination) == "" || !validSHA256(intent.PayloadHash) {
+		if !validCompactEffectIntentFields(intent) {
 			// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
 			return errors.New("invalid compact required effect intent")
 		}
@@ -2400,6 +2405,11 @@ func validateCompactEffectIntents(record CompactRecord) error {
 		return errors.New("invalid compact required effect identity")
 	}
 	return nil
+}
+
+func validCompactEffectIntentFields(intent CompactEffectIntent) bool {
+	return (intent.Class == "repository_context" || intent.Class == "requested_trace") &&
+		strings.TrimSpace(intent.Destination) != "" && validSHA256(intent.PayloadHash)
 }
 
 func forensicHistoricalCompactRecord(payload []byte, lineageID string) (historicalCompactForensicRecord, bool) {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -156,9 +156,10 @@ func NewLegacyReadOnlyError(operation, lineageID string) error {
 }
 
 type CompactRecord struct {
-	Schema   string       `json:"schema"`
-	Revision string       `json:"revision"`
-	State    CompactState `json:"state"`
+	Schema        string                `json:"schema"`
+	Revision      string                `json:"revision"`
+	State         CompactState          `json:"state"`
+	EffectIntents []CompactEffectIntent `json:"effect_intents,omitempty"`
 	// HistoricalCompat marks a record loaded through the retired-field
 	// compatibility path; such authority is read-only.
 	HistoricalCompat bool `json:"-"`
@@ -174,6 +175,14 @@ type CompactStore struct {
 	lockPath            string
 	maintenanceLockPath string
 	TracePath           string
+}
+
+type CompactEffectIntent struct {
+	Class             string `json:"class"`
+	Destination       string `json:"destination"`
+	PayloadHash       string `json:"payload_hash"`
+	AuthorityRevision string `json:"authority_revision"`
+	EventID           string `json:"event_id"`
 }
 
 type CompactStartAction string
@@ -2239,12 +2248,62 @@ func reflectCompactReviewData(previous, next CompactState) bool {
 }
 
 func makeCompactRecord(state CompactState) (CompactRecord, []byte, error) {
+	return makeCompactRecordWithIntents(state, nil)
+}
+
+func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectIntent) (CompactRecord, []byte, error) {
+	intents = append([]CompactEffectIntent(nil), intents...)
+	sort.Slice(intents, func(i, j int) bool {
+		if intents[i].Class != intents[j].Class {
+			return intents[i].Class < intents[j].Class
+		}
+		if intents[i].Destination != intents[j].Destination {
+			return intents[i].Destination < intents[j].Destination
+		}
+		return intents[i].PayloadHash < intents[j].PayloadHash
+	})
+	for index := 1; index < len(intents); index++ {
+		if intents[index-1].Class == intents[index].Class && intents[index-1].Destination == intents[index].Destination {
+			return CompactRecord{}, nil, errors.New("duplicate compact required effect intent") // refusal:by-design operator-knowledge: callers must supply one immutable intent per class and destination
+		}
+	}
 	statePayload, err := json.Marshal(state)
 	if err != nil {
 		return CompactRecord{}, nil, err
 	}
-	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
-	record := CompactRecord{Schema: compactRecordSchema, Revision: "sha256:" + hex.EncodeToString(sum[:]), State: state}
+	revision := ""
+	if len(intents) == 0 {
+		sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+		revision = "sha256:" + hex.EncodeToString(sum[:])
+	} else {
+		semantic := make([]CompactEffectIntent, len(intents))
+		for index, intent := range intents {
+			semantic[index] = CompactEffectIntent{Class: intent.Class, Destination: intent.Destination, PayloadHash: intent.PayloadHash}
+		}
+		semanticPayload, marshalErr := json.Marshal(semantic)
+		if marshalErr != nil {
+			return CompactRecord{}, nil, marshalErr
+		}
+		sum := sha256.Sum256(bytes.Join([][]byte{[]byte("gentle-ai.review-state-effects/v1\x00"), statePayload, semanticPayload}, []byte{0}))
+		revision = "sha256:" + hex.EncodeToString(sum[:])
+		for index := range intents {
+			if intents[index].AuthorityRevision == "" {
+				intents[index].AuthorityRevision = revision
+			} else if intents[index].AuthorityRevision != revision {
+				return CompactRecord{}, nil, errors.New("invalid compact required effect authority") // refusal:by-design operator-knowledge: caller-supplied authority cannot override the enclosing record revision
+			}
+			eventPayload, _ := json.Marshal([]string{intents[index].AuthorityRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
+			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
+			wantEventID := "sha256:" + hex.EncodeToString(eventSum[:])
+			if intents[index].EventID == "" {
+				intents[index].EventID = wantEventID
+			} else if intents[index].EventID != wantEventID {
+				// refusal:by-design operator-knowledge: caller-supplied immutable effect identity is inconsistent and cannot be repaired by an operator command
+				return CompactRecord{}, nil, errors.New("invalid compact required effect identity")
+			}
+		}
+	}
+	record := CompactRecord{Schema: compactRecordSchema, Revision: revision, State: state, EffectIntents: intents}
 	payload, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
 		return CompactRecord{}, nil, err
@@ -2293,16 +2352,44 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
 			OutdatedIdentity: historical}
 	}
+	if err := validateCompactEffectIntents(record); err != nil {
+		return CompactRecord{}, err
+	}
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")
 	}
 	if !record.HistoricalCompat {
-		want, _, err := makeCompactRecord(record.State)
+		want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
 		if err != nil || want.Revision != record.Revision {
 			return CompactRecord{}, errors.New("compact review state checksum mismatch")
 		}
 	}
 	return record, nil
+}
+
+func validateCompactEffectIntents(record CompactRecord) error {
+	for index, intent := range record.EffectIntents {
+		if (intent.Class != "repository_context" && intent.Class != "requested_trace") || strings.TrimSpace(intent.Destination) == "" || !validSHA256(intent.PayloadHash) {
+			// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+			return errors.New("invalid compact required effect intent")
+		}
+		if index > 0 {
+			previous := record.EffectIntents[index-1]
+			if previous.Class > intent.Class || (previous.Class == intent.Class && previous.Destination >= intent.Destination) {
+				// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+				return errors.New("compact required effect intents must be unique and canonically ordered")
+			}
+		}
+	}
+	if len(record.EffectIntents) == 0 {
+		return nil
+	}
+	want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
+	if err != nil || want.Revision != record.Revision || !reflect.DeepEqual(want.EffectIntents, record.EffectIntents) {
+		// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+		return errors.New("invalid compact required effect identity")
+	}
+	return nil
 }
 
 func forensicHistoricalCompactRecord(payload []byte, lineageID string) (historicalCompactForensicRecord, bool) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -3,6 +3,8 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"math"
@@ -1465,6 +1467,117 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 	}
 	if _, err := os.Stat(store.StatePath()); !os.IsNotExist(err) {
 		t.Fatalf("cancelled replacement published authority: %v", err)
+	}
+}
+
+func TestCompactRecordEffectIntentIdentity(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "effect-intent-identity")
+	intents := []CompactEffectIntent{
+		{Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c")},
+		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
+	}
+	record, payload, err := makeCompactRecordWithIntents(state, intents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reordered, reorderedPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{intents[1], intents[0]})
+	if err != nil || reordered.Revision != record.Revision || !bytes.Equal(reorderedPayload, payload) {
+		t.Fatalf("reordered intent set = %q, %v; want canonical revision %q and identical bytes", reordered.Revision, err, record.Revision)
+	}
+	if _, _, err := makeCompactRecordWithIntents(state, append(intents, intents[0])); err == nil {
+		t.Fatal("creation accepted duplicate semantic intent")
+	}
+	parsed, err := parseCompactRecord(payload, state.LineageID)
+	if err != nil || parsed.Revision != record.Revision || !reflect.DeepEqual(parsed.EffectIntents, record.EffectIntents) {
+		t.Fatalf("parse intent record = %#v, %v; want revision/intents %#v", parsed, err, record)
+	}
+	legacy, _, err := makeCompactRecord(state)
+	if err != nil || legacy.Revision == record.Revision {
+		t.Fatalf("legacy revision = %q, intent revision = %q, err = %v", legacy.Revision, record.Revision, err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*CompactRecord)
+	}{
+		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
+		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
+		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
+		{"forged authority revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].AuthorityRevision = hash("forged") }},
+		{"coordinated authority and event forgery", func(candidate *CompactRecord) {
+			intent := &candidate.EffectIntents[0]
+			intent.AuthorityRevision = hash("forged")
+			eventPayload, _ := json.Marshal([]string{intent.AuthorityRevision, intent.Class, intent.Destination, intent.PayloadHash})
+			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
+			intent.EventID = "sha256:" + hex.EncodeToString(eventSum[:])
+		}},
+		{"forged event identity", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = hash("forged") }},
+		{"noncanonical order", func(candidate *CompactRecord) {
+			candidate.EffectIntents[0], candidate.EffectIntents[1] = candidate.EffectIntents[1], candidate.EffectIntents[0]
+		}},
+		{"duplicate", func(candidate *CompactRecord) { candidate.EffectIntents[1] = candidate.EffectIntents[0] }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := record
+			candidate.EffectIntents = append([]CompactEffectIntent(nil), record.EffectIntents...)
+			tt.mutate(&candidate)
+			candidatePayload, _ := json.Marshal(candidate)
+			if _, err := parseCompactRecord(candidatePayload, state.LineageID); err == nil {
+				t.Fatalf("accepted invalid intents: %#v", candidate.EffectIntents)
+			}
+		})
+	}
+}
+
+func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {
+	state := newCompactTestState(t, initSnapshotRepo(t), "intent-free-history")
+	statePayload, _ := json.Marshal(state)
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+	wantRevision := "sha256:" + hex.EncodeToString(sum[:])
+	wantBytes, _ := json.MarshalIndent(struct {
+		Schema   string       `json:"schema"`
+		Revision string       `json:"revision"`
+		State    CompactState `json:"state"`
+	}{compactRecordSchema, wantRevision, state}, "", "  ")
+	record, payload, err := makeCompactRecord(state)
+	if err != nil || record.Revision != wantRevision || !bytes.Equal(payload, append(wantBytes, '\n')) {
+		t.Fatalf("intent-free compatibility = %q, %v, bytes equal %t", record.Revision, err, bytes.Equal(payload, append(wantBytes, '\n')))
+	}
+}
+
+func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "effect-intent-schema-only")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, payload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{{
+		Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	next := state
+	results := make([]LensResult, len(next.SelectedLenses))
+	for index, lens := range next.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review completed"}}
+	}
+	if err := next.CompleteReview(CompactReviewInput{
+		LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/complete-review", next); err != nil {
+		t.Fatalf("schema-only intents blocked successor: %v", err)
+	}
+	loaded, err := store.Load()
+	if err != nil || len(loaded.EffectIntents) != 0 {
+		t.Fatalf("successor intents = %#v, %v; want no premature propagation", loaded.EffectIntents, err)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1494,6 +1494,20 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)},
 		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
 	}
+	for _, tt := range []struct {
+		name   string
+		intent CompactEffectIntent
+	}{
+		{"unsupported class", CompactEffectIntent{Class: "receipt", Destination: destination, PayloadHash: hashPayload(contextPayload)}},
+		{"blank destination", CompactEffectIntent{Class: "repository_context", Destination: " ", PayloadHash: hashPayload(contextPayload)}},
+		{"invalid payload hash", CompactEffectIntent{Class: "repository_context", Destination: destination, PayloadHash: "invalid"}},
+	} {
+		t.Run("constructor rejects "+tt.name, func(t *testing.T) {
+			if _, _, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{tt.intent}); err == nil {
+				t.Fatal("malformed effect intent was accepted")
+			}
+		})
+	}
 	record, payload, err := makeCompactRecordWithIntents(state, intents)
 	if err != nil {
 		t.Fatal(err)
@@ -1523,7 +1537,12 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		mutate func(*CompactRecord)
 	}{
 		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
+		{"blank destination", func(candidate *CompactRecord) { candidate.EffectIntents[0].Destination = " " }},
 		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
+		{"omitted identity", func(candidate *CompactRecord) {
+			candidate.EffectIntents[0].BindingRevision = ""
+			candidate.EffectIntents[0].EventID = ""
+		}},
 		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
 		{"forged binding revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].BindingRevision = hash("forged") }},
 		{"coordinated binding and event forgery", func(candidate *CompactRecord) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1473,13 +1473,34 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	state := newCompactTestState(t, repo, "effect-intent-identity")
+	statePayload, _ := json.Marshal(state)
+	bindingRevision := compactStateRevision(statePayload)
+	binding := ReviewRepositoryContextBinding{LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: bindingRevision}
+	destination, err := DeriveReviewRepositoryContextHandle(context.Background(), repo, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := reviewRepositoryIdentity(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextPayload, _ := json.Marshal(reviewRepositoryContextFile{
+		Schema: ReviewRepositoryContextSchema, Handle: destination,
+		LineageID: binding.LineageID, TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+		RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+		GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+	})
 	intents := []CompactEffectIntent{
-		{Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c")},
+		{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)},
 		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
 	}
 	record, payload, err := makeCompactRecordWithIntents(state, intents)
 	if err != nil {
 		t.Fatal(err)
+	}
+	retry, retryPayload, retryErr := makeCompactRecordWithIntents(state, intents)
+	if retryErr != nil || !reflect.DeepEqual(retry, record) || !bytes.Equal(retryPayload, payload) || intents[0].BindingRevision != "" || intents[0].EventID != "" {
+		t.Fatalf("same-slice retry mutated input or drifted: record = %#v, err = %v, intents = %#v", retry, retryErr, intents)
 	}
 	reordered, reorderedPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{intents[1], intents[0]})
 	if err != nil || reordered.Revision != record.Revision || !bytes.Equal(reorderedPayload, payload) {
@@ -1493,7 +1514,7 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		t.Fatalf("parse intent record = %#v, %v; want revision/intents %#v", parsed, err, record)
 	}
 	legacy, _, err := makeCompactRecord(state)
-	if err != nil || legacy.Revision == record.Revision {
+	if err != nil || legacy.Revision != bindingRevision || legacy.Revision == record.Revision || record.EffectIntents[0].BindingRevision != bindingRevision {
 		t.Fatalf("legacy revision = %q, intent revision = %q, err = %v", legacy.Revision, record.Revision, err)
 	}
 
@@ -1504,11 +1525,11 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
 		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
 		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
-		{"forged authority revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].AuthorityRevision = hash("forged") }},
-		{"coordinated authority and event forgery", func(candidate *CompactRecord) {
+		{"forged binding revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].BindingRevision = hash("forged") }},
+		{"coordinated binding and event forgery", func(candidate *CompactRecord) {
 			intent := &candidate.EffectIntents[0]
-			intent.AuthorityRevision = hash("forged")
-			eventPayload, _ := json.Marshal([]string{intent.AuthorityRevision, intent.Class, intent.Destination, intent.PayloadHash})
+			intent.BindingRevision = hash("forged")
+			eventPayload, _ := json.Marshal([]string{candidate.State.LineageID, intent.BindingRevision, intent.Class, intent.Destination, intent.PayloadHash})
 			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
 			intent.EventID = "sha256:" + hex.EncodeToString(eventSum[:])
 		}},
@@ -1528,6 +1549,17 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 			}
 		})
 	}
+	otherState := state
+	otherState.LineageID = "effect-intent-other-lineage"
+	other, _, err := makeCompactRecordWithIntents(otherState, []CompactEffectIntent{{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)}, intents[1]})
+	if err != nil || other.EffectIntents[0].EventID == record.EffectIntents[0].EventID {
+		t.Fatalf("lineage-bound event identity = %q, %v; want different from %q", other.EffectIntents[0].EventID, err, record.EffectIntents[0].EventID)
+	}
+}
+
+func hashPayload(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1568,6 +1568,13 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 			}
 		})
 	}
+	invalidBuilder := record
+	invalidBuilder.EffectIntents = append([]CompactEffectIntent(nil), record.EffectIntents...)
+	invalidBuilder.EffectIntents[0].BindingRevision = hash("forged")
+	invalidPayload, _ := json.Marshal(invalidBuilder)
+	if _, err := parseCompactRecord(invalidPayload, state.LineageID); err == nil || !strings.Contains(err.Error(), "invalid compact required effect binding") {
+		t.Fatalf("builder error = %v; want exact effect-authority evidence", err)
+	}
 	otherState := state
 	otherState.LineageID = "effect-intent-other-lineage"
 	other, _, err := makeCompactRecordWithIntents(otherState, []CompactEffectIntent{{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)}, intents[1]})
@@ -2475,6 +2482,36 @@ func TestCompactTransportRoundTripRecoversEquivalentCurrentAuthority(t *testing.
 	}
 	if _, err := os.Stat(filepath.Join(destinationStore.Dir, "events")); !os.IsNotExist(err) {
 		t.Fatalf("compact import reconstructed event history: %v", err)
+	}
+}
+
+func TestCompactTransportRoundTripPreservesIntentAuthorityIdentity(t *testing.T) {
+	source := initSnapshotRepo(t)
+	state := newCompactTestState(t, source, "compact-intent-transport")
+	record, recordPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{{
+		Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, _ := CompactAuthoritativeStore(context.Background(), source, state.LineageID)
+	if err := writeAtomic(store.StatePath(), recordPayload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	transport, err := store.ExportTransport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(t.TempDir(), "clone")
+	gitSnapshot(t, source, "clone", "--no-local", source, destination)
+	imported, err := ImportCompactTransport(context.Background(), destination, transport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destinationStore, _ := CompactAuthoritativeStore(context.Background(), destination, state.LineageID)
+	importedPayload, err := os.ReadFile(destinationStore.StatePath())
+	if err != nil || imported.Revision != record.Revision || !bytes.Equal(importedPayload, recordPayload) {
+		t.Fatalf("intent transport changed revision/bytes: revision %q, bytes equal %t, err %v", imported.Revision, bytes.Equal(importedPayload, recordPayload), err)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1875. Slice 1 of 4. The final slice will close the issue after the complete runtime invariant is proven.

## PR Type

- [ ] `type:bug` - Bug fix
- [x] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Maintenance/tooling
- [ ] `type:breaking-change` - Breaking change

## Summary

- Adds immutable repository-context and requested-trace intent identity to compact authority records.
- Derives deterministic authority revisions and event IDs with strict tamper validation.
- Preserves exact historical bytes and revisions when no intents exist.

Production START remains intentionally unwired. Marker-backed reconciliation and its real production resolver land together in slice 2, avoiding an incomplete recovery path.

## Chain Context

```text
main
├── 📍 PR1: authority intent schema and identity (this PR)
├── PR2: marker repository and effect consumers
├── PR3: one-event CLI and STATUS routing
└── PR4: fresh-process runtime and driven bench proof
```

All PRs target `main`. Until ancestors merge, later PRs may temporarily include prior commits; GitHub recalculates them as the chain lands in order.

## Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/compact_store.go` | Adds canonical effect-intent identity and strict parsing while preserving intent-free compatibility. |
| `internal/reviewtransaction/compact_store_test.go` | Covers canonical ordering, forgery rejection, schema-only successor behavior, and exact historical identity. |

## Test Plan

- [x] `go test ./internal/reviewtransaction -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] Native high-risk review approved lineage `review-ff5c4ac88e969dec` after one bounded correction.
- [x] Pre-commit receipt validation returned `allow`.
- [x] Runtime harness: N/A for this deliberately unwired schema/identity foundation.

## Review Budget

206 additions + 6 deletions = 212 authored changed lines, below the 400-line budget.

## Rollback

Revert this work unit before production intent creation is enabled. Historical intent-free records remain byte-compatible.

## Contributor Checklist

- [x] Linked to approved issue #1875.
- [x] Exactly one `type:*` label requested.
- [x] Focused and affected Go tests pass.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] No user-visible behavior or docs change in this foundation slice.
- [x] Commit follows Conventional Commits.
- [x] No `Co-Authored-By` trailer.

## Out of Scope

#1951, Pi, #2316 sidecars, marker reconciliation, CLI/STATUS routing, generic effects, retention/compaction, and support export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact transaction records now support persisted effect intents, including class, destination, payload identity, authority revision, and event identity.
  * Effect intents are canonically ordered and validated for reliable record integrity.

* **Compatibility**
  * Existing records without effect intents remain supported and retain their historical identity and serialized representation.
  * Effect-intent data remains consistent across transport and state transitions.

* **Bug Fixes**
  * Duplicate, forged, malformed, unsupported, or inconsistently identified effect intents are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->