### PR TITLE
test(filemerge): cover Windows ACL denial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,20 +213,21 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Run native Windows junction parent tests
+      - name: Run native Windows filemerge tests
         shell: pwsh
         timeout-minutes: 5
         run: |
-          $selector = '^(TestWriteFileAtomicFollowsDirectoryJunction|TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets|TestWriteFileAtomicRejectsJunctionLoop)$'
+          $selector = '^(TestWriteFileAtomicFollowsDirectoryJunction|TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets|TestWriteFileAtomicRejectsJunctionLoop|TestWriteFileAtomicFailsClosedWhenParentACLDeniesFileCreation)$'
           $expected = @(
             'TestWriteFileAtomicFollowsDirectoryJunction'
             'TestEnsureAtomicParentDirRejectsUnsafeDirectoryJunctionTargets'
             'TestWriteFileAtomicRejectsJunctionLoop'
+            'TestWriteFileAtomicFailsClosedWhenParentACLDeniesFileCreation'
           )
           $selected = @(go test ./internal/components/filemerge -list $selector | Where-Object { $_ -match '^Test' })
-          if ($LASTEXITCODE -ne 0) { throw 'Could not list native Windows junction parent tests' }
+          if ($LASTEXITCODE -ne 0) { throw 'Could not list native Windows filemerge tests' }
           $missing = @($expected | Where-Object { $_ -notin $selected })
