### PR TITLE
fix(review): pre-pr recognizes the receipt-derived correction-only publication

### DIFF
--- a/internal/cli/review_correction_only_prepr_test.go
+++ b/internal/cli/review_correction_only_prepr_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// approvedCommittedCorrectionReceipt drives the #2017 predecessor to its
+// terminal receipt: a committed base-diff review of an already-merged
+// candidate finds a deterministic CRITICAL, the one bounded correction lands
+// as a follow-up commit, targeted validation passes, and finalize approves.
+// It returns the repository, the lineage, and the merged candidate commit
+// (the publication base of the correction-only PR).
+func approvedCommittedCorrectionReceipt(t *testing.T) (string, string, string) {
+	t.Helper()
+	repo, _, lineage := forecastCommittedCorrection(t)
+	merged := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeCommittedCorrection(t, repo, false)
+
+	authorityStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorityRecord, err := authorityStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reviewtransaction.RebuildCommittedBaseDiffCorrectionCandidate(context.Background(), repo, authorityRecord.State); err != nil {
+		t.Fatalf("rebuild committed correction: %v", err)
+	}
+	request := capturePassedCorrectionEvidenceForTest(t, repo, lineage)
+	validation := filepath.Join(t.TempDir(), "validation.json")
+	writeReviewCLIJSON(t, validation, facadeValidationResult{
+		TargetedValidationRequestHash: request.RequestHash,
+		CorrectionTargetIdentity:      request.CorrectionTargetIdentity,
+		OriginalCriteria:              facadeValidationCheck{Passed: true, Evidence: []string{"original criteria passed"}},
+		CorrectionRegression:          facadeValidationCheck{Passed: true, Evidence: []string{"correction regression passed"}},
+		FollowUps:                     []reviewtransaction.FollowUp{},
+	})
+	if err := RunReviewFacadeFinalize([]string{
+		"--cwd", repo, "--contract", ReviewIntegrationContractV1, "--validation", validation, "--captured-evidence",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("finalize corrected candidate: %v", err)
+	}
+	record, err := authorityStore.Load()
+	if err != nil || record.State.State != reviewtransaction.StateApproved {
+		t.Fatalf("fixture did not reach an approved receipt: %#v, %v", record.State.State, err)
+	}
+	return repo, lineage, merged
+}
+
+// TestPrePRAllowsCorrectionOnlyDeliveryOverMergedCandidate is issue #2017.
+//
+// The approved receipt covers the original merged candidate plus its one
+// bounded correction. The corrective PR's publication base is the merged
+// candidate itself, so its diff contains only the correction. The reporter's
+// v2.2.2 gate classified that exact projection as unrelated and denied it,
+// then STATUS recommended a START that returned blocked-scope-action — a
+// dead end with no delivery path for content the system itself prescribed.
+//
+// The accepted design: the receipt authorizes exactly this one derived
+// projection — base tree equal to the receipt's original candidate tree,
+// candidate tree equal to its corrected candidate tree — and nothing else.
+func TestPrePRAllowsCorrectionOnlyDeliveryOverMergedCandidate(t *testing.T) {
+	repo, lineage, merged := approvedCommittedCorrectionReceipt(t)
+
+	// The corrective PR: base = the merged candidate commit on the remote
+	// mainline, head = the correction commit. Pre-PR only accepts an
+	// advertised <remote>/<branch> base.
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	runReviewCLIGit(t, repo, "init", "--bare", remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "push", "origin", merged+":refs/heads/merged-main")
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeValidate([]string{
+		"--cwd", repo, "--lineage", lineage, "--gate", string(reviewtransaction.GatePrePR),
+		"--base-ref", "origin/merged-main",
+	}, &output); err != nil {
+		t.Fatalf("pre-pr denied the correction-only delivery the receipt approves (#2017): %v\n%s", err, output.String())
+	}
+}
+
+// TestPrePRCorrectionOnlyMatchesOnlyTheDerivedPair pins the #2017 boundary:
+// the receipt authorizes exactly one derived projection. A head that is not
+// the corrected tree, or a base that is not the merged original candidate,
+// still denies — the relaxation is not "the receipt covers any subset".
+func TestPrePRCorrectionOnlyMatchesOnlyTheDerivedPair(t *testing.T) {
+	repo, lineage, merged := approvedCommittedCorrectionReceipt(t)
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	runReviewCLIGit(t, repo, "init", "--bare", remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "push", "origin", merged+":refs/heads/merged-main")
+
+	t.Run("head beyond the corrected tree denies", func(t *testing.T) {
+		writeReviewStartCandidate(t, repo, "extra.go", "package candidate\n\nvar smuggled = true\n", 0o644)
+		runReviewCLIGit(t, repo, "add", "extra.go")
+		runReviewCLIGit(t, repo, "commit", "-qm", "unreviewed extra on top of the correction")
+		t.Cleanup(func() { runReviewCLIGit(t, repo, "reset", "--hard", "HEAD~1") })
+
+		var output bytes.Buffer
+		if err := RunReviewFacadeValidate([]string{
+			"--cwd", repo, "--lineage", lineage, "--gate", string(reviewtransaction.GatePrePR),
+			"--base-ref", "origin/merged-main",
+		}, &output); err == nil {
+			t.Fatalf("pre-pr allowed unreviewed content on top of the correction:\n%s", output.String())
+		}
+	})
+
+	t.Run("pre-merge base keeps the full projection allowed", func(t *testing.T) {
+		unrelated := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", merged+"~1"))
+		runReviewCLIGit(t, repo, "push", "origin", unrelated+":refs/heads/premerge-main")
+
+		var output bytes.Buffer
+		err := RunReviewFacadeValidate([]string{
+			"--cwd", repo, "--lineage", lineage, "--gate", string(reviewtransaction.GatePrePR),
+			"--base-ref", "origin/premerge-main",
+		}, &output)
+		// The pre-merge base IS the receipt's own reviewed base, so this is
+		// the full projection the gate always allowed; it must keep working.
+		if err != nil {
+			t.Fatalf("pre-pr broke the original full projection: %v\n%s", err, output.String())
+		}
+	})
+
+	t.Run("foreign base intersecting the reviewed scope denies", func(t *testing.T) {
+		// A base that is neither the receipt's reviewed base nor the merged
+		// original candidate, whose drift touches the reviewed path itself.
+		// Disjoint drift is compatible-base-advance territory and stays
+		// allowed; intersecting drift must stay outside both that proof and
+		// the #2017 derived pair.
+		runReviewCLIGit(t, repo, "branch", "foreign", merged+"~1")
+		runReviewCLIGit(t, repo, "checkout", "-q", "foreign")
+		writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\nfunc value() int {\n\treturn 99\n}\n", 0o644)
+		runReviewCLIGit(t, repo, "add", "candidate.go")
+		runReviewCLIGit(t, repo, "commit", "-qm", "foreign drift")
+		foreign := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+		runReviewCLIGit(t, repo, "checkout", "-q", "-")
+		runReviewCLIGit(t, repo, "push", "origin", foreign+":refs/heads/foreign-main")
+
+		var output bytes.Buffer
+		if err := RunReviewFacadeValidate([]string{
+			"--cwd", repo, "--lineage", lineage, "--gate", string(reviewtransaction.GatePrePR),
+			"--base-ref", "origin/foreign-main",
+		}, &output); err == nil {
+			t.Fatalf("pre-pr allowed delivery over a base the receipt never derived:\n%s", output.String())
+		}
+	})
+}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -454,7 +454,21 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if strictBinding {
 		expectedBaseTree = binding.BaseTree
 	}
-	baseMismatch := snapshot.BaseTree != expectedBaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance
+	// Issue #2017: the receipt covers the original candidate plus its one
+	// bounded correction, so the correction-only publication over the
+	// already-merged candidate is receipt-derived, never base drift. Exactly
+	// one derived pair matches — base tree equal to the receipt's original
+	// candidate tree AND candidate tree equal to the corrected final tree,
+	// with a real correction between them — and only at the PR boundary,
+	// where the merged original is the publication base. Any other subset
+	// or base still denies; tree OIDs compare against tree OIDs on both
+	// sides (initial and current snapshots store ^{tree} resolutions).
+	correctionOnlyDelivery := request.Gate == GatePrePR &&
+		record.State.InitialSnapshot.Kind == TargetBaseDiff &&
+		receipt.FinalCandidateTree != record.State.InitialSnapshot.CandidateTree &&
+		snapshot.BaseTree == record.State.InitialSnapshot.CandidateTree &&
+		snapshot.CandidateTree == receipt.FinalCandidateTree
+	baseMismatch := snapshot.BaseTree != expectedBaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance && !correctionOnlyDelivery
 	if strictBinding {
 		baseMismatch = snapshot.BaseTree != expectedBaseTree && !squashedFixDelivery && !compatibleAdvance
 	}

--- a/internal/reviewtransaction/compact_gate_base_binding_test.go
+++ b/internal/reviewtransaction/compact_gate_base_binding_test.go
@@ -57,19 +57,42 @@ func TestCompactUncorrectedGateOmitsRedundantReceiptBaseTree(t *testing.T) {
 	}
 }
 
