### PR TITLE
feat(review): reconcile repository context effects

### DIFF
--- a/internal/reviewtransaction/compact_effects.go
+++ b/internal/reviewtransaction/compact_effects.go
@@ -69,6 +69,7 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 			return compactEffectPublication{}, errors.New("applied compact effect marker is immutable") // refusal:by-design operator-knowledge: a caller may only replay the exact applied value
 		}
 		if old.State == compactEffectDurabilityLimited && marker.State != compactEffectApplied {
+			// refusal:by-design operator-knowledge: callers must only promote a durability-limited marker to applied
 			return compactEffectPublication{}, errors.New("compact effect marker transition regressed")
 		}
 		if old.State == compactEffectBlocked && marker.State == compactEffectPending {
@@ -96,6 +97,7 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 				}
 				got, readErr := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
 				if readErr != nil || got != marker {
+					// refusal:by-design world-action: the filesystem did not retain the durability marker
 					return publication, errors.New("compact effect marker durability-state rewrite failed")
 				}
 			}

--- a/internal/reviewtransaction/compact_effects.go
+++ b/internal/reviewtransaction/compact_effects.go
@@ -17,12 +17,14 @@ type compactEffectMarkerState string
 type compactEffectObservation string
 
 const (
-	compactEffectPending          compactEffectMarkerState = "pending"
-	compactEffectBlocked          compactEffectMarkerState = "blocked_conflict"
-	compactEffectApplied          compactEffectMarkerState = "applied"
-	compactEffectPendingTransient compactEffectObservation = "pending_transient"
-	compactEffectBlockedConflict  compactEffectObservation = "blocked_conflict"
-	compactEffectPlatformLimited  compactEffectObservation = "platform_durability_limited"
+	compactEffectPending           compactEffectMarkerState = "pending"
+	compactEffectBlocked           compactEffectMarkerState = "blocked_conflict"
+	compactEffectApplied           compactEffectMarkerState = "applied"
+	compactEffectDurabilityLimited compactEffectMarkerState = "durability_limited"
+	compactEffectPendingTransient  compactEffectObservation = "pending_transient"
+	compactEffectBlockedConflict   compactEffectObservation = "blocked_conflict"
+	compactEffectPlatformLimited   compactEffectObservation = "platform_durability_limited"
+	compactEffectAppliedDurable    compactEffectObservation = "applied_durable"
 )
 
 type compactEffectMarker struct {
@@ -66,6 +68,9 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 			}
 			return compactEffectPublication{}, errors.New("applied compact effect marker is immutable") // refusal:by-design operator-knowledge: a caller may only replay the exact applied value
 		}
+		if old.State == compactEffectDurabilityLimited && marker.State != compactEffectApplied {
+			return compactEffectPublication{}, errors.New("compact effect marker transition regressed")
+		}
 		if old.State == compactEffectBlocked && marker.State == compactEffectPending {
 			return compactEffectPublication{}, errors.New("compact effect marker transition regressed") // refusal:by-design operator-knowledge: callers must submit a monotonic state
 		}
@@ -80,6 +85,21 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 			return publication, err
 		}
 		publication.DurabilityLimited = true
