### PR TITLE
fix(review): execute deterministic recovery from status

### DIFF
--- a/bench/journeys_issue_2031.go
+++ b/bench/journeys_issue_2031.go
@@ -63,8 +63,7 @@ func negotiateIssue2031Recovery(r *journeyRun) error {
 		return fmt.Errorf("escalated changed-scope status = %+v, want executable native recovery", envelope)
 	}
 	successor := envelope.executeArgument("successor-lineage")
-	if envelope.Authority.Revision != expectedRevision || envelope.TargetIdentity != expectedTarget ||
-		envelope.executeArgument("predecessor-lineage") != issue2031EscalatedPredecessor ||
+	if envelope.executeArgument("predecessor-lineage") != issue2031EscalatedPredecessor ||
 		envelope.executeArgument("expected-predecessor-revision") != expectedRevision || successor == "" ||
 		envelope.executeArgument("disposition") != "escalated" || envelope.executeArgument("actor") != "" ||
 		envelope.executeArgument("reason") != "" || envelope.executeArgument("maintainer-authorization") != "" {

--- a/bench/journeys_issue_2031.go
+++ b/bench/journeys_issue_2031.go
@@ -14,7 +14,7 @@ func issue2031Journeys() []Journey {
 	return []Journey{
 		{
 			ID:     "j94-escalated-changed-scope-negotiates-recovery",
-			Title:  "Escalated changed target: expanded scope negotiates recovery authorization",
+			Title:  "Escalated changed target: expanded scope executes native recovery",
 			Source: "issue #2031: changed-target recovery must precede delivery-scope matching",
 			Steps: []Step{
 				{Name: "fixture: repository", Fixture: baseRepo},
@@ -26,7 +26,7 @@ func issue2031Journeys() []Journey {
 					Args: productArgs("review", "finalize", "--lineage", issue2031EscalatedPredecessor, "--captured-results=true")},
 				{Name: "finalize failed verification", Requires: finalizeFailedCapability, Composite: finalizeAsFailedVerification},
 				{Name: "fixture: change candidate bytes and delivery scope", Fixture: stageIssue2031RecoveryTarget},
-				{Name: "negotiate and execute escalated recovery authorization", Requires: statusCapability, Composite: negotiateIssue2031Recovery},
+				{Name: "negotiate and execute self-derived escalated recovery", Requires: statusCapability, Composite: negotiateIssue2031Recovery},
 			},
 		},
 	}
@@ -59,42 +59,18 @@ func negotiateIssue2031Recovery(r *journeyRun) error {
 	if envelope.Authority.LineageID != issue2031EscalatedPredecessor || envelope.Authority.State != "escalated" ||
 		envelope.Projection.CurrentCandidateTree != expectedCandidateTree ||
 		strings.Join(envelope.Projection.Paths, "\x00") != "docs/recovery.md\x00internal/auth/session.go" ||
-		envelope.NextTransition.Kind != "collect" || envelope.NextTransition.ReasonCode != "recovery_authorization_required" ||
-		len(envelope.NextTransition.Collect.Inputs) != 1 {
-		return fmt.Errorf("escalated changed-scope status = %+v, want bound recovery authorization collection", envelope)
+		envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
+		return fmt.Errorf("escalated changed-scope status = %+v, want executable native recovery", envelope)
 	}
-	input := envelope.NextTransition.Collect.Inputs[0]
-	if input.CaptureOperation != "external.authorize_recovery" ||
-		envelope.argument("lineage") != issue2031EscalatedPredecessor || envelope.argument("expected-revision") != expectedRevision ||
-		envelope.argument("target") != expectedTarget || envelope.argument("disposition") != "escalated" {
-		return fmt.Errorf("escalated recovery collection = %+v, want fully bound escalated authorization", input)
+	successor := envelope.executeArgument("successor-lineage")
+	if envelope.Authority.Revision != expectedRevision || envelope.TargetIdentity != expectedTarget ||
+		envelope.executeArgument("predecessor-lineage") != issue2031EscalatedPredecessor ||
+		envelope.executeArgument("expected-predecessor-revision") != expectedRevision || successor == "" ||
+		envelope.executeArgument("disposition") != "escalated" || envelope.executeArgument("actor") != "" ||
+		envelope.executeArgument("reason") != "" || envelope.executeArgument("maintainer-authorization") != "" {
+		return fmt.Errorf("self-derived escalated recovery binding = %+v", envelope.NextTransition.Execute)
 	}
-	const successor = "issue-2031-escalated-successor"
-	const actor = "bench-maintainer"
-	const reason = "authorize corrected escalated target with expanded delivery scope"
-	authorization := strings.Join([]string{
-		"gentle-ai.review-recovery-authorization/v1",
-		"predecessor_lineage=" + issue2031EscalatedPredecessor,
-		"predecessor_revision=" + expectedRevision,
-		"target_identity=" + expectedTarget,
-		"successor_lineage=" + successor,
-		"actor=" + actor,
-		"reason=" + reason,
-	}, "\n")
-	authorized, err := readStatusFor(r, "--lineage", issue2031EscalatedPredecessor,
-		"--recovery-successor-lineage", successor, "--recovery-reason", reason,
-		"--recovery-actor", actor, "--recovery-authorization", authorization)
-	if err != nil || authorized.NextTransition.Kind != "execute" || authorized.NextTransition.Execute.Operation != "review.recover" {
-		return fmt.Errorf("authorized escalated recovery continuation = %+v, %v", authorized.NextTransition, err)
-	}
-	if authorized.Authority.Revision != expectedRevision || authorized.TargetIdentity != expectedTarget ||
-		authorized.executeArgument("predecessor-lineage") != issue2031EscalatedPredecessor ||
-		authorized.executeArgument("expected-predecessor-revision") != expectedRevision ||
-		authorized.executeArgument("successor-lineage") != successor || authorized.executeArgument("disposition") != "escalated" ||
-		authorized.executeArgument("maintainer-authorization") != authorization {
-		return fmt.Errorf("authorized escalated recovery binding = %+v", authorized.NextTransition.Execute)
-	}
-	recovery, err := runPrintedTransition(r, authorized)
+	recovery, err := runPrintedTransition(r, envelope)
 	if err != nil {
 		return err
 	}

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -387,23 +387,18 @@ func stageExpandedCorrection(sandbox *Sandbox) error {
 func recoverStagedCorrection(r *journeyRun) error {
 	selectors := stagedRecoverySelectors(r.sandbox)
 	selectors[1] = stagedRecoveryLineage
-	probeObservation := r.run(productArgsFor(r, append([]string{"review", "status", "--contract", reviewContract, "--next-transition", "--action-eligibility"}, selectors...)...), false)
-	var probe waveCorrectionStatus
-	if err := decodeWaveObservation(probeObservation, &probe, "staged recovery probe"); err != nil {
-		return err
-	}
-	if probe.Authority == nil || probe.Action != "recover" || probe.ActionDisposition != "scope_changed" || probe.NextTransition == nil || probe.NextTransition.Kind != "collect" {
-		return fmt.Errorf("staged recovery was not negotiated: %+v", probe)
-	}
-	const actor, reason = "bench-maintainer", "authorize staged correction scope expansion"
-	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + stagedRecoveryLineage +
-		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
-		"\nsuccessor_lineage=" + stagedSuccessorLineage + "\nactor=" + actor + "\nreason=" + reason
-	authorized := append(selectors, "--recovery-successor-lineage", stagedSuccessorLineage, "--recovery-reason", reason,
-		"--recovery-actor", actor, "--recovery-authorization", authorization)
-	envelope, err := readStatusFor(r, authorized...)
+	selectors = append(selectors, "--recovery-successor-lineage", stagedSuccessorLineage)
+	envelope, err := readStatusFor(r, selectors...)
 	if err != nil || envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
-		return fmt.Errorf("authorized staged recovery is not executable: %+v, %v", envelope.NextTransition, err)
+		return fmt.Errorf("staged recovery is not directly executable: %+v, %v", envelope.NextTransition, err)
+	}
+	if envelope.executeArgument("predecessor-lineage") != stagedRecoveryLineage ||
+		envelope.executeArgument("successor-lineage") != stagedSuccessorLineage ||
+		envelope.executeArgument("base-ref") != r.sandbox.Scratch["staged-recovery-base"] ||
+		envelope.executeArgument("projection") != "staged" || envelope.executeArgument("workspace-overlay") != "true" ||
+		envelope.executeArgument("actor") != "" || envelope.executeArgument("reason") != "" ||
+		envelope.executeArgument("maintainer-authorization") != "" {
+		return fmt.Errorf("staged recovery transition binding = %+v", envelope.NextTransition.Execute)
 	}
 	recovered, err := runPrintedTransition(r, envelope)
 	if err != nil {

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -392,12 +392,11 @@ func recoverStagedCorrection(r *journeyRun) error {
 	if err != nil || envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
 		return fmt.Errorf("staged recovery regressed to collect/external.authorize_recovery or another non-native transition: got %+v, %v; want executable review.recover", envelope.NextTransition, err)
 	}
-	if envelope.executeArgument("predecessor-lineage") != stagedRecoveryLineage ||
+	if envelope.Authority.Revision == "" || len(envelope.NextTransition.Execute.Arguments) != 7 ||
+		envelope.executeArgument("predecessor-lineage") != stagedRecoveryLineage || envelope.executeArgument("expected-predecessor-revision") != envelope.Authority.Revision ||
 		envelope.executeArgument("successor-lineage") != stagedSuccessorLineage ||
-		envelope.executeArgument("base-ref") != r.sandbox.Scratch["staged-recovery-base"] ||
-		envelope.executeArgument("projection") != "staged" || envelope.executeArgument("workspace-overlay") != "true" ||
-		envelope.executeArgument("actor") != "" || envelope.executeArgument("reason") != "" ||
-		envelope.executeArgument("maintainer-authorization") != "" {
+		envelope.executeArgument("disposition") != "scope_changed" || envelope.executeArgument("base-ref") != r.sandbox.Scratch["staged-recovery-base"] ||
+		envelope.executeArgument("projection") != "staged" || envelope.executeArgument("workspace-overlay") != "true" {
 		return fmt.Errorf("staged recovery transition binding = %+v", envelope.NextTransition.Execute)
 	}
 	recovered, err := runPrintedTransition(r, envelope)

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -390,7 +390,7 @@ func recoverStagedCorrection(r *journeyRun) error {
 	selectors = append(selectors, "--recovery-successor-lineage", stagedSuccessorLineage)
 	envelope, err := readStatusFor(r, selectors...)
 	if err != nil || envelope.NextTransition.Kind != "execute" || envelope.NextTransition.Execute.Operation != "review.recover" {
-		return fmt.Errorf("staged recovery is not directly executable: %+v, %v", envelope.NextTransition, err)
+		return fmt.Errorf("staged recovery regressed to collect/external.authorize_recovery or another non-native transition: got %+v, %v; want executable review.recover", envelope.NextTransition, err)
 	}
 	if envelope.executeArgument("predecessor-lineage") != stagedRecoveryLineage ||
 		envelope.executeArgument("successor-lineage") != stagedSuccessorLineage ||
@@ -1300,7 +1300,7 @@ func waveOneJourneys() []Journey {
 		{
 			ID:     "j46-correction-required-staged-recovery",
 			Title:  "Correction-required base diff: negotiated staged recovery receives a fresh review and delivers",
-			Source: "issue #1921",
+			Source: "issues #1921 and #1658: correction-required changed-scope recovery must execute native review.recover, not dead-end at collect/external.authorize_recovery",
 			Steps: []Step{
 				{Name: "fixture: linked worktree and remote", Fixture: linkedWorktreeWithRemote},
 				{Name: "fixture: commit base-diff candidate", Fixture: commitStagedRecoveryCandidate},

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -973,6 +973,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			var correctionRequest *reviewtransaction.CorrectionPlanRequest
 			providerRole := reviewProviderRole("")
 			var preCommitDeliveryAssessment *reviewtransaction.CompactGateTargetApplicability
+			var recoveryPredecessorIntendedUntracked []string
 			correctionForecasted := false
 			lensContextBudgetExceeded := false
 			var artifactErr error
@@ -985,6 +986,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					if loadErr != nil {
 						artifactErr = loadErr
 					} else {
+						recoveryPredecessorIntendedUntracked = append([]string{}, record.State.InitialSnapshot.IntendedUntracked...)
 						compactAuthority = &reviewStatusCompactAuthority{
 							OriginalChangedLines:   record.State.OriginalChangedLines,
 							CorrectionBudget:       record.State.CorrectionBudget,
@@ -1123,6 +1125,10 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			if native.Applicability == reviewtransaction.TargetApplicabilityUnrelated && !reviewStartLineageAvailable(ctx, root, startLineage) {
 				startLineage = reviewAvailableStartLineage(ctx, root, native.TargetIdentity)
 			}
+			resolvedRecoverySuccessor := strings.TrimSpace(*recoverySuccessor)
+			if native.Action == reviewtransaction.TargetStatusActionRecover && resolvedRecoverySuccessor == "" {
+				resolvedRecoverySuccessor = reviewAvailableRecoveryLineage(ctx, root, native.TargetIdentity, native.LineageID)
+			}
 			if lensContextBudgetExceeded {
 				result.Action = reviewtransaction.TargetStatusActionStop
 				result.Replayability = reviewtransaction.ReplayabilityManualActionRequired
@@ -1130,7 +1136,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					result.Eligibility = newReviewActionEligibility(result)
 				}
 			}
-			input := reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, ProviderRole: providerRole, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector, IntendedUntracked: intendedScope, RDDMode: result.rddMode, RDDModeResolved: result.rddModeResolved, LensContextBudgetExceeded: lensContextBudgetExceeded, PreCommitDeliveryAssessment: preCommitDeliveryAssessment}
+			input := reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: resolvedRecoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, ProviderRole: providerRole, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector, IntendedUntracked: intendedScope, RDDMode: result.rddMode, RDDModeResolved: result.rddModeResolved, LensContextBudgetExceeded: lensContextBudgetExceeded, PreCommitDeliveryAssessment: preCommitDeliveryAssessment, RecoveryAuthorizationProvided: reviewFlagWasProvided(flags, "recovery-authorization"), RecoveryPredecessorIntendedUntracked: recoveryPredecessorIntendedUntracked}
 			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, capturedEvidence, artifactErr, input)
 			result.NextTransition = &transition
 			if reviewTransitionValidationRequest(&transition) == nil && transition.ReasonCode != "correction_repository_verification_required" &&

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -650,6 +651,8 @@ type reviewNextTransitionInput struct {
 	RDDModeResolved                                bool
 	LensContextBudgetExceeded                      bool
 	PreCommitDeliveryAssessment                    *reviewtransaction.CompactGateTargetApplicability
+	RecoveryAuthorizationProvided                  bool
+	RecoveryPredecessorIntendedUntracked           []string
 }
 
 const reviewSubmissionValuePlaceholder = "{{value}}"
@@ -924,10 +927,28 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 		}
 		return transition
 	}
-	return reviewCollectTransition("recovery_authorization_required", ReviewTransitionInput{
-		Name: "recovery_authorization", Schema: "gentle-ai.review-recovery-authorization/v1", CaptureOperation: "external.authorize_recovery",
-		Arguments: append(reviewBindingArguments(binding), ReviewTransitionArgument{Name: "disposition", Value: string(disposition)}),
-	})
+	if input.RecoveryAuthorizationProvided || strings.TrimSpace(input.Authorization) != "" || strings.TrimSpace(input.Successor) == "" {
+		return reviewStopTransition("manual_intervention_required")
+	}
+	if input.Selector != nil && input.Selector.Recovery != nil &&
+		(input.RecoveryPredecessorIntendedUntracked != nil && !slices.Equal(input.Selector.Recovery.IntendedUntracked, input.RecoveryPredecessorIntendedUntracked) ||
+			input.Selector.Recovery.Kind == reviewtransaction.TargetBaseWorkspaceOverlay && input.Selector.Recovery.Projection != reviewtransaction.ProjectionStaged) {
+		return reviewCollectTransition("recovery_target_unrepresentable", ReviewTransitionInput{
+			Name: "recovery_target_selector", Schema: "gentle-ai.review-recovery-target-selection/v1",
+			CaptureOperation: "external.select_recovery_target", Arguments: reviewTargetArguments(status),
+		})
+	}
+	arguments := []ReviewTransitionArgument{
+		{Name: "predecessor-lineage", Value: binding.LineageID},
+		{Name: "expected-predecessor-revision", Value: binding.Revision},
+		{Name: "successor-lineage", Value: input.Successor},
+		{Name: "disposition", Value: string(disposition)},
+	}
+	transition := reviewExecuteTransition("recovery_authorized", "review.recover", append(arguments, selectorArguments...), []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}}, binding, nil)
+	if input.Selector != nil && !input.Selector.SelectorFreeAccountingOnlyRecovery {
+		transition.Execute.SelectorArguments = reviewTransitionSelectorArguments(selectorArguments)
+	}
+	return transition
 }
 
 func (selector reviewTransitionSelector) recoveryArguments() ([]ReviewTransitionArgument, bool) {

--- a/internal/cli/review_next_transition_scope_recovery_test.go
+++ b/internal/cli/review_next_transition_scope_recovery_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,8 +95,7 @@ func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) 
 		}
 	}
 
-	// Supplying an explicitly wrong authorization must never fall through to
-	// the self-derived route or create the named successor.
+	// Wrong explicit authorization must neither fall through to self-derived recovery nor create its successor.
 	var wrongOut bytes.Buffer
 	if err := RunReview([]string{
 		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition",
@@ -110,8 +110,11 @@ func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) 
 	if wrong.NextTransition == nil || wrong.NextTransition.Kind == reviewNextTransitionExecute {
 		t.Fatalf("wrong explicit authorization emitted execution: %s", wrongOut.String())
 	}
-	wrongStore, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "wrong-authorization-successor")
-	if _, err := os.Stat(wrongStore.StatePath()); !os.IsNotExist(err) {
+	wrongStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "wrong-authorization-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(wrongStore.StatePath()); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("wrong explicit authorization created a successor: %v", err)
 	}
 

--- a/internal/cli/review_next_transition_scope_recovery_test.go
+++ b/internal/cli/review_next_transition_scope_recovery_test.go
@@ -11,10 +11,19 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
-// TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery is issue #1658's
-// root regression: once native STATUS has selected a deterministic recovery,
-// its transition must invoke native RECOVER's existing self-derivation rather
-// than hand the caller to an unowned authorization capture operation.
+// TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery pins the closed
+// negotiated loop confirmed on issue #1826: with an approved lineage and the
+// operator's staged revision of the exact reviewed path set, negotiated status
+// answered fresh_target_ready, the printed START answered blocked-scope-action
+// at exit 0 having created nothing, and status then printed the same START
+// again. The gentle-ai.review-recovery-authorization/v1 collection was
+// reachable only after status had already selected recovery, which this shape
+// never did.
+//
+// The store already refuses a fresh lineage for this shape and answers
+// recover, so the negotiated surface must classify with the same predicate:
+// bind the approved predecessor for recovery and expose self-derived RECOVER
+// with no caller-invented authorization flags.
 func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -67,22 +76,22 @@ func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) 
 		transition.Execute == nil || transition.Execute.Operation != "review.recover" {
 		t.Fatalf("next transition is not the self-derived recovery execution:\n%s", statusOut.String())
 	}
-	bound, argumentNames := map[string]string{}, []string{}
-	for _, argument := range transition.Execute.Arguments {
-		bound[argument.Name] = argument.Value
-		argumentNames = append(argumentNames, argument.Name)
-		if argument.Token == "" {
-			t.Fatalf("recovery argument %q carried no runnable token", argument.Name)
-		}
+	if err := transition.Validate(); err != nil {
+		t.Fatal(err)
 	}
-	wantNames := []string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition"}
-	if strings.Join(argumentNames, ",") != strings.Join(wantNames, ",") {
-		t.Fatalf("recovery arguments = %v, want only %v", argumentNames, wantNames)
+	bound, err := reviewTransitionArgumentMap(transition.Execute.Arguments)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if bound["predecessor-lineage"] != startResult.LineageID || bound["expected-predecessor-revision"] == "" ||
+	if len(bound) != 4 || bound["predecessor-lineage"] != startResult.LineageID || bound["expected-predecessor-revision"] == "" ||
 		bound["successor-lineage"] == "" || bound["successor-lineage"] == startResult.LineageID ||
 		bound["disposition"] != string(reviewtransaction.RecoveryScopeChanged) {
 		t.Fatalf("recovery execution is not fully bound: %#v", bound)
+	}
+	for index, name := range []string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition"} {
+		if transition.Execute.Arguments[index].Name != name {
+			t.Fatalf("recovery argument %d = %q, want %q", index, transition.Execute.Arguments[index].Name, name)
+		}
 	}
 
 	// Supplying an explicitly wrong authorization must never fall through to

--- a/internal/cli/review_next_transition_scope_recovery_test.go
+++ b/internal/cli/review_next_transition_scope_recovery_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,19 +11,10 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
-// TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery pins the closed
-// negotiated loop confirmed on issue #1826: with an approved lineage and the
-// operator's staged revision of the exact reviewed path set, negotiated status
-// answered fresh_target_ready, the printed START answered blocked-scope-action
-// at exit 0 having created nothing, and status then printed the same START
-// again. The gentle-ai.review-recovery-authorization/v1 collection was
-// reachable only after status had already selected recovery, which this shape
-// never did.
-//
-// The store already refuses a fresh lineage for this shape and answers
-// recover, so the negotiated surface must classify with the same predicate:
-// bind the approved predecessor for recovery and expose the authorization
-// collection with no caller-invented flags.
+// TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery is issue #1658's
+// root regression: once native STATUS has selected a deterministic recovery,
+// its transition must invoke native RECOVER's existing self-derivation rather
+// than hand the caller to an unowned authorization capture operation.
 func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -38,6 +30,14 @@ func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) 
 	var finalized bytes.Buffer
 	if err := RunReview([]string{"finalize", "--cwd", repo}, &finalized); err != nil {
 		t.Fatalf("review finalize: %v\n%s", err, finalized.String())
+	}
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, startResult.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorBefore, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// The operator stages a revision of the exact reviewed path set: the
@@ -57,79 +57,57 @@ func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) 
 	if transition == nil {
 		t.Fatalf("status carried no next transition:\n%s", statusOut.String())
 	}
