### PR TITLE
test(opencode): make background fixtures host-aware

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	opencodeactivation "github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
@@ -681,11 +683,7 @@ func TestTuiInstallOnThenSyncPreservesAndRefreshesOpenCodeActivation(t *testing.
 	previousUserHomeDir := appUserHomeDir
 	appUserHomeDir = func() (string, error) { return home, nil }
 	t.Cleanup(func() { appUserHomeDir = previousUserHomeDir })
-	binDir := t.TempDir()
-	target := filepath.Join(binDir, "opencode")
-	if err := os.WriteFile(target, []byte("#!/bin/sh\nprintf 'opencode 1.15.11\\n'\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	binDir := writeFakeOpenCodeRuntime(t)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	selection := model.Selection{Agents: []model.AgentID{model.AgentOpenCode}, Components: []model.ComponentID{model.ComponentPersona, model.ComponentSDD}, SDDMode: model.SDDModeSingle}
@@ -695,7 +693,8 @@ func TestTuiInstallOnThenSyncPreservesAndRefreshesOpenCodeActivation(t *testing.
 		t.Fatalf("TUI install error = %v", installResult.Err)
 	}
 
-	launcher := filepath.Join(home, ".gentle-ai", "bin", "opencode")
+	// Issue #3209: the managed launcher name is host-dependent.
+	launcher := opencodeactivation.ManagedLauncherPaths(home, runtime.GOOS)[0]
 	before, err := os.ReadFile(launcher)
 	if err != nil {
 		t.Fatalf("ReadFile(launcher): %v", err)
@@ -1638,11 +1637,7 @@ func TestTUIExecuteReturnsStatePersistenceFailure(t *testing.T) {
 	if err := os.Symlink(target, statePath); err != nil {
 		t.Skipf("state symlink unavailable: %v", err)
 	}
-	binDir := t.TempDir()
-	openCodeTarget := filepath.Join(binDir, "opencode")
-	if err := os.WriteFile(openCodeTarget, []byte("#!/bin/sh\nprintf 'opencode 1.15.11\\n'\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	binDir := writeFakeOpenCodeRuntime(t)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	selection := model.Selection{Agents: []model.AgentID{model.AgentOpenCode}, CommunityTools: []model.CommunityToolID{}}
@@ -1678,11 +1673,7 @@ func TestTUIExecuteRollsBackOnMalformedState(t *testing.T) {
 	if err := os.WriteFile(state.Path(home), malformedState, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	binDir := t.TempDir()
-	openCodeTarget := filepath.Join(binDir, "opencode")
-	if err := os.WriteFile(openCodeTarget, []byte("#!/bin/sh\nprintf 'opencode 1.15.11\\n'\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	binDir := writeFakeOpenCodeRuntime(t)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	selection := model.Selection{Agents: []model.AgentID{model.AgentOpenCode}, CommunityTools: []model.CommunityToolID{}}
@@ -2598,4 +2589,24 @@ func TestRunArgs_UpgradeUnsupportedOptionStopsBeforeAnyEffect(t *testing.T) {
 			}
 		})
 	}
+}
+
+// writeFakeOpenCodeRuntime places a fake opencode executable for the host OS
+// on a fresh dir and returns that dir. Windows needs a PATHEXT-visible .cmd
+// (there is no execute bit and sh scripts are not executable); issue #3209.
+func writeFakeOpenCodeRuntime(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(binDir, "opencode.cmd")
+		if err := os.WriteFile(path, []byte("@echo off\r\necho opencode 1.15.11\r\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return binDir
+	}
+	path := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'opencode 1.15.11\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return binDir
 }

--- a/internal/cli/opencode_background_test.go
+++ b/internal/cli/opencode_background_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -724,9 +725,15 @@ func TestSyncReportsManagedLauncherChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	launcher := opencodeactivation.POSIXLauncherPath(home)
-	if result.NoOp || !contains(result.ChangedFiles, launcher) || result.FilesChanged == 0 {
-		t.Fatalf("sync result = NoOp %t, FilesChanged %d, ChangedFiles %v; want launcher change", result.NoOp, result.FilesChanged, result.ChangedFiles)
+	if result.NoOp || result.FilesChanged == 0 {
+		t.Fatalf("sync result = NoOp %t, FilesChanged %d; want launcher change", result.NoOp, result.FilesChanged)
+	}
+	// Issue #3209: the managed launcher set is host-dependent (POSIX script vs
+	// cmd+ps1 pair), so the assertion must name the host's launchers.
+	for _, launcher := range opencodeactivation.ManagedLauncherPaths(home, runtime.GOOS) {
+		if !contains(result.ChangedFiles, launcher) {
+			t.Fatalf("sync ChangedFiles %v missing managed launcher %q", result.ChangedFiles, launcher)
+		}
 	}
 }
 

--- a/internal/opencode/background_test.go
+++ b/internal/opencode/background_test.go
@@ -81,21 +81,30 @@ func TestVersionPreReleasePrecedenceIgnoresBuildMetadata(t *testing.T) {
 	}
 }
 
+// resolveTargetCandidateName is the host-native candidate filename: Windows
+// has no execute bit, so the fixture must be PATHEXT-shaped there (#3209).
+func resolveTargetCandidateName() string {
+	if runtime.GOOS == "windows" {
+		return "opencode.cmd"
+	}
+	return "opencode"
+}
+
 func TestResolveTargetSkipsManagedBinAndPreventsRecursion(t *testing.T) {
 	home := t.TempDir()
 	managed := BinDir(home)
-	real := filepath.Join(t.TempDir(), "opencode")
+	real := filepath.Join(t.TempDir(), resolveTargetCandidateName())
 	if err := os.MkdirAll(managed, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(managed, "opencode"), []byte("managed"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(managed, resolveTargetCandidateName()), []byte("managed"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(real, []byte("real"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := ResolveTarget(home, "linux", managed+string(os.PathListSeparator)+filepath.Dir(real))
+	got, err := ResolveTarget(home, runtime.GOOS, managed+string(os.PathListSeparator)+filepath.Dir(real))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,16 +132,18 @@ func TestResolveTargetContinuesAfterBrokenCandidate(t *testing.T) {
 	home := t.TempDir()
 	brokenDir := t.TempDir()
 	validDir := t.TempDir()
-	broken := filepath.Join(brokenDir, "opencode")
-	if err := os.Symlink(filepath.Join(brokenDir, "missing"), broken); err != nil {
+	// A directory with the candidate name is a broken candidate on every OS:
+	// stat succeeds and IsRegular fails, so resolution must continue. A broken
+	// symlink would prove the same only where symlinks are creatable (#3209).
+	if err := os.MkdirAll(filepath.Join(brokenDir, resolveTargetCandidateName()), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	valid := filepath.Join(validDir, "opencode")
+	valid := filepath.Join(validDir, resolveTargetCandidateName())
 	if err := os.WriteFile(valid, []byte("valid"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := ResolveTarget(home, "linux", strings.Join([]string{brokenDir, validDir}, ":"))
+	got, err := ResolveTarget(home, runtime.GOOS, strings.Join([]string{brokenDir, validDir}, string(os.PathListSeparator)))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #3209

Windows Full Suite went red on the #3179 merge head — six failures, all in the PR's own tests, all one family: fixtures faking the OpenCode runtime in POSIX-only shapes (execute bits, sh scripts invisible to PATHEXT, hardcoded `:` join, symlinks, POSIX launcher paths) on a host that satisfies none of them. Production code handles Windows correctly and is untouched.

Fixtures now: derive `goos` from `runtime.GOOS`; fake the runtime per host (`opencode.cmd` with `@echo` vs sh script); join PATH with `os.PathListSeparator`; model the broken candidate as a directory — stat succeeds, `IsRegular` fails, provably broken on every OS, no symlink privileges needed; assert the host's `ManagedLauncherPaths` set instead of the POSIX path.

Honest caveat: Linux CI cannot execute these Windows branches — the definitive proof is main's Windows Full Suite after merge, which I will watch. `GOOS=windows go vet` is clean and the Linux suite is green on both modules.

Detection-gap note (recorded on the issue): PR CI compiles Windows but only main executes the full suite — same class as #3181.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved OpenCode activation and background-process test coverage across Windows and POSIX-based platforms.
  * Added validation for platform-specific managed launcher paths and Windows launcher behavior.
  * Updated target-resolution tests to handle native executable names, path separators, and cross-platform fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->