+		if marker.State == compactEffectApplied {
+			marker.State = compactEffectDurabilityLimited
+			marker.Observation = compactEffectPlatformLimited
+			payload, _ = json.Marshal(marker)
+			if rewriteErr := writeAtomic(path, append(payload, '\n'), 0o600); rewriteErr != nil {
+				var limitedSyncErr *directorySyncError
+				if !errors.As(rewriteErr, &limitedSyncErr) {
+					return publication, rewriteErr
+				}
+				got, readErr := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
+				if readErr != nil || got != marker {
+					return publication, errors.New("compact effect marker durability-state rewrite failed")
+				}
+			}
+		}
 	}
 	got, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
 	if err != nil || got != marker {
@@ -114,8 +134,8 @@ func (repository compactEffectMarkerRepository) read(lineageID, revision, eventI
 }
 
 func validateCompactEffectMarker(marker compactEffectMarker, lineageID, revision, eventID string) error {
-	validState := marker.State == compactEffectPending || marker.State == compactEffectBlocked || marker.State == compactEffectApplied
-	validObservation := marker.Observation == compactEffectPendingTransient || marker.Observation == compactEffectBlockedConflict || marker.Observation == compactEffectPlatformLimited
+	validState := marker.State == compactEffectPending || marker.State == compactEffectBlocked || marker.State == compactEffectApplied || marker.State == compactEffectDurabilityLimited
+	validObservation := marker.Observation == compactEffectPendingTransient || marker.Observation == compactEffectBlockedConflict || marker.Observation == compactEffectPlatformLimited || marker.Observation == compactEffectAppliedDurable
 	if marker.Schema != compactEffectMarkerSchema || marker.LineageID != lineageID || marker.AuthorityRevision != revision || marker.EventID != eventID || !validState || !validObservation {
 		return errors.New("invalid compact effect marker") // refusal:by-design operator-knowledge: marker schema, binding, state, and observation are closed
 	}
@@ -136,8 +156,11 @@ func (repository compactEffectMarkerRepository) path(lineageID, revision, eventI
 				return "", err
 			}
 			info, err := os.Lstat(dir)
-			if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+			if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 				return "", errors.New("unsafe compact effect marker root") // refusal:by-design world-action: private marker storage was substituted or made unsafe
+			}
+			if err := os.Chmod(dir, 0o700); err != nil {
+				return "", err
 			}
 			if err := SyncReviewDirectory(filepath.Dir(dir)); err != nil {
 				return "", err

--- a/internal/reviewtransaction/compact_effects.go
+++ b/internal/reviewtransaction/compact_effects.go
@@ -1,0 +1,152 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const compactEffectMarkerSchema = "gentle-ai.review-effect-marker/v1"
+
+type compactEffectMarkerState string
+type compactEffectObservation string
+
+const (
+	compactEffectPending          compactEffectMarkerState = "pending"
+	compactEffectBlocked          compactEffectMarkerState = "blocked_conflict"
+	compactEffectApplied          compactEffectMarkerState = "applied"
+	compactEffectPendingTransient compactEffectObservation = "pending_transient"
+	compactEffectBlockedConflict  compactEffectObservation = "blocked_conflict"
+	compactEffectPlatformLimited  compactEffectObservation = "platform_durability_limited"
+)
+
+type compactEffectMarker struct {
+	Schema            string                   `json:"schema"`
+	LineageID         string                   `json:"lineage_id"`
+	AuthorityRevision string                   `json:"authority_revision"`
+	EventID           string                   `json:"event_id"`
+	State             compactEffectMarkerState `json:"state"`
+	Observation       compactEffectObservation `json:"observation"`
+}
+
+type compactEffectMarkerRepository struct{ root string }
+type compactEffectPublication struct{ DurabilityLimited bool }
+
+func openCompactEffectMarkerRepository(ctx context.Context, repo string) (compactEffectMarkerRepository, error) {
+	base, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return compactEffectMarkerRepository{}, err
+	}
+	return compactEffectMarkerRepository{root: filepath.Join(base, "effect-markers", "v1")}, nil
+}
+
+func (repository compactEffectMarkerRepository) write(marker compactEffectMarker) (compactEffectPublication, error) {
+	if err := validateCompactEffectMarker(marker, marker.LineageID, marker.AuthorityRevision, marker.EventID); err != nil {
+		return compactEffectPublication{}, err
+	}
+	path, err := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, true)
+	if err != nil {
+		return compactEffectPublication{}, err
+	}
+	lock, err := acquireStoreLockForConvergentCompletion(context.Background(), path+".lock")
+	if err != nil {
+		return compactEffectPublication{}, err
+	}
+	defer lock.release()
+	old, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
+	if err == nil {
+		if old.State == compactEffectApplied {
+			if old == marker {
+				return compactEffectPublication{}, nil
+			}
+			return compactEffectPublication{}, errors.New("applied compact effect marker is immutable") // refusal:by-design operator-knowledge: a caller may only replay the exact applied value
+		}
+		if old.State == compactEffectBlocked && marker.State == compactEffectPending {
+			return compactEffectPublication{}, errors.New("compact effect marker transition regressed") // refusal:by-design operator-knowledge: callers must submit a monotonic state
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return compactEffectPublication{}, err
+	}
+	payload, _ := json.Marshal(marker)
+	publication := compactEffectPublication{}
+	if err := writeAtomic(path, append(payload, '\n'), 0o600); err != nil {
+		var syncErr *directorySyncError
+		if !errors.As(err, &syncErr) {
+			return publication, err
+		}
+		publication.DurabilityLimited = true
+	}
+	got, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
+	if err != nil || got != marker {
+		return publication, errors.New("compact effect marker read-back mismatch") // refusal:by-design world-action: storage did not retain the exact atomic replacement
+	}
+	return publication, nil
+}
+
+func (repository compactEffectMarkerRepository) read(lineageID, revision, eventID string) (compactEffectMarker, error) {
+	path, err := repository.path(lineageID, revision, eventID, false)
+	if err != nil {
+		return compactEffectMarker{}, err
+	}
+	payload, err := readPrivateRARFile(path)
+	if err != nil {
+		return compactEffectMarker{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var marker compactEffectMarker
+	if decoder.Decode(&marker) != nil {
+		return compactEffectMarker{}, errors.New("invalid compact effect marker JSON") // refusal:by-design world-action: private persisted marker bytes are corrupt
+	}
+	var extra any
+	if decoder.Decode(&extra) != io.EOF {
+		return compactEffectMarker{}, errors.New("invalid compact effect marker JSON") // refusal:by-design world-action: private persisted marker bytes are corrupt
+	}
+	if err := validateCompactEffectMarker(marker, lineageID, revision, eventID); err != nil {
+		return compactEffectMarker{}, err
+	}
+	return marker, nil
+}
+
+func validateCompactEffectMarker(marker compactEffectMarker, lineageID, revision, eventID string) error {
+	validState := marker.State == compactEffectPending || marker.State == compactEffectBlocked || marker.State == compactEffectApplied
+	validObservation := marker.Observation == compactEffectPendingTransient || marker.Observation == compactEffectBlockedConflict || marker.Observation == compactEffectPlatformLimited
+	if marker.Schema != compactEffectMarkerSchema || marker.LineageID != lineageID || marker.AuthorityRevision != revision || marker.EventID != eventID || !validState || !validObservation {
+		return errors.New("invalid compact effect marker") // refusal:by-design operator-knowledge: marker schema, binding, state, and observation are closed
+	}
+	return nil
+}
+
+func (repository compactEffectMarkerRepository) path(lineageID, revision, eventID string, create bool) (string, error) {
+	if validateLineageID(lineageID) != nil || !validSHA256(revision) || !validSHA256(eventID) {
+		return "", errors.New("invalid compact effect marker identity") // refusal:by-design operator-knowledge: marker identities must be validated authority components
+	}
+	if create {
+		base := filepath.Dir(filepath.Dir(repository.root))
+		if err := os.MkdirAll(base, 0o700); err != nil {
+			return "", err
+		}
+		for _, dir := range []string{base, filepath.Dir(repository.root), repository.root} {
+			if err := os.Mkdir(dir, 0o700); err != nil && !errors.Is(err, fs.ErrExist) {
+				return "", err
+			}
+			info, err := os.Lstat(dir)
+			if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+				return "", errors.New("unsafe compact effect marker root") // refusal:by-design world-action: private marker storage was substituted or made unsafe
+			}
+			if err := SyncReviewDirectory(filepath.Dir(dir)); err != nil {
+				return "", err
+			}
+		}
+	}
+	dir := filepath.Join(repository.root, lineageID, revision[7:])
+	if err := ensurePrivateRARDirectoryTree(repository.root, dir, create); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, eventID[7:]+".json"), nil
+}

--- a/internal/reviewtransaction/compact_effects_test.go
+++ b/internal/reviewtransaction/compact_effects_test.go
@@ -63,7 +63,7 @@ func TestCompactEffectMarkerStrictValidation(t *testing.T) {
 	}{
 		{"malformed", []byte("{")},
 		{"trailing JSON", append(append([]byte(nil), valid...), []byte("{}")...)},
-		{"unknown field", []byte(`{"schema":"gentle-ai.review-effect-marker/v1","lineage_id":"strict-validation","authority_revision":"` + hash("a") + `","event_id":"` + hash("b") + `","state":"pending","observation":"bounded","extra":true}`)},
+		{"unknown field", []byte(`{"schema":"gentle-ai.review-effect-marker/v1","lineage_id":"strict-validation","authority_revision":"` + hash("a") + `","event_id":"` + hash("b") + `","state":"pending","observation":"pending_transient","extra":true}`)},
 		{"wrong schema", markerPayload(marker, func(value *compactEffectMarker) { value.Schema = "wrong" })},
 		{"wrong lineage", markerPayload(marker, func(value *compactEffectMarker) { value.LineageID = "wrong" })},
 		{"wrong revision", markerPayload(marker, func(value *compactEffectMarker) { value.AuthorityRevision = hash("c") })},
@@ -116,7 +116,10 @@ func TestCompactEffectMarkerRejectsUnsafeStorageAndIdentity(t *testing.T) {
 func TestCompactEffectMarkerIsPrivateSeparateAndStable(t *testing.T) {
 	repository, marker := newCompactEffectMarkerFixture(t, "private-stable")
 	authority := filepath.Join(filepath.Dir(filepath.Dir(repository.root)), "v2", "authority.json")
-	if err := os.MkdirAll(filepath.Dir(authority), 0o700); err != nil || os.WriteFile(authority, []byte("authority\n"), 0o600) != nil {
+	if err := os.MkdirAll(filepath.Dir(authority), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(authority, []byte("authority\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	beforeAuthority, _ := os.ReadFile(authority)
@@ -234,27 +237,6 @@ func TestCompactRepositoryContextReconciliationPublishesExactIntentOnce(t *testi
 	marker, err := markers.read(state.LineageID, record.Revision, intent.EventID)
 	if err != nil || marker.State != compactEffectApplied {
 		t.Fatalf("marker = %#v, %v", marker, err)
-	}
-}
-
-func TestCompactRepositoryContextReconciliationCompletesEveryIntent(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	repo := initSnapshotRepo(t)
-	state := newCompactTestState(t, repo, "repository-context-multiple")
-	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
-	second := record.EffectIntents[0]
-	second.EventID = "sha256:" + identityHash("second-repository-context-intent")
-	record.EffectIntents = append(record.EffectIntents, second)
-	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
-	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
-		t.Fatal(err)
-	}
-	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
-	for _, intent := range record.EffectIntents {
-		marker, readErr := markers.read(state.LineageID, record.Revision, intent.EventID)
-		if readErr != nil || marker.State != compactEffectApplied {
-			t.Fatalf("intent %s marker = %#v, %v", intent.EventID, marker, readErr)
-		}
 	}
 }
 

--- a/internal/reviewtransaction/compact_effects_test.go
+++ b/internal/reviewtransaction/compact_effects_test.go
@@ -34,9 +34,6 @@ func TestCompactEffectMarkerTransitionsAreMonotonic(t *testing.T) {
 				path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
 				before, _ := os.ReadFile(path)
 				marker.State, marker.Observation = to, observationFor(to)
-				if from == compactEffectApplied && to == compactEffectApplied {
-					marker.Observation = compactEffectPlatformLimited
-				}
 				_, err := repository.write(marker)
 				wantAllowed := from == "" || allowed[[2]compactEffectMarkerState{from, to}]
 				if (err == nil) != wantAllowed {
@@ -123,7 +120,7 @@ func TestCompactEffectMarkerIsPrivateSeparateAndStable(t *testing.T) {
 		t.Fatal(err)
 	}
 	beforeAuthority, _ := os.ReadFile(authority)
-	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	marker.State, marker.Observation = compactEffectApplied, compactEffectAppliedDurable
 	if _, err := repository.write(marker); err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +162,7 @@ func TestCompactEffectMarkerConcurrentWritersConverge(t *testing.T) {
 		}()
 	}
 	wait.Wait()
-	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	marker.State, marker.Observation = compactEffectApplied, compactEffectAppliedDurable
 	if _, err := repository.write(marker); err != nil {
 		t.Fatal(err)
 	}
@@ -206,6 +203,181 @@ func TestCompactEffectMarkerRejectsCallerBeforeMutationAndReportsLimitedDurabili
 	}
 }
 
+func TestCompactRepositoryContextReconciliationPublishesExactIntentOnce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-reconcile")
+	record, payload := compactRepositoryContextIntentFixture(t, repo, state)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
+		t.Fatal(err)
+	}
+	intent := record.EffectIntents[0]
+	path, _ := reviewRepositoryContextPath(intent.Destination)
+	before, err := os.ReadFile(path)
+	if err != nil || hashPayloadBytes(bytes.TrimSuffix(before, []byte{'\n'})) != intent.PayloadHash {
+		t.Fatalf("published payload mismatch: %v", err)
+	}
+	info, _ := os.Stat(path)
+	time.Sleep(20 * time.Millisecond)
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
+		t.Fatal(err)
+	}
+	afterInfo, _ := os.Stat(path)
+	if !info.ModTime().Equal(afterInfo.ModTime()) {
+		t.Fatal("applied retry rewrote repository context")
+	}
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	marker, err := markers.read(state.LineageID, record.Revision, intent.EventID)
+	if err != nil || marker.State != compactEffectApplied {
+		t.Fatalf("marker = %#v, %v", marker, err)
+	}
+}
+
+func TestCompactRepositoryContextReconciliationCompletesEveryIntent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-multiple")
+	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
+	second := record.EffectIntents[0]
+	second.EventID = "sha256:" + identityHash("second-repository-context-intent")
+	record.EffectIntents = append(record.EffectIntents, second)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
+		t.Fatal(err)
+	}
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	for _, intent := range record.EffectIntents {
+		marker, readErr := markers.read(state.LineageID, record.Revision, intent.EventID)
+		if readErr != nil || marker.State != compactEffectApplied {
+			t.Fatalf("intent %s marker = %#v, %v", intent.EventID, marker, readErr)
+		}
+	}
+}
+
+func TestCompactRepositoryContextLimitedDurabilityPromotesOnRetry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-limited")
+	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	path, _ := markers.path(state.LineageID, record.Revision, record.EffectIntents[0].EventID, true)
+	original := syncReviewDirectory
+	syncReviewDirectory = func(dir string) error {
+		if dir == filepath.Dir(path) {
+			return errors.New("injected")
+		}
+		return original(dir)
+	}
+	if err := reconcileCompactRepositoryContext(context.Background(), CompactStore{repo: repo}, record); err == nil {
+		t.Fatal("limited durability reconciled")
+	}
+	syncReviewDirectory = original
+	t.Cleanup(func() { syncReviewDirectory = original })
+	marker, err := markers.read(state.LineageID, record.Revision, record.EffectIntents[0].EventID)
+	if err != nil || marker.State != compactEffectDurabilityLimited || marker.Observation != compactEffectPlatformLimited {
+		t.Fatalf("marker = %#v, %v", marker, err)
+	}
+	if err := reconcileCompactRepositoryContext(context.Background(), CompactStore{repo: repo}, record); err != nil {
+		t.Fatalf("retry did not promote limited marker: %v", err)
+	}
+	marker, err = markers.read(state.LineageID, record.Revision, record.EffectIntents[0].EventID)
+	if err != nil || marker.State != compactEffectApplied || marker.Observation != compactEffectAppliedDurable {
+		t.Fatalf("promoted marker = %#v, %v", marker, err)
+	}
+}
+
+func TestCompactRepositoryContextReconciliationFailsClosedOnIntentMismatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-conflict")
+	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
+	record.EffectIntents[0].PayloadHash = hash("different")
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err == nil {
+		t.Fatal("mismatched intent reconciled")
+	}
+	intent := record.EffectIntents[0]
+	if path, _ := reviewRepositoryContextPath(intent.Destination); func() bool { _, err := os.Stat(path); return !os.IsNotExist(err) }() {
+		t.Fatal("mismatched intent published repository context")
+	}
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	marker, err := markers.read(state.LineageID, record.Revision, intent.EventID)
+	if err != nil || marker.State != compactEffectBlocked {
+		t.Fatalf("marker = %#v, %v", marker, err)
+	}
+}
+
+func TestCompactRepositoryContextMustReconcileBeforeSuccessor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-successor")
+	record, payload := compactRepositoryContextIntentFixture(t, repo, state)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	intent := record.EffectIntents[0]
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	if _, err := markers.write(compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: state.LineageID,
+		AuthorityRevision: record.Revision, EventID: intent.EventID, State: compactEffectBlocked, Observation: compactEffectBlockedConflict}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/test", state); err == nil || !strings.Contains(err.Error(), "reconcile compact predecessor effects") {
+		t.Fatalf("successor error = %v", err)
+	}
+}
+
+func TestCompactRepositoryContextMustReconcileBeforeRecovery(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-recovery")
+	record, payload := compactRepositoryContextIntentFixture(t, repo, state)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	intent := record.EffectIntents[0]
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	if _, err := markers.write(compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: state.LineageID,
+		AuthorityRevision: record.Revision, EventID: intent.EventID, State: compactEffectBlocked, Observation: compactEffectBlockedConflict}); err != nil {
+		t.Fatal(err)
+	}
+	successor := state
+	successor.LineageID = "repository-context-recovery-successor"
+	_, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor,
+	})
+	if err == nil || !strings.Contains(err.Error(), "reconcile recovery predecessor effects") {
+		t.Fatalf("recovery error = %v", err)
+	}
+}
+
+func compactRepositoryContextIntentFixture(t *testing.T, repo string, state CompactState) (CompactRecord, []byte) {
+	t.Helper()
+	statePayload, _ := json.Marshal(state)
+	binding := ReviewRepositoryContextBinding{LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: compactStateRevision(statePayload)}
+	identity, err := reviewRepositoryIdentity(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := reviewRepositoryContextHandle(binding, identity)
+	contextPayload, _ := json.Marshal(reviewRepositoryContextFile{
+		Schema: ReviewRepositoryContextSchema, Handle: handle, LineageID: binding.LineageID,
+		TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+		RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+		GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+	})
+	record, payload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{{Class: "repository_context", Destination: handle, PayloadHash: hashPayloadBytes(contextPayload)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record, payload
+}
+
 func newCompactEffectMarkerFixture(t *testing.T, lineage string) (compactEffectMarkerRepository, compactEffectMarker) {
 	t.Helper()
 	repo := initSnapshotRepo(t)
@@ -221,7 +393,7 @@ func observationFor(state compactEffectMarkerState) compactEffectObservation {
 		return compactEffectBlockedConflict
 	}
 	if state == compactEffectApplied {
-		return compactEffectPlatformLimited
+		return compactEffectAppliedDurable
 	}
 	return compactEffectPendingTransient
 }

--- a/internal/reviewtransaction/compact_effects_test.go
+++ b/internal/reviewtransaction/compact_effects_test.go
@@ -1,0 +1,233 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCompactEffectMarkerTransitionsAreMonotonic(t *testing.T) {
+	states := []compactEffectMarkerState{compactEffectPending, compactEffectBlocked, compactEffectApplied}
+	allowed := map[[2]compactEffectMarkerState]bool{
+		{compactEffectPending, compactEffectPending}: true, {compactEffectPending, compactEffectBlocked}: true, {compactEffectPending, compactEffectApplied}: true,
+		{compactEffectBlocked, compactEffectBlocked}: true, {compactEffectBlocked, compactEffectApplied}: true,
+		{compactEffectApplied, compactEffectApplied}: true,
+	}
+	for _, from := range append([]compactEffectMarkerState{""}, states...) {
+		for _, to := range states {
+			name := string(from) + "_to_" + string(to)
+			t.Run(name, func(t *testing.T) {
+				repository, marker := newCompactEffectMarkerFixture(t, "case"+strings.ReplaceAll(name, "_", "-"))
+				if from != "" {
+					marker.State, marker.Observation = from, observationFor(from)
+					if _, err := repository.write(marker); err != nil {
+						t.Fatal(err)
+					}
+				}
+				path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+				before, _ := os.ReadFile(path)
+				marker.State, marker.Observation = to, observationFor(to)
+				if from == compactEffectApplied && to == compactEffectApplied {
+					marker.Observation = compactEffectPlatformLimited
+				}
+				_, err := repository.write(marker)
+				wantAllowed := from == "" || allowed[[2]compactEffectMarkerState{from, to}]
+				if (err == nil) != wantAllowed {
+					t.Fatalf("write error = %v; allowed = %v", err, wantAllowed)
+				}
+				if !wantAllowed {
+					after, _ := os.ReadFile(path)
+					if !bytes.Equal(before, after) {
+						t.Fatal("rejected regression rewrote marker")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestCompactEffectMarkerStrictValidation(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "strict-validation")
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+	valid, _ := os.ReadFile(path)
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"malformed", []byte("{")},
+		{"trailing JSON", append(append([]byte(nil), valid...), []byte("{}")...)},
+		{"unknown field", []byte(`{"schema":"gentle-ai.review-effect-marker/v1","lineage_id":"strict-validation","authority_revision":"` + hash("a") + `","event_id":"` + hash("b") + `","state":"pending","observation":"bounded","extra":true}`)},
+		{"wrong schema", markerPayload(marker, func(value *compactEffectMarker) { value.Schema = "wrong" })},
+		{"wrong lineage", markerPayload(marker, func(value *compactEffectMarker) { value.LineageID = "wrong" })},
+		{"wrong revision", markerPayload(marker, func(value *compactEffectMarker) { value.AuthorityRevision = hash("c") })},
+		{"wrong event", markerPayload(marker, func(value *compactEffectMarker) { value.EventID = hash("d") })},
+		{"invalid state", markerPayload(marker, func(value *compactEffectMarker) { value.State = "unknown" })},
+		{"invalid observation", markerPayload(marker, func(value *compactEffectMarker) { value.Observation = "unknown" })},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(path, tt.payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); err == nil {
+				t.Fatal("accepted invalid marker")
+			}
+		})
+	}
+}
+
+func TestCompactEffectMarkerRejectsUnsafeStorageAndIdentity(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "unsafe-storage")
+	for _, identity := range []struct{ lineage, revision, event string }{{"../escape", marker.AuthorityRevision, marker.EventID}, {marker.LineageID, "bad", marker.EventID}, {marker.LineageID, marker.AuthorityRevision, "bad"}} {
+		if _, err := repository.path(identity.lineage, identity.revision, identity.event, true); err == nil {
+			t.Fatal("accepted invalid path component")
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(repository.root), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), repository.root); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.write(marker); err == nil {
+		t.Fatal("accepted symlink root")
+	}
+
+	repository, marker = newCompactEffectMarkerFixture(t, "non-regular")
+	path, err := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); err == nil {
+		t.Fatal("accepted non-regular marker")
+	}
+}
+
+func TestCompactEffectMarkerIsPrivateSeparateAndStable(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "private-stable")
+	authority := filepath.Join(filepath.Dir(filepath.Dir(repository.root)), "v2", "authority.json")
+	if err := os.MkdirAll(filepath.Dir(authority), 0o700); err != nil || os.WriteFile(authority, []byte("authority\n"), 0o600) != nil {
+		t.Fatal(err)
+	}
+	beforeAuthority, _ := os.ReadFile(authority)
+	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+	before, _ := os.ReadFile(path)
+	info, _ := os.Stat(path)
+	time.Sleep(20 * time.Millisecond)
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(path)
+	afterInfo, _ := os.Stat(path)
+	afterAuthority, _ := os.ReadFile(authority)
+	if !bytes.Equal(before, after) || !info.ModTime().Equal(afterInfo.ModTime()) || !bytes.Equal(beforeAuthority, afterAuthority) {
+		t.Fatal("exact replay or separate authority bytes changed")
+	}
+	for dir := filepath.Dir(path); dir != filepath.Dir(filepath.Dir(repository.root)); dir = filepath.Dir(dir) {
+		info, err := os.Stat(dir)
+		if err != nil || info.Mode().Perm()&0o077 != 0 {
+			t.Fatalf("directory %q is not private", dir)
+		}
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("marker mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestCompactEffectMarkerConcurrentWritersConverge(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "convergence")
+	var wait sync.WaitGroup
+	for i := range 30 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			candidate := marker
+			candidate.State = []compactEffectMarkerState{compactEffectPending, compactEffectBlocked, compactEffectApplied}[i%3]
+			candidate.Observation = observationFor(candidate.State)
+			_, _ = repository.write(candidate)
+		}()
+	}
+	wait.Wait()
+	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); err != nil || got != marker {
+		t.Fatalf("marker = %#v, %v", got, err)
+	}
+}
+
+func TestCompactEffectMarkerRejectsCallerBeforeMutationAndReportsLimitedDurability(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "publication")
+	marker.Observation = "unknown"
+	if _, err := repository.write(marker); err == nil {
+		t.Fatal("accepted invalid caller marker")
+	}
+	if _, err := os.Stat(filepath.Dir(filepath.Dir(repository.root))); !os.IsNotExist(err) {
+		t.Fatalf("storage mutated: %v", err)
+	}
+	marker.Observation = compactEffectPendingTransient
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	marker.State, marker.Observation = compactEffectBlocked, compactEffectBlockedConflict
+	path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+	original := syncReviewDirectory
+	syncReviewDirectory = func(dir string) error {
+		if dir == filepath.Dir(path) {
+			return errors.New("injected")
+		}
+		return original(dir)
+	}
+	t.Cleanup(func() { syncReviewDirectory = original })
+	result, err := repository.write(marker)
+	if err != nil || !result.DurabilityLimited {
+		t.Fatalf("publication = %#v, %v", result, err)
+	}
+	if got, readErr := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); readErr != nil || got != marker {
+		t.Fatalf("published marker = %#v, %v", got, readErr)
+	}
+}
+
+func newCompactEffectMarkerFixture(t *testing.T, lineage string) (compactEffectMarkerRepository, compactEffectMarker) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	repository, err := openCompactEffectMarkerRepository(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repository, compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: lineage, AuthorityRevision: hash("a"), EventID: hash("b"), State: compactEffectPending, Observation: compactEffectPendingTransient}
+}
+
+func observationFor(state compactEffectMarkerState) compactEffectObservation {
+	if state == compactEffectBlocked {
+		return compactEffectBlockedConflict
+	}
+	if state == compactEffectApplied {
+		return compactEffectPlatformLimited
+	}
+	return compactEffectPendingTransient
+}
+
+func markerPayload(marker compactEffectMarker, mutate func(*compactEffectMarker)) []byte {
+	mutate(&marker)
+	payload, _ := json.Marshal(marker)
+	return payload
+}