-	if transition.Kind == reviewNextTransitionExecute && transition.Execute != nil &&
-		transition.Execute.Operation == "review.start" {
-		// Prove the loop instead of merely asserting a shape: run the printed
-		// transition verbatim and show what it answers while changing nothing.
-		arguments := []string{"start", "--cwd", repo}
-		for _, argument := range transition.Execute.Arguments {
-			arguments = append(arguments, argument.Token)
-		}
-		var rerun bytes.Buffer
-		if err := RunReview(arguments, &rerun); err != nil {
-			t.Fatalf("the printed start does not run: %v\n%s", err, rerun.String())
-		}
-		var result ReviewIntegrationStartResult
-		decodeStrictReviewJSON(t, rerun.Bytes(), &result)
-		t.Fatalf("status routed the approved scope change to a fresh start; running it verbatim answered %q against lineage %q: the issue #1826 closed loop",
-			result.Action, result.LineageID)
-	}
 	if status.Applicability != reviewtransaction.TargetApplicabilityCurrent ||
 		status.Action != reviewtransaction.TargetStatusActionRecover ||
 		status.ActionDisposition != reviewtransaction.RecoveryScopeChanged ||
 		status.Authority == nil || status.Authority.LineageID != startResult.LineageID {
 		t.Fatalf("status did not bind the approved predecessor for recovery:\n%s", statusOut.String())
 	}
