### PR TITLE
test(review): pin correction-phase repository-context convergence

### DIFF
--- a/internal/cli/review_correction_context_convergence_test.go
+++ b/internal/cli/review_correction_context_convergence_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCorrectionPhaseRepositoryContextStaysExecutable extends the
+// STATUS/START convergence property (#3150) into the correction phase, where
+// a 2.4.0-rc.7 field report (#2541, 2026-08-13 occurrence) hit its inverse:
+// after the correction moved the authority revision, STATUS re-emitted a
+// transition whose own repository-context binding was rejected as invalid,
+// and re-querying reoffered the identical pairing forever.
+//
+// The property: drive a faithful staged correction cycle — two newly added
+// files, one deterministic CRITICAL finding, accepted forecast, bounded edit,
+// passed repository verification — then execute the targeted-validation input
+// EXACTLY as the provider hands it over, name/value tokens and opaque handle
+// included. The handle must resolve and the immutable corrected tree must
+// answer. Green on Linux today, which is itself evidence: the field failure
+// did not reproduce here, pointing the investigation at Windows
+// repository-identity derivation rather than at the correction flow. If
+// handle re-publication on revision advance ever regresses, this test goes
+// red naming the exact hop.
+func TestCorrectionPhaseRepositoryContextStaysExecutable(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	// Reporter's shape: two newly added source files, staged projection.
+	for name, content := range map[string]string{
+		"alpha.go": "package candidate\n\nfunc Alpha() int { return 1 }\n",
+		"beta.go":  "package candidate\n\nfunc Beta() int { return 2 }\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runReviewCLIGit(t, repo, "add", "alpha.go", "beta.go")
+
+	var startOut bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
+		"--lineage", "probe-2541", "--projection", "staged",
+	}), &startOut); err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut.String())
+	}
+	started := decodeNegotiatedReviewStart(t, startOut.Bytes())
+	t.Logf("started: risk=%s lenses=%v", started.RiskLevel, started.SelectedLenses)
+
+	finalizeArgs := []string{"--cwd", repo, "--lineage", started.LineageID}
+	for index, lens := range started.SelectedLenses {
+		resultPath := filepath.Join(t.TempDir(), fmt.Sprintf("result-%d.json", index))
+		findings := []facadeFinding{}
+		if index == 0 {
+			findings = []facadeFinding{{
+				Location: "alpha.go:1", Severity: "CRITICAL", Claim: "candidate exposes the wrong behavior",
+				ProofRefs:     []string{"exact changed hunk", "reproduced candidate failure"},
+				EvidenceClass: "deterministic", CausalDisposition: "introduced",
+			}}
+		}
+		writeReviewCLIJSON(t, resultPath, facadeReviewerResult{
+			Lens: lens, Findings: findings, Evidence: []string{"inspected the exact frozen candidate"},
+		})
+		finalizeArgs = append(finalizeArgs, "--result", resultPath)
+	}
+	if err := finalizeReviewCLIArgs(t, repo, finalizeArgs, &bytes.Buffer{}); err != nil {
+		t.Fatalf("finalize results: %v", err)
+	}
+	if err := RunReviewFacadeFinalize([]string{
+		"--cwd", repo, "--lineage", started.LineageID, "--correction-lines", "2",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("forecast: %v", err)
+	}
+
+	// Reporter's order: read the correction plan from STATUS FIRST, then edit.
+	kind0, reason0, _, _ := reviewNegotiatedTransition(t, repo, "--lineage", started.LineageID, "--projection", "staged")
+	t.Logf("post-forecast: kind=%s reason=%s", kind0, reason0)
+
+	// The bounded correction: change one staged file and restage it, so the
+	// live staged target moves past the frozen one.
+	if err := os.WriteFile(filepath.Join(repo, "alpha.go"), []byte("package candidate\n\nfunc Alpha() int { return 10 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "alpha.go")
+
+	// Follow the negotiated route exactly as a consumer does, up to eight hops,
+	// satisfying the repository-verification collect the way the facade defines.
+	for hop := 1; hop <= 8; hop++ {
+		statusArgs := []string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+			"--agent", "claude-code", "--next-transition", "--lineage", started.LineageID, "--projection", "staged"}
+		var raw bytes.Buffer
+		if err := RunReview(statusArgs, &raw); err != nil {
+			t.Fatalf("status hop %d: %v", hop, err)
+		}
+		var parsed ReviewTargetStatusResult
+		decodeStrictReviewJSON(t, raw.Bytes(), &parsed)
+		transition := parsed.NextTransition
+		if transition == nil {
+			t.Fatalf("hop %d: no transition", hop)
+		}
+		kind, reason := string(transition.Kind), transition.ReasonCode
+		t.Logf("hop %d: kind=%s reason=%s", hop, kind, reason)
+
+		if kind == "collect" && reason == "correction_repository_verification_required" {
+			target := transitionArgumentValue(t, transition, "target")
+			revision := transitionArgumentValue(t, transition, "expected-revision")
+			passed := filepath.Join(t.TempDir(), "passed.txt")
+			if err := os.WriteFile(passed, []byte("full repository verification passed\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := RunReviewCaptureEvidence([]string{"--cwd", repo, "--lineage", started.LineageID,
+				"--target", target, "--expected-revision", revision,
+				"--outcome", "passed", "--input", passed}, &bytes.Buffer{}); err != nil {
+				t.Fatalf("capture passed evidence: %v", err)
+			}
+			t.Logf("        published passed evidence for %s", target[:24])
+			continue
+		}
+		if kind == "collect" && reason == "targeted_validation_required" {
+			if len(transition.Collect.Inputs) == 0 {
+				t.Fatalf("targeted_validation_required carries no inputs")
+			}
+			input := transition.Collect.Inputs[0]
+			var inputTokens []string
+			for _, argument := range input.Arguments {
+				token := argument.Token
+				if token == "" {
+					token = "--" + argument.Name + "=" + argument.Value
+				}
+				inputTokens = append(inputTokens, token)
+				t.Logf("        input %s", token[:min(88, len(token))])
+			}
+			t.Logf("        capture op=%s; executing inspect-candidate with exact tokens", input.CaptureOperation)
+			var out bytes.Buffer
+			err := RunReview(append(append([]string{"inspect-candidate"}, inputTokens...), "--operation", "name-status"), &out)
+			text := out.String()
+			if strings.Contains(text, "binding is invalid") || strings.Contains(fmt.Sprint(err), "binding is invalid") {
+				t.Fatalf("REPRODUCED at hop %d: the exact provider-issued repository-context was rejected:\n%v\n%s", hop, err, text)
+			}
+			if err != nil {
+				t.Logf("        inspect-candidate ended: %v / %s", err, text[:min(300, len(text))])
+				return
+			}
+			t.Logf("        inspect-candidate ok (%d bytes); probe goal reached — the handle resolved", len(text))
+			return
+		}
+		if kind != "execute" {
+			t.Logf("        collect/stop reached; probe stops here")
+			return
+		}
+		operation := transition.Execute.Operation
+		var tokens []string
+		for _, argument := range transition.Execute.Arguments {
+			tokens = append(tokens, argument.Token)
+			if strings.HasPrefix(argument.Token, "--repository-context=") || strings.HasPrefix(argument.Token, "--expected-revision=") || strings.HasPrefix(argument.Token, "--target=") || strings.HasPrefix(argument.Token, "--request-hash=") {
+				t.Logf("        %s", argument.Token[:min(70, len(argument.Token))])
+			}
+		}
+		t.Logf("        op=%s", operation)
+		verb := strings.TrimPrefix(operation, "review.")
+		var out bytes.Buffer
+		err := RunReview(append([]string{verb}, tokens...), &out)
+		text := out.String()
+		if err != nil || strings.Contains(text, "binding is invalid") {
+			if strings.Contains(text+fmt.Sprint(err), "binding is invalid") {
+				t.Fatalf("REPRODUCED: exact transition rejected its own repository-context binding at hop %d:\n%v\n%s", hop, err, text)
+			}
+			t.Logf("        execution ended: %v / %s", err, text[:min(300, len(text))])
+			return
+		}
+		t.Logf("        executed ok (%d bytes)", len(text))
+	}
+}


### PR DESCRIPTION
Closes #3172. Refs #3170 (the Windows-only residue this test isolates) and the 2026-08-13 occurrence on #2541 that motivated it.

Closes #3170 is deliberately NOT claimed: this pins the Linux-green property and isolates the defect to Windows identity derivation; it does not fix Windows.

## What it proves

A faithful staged correction cycle — two newly added files, one deterministic CRITICAL finding, accepted forecast, bounded edit within budget, passed repository verification — reaches `targeted_validation_required`, and **executing the provider's input verbatim** (name/value tokens, opaque repository-context handle, request hash) resolves the handle and reads the immutable corrected tree.

That is the exact step the rc.7 Windows reporter could not execute (`review repository context binding is invalid`, surviving STATUS refresh). Green here is the finding as much as the guard: the correction flow's handle re-publication is correct on Linux, so the investigation belongs to Windows repository-identity derivation — the handle re-derivation hashes GitCommonDir/GitDir/root paths, and a normalization drift between publisher and resolver produces precisely this failure on precisely that platform.

## What the probe taught along the way, kept in the test

- The consumer's ORDER matters: reading the correction plan before editing is what keeps the relation classified as correction rather than scope-change recovery.
- An over-budget forecast escalates (my first probe self-inflicted `native_stop_required` by forecasting 13 lines against a budget of 3 — the budget floor is real).
- STATUS hops must carry the lineage AND the projection; without `--projection staged` the workspace projection answers instead, offering fresh START forever.
- Collect inputs hand arguments as name/value pairs, not pre-built tokens.

Each of those is a consumer mistake the negotiated route answers truthfully — none reproduced the reporter's failure, which is what makes the Windows isolation solid.

Verified: root suite, bench with cleared cache, vet on linux/windows/darwin, deadcode ratchet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for correction workflows involving repository context.
  * Verified that negotiated review transitions remain executable through follow-up corrections and targeted validation.
  * Added checks for successful repository verification, valid execution inputs, and appropriate handling of terminal states or execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->