--- a/internal/reviewtransaction/compact_repository_context.go
+++ b/internal/reviewtransaction/compact_repository_context.go
@@ -1,0 +1,96 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"path/filepath"
+)
+
+func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, record CompactRecord) error {
+	for _, intent := range record.EffectIntents {
+		if intent.Class != "repository_context" {
+			continue
+		}
+		markers, err := openCompactEffectMarkerRepository(ctx, store.repo)
+		if err != nil {
+			return err
+		}
+		marker := compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: record.State.LineageID,
+			AuthorityRevision: record.Revision, EventID: intent.EventID}
+		if existing, readErr := markers.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); readErr == nil {
+			if existing.State == compactEffectApplied {
+				continue
+			}
+			if existing.State == compactEffectBlocked {
+				return errors.New("repository context effect is blocked by an identity conflict")
+			}
+		} else if !errors.Is(readErr, fs.ErrNotExist) {
+			return readErr
+		}
+
+		binding := ReviewRepositoryContextBinding{LineageID: record.State.LineageID,
+			TargetIdentity: record.State.InitialSnapshot.Identity, Revision: intent.BindingRevision}
+		identity, err := reviewRepositoryIdentity(ctx, store.repo)
+		if err != nil {
+			return writeCompactRepositoryContextMarker(markers, marker, compactEffectPending, compactEffectPendingTransient, err)
+		}
+		handle := reviewRepositoryContextHandle(binding, identity)
+		contextRecord := reviewRepositoryContextFile{
+			Schema: ReviewRepositoryContextSchema, Handle: handle, LineageID: binding.LineageID,
+			TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+			RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+			GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+		}
+		payload, err := json.Marshal(contextRecord)
+		if err != nil {
+			return err
+		}
+		if handle != intent.Destination || hashPayloadBytes(payload) != intent.PayloadHash {
+			return writeCompactRepositoryContextMarker(markers, marker, compactEffectBlocked, compactEffectBlockedConflict,
+				errors.New("repository context effect binding or payload does not match committed intent"))
+		}
+		path, err := reviewRepositoryContextPath(handle)
+		if err == nil {
+			var home string
+			home, err = reviewRepositoryContextHome()
+			if err == nil {
+				var root string
+				root, err = ensureReviewRepositoryContextStorageRoot(home, true)
+				if err == nil {
+					err = ensurePrivateLocatorDirectory(root, filepath.Dir(path))
+				}
+			}
+		}
+		if err == nil {
+			err = publishReviewRepositoryContext(path, append(payload, '\n'))
+		}
+		if err != nil {
+			return writeCompactRepositoryContextMarker(markers, marker, compactEffectPending, compactEffectPendingTransient, err)
+		}
+		if err := writeCompactRepositoryContextMarker(markers, marker, compactEffectApplied, compactEffectAppliedDurable, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeCompactRepositoryContextMarker(repository compactEffectMarkerRepository, marker compactEffectMarker, state compactEffectMarkerState, observation compactEffectObservation, cause error) error {
+	marker.State, marker.Observation = state, observation
+	publication, err := repository.write(marker)
+	if err != nil {
+		return err
+	}
+	if cause != nil {
+		return cause
+	}
+	if publication.DurabilityLimited {
+		return errors.New("repository context marker durability is limited")
+	}
+	return nil
+}
+
+func hashPayloadBytes(payload []byte) string {
+	return "sha256:" + identityHash(string(payload))
+}

--- a/internal/reviewtransaction/compact_repository_context.go
+++ b/internal/reviewtransaction/compact_repository_context.go
@@ -27,6 +27,7 @@ func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, 
 				continue
 			}
 			if existing.State == compactEffectBlocked {
+				// refusal:by-design operator-knowledge: the operator must reconcile which repository identity should own the committed context effect
 				return errors.New("repository context effect is blocked by an identity conflict")
 			}
 		} else if !errors.Is(readErr, fs.ErrNotExist) {
@@ -52,6 +53,7 @@ func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, 
 		}
 		if handle != intent.Destination || hashPayloadBytes(payload) != intent.PayloadHash {
 			return writeCompactRepositoryContextMarker(markers, marker, compactEffectBlocked, compactEffectBlockedConflict,
+				// refusal:by-design operator-knowledge: persisted authority is inconsistent and no operator command may rewrite it
 				errors.New("repository context effect binding or payload does not match committed intent"))
 		}
 		path, err := reviewRepositoryContextPath(handle)
