### PR TITLE
docs(security): add private vulnerability reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities only through GitHub's private
+[Report a vulnerability](https://github.com/Gentleman-Programming/gentle-ai/security/advisories/new) flow. Do not disclose vulnerability details in public Issues or Discussions.
+If you do not see the private reporting option, it may not yet be enabled for this repository.
+
+To help maintainers assess the report, include:
+
+- The affected release or revision and the environment where you observed it.
+- A concise description of the impact and steps to reproduce it.
+- A minimal, safe proof of concept or other evidence, if available.
+- Any suggested mitigation or fix.
+
+Remove or redact credentials, access tokens, personal data, private repository
+information, and other sensitive material before submitting a report.
+
+## Supported Releases
+
+| Release channel | Security support |
+| --- | --- |
+| Latest stable release | Supported |
+| Current published prerelease | Supported |
+| Older releases | Not supported |
+| `main` | Not supported |
+
+## Coordination
+
+Maintainers assess private reports and coordinate remediation and advisory
+publication with the reporter when appropriate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,9 @@ This project follows a strict issue-first workflow:
 
 PRs that are not linked to an approved issue will be **automatically rejected** by CI.
 
+For suspected security vulnerabilities, follow the [security policy](.github/SECURITY.md)
+instead of opening a public Issue or Discussion.
+
 ---
 
 ## Looking for something to work on?


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3273

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds `.github/SECURITY.md` as the canonical policy for reporting suspected vulnerabilities.
- Directs reporters to GitHub Private Vulnerability Reporting and away from public Issues and Discussions.
- Documents supported release channels, privacy-safe reporting guidance, and coordinated remediation expectations.
- Links the security policy from `CONTRIBUTING.md`.

GitHub Private Vulnerability Reporting must still be enabled by a repository owner or administrator before the private reporting flow becomes available. This repository setting cannot be activated through this documentation-only PR.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `.github/SECURITY.md` | Adds the canonical private vulnerability disclosure policy, supported release channels, report guidance, and coordination expectations. |
| `CONTRIBUTING.md` | Directs suspected vulnerability reports to the security policy instead of public Issues or Discussions. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):**

OpenCode with OpenAI GPT-5.6 Sol and GPT-5.6 Terra.

**Material scope:**

AI assistance was used to analyze issue #3273, draft the security policy and contributing-guide update, and perform a structural review of the resulting documentation diff.

**Verification performed:**

The final diff was read back and checked with `git diff --check`. The policy path and `CONTRIBUTING.md` link target were verified locally. GitHub release data was checked to confirm that the current channels are stable `v2.3.0` and prerelease `v2.4.0-rc.8`; the policy intentionally uses durable channel names rather than version numbers.

The contributor reviewed and accepts responsibility for the complete submission.

---

## 🧪 Test Plan

This is a documentation-only change with no executable behavior.

- [x] `git diff --check`
- [x] Confirmed that `.github/SECURITY.md` is in a GitHub-supported security-policy location.
- [x] Confirmed that the relative link from `CONTRIBUTING.md` resolves to `.github/SECURITY.md`.
- [x] Confirmed current stable and prerelease channels through the GitHub Releases API.
- [ ] Unit tests pass (`go test ./...`) — Not run locally; no Go files changed.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — Not applicable; no Go files changed.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Not run locally; no runtime behavior changed.
- [x] Manually tested locally — Structural documentation readback completed.

**Benchmark Validation:** N/A. This change does not affect review lifecycle behavior, gates, recovery, delivery, benchmark implementation, corpus, classifiers, or measured product behavior.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR contains 34 changed lines, below the 400-line budget |
| Check Issue Reference | ⏳ | PR body contains `Closes #3273` |
| Check Issue Has `status:approved` | ✅ | Issue #3273 has `status:approved` |
| Check PR Has `type:*` Label | ⏳ | A maintainer must apply exactly `type:docs` |
| Unit Tests | ⏳ | Runs in CI |
| Go Format | ⏳ | Runs in CI |
| E2E Tests | ⏳ | Runs in CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the `type:docs` label to this PR — Maintainer action required
- [ ] Unit tests pass (`go test ./...`) — Pending CI
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — Pending CI
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Pending CI
- [x] Benchmark validation is not applicable, as explained in the Test Plan
- [x] I have updated documentation where necessary
- [x] My commit follows Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] My commit does not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

A repository owner or administrator must enable **Private vulnerability reporting** under the repository security settings. Until that setting is enabled, the policy's private **Report a vulnerability** link will not provide the intended reporting flow.

After activation, verify the setting with:

```bash
gh api repos/Gentleman-Programming/gentle-ai/private-vulnerability-reporting \
  --jq '.enabled'
```

The expected result is `true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy explaining how to privately report vulnerabilities.
  * Documented required report details, sensitive-data handling, supported release channels, and coordination procedures.
  * Updated contribution guidance to direct suspected security issues to the private reporting process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->