### PR TITLE
test: platform-aware marker mode and honest relative-root skip

### DIFF
--- a/internal/reviewtransaction/compact_effects_test.go
+++ b/internal/reviewtransaction/compact_effects_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -90,8 +92,15 @@ func TestCompactEffectMarkerIsPrivateSeparateAndStable(t *testing.T) {
 	if !bytes.Equal(before, after) || !info.ModTime().Equal(afterInfo.ModTime()) || !bytes.Equal(beforeAuthority, afterAuthority) {
 		t.Fatal("exact replay or separate authority bytes changed")
 	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("marker mode = %o", info.Mode().Perm())
+	// Windows cannot represent 0600: Chmod honors only the write bit and
+	// Stat reports 0666; ownership privacy is enforced by the RAR security
+	// descriptor checks instead (#3231).
+	wantMarkerMode := fs.FileMode(0o600)
+	if runtime.GOOS == "windows" {
+		wantMarkerMode = 0o666
+	}
+	if info.Mode().Perm() != wantMarkerMode {
+		t.Fatalf("marker mode = %o, want %o", info.Mode().Perm(), wantMarkerMode)
 	}
 }
 

--- a/internal/reviewtransaction/compact_role_result_slot_test.go
+++ b/internal/reviewtransaction/compact_role_result_slot_test.go
@@ -62,13 +62,16 @@ func TestCompactRoleResultSlotsPreserveImmutablePublicationSemantics(t *testing.
 }
 
 func TestCompactRoleResultSlotAcceptsCompatibleRelativeStoreRoot(t *testing.T) {
-	// filepath.Rel(package cwd, t.TempDir()) is impossible across Windows
-	// volumes (runner temp C: vs workspace D:), so the relative root is
-	// built by construction under a same-volume working directory (#3229).
-	t.Chdir(t.TempDir())
-	storeDir := filepath.Join("nested", "role-result-store")
-	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
 		t.Fatal(err)
+	}
+	// A same-volume relative path is the test's input contract; Windows
+	// runners keep temp on another volume, where the OS cannot express it
+	// at all — skip rather than reshape the capability under test (#3231).
+	storeDir, err := filepath.Rel(workingDirectory, t.TempDir())
+	if err != nil {
+		t.Skipf("no same-volume relative store root available: %v", err)
 	}
 	payload := []byte(`{"results":[]}` + "\n")
 	key := compactRefuterRoleResultSlotKey()


### PR DESCRIPTION
Closes #3233

Fixture classes 2 and 3 of the #3231 cluster; the possible product breakage (class 1) stays open in #3231 for a Windows-machine confirmation and is NOT closed by this PR.

- Marker privacy pin: per-OS expectation (0600 is unrepresentable on Windows; the descriptor checks own privacy there).
- Relative store root: back to the original `filepath.Rel` contract with an honest skip when the OS cannot express a same-volume relative path — the #3229 chdir variant reshaped the input under test and still failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform validation of marker file permissions while preserving privacy checks.
  * Updated temporary-directory path testing to work reliably across different filesystem volumes.
  * Tests now skip gracefully when a compatible relative path cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->