### PR TITLE
test(review): enforce provider isolation and retry coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
             completed_once("j81-rc1-consecutive-rescope-repair-executes-printed-command") and
             completed_once("j75-intended-untracked-selection-executes-printed-start")
           ' "$RUNNER_TEMP/bench-portable.json"
+          "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j104-compiled-provider-capture-retries-same-binding --out "$RUNNER_TEMP/bench-provider-capture.json"
+          jq -e '
+            def completed_once($id):
+              [.journeys[] | select(.id == $id)] as $matches
+              | ($matches | length == 1) and ($matches[0].status == "completed");
+            completed_once("j104-compiled-provider-capture-retries-same-binding")
+          ' "$RUNNER_TEMP/bench-provider-capture.json"
           # Transition axis (#2829): sequences of ordinary operations, which is
           # how #2830 shipped. #2830 now refuses the second consecutive rescope
           # before publication, so every transition journey must complete.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             completed_once("j55-sdd-mismatched-authority-receipt-fails-closed") and
             completed_once("j56-sdd-non-allow-post-apply-gate-fails-closed") and
             completed_once("j58-sdd-foreign-openspec-path-fails-closed") and
+            completed_once("j104-repository-context-survives-fresh-process") and
             completed_once("j81-rc1-consecutive-rescope-repair-executes-printed-command") and
             completed_once("j75-intended-untracked-selection-executes-printed-start")
           ' "$RUNNER_TEMP/bench-portable.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,15 @@ jobs:
             throw 'Real-agent detection E2E is missing'
           }
 
+      - name: Verify live OpenCode provider isolation E2E is registered
+        shell: pwsh
+        run: |
+          if ($env:RUNNER_OS -ne 'Linux') { exit 0 }
+          $tests = go test -list '^TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport$' ./e2e/organicruntime
+          if ($LASTEXITCODE -ne 0 -or $tests -notcontains 'TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport') {
+            throw 'Live OpenCode provider isolation E2E is missing'
+          }
+
       - name: Run organic journeys
         # No -run filter: a renamed test must fail this job loudly, never let
         # go test exit 0 having matched nothing. The gated real-agent journey
@@ -379,6 +388,9 @@ jobs:
           # The Linux-only Codex journey invokes the registered adapter through
           # the product CLI under a process-scoped denying proxy and strace.
           GENTLE_AI_CODEX_RUNTIME_E2E: ${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}
+          # The live OpenCode transport stays on Ubuntu because its process-scoped
+          # loopback denying proxy and strace proof require Linux.
+          GENTLE_AI_OPENCODE_RUNTIME_E2E: ${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}
           # The large-workspace journey spawns one Git subprocess per intended
           # untracked path, so its cost is dominated by process creation. Linux
           # absorbs it; Windows does not, and gating it here keeps the real

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -669,6 +669,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue2906Journeys()...)
 	journeys = append(journeys, issue2138Journeys()...)
 	journeys = append(journeys, issue3043Journeys()...)
+	journeys = append(journeys, providerCaptureRetryJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -54,6 +54,7 @@ func journeySources() []journeySource {
 		{"journeys_issue2906.go", issue2906Journeys()},
 		{"journeys_issue_2138.go", issue2138Journeys()},
 		{"journeys_issue_3043.go", issue3043Journeys()},
+		{"journeys_provider_capture.go", providerCaptureRetryJourneys()},
 	}
 }
 