@@ -89,6 +91,7 @@ func writeCompactRepositoryContextMarker(repository compactEffectMarkerRepositor
 		return cause
 	}
 	if publication.DurabilityLimited {
+		// refusal:by-design world-action: durable filesystem persistence must be restored before the marker can be promoted
 		return errors.New("repository context marker durability is limited")
 	}
 	return nil

--- a/internal/reviewtransaction/compact_repository_context.go
+++ b/internal/reviewtransaction/compact_repository_context.go
@@ -9,13 +9,16 @@ import (
 )
 
 func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, record CompactRecord) error {
+	var markers compactEffectMarkerRepository
 	for _, intent := range record.EffectIntents {
-		if intent.Class != "repository_context" {
+		if intent.Class != compactEffectClassRepositoryContext {
 			continue
 		}
-		markers, err := openCompactEffectMarkerRepository(ctx, store.repo)
-		if err != nil {
-			return err
+		if markers.root == "" {
+			var err error
+			if markers, err = openCompactEffectMarkerRepository(ctx, store.repo); err != nil {
+				return err
+			}
 		}
 		marker := compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: record.State.LineageID,
 			AuthorityRevision: record.Revision, EventID: intent.EventID}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -289,6 +289,9 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if err != nil {
 		return CompactRecord{}, fmt.Errorf("load recovery predecessor: %w", err)
 	}
+	if err := reconcileCompactRepositoryContext(ctx, predecessorStore, predecessor); err != nil {
+		return CompactRecord{}, fmt.Errorf("reconcile recovery predecessor effects: %w", err)
+	}
 	if predecessor.Revision != request.ExpectedPredecessorRevision {
 		return CompactRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
 	}
@@ -1929,6 +1932,11 @@ func (store CompactStore) replaceContextGuarded(ctx context.Context, expectedRev
 		current = &loaded
 	} else if !os.IsNotExist(err) {
 		return "", err
+	}
+	if current != nil {
+		if err := reconcileCompactRepositoryContext(ctx, store, *current); err != nil {
+			return "", fmt.Errorf("reconcile compact predecessor effects: %w", err)
+		}
 	}
 	record, payload, err := makeCompactRecord(next)
 	if err != nil {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -17,7 +17,11 @@ import (
 	"time"
 )
 
-const compactRecordSchema = "gentle-ai.review-state-record/v2"
+const (
+	compactRecordSchema                 = "gentle-ai.review-state-record/v2"
+	compactEffectClassRepositoryContext = "repository_context"
+	compactEffectClassRequestedTrace    = "requested_trace"
+)
 
 // Compact store entry artifact names. Every file the compact store writes
 // under a lineage directory must be named here so the reclaim authority
@@ -2281,8 +2285,7 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 	}
 	bindingRevision := compactStateRevision(statePayload)
 	revision := bindingRevision
-	if len(intents) == 0 {
-	} else {
+	if len(intents) > 0 {
 		semantic := make([]struct {
 			Class       string `json:"class"`
 			Destination string `json:"destination"`
@@ -2387,7 +2390,7 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 
 func validateCompactEffectIntents(record CompactRecord) error {
 	for index, intent := range record.EffectIntents {
-		if (intent.Class != "repository_context" && intent.Class != "requested_trace") || strings.TrimSpace(intent.Destination) == "" || !validSHA256(intent.PayloadHash) {
+		if (intent.Class != compactEffectClassRepositoryContext && intent.Class != compactEffectClassRequestedTrace) || strings.TrimSpace(intent.Destination) == "" || !validSHA256(intent.PayloadHash) {
 			// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
 			return errors.New("invalid compact required effect intent")
 		}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -178,11 +178,11 @@ type CompactStore struct {
 }
 
 type CompactEffectIntent struct {
-	Class             string `json:"class"`
-	Destination       string `json:"destination"`
-	PayloadHash       string `json:"payload_hash"`
-	AuthorityRevision string `json:"authority_revision"`
-	EventID           string `json:"event_id"`
+	Class           string `json:"class"`
+	Destination     string `json:"destination"`
+	PayloadHash     string `json:"payload_hash"`
+	BindingRevision string `json:"binding_revision"`
+	EventID         string `json:"event_id"`
 }
 
 type CompactStartAction string
@@ -2271,14 +2271,19 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 	if err != nil {
 		return CompactRecord{}, nil, err
 	}
-	revision := ""
+	bindingRevision := compactStateRevision(statePayload)
+	revision := bindingRevision
 	if len(intents) == 0 {
-		sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
-		revision = "sha256:" + hex.EncodeToString(sum[:])
 	} else {
-		semantic := make([]CompactEffectIntent, len(intents))
+		semantic := make([]struct {
+			Class       string `json:"class"`
+			Destination string `json:"destination"`
+			PayloadHash string `json:"payload_hash"`
+		}, len(intents))
 		for index, intent := range intents {
-			semantic[index] = CompactEffectIntent{Class: intent.Class, Destination: intent.Destination, PayloadHash: intent.PayloadHash}
+			semantic[index].Class = intent.Class
+			semantic[index].Destination = intent.Destination
+			semantic[index].PayloadHash = intent.PayloadHash
 		}
 		semanticPayload, marshalErr := json.Marshal(semantic)
 		if marshalErr != nil {
@@ -2287,12 +2292,12 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 		sum := sha256.Sum256(bytes.Join([][]byte{[]byte("gentle-ai.review-state-effects/v1\x00"), statePayload, semanticPayload}, []byte{0}))
 		revision = "sha256:" + hex.EncodeToString(sum[:])
 		for index := range intents {
-			if intents[index].AuthorityRevision == "" {
-				intents[index].AuthorityRevision = revision
-			} else if intents[index].AuthorityRevision != revision {
-				return CompactRecord{}, nil, errors.New("invalid compact required effect authority") // refusal:by-design operator-knowledge: caller-supplied authority cannot override the enclosing record revision
+			if intents[index].BindingRevision == "" {
+				intents[index].BindingRevision = bindingRevision
+			} else if intents[index].BindingRevision != bindingRevision {
+				return CompactRecord{}, nil, errors.New("invalid compact required effect binding") // refusal:by-design operator-knowledge: caller-supplied binding cannot override the enclosing state identity
 			}
-			eventPayload, _ := json.Marshal([]string{intents[index].AuthorityRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
+			eventPayload, _ := json.Marshal([]string{state.LineageID, intents[index].BindingRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
 			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
 			wantEventID := "sha256:" + hex.EncodeToString(eventSum[:])
 			if intents[index].EventID == "" {
@@ -2309,6 +2314,11 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 		return CompactRecord{}, nil, err
 	}
 	return record, append(payload, '\n'), nil
+}
+
+func compactStateRevision(statePayload []byte) string {
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // CompactRevisionForState derives the exact content-addressed revision without

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -156,9 +156,10 @@ func NewLegacyReadOnlyError(operation, lineageID string) error {
 }
 
 type CompactRecord struct {
-	Schema   string       `json:"schema"`
-	Revision string       `json:"revision"`
-	State    CompactState `json:"state"`
+	Schema        string                `json:"schema"`
+	Revision      string                `json:"revision"`
+	State         CompactState          `json:"state"`
+	EffectIntents []CompactEffectIntent `json:"effect_intents,omitempty"`
 	// HistoricalCompat marks a record loaded through the retired-field
 	// compatibility path; such authority is read-only.
 	HistoricalCompat bool `json:"-"`
@@ -174,6 +175,14 @@ type CompactStore struct {
 	lockPath            string
 	maintenanceLockPath string
 	TracePath           string
+}
+
+type CompactEffectIntent struct {
+	Class             string `json:"class"`
+	Destination       string `json:"destination"`
+	PayloadHash       string `json:"payload_hash"`
+	AuthorityRevision string `json:"authority_revision"`
+	EventID           string `json:"event_id"`
 }
 
 type CompactStartAction string
@@ -2239,12 +2248,62 @@ func reflectCompactReviewData(previous, next CompactState) bool {
 }
 
 func makeCompactRecord(state CompactState) (CompactRecord, []byte, error) {
+	return makeCompactRecordWithIntents(state, nil)
+}
+
+func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectIntent) (CompactRecord, []byte, error) {
+	intents = append([]CompactEffectIntent(nil), intents...)
+	sort.Slice(intents, func(i, j int) bool {
+		if intents[i].Class != intents[j].Class {
+			return intents[i].Class < intents[j].Class
+		}
+		if intents[i].Destination != intents[j].Destination {
+			return intents[i].Destination < intents[j].Destination
+		}
+		return intents[i].PayloadHash < intents[j].PayloadHash
+	})
+	for index := 1; index < len(intents); index++ {
+		if intents[index-1].Class == intents[index].Class && intents[index-1].Destination == intents[index].Destination {
+			return CompactRecord{}, nil, errors.New("duplicate compact required effect intent") // refusal:by-design operator-knowledge: callers must supply one immutable intent per class and destination
+		}
+	}
 	statePayload, err := json.Marshal(state)
 	if err != nil {
 		return CompactRecord{}, nil, err
 	}
-	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
-	record := CompactRecord{Schema: compactRecordSchema, Revision: "sha256:" + hex.EncodeToString(sum[:]), State: state}
+	revision := ""
+	if len(intents) == 0 {
+		sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+		revision = "sha256:" + hex.EncodeToString(sum[:])
+	} else {
+		semantic := make([]CompactEffectIntent, len(intents))
+		for index, intent := range intents {
+			semantic[index] = CompactEffectIntent{Class: intent.Class, Destination: intent.Destination, PayloadHash: intent.PayloadHash}
+		}
+		semanticPayload, marshalErr := json.Marshal(semantic)
+		if marshalErr != nil {
+			return CompactRecord{}, nil, marshalErr
+		}
+		sum := sha256.Sum256(bytes.Join([][]byte{[]byte("gentle-ai.review-state-effects/v1\x00"), statePayload, semanticPayload}, []byte{0}))
+		revision = "sha256:" + hex.EncodeToString(sum[:])
+		for index := range intents {
+			if intents[index].AuthorityRevision == "" {
+				intents[index].AuthorityRevision = revision
+			} else if intents[index].AuthorityRevision != revision {
+				return CompactRecord{}, nil, errors.New("invalid compact required effect authority") // refusal:by-design operator-knowledge: caller-supplied authority cannot override the enclosing record revision
+			}
+			eventPayload, _ := json.Marshal([]string{intents[index].AuthorityRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
+			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
+			wantEventID := "sha256:" + hex.EncodeToString(eventSum[:])
+			if intents[index].EventID == "" {
+				intents[index].EventID = wantEventID
+			} else if intents[index].EventID != wantEventID {
+				// refusal:by-design operator-knowledge: caller-supplied immutable effect identity is inconsistent and cannot be repaired by an operator command
+				return CompactRecord{}, nil, errors.New("invalid compact required effect identity")
+			}
+		}
+	}
+	record := CompactRecord{Schema: compactRecordSchema, Revision: revision, State: state, EffectIntents: intents}
 	payload, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
 		return CompactRecord{}, nil, err
@@ -2293,16 +2352,44 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
 			OutdatedIdentity: historical}
 	}
+	if err := validateCompactEffectIntents(record); err != nil {
+		return CompactRecord{}, err
+	}
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")
 	}
 	if !record.HistoricalCompat {
-		want, _, err := makeCompactRecord(record.State)
+		want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
 		if err != nil || want.Revision != record.Revision {
 			return CompactRecord{}, errors.New("compact review state checksum mismatch")
 		}
 	}
 	return record, nil
+}
+
+func validateCompactEffectIntents(record CompactRecord) error {
+	for index, intent := range record.EffectIntents {
+		if (intent.Class != "repository_context" && intent.Class != "requested_trace") || strings.TrimSpace(intent.Destination) == "" || !validSHA256(intent.PayloadHash) {
+			// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+			return errors.New("invalid compact required effect intent")
+		}
+		if index > 0 {
+			previous := record.EffectIntents[index-1]
+			if previous.Class > intent.Class || (previous.Class == intent.Class && previous.Destination >= intent.Destination) {
+				// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+				return errors.New("compact required effect intents must be unique and canonically ordered")
+			}
+		}
+	}
+	if len(record.EffectIntents) == 0 {
+		return nil
+	}
+	want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
+	if err != nil || want.Revision != record.Revision || !reflect.DeepEqual(want.EffectIntents, record.EffectIntents) {
+		// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+		return errors.New("invalid compact required effect identity")
+	}
+	return nil
 }
 
 func forensicHistoricalCompactRecord(payload []byte, lineageID string) (historicalCompactForensicRecord, bool) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1578,7 +1578,7 @@ func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing
 	}
 }
 
-func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
+func TestCompactEffectIntentMismatchBlocksSuccessor(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	state := newCompactTestState(t, repo, "effect-intent-schema-only")
 	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
@@ -1604,12 +1604,12 @@ func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Replace(record.Revision, "review/complete-review", next); err != nil {
-		t.Fatalf("schema-only intents blocked successor: %v", err)
+	if _, err := store.Replace(record.Revision, "review/complete-review", next); err == nil || !strings.Contains(err.Error(), "binding or payload does not match") {
+		t.Fatalf("successor mismatch error = %v", err)
 	}
 	loaded, err := store.Load()
-	if err != nil || len(loaded.EffectIntents) != 0 {
-		t.Fatalf("successor intents = %#v, %v; want no premature propagation", loaded.EffectIntents, err)
+	if err != nil || loaded.Revision != record.Revision {
+		t.Fatalf("authority after refusal = %#v, %v", loaded, err)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -3,6 +3,8 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"math"
@@ -1465,6 +1467,117 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 	}
 	if _, err := os.Stat(store.StatePath()); !os.IsNotExist(err) {
 		t.Fatalf("cancelled replacement published authority: %v", err)
+	}
+}
+
+func TestCompactRecordEffectIntentIdentity(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "effect-intent-identity")
+	intents := []CompactEffectIntent{
+		{Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c")},
+		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
+	}
+	record, payload, err := makeCompactRecordWithIntents(state, intents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reordered, reorderedPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{intents[1], intents[0]})
+	if err != nil || reordered.Revision != record.Revision || !bytes.Equal(reorderedPayload, payload) {
+		t.Fatalf("reordered intent set = %q, %v; want canonical revision %q and identical bytes", reordered.Revision, err, record.Revision)
+	}
+	if _, _, err := makeCompactRecordWithIntents(state, append(intents, intents[0])); err == nil {
+		t.Fatal("creation accepted duplicate semantic intent")
+	}
+	parsed, err := parseCompactRecord(payload, state.LineageID)
+	if err != nil || parsed.Revision != record.Revision || !reflect.DeepEqual(parsed.EffectIntents, record.EffectIntents) {
+		t.Fatalf("parse intent record = %#v, %v; want revision/intents %#v", parsed, err, record)
+	}
+	legacy, _, err := makeCompactRecord(state)
+	if err != nil || legacy.Revision == record.Revision {
+		t.Fatalf("legacy revision = %q, intent revision = %q, err = %v", legacy.Revision, record.Revision, err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*CompactRecord)
+	}{
+		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
+		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
+		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
+		{"forged authority revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].AuthorityRevision = hash("forged") }},
+		{"coordinated authority and event forgery", func(candidate *CompactRecord) {
+			intent := &candidate.EffectIntents[0]
+			intent.AuthorityRevision = hash("forged")
+			eventPayload, _ := json.Marshal([]string{intent.AuthorityRevision, intent.Class, intent.Destination, intent.PayloadHash})
+			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
+			intent.EventID = "sha256:" + hex.EncodeToString(eventSum[:])
+		}},
+		{"forged event identity", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = hash("forged") }},
+		{"noncanonical order", func(candidate *CompactRecord) {
+			candidate.EffectIntents[0], candidate.EffectIntents[1] = candidate.EffectIntents[1], candidate.EffectIntents[0]
+		}},
+		{"duplicate", func(candidate *CompactRecord) { candidate.EffectIntents[1] = candidate.EffectIntents[0] }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := record
+			candidate.EffectIntents = append([]CompactEffectIntent(nil), record.EffectIntents...)
+			tt.mutate(&candidate)
+			candidatePayload, _ := json.Marshal(candidate)
+			if _, err := parseCompactRecord(candidatePayload, state.LineageID); err == nil {
+				t.Fatalf("accepted invalid intents: %#v", candidate.EffectIntents)
+			}
+		})
+	}
+}
+
+func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {
+	state := newCompactTestState(t, initSnapshotRepo(t), "intent-free-history")
+	statePayload, _ := json.Marshal(state)
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+	wantRevision := "sha256:" + hex.EncodeToString(sum[:])
+	wantBytes, _ := json.MarshalIndent(struct {
+		Schema   string       `json:"schema"`
+		Revision string       `json:"revision"`
+		State    CompactState `json:"state"`
+	}{compactRecordSchema, wantRevision, state}, "", "  ")
+	record, payload, err := makeCompactRecord(state)
+	if err != nil || record.Revision != wantRevision || !bytes.Equal(payload, append(wantBytes, '\n')) {
+		t.Fatalf("intent-free compatibility = %q, %v, bytes equal %t", record.Revision, err, bytes.Equal(payload, append(wantBytes, '\n')))
+	}
+}
+
+func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "effect-intent-schema-only")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, payload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{{
+		Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	next := state
+	results := make([]LensResult, len(next.SelectedLenses))
+	for index, lens := range next.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review completed"}}
+	}
+	if err := next.CompleteReview(CompactReviewInput{
+		LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/complete-review", next); err != nil {
+		t.Fatalf("schema-only intents blocked successor: %v", err)
+	}
+	loaded, err := store.Load()
+	if err != nil || len(loaded.EffectIntents) != 0 {
+		t.Fatalf("successor intents = %#v, %v; want no premature propagation", loaded.EffectIntents, err)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1473,13 +1473,34 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	state := newCompactTestState(t, repo, "effect-intent-identity")
+	statePayload, _ := json.Marshal(state)
+	bindingRevision := compactStateRevision(statePayload)
+	binding := ReviewRepositoryContextBinding{LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: bindingRevision}
+	destination, err := DeriveReviewRepositoryContextHandle(context.Background(), repo, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := reviewRepositoryIdentity(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextPayload, _ := json.Marshal(reviewRepositoryContextFile{
+		Schema: ReviewRepositoryContextSchema, Handle: destination,
+		LineageID: binding.LineageID, TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+		RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+		GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+	})
 	intents := []CompactEffectIntent{
-		{Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c")},
+		{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)},
 		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
 	}
 	record, payload, err := makeCompactRecordWithIntents(state, intents)
 	if err != nil {
 		t.Fatal(err)
+	}
+	retry, retryPayload, retryErr := makeCompactRecordWithIntents(state, intents)
+	if retryErr != nil || !reflect.DeepEqual(retry, record) || !bytes.Equal(retryPayload, payload) || intents[0].BindingRevision != "" || intents[0].EventID != "" {
+		t.Fatalf("same-slice retry mutated input or drifted: record = %#v, err = %v, intents = %#v", retry, retryErr, intents)
 	}
 	reordered, reorderedPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{intents[1], intents[0]})
 	if err != nil || reordered.Revision != record.Revision || !bytes.Equal(reorderedPayload, payload) {
@@ -1493,7 +1514,7 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		t.Fatalf("parse intent record = %#v, %v; want revision/intents %#v", parsed, err, record)
 	}
 	legacy, _, err := makeCompactRecord(state)
-	if err != nil || legacy.Revision == record.Revision {
+	if err != nil || legacy.Revision != bindingRevision || legacy.Revision == record.Revision || record.EffectIntents[0].BindingRevision != bindingRevision {
 		t.Fatalf("legacy revision = %q, intent revision = %q, err = %v", legacy.Revision, record.Revision, err)
 	}
 
@@ -1504,11 +1525,11 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
 		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
 		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
-		{"forged authority revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].AuthorityRevision = hash("forged") }},
-		{"coordinated authority and event forgery", func(candidate *CompactRecord) {
+		{"forged binding revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].BindingRevision = hash("forged") }},
+		{"coordinated binding and event forgery", func(candidate *CompactRecord) {
 			intent := &candidate.EffectIntents[0]
-			intent.AuthorityRevision = hash("forged")
-			eventPayload, _ := json.Marshal([]string{intent.AuthorityRevision, intent.Class, intent.Destination, intent.PayloadHash})
+			intent.BindingRevision = hash("forged")
+			eventPayload, _ := json.Marshal([]string{candidate.State.LineageID, intent.BindingRevision, intent.Class, intent.Destination, intent.PayloadHash})
 			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
 			intent.EventID = "sha256:" + hex.EncodeToString(eventSum[:])
 		}},
@@ -1528,6 +1549,17 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 			}
 		})
 	}
+	otherState := state
+	otherState.LineageID = "effect-intent-other-lineage"
+	other, _, err := makeCompactRecordWithIntents(otherState, []CompactEffectIntent{{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)}, intents[1]})
+	if err != nil || other.EffectIntents[0].EventID == record.EffectIntents[0].EventID {
+		t.Fatalf("lineage-bound event identity = %q, %v; want different from %q", other.EffectIntents[0].EventID, err, record.EffectIntents[0].EventID)
+	}
+}
+
+func hashPayload(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1491,7 +1491,7 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
 	})
 	intents := []CompactEffectIntent{
-		{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)},
+		{Class: "repository_context", Destination: destination, PayloadHash: hashPayloadBytes(contextPayload)},
 		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
 	}
 	record, payload, err := makeCompactRecordWithIntents(state, intents)
@@ -1525,6 +1525,7 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
 		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
 		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
+		{"forged record revision", func(candidate *CompactRecord) { candidate.Revision = hash("forged") }},
 		{"forged binding revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].BindingRevision = hash("forged") }},
 		{"coordinated binding and event forgery", func(candidate *CompactRecord) {
 			intent := &candidate.EffectIntents[0]
@@ -1551,15 +1552,10 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 	}
 	otherState := state
 	otherState.LineageID = "effect-intent-other-lineage"
-	other, _, err := makeCompactRecordWithIntents(otherState, []CompactEffectIntent{{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)}, intents[1]})
+	other, _, err := makeCompactRecordWithIntents(otherState, []CompactEffectIntent{{Class: "repository_context", Destination: destination, PayloadHash: hashPayloadBytes(contextPayload)}, intents[1]})
 	if err != nil || other.EffectIntents[0].EventID == record.EffectIntents[0].EventID {
 		t.Fatalf("lineage-bound event identity = %q, %v; want different from %q", other.EffectIntents[0].EventID, err, record.EffectIntents[0].EventID)
 	}
-}
-
-func hashPayload(payload []byte) string {
-	sum := sha256.Sum256(payload)
-	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {
@@ -1579,6 +1575,7 @@ func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing
 }
 
 func TestCompactEffectIntentMismatchBlocksSuccessor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	repo := initSnapshotRepo(t)
 	state := newCompactTestState(t, repo, "effect-intent-schema-only")
 	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)


### PR DESCRIPTION
## Linked Issue

Closes #1875

---

## PR Type

- [ ] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Reconstruct and publish repository-context effects from compact authority.
- Persist monotonic durable effect outcomes and retry durability-limited publications.
- Require predecessor repository-context reconciliation before successor or recovery transitions.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_effects.go` | Adds durable publication observations and monotonic durability-limited promotion. |
| `internal/reviewtransaction/compact_repository_context.go` | Reconstructs, validates, and idempotently publishes repository-context intents. |
| `internal/reviewtransaction/compact_store.go` | Gates ordinary successors and recovery on predecessor effect reconciliation. |
| `internal/reviewtransaction/*_test.go` | Covers exact publication, replay, conflicts, durability retry, and transition gates. |

---

## Test Plan

- [x] Unit tests pass: `go test ./internal/reviewtransaction`
- [x] Full unit suite passes: `go test ./...`
- [x] Go vet passes: `go vet ./...`
- [x] Go format passes: `go run ./internal/gofmtcheck`
- [x] Receipt validation allows the exact staged candidate at the pre-commit gate.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - N/A; this slice changes internal compact-authority persistence and has focused plus full Go coverage, not a Docker E2E operator flow.
- [ ] Benchmark validation - N/A; this intermediate storage/reconciliation slice does not change the bench corpus, classifier, or exposed lifecycle command behavior.

---

## Budget

339 authored changed lines: 319 additions + 20 deletions. This remains below the 400-line review limit.

## Rollback

Revert commit `8faae0a5a71f16dd6248cac7df653e13c6856ff8` to remove repository-context reconciliation, durability promotion, and successor/recovery gates as one independent work unit.

## Out of Scope

- Requested-trace effect reconciliation.
- CLI/STATUS exposure and operator-facing runtime flow.
- Changes to compact effect-intent schema or repository-context v1 payload format.

## Chain Context

PR2b is an intermediate slice in the #1875 chain. It builds on the PR1 intent identity and PR2a private marker ledger commits already present in this branch ancestry. `Closes #1875` is intentional because this slice must not close the issue.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Requested the appropriate `type:*` label without assuming label authority
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E applicability is explained in the Test Plan
- [x] Benchmark applicability is explained in the Test Plan
- [x] Documentation is not required for this internal intermediate slice
- [x] Commits follow Conventional Commits
- [x] Commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

- Guard population: reconciliation applies only to committed `repository_context` intents in the predecessor compact record. Other intent classes remain untouched for later slices.
- Integrity challenge: destination and payload are reconstructed from committed binding authority and must match both committed destination and payload hash before publication.
- RDD receipt: lineage `review-6d04f5f1ef6489ca`; candidate tree `2daa0a587bc6227129b69b1a8be2f67dd0346d7a`; pre-commit result `allow`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable repository-context updates tied to committed changes.
  * Added validation for conflicting, incomplete, or tampered effect records.
  * Added compatibility for existing records without effect metadata.

* **Bug Fixes**
  * Improved handling of concurrent updates, retries, interrupted operations, and limited durability conditions.
  * Prevented successor updates or recovery until required preceding changes are reconciled.
  * Ensured effect updates are published exactly once and safely rejected when intent or identity does not match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->