-          if ($missing.Count -gt 0) { throw "Missing native Windows junction parent tests: $($missing -join ', ')" }
+          if ($missing.Count -gt 0) { throw "Missing native Windows filemerge tests: $($missing -join ', ')" }
           go test -v ./internal/components/filemerge -count=1 -run $selector
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/internal/components/filemerge/writer_acl_windows_test.go
+++ b/internal/components/filemerge/writer_acl_windows_test.go
@@ -1,0 +1,333 @@
+//go:build windows
+
+package filemerge
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWriteFileAtomicFailsClosedWhenParentACLDeniesFileCreation(t *testing.T) {
+	dir := createWindowsTestDirectory(t, t.TempDir())
+	target := filepath.Join(dir, "config.txt")
+	originalContent := []byte("original\n")
+	if err := os.WriteFile(target, originalContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	dirHandle := openWindowsTestPath(t, dir, windows.READ_CONTROL|windows.WRITE_DAC, true)
+	t.Cleanup(func() {
+		if err := windows.CloseHandle(dirHandle); err != nil {
+			t.Errorf("CloseHandle(parent) error = %v", err)
+		}
+	})
+	originalParentDACL := readWindowsTestDACL(t, dir)
+	originalTargetDACL := readWindowsTestDACL(t, target)
+	t.Cleanup(func() {
+		restoreWindowsTestDACL(t, dirHandle, originalParentDACL)
+		assertWindowsTestDACL(t, dir, originalParentDACL)
+	})
+
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatalf("GetTokenUser() error = %v", err)
+	}
+	trustee := windows.TRUSTEE{
+		TrusteeForm:  windows.TRUSTEE_IS_SID,
+		TrusteeType:  windows.TRUSTEE_IS_USER,
+		TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+	}
+	deniedACL, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			// FILE_WRITE_DATA is FILE_ADD_FILE when the secured object is a directory.
+			AccessPermissions: windows.FILE_WRITE_DATA,
+			AccessMode:        windows.DENY_ACCESS,
+			Trustee:           trustee,
+		},
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Trustee:           trustee,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ACLFromEntries(deny FILE_ADD_FILE) error = %v", err)
+	}
+	if err := windows.SetSecurityInfo(
+		dirHandle,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		deniedACL,
+		nil,
+	); err != nil {
+		t.Fatalf("SetSecurityInfo(deny FILE_ADD_FILE) error = %v", err)
+	}
+	assertWindowsTestDACL(t, target, originalTargetDACL)
+
+	entriesBefore := readWindowsTestDirectory(t, dir)
+	probe := filepath.Join(dir, "namespace-probe")
+	probeFile, probeErr := os.OpenFile(probe, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if probeErr == nil {
+		_ = probeFile.Close()
+		_ = os.Remove(probe)
+		t.Fatal("OpenFile(namespace probe) error = nil, want parent ACL to deny file creation")
+	}
+	if !errors.Is(probeErr, os.ErrPermission) {
+		t.Fatalf("OpenFile(namespace probe) error = %v, want os.ErrPermission", probeErr)
+	}
+	if entriesAfterProbe := readWindowsTestDirectory(t, dir); !slices.Equal(entriesAfterProbe, entriesBefore) {
+		t.Fatalf("directory entries after denied namespace probe = %v, want %v", entriesAfterProbe, entriesBefore)
+	}
+
+	parentDACLBefore := readWindowsTestDACL(t, dir)
+	contentBefore, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("ReadFile(target before write) error = %v", readErr)
+	}
+	metadataBefore := readWindowsTestTargetMetadata(t, target)
+
+	result, err := WriteFileAtomic(target, []byte("replacement\n"), 0o600)
+	if err == nil {
+		t.Fatal("WriteFileAtomic() error = nil, want parent ACL failure")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("WriteFileAtomic() error = %v, want os.ErrPermission", err)
+	}
+	if result != (WriteResult{}) {
+		t.Fatalf("WriteFileAtomic() result = %+v, want no change", result)
+	}
+
+	metadataAfter := readWindowsTestTargetMetadata(t, target)
+	contentAfter, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("ReadFile(target after write) error = %v", readErr)
+	}
+	if !bytes.Equal(contentAfter, contentBefore) || !bytes.Equal(contentAfter, originalContent) {
+		t.Fatalf("target content after failure = %q, want unchanged %q", contentAfter, originalContent)
+	}
+	if metadataAfter != metadataBefore {
+		t.Fatalf("target metadata changed after failure:\n got  %+v\n want %+v", metadataAfter, metadataBefore)
+	}
+	assertWindowsTestDACL(t, target, originalTargetDACL)
+	assertWindowsTestDACL(t, dir, parentDACLBefore)
+
+	entriesAfter := readWindowsTestDirectory(t, dir)
+	if !slices.Equal(entriesAfter, entriesBefore) {
+		t.Fatalf("directory entries after failure = %v, want unchanged %v", entriesAfter, entriesBefore)
+	}
+	for _, name := range entriesAfter {
+		if strings.HasPrefix(name, ".gentle-ai-") {
+			t.Fatalf("temporary artifact %q remains after failure", name)
+		}
+	}
+}
+
+func createWindowsTestDirectory(t *testing.T, root string) string {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatalf("GetTokenUser() error = %v", err)
+	}
+	dacl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("ACLFromEntries(fixture) error = %v", err)
+	}
+	descriptor, err := windows.NewSecurityDescriptor()
+	if err != nil {
+		t.Fatalf("NewSecurityDescriptor() error = %v", err)
+	}
+	if err := descriptor.SetDACL(dacl, true, false); err != nil {
+		t.Fatalf("SECURITY_DESCRIPTOR.SetDACL() error = %v", err)
+	}
+	if err := descriptor.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
+		t.Fatalf("SECURITY_DESCRIPTOR.SetControl() error = %v", err)
+	}
+
+	dir := filepath.Join(root, "acl-denied")
+	dirPtr, err := windows.UTF16PtrFromString(dir)
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString(%q) error = %v", dir, err)
+	}
+	attributes := windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: descriptor,
+	}
+	if err := windows.CreateDirectory(dirPtr, &attributes); err != nil {
+		t.Fatalf("CreateDirectory(fixture) error = %v", err)
+	}
+	return dir
+}
+
+type windowsTestDACLState struct {
+	control windows.SECURITY_DESCRIPTOR_CONTROL
+	bytes   []byte
+}
+
+type windowsTestACLHeader struct {
+	revision uint8
+	reserved uint8
+	size     uint16
+	aceCount uint16
+	padding  uint16
+}
+
+func readWindowsTestDACL(t *testing.T, path string) windowsTestDACLState {
+	t.Helper()
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo(%q) error = %v", path, err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatalf("SECURITY_DESCRIPTOR.Control(%q) error = %v", path, err)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		t.Fatalf("SECURITY_DESCRIPTOR.DACL(%q) error = %v", path, err)
+	}
+	if dacl == nil {
+		t.Fatalf("SECURITY_DESCRIPTOR.DACL(%q) = nil, want a concrete DACL", path)
+	}
+	header := (*windowsTestACLHeader)(unsafe.Pointer(dacl))
+	if header.size < uint16(unsafe.Sizeof(*header)) {
+		t.Fatalf("DACL(%q) size = %d, want at least %d", path, header.size, unsafe.Sizeof(*header))
+	}
+	daclBytes := bytes.Clone(unsafe.Slice((*byte)(unsafe.Pointer(dacl)), int(header.size)))
+	return windowsTestDACLState{control: control, bytes: daclBytes}
+}
+
+func windowsTestACL(t *testing.T, state windowsTestDACLState) *windows.ACL {
+	t.Helper()
+	if len(state.bytes) < int(unsafe.Sizeof(windowsTestACLHeader{})) {
+		t.Fatalf("saved DACL size = %d, want a complete ACL header", len(state.bytes))
+	}
+	return (*windows.ACL)(unsafe.Pointer(&state.bytes[0]))
+}
+
+func windowsTestDACLInformation(control windows.SECURITY_DESCRIPTOR_CONTROL) windows.SECURITY_INFORMATION {
+	information := windows.SECURITY_INFORMATION(
+		windows.DACL_SECURITY_INFORMATION | windows.UNPROTECTED_DACL_SECURITY_INFORMATION,
+	)
+	if control&windows.SE_DACL_PROTECTED != 0 {
+		information = windows.SECURITY_INFORMATION(
+			windows.DACL_SECURITY_INFORMATION | windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		)
+	}
+	return information
+}
+
+func restoreWindowsTestDACL(t *testing.T, handle windows.Handle, state windowsTestDACLState) {
+	t.Helper()
+	if err := windows.SetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windowsTestDACLInformation(state.control),
+		nil,
+		nil,
+		windowsTestACL(t, state),
+		nil,
+	); err != nil {
+		t.Fatalf("restore original parent DACL error = %v", err)
+	}
+}
+
+func assertWindowsTestDACL(t *testing.T, path string, want windowsTestDACLState) {
+	t.Helper()
+	got := readWindowsTestDACL(t, path)
+	if got.control != want.control || !bytes.Equal(got.bytes, want.bytes) {
+		t.Fatalf("DACL changed for %q:\n got  control=%#x bytes=%x\n want control=%#x bytes=%x", path, got.control, got.bytes, want.control, want.bytes)
+	}
+}
+
+func openWindowsTestPath(t *testing.T, path string, access uint32, directory bool) windows.Handle {
+	t.Helper()
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString(%q) error = %v", path, err)
+	}
+	attributes := uint32(windows.FILE_ATTRIBUTE_NORMAL)
+	if directory {
+		attributes = windows.FILE_FLAG_BACKUP_SEMANTICS
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		access,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		attributes,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("CreateFile(%q) error = %v", path, err)
+	}
+	return handle
+}
+
+type windowsTestTargetMetadata struct {
+	attributes         uint32
+	creationTime       windows.Filetime
+	lastWriteTime      windows.Filetime
+	volumeSerialNumber uint32
+	fileSizeHigh       uint32
+	fileSizeLow        uint32
+	numberOfLinks      uint32
+	fileIndexHigh      uint32
+	fileIndexLow       uint32
+}
+
+func readWindowsTestTargetMetadata(t *testing.T, path string) windowsTestTargetMetadata {
+	t.Helper()
+	handle := openWindowsTestPath(t, path, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL, false)
+	defer windows.CloseHandle(handle)
+	var metadata windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &metadata); err != nil {
+		t.Fatalf("GetFileInformationByHandle(%q) error = %v", path, err)
+	}
+	return windowsTestTargetMetadata{
+		attributes:         metadata.FileAttributes,
+		creationTime:       metadata.CreationTime,
+		lastWriteTime:      metadata.LastWriteTime,
+		volumeSerialNumber: metadata.VolumeSerialNumber,
+		fileSizeHigh:       metadata.FileSizeHigh,
+		fileSizeLow:        metadata.FileSizeLow,
+		numberOfLinks:      metadata.NumberOfLinks,
+		fileIndexHigh:      metadata.FileIndexHigh,
+		fileIndexLow:       metadata.FileIndexLow,
+	}
+}
+
+func readWindowsTestDirectory(t *testing.T, path string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", path, err)
+	}
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #298

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add a native Windows ACL regression for `WriteFileAtomic` when the parent denies `FILE_ADD_FILE`.
- Prove the operation fails closed without changing target content, stable metadata, DACL bytes/control flags, or directory entries.
- Run the regression in the existing PR-time native Windows filemerge job.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/filemerge/writer_acl_windows_test.go` | Creates a protected DACL fixture, proves direct file creation is denied, exercises `WriteFileAtomic`, and verifies unchanged state plus safe cleanup. |
| `.github/workflows/ci.yml` | Adds the ACL regression to the exact native Windows filemerge selector and expected-test guard. |

---

## 🧪 Test Plan

**Focused unit tests**
```bash
go test ./internal/components/filemerge -count=1
```
Passed on Linux.

**Static and cross-platform checks**
```bash
go vet ./internal/components/filemerge
GOOS=windows GOARCH=amd64 go vet ./internal/components/filemerge
GOOS=windows GOARCH=amd64 go test -c ./internal/components/filemerge
go run ./internal/gofmtcheck
git diff --check
```
Passed.

**Native Windows execution**

Not available locally. The updated PR-time Windows job is the required execution evidence for the ACL behavior.

**E2E and benchmark validation**

N/A. This is test/CI-only filemerge coverage; it changes no production behavior, review lifecycle, delivery gate, benchmark corpus, classifier, or benchmark claim.

- [x] Focused unit tests pass
- [x] Go format passes
- [ ] Native Windows regression passes — pending CI
- [ ] E2E tests pass — not run; not applicable to this test-only scope
- [ ] Manually tested on Windows — unavailable locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 342 changed lines, within the 400-line budget |
| Check Issue Reference | ⏳ | `Closes #298` |
| Check Issue Has `status:approved` | ⏳ | Issue #298 is approved |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` will be applied |
| Unit Tests | ⏳ | CI confirmation pending |
| Go Format | ⏳ | Passed locally |
| Windows Runtime | ⏳ | Runs the real ACL regression on native Windows |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] The matching `type:bug` classification is selected; the GitHub label is applied separately
- [x] Focused unit tests pass
- [x] Go format passes
- [ ] E2E tests pass — not run; not applicable to this test-only scope
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation is not required; production behavior is unchanged
- [x] Commit follows Conventional Commits
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The latest maintainer contract supersedes the original relax-and-succeed proposal. This PR adds no ACL recovery or permission relaxation. The direct namespace probe proves the fixture truly denies creation before `WriteFileAtomic` runs. Cleanup restores the original parent DACL through a retained `WRITE_DAC` handle.

Receipt-driven review was globally disabled, so the candidate was reviewed under ordinary repository policy without claiming a receipt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows file-writing reliability when directory permissions prevent file creation.
  * Ensured failed writes leave existing file contents, metadata, permissions, directory contents, and temporary files unchanged.

* **Tests**
  * Added comprehensive Windows coverage for permission-denied scenarios.
  * Expanded automated validation to include the new native Windows file-writing test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->