### PR TITLE
fix(review): authority-lock deadline bounds stalls, not queue length

### DIFF
--- a/internal/reviewtransaction/rar_lock_progress_test.go
+++ b/internal/reviewtransaction/rar_lock_progress_test.go
@@ -1,0 +1,101 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRARLockWaiterSurvivesRotatingQueueBeyondFixedBudget is issue #3239's
+// positive property: the bounded waiter's deadline bounds time without an
+// ownership change, never total queue length. Five holders each keeping the
+// lock ~500ms serialize well past the 2s budget, and every waiter still
+// acquires because ownership keeps rotating.
+func TestRARLockWaiterSurvivesRotatingQueueBeyondFixedBudget(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "lock-progress")
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createPrivateRARDirectory(filepath.Dir(dir)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createPrivateRARDirectory(dir); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(dir, "authority.lock")
+
+	const workers = 5
+	const hold = 500 * time.Millisecond
+	var group sync.WaitGroup
+	errs := make(chan error, workers)
+	start := time.Now()
+	for index := 0; index < workers; index++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			lock, err := acquireRARAuthorityLock(context.Background(), lockPath)
+			if err != nil {
+				errs <- err
+				return
+			}
+			time.Sleep(hold)
+			errs <- lock.release()
+		}()
+	}
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("rotating-queue waiter failed: %v", err)
+		}
+	}
+	if elapsed := time.Since(start); elapsed < time.Duration(workers)*hold {
+		t.Fatalf("holders did not serialize: elapsed %s", elapsed)
+	}
+}
+
+// TestRARLockWaiterStillTimesOutOnStuckHolder pins the unchanged liveness
+// guarantee: with no ownership change at all, the waiter fails in exactly the
+// configured budget, never extended by the progress reset.
+func TestRARLockWaiterStillTimesOutOnStuckHolder(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	dir := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "lock-stuck")
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createPrivateRARDirectory(filepath.Dir(dir)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createPrivateRARDirectory(dir); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(dir, "authority.lock")
+
+	holder, err := acquireRARAuthorityLock(context.Background(), lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := holder.release(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	start := time.Now()
+	_, err = acquireRARAuthorityLock(context.Background(), lockPath)
+	elapsed := time.Since(start)
+	if !errors.Is(err, ErrAuthorityLockTimeout) {
+		t.Fatalf("stuck-holder wait error = %v, want authority lock timeout", err)
+	}
+	if elapsed < maintenanceLockTimeout || elapsed > 3*maintenanceLockTimeout {
+		t.Fatalf("stuck-holder timeout fired at %s, want ~%s without progress extensions", elapsed, maintenanceLockTimeout)
+	}
+	if _, statErr := os.Lstat(lockPath); statErr != nil {
+		t.Fatalf("lock record vanished during contention: %v", statErr)
+	}
+}

--- a/internal/reviewtransaction/rar_path_safety.go
+++ b/internal/reviewtransaction/rar_path_safety.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -416,7 +417,7 @@ func acquireRARAuthorityLock(ctx context.Context, path string) (*storeLock, erro
 	if err := validatePrivateRARFile(path); err != nil {
 		return nil, err
 	}
-	lock, err := acquireBoundedRARLock(ctx, func() (*storeLock, error) {
+	lock, err := acquireBoundedRARLock(ctx, path, func() (*storeLock, error) {
 		return acquirePrivateRARLocalStoreLock(path)
 	})
 	if err != nil {
@@ -496,12 +497,32 @@ func acquirePrivateRARLocalStoreLock(path string) (*storeLock, error) {
 	return &storeLock{file: file, owner: owner}, nil
 }
 
+// rarLockProgress fingerprints the live lock owner record so the bounded
+// waiter can tell a rotating, healthy queue from a stuck holder. Every
+// acquisition rewrites and fsyncs the owner payload, so modification time
+// plus size changes exactly when ownership changes hands.
+func rarLockProgress(path string) string {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return ""
+	}
+	return info.ModTime().String() + "/" + strconv.FormatInt(info.Size(), 10)
+}
+
 func acquireBoundedRARLock(
 	ctx context.Context,
+	path string,
 	acquire func() (*storeLock, error),
 ) (*storeLock, error) {
+	// The timeout exists to detect a dead or stuck holder, not to bound the
+	// queue length: under full-shard load the fsync-heavy critical section
+	// legitimately serializes many waiters past any fixed total budget
+	// (issue #3239). The deadline therefore bounds time WITHOUT an ownership
+	// change; observed progress restarts it, and a genuinely stuck holder
+	// still fails in exactly maintenanceLockTimeout.
 	deadline := time.NewTimer(maintenanceLockTimeout)
 	defer deadline.Stop()
+	lastProgress := rarLockProgress(path)
 	for {
 		lock, err := acquire()
 		if err == nil {
@@ -516,6 +537,13 @@ func acquireBoundedRARLock(
 		case <-deadline.C:
 			return nil, &AuthorityLockTimeoutError{Timeout: maintenanceLockTimeout}
 		case <-time.After(10 * time.Millisecond):
+			if progress := rarLockProgress(path); progress != lastProgress && progress != "" {
+				lastProgress = progress
+				if !deadline.Stop() {
+					<-deadline.C
+				}
+				deadline.Reset(maintenanceLockTimeout)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #3239

The audit's verdict: productive contention meeting a wrongly-shaped budget — not defective test synchronization, not environment debt to paper over. The 2s deadline bounded total wait when its purpose is stuck-holder detection; under full-shard Windows load, eight legitimate publishers serializing fsync-heavy critical sections exceed any fixed total budget while the system is perfectly live.

The waiter now restarts its deadline on observed ownership rotation (the lock owner record's mtime+size change on every acquisition, which each holder rewrites and syncs). A healthy queue converges however long it takes; a stuck holder still fails in exactly 2s — the timeout's original guarantee, unchanged for the case it exists to catch. No timeout value was inflated.

Properties pinned: `TestRARLockWaiterSurvivesRotatingQueueBeyondFixedBudget` (5×500ms holders, all acquire past the budget) and `TestRARLockWaiterStillTimesOutOnStuckHolder` (2.00s, no extension).

Verification: root suite, 3-OS vet, deadcode ratchet, bench module, full 99-journey driven corpus — zero failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authority-lock waiting so active ownership rotation can continue beyond the initial timeout.
  - Preserved timeout behavior when the current lock holder makes no progress.
  - Maintained serialized access and lock records during contention.

- **Tests**
  - Added coverage for rotating lock holders, stalled holders, timeout errors, and lock-record preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->