### PR TITLE
test: make two #3225 fixtures platform-aware

### DIFF
--- a/internal/providercontractbundle/bundle_test.go
+++ b/internal/providercontractbundle/bundle_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"testing"
 )
@@ -44,8 +46,16 @@ func TestGenerateIsDeterministicAndVerifiable(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if info.Mode().Perm() != bundleFileMode || !info.ModTime().Equal(bundleTimestamp) {
-			t.Fatalf("generated %s metadata = %s %s, want %04o %s", name, info.Mode(), info.ModTime(), bundleFileMode, bundleTimestamp)
+		// Windows cannot represent 0644: Chmod only honors the write bit and
+		// Stat reports 0666. Bundle determinism is content-level (asserted
+		// above) and published archives build on Linux; the staging mode is
+		// best-effort metadata, so the expectation is per-OS (#3229).
+		wantMode := fs.FileMode(bundleFileMode)
+		if runtime.GOOS == "windows" {
+			wantMode = 0o666
+		}
+		if info.Mode().Perm() != wantMode || !info.ModTime().Equal(bundleTimestamp) {
+			t.Fatalf("generated %s metadata = %s %s, want %04o %s", name, info.Mode(), info.ModTime(), wantMode, bundleTimestamp)
 		}
 	}
 	if err := VerifyStaging(first); err != nil {

--- a/internal/reviewtransaction/compact_role_result_slot_test.go
+++ b/internal/reviewtransaction/compact_role_result_slot_test.go
@@ -62,12 +62,12 @@ func TestCompactRoleResultSlotsPreserveImmutablePublicationSemantics(t *testing.
 }
 
 func TestCompactRoleResultSlotAcceptsCompatibleRelativeStoreRoot(t *testing.T) {
-	workingDirectory, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	storeDir, err := filepath.Rel(workingDirectory, t.TempDir())
-	if err != nil {
+	// filepath.Rel(package cwd, t.TempDir()) is impossible across Windows
+	// volumes (runner temp C: vs workspace D:), so the relative root is
+	// built by construction under a same-volume working directory (#3229).
+	t.Chdir(t.TempDir())
+	storeDir := filepath.Join("nested", "role-result-store")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	payload := []byte(`{"results":[]}` + "\n")


### PR DESCRIPTION
Closes #3229

The last two Windows Full Suite reds after #3227: both fixtures of #3225's provider-contract work, both platform-naive, production untouched. Staging perm expectation goes per-OS (Windows cannot represent 0644; content-level determinism is asserted separately and published archives build on Linux), and the compatible-relative-store-root proof builds its relative path under a same-volume chdir instead of Rel across drives. Same detection class as #3209/#3181: only main executes the full Windows suite. Watching main's Windows Full Suite after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform validation of staged file metadata, including Windows-specific file permissions.
  * Updated temporary-directory path testing to avoid failures when paths reside on different volumes.
  * Preserved existing timestamp validation and review transaction coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->