### PR TITLE
feat(review): materialize the Go-issued provider task for the pi host relay

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -259,6 +259,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	runtimeAgent := flags.String("agent", "", "compiled reviewer runtime that invokes the provider-owned request; mutually exclusive with --input and --preflight")
 	input := flags.String("input", "", "raw reviewer result JSON file or - for stdin; `gentle-ai review schema reviewer` emits the schema and a working example")
 	preflight := flags.Bool("preflight", false, "validate the capture binding and, when --input is supplied, the result admission without persisting anything")
+	materialize := flags.Bool("materialize", false, "print the exact Go-materialized opaque provider task for a host-relay --agent runtime without capturing anything; mutually exclusive with --input and --preflight")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -267,6 +268,14 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	}
 	providerRuntime := model.AgentID(strings.TrimSpace(*runtimeAgent))
 	providerExecution := providerRuntime != ""
+	if *materialize {
+		if *preflight || strings.TrimSpace(*input) != "" {
+			return reviewPreflightError(errors.New("review capture-result --materialize only prints the Go-materialized provider task and cannot be combined with --input or --preflight")) // refusal:by-design world-action: materialization is read-only and never authors or admits reviewer output
+		}
+		if !providerExecution {
+			return reviewPreflightError(errors.New("review capture-result --materialize requires --agent naming the host-relay runtime")) // refusal:by-design operator-knowledge: only a compiled host-relay runtime identity selects the materialize form
+		}
+	}
 	if flags.NArg() != 0 || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*target) == "" ||
 		strings.TrimSpace(*lens) == "" || *order < 0 || (!*preflight && strings.TrimSpace(*input) == "" && !providerExecution) {
 		return reviewPreflightError(errors.New("review capture-result requires an exact repository context, --lineage, --target, --lens, --order, and either --input or --agent (or --preflight); `gentle-ai review status --contract gentle-ai.review-integration/v1 --next-transition` prints the exact bindings and `gentle-ai review schema reviewer` emits the result schema with a working example"))
@@ -288,7 +297,14 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		if _, err := reviewRuntimeWithImmutableTransport(string(providerRuntime)); err != nil {
 			return reviewPreflightError(err)
 		}
-		if !reviewProviderCaptureRuntime(providerRuntime) {
+		if *materialize {
+			if reviewProviderCaptureRuntime(providerRuntime) {
+				return reviewPreflightError(fmt.Errorf("review capture-result --materialize is unavailable for %q: a compiled runtime materializes internally; run the capture operation without --materialize", providerRuntime)) // refusal:by-design operator-knowledge: compiled subprocess adapters already receive the Go-materialized request in-process
+			}
+			if !reviewProviderHostRelayMaterializeRuntime(providerRuntime) {
+				return reviewPreflightError(fmt.Errorf("review capture-result provider runtime %q is host-mediated; use its live transport collection", providerRuntime)) // refusal:by-design world-action: only the Pi host relay collects a printed provider task
+			}
+		} else if !reviewProviderCaptureRuntime(providerRuntime) {
 			return reviewPreflightError(fmt.Errorf("review capture-result provider runtime %q is host-mediated; use its live transport collection", providerRuntime)) // refusal:by-design world-action: only compiled subprocess adapters use this capture path
 		}
 	}
@@ -328,9 +344,10 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		}
 	}
 	// --preflight verifies the capture binding without reading or persisting
-	// any result, so it stays reachable under a frozen switch. Everything else
+	// any result, and --materialize only prints the Go-materialized provider
+	// task, so both stay reachable under a frozen switch. Everything else
 	// here publishes a reviewer result into the store.
