### PR TITLE
feat(bench): prove fresh repository context replay

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -668,6 +668,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, managedAssetJourneys()...)
 	journeys = append(journeys, issue2906Journeys()...)
 	journeys = append(journeys, issue2138Journeys()...)
+	journeys = append(journeys, repositoryContextJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -53,6 +53,7 @@ func journeySources() []journeySource {
 		{"journeys_managed_assets.go", managedAssetJourneys()},
 		{"journeys_issue2906.go", issue2906Journeys()},
 		{"journeys_issue_2138.go", issue2138Journeys()},
+		{"journeys_repository_context.go", repositoryContextJourneys()},
 	}
 }
 

--- a/bench/journeys_repository_context.go
+++ b/bench/journeys_repository_context.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type repositoryContextReference struct {
+	Capability     string `json:"capability"`
+	Handle         string `json:"handle"`
+	Revision       string `json:"revision"`
+	TargetIdentity string `json:"target_identity"`
+	EventID        string `json:"event_id"`
+	Outcome        string `json:"outcome"`
+}
+
+type repositoryContextStart struct {
+	LineageID         string                     `json:"lineage_id"`
+	RepositoryContext repositoryContextReference `json:"repository_context"`
+}
+
+type repositoryContextStatus struct {
+	Authority struct {
+		LineageID string `json:"lineage_id"`
+		Revision  string `json:"revision"`
+	} `json:"authority"`
+	TargetIdentity    string                      `json:"target_identity"`
+	RepositoryContext *repositoryContextReference `json:"repository_context"`
+}
+
+func driveRepositoryContextFreshProcesses(r *journeyRun) error {
+	negotiated, err := readStatusForContract(r, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	if negotiated.NextTransition.Kind != "execute" || negotiated.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("repository-context START transition = %+v", negotiated.NextTransition)
+	}
+	args, err := printedCommandArguments(negotiated.NextTransition.Execute.Command)
+	if err != nil {
+		return err
+	}
+	for index, argument := range args {
+		if argument == "--consent=relay" {
+			args[index] = "--consent=granted"
+		}
+	}
+	started := r.run(args, false)
+	var start repositoryContextStart
+	if err := decodeRepositoryContextObservation(r, started, &start, "START"); err != nil {
+		return err
+	}
+	want := start.RepositoryContext
+	if start.LineageID == "" || want.Handle == "" || want.EventID == "" || want.Outcome != "applied" ||
+		want.Revision == "" || want.TargetIdentity == "" {
+		return fmt.Errorf("START repository context = %+v, lineage=%q", want, start.LineageID)
+	}
+	if leaksRepositoryPath(started.Stdout, r.sandbox.Repo) {
+		return fmt.Errorf("START leaked repository path in its public envelope")
+	}
+
+	var capture statusEnvelope
+	for attempt := 1; attempt <= 2; attempt++ {
+		observation := r.run(productArgsFor(r, "review", "status", "--contract", reviewContractV2,
+			"--lineage", start.LineageID, "--next-transition"), false)
+		var status repositoryContextStatus
+		if err := decodeRepositoryContextObservation(r, observation, &status, fmt.Sprintf("STATUS retry %d", attempt)); err != nil {
+			return err
+		}
+		if status.RepositoryContext == nil || *status.RepositoryContext != want ||
+			status.Authority.LineageID != start.LineageID || status.Authority.Revision != want.Revision ||
+			status.TargetIdentity != want.TargetIdentity {
+			return fmt.Errorf("STATUS retry %d changed repository context: authority=%+v context=%+v", attempt, status.Authority, status.RepositoryContext)
+		}
+		if leaksRepositoryPath(observation.Stdout, r.sandbox.Repo) {
+			return fmt.Errorf("STATUS retry %d leaked repository path in its public envelope", attempt)
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &capture); err != nil {
+			return fmt.Errorf("parse STATUS capture binding: %w", err)
+		}
+	}
+
+	foreign := "gairc_v1_" + strings.Repeat("0", 64)
+	if capture.NextTransition.Kind != "collect" || len(capture.NextTransition.Collect.Inputs) != 1 {
+		return fmt.Errorf("STATUS did not publish one capture binding: %+v", capture.NextTransition)
+	}
+	payload, err := synthesizeReviewerResult(capture.NextTransition.Collect.Inputs[0].ArtifactSubject.SubjectHash, capture.paths())
+	if err != nil {
+		return err
+	}
+	input, err := writeScratch(r.sandbox, "foreign-context-reviewer.json", payload)
+	if err != nil {
+		return err
+	}
+	refused := r.run([]string{"review", "capture-result",
+		"--lineage", capture.argument("lineage"), "--target", capture.argument("target"),
+		"--expected-revision", capture.argument("expected-revision"), "--lens", capture.argument("lens"),
+		"--order", capture.argument("order"), "--repository-context", foreign, "--input", input}, false)
+	if refused.ExitCode == 0 || !strings.Contains(refused.Stderr, "repository context") {
+		return fmt.Errorf("foreign repository context was not rejected: exit=%d stderr=%q", refused.ExitCode, firstLine(refused.Stderr))
+	}
+	after := r.run(productArgsFor(r, "review", "status", "--contract", reviewContractV2, "--lineage", start.LineageID, "--next-transition"), false)
+	var unchanged repositoryContextStatus
+	if err := decodeRepositoryContextObservation(r, after, &unchanged, "STATUS after foreign handle"); err != nil {
+		return err
+	}
+	if unchanged.RepositoryContext == nil || *unchanged.RepositoryContext != want {
+		return fmt.Errorf("foreign-handle refusal changed repository context: %+v", unchanged.RepositoryContext)
+	}
+	return nil
+}
+
+func decodeRepositoryContextObservation(r *journeyRun, observation Observation, value any, label string) error {
+	if observation.ExitCode != 0 {
+		return fmt.Errorf("%s exited %d: %s", label, observation.ExitCode, firstLine(observation.Stderr))
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), value); err != nil {
+		return fmt.Errorf("parse %s: %w", label, err)
+	}
+	return nil
+}
+
+func leaksRepositoryPath(output, repo string) bool {
+	return strings.Contains(output, repo) || strings.Contains(output, strings.ReplaceAll(repo, `\`, `\\`))
+}
+
+func repositoryContextJourneys() []Journey {
+	return []Journey{{
+		ID:     "j103-repository-context-survives-fresh-process",
+		Title:  "Repository context reconciliation survives fresh START and STATUS processes",
+		Source: "issue #1875: one committed repository_context event must reconcile path-free and replay idempotently across native CLI processes",
+		Steps: []Step{
+			{Name: "fixture: repository", Fixture: baseRepo},
+			{Name: "fixture: staged ordinary-code candidate", Fixture: stageOrdinaryCode},
+			{Name: "enable review mode only in the disposable journey clone", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--scope", "clone", "--json")},
+			{Name: "drive START, fresh STATUS retries, and foreign-handle refusal", Requires: frozenLineageStatusCapability, Composite: driveRepositoryContextFreshProcesses},
+		},
+	}}
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -87,9 +87,11 @@ func TestPortableSDDFailClosedAuthorityJourneysAreRegistered(t *testing.T) {
 	// 98 -> 99: #3102 adds j101, which drives the root-commit base-diff STATUS
 	// stop that must replace an otherwise unexecutable START transition. 99 ->
 	// 100: #2773 adds j102, which drives the immutable reviewer-context capacity
-	// terminal instead of accepting an impossible reviewer slot.
-	if got := len(seen); got != 100 {
-		t.Errorf("core journey count = %d, want 100", got)
+	// terminal instead of accepting an impossible reviewer slot. 100 -> 101:
+	// #1875 adds j103, which drives repository-context reconciliation across
+	// fresh native START and STATUS processes.
+	if got := len(seen); got != 101 {
+		t.Errorf("core journey count = %d, want 101", got)
 	}
 	for id, found := range want {
 		if !found {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1012,9 +1012,20 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 								lensContextBudgetExceeded = reviewLensContextStatusBudgetExhausted(ctx, root, record.State, record.Revision)
 							}
 							if artifactErr == nil && !lensContextBudgetExceeded {
-								repositoryContext, artifactErr = reviewtransaction.PublishReviewRepositoryContext(ctx, root, reviewtransaction.ReviewRepositoryContextBinding{
-									LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity, Revision: record.Revision,
-								})
+								if hasRepositoryContextIntent(record.EffectIntents) {
+									var reconciled reviewtransaction.CompactRepositoryContextResult
+									reconciled, artifactErr = reviewtransaction.ReconcileCompactRepositoryContext(ctx, store, record)
+									repositoryContext = reconciled.Handle
+									result.RepositoryContext = &ReviewRepositoryContextReference{
+										Capability: reviewtransaction.ReviewRepositoryContextCapability, Handle: reconciled.Handle,
+										Revision: record.Revision, TargetIdentity: record.State.InitialSnapshot.Identity,
+										EventID: reconciled.EventID, Outcome: reconciled.Outcome,
+									}
+								} else {
+									repositoryContext, artifactErr = reviewtransaction.PublishReviewRepositoryContext(ctx, root, reviewtransaction.ReviewRepositoryContextBinding{
+										LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity, Revision: record.Revision,
+									})
+								}
 							}
 							if artifactErr == nil && !lensContextBudgetExceeded {
 								contextBuilder := reviewtransaction.SnapshotBuilder{Repo: root}
@@ -1118,6 +1129,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		return fmt.Errorf("inventory review authority: %w", err)
 	}
 	return encodeReviewJSON(stdout, report)
+}
+
+func hasRepositoryContextIntent(intents []reviewtransaction.CompactEffectIntent) bool {
+	for _, intent := range intents {
+		if intent.Class == "repository_context" {
+			return true
+		}
+	}
+	return false
 }
 
 func RunReviewRecover(args []string, stdout io.Writer) error {
@@ -1960,7 +1980,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		return nil
 	}
 	started, err := reviewtransaction.StartCompactAuthority(ctx, root, reviewtransaction.CompactStartRequest{
-		State: state, TracePath: strings.TrimSpace(*tracePath), ExplicitLineage: explicitLineage, BeforeCreate: beforeCreate,
+		State: state, TracePath: strings.TrimSpace(*tracePath), ExplicitLineage: explicitLineage, RepositoryContext: *contract == ReviewIntegrationContractV2, BeforeCreate: beforeCreate,
 	})
 	if err != nil {
 		return fmt.Errorf("start compact facade review: %w", err)
@@ -2024,18 +2044,27 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	var repositoryContext *ReviewRepositoryContextReference
 	if authority.State == reviewtransaction.StateReviewing &&
 		(started.Action == reviewtransaction.CompactStartCreated || started.Action == reviewtransaction.CompactStartResumed) {
-		binding := reviewtransaction.ReviewRepositoryContextBinding{
-			LineageID: authority.LineageID, TargetIdentity: authority.InitialSnapshot.Identity, Revision: started.Record.Revision,
+		var reconciled reviewtransaction.CompactRepositoryContextResult
+		var contextErr error
+		if hasRepositoryContextIntent(started.Record.EffectIntents) {
+			var store reviewtransaction.CompactStore
+			store, contextErr = reviewtransaction.CompactAuthoritativeStore(ctx, root, authority.LineageID)
+			if contextErr == nil {
+				reconciled, contextErr = reviewtransaction.ReconcileCompactRepositoryContext(ctx, store, started.Record)
+			}
+		} else {
+			reconciled.Handle, contextErr = reviewtransaction.PublishReviewRepositoryContext(ctx, root, reviewtransaction.ReviewRepositoryContextBinding{
+				LineageID: authority.LineageID, TargetIdentity: authority.InitialSnapshot.Identity, Revision: started.Record.Revision,
+			})
 		}
-		handle, contextErr := reviewtransaction.PublishReviewRepositoryContext(ctx, root, binding)
 		if contextErr != nil {
 			return &reviewStartContextError{
 				AuthoritySelected: true, LineageID: authority.LineageID, StoreRevision: started.Record.Revision, Cause: contextErr,
 			}
 		}
 		repositoryContext = &ReviewRepositoryContextReference{
-			Capability: reviewtransaction.ReviewRepositoryContextCapability, Handle: handle, Revision: started.Record.Revision,
-			TargetIdentity: authority.InitialSnapshot.Identity,
+			Capability: reviewtransaction.ReviewRepositoryContextCapability, Handle: reconciled.Handle, Revision: started.Record.Revision,
+			TargetIdentity: authority.InitialSnapshot.Identity, EventID: reconciled.EventID, Outcome: reconciled.Outcome,
 		}
 	}
 	negotiatedResult, err := newReviewIntegrationStartResult(legacyResult, assessment, authority.InitialSnapshot.Kind, frozenContext, repositoryContext, *contract)

--- a/internal/cli/review_repository_context_test.go
+++ b/internal/cli/review_repository_context_test.go
@@ -448,7 +448,7 @@ func TestNegotiatedStartPublishesStableOpaqueRepositoryContext(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 2 }\n", 0o644)
 
-	args := boundNegotiatedStartArgs(t, []string{"--cwd", repo, "--contract", ReviewIntegrationContractV1, "--lineage", "repository-context-start"})
+	args := boundNegotiatedStartArgs(t, []string{"--cwd", repo, "--contract", ReviewIntegrationContractV2, "--lineage", "repository-context-start"})
 	var first bytes.Buffer
 	if err := RunReviewFacadeStart(args, &first); err != nil {
 		t.Fatal(err)
@@ -456,7 +456,8 @@ func TestNegotiatedStartPublishesStableOpaqueRepositoryContext(t *testing.T) {
 	var started ReviewIntegrationStartResult
 	decodeStrictReviewJSON(t, first.Bytes(), &started)
 	if started.RepositoryContext == nil || started.RepositoryContext.Capability != reviewtransaction.ReviewRepositoryContextCapability ||
-		started.RepositoryContext.Handle == "" || !validReviewCapabilitySHA256(started.RepositoryContext.Revision) {
+		started.RepositoryContext.Handle == "" || !validReviewCapabilitySHA256(started.RepositoryContext.Revision) ||
+		!validReviewCapabilitySHA256(started.RepositoryContext.EventID) || started.RepositoryContext.Outcome != reviewtransaction.CompactRepositoryContextApplied {
 		t.Fatalf("repository context = %#v", started.RepositoryContext)
 	}
 	if bytes.Contains(first.Bytes(), []byte(repo)) || bytes.Contains(first.Bytes(), []byte(filepath.Join(repo, ".git"))) {
@@ -478,6 +479,25 @@ func TestNegotiatedStartPublishesStableOpaqueRepositoryContext(t *testing.T) {
 	if retry.Action != string(reviewtransaction.CompactStartResumed) || retry.RepositoryContext == nil ||
 		retry.RepositoryContext.Handle != started.RepositoryContext.Handle || retry.RepositoryContext.Revision != started.RepositoryContext.Revision {
 		t.Fatalf("resumed repository context = %#v", retry)
+	}
+	var statusOutput bytes.Buffer
+	if err := RunReviewStatus([]string{"--cwd", repo, "--contract", ReviewIntegrationContractV2, "--lineage", started.LineageID, "--next-transition"}, &statusOutput); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.RepositoryContext == nil || status.RepositoryContext.Handle != started.RepositoryContext.Handle ||
+		status.RepositoryContext.EventID != started.RepositoryContext.EventID || status.RepositoryContext.Outcome != reviewtransaction.CompactRepositoryContextApplied {
+		t.Fatalf("status repository context = %#v", status.RepositoryContext)
+	}
+}
+
+func TestStatusRepositoryContextIntentSelection(t *testing.T) {
+	if hasRepositoryContextIntent([]reviewtransaction.CompactEffectIntent{{Class: "receipt"}}) {
+		t.Fatal("START/STATUS effect-only authority selected repository context reconciliation")
+	}
+	if !hasRepositoryContextIntent([]reviewtransaction.CompactEffectIntent{{Class: "repository_context"}}) {
+		t.Fatal("repository context authority preserved direct publication fallback")
 	}
 }
 

--- a/internal/cli/review_start_contract.go
+++ b/internal/cli/review_start_contract.go
@@ -46,10 +46,12 @@ type ReviewIntegrationStartResult struct {
 // ReviewRepositoryContextReference is the path-free provider context that a
 // capture transition can carry across process cwd boundaries.
 type ReviewRepositoryContextReference struct {
-	Capability     string `json:"capability"`
-	Handle         string `json:"handle"`
-	Revision       string `json:"revision"`
-	TargetIdentity string `json:"target_identity"`
+	Capability     string                                            `json:"capability"`
+	Handle         string                                            `json:"handle"`
+	Revision       string                                            `json:"revision"`
+	TargetIdentity string                                            `json:"target_identity"`
+	EventID        string                                            `json:"event_id,omitempty"`
+	Outcome        reviewtransaction.CompactRepositoryContextOutcome `json:"outcome,omitempty"`
 }
 
 func newReviewIntegrationStartResult(legacy ReviewFacadeStartResult, assessment reviewtransaction.RiskAssessment, targetMode reviewtransaction.TargetKind, frozenContext *reviewtransaction.FrozenCandidateContext, repositoryContext *ReviewRepositoryContextReference, contracts ...string) (ReviewIntegrationStartResult, error) {

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -87,6 +87,7 @@ type ReviewTargetStatusResult struct {
 	Eligibility            *ReviewActionEligibility                             `json:"eligibility,omitempty"`
 	Forecast               *ReviewForecast                                      `json:"forecast,omitempty"`
 	NextTransition         *ReviewNextTransition                                `json:"next_transition,omitempty"`
+	RepositoryContext      *ReviewRepositoryContextReference                    `json:"repository_context,omitempty"`
 	ValidationRequest      *reviewtransaction.TargetedValidationRequest         `json:"validation_request,omitempty"`
 	FinalVerificationRetry *reviewtransaction.FinalVerificationRetryEligibility `json:"final_verification_retry,omitempty"`
 	decision               reviewtransaction.TargetStatusDecision               `json:"-"`

--- a/internal/reviewtransaction/compact_effects.go
+++ b/internal/reviewtransaction/compact_effects.go
@@ -17,12 +17,14 @@ type compactEffectMarkerState string
 type compactEffectObservation string
 
 const (
-	compactEffectPending          compactEffectMarkerState = "pending"
-	compactEffectBlocked          compactEffectMarkerState = "blocked_conflict"
-	compactEffectApplied          compactEffectMarkerState = "applied"
-	compactEffectPendingTransient compactEffectObservation = "pending_transient"
-	compactEffectBlockedConflict  compactEffectObservation = "blocked_conflict"
-	compactEffectPlatformLimited  compactEffectObservation = "platform_durability_limited"
+	compactEffectPending           compactEffectMarkerState = "pending"
+	compactEffectBlocked           compactEffectMarkerState = "blocked_conflict"
+	compactEffectApplied           compactEffectMarkerState = "applied"
+	compactEffectDurabilityLimited compactEffectMarkerState = "durability_limited"
+	compactEffectPendingTransient  compactEffectObservation = "pending_transient"
+	compactEffectBlockedConflict   compactEffectObservation = "blocked_conflict"
+	compactEffectPlatformLimited   compactEffectObservation = "platform_durability_limited"
+	compactEffectAppliedDurable    compactEffectObservation = "applied_durable"
 )
 
 type compactEffectMarker struct {
@@ -66,6 +68,9 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 			}
 			return compactEffectPublication{}, errors.New("applied compact effect marker is immutable") // refusal:by-design operator-knowledge: a caller may only replay the exact applied value
 		}
+		if old.State == compactEffectDurabilityLimited && marker.State != compactEffectApplied {
+			return compactEffectPublication{}, errors.New("compact effect marker transition regressed")
+		}
 		if old.State == compactEffectBlocked && marker.State == compactEffectPending {
 			return compactEffectPublication{}, errors.New("compact effect marker transition regressed") // refusal:by-design operator-knowledge: callers must submit a monotonic state
 		}
@@ -80,6 +85,21 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 			return publication, err
 		}
 		publication.DurabilityLimited = true
+		if marker.State == compactEffectApplied {
+			marker.State = compactEffectDurabilityLimited
+			marker.Observation = compactEffectPlatformLimited
+			payload, _ = json.Marshal(marker)
+			if rewriteErr := writeAtomic(path, append(payload, '\n'), 0o600); rewriteErr != nil {
+				var limitedSyncErr *directorySyncError
+				if !errors.As(rewriteErr, &limitedSyncErr) {
+					return publication, rewriteErr
+				}
+				got, readErr := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
+				if readErr != nil || got != marker {
+					return publication, errors.New("compact effect marker durability-state rewrite failed")
+				}
+			}
+		}
 	}
 	got, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
 	if err != nil || got != marker {
@@ -114,8 +134,8 @@ func (repository compactEffectMarkerRepository) read(lineageID, revision, eventI
 }
 
 func validateCompactEffectMarker(marker compactEffectMarker, lineageID, revision, eventID string) error {
-	validState := marker.State == compactEffectPending || marker.State == compactEffectBlocked || marker.State == compactEffectApplied
-	validObservation := marker.Observation == compactEffectPendingTransient || marker.Observation == compactEffectBlockedConflict || marker.Observation == compactEffectPlatformLimited
+	validState := marker.State == compactEffectPending || marker.State == compactEffectBlocked || marker.State == compactEffectApplied || marker.State == compactEffectDurabilityLimited
+	validObservation := marker.Observation == compactEffectPendingTransient || marker.Observation == compactEffectBlockedConflict || marker.Observation == compactEffectPlatformLimited || marker.Observation == compactEffectAppliedDurable
 	if marker.Schema != compactEffectMarkerSchema || marker.LineageID != lineageID || marker.AuthorityRevision != revision || marker.EventID != eventID || !validState || !validObservation {
 		return errors.New("invalid compact effect marker") // refusal:by-design operator-knowledge: marker schema, binding, state, and observation are closed
 	}
@@ -136,8 +156,11 @@ func (repository compactEffectMarkerRepository) path(lineageID, revision, eventI
 				return "", err
 			}
 			info, err := os.Lstat(dir)
-			if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+			if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 				return "", errors.New("unsafe compact effect marker root") // refusal:by-design world-action: private marker storage was substituted or made unsafe
+			}
+			if err := os.Chmod(dir, 0o700); err != nil {
+				return "", err
 			}
 			if err := SyncReviewDirectory(filepath.Dir(dir)); err != nil {
 				return "", err

--- a/internal/reviewtransaction/compact_effects.go
+++ b/internal/reviewtransaction/compact_effects.go
@@ -1,0 +1,152 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const compactEffectMarkerSchema = "gentle-ai.review-effect-marker/v1"
+
+type compactEffectMarkerState string
+type compactEffectObservation string
+
+const (
+	compactEffectPending          compactEffectMarkerState = "pending"
+	compactEffectBlocked          compactEffectMarkerState = "blocked_conflict"
+	compactEffectApplied          compactEffectMarkerState = "applied"
+	compactEffectPendingTransient compactEffectObservation = "pending_transient"
+	compactEffectBlockedConflict  compactEffectObservation = "blocked_conflict"
+	compactEffectPlatformLimited  compactEffectObservation = "platform_durability_limited"
+)
+
+type compactEffectMarker struct {
+	Schema            string                   `json:"schema"`
+	LineageID         string                   `json:"lineage_id"`
+	AuthorityRevision string                   `json:"authority_revision"`
+	EventID           string                   `json:"event_id"`
+	State             compactEffectMarkerState `json:"state"`
+	Observation       compactEffectObservation `json:"observation"`
+}
+
+type compactEffectMarkerRepository struct{ root string }
+type compactEffectPublication struct{ DurabilityLimited bool }
+
+func openCompactEffectMarkerRepository(ctx context.Context, repo string) (compactEffectMarkerRepository, error) {
+	base, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return compactEffectMarkerRepository{}, err
+	}
+	return compactEffectMarkerRepository{root: filepath.Join(base, "effect-markers", "v1")}, nil
+}
+
+func (repository compactEffectMarkerRepository) write(marker compactEffectMarker) (compactEffectPublication, error) {
+	if err := validateCompactEffectMarker(marker, marker.LineageID, marker.AuthorityRevision, marker.EventID); err != nil {
+		return compactEffectPublication{}, err
+	}
+	path, err := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, true)
+	if err != nil {
+		return compactEffectPublication{}, err
+	}
+	lock, err := acquireStoreLockForConvergentCompletion(context.Background(), path+".lock")
+	if err != nil {
+		return compactEffectPublication{}, err
+	}
+	defer lock.release()
+	old, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
+	if err == nil {
+		if old.State == compactEffectApplied {
+			if old == marker {
+				return compactEffectPublication{}, nil
+			}
+			return compactEffectPublication{}, errors.New("applied compact effect marker is immutable") // refusal:by-design operator-knowledge: a caller may only replay the exact applied value
+		}
+		if old.State == compactEffectBlocked && marker.State == compactEffectPending {
+			return compactEffectPublication{}, errors.New("compact effect marker transition regressed") // refusal:by-design operator-knowledge: callers must submit a monotonic state
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return compactEffectPublication{}, err
+	}
+	payload, _ := json.Marshal(marker)
+	publication := compactEffectPublication{}
+	if err := writeAtomic(path, append(payload, '\n'), 0o600); err != nil {
+		var syncErr *directorySyncError
+		if !errors.As(err, &syncErr) {
+			return publication, err
+		}
+		publication.DurabilityLimited = true
+	}
+	got, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
+	if err != nil || got != marker {
+		return publication, errors.New("compact effect marker read-back mismatch") // refusal:by-design world-action: storage did not retain the exact atomic replacement
+	}
+	return publication, nil
+}
+
+func (repository compactEffectMarkerRepository) read(lineageID, revision, eventID string) (compactEffectMarker, error) {
+	path, err := repository.path(lineageID, revision, eventID, false)
+	if err != nil {
+		return compactEffectMarker{}, err
+	}
+	payload, err := readPrivateRARFile(path)
+	if err != nil {
+		return compactEffectMarker{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var marker compactEffectMarker
+	if decoder.Decode(&marker) != nil {
+		return compactEffectMarker{}, errors.New("invalid compact effect marker JSON") // refusal:by-design world-action: private persisted marker bytes are corrupt
+	}
+	var extra any
+	if decoder.Decode(&extra) != io.EOF {
+		return compactEffectMarker{}, errors.New("invalid compact effect marker JSON") // refusal:by-design world-action: private persisted marker bytes are corrupt
+	}
+	if err := validateCompactEffectMarker(marker, lineageID, revision, eventID); err != nil {
+		return compactEffectMarker{}, err
+	}
+	return marker, nil
+}
+
+func validateCompactEffectMarker(marker compactEffectMarker, lineageID, revision, eventID string) error {
+	validState := marker.State == compactEffectPending || marker.State == compactEffectBlocked || marker.State == compactEffectApplied
+	validObservation := marker.Observation == compactEffectPendingTransient || marker.Observation == compactEffectBlockedConflict || marker.Observation == compactEffectPlatformLimited
+	if marker.Schema != compactEffectMarkerSchema || marker.LineageID != lineageID || marker.AuthorityRevision != revision || marker.EventID != eventID || !validState || !validObservation {
+		return errors.New("invalid compact effect marker") // refusal:by-design operator-knowledge: marker schema, binding, state, and observation are closed
+	}
+	return nil
+}
+
+func (repository compactEffectMarkerRepository) path(lineageID, revision, eventID string, create bool) (string, error) {
+	if validateLineageID(lineageID) != nil || !validSHA256(revision) || !validSHA256(eventID) {
+		return "", errors.New("invalid compact effect marker identity") // refusal:by-design operator-knowledge: marker identities must be validated authority components
+	}
+	if create {
+		base := filepath.Dir(filepath.Dir(repository.root))
+		if err := os.MkdirAll(base, 0o700); err != nil {
+			return "", err
+		}
+		for _, dir := range []string{base, filepath.Dir(repository.root), repository.root} {
+			if err := os.Mkdir(dir, 0o700); err != nil && !errors.Is(err, fs.ErrExist) {
+				return "", err
+			}
+			info, err := os.Lstat(dir)
+			if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+				return "", errors.New("unsafe compact effect marker root") // refusal:by-design world-action: private marker storage was substituted or made unsafe
+			}
+			if err := SyncReviewDirectory(filepath.Dir(dir)); err != nil {
+				return "", err
+			}
+		}
+	}
+	dir := filepath.Join(repository.root, lineageID, revision[7:])
+	if err := ensurePrivateRARDirectoryTree(repository.root, dir, create); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, eventID[7:]+".json"), nil
+}

--- a/internal/reviewtransaction/compact_effects.go
+++ b/internal/reviewtransaction/compact_effects.go
@@ -69,7 +69,7 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 			return compactEffectPublication{}, errors.New("applied compact effect marker is immutable") // refusal:by-design operator-knowledge: a caller may only replay the exact applied value
 		}
 		if old.State == compactEffectDurabilityLimited && marker.State != compactEffectApplied {
-			return compactEffectPublication{}, errors.New("compact effect marker transition regressed")
+			return compactEffectPublication{}, errors.New("compact effect marker transition regressed") // refusal:by-design operator-knowledge: only an applied retry can promote a durability-limited marker
 		}
 		if old.State == compactEffectBlocked && marker.State == compactEffectPending {
 			return compactEffectPublication{}, errors.New("compact effect marker transition regressed") // refusal:by-design operator-knowledge: callers must submit a monotonic state
@@ -96,7 +96,7 @@ func (repository compactEffectMarkerRepository) write(marker compactEffectMarker
 				}
 				got, readErr := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID)
 				if readErr != nil || got != marker {
-					return publication, errors.New("compact effect marker durability-state rewrite failed")
+					return publication, errors.New("compact effect marker durability-state rewrite failed") // refusal:by-design world-action: storage did not retain the required fail-closed durability state
 				}
 			}
 		}

--- a/internal/reviewtransaction/compact_effects_test.go
+++ b/internal/reviewtransaction/compact_effects_test.go
@@ -34,9 +34,6 @@ func TestCompactEffectMarkerTransitionsAreMonotonic(t *testing.T) {
 				path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
 				before, _ := os.ReadFile(path)
 				marker.State, marker.Observation = to, observationFor(to)
-				if from == compactEffectApplied && to == compactEffectApplied {
-					marker.Observation = compactEffectPlatformLimited
-				}
 				_, err := repository.write(marker)
 				wantAllowed := from == "" || allowed[[2]compactEffectMarkerState{from, to}]
 				if (err == nil) != wantAllowed {
@@ -123,7 +120,7 @@ func TestCompactEffectMarkerIsPrivateSeparateAndStable(t *testing.T) {
 		t.Fatal(err)
 	}
 	beforeAuthority, _ := os.ReadFile(authority)
-	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	marker.State, marker.Observation = compactEffectApplied, compactEffectAppliedDurable
 	if _, err := repository.write(marker); err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +162,7 @@ func TestCompactEffectMarkerConcurrentWritersConverge(t *testing.T) {
 		}()
 	}
 	wait.Wait()
-	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	marker.State, marker.Observation = compactEffectApplied, compactEffectAppliedDurable
 	if _, err := repository.write(marker); err != nil {
 		t.Fatal(err)
 	}
@@ -206,6 +203,181 @@ func TestCompactEffectMarkerRejectsCallerBeforeMutationAndReportsLimitedDurabili
 	}
 }
 
+func TestCompactRepositoryContextReconciliationPublishesExactIntentOnce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-reconcile")
+	record, payload := compactRepositoryContextIntentFixture(t, repo, state)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
+		t.Fatal(err)
+	}
+	intent := record.EffectIntents[0]
+	path, _ := reviewRepositoryContextPath(intent.Destination)
+	before, err := os.ReadFile(path)
+	if err != nil || hashPayloadBytes(bytes.TrimSuffix(before, []byte{'\n'})) != intent.PayloadHash {
+		t.Fatalf("published payload mismatch: %v", err)
+	}
+	info, _ := os.Stat(path)
+	time.Sleep(20 * time.Millisecond)
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
+		t.Fatal(err)
+	}
+	afterInfo, _ := os.Stat(path)
+	if !info.ModTime().Equal(afterInfo.ModTime()) {
+		t.Fatal("applied retry rewrote repository context")
+	}
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	marker, err := markers.read(state.LineageID, record.Revision, intent.EventID)
+	if err != nil || marker.State != compactEffectApplied {
+		t.Fatalf("marker = %#v, %v", marker, err)
+	}
+}
+
+func TestCompactRepositoryContextReconciliationCompletesEveryIntent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-multiple")
+	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
+	second := record.EffectIntents[0]
+	second.EventID = "sha256:" + identityHash("second-repository-context-intent")
+	record.EffectIntents = append(record.EffectIntents, second)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err != nil {
+		t.Fatal(err)
+	}
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	for _, intent := range record.EffectIntents {
+		marker, readErr := markers.read(state.LineageID, record.Revision, intent.EventID)
+		if readErr != nil || marker.State != compactEffectApplied {
+			t.Fatalf("intent %s marker = %#v, %v", intent.EventID, marker, readErr)
+		}
+	}
+}
+
+func TestCompactRepositoryContextLimitedDurabilityPromotesOnRetry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-limited")
+	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	path, _ := markers.path(state.LineageID, record.Revision, record.EffectIntents[0].EventID, true)
+	original := syncReviewDirectory
+	syncReviewDirectory = func(dir string) error {
+		if dir == filepath.Dir(path) {
+			return errors.New("injected")
+		}
+		return original(dir)
+	}
+	if err := reconcileCompactRepositoryContext(context.Background(), CompactStore{repo: repo}, record); err == nil {
+		t.Fatal("limited durability reconciled")
+	}
+	syncReviewDirectory = original
+	t.Cleanup(func() { syncReviewDirectory = original })
+	marker, err := markers.read(state.LineageID, record.Revision, record.EffectIntents[0].EventID)
+	if err != nil || marker.State != compactEffectDurabilityLimited || marker.Observation != compactEffectPlatformLimited {
+		t.Fatalf("marker = %#v, %v", marker, err)
+	}
+	if err := reconcileCompactRepositoryContext(context.Background(), CompactStore{repo: repo}, record); err != nil {
+		t.Fatalf("retry did not promote limited marker: %v", err)
+	}
+	marker, err = markers.read(state.LineageID, record.Revision, record.EffectIntents[0].EventID)
+	if err != nil || marker.State != compactEffectApplied || marker.Observation != compactEffectAppliedDurable {
+		t.Fatalf("promoted marker = %#v, %v", marker, err)
+	}
+}
+
+func TestCompactRepositoryContextReconciliationFailsClosedOnIntentMismatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-conflict")
+	record, _ := compactRepositoryContextIntentFixture(t, repo, state)
+	record.EffectIntents[0].PayloadHash = hash("different")
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := reconcileCompactRepositoryContext(context.Background(), store, record); err == nil {
+		t.Fatal("mismatched intent reconciled")
+	}
+	intent := record.EffectIntents[0]
+	if path, _ := reviewRepositoryContextPath(intent.Destination); func() bool { _, err := os.Stat(path); return !os.IsNotExist(err) }() {
+		t.Fatal("mismatched intent published repository context")
+	}
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	marker, err := markers.read(state.LineageID, record.Revision, intent.EventID)
+	if err != nil || marker.State != compactEffectBlocked {
+		t.Fatalf("marker = %#v, %v", marker, err)
+	}
+}
+
+func TestCompactRepositoryContextMustReconcileBeforeSuccessor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-successor")
+	record, payload := compactRepositoryContextIntentFixture(t, repo, state)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	intent := record.EffectIntents[0]
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	if _, err := markers.write(compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: state.LineageID,
+		AuthorityRevision: record.Revision, EventID: intent.EventID, State: compactEffectBlocked, Observation: compactEffectBlockedConflict}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/test", state); err == nil || !strings.Contains(err.Error(), "reconcile compact predecessor effects") {
+		t.Fatalf("successor error = %v", err)
+	}
+}
+
+func TestCompactRepositoryContextMustReconcileBeforeRecovery(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "repository-context-recovery")
+	record, payload := compactRepositoryContextIntentFixture(t, repo, state)
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	intent := record.EffectIntents[0]
+	markers, _ := openCompactEffectMarkerRepository(context.Background(), repo)
+	if _, err := markers.write(compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: state.LineageID,
+		AuthorityRevision: record.Revision, EventID: intent.EventID, State: compactEffectBlocked, Observation: compactEffectBlockedConflict}); err != nil {
+		t.Fatal(err)
+	}
+	successor := state
+	successor.LineageID = "repository-context-recovery-successor"
+	_, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor,
+	})
+	if err == nil || !strings.Contains(err.Error(), "reconcile recovery predecessor effects") {
+		t.Fatalf("recovery error = %v", err)
+	}
+}
+
+func compactRepositoryContextIntentFixture(t *testing.T, repo string, state CompactState) (CompactRecord, []byte) {
+	t.Helper()
+	statePayload, _ := json.Marshal(state)
+	binding := ReviewRepositoryContextBinding{LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: compactStateRevision(statePayload)}
+	identity, err := reviewRepositoryIdentity(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := reviewRepositoryContextHandle(binding, identity)
+	contextPayload, _ := json.Marshal(reviewRepositoryContextFile{
+		Schema: ReviewRepositoryContextSchema, Handle: handle, LineageID: binding.LineageID,
+		TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+		RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+		GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+	})
+	record, payload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{{Class: "repository_context", Destination: handle, PayloadHash: hashPayloadBytes(contextPayload)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record, payload
+}
+
 func newCompactEffectMarkerFixture(t *testing.T, lineage string) (compactEffectMarkerRepository, compactEffectMarker) {
 	t.Helper()
 	repo := initSnapshotRepo(t)
@@ -221,7 +393,7 @@ func observationFor(state compactEffectMarkerState) compactEffectObservation {
 		return compactEffectBlockedConflict
 	}
 	if state == compactEffectApplied {
-		return compactEffectPlatformLimited
+		return compactEffectAppliedDurable
 	}
 	return compactEffectPendingTransient
 }

--- a/internal/reviewtransaction/compact_effects_test.go
+++ b/internal/reviewtransaction/compact_effects_test.go
@@ -1,0 +1,233 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCompactEffectMarkerTransitionsAreMonotonic(t *testing.T) {
+	states := []compactEffectMarkerState{compactEffectPending, compactEffectBlocked, compactEffectApplied}
+	allowed := map[[2]compactEffectMarkerState]bool{
+		{compactEffectPending, compactEffectPending}: true, {compactEffectPending, compactEffectBlocked}: true, {compactEffectPending, compactEffectApplied}: true,
+		{compactEffectBlocked, compactEffectBlocked}: true, {compactEffectBlocked, compactEffectApplied}: true,
+		{compactEffectApplied, compactEffectApplied}: true,
+	}
+	for _, from := range append([]compactEffectMarkerState{""}, states...) {
+		for _, to := range states {
+			name := string(from) + "_to_" + string(to)
+			t.Run(name, func(t *testing.T) {
+				repository, marker := newCompactEffectMarkerFixture(t, "case"+strings.ReplaceAll(name, "_", "-"))
+				if from != "" {
+					marker.State, marker.Observation = from, observationFor(from)
+					if _, err := repository.write(marker); err != nil {
+						t.Fatal(err)
+					}
+				}
+				path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+				before, _ := os.ReadFile(path)
+				marker.State, marker.Observation = to, observationFor(to)
+				if from == compactEffectApplied && to == compactEffectApplied {
+					marker.Observation = compactEffectPlatformLimited
+				}
+				_, err := repository.write(marker)
+				wantAllowed := from == "" || allowed[[2]compactEffectMarkerState{from, to}]
+				if (err == nil) != wantAllowed {
+					t.Fatalf("write error = %v; allowed = %v", err, wantAllowed)
+				}
+				if !wantAllowed {
+					after, _ := os.ReadFile(path)
+					if !bytes.Equal(before, after) {
+						t.Fatal("rejected regression rewrote marker")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestCompactEffectMarkerStrictValidation(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "strict-validation")
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+	valid, _ := os.ReadFile(path)
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"malformed", []byte("{")},
+		{"trailing JSON", append(append([]byte(nil), valid...), []byte("{}")...)},
+		{"unknown field", []byte(`{"schema":"gentle-ai.review-effect-marker/v1","lineage_id":"strict-validation","authority_revision":"` + hash("a") + `","event_id":"` + hash("b") + `","state":"pending","observation":"bounded","extra":true}`)},
+		{"wrong schema", markerPayload(marker, func(value *compactEffectMarker) { value.Schema = "wrong" })},
+		{"wrong lineage", markerPayload(marker, func(value *compactEffectMarker) { value.LineageID = "wrong" })},
+		{"wrong revision", markerPayload(marker, func(value *compactEffectMarker) { value.AuthorityRevision = hash("c") })},
+		{"wrong event", markerPayload(marker, func(value *compactEffectMarker) { value.EventID = hash("d") })},
+		{"invalid state", markerPayload(marker, func(value *compactEffectMarker) { value.State = "unknown" })},
+		{"invalid observation", markerPayload(marker, func(value *compactEffectMarker) { value.Observation = "unknown" })},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(path, tt.payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); err == nil {
+				t.Fatal("accepted invalid marker")
+			}
+		})
+	}
+}
+
+func TestCompactEffectMarkerRejectsUnsafeStorageAndIdentity(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "unsafe-storage")
+	for _, identity := range []struct{ lineage, revision, event string }{{"../escape", marker.AuthorityRevision, marker.EventID}, {marker.LineageID, "bad", marker.EventID}, {marker.LineageID, marker.AuthorityRevision, "bad"}} {
+		if _, err := repository.path(identity.lineage, identity.revision, identity.event, true); err == nil {
+			t.Fatal("accepted invalid path component")
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(repository.root), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), repository.root); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.write(marker); err == nil {
+		t.Fatal("accepted symlink root")
+	}
+
+	repository, marker = newCompactEffectMarkerFixture(t, "non-regular")
+	path, err := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); err == nil {
+		t.Fatal("accepted non-regular marker")
+	}
+}
+
+func TestCompactEffectMarkerIsPrivateSeparateAndStable(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "private-stable")
+	authority := filepath.Join(filepath.Dir(filepath.Dir(repository.root)), "v2", "authority.json")
+	if err := os.MkdirAll(filepath.Dir(authority), 0o700); err != nil || os.WriteFile(authority, []byte("authority\n"), 0o600) != nil {
+		t.Fatal(err)
+	}
+	beforeAuthority, _ := os.ReadFile(authority)
+	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+	before, _ := os.ReadFile(path)
+	info, _ := os.Stat(path)
+	time.Sleep(20 * time.Millisecond)
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(path)
+	afterInfo, _ := os.Stat(path)
+	afterAuthority, _ := os.ReadFile(authority)
+	if !bytes.Equal(before, after) || !info.ModTime().Equal(afterInfo.ModTime()) || !bytes.Equal(beforeAuthority, afterAuthority) {
+		t.Fatal("exact replay or separate authority bytes changed")
+	}
+	for dir := filepath.Dir(path); dir != filepath.Dir(filepath.Dir(repository.root)); dir = filepath.Dir(dir) {
+		info, err := os.Stat(dir)
+		if err != nil || info.Mode().Perm()&0o077 != 0 {
+			t.Fatalf("directory %q is not private", dir)
+		}
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("marker mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestCompactEffectMarkerConcurrentWritersConverge(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "convergence")
+	var wait sync.WaitGroup
+	for i := range 30 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			candidate := marker
+			candidate.State = []compactEffectMarkerState{compactEffectPending, compactEffectBlocked, compactEffectApplied}[i%3]
+			candidate.Observation = observationFor(candidate.State)
+			_, _ = repository.write(candidate)
+		}()
+	}
+	wait.Wait()
+	marker.State, marker.Observation = compactEffectApplied, compactEffectPlatformLimited
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); err != nil || got != marker {
+		t.Fatalf("marker = %#v, %v", got, err)
+	}
+}
+
+func TestCompactEffectMarkerRejectsCallerBeforeMutationAndReportsLimitedDurability(t *testing.T) {
+	repository, marker := newCompactEffectMarkerFixture(t, "publication")
+	marker.Observation = "unknown"
+	if _, err := repository.write(marker); err == nil {
+		t.Fatal("accepted invalid caller marker")
+	}
+	if _, err := os.Stat(filepath.Dir(filepath.Dir(repository.root))); !os.IsNotExist(err) {
+		t.Fatalf("storage mutated: %v", err)
+	}
+	marker.Observation = compactEffectPendingTransient
+	if _, err := repository.write(marker); err != nil {
+		t.Fatal(err)
+	}
+	marker.State, marker.Observation = compactEffectBlocked, compactEffectBlockedConflict
+	path, _ := repository.path(marker.LineageID, marker.AuthorityRevision, marker.EventID, false)
+	original := syncReviewDirectory
+	syncReviewDirectory = func(dir string) error {
+		if dir == filepath.Dir(path) {
+			return errors.New("injected")
+		}
+		return original(dir)
+	}
+	t.Cleanup(func() { syncReviewDirectory = original })
+	result, err := repository.write(marker)
+	if err != nil || !result.DurabilityLimited {
+		t.Fatalf("publication = %#v, %v", result, err)
+	}
+	if got, readErr := repository.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); readErr != nil || got != marker {
+		t.Fatalf("published marker = %#v, %v", got, readErr)
+	}
+}
+
+func newCompactEffectMarkerFixture(t *testing.T, lineage string) (compactEffectMarkerRepository, compactEffectMarker) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	repository, err := openCompactEffectMarkerRepository(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repository, compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: lineage, AuthorityRevision: hash("a"), EventID: hash("b"), State: compactEffectPending, Observation: compactEffectPendingTransient}
+}
+
+func observationFor(state compactEffectMarkerState) compactEffectObservation {
+	if state == compactEffectBlocked {
+		return compactEffectBlockedConflict
+	}
+	if state == compactEffectApplied {
+		return compactEffectPlatformLimited
+	}
+	return compactEffectPendingTransient
+}
+
+func markerPayload(marker compactEffectMarker, mutate func(*compactEffectMarker)) []byte {
+	mutate(&marker)
+	payload, _ := json.Marshal(marker)
+	return payload
+}

--- a/internal/reviewtransaction/compact_repository_context.go
+++ b/internal/reviewtransaction/compact_repository_context.go
@@ -1,0 +1,96 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"path/filepath"
+)
+
+func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, record CompactRecord) error {
+	for _, intent := range record.EffectIntents {
+		if intent.Class != "repository_context" {
+			continue
+		}
+		markers, err := openCompactEffectMarkerRepository(ctx, store.repo)
+		if err != nil {
+			return err
+		}
+		marker := compactEffectMarker{Schema: compactEffectMarkerSchema, LineageID: record.State.LineageID,
+			AuthorityRevision: record.Revision, EventID: intent.EventID}
+		if existing, readErr := markers.read(marker.LineageID, marker.AuthorityRevision, marker.EventID); readErr == nil {
+			if existing.State == compactEffectApplied {
+				continue
+			}
+			if existing.State == compactEffectBlocked {
+				return errors.New("repository context effect is blocked by an identity conflict")
+			}
+		} else if !errors.Is(readErr, fs.ErrNotExist) {
+			return readErr
+		}
+
+		binding := ReviewRepositoryContextBinding{LineageID: record.State.LineageID,
+			TargetIdentity: record.State.InitialSnapshot.Identity, Revision: intent.BindingRevision}
+		identity, err := reviewRepositoryIdentity(ctx, store.repo)
+		if err != nil {
+			return writeCompactRepositoryContextMarker(markers, marker, compactEffectPending, compactEffectPendingTransient, err)
+		}
+		handle := reviewRepositoryContextHandle(binding, identity)
+		contextRecord := reviewRepositoryContextFile{
+			Schema: ReviewRepositoryContextSchema, Handle: handle, LineageID: binding.LineageID,
+			TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+			RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+			GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+		}
+		payload, err := json.Marshal(contextRecord)
+		if err != nil {
+			return err
+		}
+		if handle != intent.Destination || hashPayloadBytes(payload) != intent.PayloadHash {
+			return writeCompactRepositoryContextMarker(markers, marker, compactEffectBlocked, compactEffectBlockedConflict,
+				errors.New("repository context effect binding or payload does not match committed intent"))
+		}
+		path, err := reviewRepositoryContextPath(handle)
+		if err == nil {
+			var home string
+			home, err = reviewRepositoryContextHome()
+			if err == nil {
+				var root string
+				root, err = ensureReviewRepositoryContextStorageRoot(home, true)
+				if err == nil {
+					err = ensurePrivateLocatorDirectory(root, filepath.Dir(path))
+				}
+			}
+		}
+		if err == nil {
+			err = publishReviewRepositoryContext(path, append(payload, '\n'))
+		}
+		if err != nil {
+			return writeCompactRepositoryContextMarker(markers, marker, compactEffectPending, compactEffectPendingTransient, err)
+		}
+		if err := writeCompactRepositoryContextMarker(markers, marker, compactEffectApplied, compactEffectAppliedDurable, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeCompactRepositoryContextMarker(repository compactEffectMarkerRepository, marker compactEffectMarker, state compactEffectMarkerState, observation compactEffectObservation, cause error) error {
+	marker.State, marker.Observation = state, observation
+	publication, err := repository.write(marker)
+	if err != nil {
+		return err
+	}
+	if cause != nil {
+		return cause
+	}
+	if publication.DurabilityLimited {
+		return errors.New("repository context marker durability is limited")
+	}
+	return nil
+}
+
+func hashPayloadBytes(payload []byte) string {
+	return "sha256:" + identityHash(string(payload))
+}

--- a/internal/reviewtransaction/compact_repository_context.go
+++ b/internal/reviewtransaction/compact_repository_context.go
@@ -8,6 +8,68 @@ import (
 	"path/filepath"
 )
 
+type CompactRepositoryContextOutcome string
+
+const (
+	CompactRepositoryContextApplied           CompactRepositoryContextOutcome = "applied"
+	CompactRepositoryContextPending           CompactRepositoryContextOutcome = "pending"
+	CompactRepositoryContextBlocked           CompactRepositoryContextOutcome = "blocked_conflict"
+	CompactRepositoryContextDurabilityLimited CompactRepositoryContextOutcome = "durability_limited"
+)
+
+type CompactRepositoryContextResult struct {
+	Handle  string
+	EventID string
+	Outcome CompactRepositoryContextOutcome
+}
+
+func compactRepositoryContextIntent(ctx context.Context, repo string, state CompactState) (CompactEffectIntent, error) {
+	statePayload, err := json.Marshal(state)
+	if err != nil {
+		return CompactEffectIntent{}, err
+	}
+	binding := ReviewRepositoryContextBinding{LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: compactStateRevision(statePayload)}
+	identity, err := reviewRepositoryIdentity(ctx, repo)
+	if err != nil {
+		return CompactEffectIntent{}, err
+	}
+	handle := reviewRepositoryContextHandle(binding, identity)
+	payload, err := json.Marshal(reviewRepositoryContextFile{
+		Schema: ReviewRepositoryContextSchema, Handle: handle, LineageID: binding.LineageID,
+		TargetIdentity: binding.TargetIdentity, Revision: binding.Revision, RepositoryIdentity: identity.RepositoryIdentity,
+		RepositoryRoot: identity.RepositoryRoot, GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+	})
+	if err != nil {
+		return CompactEffectIntent{}, err
+	}
+	return CompactEffectIntent{Class: "repository_context", Destination: handle, PayloadHash: hashPayloadBytes(payload)}, nil
+}
+
+func ReconcileCompactRepositoryContext(ctx context.Context, store CompactStore, record CompactRecord) (CompactRepositoryContextResult, error) {
+	var selected *CompactEffectIntent
+	for index := range record.EffectIntents {
+		if record.EffectIntents[index].Class == "repository_context" {
+			if selected != nil {
+				return CompactRepositoryContextResult{}, errors.New("compact authority has multiple repository context effects") // refusal:by-design world-action: persisted authority violates the one-event schema and no operator command may rewrite it
+			}
+			selected = &record.EffectIntents[index]
+		}
+	}
+	if selected == nil {
+		return CompactRepositoryContextResult{}, errors.New("compact authority has no repository context effect") // refusal:by-design operator-knowledge: this reconciler only accepts authority created by negotiated START
+	}
+	err := reconcileCompactRepositoryContext(ctx, store, record)
+	markers, openErr := openCompactEffectMarkerRepository(ctx, store.repo)
+	if openErr != nil {
+		return CompactRepositoryContextResult{}, openErr
+	}
+	marker, readErr := markers.read(record.State.LineageID, record.Revision, selected.EventID)
+	if readErr != nil {
+		return CompactRepositoryContextResult{}, errors.Join(err, readErr)
+	}
+	return CompactRepositoryContextResult{Handle: selected.Destination, EventID: selected.EventID, Outcome: CompactRepositoryContextOutcome(marker.State)}, err
+}
+
 func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, record CompactRecord) error {
 	for _, intent := range record.EffectIntents {
 		if intent.Class != "repository_context" {
@@ -24,7 +86,7 @@ func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, 
 				continue
 			}
 			if existing.State == compactEffectBlocked {
-				return errors.New("repository context effect is blocked by an identity conflict")
+				return errors.New("repository context effect is blocked by an identity conflict") // refusal:by-design world-action: an immutable marker proves committed effect identity conflict
 			}
 		} else if !errors.Is(readErr, fs.ErrNotExist) {
 			return readErr
@@ -49,7 +111,7 @@ func reconcileCompactRepositoryContext(ctx context.Context, store CompactStore, 
 		}
 		if handle != intent.Destination || hashPayloadBytes(payload) != intent.PayloadHash {
 			return writeCompactRepositoryContextMarker(markers, marker, compactEffectBlocked, compactEffectBlockedConflict,
-				errors.New("repository context effect binding or payload does not match committed intent"))
+				errors.New("repository context effect binding or payload does not match committed intent")) // refusal:by-design world-action: committed effect identity cannot be rewritten by an operator
 		}
 		path, err := reviewRepositoryContextPath(handle)
 		if err == nil {
@@ -86,7 +148,7 @@ func writeCompactRepositoryContextMarker(repository compactEffectMarkerRepositor
 		return cause
 	}
 	if publication.DurabilityLimited {
-		return errors.New("repository context marker durability is limited")
+		return errors.New("repository context marker durability is limited") // refusal:by-design world-action: the platform could not prove directory durability; retrying the same event may promote it
 	}
 	return nil
 }

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -289,6 +289,9 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if err != nil {
 		return CompactRecord{}, fmt.Errorf("load recovery predecessor: %w", err)
 	}
+	if err := reconcileCompactRepositoryContext(ctx, predecessorStore, predecessor); err != nil {
+		return CompactRecord{}, fmt.Errorf("reconcile recovery predecessor effects: %w", err)
+	}
 	if predecessor.Revision != request.ExpectedPredecessorRevision {
 		return CompactRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
 	}
@@ -1929,6 +1932,11 @@ func (store CompactStore) replaceContextGuarded(ctx context.Context, expectedRev
 		current = &loaded
 	} else if !os.IsNotExist(err) {
 		return "", err
+	}
+	if current != nil {
+		if err := reconcileCompactRepositoryContext(ctx, store, *current); err != nil {
+			return "", fmt.Errorf("reconcile compact predecessor effects: %w", err)
+		}
 	}
 	record, payload, err := makeCompactRecord(next)
 	if err != nil {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -178,11 +178,11 @@ type CompactStore struct {
 }
 
 type CompactEffectIntent struct {
-	Class             string `json:"class"`
-	Destination       string `json:"destination"`
-	PayloadHash       string `json:"payload_hash"`
-	AuthorityRevision string `json:"authority_revision"`
-	EventID           string `json:"event_id"`
+	Class           string `json:"class"`
+	Destination     string `json:"destination"`
+	PayloadHash     string `json:"payload_hash"`
+	BindingRevision string `json:"binding_revision"`
+	EventID         string `json:"event_id"`
 }
 
 type CompactStartAction string
@@ -2271,14 +2271,19 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 	if err != nil {
 		return CompactRecord{}, nil, err
 	}
-	revision := ""
+	bindingRevision := compactStateRevision(statePayload)
+	revision := bindingRevision
 	if len(intents) == 0 {
-		sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
-		revision = "sha256:" + hex.EncodeToString(sum[:])
 	} else {
-		semantic := make([]CompactEffectIntent, len(intents))
+		semantic := make([]struct {
+			Class       string `json:"class"`
+			Destination string `json:"destination"`
+			PayloadHash string `json:"payload_hash"`
+		}, len(intents))
 		for index, intent := range intents {
-			semantic[index] = CompactEffectIntent{Class: intent.Class, Destination: intent.Destination, PayloadHash: intent.PayloadHash}
+			semantic[index].Class = intent.Class
+			semantic[index].Destination = intent.Destination
+			semantic[index].PayloadHash = intent.PayloadHash
 		}
 		semanticPayload, marshalErr := json.Marshal(semantic)
 		if marshalErr != nil {
@@ -2287,12 +2292,12 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 		sum := sha256.Sum256(bytes.Join([][]byte{[]byte("gentle-ai.review-state-effects/v1\x00"), statePayload, semanticPayload}, []byte{0}))
 		revision = "sha256:" + hex.EncodeToString(sum[:])
 		for index := range intents {
-			if intents[index].AuthorityRevision == "" {
-				intents[index].AuthorityRevision = revision
-			} else if intents[index].AuthorityRevision != revision {
-				return CompactRecord{}, nil, errors.New("invalid compact required effect authority") // refusal:by-design operator-knowledge: caller-supplied authority cannot override the enclosing record revision
+			if intents[index].BindingRevision == "" {
+				intents[index].BindingRevision = bindingRevision
+			} else if intents[index].BindingRevision != bindingRevision {
+				return CompactRecord{}, nil, errors.New("invalid compact required effect binding") // refusal:by-design operator-knowledge: caller-supplied binding cannot override the enclosing state identity
 			}
-			eventPayload, _ := json.Marshal([]string{intents[index].AuthorityRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
+			eventPayload, _ := json.Marshal([]string{state.LineageID, intents[index].BindingRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
 			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
 			wantEventID := "sha256:" + hex.EncodeToString(eventSum[:])
 			if intents[index].EventID == "" {
@@ -2309,6 +2314,11 @@ func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectInt
 		return CompactRecord{}, nil, err
 	}
 	return record, append(payload, '\n'), nil
+}
+
+func compactStateRevision(statePayload []byte) string {
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // CompactRevisionForState derives the exact content-addressed revision without

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -196,9 +196,10 @@ const (
 )
 
 type CompactStartRequest struct {
-	State           CompactState
-	TracePath       string
-	ExplicitLineage bool
+	State             CompactState
+	TracePath         string
+	ExplicitLineage   bool
+	RepositoryContext bool
 	// BeforeCreate runs under the START lock only after existing-authority
 	// selection is exhausted and immediately before a new record is built. It
 	// may validate derived response material without running for resumes.
@@ -1360,12 +1361,25 @@ func StartCompactAuthority(ctx context.Context, repo string, request CompactStar
 			return CompactStartResult{}, err
 		}
 	}
-	record, payload, err := makeCompactRecord(request.State)
+	var intents []CompactEffectIntent
+	if request.RepositoryContext {
+		intent, intentErr := compactRepositoryContextIntent(ctx, requestedStore.repo, request.State)
+		if intentErr != nil {
+			return CompactStartResult{}, intentErr
+		}
+		intents = []CompactEffectIntent{intent}
+	}
+	record, payload, err := makeCompactRecordWithIntents(request.State, intents)
 	if err != nil {
 		return CompactStartResult{}, err
 	}
 	if err := writeAtomic(requestedStore.StatePath(), payload, 0o644); err != nil {
 		return CompactStartResult{}, err
+	}
+	if request.RepositoryContext {
+		if _, err := ReconcileCompactRepositoryContext(ctx, requestedStore, record); err != nil {
+			return CompactStartResult{}, fmt.Errorf("reconcile review start repository context: %w", err)
+		}
 	}
 	if request.TracePath != "" {
 		recordCompactTrace(request.TracePath, CompactTraceEntry{

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -156,9 +156,10 @@ func NewLegacyReadOnlyError(operation, lineageID string) error {
 }
 
 type CompactRecord struct {
-	Schema   string       `json:"schema"`
-	Revision string       `json:"revision"`
-	State    CompactState `json:"state"`
+	Schema        string                `json:"schema"`
+	Revision      string                `json:"revision"`
+	State         CompactState          `json:"state"`
+	EffectIntents []CompactEffectIntent `json:"effect_intents,omitempty"`
 	// HistoricalCompat marks a record loaded through the retired-field
 	// compatibility path; such authority is read-only.
 	HistoricalCompat bool `json:"-"`
@@ -174,6 +175,14 @@ type CompactStore struct {
 	lockPath            string
 	maintenanceLockPath string
 	TracePath           string
+}
+
+type CompactEffectIntent struct {
+	Class             string `json:"class"`
+	Destination       string `json:"destination"`
+	PayloadHash       string `json:"payload_hash"`
+	AuthorityRevision string `json:"authority_revision"`
+	EventID           string `json:"event_id"`
 }
 
 type CompactStartAction string
@@ -2239,12 +2248,62 @@ func reflectCompactReviewData(previous, next CompactState) bool {
 }
 
 func makeCompactRecord(state CompactState) (CompactRecord, []byte, error) {
+	return makeCompactRecordWithIntents(state, nil)
+}
+
+func makeCompactRecordWithIntents(state CompactState, intents []CompactEffectIntent) (CompactRecord, []byte, error) {
+	intents = append([]CompactEffectIntent(nil), intents...)
+	sort.Slice(intents, func(i, j int) bool {
+		if intents[i].Class != intents[j].Class {
+			return intents[i].Class < intents[j].Class
+		}
+		if intents[i].Destination != intents[j].Destination {
+			return intents[i].Destination < intents[j].Destination
+		}
+		return intents[i].PayloadHash < intents[j].PayloadHash
+	})
+	for index := 1; index < len(intents); index++ {
+		if intents[index-1].Class == intents[index].Class && intents[index-1].Destination == intents[index].Destination {
+			return CompactRecord{}, nil, errors.New("duplicate compact required effect intent") // refusal:by-design operator-knowledge: callers must supply one immutable intent per class and destination
+		}
+	}
 	statePayload, err := json.Marshal(state)
 	if err != nil {
 		return CompactRecord{}, nil, err
 	}
-	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
-	record := CompactRecord{Schema: compactRecordSchema, Revision: "sha256:" + hex.EncodeToString(sum[:]), State: state}
+	revision := ""
+	if len(intents) == 0 {
+		sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+		revision = "sha256:" + hex.EncodeToString(sum[:])
+	} else {
+		semantic := make([]CompactEffectIntent, len(intents))
+		for index, intent := range intents {
+			semantic[index] = CompactEffectIntent{Class: intent.Class, Destination: intent.Destination, PayloadHash: intent.PayloadHash}
+		}
+		semanticPayload, marshalErr := json.Marshal(semantic)
+		if marshalErr != nil {
+			return CompactRecord{}, nil, marshalErr
+		}
+		sum := sha256.Sum256(bytes.Join([][]byte{[]byte("gentle-ai.review-state-effects/v1\x00"), statePayload, semanticPayload}, []byte{0}))
+		revision = "sha256:" + hex.EncodeToString(sum[:])
+		for index := range intents {
+			if intents[index].AuthorityRevision == "" {
+				intents[index].AuthorityRevision = revision
+			} else if intents[index].AuthorityRevision != revision {
+				return CompactRecord{}, nil, errors.New("invalid compact required effect authority") // refusal:by-design operator-knowledge: caller-supplied authority cannot override the enclosing record revision
+			}
+			eventPayload, _ := json.Marshal([]string{intents[index].AuthorityRevision, intents[index].Class, intents[index].Destination, intents[index].PayloadHash})
+			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
+			wantEventID := "sha256:" + hex.EncodeToString(eventSum[:])
+			if intents[index].EventID == "" {
+				intents[index].EventID = wantEventID
+			} else if intents[index].EventID != wantEventID {
+				// refusal:by-design operator-knowledge: caller-supplied immutable effect identity is inconsistent and cannot be repaired by an operator command
+				return CompactRecord{}, nil, errors.New("invalid compact required effect identity")
+			}
+		}
+	}
+	record := CompactRecord{Schema: compactRecordSchema, Revision: revision, State: state, EffectIntents: intents}
 	payload, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
 		return CompactRecord{}, nil, err
@@ -2293,16 +2352,44 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
 			OutdatedIdentity: historical}
 	}
+	if err := validateCompactEffectIntents(record); err != nil {
+		return CompactRecord{}, err
+	}
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")
 	}
 	if !record.HistoricalCompat {
-		want, _, err := makeCompactRecord(record.State)
+		want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
 		if err != nil || want.Revision != record.Revision {
 			return CompactRecord{}, errors.New("compact review state checksum mismatch")
 		}
 	}
 	return record, nil
+}
+
+func validateCompactEffectIntents(record CompactRecord) error {
+	for index, intent := range record.EffectIntents {
+		if (intent.Class != "repository_context" && intent.Class != "requested_trace") || strings.TrimSpace(intent.Destination) == "" || !validSHA256(intent.PayloadHash) {
+			// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+			return errors.New("invalid compact required effect intent")
+		}
+		if index > 0 {
+			previous := record.EffectIntents[index-1]
+			if previous.Class > intent.Class || (previous.Class == intent.Class && previous.Destination >= intent.Destination) {
+				// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+				return errors.New("compact required effect intents must be unique and canonically ordered")
+			}
+		}
+	}
+	if len(record.EffectIntents) == 0 {
+		return nil
+	}
+	want, _, err := makeCompactRecordWithIntents(record.State, append([]CompactEffectIntent(nil), record.EffectIntents...))
+	if err != nil || want.Revision != record.Revision || !reflect.DeepEqual(want.EffectIntents, record.EffectIntents) {
+		// refusal:by-design operator-knowledge: persisted authority is corrupt and cannot be repaired by an operator command
+		return errors.New("invalid compact required effect identity")
+	}
+	return nil
 }
 
 func forensicHistoricalCompactRecord(payload []byte, lineageID string) (historicalCompactForensicRecord, bool) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1578,7 +1578,7 @@ func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing
 	}
 }
 
-func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
+func TestCompactEffectIntentMismatchBlocksSuccessor(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	state := newCompactTestState(t, repo, "effect-intent-schema-only")
 	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
@@ -1604,12 +1604,12 @@ func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Replace(record.Revision, "review/complete-review", next); err != nil {
-		t.Fatalf("schema-only intents blocked successor: %v", err)
+	if _, err := store.Replace(record.Revision, "review/complete-review", next); err == nil || !strings.Contains(err.Error(), "binding or payload does not match") {
+		t.Fatalf("successor mismatch error = %v", err)
 	}
 	loaded, err := store.Load()
-	if err != nil || len(loaded.EffectIntents) != 0 {
-		t.Fatalf("successor intents = %#v, %v; want no premature propagation", loaded.EffectIntents, err)
+	if err != nil || loaded.Revision != record.Revision {
+		t.Fatalf("authority after refusal = %#v, %v", loaded, err)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -3,6 +3,8 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"math"
@@ -1465,6 +1467,117 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 	}
 	if _, err := os.Stat(store.StatePath()); !os.IsNotExist(err) {
 		t.Fatalf("cancelled replacement published authority: %v", err)
+	}
+}
+
+func TestCompactRecordEffectIntentIdentity(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "effect-intent-identity")
+	intents := []CompactEffectIntent{
+		{Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c")},
+		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
+	}
+	record, payload, err := makeCompactRecordWithIntents(state, intents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reordered, reorderedPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{intents[1], intents[0]})
+	if err != nil || reordered.Revision != record.Revision || !bytes.Equal(reorderedPayload, payload) {
+		t.Fatalf("reordered intent set = %q, %v; want canonical revision %q and identical bytes", reordered.Revision, err, record.Revision)
+	}
+	if _, _, err := makeCompactRecordWithIntents(state, append(intents, intents[0])); err == nil {
+		t.Fatal("creation accepted duplicate semantic intent")
+	}
+	parsed, err := parseCompactRecord(payload, state.LineageID)
+	if err != nil || parsed.Revision != record.Revision || !reflect.DeepEqual(parsed.EffectIntents, record.EffectIntents) {
+		t.Fatalf("parse intent record = %#v, %v; want revision/intents %#v", parsed, err, record)
+	}
+	legacy, _, err := makeCompactRecord(state)
+	if err != nil || legacy.Revision == record.Revision {
+		t.Fatalf("legacy revision = %q, intent revision = %q, err = %v", legacy.Revision, record.Revision, err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*CompactRecord)
+	}{
+		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
+		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
+		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
+		{"forged authority revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].AuthorityRevision = hash("forged") }},
+		{"coordinated authority and event forgery", func(candidate *CompactRecord) {
+			intent := &candidate.EffectIntents[0]
+			intent.AuthorityRevision = hash("forged")
+			eventPayload, _ := json.Marshal([]string{intent.AuthorityRevision, intent.Class, intent.Destination, intent.PayloadHash})
+			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
+			intent.EventID = "sha256:" + hex.EncodeToString(eventSum[:])
+		}},
+		{"forged event identity", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = hash("forged") }},
+		{"noncanonical order", func(candidate *CompactRecord) {
+			candidate.EffectIntents[0], candidate.EffectIntents[1] = candidate.EffectIntents[1], candidate.EffectIntents[0]
+		}},
+		{"duplicate", func(candidate *CompactRecord) { candidate.EffectIntents[1] = candidate.EffectIntents[0] }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := record
+			candidate.EffectIntents = append([]CompactEffectIntent(nil), record.EffectIntents...)
+			tt.mutate(&candidate)
+			candidatePayload, _ := json.Marshal(candidate)
+			if _, err := parseCompactRecord(candidatePayload, state.LineageID); err == nil {
+				t.Fatalf("accepted invalid intents: %#v", candidate.EffectIntents)
+			}
+		})
+	}
+}
+
+func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {
+	state := newCompactTestState(t, initSnapshotRepo(t), "intent-free-history")
+	statePayload, _ := json.Marshal(state)
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-state/v2\x00"), statePayload...))
+	wantRevision := "sha256:" + hex.EncodeToString(sum[:])
+	wantBytes, _ := json.MarshalIndent(struct {
+		Schema   string       `json:"schema"`
+		Revision string       `json:"revision"`
+		State    CompactState `json:"state"`
+	}{compactRecordSchema, wantRevision, state}, "", "  ")
+	record, payload, err := makeCompactRecord(state)
+	if err != nil || record.Revision != wantRevision || !bytes.Equal(payload, append(wantBytes, '\n')) {
+		t.Fatalf("intent-free compatibility = %q, %v, bytes equal %t", record.Revision, err, bytes.Equal(payload, append(wantBytes, '\n')))
+	}
+}
+
+func TestCompactEffectIntentsRemainSchemaOnly(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, "effect-intent-schema-only")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, payload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{{
+		Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	next := state
+	results := make([]LensResult, len(next.SelectedLenses))
+	for index, lens := range next.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review completed"}}
+	}
+	if err := next.CompleteReview(CompactReviewInput{
+		LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/complete-review", next); err != nil {
+		t.Fatalf("schema-only intents blocked successor: %v", err)
+	}
+	loaded, err := store.Load()
+	if err != nil || len(loaded.EffectIntents) != 0 {
+		t.Fatalf("successor intents = %#v, %v; want no premature propagation", loaded.EffectIntents, err)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1473,13 +1473,34 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	state := newCompactTestState(t, repo, "effect-intent-identity")
+	statePayload, _ := json.Marshal(state)
+	bindingRevision := compactStateRevision(statePayload)
+	binding := ReviewRepositoryContextBinding{LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: bindingRevision}
+	destination, err := DeriveReviewRepositoryContextHandle(context.Background(), repo, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := reviewRepositoryIdentity(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextPayload, _ := json.Marshal(reviewRepositoryContextFile{
+		Schema: ReviewRepositoryContextSchema, Handle: destination,
+		LineageID: binding.LineageID, TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
+		RepositoryIdentity: identity.RepositoryIdentity, RepositoryRoot: identity.RepositoryRoot,
+		GitCommonDir: identity.GitCommonDir, GitDir: identity.GitDir,
+	})
 	intents := []CompactEffectIntent{
-		{Class: "repository_context", Destination: "native-reviewer", PayloadHash: hash("c")},
+		{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)},
 		{Class: "requested_trace", Destination: "requested-output", PayloadHash: hash("d")},
 	}
 	record, payload, err := makeCompactRecordWithIntents(state, intents)
 	if err != nil {
 		t.Fatal(err)
+	}
+	retry, retryPayload, retryErr := makeCompactRecordWithIntents(state, intents)
+	if retryErr != nil || !reflect.DeepEqual(retry, record) || !bytes.Equal(retryPayload, payload) || intents[0].BindingRevision != "" || intents[0].EventID != "" {
+		t.Fatalf("same-slice retry mutated input or drifted: record = %#v, err = %v, intents = %#v", retry, retryErr, intents)
 	}
 	reordered, reorderedPayload, err := makeCompactRecordWithIntents(state, []CompactEffectIntent{intents[1], intents[0]})
 	if err != nil || reordered.Revision != record.Revision || !bytes.Equal(reorderedPayload, payload) {
@@ -1493,7 +1514,7 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		t.Fatalf("parse intent record = %#v, %v; want revision/intents %#v", parsed, err, record)
 	}
 	legacy, _, err := makeCompactRecord(state)
-	if err != nil || legacy.Revision == record.Revision {
+	if err != nil || legacy.Revision != bindingRevision || legacy.Revision == record.Revision || record.EffectIntents[0].BindingRevision != bindingRevision {
 		t.Fatalf("legacy revision = %q, intent revision = %q, err = %v", legacy.Revision, record.Revision, err)
 	}
 
@@ -1504,11 +1525,11 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 		{"unknown class", func(candidate *CompactRecord) { candidate.EffectIntents[0].Class = "unknown" }},
 		{"invalid payload hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].PayloadHash = "invalid" }},
 		{"invalid event hash", func(candidate *CompactRecord) { candidate.EffectIntents[0].EventID = "invalid" }},
-		{"forged authority revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].AuthorityRevision = hash("forged") }},
-		{"coordinated authority and event forgery", func(candidate *CompactRecord) {
+		{"forged binding revision", func(candidate *CompactRecord) { candidate.EffectIntents[0].BindingRevision = hash("forged") }},
+		{"coordinated binding and event forgery", func(candidate *CompactRecord) {
 			intent := &candidate.EffectIntents[0]
-			intent.AuthorityRevision = hash("forged")
-			eventPayload, _ := json.Marshal([]string{intent.AuthorityRevision, intent.Class, intent.Destination, intent.PayloadHash})
+			intent.BindingRevision = hash("forged")
+			eventPayload, _ := json.Marshal([]string{candidate.State.LineageID, intent.BindingRevision, intent.Class, intent.Destination, intent.PayloadHash})
 			eventSum := sha256.Sum256(append([]byte("gentle-ai.review-effect-event/v1\x00"), eventPayload...))
 			intent.EventID = "sha256:" + hex.EncodeToString(eventSum[:])
 		}},
@@ -1528,6 +1549,17 @@ func TestCompactRecordEffectIntentIdentity(t *testing.T) {
 			}
 		})
 	}
+	otherState := state
+	otherState.LineageID = "effect-intent-other-lineage"
+	other, _, err := makeCompactRecordWithIntents(otherState, []CompactEffectIntent{{Class: "repository_context", Destination: destination, PayloadHash: hashPayload(contextPayload)}, intents[1]})
+	if err != nil || other.EffectIntents[0].EventID == record.EffectIntents[0].EventID {
+		t.Fatalf("lineage-bound event identity = %q, %v; want different from %q", other.EffectIntents[0].EventID, err, record.EffectIntents[0].EventID)
+	}
+}
+
+func hashPayload(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func TestCompactRecordWithoutIntentsRetainsHistoricalIdentityAndBytes(t *testing.T) {

--- a/internal/reviewtransaction/repository_context_test.go
+++ b/internal/reviewtransaction/repository_context_test.go
@@ -48,6 +48,51 @@ func TestReviewRepositoryContextPublishesOpaquePrivateBinding(t *testing.T) {
 	}
 }
 
+func TestReviewRepositoryContextValidatesAndReturnsOneRecordSnapshot(t *testing.T) {
+	repo, binding := reviewRepositoryContextFixture(t, "repository-context-snapshot")
+	handle, err := PublishReviewRepositoryContext(context.Background(), repo, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, binding.LineageID)
+	initial, _ := store.Load()
+	loaded, payload := compactRepositoryContextIntentFixture(t, repo, initial.State)
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reconciled, err := ReconcileCompactRepositoryContext(context.Background(), store, loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveReviewRepositoryContextLoadedHook = func() {
+		resolveReviewRepositoryContextLoadedHook = func() {}
+		current, _ := store.Load()
+		next := current.State
+		_ = next.Invalidate("advance after snapshot")
+		_, _ = store.Replace(current.Revision, "review/invalidate", next)
+	}
+	t.Cleanup(func() { resolveReviewRepositoryContextLoadedHook = func() {} })
+	_, resolved, err := ResolveReviewRepositoryContextBinding(context.Background(), handle)
+	binding.Revision = loaded.Revision
+	if err != nil || resolved != binding {
+		t.Fatalf("resolved binding = %#v, %v; want validated snapshot %#v", resolved, err, binding)
+	}
+	if reconciled.Handle != handle {
+		t.Fatalf("reconciled handle = %q, want %q", reconciled.Handle, handle)
+	}
+
+	staleRepo, staleBinding := reviewRepositoryContextFixture(t, "repository-context-stale-direct")
+	staleHandle, _ := PublishReviewRepositoryContext(context.Background(), staleRepo, staleBinding)
+	staleStore, _ := CompactAuthoritativeStore(context.Background(), staleRepo, staleBinding.LineageID)
+	staleRecord, _ := staleStore.Load()
+	staleNext := staleRecord.State
+	_ = staleNext.Invalidate("advance without intent")
+	_, _ = staleStore.Replace(staleRecord.Revision, "review/invalidate", staleNext)
+	if _, _, err := ResolveReviewRepositoryContextBinding(context.Background(), staleHandle); err == nil {
+		t.Fatal("stale direct-published handle jumped to a record without matching intent")
+	}
+}
+
 func TestReviewRepositoryContextRedactsTargetedValidationDerivationCause(t *testing.T) {
 	repo := t.TempDir()
 	cause := &GitCommandError{

--- a/internal/reviewtransaction/repository_locator.go
+++ b/internal/reviewtransaction/repository_locator.go
@@ -266,11 +266,23 @@ func resolveReviewRepositoryContext(ctx context.Context, handle string) (string,
 	if err != nil {
 		return "", ReviewRepositoryContextBinding{}, err
 	}
-	if err := validateLiveReviewRepositoryContext(ctx, root, binding); err != nil {
+	store, err := CompactAuthoritativeStore(ctx, root, binding.LineageID)
+	if err != nil {
 		return "", ReviewRepositoryContextBinding{}, err
 	}
+	record, err := store.LoadContext(ctx)
+	if err != nil {
+		return "", ReviewRepositoryContextBinding{}, err
+	}
+	resolveReviewRepositoryContextLoadedHook()
+	if err := validateReviewRepositoryContextRecord(ctx, root, binding, record); err != nil {
+		return "", ReviewRepositoryContextBinding{}, err
+	}
+	binding.Revision = record.Revision
 	return root, binding, nil
 }
+
+var resolveReviewRepositoryContextLoadedHook = func() {}
 
 // resolveOpaqueReviewRepositoryContext proves the private locator still names
 // its original Git worktree without reading compact authority or Git content.
@@ -361,8 +373,21 @@ func validateLiveReviewRepositoryContext(ctx context.Context, repo string, bindi
 	if err != nil {
 		return err
 	}
-	if record.Revision != binding.Revision || record.State.LineageID != binding.LineageID {
+	return validateReviewRepositoryContextRecord(ctx, repo, binding, record)
+}
+
+func validateReviewRepositoryContextRecord(ctx context.Context, repo string, binding ReviewRepositoryContextBinding, record CompactRecord) error {
+	if record.State.LineageID != binding.LineageID {
 		return errors.New("review repository context is stale or has no live matching authority")
+	}
+	if record.Revision != binding.Revision {
+		matched := false
+		for _, intent := range record.EffectIntents {
+			matched = matched || intent.Class == "repository_context" && intent.BindingRevision == binding.Revision
+		}
+		if !matched {
+			return errors.New("review repository context is stale or has no live matching authority")
+		}
 	}
 	switch record.State.State {
 	case StateReviewing:


### PR DESCRIPTION
## Linked Issue

Closes #1875

## PR Type

- [x] `type:feature` - New feature (non-breaking change that adds functionality)

## Summary

- Adds truthful fresh-process driven proof `j103` for repository-context reconciliation across negotiated START and repeated STATUS processes.
- Proves replay preserves the same path-free handle, event, revision, target, and applied outcome.
- Proves a complete capture request with a foreign repository-context handle fails closed without mutating the reconciled context.

## Chain Context

This is the final #1875 slice after #3127, #3148, #3165, and #3166. The earlier slices bind durable intent, add the effect ledger, reconcile repository context, and expose START/STATUS projection; this slice supplies the truthful driven runtime proof and closes the issue.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_repository_context.go` | Adds `j103` and drives native START, fresh STATUS retries, and foreign-handle refusal. |
| `bench/journeys.go` | Registers the new repository-context journey. |
| `bench/journeys_id_collision_test.go` | Adds the new journey source to collision protection. |
| `bench/journeys_sdd_test.go` | Advances the core journey-count pin from 100 to 101. |

## Test Plan

- [x] Focused driven run: `j103`, 1/1 completed.
- [x] Full driven run: 101/101 completed.
- [x] Independent lineage validation approved the exact staged candidate.
- [x] Pre-commit gate returned `allow` for lineage `review-33483224d9ef9a4c`.

## Budget

- Authored budget: 150 changed lines (147 additions, 3 deletions).
- Limit: 400 changed lines.

## Rollback

Revert commit `4938d84d5b88f2d0c3b43e17bb10c88860617485` to remove `j103`, its registration and collision source, and restore the core journey-count pin without reverting the runtime implementation in #3127, #3148, #3165, or #3166.

## Exclusions

- No runtime or authority implementation changes.
- No additional effect classes, recovery flows, or transport changes.
- No generated `.codegraph` state.
- No changes outside the four approved bench files.

## Contributor Checklist

- [x] PR closes approved issue #1875.
- [x] Exactly one feature checkbox is selected.
- [x] Focused and full driven runtime evidence is recorded.
- [x] Change stays within the 400-line budget.
- [x] Commit follows Conventional Commits and has no AI attribution.

## Receipt

The pre-commit receipt returned `allow` for candidate tree `a5597b8e881bc1fcb59451455d8c33d82e8ae90f` and paths digest `sha256:8378035f6a282c3a168ab12885ebfa032cdf4a43db970a1ffcdba2088c5655ea`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository context reconciliation during review start and status operations.
  * Status responses now include repository context handles, event IDs, and outcomes.
  * Added safeguards to reject mismatched or foreign repository context references.
  * Added support for tracking pending, applied, blocked, and limited-durability outcomes.
* **Bug Fixes**
  * Repository context is now preserved across retries, recovery, and successor operations.
  * Improved validation prevents inconsistent context updates and unauthorized path disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->