### PR TITLE
test(review): guard retired advisory command

### DIFF
--- a/internal/cli/review_retired_verb_test.go
+++ b/internal/cli/review_retired_verb_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -10,6 +12,54 @@ import (
 // "CLI verb dispatch loses cases... An unknown verb must return the
 // existing `unknown review command %q`, never a panic or silent no-op").
 // One test per retired verb, added in the same slice that retires it.
+
+// TestReviewRetiredVerbAdvisoryIsUnknownCommand verifies both former advisory
+// command shapes refuse before they can alter the fixture's source or shared
+// Git-common-dir authority.
+func TestReviewRetiredVerbAdvisoryIsUnknownCommand(t *testing.T) {
+	repo, contextArgs, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	handle := contextArgs[slices.Index(contextArgs, "--repository-context")+1]
+	lens := contextArgs[slices.Index(contextArgs, "--lens")+1]
+	sourceBefore := [3]string{
+		runReviewCLIGit(t, repo, "status", "--porcelain=v2", "--untracked-files=all"),
+		runReviewCLIGit(t, repo, "rev-parse", "HEAD"),
+		runReviewCLIGit(t, repo, "diff", "--binary", "--full-index", "--no-color", "--no-ext-diff", "--no-textconv", "HEAD"),
+	}
+	authorityBefore := cliReviewAuthoritySnapshot(t, repo)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "prompt", args: []string{"advisory", "prompt", "--repository-context", handle, "--lens", lens, "--runtime", "claude-code"}},
+		{name: "validate", args: []string{"advisory", "validate", "--repository-context", handle, "--lens", lens, "--input", "result.json"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := RunReview(test.args, &output)
+			if err == nil {
+				t.Fatal("retired verb advisory was accepted, want unknown-command refusal")
+			}
+			if want := `unknown review command "advisory"`; err.Error() != want {
+				t.Fatalf("retired verb advisory error = %q, want %q", err.Error(), want)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("retired verb advisory wrote output before refusing: %q", output.String())
+			}
+			if sourceAfter := [3]string{
+				runReviewCLIGit(t, repo, "status", "--porcelain=v2", "--untracked-files=all"),
+				runReviewCLIGit(t, repo, "rev-parse", "HEAD"),
+				runReviewCLIGit(t, repo, "diff", "--binary", "--full-index", "--no-color", "--no-ext-diff", "--no-textconv", "HEAD"),
+			}; sourceAfter != sourceBefore {
+				t.Fatalf("retired verb advisory mutated tracked source: before=%q after=%q", sourceBefore, sourceAfter)
+			}
+			if authorityAfter := cliReviewAuthoritySnapshot(t, repo); !reflect.DeepEqual(authorityAfter, authorityBefore) {
+				t.Fatalf("retired verb advisory mutated review authority: before=%#v after=%#v", authorityBefore, authorityAfter)
+			}
+		})
+	}
+}
 
 // TestReviewRetiredVerbReconcileAuthorityIsUnknownCommand is WU7's (S3a)
 // threat-matrix proof: once RunReviewReconcileAuthority and its dispatch


### PR DESCRIPTION
## 🔗 Linked Issue

Fixes #3235

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Plant the exact retired `review advisory prompt` and `review advisory validate` command shapes.
- Prove the real dispatcher refuses both through the canonical unknown-command boundary.
- Prove neither invocation emits stdout or mutates tracked source or Git-common-dir review authority.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_retired_verb_test.go` | Adds one direct retirement decoy covering both legacy advisory subcommands and no-mutation evidence. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode multi-agent workflow; orchestrator `openai/gpt-5.6-sol`; delegated model identities recorded by the runtime where available.

**Material scope:** Removed-guard audit, direct decoy design, test implementation, RED overlay, and independent verification. The maintainer required no unproven guard-removal argument before RC.8.

**Verification performed:** Focused uncached test, temporary untracked Go overlay that restored advisory dispatch and turned both cases RED, full uncached root suite, vet, tidy diff, gofmt, refusal and deadcode ratchets, patch-equivalent rebase, and diff checks.

---

## 🧪 Test Plan

```bash
go test ./internal/cli -run '^TestReviewRetiredVerbAdvisoryIsUnknownCommand$' -count=1
go test ./... -count=1
go vet ./...
go mod tidy -diff
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
go test ./internal/cli -run TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign -count=1
```

A temporary Go overlay reintroduced advisory dispatch without modifying tracked files. Both decoy cases then failed, proving the guard detects a restored command instead of merely documenting current behavior.

Benchmark validation is intentionally not applicable. The benchmark classifier truthfully marks an unknown review command as unsupported; teaching it to complete this retirement check would weaken corpus semantics. The direct CLI decoy is the correct boundary.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests are not applicable; production behavior is unchanged and the real dispatcher is exercised directly
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (50 additions)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E/benchmark applicability is explained above
- [x] Documentation changes are not required for this regression guard
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is a safety-net coverage-gap closure, not a production fix. Review the command shapes and before/after authority snapshot. No compatibility alias or retired-command implementation is added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retired advisory commands now consistently return an unknown-command error without producing output or changing repository state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->