-	if !*preflight {
+	if !*preflight && !*materialize {
 		if err := authorizeReviewAuthorityMutation(ctx, root); err != nil {
 			return err
 		}
@@ -393,6 +410,20 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		}
 		if request.Binding.Lineage != state.LineageID || request.Binding.Target != state.InitialSnapshot.Identity || request.Binding.Revision != record.Revision || request.Binding.Lens != *lens || request.Binding.Order != *order || request.Subject != subject {
 			return reviewPreflightError(errors.New("provider reviewer invocation no longer matches the current reviewing authority")) // refusal:by-design world-action: only a fresh negotiated collection binding may invoke a provider runtime
+		}
+		if *materialize {
+			if *subjectHash != "" && *subjectHash != subject.SubjectHash {
+				return reviewPreflightError(errors.New("materialize subject hash does not match the provider-owned authority; refresh the binding with gentle-ai review status --cwd <repo> --contract <same-contract> --next-transition"))
+			}
+			// The host relay pipes these exact bytes verbatim into its fresh
+			// locked-down reviewer subprocess, so they leave here raw: no JSON
+			// envelope, no trailing newline, and nothing captured, consumed, or
+			// mutated. Submission returns through the existing --input path
+			// with this same binding.
+			if _, err := stdout.Write(request.Invocation.Prompt()); err != nil {
+				return fmt.Errorf("write materialized provider task: %w", err)
+			}
+			return nil
 		}
 		adapter, adapterErr := reviewProviderAdapter(reviewProviderRoleLens, providerRuntime)
 		if adapterErr != nil {

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -554,11 +554,24 @@ func reviewCaptureInput(binding ReviewTransitionBinding, lens string, order int,
 		case reviewProviderCaptureRuntime(runtime[0]):
 			input.Arguments = append(input.Arguments, ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])})
 		case reviewProviderHostRelayMaterializeRuntime(runtime[0]):
-			// The Pi host relay learns the whole flow from these two tokens:
-			// it first runs this exact materialize form to receive the
-			// Go-issued opaque prompt bytes, relays them through its fresh
-			// locked-down reviewer subprocess, and then submits the raw
-			// result through the existing --input path with the same binding.
+			// The Pi host relay learns the whole flow from this one input: the
+			// materialize arguments are only the prelude that prints the
+			// Go-issued opaque prompt bytes for its fresh locked-down reviewer
+			// subprocess, and the submission descriptor -- the same binding
+			// tokens with the raw result substituted into --input -- is what
+			// actually advances reviewing authority.
+			tokens := make([]string, 0, len(input.Arguments)+1)
+			for _, argument := range input.Arguments {
+				tokens = append(tokens, reviewTransitionArgumentToken(argument))
+			}
+			tokens = append(tokens, "--input="+reviewSubmissionValuePlaceholder)
+			input.Submission = &ReviewTransitionSubmission{
+				OperationToken: "capture-result", ArgumentTokens: tokens,
+				Value: &ReviewTransitionSubmissionValue{
+					Slot: "reviewer_result", Domain: "artifact_path_or_stdin", Schema: reviewReviewerSchemaID,
+					SubstitutionLocation: len(tokens) - 1,
+				},
+			}
 			input.Arguments = append(input.Arguments,
 				ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])},
 				ReviewTransitionArgument{Name: "materialize", Value: "true"})

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -467,7 +467,7 @@ func reviewFinalizeNextTransition(state reviewtransaction.CompactState, revision
 
 func reviewMissingCaptureTransition(binding ReviewTransitionBinding, selectedLenses []string, artifacts []ReviewTransitionArtifact, context *reviewCaptureContext, runtime ...model.AgentID) ReviewNextTransition {
 	providerRuntime := model.AgentID("")
-	if len(runtime) > 0 && reviewProviderCaptureRuntime(runtime[0]) {
+	if len(runtime) > 0 && (reviewProviderCaptureRuntime(runtime[0]) || reviewProviderHostRelayMaterializeRuntime(runtime[0])) {
 		providerRuntime = runtime[0]
 	}
 	captured := make(map[int]bool, len(artifacts))
@@ -549,8 +549,20 @@ func reviewCaptureInput(binding ReviewTransitionBinding, lens string, order int,
 			input.BaseTree, input.CandidateTree = context.FrozenContext.BaseTree, context.FrozenContext.CandidateTree
 		}
 	}
-	if len(runtime) > 0 && reviewProviderCaptureRuntime(runtime[0]) {
-		input.Arguments = append(input.Arguments, ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])})
+	if len(runtime) > 0 {
+		switch {
+		case reviewProviderCaptureRuntime(runtime[0]):
+			input.Arguments = append(input.Arguments, ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])})
+		case reviewProviderHostRelayMaterializeRuntime(runtime[0]):
+			// The Pi host relay learns the whole flow from these two tokens:
+			// it first runs this exact materialize form to receive the
+			// Go-issued opaque prompt bytes, relays them through its fresh
+			// locked-down reviewer subprocess, and then submits the raw
+			// result through the existing --input path with the same binding.
+			input.Arguments = append(input.Arguments,
+				ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])},
+				ReviewTransitionArgument{Name: "materialize", Value: "true"})
+		}
 	}
 	return input
 }

