### PR TITLE
test(opencode): normalize fixture paths the way ResolveTarget does

### DIFF
--- a/internal/opencode/background_test.go
+++ b/internal/opencode/background_test.go
@@ -108,9 +108,26 @@ func TestResolveTargetSkipsManagedBinAndPreventsRecursion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != real {
+	if got != normalizedCandidatePath(t, real) {
 		t.Fatalf("ResolveTarget() = %q, want %q", got, real)
 	}
+}
+
+// normalizedCandidatePath resolves the fixture path exactly the way
+// ResolveTarget resolves candidates (EvalSymlinks + Abs): on Windows
+// t.TempDir() hands out 8.3 short names that production expands (#3209),
+// and on macOS /tmp itself is a symlink.
+func normalizedCandidatePath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absolute, err := filepath.Abs(resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return absolute
 }
 
 func TestResolveTargetRejectsEmptyAndRelativeEntries(t *testing.T) {
@@ -147,7 +164,7 @@ func TestResolveTargetContinuesAfterBrokenCandidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != valid {
+	if got != normalizedCandidatePath(t, valid) {
 		t.Fatalf("ResolveTarget() = %q, want %q", got, valid)
 	}
 }


### PR DESCRIPTION
Closes #3209

#3211 cleared four of six; the remaining two ResolveTarget failures are a pure normalization mismatch: production resolves candidates via EvalSymlinks+Abs (expanding Windows 8.3 short names, RUNNER~1 → runneradmin), while the fixtures compared against t.TempDir()'s short form — same file, two spellings. The fixtures now normalize their expected paths through the identical resolution; on macOS this also absorbs the /tmp symlink. Watching main's Windows Full Suite after merge as the definitive proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved path-resolution test coverage to reliably handle symbolic links and platform-specific temporary directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->