-// TestCompactPrePRBaseMismatchNamesExpectedAndActualBase rebuilds the community
-// fixture: a correction receipt whose publication base is the pre-correction
-// candidate — the exact tree the pre-commit allow envelope reported. The gate is
-// right to refuse, but the refusal published only what it found and never what
-// it required, so the operator read their own value echoed back with no
-// expectation anywhere in the envelope.
-func TestCompactPrePRBaseMismatchNamesExpectedAndActualBase(t *testing.T) {
-	repo, state, receipt, baseRef := approvedCompactFixDiffFixture(t, "compact-pre-pr-base-mismatch")
+// TestCompactPrePRAllowsCorrectionOnlyDeliveryOverPreCorrectionBase is issue
+// #2017 at the unit level. The publication base is the pre-correction
+// candidate — the receipt-derived correction-only projection. This used to be
+// framed as an operator error ("took the base from the pre-commit allow
+// envelope"), and the gate refused it; the maintainer decision on #2017
+// reverses that judgment: the receipt covers the original candidate plus its
+// one bounded correction, so the correction-only publication over the merged
+// original is exactly what the receipt approves. No other base is relaxed.
+func TestCompactPrePRAllowsCorrectionOnlyDeliveryOverPreCorrectionBase(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCompactFixDiffFixture(t, "compact-pre-pr-correction-only")
 	remote := strings.TrimSpace(gitSnapshot(t, repo, "remote", "get-url", "origin"))
 	preCorrection := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	gitSnapshot(t, repo, "add", "-A")
 	gitSnapshot(t, repo, "commit", "-m", "deliver corrected candidate")
 	gitSnapshot(t, repo, "--git-dir", remote, "update-ref", "refs/heads/"+strings.TrimPrefix(baseRef, "origin/"), preCorrection)
+
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef,
+	})
+	if got.Result != GateAllow {
+		t.Fatalf("correction-only delivery over the pre-correction candidate = %#v, want allow (#2017)", got)
+	}
+}
+
+// TestCompactPrePRBaseMismatchNamesExpectedAndActualBase pins the denial
+// diagnostics contract: a refusal must publish what the gate required, not
+// just what it found. Pre-PR derives its base as the merge-base with HEAD,
+// so the reachable foreign base is an OLDER ancestor — a stale mainline
+// behind the reviewed base. That base is neither the reviewed base nor the
+// #2017 receipt-derived correction-only base, and must still deny.
+func TestCompactPrePRBaseMismatchNamesExpectedAndActualBase(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCompactFixDiffFixture(t, "compact-pre-pr-base-mismatch")
+	stale := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD~2"))
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "deliver corrected candidate")
+	gitSnapshot(t, repo, "push", "-q", "-f", "origin", stale+":refs/heads/"+strings.TrimPrefix(baseRef, "origin/"))
 
 	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
 		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef,