--- a/internal/cli/review_provider_materialize_test.go
+++ b/internal/cli/review_provider_materialize_test.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// piHostRelayCaptureBinding renders the exact binding argument vector the
+// negotiated collect transition hands the Pi host: the opaque repository
+// context plus the frozen lineage, target, revision, lens, order, and
+// provider-owned subject hash.
+func piHostRelayCaptureBinding(t *testing.T, repo string, args []string, record reviewtransaction.CompactRecord) []string {
+	t.Helper()
+	handle := args[slices.Index(args, "--repository-context")+1]
+	lens := record.State.SelectedLenses[0]
+	subjectHash := admittedReviewerResultForTest(t, repo, record, lens, 0).SubjectHash
+	return []string{
+		"--repository-context", handle,
+		"--lineage", record.State.LineageID, "--target", record.State.InitialSnapshot.Identity,
+		"--expected-revision", record.Revision, "--lens", lens, "--order", "0",
+		"--subject-hash", subjectHash,
+	}
+}
+
+func TestReviewCaptureResultMaterializePrintsPiProviderTaskWithoutCapturing(t *testing.T) {
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, args, record, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	binding := piHostRelayCaptureBinding(t, repo, args, record)
+	handle := args[slices.Index(args, "--repository-context")+1]
+	lens := record.State.SelectedLenses[0]
+
+	var first bytes.Buffer
+	if err := RunReviewCaptureResult(append(slices.Clone(binding), "--agent", string(model.AgentPi), "--materialize=true"), &first); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(first.Bytes(), []byte(record.State.InitialSnapshot.Identity)) {
+		t.Fatal("materialized provider task omits the frozen target identity")
+	}
+	var native bytes.Buffer
+	if err := RunReview([]string{"lens-context", "--repository-context", handle, "--lens", lens}, &native); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first.Bytes(), native.Bytes()) {
+		t.Fatalf("materialized bytes diverged from the Go-materialized lens context\nmaterialize:\n%s\nnative:\n%s", first.Bytes(), native.Bytes())
+	}
+	var second bytes.Buffer
+	if err := RunReviewCaptureResult(append(slices.Clone(binding), "--agent", string(model.AgentPi), "--materialize=true"), &second); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatal("repeated materialization changed the provider task bytes")
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, record.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slot, err := reviewtransaction.ReadCompactReviewerResultSlot(store.Dir, 0, lens)
+	if err != nil || slot.Occupied {
+		t.Fatalf("materialize occupied the reviewer result slot: %#v, %v", slot, err)
+	}
+
+	stale := replaceInspectionArg(t, slices.Clone(binding), "--subject-hash", "sha256:"+strings.Repeat("0", 64))
+	err = RunReviewCaptureResult(append(stale, "--agent", string(model.AgentPi), "--materialize=true"), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "materialize subject hash does not match") {
+		t.Fatalf("stale materialize subject hash refusal = %v", err)
+	}
+}
+
+func TestReviewCaptureResultMaterializedPiTaskSubmitsThroughExistingInputPath(t *testing.T) {
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, args, record, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	binding := piHostRelayCaptureBinding(t, repo, args, record)
+	lens := record.State.SelectedLenses[0]
+	if err := RunReviewCaptureResult(append(slices.Clone(binding), "--agent", string(model.AgentPi), "--materialize=true"), &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(t.TempDir(), "pi-result.json")
+	if err := os.WriteFile(input, admittedReviewerPayloadForTest(t, repo, record, lens, 0), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult(append(slices.Clone(binding), "--input", input), &output); err != nil {
+		t.Fatal(err)
+	}
+	var artifact reviewResultArtifact
+	decodeStrictReviewJSON(t, output.Bytes(), &artifact)
+	if artifact.Lens != lens || artifact.SelectedOrder != 0 || artifact.AdmissionDecision != reviewtransaction.ArtifactAdmissionCompleted {
+		t.Fatalf("submitted reviewer artifact = %#v", artifact)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, record.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slot, err := reviewtransaction.ReadCompactReviewerResultSlot(store.Dir, 0, lens)
+	if err != nil || !slot.Occupied {
+		t.Fatalf("submission did not occupy the reviewer result slot: %#v, %v", slot, err)
+	}
+}
+
+func TestReviewCaptureResultMaterializeRefusals(t *testing.T) {
+	fakeBinding := []string{
+		"--repository-context", "rctx1_" + strings.Repeat("0", 64),
+		"--lineage", "materialize-refusals", "--target", "sha256:" + strings.Repeat("0", 64),
+		"--expected-revision", "sha256:" + strings.Repeat("1", 64), "--lens", "review-reliability", "--order", "0",
+	}
+	tests := []struct {
+		name string
+		env  string
+		argv []string
+		want string
+	}{
+		{
+			name: "compiled claude-code runtime", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentClaudeCode), "--materialize=true"),
+			want: "materializes internally",
+		},
+		{
+			name: "compiled codex runtime", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentCodex), "--materialize=true"),
+			want: "materializes internally",
+		},
+		{
+			name: "opencode keeps its host-mediated refusal", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentOpenCode), "--materialize=true"),
+			want: "is host-mediated; use its live transport collection",
+		},
+		{
+			name: "combined with input", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentPi), "--materialize=true", "--input", "-"),
+			want: "cannot be combined with --input or --preflight",
+		},
+		{
+			name: "combined with preflight", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentPi), "--materialize=true", "--preflight=true"),
+			want: "cannot be combined with --input or --preflight",
+		},
+		{
+			name: "without agent", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--materialize=true"),
+			want: "requires --agent",
+		},
+		{
+			name: "without relay handshake", env: "",
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentPi), "--materialize=true"),
+			want: "not eligible for immutable receipt review",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(reviewPiHostRelayContractEnvironment, test.env)
+			err := RunReviewCaptureResult(test.argv, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("materialize refusal = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestNegotiatedStatusRendersPiHostRelayMaterializeCaptureInput(t *testing.T) {
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, _, record, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", record.State.LineageID, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentPi), "--next-transition",
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if err := status.Validate(); err != nil {
+		t.Fatalf("pi host relay STATUS is invalid: %v", err)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "reviewer_results_required" || status.NextTransition.Collect == nil ||
+		len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("pi host relay transition = %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.CaptureOperation != "review.capture-result" {
+		t.Fatalf("pi host relay capture operation = %q", input.CaptureOperation)
+	}
+	tokens := map[string]string{}
+	for _, argument := range input.Arguments {
+		tokens[argument.Name] = argument.Token
+	}
+	if tokens["agent"] != "--agent="+string(model.AgentPi) || tokens["materialize"] != "--materialize=true" {
+		t.Fatalf("pi host relay capture arguments = %#v", input.Arguments)
+	}
+
+	var compiled bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", record.State.LineageID, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentClaudeCode), "--next-transition",
+	}, &compiled); err != nil {
+		t.Fatal(err)
+	}
+	var compiledStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, compiled.Bytes(), &compiledStatus)
+	if compiledStatus.NextTransition == nil || compiledStatus.NextTransition.Collect == nil ||
+		len(compiledStatus.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("compiled runtime transition = %#v", compiledStatus.NextTransition)
+	}
+	compiledArguments, err := reviewTransitionArgumentMap(compiledStatus.NextTransition.Collect.Inputs[0].Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, leaked := compiledArguments["materialize"]; leaked || compiledArguments["agent"] != string(model.AgentClaudeCode) {
+		t.Fatalf("compiled runtime capture arguments changed: %#v", compiledStatus.NextTransition.Collect.Inputs[0].Arguments)
+	}
+}