--- a/bench/journeys_provider_capture.go
+++ b/bench/journeys_provider_capture.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const providerCaptureRetryLineage = "compiled-provider-capture-retry"
+
+var providerCaptureRetryStatusCapability = &Capability{Verb: []string{"review", "status"}, Flags: []string{
+	"--cwd", "--contract", "--agent", "--lineage", "--next-transition",
+}}
+
+var providerCaptureRetryCapability = &Capability{Verb: []string{"review", "capture-result"}, Flags: []string{
+	"--agent", "--repository-context", "--expected-revision", "--lineage", "--target", "--lens", "--order",
+}}
+
+func providerCaptureRetryJourneys() []Journey {
+	return []Journey{{
+		ID:     "j104-compiled-provider-capture-retries-same-binding",
+		Title:  "Compiled provider capture retries the same pending binding after a transport failure",
+		Source: "issue #3138: Go owns provider capture binding and retry lifecycle",
+		Steps: []Step{
+			{Name: "fixture: isolated Claude provider fake", Fixture: providerCaptureRetryFixture},
+			{Name: "fixture: stage candidate", Fixture: stageWaveCandidate},
+			{Name: "negotiate and start the Claude provider review", Requires: providerCaptureRetryStatusCapability, Composite: startProviderCaptureRetry},
+			{Name: "failed provider capture preserves the exact pending binding", Requires: providerCaptureRetryCapability, Composite: retryProviderCapture},
+			{Name: "finalize the captured provider result into validation", Requires: finalizeResultsCapability, Composite: finalizeProviderCaptureRetry},
+		},
+	}}
+}
+
+func providerCaptureRetryFixture(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	bin := filepath.Join(sandbox.Root, "provider-bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		return err
+	}
+	launcher := filepath.Join(bin, "claude")
+	const script = `#!/bin/sh
+set -eu
+prompt="$0.prompt"
+attempts="$0.attempts"
+cat > "$prompt"
+attempt=0
+if [ -f "$attempts" ]; then attempt=$(cat "$attempts"); fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$attempts"
+if [ "$attempt" -eq 1 ]; then exit 1; fi
+subject=$(sed -n 's/.*"subject_hash":"\([^"]*\)".*/\1/p' "$prompt" | head -n 1)
+test -n "$subject"
+printf '{"subject_hash":"%s","inspection":{"status":"completed","paths":["candidate.go"]},"findings":[],"evidence":["inspected the complete frozen candidate"]}\n' "$subject"
+`
+	if err := os.WriteFile(launcher, []byte(script), 0o755); err != nil {
+		return err
+	}
+	sandbox.PathOverride = bin
+	sandbox.Scratch["provider-capture-attempts"] = launcher + ".attempts"
+	return nil
+}
+
+func providerCaptureRetryStatus(r *journeyRun) (statusEnvelope, json.RawMessage, error) {
+	observation := r.run([]string{"review", "status", "--cwd", r.sandbox.Repo, "--contract", reviewContractV2,
+		"--agent", "claude-code", "--lineage", providerCaptureRetryLineage, "--next-transition"}, false)
+	if observation.ExitCode != 0 {
+		return statusEnvelope{}, nil, fmt.Errorf("provider STATUS exited %d: %s", observation.ExitCode, firstLine(observation.Stderr))
+	}
+	var status statusEnvelope
+	var document struct {
+		NextTransition struct {
+			Collect struct {
+				Inputs []json.RawMessage `json:"inputs"`
+			} `json:"collect"`
+		} `json:"next_transition"`
+	}
+	if err := json.Unmarshal([]byte(observation.Stdout), &status); err != nil {
+		return statusEnvelope{}, nil, fmt.Errorf("decode provider STATUS: %w", err)
+	}
+	if err := json.Unmarshal([]byte(observation.Stdout), &document); err != nil {
+		return statusEnvelope{}, nil, fmt.Errorf("decode exact provider STATUS binding: %w", err)
+	}
+	if len(document.NextTransition.Collect.Inputs) == 1 {
+		return status, document.NextTransition.Collect.Inputs[0], nil
+	}
+	return status, nil, nil
+}
+
+func startProviderCaptureRetry(r *journeyRun) error {
+	status, _, err := providerCaptureRetryStatus(r)
+	if err != nil {
+		return err
+	}
+	if status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("provider START transition = %+v", status.NextTransition)
+	}
+	args, err := printedCommandArguments(status.NextTransition.Execute.Command)
+	if err != nil {
+		return err
+	}
+	consent, agent := false, false
+	for index, argument := range args {
+		if argument == "--consent=relay" {
+			args[index], consent = "--consent=granted", true
+		}
+		if argument == "--agent=claude-code" {
+			agent = true
+		}
+	}
+	if !consent || !agent {
+		return fmt.Errorf("provider START did not carry the negotiated Claude binding: %v", args)
+	}
+	if observation := r.run(append(args, "--focus", "reliability"), false); observation.ExitCode != 0 {
+		return fmt.Errorf("provider START failed: %s", firstLine(observation.Stderr))
+	}
+	return nil
+}
+
+func providerCaptureRetryArguments(status statusEnvelope) ([]string, error) {
+	if status.NextTransition.Kind != "collect" || len(status.NextTransition.Collect.Inputs) != 1 ||
+		status.NextTransition.Collect.Inputs[0].Name != "reviewer_result" || status.argument("repository-context") == "" ||
+		status.argument("expected-revision") == "" || status.argument("lineage") != providerCaptureRetryLineage ||
+		status.argument("target") == "" || status.argument("lens") == "" || status.argument("order") == "" {
+		return nil, fmt.Errorf("provider capture binding = %+v", status.NextTransition)
+	}
+	return []string{"review", "capture-result", "--agent", "claude-code",
+		"--repository-context", status.argument("repository-context"), "--expected-revision", status.argument("expected-revision"),
+		"--lineage", status.argument("lineage"), "--target", status.argument("target"), "--lens", status.argument("lens"), "--order", status.argument("order")}, nil
+}
+
+func retryProviderCapture(r *journeyRun) error {
+	before, pending, err := providerCaptureRetryStatus(r)
+	if err != nil {
+		return err
+	}
+	args, err := providerCaptureRetryArguments(before)
+	if err != nil {
+		return err
+	}
+	if len(pending) == 0 {
+		return fmt.Errorf("provider capture has no pending binding: %+v", before.NextTransition)
+	}
+	if observation := r.run(args, true); observation.ExitCode == 0 {
+		return fmt.Errorf("first provider capture unexpectedly succeeded: %s", observation.Stdout)
+	}
+	if attempts, err := os.ReadFile(r.sandbox.Scratch["provider-capture-attempts"]); err != nil || string(attempts) != "1\n" {
+		return fmt.Errorf("failed provider capture attempts = %q, %v; want first invocation", attempts, err)
+	}
+	after, retried, err := providerCaptureRetryStatus(r)
+	if err != nil {
+		return err
+	}
+	if len(retried) == 0 {
+		return fmt.Errorf("provider retry has no pending binding: %+v", after.NextTransition)
+	}
+	if !bytes.Equal(pending, retried) {
+		return fmt.Errorf("failed provider capture changed the pending binding:\nbefore=%s\nafter=%s", pending, retried)
+	}
+	if observation := r.run(args, true); observation.ExitCode != 0 {
+		return fmt.Errorf("valid provider result bound to the exact pending subject failed: %s", firstLine(observation.Stderr))
+	}
+	if attempts, err := os.ReadFile(r.sandbox.Scratch["provider-capture-attempts"]); err != nil || string(attempts) != "2\n" {
+		return fmt.Errorf("provider retry attempts = %q, %v; want two adapter invocations", attempts, err)
+	}
+	if advanced, _, err := providerCaptureRetryStatus(r); err != nil || advanced.NextTransition.Kind != "execute" || advanced.NextTransition.Execute.Operation != "review.finalize" {
+		return fmt.Errorf("provider capture did not advance to normal finalize: %+v, %v", advanced.NextTransition, err)
+	}
+	return nil
+}
+
+func finalizeProviderCaptureRetry(r *journeyRun) error {
+	status, _, err := providerCaptureRetryStatus(r)
+	if err != nil {
+		return err
+	}
+	if status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.finalize" {
+		return fmt.Errorf("provider capture finalize transition = %+v", status.NextTransition)
+	}
+	if observation := r.run([]string{"review", "finalize", "--cwd", r.sandbox.Repo,
+		"--lineage", providerCaptureRetryLineage, "--captured-results=true"}, false); observation.ExitCode != 0 {
+		return fmt.Errorf("provider capture finalize failed: %s", firstLine(observation.Stderr))
+	}
+	validated, _, err := providerCaptureRetryStatus(r)
+	if err != nil || validated.Authority.State != "validating" {
+		return fmt.Errorf("provider capture finalize state = %q, %v; want validating", validated.Authority.State, err)
+	}
+	return nil
+}

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -12,6 +12,7 @@ j100-pre-push-unqualified-selector-ignores-unreachable-remote
 j101-zero-path-base-diff-stops-before-start
 j102-status-stops-oversized-lens-context
 j103-sdd-interrupted-settlement-omits-evidence
