### PR TITLE
fix(tui): isolate default OpenCode model config from custom SDD profiles

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3510,6 +3510,9 @@ func (m Model) goBack(cmd *tea.Cmd) Model {
 }
 
 func (m *Model) setScreen(next Screen) {
+	if (m.Screen == ScreenProfiles || m.Screen == ScreenProfileCreate) && next != ScreenProfiles && next != ScreenProfileCreate {
+		m.Selection.ModelAssignments = nil
+	}
 	m.PreviousScreen = m.Screen
 	m.Screen = next
 	m.Cursor = 0
@@ -3523,6 +3526,7 @@ func (m *Model) setScreen(next Screen) {
 		m.PinErr = nil
 	}
 	if next == ScreenProfiles {
+		m.Selection.ModelAssignments = nil
 		// Refresh on entry without replacing valid data with an empty error state.
 		profiles, err := readProfilesFn(opencode.DefaultSettingsPath())
 		if err != nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4799,6 +4799,76 @@ func TestModelConfigOpenCodeNoPrePopulationWhenFileEmpty(t *testing.T) {
 	}
 }
 
+// TestModelConfigOpenCodeIsolatedFromCustomSDDProfiles verifies that accessing
+// or editing a custom SDD profile does not bleed profile assignments into the
+// default gentle-orchestrator / Configure OpenCode models screen.
+func TestModelConfigOpenCodeIsolatedFromCustomSDDProfiles(t *testing.T) {
+	defaultAssignment := model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"}
+	profileAssignment := model.ModelAssignment{ProviderID: "openai", ModelID: "o3"}
+
+	orig := readCurrentAssignmentsFn
+	readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+		return map[string]model.ModelAssignment{
+			"gentle-orchestrator": defaultAssignment,
+		}, nil
+	}
+	t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+	origProfiles := readProfilesFn
+	readProfilesFn = func(_ string) ([]model.Profile, error) {
+		return []model.Profile{
+			{
+				Name:              "high-performance",
+				OrchestratorModel: profileAssignment,
+				PhaseAssignments: map[string]model.ModelAssignment{
+					"sdd-apply": profileAssignment,
+				},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { readProfilesFn = origProfiles })
+
+	origStat := osStatModelCache
+	osStatModelCache = func(name string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStatModelCache = origStat })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	// 1. Enter ScreenProfiles
+	m.setScreen(ScreenProfiles)
+
+	// 2. Select the custom profile (cursor 0) to edit
+	m.Cursor = 0
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.Screen != ScreenProfileCreate {
+		t.Fatalf("expected ScreenProfileCreate, got %v", state.Screen)
+	}
+
+	// 3. Exit profile creation back to ScreenProfiles and then ScreenWelcome
+	state.setScreen(ScreenProfiles)
+	state.setScreen(ScreenWelcome)
+
+	// 4. Open ScreenModelConfig -> Configure OpenCode models
+	state.setScreen(ScreenModelConfig)
+	state.Cursor = 1 // Configure OpenCode models
+	updatedModelConfig, _ := state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	finalState := updatedModelConfig.(Model)
+
+	if finalState.Screen != ScreenModelPicker {
+		t.Fatalf("expected ScreenModelPicker, got %v", finalState.Screen)
+	}
+
+	if finalState.Selection.ModelAssignments == nil {
+		t.Fatal("expected pre-populated ModelAssignments from default gentle-orchestrator, got nil")
+	}
+
+	got := finalState.Selection.ModelAssignments["gentle-orchestrator"]
+	if got != defaultAssignment {
+		t.Errorf("gentle-orchestrator loaded profile assignment %+v, want default %+v", got, defaultAssignment)
+	}
+}
+
 // TestCustomSkillPickerBackGoesToStrictTDD verifies that in the custom preset,
 // with OpenCode + SDD + Skills, pressing Back on ScreenSkillPicker goes to ScreenStrictTDD
 // and NOT directly to ScreenSDDMode. StrictTDD must come before SDDMode in the back chain.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #950

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Clear transient profile model assignments on entering or exiting profile screens (`ScreenProfiles` and `ScreenProfileCreate`) so they do not leak into the default `gentle-orchestrator` model configuration screen.
- Ensure navigating to **Configure Models -> Configure OpenCode Models** properly loads the base `gentle-orchestrator` / `opencode.json` configuration rather than the last viewed custom SDD profile.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Reset `m.Selection.ModelAssignments = nil` in `setScreen` when entering `ScreenProfiles` or exiting from profile creation/editing screens to non-profile screens. |
| `internal/tui/model_test.go` | Added unit test `TestModelConfigOpenCodeIsolatedFromCustomSDDProfiles` verifying isolation between profile editing and default OpenCode model configuration. |

---

## 🤖 AI Assistance

- [x] **None** — No material AI assistance was used.
- [ ] **Material assistance used** — Complete all applicable declaration fields below.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/tui -run TestModelConfigOpenCode -v
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Unit tests pass (`go test ./internal/tui`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR stays within 400 changed lines |
| Check Issue Reference | ⏳ | PR body contains `Closes #950` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Benchmark validation completed: N/A, TUI state isolation fix
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale model assignments from persisting when leaving or reopening profile screens.
  - Ensured custom SDD profile configuration does not overwrite default OpenCode model assignments.

- **Tests**
  - Added coverage verifying model assignments remain isolated across profile configuration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->