--- a/internal/cli/review_provider_materialize_test.go
+++ b/internal/cli/review_provider_materialize_test.go
@@ -196,6 +196,20 @@ func TestNegotiatedStatusRendersPiHostRelayMaterializeCaptureInput(t *testing.T)
 	if tokens["agent"] != "--agent="+string(model.AgentPi) || tokens["materialize"] != "--materialize=true" {
 		t.Fatalf("pi host relay capture arguments = %#v", input.Arguments)
 	}
+	wantTokens := make([]string, 0, len(input.Arguments)-1)
+	for _, argument := range input.Arguments {
+		if argument.Name != "agent" && argument.Name != "materialize" {
+			wantTokens = append(wantTokens, argument.Token)
+		}
+	}
+	wantTokens = append(wantTokens, "--input={{value}}")
+	if input.Submission == nil || input.Submission.OperationToken != "capture-result" ||
+		!slices.Equal(input.Submission.ArgumentTokens, wantTokens) || len(input.Submission.Values) != 0 ||
+		input.Submission.Value == nil || input.Submission.Value.Slot != "reviewer_result" ||
+		input.Submission.Value.Domain != "artifact_path_or_stdin" || input.Submission.Value.Schema != reviewReviewerSchemaID ||
+		input.Submission.Value.SubstitutionLocation != len(wantTokens)-1 {
+		t.Fatalf("pi host relay submission = %#v, want tokens %v", input.Submission, wantTokens)
+	}
 
 	var compiled bytes.Buffer
 	if err := RunReview([]string{
@@ -214,7 +228,8 @@ func TestNegotiatedStatusRendersPiHostRelayMaterializeCaptureInput(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, leaked := compiledArguments["materialize"]; leaked || compiledArguments["agent"] != string(model.AgentClaudeCode) {
-		t.Fatalf("compiled runtime capture arguments changed: %#v", compiledStatus.NextTransition.Collect.Inputs[0].Arguments)
+	if _, leaked := compiledArguments["materialize"]; leaked || compiledArguments["agent"] != string(model.AgentClaudeCode) ||
+		compiledStatus.NextTransition.Collect.Inputs[0].Submission != nil {
+		t.Fatalf("compiled runtime capture rendering changed: %#v", compiledStatus.NextTransition.Collect.Inputs[0])
 	}
 }

--- a/internal/cli/review_provider_runtime.go
+++ b/internal/cli/review_provider_runtime.go
@@ -44,3 +44,15 @@ var reviewProviderAdapterFor = func(contract reviewerprovider.Contract, agent mo
 func reviewProviderCaptureRuntime(agent model.AgentID) bool {
 	return agent == model.AgentClaudeCode || agent == model.AgentCodex
 }
+
+// reviewProviderHostRelayMaterializeRuntime reports whether the runtime's
+// compiled immutable transport is the Pi host relay: the one transport whose
+// host first prints the exact Go-materialized opaque provider task
+// (`review capture-result ... --agent=pi --materialize=true`), runs its own
+// fresh locked-down reviewer subprocess on those bytes, and then submits the
+// raw result through the existing --input path with the same binding. The
+// answer stays false without the exact relay handshake, so materialization is
+// never offered to a Pi installation whose launcher cannot collect it.
+func reviewProviderHostRelayMaterializeRuntime(agent model.AgentID) bool {
+	return reviewImmutableRuntimeCapability(agent).Transport == reviewImmutableTransportPiHostRelay
+}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -722,6 +722,20 @@ func (result ReviewTargetStatusResult) validateSubmissionDescriptors() error {
 		if want == nil || !reflect.DeepEqual(*input.Submission, *want) {
 			return errors.New("targeted validation submission descriptor is not provider-bound") // refusal:by-design world-action: only a provider code fix can bind descriptor tokens to its request
 		}
+	case "reviewer_results_required":
+		// Only the pi host-relay capture input carries a submission: its
+		// materialize arguments are a non-advancing prelude, so the --input
+		// descriptor is what advances authority. Transition.Validate() above
+		// already pinned the descriptor tokens to the reviewed binding.
+		for _, input := range transition.Collect.Inputs {
+			if input.Submission == nil {
+				continue
+			}
+			arguments, err := reviewTransitionArgumentMap(input.Arguments)
+			if err != nil || !reviewProviderHostRelayMaterializeRuntime(model.AgentID(arguments["agent"])) {
+				return errors.New("submission descriptor is attached to an unrelated collection input") // refusal:by-design world-action: only a provider code fix can remove the unrelated descriptor
+			}
+		}
 	case "verification_evidence_required", "correction_repository_verification_required":
 		if result.Schema == ReviewIntegrationStatusSchemaV4 {
 			for _, input := range transition.Collect.Inputs {
@@ -1177,7 +1191,7 @@ func (transition ReviewNextTransition) Validate() error {
 			if err != nil {
 				return err
 			}
-			submissionAllowed := input.CaptureOperation == "external.plan_correction" || input.CaptureOperation == "external.run_targeted_validation" || input.CaptureOperation == "review.capture-evidence"
+			submissionAllowed := input.CaptureOperation == "external.plan_correction" || input.CaptureOperation == "external.run_targeted_validation" || input.CaptureOperation == "review.capture-evidence" || input.CaptureOperation == "review.capture-result"
 			if input.Submission != nil && !submissionAllowed {
 				return errors.New("collection transition submission placement is invalid") // refusal:by-design world-action: only a provider code fix can place a descriptor on a supported input
 			}
@@ -1203,8 +1217,20 @@ func (transition ReviewNextTransition) Validate() error {
 				if hostRelayMaterialize {
 					// A host-relay capture input carries both --agent and
 					// --materialize=true: the host materializes first, then
-					// submits through the existing --input path.
+					// advances authority through the submission descriptor.
 					argumentCount += 2
+					expected := make([]string, 0, len(input.Arguments)-1)
+					for _, argument := range input.Arguments {
+						if argument.Name != "agent" && argument.Name != "materialize" {
+							expected = append(expected, reviewTransitionArgumentToken(argument))
+						}
+					}
+					expected = append(expected, "--input="+reviewSubmissionValuePlaceholder)
+					if input.Submission == nil || !reflect.DeepEqual(input.Submission.ArgumentTokens, expected) {
+						return errors.New("host-relay capture transition submission does not advance the reviewed binding") // refusal:by-design world-action: only a provider code fix can make the rendered transition advance authority
+					}
+				} else if input.Submission != nil {
+					return errors.New("collection transition submission placement is invalid") // refusal:by-design world-action: only a provider code fix can place a descriptor on a supported input
 				}
 				if len(arguments) != argumentCount || !reviewStartSupportedLens(arguments["lens"]) || orderErr != nil || order < 0 ||
 					!validReviewCapabilitySHA256(arguments["expected-revision"]) || !validReviewCapabilitySHA256(arguments["target"]) ||
@@ -1304,6 +1330,9 @@ func (input ReviewTransitionInput) submissionRepositoryContext() (string, error)
 }
 
 func (submission ReviewTransitionSubmission) Validate() error {
+	if submission.OperationToken == "capture-result" {
+		return submission.validateCaptureResult()
+	}
 	if submission.Value != nil {
 		return submission.validateFinalize()
 	}
@@ -1335,6 +1364,29 @@ func (submission ReviewTransitionSubmission) Validate() error {
 	}) || input.Slot != "input" || input.Domain != "artifact_path_or_stdin" || input.Schema != reviewVerificationEvidenceSchemaID ||
 		input.Minimum != 0 || input.Maximum != 0 || len(input.AllowedValues) != 0 || input.SubstitutionLocation != 5 {
 		return errors.New("verification evidence submission descriptor values are invalid") // refusal:by-design world-action: only a provider code fix can restore the capture value domains
+	}
+	return nil
+}
+
+// validateCaptureResult is the pi host-relay reviewer-result submission: the
+// materialize arguments only obtain the prompt bytes, so this descriptor --
+// the same binding tokens with the raw result substituted into --input -- is
+// the part of the rendered transition that advances reviewing authority.
+func (submission ReviewTransitionSubmission) validateCaptureResult() error {
+	if submission.Value == nil || len(submission.Values) != 0 || len(submission.ArgumentTokens) < 7 ||
+		submission.Value.SubstitutionLocation != len(submission.ArgumentTokens)-1 {
+		return errors.New("submission descriptor identity is incomplete") // refusal:by-design world-action: only a provider code fix can restore descriptor identity
+	}
+	for _, token := range submission.ArgumentTokens {
+		if strings.TrimSpace(token) == "" || !strings.HasPrefix(token, "--") || strings.ContainsAny(token, " \t\r\n") || strings.HasPrefix(token, "--cwd=") {
+			return errors.New("submission descriptor contains an unsafe argument token") // refusal:by-design world-action: only a provider code fix can emit safe argv tokens
+		}
+	}
+	if submission.ArgumentTokens[len(submission.ArgumentTokens)-1] != "--input="+reviewSubmissionValuePlaceholder ||
+		submission.Value.Slot != "reviewer_result" || submission.Value.Domain != "artifact_path_or_stdin" ||
+		submission.Value.Schema != reviewReviewerSchemaID || submission.Value.Minimum != 0 ||
+		submission.Value.Maximum != 0 || len(submission.Value.AllowedValues) != 0 {
+		return errors.New("reviewer result submission descriptor value is invalid") // refusal:by-design world-action: only a provider code fix can restore the capture value domain
 	}
 	return nil
 }

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -1195,14 +1195,24 @@ func (transition ReviewNextTransition) Validate() error {
 					argumentCount = 7
 				}
 				providerRuntime := model.AgentID(arguments["agent"])
-				if providerRuntime != "" && reviewProviderCaptureRuntime(providerRuntime) {
+				providerCapture := providerRuntime != "" && reviewProviderCaptureRuntime(providerRuntime)
+				hostRelayMaterialize := providerRuntime != "" && reviewProviderHostRelayMaterializeRuntime(providerRuntime)
+				if providerCapture {
 					argumentCount++
+				}
+				if hostRelayMaterialize {
+					// A host-relay capture input carries both --agent and
+					// --materialize=true: the host materializes first, then
+					// submits through the existing --input path.
+					argumentCount += 2
 				}
 				if len(arguments) != argumentCount || !reviewStartSupportedLens(arguments["lens"]) || orderErr != nil || order < 0 ||
 					!validReviewCapabilitySHA256(arguments["expected-revision"]) || !validReviewCapabilitySHA256(arguments["target"]) ||
 					strings.TrimSpace(arguments["lineage"]) == "" || reviewtransaction.ValidateReviewRepositoryContextHandle(arguments["repository-context"]) != nil ||
 					input.ArtifactSubject == nil || input.ChangedPathManifest == nil ||
-					nativeGitTransport && arguments["subject-hash"] != input.ArtifactSubject.SubjectHash || providerRuntime != "" && !reviewProviderCaptureRuntime(providerRuntime) ||
+					nativeGitTransport && arguments["subject-hash"] != input.ArtifactSubject.SubjectHash ||
+					providerRuntime != "" && !providerCapture && !hostRelayMaterialize ||
+					hostRelayMaterialize && arguments["materialize"] != "true" ||
 					legacyTransport && input.CandidateDiff == nil || nativeGitTransport && (!validReviewGitTree(input.BaseTree) || !validReviewGitTree(input.CandidateTree)) ||
 					(!legacyTransport && !nativeGitTransport) {
 					return errors.New("review capture transition lacks an exact repository and authority binding")


### PR DESCRIPTION
Second slice of the pi host-relay contract (follows #3254; prerequisite for gentle-pi#311 P4).

- `gentle-ai review capture-result <binding> --agent pi --materialize` prints the exact Go-materialized opaque provider task bytes to stdout — read-only, idempotent, no slot consumed. Only the `pi_host_relay` transport passes; compiled runtimes and OpenCode keep their existing refusals byte-identical (no dual path).
- The negotiated pi capture input now carries the materialize prelude in its arguments AND the provider-owned completing form in its submission (`capture-result` binding tokens + `--input={{value}}` slot) — the transition advances by its own tokens. Claude/codex/opencode renderings pinned unchanged.
- RDD: full 4R high-risk review to approved receipt `review-3f8df3f8ba16fe26` — the review itself corroborated the non-advancing-transition CRITICAL and the bounded correction (98/151 lines) added the submission form, targeted-validated with double PASS. Pre-push gate: allow.
- Verification: root suite green, deadcode ratchet clean, bench + 99-journey driven corpus exit 0 (pre-correction tree; correction is cli-only, package re-verified in full).

Follow-up noted by the validator: the review-ledger contract doc line about capture inputs should mention the submission descriptor — filing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to materialize host-relay review tasks and print the exact provider prompt for external execution.
  * Added support for submitting materialized results through the existing review input flow.
  * Added validation for supported runtimes, required agents, safe arguments, and valid submission formats.
  * Review status transitions now provide the necessary materialization and submission details.

* **Bug Fixes**
  * Prevented materialization from altering captures or occupying reviewer-result slots before submission.
  * Added safeguards against stale or invalid materialized task submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #3264.
