### PR TITLE
fix(claude-code): grant sdd-explore Engram read tools

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -822,6 +822,40 @@ func TestFourRReviewAgentAssets(t *testing.T) {
 	}
 }
 
+// TestClaudeSDDPhaseAgentsCarryEngramReadTools guards the SDD Context Protocol:
+// phase agents resolve artifact references against the active backend instead of
+// consuming paraphrased artifact bodies. An agent that can write to Engram but
+// never read from it cannot comply, and the failure is silent — it still returns
+// a confident report built only from what the orchestrator inlined.
+func TestClaudeSDDPhaseAgentsCarryEngramReadTools(t *testing.T) {
+	phaseAgents := []string{"sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks"}
+	readTools := []string{
+		"mcp__plugin_engram_engram__mem_search",
+		"mcp__plugin_engram_engram__mem_get_observation",
+	}
+
+	toolsLine := func(content string) string {
+		for _, line := range strings.Split(content, "\n") {
+			if strings.HasPrefix(line, "tools:") {
+				return line
+			}
+		}
+		return ""
+	}
+
+	for _, agent := range phaseAgents {
+		tools := toolsLine(MustRead("claude/agents/" + agent + ".md"))
+		if tools == "" {
+			t.Fatalf("claude/agents/%s.md declares no tools allowlist", agent)
+		}
+		for _, want := range readTools {
+			if !strings.Contains(tools, want) {
+				t.Fatalf("claude/agents/%s.md grants no %s: it can write to Engram but never read from it", agent, want)
+			}
+		}
+	}
+}
+
 func TestOpenCodeSDDOrchestratorRequiresSessionPreflight(t *testing.T) {
 	content := MustRead("opencode/sdd-orchestrator.md")
 

--- a/internal/assets/claude/agents/sdd-explore.md
+++ b/internal/assets/claude/agents/sdd-explore.md
@@ -6,7 +6,7 @@ description: >
   clarify requirements — before any proposal or spec is written.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
-tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_save
+tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 
 You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further.

--- a/testdata/golden/sdd-claude-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-explore.golden
@@ -5,7 +5,7 @@ description: >
   a feature, investigate the codebase, understand current architecture, compare approaches, or
   clarify requirements — before any proposal or spec is written.
 model: sonnet
-tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_save
+tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 
 You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1976

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

`sdd-explore` was the only Claude SDD phase agent whose frontmatter granted `mem_save` without `mem_search` or `mem_get_observation`. It could write to Engram but never read from it.

With an `engram` or `hybrid` artifact store that breaks the SDD Context Protocol at the first phase: the orchestrator hands the agent artifact references (topic keys) it structurally cannot resolve. The failure is silent — the agent does not error, it returns a confident report grounded only in whatever the orchestrator paraphrased into the prompt, which is the copied-artifact-body anti-pattern the protocol forbids. Because exploration runs first, propose, spec and design all build on that unverified foundation.

The gap is specific to the Claude asset. `cursor` and `kimi` declare no `tools:` allowlist for this agent, and `kiro` grants `@engram` wholesale, so no other runtime asset needed a change. The Pi issues (#602, #1024) are a different shape and stay out of scope, as #1976 notes.

Beyond the one-line asset fix, this adds a parity test across all five Claude SDD phase agents so the asymmetry cannot silently return.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/claude/agents/sdd-explore.md` | Added `mem_search` and `mem_get_observation` to the `tools:` allowlist, matching the ordering its four sibling phase agents already use. |
| `internal/assets/assets_test.go` | Added `TestClaudeSDDPhaseAgentsCarryEngramReadTools`, asserting every Claude SDD phase agent that can write to Engram can also read from it. |
| `testdata/golden/sdd-claude-agent-sdd-explore.golden` | Regenerated via `-update`; the only golden affected, one line. |

---

## 🧪 Test Plan

**The new test was verified in both directions** — it is not a test that passes regardless:

```bash
# with the fix
go test ./internal/assets/ -run TestClaudeSDDPhaseAgentsCarryEngramReadTools
# ok

# with the asset change stashed
--- FAIL: TestClaudeSDDPhaseAgentsCarryEngramReadTools
    assets_test.go:853: claude/agents/sdd-explore.md grants no
    mcp__plugin_engram_engram__mem_search: it can write to Engram but never read from it
```

**Affected packages** — all green:

```bash
go test ./internal/assets/... ./internal/components/ ./internal/agents/...
# ok (all)
```

**Go Format**

```bash
go run ./internal/gofmtcheck   # clean
go vet ./internal/assets/      # clean
```

**Full suite** — I want to be transparent here rather than tick a box. `go test ./...` is not fully green on macOS on unmodified `main`; I captured a baseline before starting and confirmed the same packages fail with and without this change. None of them are touched by it. Two of the causes I identified are environment-specific rather than defects in `main`:

- `internal/update` — macOS ships bash 3.2.57, and the release scripts use `[[ -v VAR ]]` (bash 4.2+) and `declare -A` (bash 4.0+).
- `internal/advisoryreview` — the macOS `/var` → `/private/var` symlink makes the codex adapter's `-C` path compare unequal to the resolved cwd.

The others (`e2e/organicruntime`, `internal/app`, `internal/cli`, `internal/components/engram`, `internal/reviewtransaction`, `internal/sddstatus`) I did not classify, since none are in this change's blast radius. Happy to open a separate issue for the macOS contributor-setup failures if that is useful.

**E2E Tests** — not run locally; leaving these to CI.

**Benchmark Validation** — N/A. This changes a Claude agent asset's tool allowlist. It does not touch review lifecycle, gates, recovery, delivery, the benchmark implementation/corpus/classifier, or any benchmark claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The SDD exploration phase can now search and retrieve relevant Engram memories.

* **Bug Fixes**
  * Improved consistency across SDD phase agents by ensuring required memory-reading capabilities are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->