@@ -84,8 +107,8 @@ func TestCompactPrePRBaseMismatchNamesExpectedAndActualBase(t *testing.T) {
 	if got.Context.BaseMismatch.Expected != receipt.BaseTree {
 		t.Fatalf("expected base = %q, want the reviewed base %q", got.Context.BaseMismatch.Expected, receipt.BaseTree)
 	}
-	if got.Context.BaseMismatch.Actual != got.Context.BaseTree || got.Context.BaseMismatch.Actual != state.InitialSnapshot.CandidateTree {
-		t.Fatalf("actual base = %q, want the live derived base %q", got.Context.BaseMismatch.Actual, got.Context.BaseTree)
+	if got.Context.BaseMismatch.Actual != got.Context.BaseTree || got.Context.BaseMismatch.Actual == state.InitialSnapshot.CandidateTree {
+		t.Fatalf("actual base = %q, want the live foreign base %q", got.Context.BaseMismatch.Actual, got.Context.BaseTree)
 	}
 	if got.Context.ReceiptBaseTree != receipt.BaseTree {
 		t.Fatalf("denial receipt_base_tree = %q, want the reviewed base %q", got.Context.ReceiptBaseTree, receipt.BaseTree)


### PR DESCRIPTION
Closes #2017

## Problem

An ordinary post-merge base-diff review finds a severe defect, approves its one bounded correction, and finalizes — the receipt covers the original merged candidate plus the correction. The corrective PR's publication base is the merged candidate itself, so `pre-pr` derived a base equal to the original candidate tree, compared it against the receipt's reviewed base, and denied with `current repository base no longer matches compact authority`. STATUS then recommended a `review.start` that returned `blocked-scope-action`: a dead end with no delivery path for content the system itself prescribed.

## Design (maintainer-approved on the issue)

The receipt authorizes exactly one derived projection, only at the PR boundary:

- base tree == the receipt's original candidate tree (the correction invariant already forces `correction.BaseTree == initial.CandidateTree`)
- candidate tree == the corrected final tree
- a real correction exists between them (`FinalCandidateTree != InitialSnapshot.CandidateTree`)
- the lineage is a base-diff review

Tree OIDs compare against tree OIDs on both sides (the #3176 lesson). Nothing transitive, no other subsets.

## Guards

- CLI level (`review_correction_only_prepr_test.go`): the exact #2017 topology allows; a head with an unreviewed commit on top denies; the original full projection stays allowed; a foreign base with drift intersecting the reviewed scope denies.
- Unit level (`compact_gate_base_binding_test.go`): the community diagnostics fixture was this exact topology framed as operator error — it now asserts the allow, and the expected/actual base-mismatch diagnostics are pinned against a genuinely stale ancestor base (pre-PR derives its base as the merge-base with HEAD, so stale mainlines are the reachable foreign case; disjoint lateral drift was already sanctioned by compatible base advance, untouched here).

## Verification

- `go test ./...` green on both modules (bench included in the first full pass)
- `GOOS=linux|windows|darwin go vet ./...` clean
- `scripts/deadcode-ratchet.sh`: no new unreachable functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-PR workflows now allow valid correction-only deliveries over the pre-correction base.
  * Invalid deliveries involving unreviewed changes, mismatched bases, or unrelated reviewed scopes remain blocked.

* **Tests**
  * Added coverage for approved correction-only delivery scenarios and rejection of unauthorized or unrelated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->