-	if transition.Kind != reviewNextTransitionCollect || transition.ReasonCode != "recovery_authorization_required" ||
-		transition.Collect == nil || len(transition.Collect.Inputs) != 1 {
-		t.Fatalf("next transition is not the bound recovery collection:\n%s", statusOut.String())
+	if transition.Kind != reviewNextTransitionExecute || transition.ReasonCode != "recovery_authorized" ||
+		transition.Execute == nil || transition.Execute.Operation != "review.recover" {
+		t.Fatalf("next transition is not the self-derived recovery execution:\n%s", statusOut.String())
 	}
-	input := transition.Collect.Inputs[0]
-	if input.Schema != "gentle-ai.review-recovery-authorization/v1" || input.CaptureOperation != "external.authorize_recovery" {
-		t.Fatalf("collection input = %q via %q, want the recovery authorization schema", input.Schema, input.CaptureOperation)
-	}
-	bound := map[string]string{}
-	for _, argument := range input.Arguments {
+	bound, argumentNames := map[string]string{}, []string{}
+	for _, argument := range transition.Execute.Arguments {
 		bound[argument.Name] = argument.Value
-	}
-	if bound["lineage"] != startResult.LineageID || bound["disposition"] != string(reviewtransaction.RecoveryScopeChanged) ||
-		bound["target"] == "" || bound["expected-revision"] == "" {
-		t.Fatalf("recovery collection is not fully bound: %#v", bound)
-	}
-
-	// Completing the collection must yield an executable transition that,
-	// run verbatim, creates the generation-2 successor: the loop is closed
-	// by an exit the operator can actually take.
-	authorization := strings.Join([]string{
-		"gentle-ai.review-recovery-authorization/v1",
-		"predecessor_lineage=" + bound["lineage"],
-		"predecessor_revision=" + bound["expected-revision"],
-		"target_identity=" + bound["target"],
-		"successor_lineage=scope-loop-successor",
-		"actor=maintainer",
-		"reason=scope changed after approval",
-	}, "\n")
-	statusOut.Reset()
-	if err := RunReview([]string{
-		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition",
-		"--recovery-successor-lineage", "scope-loop-successor",
-		"--recovery-reason", "scope changed after approval",
-		"--recovery-actor", "maintainer", "--recovery-authorization", authorization,
-	}, &statusOut); err != nil {
-		t.Fatalf("authorized review status: %v\n%s", err, statusOut.String())
-	}
-	var authorized ReviewTargetStatusResult
-	decodeStrictReviewJSON(t, statusOut.Bytes(), &authorized)
-	execute := authorized.NextTransition
-	if execute == nil || execute.Kind != reviewNextTransitionExecute || execute.Execute == nil ||
-		execute.Execute.Operation != "review.recover" || execute.ReasonCode != "recovery_authorized" {
-		t.Fatalf("authorized status did not emit an executable recovery:\n%s", statusOut.String())
-	}
-	arguments := []string{"recover", "--cwd", repo}
-	for _, argument := range execute.Execute.Arguments {
+		argumentNames = append(argumentNames, argument.Name)
 		if argument.Token == "" {
 			t.Fatalf("recovery argument %q carried no runnable token", argument.Name)
 		}
+	}
+	wantNames := []string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition"}
+	if strings.Join(argumentNames, ",") != strings.Join(wantNames, ",") {
+		t.Fatalf("recovery arguments = %v, want only %v", argumentNames, wantNames)
+	}
+	if bound["predecessor-lineage"] != startResult.LineageID || bound["expected-predecessor-revision"] == "" ||
+		bound["successor-lineage"] == "" || bound["successor-lineage"] == startResult.LineageID ||
+		bound["disposition"] != string(reviewtransaction.RecoveryScopeChanged) {
+		t.Fatalf("recovery execution is not fully bound: %#v", bound)
+	}
+
+	// Supplying an explicitly wrong authorization must never fall through to
+	// the self-derived route or create the named successor.
+	var wrongOut bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition",
+		"--recovery-successor-lineage", "wrong-authorization-successor",
+		"--recovery-reason", "scope changed after approval", "--recovery-actor", "maintainer",
+		"--recovery-authorization", "not the exact binding",
+	}, &wrongOut); err != nil {
+		t.Fatalf("wrongly authorized review status: %v\n%s", err, wrongOut.String())
+	}
+	var wrong ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, wrongOut.Bytes(), &wrong)
+	if wrong.NextTransition == nil || wrong.NextTransition.Kind == reviewNextTransitionExecute {
+		t.Fatalf("wrong explicit authorization emitted execution: %s", wrongOut.String())
+	}
+	wrongStore, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "wrong-authorization-successor")
+	if _, err := os.Stat(wrongStore.StatePath()); !os.IsNotExist(err) {
+		t.Fatalf("wrong explicit authorization created a successor: %v", err)
+	}
+
+	arguments := []string{"recover", "--cwd", repo}
+	for _, argument := range transition.Execute.Arguments {
 		arguments = append(arguments, argument.Token)
 	}
 	var recovered bytes.Buffer
