### PR TITLE
test(review): tokenize the granted consent invocation with the shipped splitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,10 @@ jobs:
     needs: go-format
     if: always()
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # Issue #3185: the Windows suite legitimately runs 11-13 minutes; a 15m
+    # go-test budget flaked on slow runners with every test passing. The job
+    # limit still bounds a real hang.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -394,7 +397,7 @@ jobs:
           # absorbs it; Windows does not, and gating it here keeps the real
           # coverage where it is affordable instead of deleting it outright.
           GENTLE_AI_LARGE_WORKSPACE_E2E: ${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}
-        run: go test -tags real_agent_e2e -v ./e2e/organicruntime -count=1 -timeout=15m
+        run: go test -tags real_agent_e2e -v ./e2e/organicruntime -count=1 -timeout=25m
 
   e2e-tests:
     name: E2E Tests (${{ matrix.platform.name }})

--- a/internal/cli/review_status_start_convergence_test.go
+++ b/internal/cli/review_status_start_convergence_test.go
@@ -205,12 +205,11 @@ func runReviewStartFollowingConsent(t *testing.T, tokens []string) string {
 		if choice.Answer != "granted" {
 			continue
 		}
-		fields := strings.Fields(choice.Invocation)
-		if len(fields) < 2 || fields[0] != "gentle-ai" {
-			t.Fatalf("granted invocation is not executable as returned: %q", choice.Invocation)
-		}
+		// Issue #3181: the rendered invocation quotes paths (Windows --cwd),
+		// so it must be tokenized by the shipped splitter, never by
+		// whitespace alone.
 		var granted bytes.Buffer
-		if err := RunReview(fields[2:], &granted); err != nil {
+		if err := RunReview(invocationArgs(t, choice.Invocation), &granted); err != nil {
 			t.Fatalf("the granted invocation the consent envelope named failed: %v\n%s", err, granted.String())
 		}
 		return granted.String()


### PR DESCRIPTION
Closes #3181

Windows Full Suite has been red on main since #3150 (first failure 08a58756). `runReviewStartFollowingConsent` tokenized the consent envelope's granted invocation with `strings.Fields`, so the quoted Windows `--cwd` path kept its leading quote (`'C:\...`) and `review start` failed with `operation_outcome_unknown` / `CreateFile ... 'C:: The filename, directory name, or volume label syntax is incorrect`. Linux temp paths need no quoting, which is exactly how this slipped through the Linux suite.

Fix: parse with the shipped `invocationArgs`/`SplitPrintedCommandWords` like every other consent test. Test-only change.

Verified: target test green on Linux, `go vet` clean for linux/windows/darwin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command parsing when rerunning consent-granted invocations.
  * Preserved quoted paths, including Windows `--cwd` values, to ensure commands execute correctly.
* **Reliability**
  * Extended automated end-to-end test time limits to support longer-running validation scenarios and reduce premature test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Also closes #3185: the Organic Runtime E2E suite gets timeout headroom (25m go-test / 30m job) — the Windows job legitimately runs 11-13 minutes of passing tests and flaked twice on this PR against the 15m budget.
