### PR TITLE
fix(opencode): grant CodeGraph to explore

### DIFF
--- a/bench/journeys_issue_2138.go
+++ b/bench/journeys_issue_2138.go
@@ -87,7 +87,7 @@ func issue2138AssertGeneratedFallbacks(mode string) func(*Sandbox, Observation) 
 		}
 		wantTools := map[string]map[string]bool{
 			"general": {"read": true, "write": true, "edit": true, "bash": true, "task": false},
-			"explore": {"read": true, "write": false, "edit": false, "bash": false, "task": false},
+			"explore": {"read": true, "write": false, "edit": false, "bash": false, "task": false, "codegraph_codegraph_explore": true},
 		}
 		for name, toolsWant := range wantTools {
 			raw, ok := agents[name].(map[string]any)

--- a/internal/assets/opencode/sdd-overlay-multi.json
+++ b/internal/assets/opencode/sdd-overlay-multi.json
@@ -66,7 +66,8 @@
         "write": false,
         "edit": false,
         "bash": false,
-        "task": false
+        "task": false,
+        "codegraph_codegraph_explore": true
       }
     },
     "sdd-init": {

--- a/internal/assets/opencode/sdd-overlay-single.json
+++ b/internal/assets/opencode/sdd-overlay-single.json
@@ -66,7 +66,8 @@
         "write": false,
         "edit": false,
         "bash": false,
-        "task": false
+        "task": false,
+        "codegraph_codegraph_explore": true
       }
     },
     "sdd-init": {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -2687,6 +2687,13 @@ func TestInjectOpenCodeNativeFallbackAgentsPromptsAlignedWithGentlePi(t *testing
 			}
 
 			agentMap := root["agent"].(map[string]any)
+			if rootTools, ok := root["tools"].(map[string]any); ok {
+				for _, forbidden := range []string{"codegraph_*", "codegraph_codegraph_explore"} {
+					if _, exists := rootTools[forbidden]; exists {
+						t.Fatalf("root tools unexpectedly grant %q", forbidden)
+					}
+				}
+			}
 			for _, fallbackAgent := range []string{"general", "explore"} {
 				agent, ok := agentMap[fallbackAgent].(map[string]any)
 				if !ok {
@@ -2726,14 +2733,50 @@ func TestInjectOpenCodeNativeFallbackAgentsPromptsAlignedWithGentlePi(t *testing
 					"bash":  fallbackAgent == "general",
 					"task":  false,
 				}
+				if fallbackAgent == "explore" {
+					wantTools["codegraph_codegraph_explore"] = true
+				}
 				for tool, want := range wantTools {
 					got, exists := tools[tool].(bool)
 					if !exists || got != want {
 						t.Errorf("agent %q tool %q = %v, want %t", fallbackAgent, tool, tools[tool], want)
 					}
 				}
+				if fallbackAgent == "explore" {
+					for _, forbidden := range []string{"codegraph_*", "apply_patch"} {
+						if _, exists := tools[forbidden]; exists {
+							t.Errorf("explore tools unexpectedly configure %q", forbidden)
+						}
+					}
+				}
 			}
 		})
+	}
+}
+
+func TestInjectOpenCodePreservesExploreCodeGraphDenyAndCustomTool(t *testing.T) {
+	mockNoPackageManager(t)
+	home := t.TempDir()
+	settingsPath := opencodeAdapter().SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"agent":{"explore":{"tools":{"custom_readonly":true},"permission":{"codegraph_codegraph_explore":"deny"}}}}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Inject(home, opencodeAdapter(), model.SDDModeSingle); err != nil {
+		t.Fatal(err)
+	}
+
+	explore := readOpenCodeAgents(t, settingsPath)["explore"].(map[string]any)
+	tools := explore["tools"].(map[string]any)
+	if tools["codegraph_codegraph_explore"] != true || tools["custom_readonly"] != true {
+		t.Fatalf("explore tools lost managed or custom key: %#v", tools)
+	}
+	// OpenCode 1.18.18 normalizes agent tools before agent permission.
+	if got := explore["permission"].(map[string]any)["codegraph_codegraph_explore"]; got != "deny" {
+		t.Fatalf("agent CodeGraph permission = %v, want deny", got)
 	}
 }
 
