### PR TITLE
fix(review): pre-push discovery baseline carries the base tree, not the commit

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -3478,7 +3478,7 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 					prePushBaseline, prePushBaselineOK = baseline, true
 				}
 			}
-			if prePushBaselineOK && CompactLeafProvablyUnrelatedToPrePushCandidate(record.State, prePushBaseline.PushBaseRef, prePushBaseline.Paths) {
+			if prePushBaselineOK && CompactLeafProvablyUnrelatedToPrePushCandidate(record.State, prePushBaseline.PushBaseTree, prePushBaseline.Paths) {
 				continue
 			}
 		}

--- a/internal/cli/review_facade_prepush_baseline_test.go
+++ b/internal/cli/review_facade_prepush_baseline_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestBuildCompactPrePushDiscoveryBaselineCarriesTheBaseTree is issue #3176.
+//
+// The #1886 fast path compares the baseline against each leaf's
+// CurrentSnapshot.BaseTree, which SnapshotBuilder derives as
+// `rev-parse <ref>^{tree}`. The original baseline carried the push base
+// COMMIT oid instead, so the equality could never hold and the skip never
+// fired — the optimization shipped permanently inert. This test derives both
+// sides from a real repository, which is exactly what the original
+// synthetic-string tests failed to do.
+func TestBuildCompactPrePushDiscoveryBaselineCarriesTheBaseTree(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	ctx := context.Background()
+
+	// A bare remote with the current branch pushed and tracking configured:
+	// the push base the baseline must resolve.
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	if _, err := runGit(ctx, repo, "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runGit(ctx, repo, "remote", "add", "origin", remote); err != nil {
+		t.Fatal(err)
+	}
+	branch, err := runGit(ctx, repo, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runGit(ctx, repo, "push", "--set-upstream", "origin", branch); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unpushed work on top, so the live push candidate is non-empty.
+	if err := os.WriteFile(filepath.Join(repo, "unpushed.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runGit(ctx, repo, "add", "unpushed.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runGit(ctx, repo, "commit", "-m", "unpushed candidate"); err != nil {
+		t.Fatal(err)
+	}
+
+	baseline, err := BuildCompactPrePushDiscoveryBaseline(ctx, repo)
+	if err != nil {
+		t.Fatalf("BuildCompactPrePushDiscoveryBaseline() error = %v", err)
+	}
+
+	// The leaf side of the comparison, built the way production leaves are:
+	// a BaseDiff snapshot whose BaseTree is `rev-parse <base>^{tree}`.
+	leaf, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).BuildStoredSnapshot(ctx, reviewtransaction.Target{
+		Kind:              reviewtransaction.TargetBaseDiff,
+		BaseRef:           "origin/" + branch,
+		IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseline.PushBaseTree != leaf.BaseTree {
+		t.Fatalf("baseline push base %q does not match a real leaf's BaseTree %q; the fast-path equality can never fire (#3176)", baseline.PushBaseTree, leaf.BaseTree)
+	}
+	if len(baseline.Paths) != 1 || baseline.Paths[0] != "unpushed.txt" {
+		t.Fatalf("baseline live paths = %v, want [unpushed.txt]", baseline.Paths)
+	}
+
+	// End to end: a disjoint BaseDiff leaf on the same base is now provably
+	// unrelated to the live push candidate and gets skipped.
+	state := reviewtransaction.CompactState{
+		Schema:          reviewtransaction.CompactStateSchema,
+		GenesisPaths:    []string{"somewhere/else.txt"},
+		CurrentSnapshot: reviewtransaction.Snapshot{Kind: reviewtransaction.TargetBaseDiff, BaseTree: leaf.BaseTree},
+	}
+	if !CompactLeafProvablyUnrelatedToPrePushCandidate(state, baseline.PushBaseTree, baseline.Paths) {
+		t.Fatal("disjoint same-base leaf was not skipped against a real-repository baseline (#3176)")
+	}
+}

--- a/internal/cli/review_facade_prepush_filter.go
+++ b/internal/cli/review_facade_prepush_filter.go
@@ -19,8 +19,12 @@ import (
 // push base is the commit the remote tracking branch points to, resolved via
 // the configured upstream ref.
 type CompactPrePushDiscoveryBaseline struct {
-	PushBaseRef string   // commit OID of the remote tracking base (the push base)
-	Paths       []string // live changed paths between PushBaseRef and HEAD
+	// PushBaseTree is the TREE oid of the remote tracking base (the push
+	// base). It must be a tree, not the commit, because leaf snapshots store
+	// BaseTree as `rev-parse <ref>^{tree}` — issue #3176: comparing the
+	// commit oid here made the fast path permanently inert.
+	PushBaseTree string
+	Paths        []string // live changed paths between the push base and HEAD
 }
 
 // BuildCompactPrePushDiscoveryBaseline resolves the baseline once. A non-nil
@@ -41,7 +45,7 @@ func BuildCompactPrePushDiscoveryBaseline(ctx context.Context, repo string) (Com
 	if err != nil {
 		return CompactPrePushDiscoveryBaseline{}, err
 	}
-	return CompactPrePushDiscoveryBaseline{PushBaseRef: baseRef, Paths: snapshot.Paths}, nil
+	return CompactPrePushDiscoveryBaseline{PushBaseTree: snapshot.BaseTree, Paths: snapshot.Paths}, nil
 }
 
 // resolvePrePushBaseCommit resolves the push base commit (the commit the remote
@@ -87,7 +91,7 @@ func runGit(ctx context.Context, repo string, args ...string) (string, error) {
 }
 
 // CompactLeafProvablyUnrelatedToPrePushCandidate reports whether state provably
-// cannot govern the live pre-push candidate described by liveBaseRef and
+// cannot govern the live pre-push candidate described by liveBaseTree and
 // liveChangedPaths. Mirrors the byte-identity argument from
 // CompactLeafProvablyUnrelatedToPreCommitBaseline but for pre-push so we do not
 // pay for an extra SnapshotBuilder.Build per leaf.
@@ -95,7 +99,7 @@ func runGit(ctx context.Context, repo string, args ...string) (string, error) {
 // Returns true (skip the leaf's AssessCompactGateTarget call) when ALL hold:
 //   - Kind == TargetBaseDiff
 //   - GenesisPaths != nil
-//   - CurrentSnapshot.BaseTree == liveBaseRef
+//   - CurrentSnapshot.BaseTree == liveBaseTree
 //   - state.GenesisPaths are disjoint from liveChangedPaths
 //
 // Returns false otherwise (and for TargetBaseWorkspaceOverlay, TargetCurrentChanges,
@@ -105,7 +109,7 @@ func runGit(ctx context.Context, repo string, args ...string) (string, error) {
 // before calling this predicate. This function assumes the CompactState has already
 // passed validation in the caller's context (discoverCompactFacadeGateReview calls
 // store.Load() which validates before this predicate is reached).
-func CompactLeafProvablyUnrelatedToPrePushCandidate(state reviewtransaction.CompactState, liveBaseRef string, liveChangedPaths []string) bool {
+func CompactLeafProvablyUnrelatedToPrePushCandidate(state reviewtransaction.CompactState, liveBaseTree string, liveChangedPaths []string) bool {
 	current := state.CurrentSnapshot
 	if current.Kind != reviewtransaction.TargetBaseDiff {
 		return false
@@ -113,7 +117,7 @@ func CompactLeafProvablyUnrelatedToPrePushCandidate(state reviewtransaction.Comp
 	if len(state.GenesisPaths) == 0 {
 		return false
 	}
-	if current.BaseTree != liveBaseRef {
+	if current.BaseTree != liveBaseTree {
 		return false
 	}
 	return pathsAreDisjoint(state.GenesisPaths, liveChangedPaths)


### PR DESCRIPTION
Closes #3176

## Problem

#2277's `CompactLeafProvablyUnrelatedToPrePushCandidate` requires `current.BaseTree == liveBaseRef` before it may skip a leaf. The leaf side is a **tree** OID (`SnapshotBuilder.resolveTree` = `rev-parse <ref>^{tree}`); the baseline side was `PushBaseRef`, a **commit** OID (`rev-parse <remote>/<branch>^{commit}`). The equality can never hold, so the predicate returned false for every leaf and the #1886 optimization was completely inert — fail-safe, but doing nothing.

## Fix

`BuildCompactPrePushDiscoveryBaseline` now stores `snapshot.BaseTree` (the field is renamed `PushBaseTree` so the type states the contract). The predicate and facade call site follow.

## Why the original tests missed it

They placed the same synthetic string on both sides of the comparison. The new `TestBuildCompactPrePushDiscoveryBaselineCarriesTheBaseTree` derives both sides from a real repository (bare origin + tracking branch + unpushed commit): RED with the commit OID (`295c95c6…` vs `3e21a205…`), GREEN with the tree, and asserts end to end that a disjoint same-base leaf is actually skipped.

## Verification

- `go test ./...` green on both modules (root + bench, cache cleaned)
- `GOOS=linux|windows|darwin go vet ./...` clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-push change discovery by accurately identifying unrelated changes from the correct baseline.
  * Prevented valid changes from being incorrectly skipped when they share the same base.
  * Added coverage for pre-push scenarios involving unpushed commits and disjoint changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->