+j104-compiled-provider-capture-retries-same-binding
 j11-unborn-head
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim

--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -389,22 +390,7 @@ func TestCodexProviderAdapterUsesPinnedLocalRuntime(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var proxyLock sync.Mutex
-	proxyRequests := 0
-	proxy := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if !codexProxyTargetIsExternal(request) {
-			t.Errorf("denying proxy received a loopback or missing target: %s %q", request.Method, request.Host)
-			writer.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		proxyLock.Lock()
-		proxyRequests++
-		proxyLock.Unlock()
-		// The proxy is process-scoped through this command's environment. Any
-		// attempted external request receives an explicit refusal instead of a
-		// route to the host network.
-		writer.WriteHeader(http.StatusForbidden)
-	}))
+	proxy := newLoopbackDenyingProxy(t)
 	defer proxy.Close()
 
 	traceBase := filepath.Join(t.TempDir(), "codex-connect")
@@ -412,16 +398,16 @@ func TestCodexProviderAdapterUsesPinnedLocalRuntime(t *testing.T) {
 	wrapper := filepath.Join(bin, "codex")
 	if err := os.WriteFile(wrapper, []byte(`#!/bin/sh
 set -eu
-exec "$GENTLE_AI_CODEX_TRACE_BINARY" -ff -o "$GENTLE_AI_CODEX_TRACE_LOG" -e trace=connect "$GENTLE_AI_CODEX_TRACE_TARGET" "$@"
+exec "$GENTLE_AI_RUNTIME_TRACE_BINARY" -ff -o "$GENTLE_AI_RUNTIME_TRACE_LOG" -e trace=connect "$GENTLE_AI_RUNTIME_TRACE_TARGET" "$@"
 `), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	environment := append(harness.environment(),
 		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GENTLE_AI_CODEX_REVIEWER_LOOPBACK_BASE_URL="+server.URL+"/v1",
-		"GENTLE_AI_CODEX_TRACE_BINARY="+strace,
-		"GENTLE_AI_CODEX_TRACE_LOG="+traceBase,
-		"GENTLE_AI_CODEX_TRACE_TARGET="+binary,
+		"GENTLE_AI_RUNTIME_TRACE_BINARY="+strace,
+		"GENTLE_AI_RUNTIME_TRACE_LOG="+traceBase,
+		"GENTLE_AI_RUNTIME_TRACE_TARGET="+binary,
 		"HTTP_PROXY="+proxy.URL,
 		"HTTPS_PROXY="+proxy.URL,
 		"ALL_PROXY="+proxy.URL,
@@ -442,9 +428,7 @@ exec "$GENTLE_AI_CODEX_TRACE_BINARY" -ff -o "$GENTLE_AI_CODEX_TRACE_LOG" -e trac
 	if responseRequests != 1 {
 		t.Fatalf("registered Codex loopback made %d root, %d model, and %d Responses requests; want exactly one Responses request", rootRequests, modelRequests, responseRequests)
 	}
-	proxyLock.Lock()
-	denied := proxyRequests
-	proxyLock.Unlock()
+	denied := proxy.deniedRequests()
 	if denied == 0 {
 		t.Fatal("Codex made no externally addressed request through the denying proxy; the external-refusal path was not exercised")
 	}
@@ -527,7 +511,53 @@ func codexTracedConnectAddress(line string) (netip.Addr, bool, error) {
 	return address, true, nil
 }
 
-func codexProxyTargetIsExternal(request *http.Request) bool {
+type loopbackDenyingProxy struct {
+	*httptest.Server
+	lock     sync.Mutex
+	requests int
+}
+
+func newLoopbackDenyingProxy(t *testing.T) *loopbackDenyingProxy {
+	t.Helper()
+	proxy := &loopbackDenyingProxy{}
+	proxy.Server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if !denyingProxyTargetIsExternal(request) {
+			forwarded := request.Clone(request.Context())
+			forwarded.RequestURI = ""
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			transport.Proxy = nil
+			defer transport.CloseIdleConnections()
+			response, err := transport.RoundTrip(forwarded)
+			if err != nil {
+				http.Error(writer, fmt.Sprintf("loopback proxy forward: %v", err), http.StatusBadGateway)
+				return
+			}
+			defer response.Body.Close()
+			for name, values := range response.Header {
+				writer.Header()[name] = append([]string{}, values...)
+			}
+			writer.WriteHeader(response.StatusCode)
+			_, _ = io.Copy(writer, response.Body)
+			return
+		}
+		proxy.lock.Lock()
+		proxy.requests++
+		proxy.lock.Unlock()
+		// The proxy is process-scoped through a command's environment. Any
+		// attempted external request receives an explicit refusal instead of a
+		// route to the host network.
+		writer.WriteHeader(http.StatusForbidden)
+	}))
+	return proxy
+}
+
+func (proxy *loopbackDenyingProxy) deniedRequests() int {
+	proxy.lock.Lock()
+	defer proxy.lock.Unlock()
+	return proxy.requests
+}
+
+func denyingProxyTargetIsExternal(request *http.Request) bool {
 	host := request.URL.Hostname()
 	if host == "" {
 		host = request.Host
@@ -609,10 +639,20 @@ func TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport(t *testing.T) {
 	if testing.Short() || strings.TrimSpace(os.Getenv("GENTLE_AI_OPENCODE_RUNTIME_E2E")) != "1" {
 		t.Skip("set GENTLE_AI_OPENCODE_RUNTIME_E2E=1 to verify the pinned ordinary OpenCode runtime")
 	}
-	binary := "/home/gentleman/.npm-global/bin/opencode"
+	if runtime.GOOS != "linux" {
+		t.Fatal("OpenCode egress isolation requires Linux")
+	}
+	strace, err := exec.LookPath("strace")
+	if err != nil {
+		t.Fatalf("OpenCode egress isolation unavailable: strace is required: %v", err)
+	}
+	binary, err := exec.LookPath("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
 	version, err := exec.Command(binary, "--version").Output()
-	if err != nil || strings.TrimSpace(string(version)) != "1.18.10" {
-		t.Fatalf("OpenCode version = %q, %v", strings.TrimSpace(string(version)), err)
+	if err != nil || strings.TrimSpace(string(version)) != pinnedOpenCodeVersion {
+		t.Fatalf("OpenCode version = %q, want %q (error %v)", strings.TrimSpace(string(version)), pinnedOpenCodeVersion, err)
 	}
 
 	harness := newOrganicHarness(t)
@@ -700,6 +740,25 @@ func TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport(t *testing.T) {
 		writeOpenCodeChatText(writer, "review task complete")
 	}))
 	defer server.Close()
+	proxy := newLoopbackDenyingProxy(t)
+	defer proxy.Close()
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	probe := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	response, err := probe.Get("http://opencode-egress-proof.invalid/")
+	if err != nil {
+		t.Fatalf("loopback denying proxy probe: %v", err)
+	}
+	if response.StatusCode != http.StatusForbidden {
+		_ = response.Body.Close()
+		t.Fatalf("loopback denying proxy probe status = %d, want %d", response.StatusCode, http.StatusForbidden)
+	}
+	_ = response.Body.Close()
+	if proxy.deniedRequests() != 1 {
+		t.Fatal("loopback denying proxy did not refuse the external egress probe")
+	}
 
 	pluginSource, err := assets.Read("opencode/plugins/opencode-review-transport.ts")
 	if err != nil {
@@ -734,12 +793,32 @@ func TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport(t *testing.T) {
 	}
 	context, cancel := context.WithTimeout(t.Context(), organicAgentTimeout)
 	defer cancel()
-	command := exec.CommandContext(context, binary, "run", "--format", "json", "--dir", harness.repo.worktree, "--model", "loopback/loopback", "start the Go-bound reviewer task")
+	traceBase := filepath.Join(t.TempDir(), "opencode-connect")
+	bin := t.TempDir()
+	wrapper := filepath.Join(bin, "opencode")
+	if err := os.WriteFile(wrapper, []byte(`#!/bin/sh
+set -eu
+exec "$GENTLE_AI_RUNTIME_TRACE_BINARY" -ff -o "$GENTLE_AI_RUNTIME_TRACE_LOG" -e trace=connect "$GENTLE_AI_RUNTIME_TRACE_TARGET" "$@"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(context, wrapper, "run", "--format", "json", "--dir", harness.repo.worktree, "--model", "loopback/loopback", "start the Go-bound reviewer task")
 	command.Dir = harness.repo.worktree
 	command.Env = append(harness.environment(),
 		"OPENCODE_CONFIG_DIR="+configDirectory,
 		"OPENCODE_CONFIG_CONTENT="+string(config),
-		"PATH="+filepath.Dir(organicBinary)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"PATH="+bin+string(os.PathListSeparator)+filepath.Dir(organicBinary)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GENTLE_AI_RUNTIME_TRACE_BINARY="+strace,
+		"GENTLE_AI_RUNTIME_TRACE_LOG="+traceBase,
+		"GENTLE_AI_RUNTIME_TRACE_TARGET="+binary,
+		"HTTP_PROXY="+proxy.URL,
+		"HTTPS_PROXY="+proxy.URL,
+		"ALL_PROXY="+proxy.URL,
+		"http_proxy="+proxy.URL,
+		"https_proxy="+proxy.URL,
+		"all_proxy="+proxy.URL,
+		"NO_PROXY=127.0.0.1,localhost,::1",
+		"no_proxy=127.0.0.1,localhost,::1",
 	)
 	output, runErr := command.CombinedOutput()
 	lock.Lock()
@@ -754,6 +833,16 @@ func TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport(t *testing.T) {
 	if !issued || !seen || calls == 0 {
 		t.Fatalf("ordinary OpenCode transport task=%t canonical=%t provider_requests=%d\n%s", issued, seen, calls, output)
 	}
+	connections, err := codexTracedConnectAddresses(traceBase)
+	if err != nil {
+		t.Fatalf("OpenCode egress trace is unavailable: %v", err)
+	}
+	for _, address := range connections {
+		if !address.IsLoopback() {
+			t.Fatalf("OpenCode bypassed egress isolation with a non-loopback connect to %s", address)
+		}
+	}
+	t.Logf("OpenCode egress proof: %d external attempts denied by the loopback proxy; strace observed %d Internet-socket connects, all loopback: %v", proxy.deniedRequests(), len(connections), connections)
 	if result := harness.finalize(lineage, "--captured-results=true"); result.State != organicStateValidating {
 		t.Fatalf("OpenCode capture did not enter validation: %#v", result)
 	}

--- a/internal/assets/formatter_ordering_test.go
+++ b/internal/assets/formatter_ordering_test.go
@@ -100,6 +100,14 @@ func TestOrganicRuntimeE2EUsesInstalledOpenCodePin(t *testing.T) {
 	if strings.Count(string(data), install) != 1 {
 		t.Fatalf("organic runtime E2E must install exact supported OpenCode pin %q once", install)
 	}
+	for _, required := range []string{
+		"TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport",
+		`GENTLE_AI_OPENCODE_RUNTIME_E2E: ${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}`,
+	} {
+		if !strings.Contains(string(data), required) {
+			t.Fatalf("organic runtime E2E is missing live OpenCode provider isolation guard %q", required)
+		}
+	}
 }
 
 func TestWindowsReleaseBlockerCannotSkipOwnerRebinding(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Fixes #3138

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Activate the real pinned OpenCode ordinary-session isolation proof on Ubuntu CI with loopback-only egress enforcement.
- Add driven journey j104 proving provider transport failure preserves the exact pending binding and retry reaches native validation.
- Pin both coverage paths structurally so future workflow or corpus edits cannot silently disable them.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `e2e/organicruntime/organic_runtime_test.go` | Resolves pinned OpenCode from PATH and proves poison isolation with a denying proxy plus `strace`. |
| `.github/workflows/ci.yml` | Activates and registers the live proof on Ubuntu only; gates driven j104 completion. |
| `internal/assets/formatter_ordering_test.go` | Prevents workflow pin, env, or registration drift. |
| `bench/journeys_provider_capture.go` | Drives failure, byte-identical binding retry, successful capture, and native finalization. |
| Bench registry and manifest | Registers unique journey j104 and updates the canonical corpus. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode multi-agent workflow; orchestrator `openai/gpt-5.6-sol`; delegated model identities recorded by the runtime where available.

**Material scope:** Coverage-gap audit, test and journey implementation, egress-isolation hardening, CI wiring, and independent verification. The maintainer required no known provider exposure to remain pending before RC.8.

**Verification performed:** Fresh uncached root and bench suites, real pinned OpenCode 1.18.10 under isolated PATH, denying proxy and strace evidence, exact driven j104 and portable corpus execution, Windows cross-compilation, static workflow guards, and Docker E2E.

---

## 🧪 Test Plan

```bash
go test ./... -count=1
go vet ./...
go mod tidy -diff
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
(cd bench && go test ./... -count=1 && go vet ./...)
GOOS=windows GOARCH=amd64 go test -c ./e2e/organicruntime
cd e2e && ./docker-test.sh
```

**Live OpenCode proof**

Pinned OpenCode `1.18.10` passed through the registered production route. The local proxy denied four external attempts; `strace` observed four Internet-socket connects, all to `127.0.0.1`. No successful non-loopback or paid-provider call occurred.

**Benchmark validation**

- Portable corpus: 98 completed, 0 unsupported, 0 failed.
- j104 focused run: 1 completed, 0 unsupported, 0 failed.
- j104 proves the first provider failure leaves the pending binding byte-identical, the second result is captured against the same subject, and native finalize enters validation.
- Corpus audit found no stale references to the retired advisory transport path.

**Docker E2E**

Ubuntu, Arch, and Fedora each passed 79 scenarios with 0 failures; the script's two opt-in tiers remained skipped.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (369 authored lines)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed in driven mode
- [x] Documentation changes are not required; this activates and pins existing provider contracts
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review commit `73393196` first for live OpenCode isolation and workflow pinning. Review commit `aca4c789` separately for the portable driven retry lifecycle. Each commit has an independent rollback boundary.

This PR intentionally changes no production provider semantics. It closes the last known evidence gaps before `v2.4.0-rc.8`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmark covering provider-capture retry recovery while preserving the original binding and completing validation successfully.
  * Added the journey to the benchmark suite and validation manifest.

* **Tests**
  * Expanded Codex and OpenCode runtime checks to confirm network activity remains loopback-only.
  * Enabled OpenCode runtime coverage on Ubuntu and verified the configured provider transport.
  * Added coverage for journey registration and identifier collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->