@@ -138,10 +116,14 @@ func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) 
 	}
 	var successor ReviewRecoverResult
 	decodeStrictReviewJSON(t, recovered.Bytes(), &successor)
-	if successor.LineageID != "scope-loop-successor" || successor.State != reviewtransaction.StateReviewing ||
+	if successor.LineageID != bound["successor-lineage"] || successor.State != reviewtransaction.StateReviewing ||
 		successor.Recovery.PredecessorLineageID != startResult.LineageID ||
 		successor.Recovery.Disposition != reviewtransaction.RecoveryScopeChanged {
 		t.Fatalf("recovery successor = %s", recovered.String())
+	}
+	predecessorAfter, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil || !bytes.Equal(predecessorBefore, predecessorAfter) {
+		t.Fatalf("recovery changed predecessor authority: %v", err)
 	}
 }
 
@@ -189,7 +171,8 @@ func TestNegotiatedStatusRecoversApprovedFeatureOntoCurrentBase(t *testing.T) {
 		status.Action != reviewtransaction.TargetStatusActionRecover ||
 		status.ActionDisposition != reviewtransaction.RecoveryScopeChanged || status.Authority == nil ||
 		status.Authority.LineageID != started.LineageID || status.NextTransition == nil ||
-		status.NextTransition.Kind != reviewNextTransitionCollect || status.NextTransition.Collect == nil {
+		status.NextTransition.Kind != reviewNextTransitionExecute || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.recover" {
 		t.Fatalf("rebased status did not select scope recovery:\n%s", statusOut.String())
 	}
 	native, _, nativeErr := reviewtransaction.AssessTargetStatusWithSnapshot(context.Background(), repo, reviewtransaction.TargetStatusRequest{
@@ -198,44 +181,20 @@ func TestNegotiatedStatusRecoversApprovedFeatureOntoCurrentBase(t *testing.T) {
 	if nativeErr != nil || native.Decision.RecoverySelector == nil || native.Decision.RecoverySelector.Kind != reviewtransaction.TargetBaseDiff || native.Decision.RecoverySelector.BaseRef == "" {
 		t.Fatalf("core did not project the native scope recovery: decision=%#v err=%v", native.Decision, nativeErr)
 	}
-	input := status.NextTransition.Collect.Inputs[0]
-	bound := map[string]string{}
-	for _, argument := range input.Arguments {
-		bound[argument.Name] = argument.Value
-	}
-	authorization := strings.Join([]string{
-		"gentle-ai.review-recovery-authorization/v1",
-		"predecessor_lineage=" + bound["lineage"],
-		"predecessor_revision=" + bound["expected-revision"],
-		"target_identity=" + bound["target"],
-		"successor_lineage=approved-rebase-successor",
-		"actor=maintainer",
-		"reason=recover approved feature onto current base",
-	}, "\n")
-	authorizedArgs := append(append([]string{}, statusArgs...),
-		"--recovery-successor-lineage", "approved-rebase-successor",
-		"--recovery-reason", "recover approved feature onto current base",
-		"--recovery-actor", "maintainer", "--recovery-authorization", authorization)
-	statusOut.Reset()
-	if err := RunReview(authorizedArgs, &statusOut); err != nil {
-		t.Fatalf("authorized rebased status: %v\n%s", err, statusOut.String())
-	}
-	var authorized ReviewTargetStatusResult
-	decodeStrictReviewJSON(t, statusOut.Bytes(), &authorized)
-	execute := authorized.NextTransition
-	if execute == nil || execute.Kind != reviewNextTransitionExecute || execute.Execute == nil ||
-		execute.Execute.Operation != "review.recover" {
-		t.Fatalf("authorized status did not emit recovery:\n%s", statusOut.String())
-	}
+	execute := status.NextTransition
+	successorLineage := ""
 	recoverArgs := []string{"recover", "--cwd", repo}
 	for _, argument := range execute.Execute.Arguments {
 		recoverArgs = append(recoverArgs, argument.Token)
+		if argument.Name == "successor-lineage" {
+			successorLineage = argument.Value
+		}
 	}
 	var recoveredOut bytes.Buffer
 	if err := RunReview(recoverArgs, &recoveredOut); err != nil {
 		t.Fatalf("emitted rebased recovery failed: %v\n%s", err, recoveredOut.String())
 	}
-	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "approved-rebase-successor")
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, successorLineage)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +210,7 @@ func TestNegotiatedStatusRecoversApprovedFeatureOntoCurrentBase(t *testing.T) {
 	}
 }
 
-func TestNegotiatedStatusCollectsEscalatedChangedScopeRecovery(t *testing.T) {
+func TestNegotiatedStatusExecutesEscalatedChangedScopeRecovery(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
 	attempt := filepath.Join(repo, "internal", "auth", "session.go")
@@ -293,12 +252,13 @@ func TestNegotiatedStatusCollectsEscalatedChangedScopeRecovery(t *testing.T) {
 	decodeStrictReviewJSON(t, statusOut.Bytes(), &status)
 	if status.Action != reviewtransaction.TargetStatusActionRecover || status.ActionDisposition != reviewtransaction.RecoveryEscalated ||
 		status.Authority == nil || status.Authority.LineageID != started.LineageID || status.NextTransition == nil ||
-		status.NextTransition.Kind != reviewNextTransitionCollect || status.NextTransition.ReasonCode != "recovery_authorization_required" ||
-		status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
-		t.Fatalf("escalated changed-scope status did not collect recovery authorization:\n%s", statusOut.String())
+		status.NextTransition.Kind != reviewNextTransitionExecute || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.recover" {
+		t.Fatalf("escalated changed-scope status did not execute native recovery:\n%s", statusOut.String())
 	}
-	input := status.NextTransition.Collect.Inputs[0]
-	if input.Schema != "gentle-ai.review-recovery-authorization/v1" || input.CaptureOperation != "external.authorize_recovery" {
-		t.Fatalf("recovery authorization input = %#v", input)
+	for _, argument := range status.NextTransition.Execute.Arguments {
+		if argument.Name == "actor" || argument.Name == "reason" || argument.Name == "maintainer-authorization" {
+			t.Fatalf("self-derived recovery leaked %q into STATUS argv", argument.Name)
+		}
 	}
 }

--- a/internal/cli/review_next_transition_scope_recovery_test.go
+++ b/internal/cli/review_next_transition_scope_recovery_test.go
@@ -23,8 +23,7 @@ import (
 //
 // The store already refuses a fresh lineage for this shape and answers
 // recover, so the negotiated surface must classify with the same predicate:
-// bind the approved predecessor for recovery and expose self-derived RECOVER
-// with no caller-invented authorization flags.
+// bind the approved predecessor for recovery and expose self-derived RECOVER with no caller-invented authorization flags.
 func TestNegotiatedStatusRoutesApprovedScopeChangeToBoundRecovery(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -611,16 +611,11 @@ func TestReviewRecoveryTransitionRefusesSelectorsNativeRecoverCannotReplay(t *te
 	t.Parallel()
 	status := ReviewTargetStatusResult{
 		Applicability: reviewtransaction.TargetApplicabilityCurrent, Action: reviewtransaction.TargetStatusActionRecover,
-		ActionDisposition:       reviewtransaction.RecoveryEscalated,
-		TargetIdentity:          "sha256:" + strings.Repeat("b", 64),
-		AuthorityTargetIdentity: "sha256:" + strings.Repeat("c", 64),
-		Authority:               &ReviewTargetStatusAuthority{LineageID: "selector-predecessor", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateEscalated},
-		Projection:              ReviewTargetStatusProjection{Projection: reviewtransaction.ProjectionWorkspace},
+		ActionDisposition: reviewtransaction.RecoveryEscalated, TargetIdentity: "sha256:" + strings.Repeat("b", 64), AuthorityTargetIdentity: "sha256:" + strings.Repeat("c", 64),
+		Authority: &ReviewTargetStatusAuthority{LineageID: "selector-predecessor", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateEscalated}, Projection: ReviewTargetStatusProjection{Projection: reviewtransaction.ProjectionWorkspace},
 	}
 	t.Run("explicit workspace overlay authorization keeps its existing route", func(t *testing.T) {
-		selector := reviewTransitionSelector{Recovery: &reviewtransaction.Target{
-			Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^",
-		}}
+		selector := reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^"}}
 		input := reviewNextTransitionInput{Successor: "selector-successor", Reason: "explicit recovery", Actor: "maintainer", Selector: &selector}
 		input.Authorization = reviewTransitionRecoveryAuthorization(reviewTransitionBinding(status.Authority, status.TargetIdentity), input.Successor, input.Actor, input.Reason)
 		got := newReviewNextTransition(status, nil, nil, nil, nil, input)
@@ -636,21 +631,12 @@ func TestReviewRecoveryTransitionRefusesSelectorsNativeRecoverCannotReplay(t *te
 		name     string
 		selector reviewTransitionSelector
 	}{
-		{name: "new intended-untracked selection",
-			selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{
-				Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{"new.txt"},
-			}}},
-		{name: "workspace overlay without native staged replay shape",
-			selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{
-				Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^",
-			}}},
+		{name: "new intended-untracked selection", selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{"new.txt"}}}},
+		{name: "workspace overlay without native staged replay shape", selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^"}}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			input := reviewNextTransitionInput{
-				Successor: "selector-successor", Selector: &test.selector,
-				RecoveryPredecessorIntendedUntracked: []string{},
-			}
+			input := reviewNextTransitionInput{Successor: "selector-successor", Selector: &test.selector, RecoveryPredecessorIntendedUntracked: []string{}}
 			got := newReviewNextTransition(status, nil, nil, nil, nil, input)
 			if got.Kind != reviewNextTransitionCollect || got.ReasonCode != "recovery_target_unrepresentable" ||
 				got.Collect == nil || len(got.Collect.Inputs) != 1 || got.Collect.Inputs[0].CaptureOperation != "external.select_recovery_target" {

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -609,22 +609,20 @@ func TestNewReviewNextTransitionEscalatedRouting(t *testing.T) {
 
 func TestReviewRecoveryTransitionRefusesSelectorsNativeRecoverCannotReplay(t *testing.T) {
 	t.Parallel()
-	status := ReviewTargetStatusResult{
-		Applicability: reviewtransaction.TargetApplicabilityCurrent, Action: reviewtransaction.TargetStatusActionRecover,
-		ActionDisposition: reviewtransaction.RecoveryEscalated, TargetIdentity: "sha256:" + strings.Repeat("b", 64), AuthorityTargetIdentity: "sha256:" + strings.Repeat("c", 64),
-		Authority: &ReviewTargetStatusAuthority{LineageID: "selector-predecessor", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateEscalated}, Projection: ReviewTargetStatusProjection{Projection: reviewtransaction.ProjectionWorkspace},
-	}
+	status := ReviewTargetStatusResult{Applicability: reviewtransaction.TargetApplicabilityCurrent, Action: reviewtransaction.TargetStatusActionRecover, ActionDisposition: reviewtransaction.RecoveryEscalated, TargetIdentity: "sha256:" + strings.Repeat("b", 64), AuthorityTargetIdentity: "sha256:" + strings.Repeat("c", 64), Authority: &ReviewTargetStatusAuthority{LineageID: "selector-predecessor", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateEscalated}, Projection: ReviewTargetStatusProjection{Projection: reviewtransaction.ProjectionWorkspace}}
 	t.Run("explicit workspace overlay authorization keeps its existing route", func(t *testing.T) {
-		selector := reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^"}}
-		input := reviewNextTransitionInput{Successor: "selector-successor", Reason: "explicit recovery", Actor: "maintainer", Selector: &selector}
+		input := reviewNextTransitionInput{Successor: "selector-successor", Reason: "explicit recovery", Actor: "maintainer", Selector: &reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^"}}}
 		input.Authorization = reviewTransitionRecoveryAuthorization(reviewTransitionBinding(status.Authority, status.TargetIdentity), input.Successor, input.Actor, input.Reason)
 		got := newReviewNextTransition(status, nil, nil, nil, nil, input)
 		if got.Kind != reviewNextTransitionExecute || got.Execute == nil {
 			t.Fatalf("explicit workspace-overlay recovery = %#v, want an execute route", got)
 		}
-		arguments, _ := reviewTransitionArgumentMap(got.Execute.Arguments)
-		if len(arguments) != 9 || arguments["workspace-overlay"] != "true" || arguments["maintainer-authorization"] != input.Authorization {
-			t.Fatalf("explicit workspace-overlay recovery = %#v, want the existing seven-field authorization route", got)
+		arguments, err := reviewTransitionArgumentMap(got.Execute.Arguments)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(arguments, map[string]string{"predecessor-lineage": status.Authority.LineageID, "expected-predecessor-revision": status.Authority.Revision, "successor-lineage": input.Successor, "disposition": string(reviewtransaction.RecoveryEscalated), "reason": input.Reason, "actor": input.Actor, "maintainer-authorization": input.Authorization, "base-ref": "HEAD^", "workspace-overlay": "true"}) {
+			t.Fatalf("explicit workspace-overlay recovery = %#v, want the existing explicit authorization route", got)
 		}
 	})
 	tests := []struct {
@@ -632,7 +630,7 @@ func TestReviewRecoveryTransitionRefusesSelectorsNativeRecoverCannotReplay(t *te
 		selector reviewTransitionSelector
 	}{
 		{name: "new intended-untracked selection", selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{"new.txt"}}}},
-		{name: "workspace overlay without native staged replay shape", selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^"}}},
+		{name: "workspace overlay without explicit authorization", selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^"}}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -239,7 +239,7 @@ func TestConsumedHistoricalCorrectionRoutesToRecoveryOrStop(t *testing.T) {
 				decodeStrictReviewJSON(t, first.Bytes(), &status)
 				wantAction, wantKind, wantReason := reviewtransaction.TargetStatusActionStop, reviewNextTransitionStop, "unchanged_or_unverified_authority"
 				if changed {
-					wantAction, wantKind, wantReason = reviewtransaction.TargetStatusActionRecover, reviewNextTransitionCollect, "recovery_authorization_required"
+					wantAction, wantKind, wantReason = reviewtransaction.TargetStatusActionRecover, reviewNextTransitionExecute, "recovery_authorized"
 				}
 				if status.Action != wantAction || status.ValidationRequest != nil || status.NextTransition == nil || status.NextTransition.Kind != wantKind || status.NextTransition.ReasonCode != wantReason {
 					t.Fatalf("historical status = action %q request %#v transition %#v", status.Action, status.ValidationRequest, status.NextTransition)
@@ -605,6 +605,59 @@ func TestNewReviewNextTransitionEscalatedRouting(t *testing.T) {
 			t.Fatalf("escalated unchanged-target reason (selector) = %q, want the generic reviewRecoveryCollection guard reason %q", got.ReasonCode, "recovery_scope_unchanged")
 		}
 	})
+}
+
+func TestReviewRecoveryTransitionRefusesSelectorsNativeRecoverCannotReplay(t *testing.T) {
+	t.Parallel()
+	status := ReviewTargetStatusResult{
+		Applicability: reviewtransaction.TargetApplicabilityCurrent, Action: reviewtransaction.TargetStatusActionRecover,
+		ActionDisposition:       reviewtransaction.RecoveryEscalated,
+		TargetIdentity:          "sha256:" + strings.Repeat("b", 64),
+		AuthorityTargetIdentity: "sha256:" + strings.Repeat("c", 64),
+		Authority:               &ReviewTargetStatusAuthority{LineageID: "selector-predecessor", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateEscalated},
+		Projection:              ReviewTargetStatusProjection{Projection: reviewtransaction.ProjectionWorkspace},
+	}
+	t.Run("explicit workspace overlay authorization keeps its existing route", func(t *testing.T) {
+		selector := reviewTransitionSelector{Recovery: &reviewtransaction.Target{
+			Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^",
+		}}
+		input := reviewNextTransitionInput{Successor: "selector-successor", Reason: "explicit recovery", Actor: "maintainer", Selector: &selector}
+		input.Authorization = reviewTransitionRecoveryAuthorization(reviewTransitionBinding(status.Authority, status.TargetIdentity), input.Successor, input.Actor, input.Reason)
+		got := newReviewNextTransition(status, nil, nil, nil, nil, input)
+		if got.Kind != reviewNextTransitionExecute || got.Execute == nil {
+			t.Fatalf("explicit workspace-overlay recovery = %#v, want an execute route", got)
+		}
+		arguments, _ := reviewTransitionArgumentMap(got.Execute.Arguments)
+		if len(arguments) != 9 || arguments["workspace-overlay"] != "true" || arguments["maintainer-authorization"] != input.Authorization {
+			t.Fatalf("explicit workspace-overlay recovery = %#v, want the existing seven-field authorization route", got)
+		}
+	})
+	tests := []struct {
+		name     string
+		selector reviewTransitionSelector
+	}{
+		{name: "new intended-untracked selection",
+			selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{
+				Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{"new.txt"},
+			}}},
+		{name: "workspace overlay without native staged replay shape",
+			selector: reviewTransitionSelector{Recovery: &reviewtransaction.Target{
+				Kind: reviewtransaction.TargetBaseWorkspaceOverlay, Projection: reviewtransaction.ProjectionWorkspace, BaseRef: "HEAD^",
+			}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := reviewNextTransitionInput{
+				Successor: "selector-successor", Selector: &test.selector,
+				RecoveryPredecessorIntendedUntracked: []string{},
+			}
+			got := newReviewNextTransition(status, nil, nil, nil, nil, input)
+			if got.Kind != reviewNextTransitionCollect || got.ReasonCode != "recovery_target_unrepresentable" ||
+				got.Collect == nil || len(got.Collect.Inputs) != 1 || got.Collect.Inputs[0].CaptureOperation != "external.select_recovery_target" {
+				t.Fatalf("unreplayable selector transition = %#v, want a refusal before execute", got)
+			}
+		})
+	}
 }
 
 // TestReviewNextTransitionExecuteArgumentValidatesAgainstPublishedSchema is

--- a/internal/cli/review_recover_convergence_test.go
+++ b/internal/cli/review_recover_convergence_test.go
@@ -11,8 +11,7 @@ import (
 // TestNegotiatedRecoverTransitionRunsVerbatimForStagedPredecessorAfterRebase
 // is the first leg of the rc.7 report on #2645: a staged review is approved,
 // its exact candidate is committed and rebased across a disjoint parent
-// advance (patch-identical), STATUS binds the approved predecessor and renders
-// a complete self-derived native RECOVER command — which must run verbatim. Root 13's
+// advance (patch-identical), STATUS binds the approved predecessor and renders a complete self-derived native RECOVER command — which must run verbatim. Root 13's
 // property for RECOVER: STATUS never renders a recovery its own preflight
 // refuses.
 func TestNegotiatedRecoverTransitionRunsVerbatimForStagedPredecessorAfterRebase(t *testing.T) {

--- a/internal/cli/review_recover_convergence_test.go
+++ b/internal/cli/review_recover_convergence_test.go
@@ -11,9 +11,8 @@ import (
 // TestNegotiatedRecoverTransitionRunsVerbatimForStagedPredecessorAfterRebase
 // is the first leg of the rc.7 report on #2645: a staged review is approved,
 // its exact candidate is committed and rebased across a disjoint parent
-// advance (patch-identical), STATUS binds the approved predecessor, collects
-// the exclusion and the exact maintainer authorization, and renders a
-// complete native RECOVER command — which must then run verbatim. Root 13's
+// advance (patch-identical), STATUS binds the approved predecessor and renders
+// a complete self-derived native RECOVER command — which must run verbatim. Root 13's
 // property for RECOVER: STATUS never renders a recovery its own preflight
 // refuses.
 func TestNegotiatedRecoverTransitionRunsVerbatimForStagedPredecessorAfterRebase(t *testing.T) {
@@ -71,48 +70,22 @@ func TestNegotiatedRecoverTransitionRunsVerbatimForStagedPredecessorAfterRebase(
 	if status.Action != reviewtransaction.TargetStatusActionRecover {
 		t.Skipf("status routed the rebased staged candidate to %q/%q rather than recover; this leg pins only the rendered-recover contract", status.Action, transition.ReasonCode)
 	}
-	if transition.Kind != reviewNextTransitionCollect || transition.ReasonCode != "recovery_authorization_required" {
-		t.Fatalf("next transition is not the recovery collection: %s %s\n%s", transition.Kind, transition.ReasonCode, statusOut.String())
-	}
-	bound := map[string]string{}
-	for _, argument := range transition.Collect.Inputs[0].Arguments {
-		bound[argument.Name] = argument.Value
-	}
-	authorization := strings.Join([]string{
-		"gentle-ai.review-recovery-authorization/v1",
-		"predecessor_lineage=" + bound["lineage"],
-		"predecessor_revision=" + bound["expected-revision"],
-		"target_identity=" + bound["target"],
-		"successor_lineage=staged-rebase-successor",
-		"actor=maintainer",
-		"reason=rebase across disjoint parent advance",
-	}, "\n")
-
-	statusOut.Reset()
-	if err := RunReview([]string{
-		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition",
-		"--lineage", startResult.LineageID,
-		"--recovery-successor-lineage", "staged-rebase-successor",
-		"--recovery-reason", "rebase across disjoint parent advance",
-		"--recovery-actor", "maintainer", "--recovery-authorization", authorization,
-	}, &statusOut); err != nil {
-		t.Fatalf("authorized status: %v\n%s", err, statusOut.String())
-	}
-	var authorized ReviewTargetStatusResult
-	decodeStrictReviewJSON(t, statusOut.Bytes(), &authorized)
-	execute := authorized.NextTransition
-	if execute == nil || execute.Kind != reviewNextTransitionExecute || execute.Execute == nil ||
-		execute.Execute.Operation != "review.recover" || execute.ReasonCode != "recovery_authorized" {
-		t.Fatalf("authorized status did not render an executable recovery:\n%s", statusOut.String())
+	if transition.Kind != reviewNextTransitionExecute || transition.Execute == nil ||
+		transition.Execute.Operation != "review.recover" || transition.ReasonCode != "recovery_authorized" {
+		t.Fatalf("status did not render an executable recovery:\n%s", statusOut.String())
 	}
 
 	// The property: the rendered command runs verbatim.
 	arguments := []string{"recover", "--cwd", repo}
-	for _, argument := range execute.Execute.Arguments {
+	successorLineage := ""
+	for _, argument := range transition.Execute.Arguments {
 		if argument.Token == "" {
 			t.Fatalf("recovery argument %q carried no runnable token", argument.Name)
 		}
 		arguments = append(arguments, argument.Token)
+		if argument.Name == "successor-lineage" {
+			successorLineage = argument.Value
+		}
 	}
 	var recovered bytes.Buffer
 	if err := RunReview(arguments, &recovered); err != nil {
@@ -120,7 +93,7 @@ func TestNegotiatedRecoverTransitionRunsVerbatimForStagedPredecessorAfterRebase(
 	}
 	var successor ReviewRecoverResult
 	decodeStrictReviewJSON(t, recovered.Bytes(), &successor)
-	if successor.LineageID != "staged-rebase-successor" ||
+	if successor.LineageID != successorLineage ||
 		successor.Recovery.PredecessorLineageID != startResult.LineageID {
 		t.Fatalf("recovery successor = %s", recovered.String())
 	}

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -415,7 +415,7 @@ func TestStatusRecoverTransitionExecutesApprovedStagedScopeExpansion(t *testing.
 	probe := selectorTransitionStatus(t, repo, selectors...)
 	if probe.Action != reviewtransaction.TargetStatusActionRecover ||
 		probe.ActionDisposition != reviewtransaction.RecoveryScopeChanged ||
-		probe.NextTransition == nil || probe.NextTransition.Collect == nil {
+		probe.NextTransition == nil || probe.NextTransition.Execute == nil || probe.NextTransition.Execute.Operation != "review.recover" {
 		t.Fatalf("staged scope probe = %#v", probe)
 	}
 	reason, actor, successor := "include staged release notes", "maintainer", "staged-scope-successor"
@@ -586,7 +586,7 @@ func TestStatusRecoverTransitionExecutesCorrectionRequiredStagedScopeExpansion(t
 	}
 	probe := selectorTransitionStatus(t, repo, selectors...)
 	if probe.Action != reviewtransaction.TargetStatusActionRecover || probe.ActionDisposition != reviewtransaction.RecoveryScopeChanged ||
-		probe.NextTransition == nil || probe.NextTransition.Collect == nil {
+		probe.NextTransition == nil || probe.NextTransition.Execute == nil || probe.NextTransition.Execute.Operation != "review.recover" {
 		t.Fatalf("correction-required staged scope probe = %#v", probe)
 	}
 	const successor, actor, reason = "correction-staged-successor", "maintainer", "authorize staged correction scope expansion"

--- a/internal/cli/review_start_lineage.go
+++ b/internal/cli/review_start_lineage.go
@@ -52,9 +52,28 @@ func reviewDerivedStartLineage(targetIdentity string) string {
 // already emitted, so the ordinary first review of a candidate is untouched,
 // and a repeated start on that candidate still resumes rather than forking.
 func reviewAvailableStartLineage(ctx context.Context, root, targetIdentity string) string {
-	derived := reviewDerivedStartLineage(targetIdentity)
-	if derived == "" || reviewStartLineageAvailable(ctx, root, derived) {
+	available := reviewAvailableDerivedLineage(ctx, root, targetIdentity)
+	if available == reviewDerivedStartLineage(targetIdentity) {
 		return ""
+	}
+	return available
+}
+
+func reviewAvailableRecoveryLineage(ctx context.Context, root, targetIdentity, predecessor string) string {
+	available := reviewAvailableDerivedLineage(ctx, root, targetIdentity)
+	if available == predecessor {
+		return ""
+	}
+	return available
+}
+
+func reviewAvailableDerivedLineage(ctx context.Context, root, targetIdentity string) string {
+	derived := reviewDerivedStartLineage(targetIdentity)
+	if derived == "" {
+		return ""
+	}
+	if reviewStartLineageAvailable(ctx, root, derived) {
+		return derived
 	}
 	for suffix := 2; suffix <= reviewStartLineageSuffixLimit; suffix++ {
 		candidate := fmt.Sprintf("%s-%d", derived, suffix)

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -294,7 +294,7 @@ func newReviewActionEligibility(status ReviewTargetStatusResult) *ReviewActionEl
 		allowed.Action, allowed.ReasonCode = "stop", reviewActionForbiddenReconciliation
 	case reviewtransaction.TargetStatusActionRecover:
 		allowed.Action, allowed.Disposition = "review.recover", status.ActionDisposition
-		allowed.RequiredInputs = []string{"predecessor_lineage", "expected_predecessor_revision", "successor_lineage", "disposition", "reason", "actor", "maintainer_authorization"}
+		allowed.RequiredInputs = []string{"predecessor_lineage", "expected_predecessor_revision", "successor_lineage", "disposition"}
 		allowed.ReasonCode = reviewActionEligibleRecovery
 		if status.ActionDisposition == reviewtransaction.RecoveryEscalated {
 			allowed.ReasonCode = reviewActionEligibleEscalatedRecovery
@@ -1550,7 +1550,9 @@ func validateReviewTransitionExecution(execution ReviewTransitionExecution, argu
 		if execution.SelectorArguments != nil && !reflect.DeepEqual(*execution.SelectorArguments, wantSelectors) {
 			return errors.New("review recover transition selectors are invalid")
 		}
-		if !exact([]string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition", "reason", "actor", "maintainer-authorization"}, wantSelectors) ||
+		explicitAuthorization := exact([]string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition", "reason", "actor", "maintainer-authorization"}, wantSelectors)
+		selfDerivedAuthorization := exact([]string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition"}, wantSelectors)
+		if (!explicitAuthorization && !selfDerivedAuthorization) ||
 			arguments["predecessor-lineage"] != execution.Binding.LineageID ||
 			arguments["expected-predecessor-revision"] != execution.Binding.Revision ||
 			!validReviewIntegrationLineage(arguments["successor-lineage"]) ||
@@ -1572,7 +1574,7 @@ func validateReviewTransitionExecution(execution ReviewTransitionExecution, argu
 		committed, hasCommitted := arguments["committed-only"]
 		projection, hasProjection := arguments["projection"]
 		workspaceOverlay, hasWorkspaceOverlay := arguments["workspace-overlay"]
-		if arguments["maintainer-authorization"] != wantAuthorization ||
+		if explicitAuthorization && arguments["maintainer-authorization"] != wantAuthorization ||
 			hasBase && !validReviewTransitionSelector(base) ||
 			hasCommitted && (!hasBase || committed != "true") ||
 			hasProjection && projection != string(reviewtransaction.ProjectionWorkspace) &&


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1658

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Replace the unowned `external.authorize_recovery` collection with executable native recovery for deterministic legal recovery shapes.
- Reuse native RECOVER self-derivation while preserving explicit authorization compatibility and selector fail-closed behavior.
- Add behavior-first recovery coverage and update driven journeys j46 and j94.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_next_transition.go` | Emit minimal executable RECOVER transitions and refuse selectors native RECOVER cannot replay. |
| `internal/cli/review_facade.go`, `review_start_lineage.go` | Resolve an explicit bounded successor and retain predecessor selector context. |
| `internal/cli/review_status_contract.go` | Validate the minimal self-derived shape and the existing explicit seven-field shape. |
| Recovery tests | Prove verbatim execution, predecessor immutability, wrong-binding refusal, and explicit compatibility. |
| `bench/journeys_issue_2031.go`, `bench/journeys_wave1.go` | Execute direct self-derived recovery in driven j94 and j46. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model:** OpenCode with `openai/gpt-5.6-sol`

**Material scope:** Root-cause mapping, implementation support, behavior-first test design, scope correction, CI failure diagnosis, and review orchestration.

**Verification performed:** Independent diff validation, focused Go tests, benchmark build/vet/declaration checks, driven j46/j94 execution, native four-lens review of the original exact candidate, and complete GitHub CI after the final correction.

---

## 🧪 Test Plan

- [x] `git diff --check origin/main...HEAD`
- [x] `go run ./internal/gofmtcheck`
- [x] Focused recovery and selector tests
- [x] `cd bench && go build ./...`
- [x] `cd bench && go vet ./...`
- [x] Focused bench corpus and manifest declaration tests
- [x] Driven j46: `1 completed, 0 unsupported, 0 failed`
- [x] Driven j94: `1 completed, 0 unsupported, 0 failed`
- [x] GitHub Unit Tests
- [x] GitHub Windows, Darwin, and organic runtime checks
- [x] GitHub E2E on Ubuntu, Arch, and Fedora

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | Exactly 400 changed lines (200 additions, 200 deletions). |
| Check Issue Reference | ✅ | Links approved #1658. |
| Check Issue Has `status:approved` | ✅ | #1658 is approved. |
| Check PR Has `type:*` Label | ✅ | Exactly one `type:bug` label. |
| Unit Tests | ✅ | Passed in CI. |
| Go Format | ✅ | Passed in CI. |
| E2E Tests | ✅ | Passed in CI. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E tests pass
- [x] Benchmark validation completed
- [x] Documentation impact reviewed; no separate user documentation change is required
- [x] Commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] Commits contain no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The exact pre-rebase workspace candidate completed high-risk four-lens native review. After a non-overlapping base advance, installed Gentle AI 2.4.0-rc.8 reproduced the `external.authorize_recovery` dead end fixed here. Delivery was therefore explicitly switched to clone-local `disabled/unmanaged` ordinary policy before publication.

The first CI run correctly exposed stale j46 expectations for the old collect flow. Commit `79d44da7` updates j46 to execute the direct transition and compacts existing test churn so the final PR remains exactly at the 400-line budget. The final CI run is fully green.

The new selector refusal was challenged against legitimate populations: explicit seven-field workspace-overlay recovery retains its existing route, while only authorization-free selectors that native RECOVER cannot reproduce are refused. No guard-population baseline change is intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery can execute directly through a self-derived transition when sufficient context is available.
  * Recovery automatically discovers and validates successor lineage details.
  * Recovery commands may omit explicit reason, actor, and maintainer authorization when derived internally.
* **Bug Fixes**
  * Improved validation of recovery targets, revisions, predecessors, successors, workspace overlays, and dispositions.
  * Prevented recovery with incompatible targets or unsupported projections.
  * Preserved explicitly authorized recovery workflows and requests authorization only when native recovery cannot replay the selected target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->