### PR TITLE
fix(review): recover inherits the predecessor's frozen intended-untracked declaration

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1204,8 +1204,18 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 		}
 	}
 	// Issue #2394: a recovery successor declares scope exactly the way a fresh
-	// START does, so it never re-sweeps the worktree either.
+	// START does, so it never re-sweeps the worktree either. Issue #3159:
+	// inheriting the predecessor's frozen, explicitly authorized declaration
+	// is not a sweep — those exact paths were human-selected and frozen into
+	// the authority being recovered, and dropping them silently rebinds the
+	// successor to a partial candidate. Only the current-changes successor
+	// carries the declaration forward; base-diff, overlay, and release
+	// scopes never hold intended-untracked paths.
 	intended := []string{}
+	if !*releaseScope && !*committedOnly && !stagedScopeOverlay && !overlay &&
+		predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetCurrentChanges {
+		intended = append(intended, predecessorRecord.State.InitialSnapshot.IntendedUntracked...)
+	}
 	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
 	if *committedOnly {
 		target.Kind, target.BaseRef = reviewtransaction.TargetBaseDiff, base

--- a/internal/cli/review_recover_intended_untracked_test.go
+++ b/internal/cli/review_recover_intended_untracked_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// escalatedIntendedUntrackedRecoveryFixture is the #3159 predecessor: an
+// escalated current-changes authority whose frozen snapshot carries two
+// explicitly declared intended-untracked paths alongside a tracked change.
+func escalatedIntendedUntrackedRecoveryFixture(t *testing.T, lineage string) (string, reviewtransaction.CompactRecord) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"notes-a.txt", "notes-b.txt"} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte("untracked but explicitly selected\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage,
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest,
+		"--intended-untracked", "notes-a.txt", "--intended-untracked", "notes-b.txt"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{
+		Findings: []facadeFinding{{
+			Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "candidate regression",
+			ProofRefs:     []string{"differential test fails only on candidate"},
+			EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+		}}, Evidence: []string{"focused differential test failed"},
+	})
+	if err := finalizeReviewCLIArgs(t, repo, []string{"--cwd", repo, "--lineage", lineage,
+		"--result", resultPath, "--correction-lines", "1000"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if predecessor.State.State != reviewtransaction.StateEscalated ||
+		len(predecessor.State.InitialSnapshot.IntendedUntracked) != 2 {
+		t.Fatalf("fixture did not reach an escalated authority carrying the declared selection: %#v", predecessor.State.InitialSnapshot)
+	}
+	return repo, predecessor
+}
+
+// TestReviewRecoverInheritsDeclaredIntendedUntracked is #3159.
+//
+// `review recover` hardcoded the successor's intended-untracked declaration
+// to empty, citing #2394's rule that a recovery successor must not re-sweep
+// the worktree. The rule is right and stays; the hardcoding overshot it.
+// Inheriting the predecessor's frozen, explicitly authorized declaration is
+// not a sweep — those exact paths were selected by a human and frozen into
+// the authority being recovered. Dropping them silently rebound the successor
+// to a tracked-only target, so the lifecycle routed reviewer collection
+// toward a partial candidate while the user believed the complete one was
+// under review. The rc.7 reporter's client refused to treat that partial
+// review as approval, which is the only reason this was caught.
+func TestReviewRecoverInheritsDeclaredIntendedUntracked(t *testing.T) {
+	repo, predecessor := escalatedIntendedUntrackedRecoveryFixture(t, "recover-3159")
+
+	// Apply the fix that verification asked for: the successor candidate must
+	// differ from the escalated predecessor.
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The maintainer authorizes the COMPLETE candidate: the successor identity
+	// is derived with the predecessor's declared selection, exactly as the
+	// reporter expected recovery to bind.
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	complete, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: append([]string{}, predecessor.State.InitialSnapshot.IntendedUntracked...),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision,
+		complete.Identity, "maintainer", "recover the complete authorized candidate")
+
+	var output bytes.Buffer
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "recover-3159-successor", "--disposition", "escalated",
+		"--reason", "recover the complete authorized candidate", "--actor", "maintainer",
+		"--maintainer-authorization", authorization,
+	}, &output); err != nil {
+		t.Fatalf("recovery authorized against the complete candidate identity was refused: %v\n%s", err, output.String())
+	}
+	var recovered ReviewRecoverResult
+	if err := json.Unmarshal(output.Bytes(), &recovered); err != nil {
+		t.Fatalf("decode recover result: %v\n%s", err, output.String())
+	}
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "recover-3159-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := successor.State.InitialSnapshot.IntendedUntracked, predecessor.State.InitialSnapshot.IntendedUntracked; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("successor dropped the declared intended-untracked selection: got %v, want %v; the successor target represents a partial candidate", got, want)
+	}
+	if successor.State.InitialSnapshot.Identity != complete.Identity {
+		t.Fatalf("successor identity %s does not bind the complete authorized candidate %s", successor.State.InitialSnapshot.Identity, complete.Identity)
+	}
+}
+
+// TestReviewRecoverStillNeverSweepsUndeclaredUntracked is #2394's guard,
+// restated against the fix: inheritance carries ONLY the frozen declaration.
+// An untracked file that appeared after the predecessor froze must stay out
+// of the successor, no matter that it would be eligible for a fresh START.
+func TestReviewRecoverStillNeverSweepsUndeclaredUntracked(t *testing.T) {
+	repo, predecessor := escalatedIntendedUntrackedRecoveryFixture(t, "recover-3159-nosweep")
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Appears AFTER the predecessor froze: never declared, never authorized.
+	if err := os.WriteFile(filepath.Join(repo, "appeared-later.txt"), []byte("credential-shaped surprise\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	complete, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: append([]string{}, predecessor.State.InitialSnapshot.IntendedUntracked...),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision,
+		complete.Identity, "maintainer", "recover without sweeping")
+
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "recover-3159-nosweep-successor", "--disposition", "escalated",
+		"--reason", "recover without sweeping", "--actor", "maintainer",
+		"--maintainer-authorization", authorization,
+	}, io.Discard); err != nil {
+		t.Fatalf("recovery refused: %v", err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "recover-3159-nosweep-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range successor.State.InitialSnapshot.IntendedUntracked {
+		if path == "appeared-later.txt" {
+			t.Fatalf("recovery swept an undeclared untracked file into the successor: %v; this is exactly what #2394 forbids", successor.State.InitialSnapshot.IntendedUntracked)
+		}
+	}
+	for _, path := range successor.State.InitialSnapshot.Paths {
+		if path == "appeared-later.txt" {
+			t.Fatalf("successor manifest contains the undeclared untracked file: %v", successor.State.InitialSnapshot.Paths)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3159

## Root cause

`RunReviewRecover` hardcoded `intended := []string{}` citing #2394's rule that a recovery successor never re-sweeps the worktree. The rule is correct and stays — but the hardcoding overshot it: no flag exists on `review recover`, so the successor could never carry even the predecessor's frozen, explicitly human-authorized declaration. The successor silently rebound to a partial (tracked-only) candidate, and a maintainer authorization built against the complete candidate identity was refused with `escalated recovery requires an exact maintainer authorization binding`. `compactRecoveredEvidenceScopeMatches` already expects predecessor/successor equality on `IntendedUntracked`, confirming inheritance was the intended contract.

## Fix

Inherit `predecessor.InitialSnapshot.IntendedUntracked` only when the successor target stays `TargetCurrentChanges` (none of `--release-scope`, `--committed-only`, `--workspace-overlay`, or an overlay predecessor). Base-diff, overlay, and release scopes never hold intended-untracked paths.

## #2394 stays intact

- Inheritance carries ONLY the frozen declaration — never a fresh worktree sweep.
- `TestReviewRecoverStillNeverSweepsUndeclaredUntracked`: an untracked file that appears after the predecessor froze stays out of the successor, even though a fresh START could have selected it.

## Verification

- New RED→GREEN: `TestReviewRecoverInheritsDeclaredIntendedUntracked` (authorization against the complete identity was refused before the fix, binds after).
- `go test ./...` green on both modules (root + bench, cache cleaned).
- `GOOS=linux|windows|darwin go vet ./...` clean.
- `scripts/deadcode-ratchet.sh`: no new unreachable functions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review recovery now preserves explicitly selected untracked files from the predecessor review.
  * Newly appearing untracked files are no longer unintentionally included in recovered reviews.
  * Other recovery modes continue to work without inheriting untracked-file selections.

* **Tests**
  * Added coverage to verify intended untracked files are preserved accurately during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->