@@ -4348,6 +4391,9 @@ func TestInjectKilocodeKeepsLegacyBackgroundAgentsPluginAndRemovesOpenCodeReview
 	}
 	if _, exists := agentMap["gentle-orchestrator"]; !exists {
 		t.Fatalf("Kilocode settings must retain gentle-orchestrator agent: %v", agentMap)
+	}
+	if strings.Contains(string(settings), "codegraph_codegraph_explore") {
+		t.Fatal("Kilocode settings must not receive the OpenCode CodeGraph grant")
 	}
 	for _, fallbackAgent := range []string{"general", "explore"} {
 		if _, exists := agentMap[fallbackAgent]; exists {

--- a/testdata/golden/sdd-opencode-multi-settings.golden
+++ b/testdata/golden/sdd-opencode-multi-settings.golden
@@ -7,6 +7,7 @@
       "prompt": "You are the explore fallback sub-agent aligned with gentle-pi guidance.\n- Independently inspect codebase files and execution paths in full without relying on unverified assumptions.\n- Read relevant code files completely before reaching conclusions.\n- Perform exploration, analysis, and discovery ONLY. Do not create, edit, or delete files.\n- Return concise, structured findings naming affected files, code paths, and clear recommendations.\n\n\u003c!-- gentle-ai:agent-language-contract --\u003e\n## Artifact Language Contract\n\nGenerated artifacts (code, comments, UI copy, docs, specs, tests, commit messages, memory entries) default to English. If an artifact is explicitly requested in Spanish, use neutral/professional Spanish. Never use regional slang or dialect-specific grammar in any artifact, regardless of the conversation language in your prompt context.\n\nBefore any Write/Edit whose content is an artifact, re-verify these artifact language rules.\n\u003c!-- /gentle-ai:agent-language-contract --\u003e\n",
       "tools": {
         "bash": false,
+        "codegraph_codegraph_explore": true,
         "edit": false,
         "read": true,
         "task": false,


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1096

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Grant OpenCode's generated `explore` worker the exact read-only `codegraph_codegraph_explore` MCP tool.
- Keep the native deny-by-default boundary intact without a root grant or wildcard that could broaden other agents or future CodeGraph tools.
- Cover single/multi generation, explicit agent-local denial, Kilo isolation, golden output, and the public fallback-agent benchmark journey.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/sdd-overlay-{single,multi}.json` | Add the exact CodeGraph exploration tool only to `agent.explore.tools`. |
| `internal/components/sdd/inject_test.go` | Verify agent-local scope, read-only boundaries, custom tool preservation, explicit denial, and Kilo isolation. |
| `bench/journeys_issue_2138.go` | Require the exact CodeGraph tool in public single/multi generated fallback settings. |
| `testdata/golden/sdd-opencode-multi-settings.golden` | Record the generated multi-mode grant. |

---

## 🧪 Test Plan

**Focused unit and golden tests**

```bash
go test ./internal/components/sdd -count=1
go test ./internal/components -run TestGoldenSDD -count=1
```

**Go format and diff integrity**

```bash
go run ./internal/gofmtcheck
git diff --check origin/main...HEAD
```

**Benchmark validation**

```text
j2138-opencode-native-fallback-boundary
1 completed, 0 unsupported, 0 failed
2 commands, 0 model runs
```

**Runtime permission probe**

OpenCode 1.18.18 was exercised with temporary HOME/XDG/config state and no model call. The exact tool resolved to `allow`; exact and wildcard agent-local denies both prevailed; Bash, edit, and task remained denied, and Apply Patch remained absent.

- [x] Focused unit tests pass
- [x] Go format passes
- [ ] Full repository `go test ./...` runs in CI
- [ ] Docker E2E runs in CI
- [x] Manually tested the affected OpenCode permission behavior
- [x] Benchmark validation completed

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 55 changed lines, below the 400-line budget |
| Check Issue Reference | ⏳ | Links approved issue #1096 |
| Check Issue Has `status:approved` | ⏳ | Issue #1096 is open and approved |
| Check PR Has type:* Label | ⏳ | `type:bug` will be the only type label |
| Unit Tests | ⏳ | CI authoritative full suite |
| Go Format | ✅ | Focused local check passed |
| E2E Tests | ⏳ | CI authoritative Docker suite |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label
- [x] Focused unit tests pass
- [x] Go format passes
- [ ] Full repository and Docker E2E suites are delegated to CI
- [x] Benchmark validation completed
- [x] Documentation is not required for this internal generated-agent capability fix
- [x] My commit follows Conventional Commits format
- [x] My commit does not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The grant is intentionally the exact OpenCode MCP tool name, not `codegraph_*`. This preserves the native `explore` deny-by-default model and avoids authorizing unrelated or future CodeGraph tools. Users can still revoke it with an exact or wildcard deny under `agent.explore.permission`.

Native reliability review completed with no findings. Receipt: `sha256:dfdbdc7354f7a8d1266c6958a97ed51214020de0b7938ced668bcc56fb025f84`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The read-only Explore agent can now use the CodeGraph exploration tool.
  * Existing custom tool permissions and explicit denials are preserved when configuring fallback agents.
* **Bug Fixes**
  * Prevented broader CodeGraph and patch tools from being unintentionally granted to fallback agents.
  * Ensured OpenCode-specific permissions are not applied to Kilocode configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->