### PR TITLE
docs: update current prerelease guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 > go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest
 > ```
 >
-> To opt into the current prerelease, [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), install its exact tag:
+> To opt into the current prerelease, [`v2.4.0-rc.8`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.8), install its exact tag:
 >
 > ```bash
-> go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.1
+> go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.8
 > ```
 >
 > Use `@main` only for unreleased development changes. See the [full RDD version policy](docs/quickstart.md#version-policy).
@@ -168,7 +168,7 @@ $env:GENTLE_AI_CHANNEL="beta"; go install github.com/gentleman-programming/gentl
 
 Receipt-Driven Development (RDD) started in `gentle-ai` `v1.47.0` on 2026-07-10, with the first bounded native review transactions, and became the supported stable path in `v2.2.0`. Those are historical milestones; the negotiated public review contract was published in `v2.1.6`.
 
-The current stable release is [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0). The current prerelease is [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1). `main` is unreleased development.
+The current stable release is [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0). The current prerelease is [`v2.4.0-rc.8`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.8). `main` is unreleased development.
 
 **Stable channel (`@latest`, currently `v2.3.0`)**
 
@@ -177,10 +177,10 @@ go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest
 gentle-ai version
 ```
 
-**Prerelease channel (`v2.4.0-rc.1`)**
+**Prerelease channel (`v2.4.0-rc.8`)**
 
 ```bash
-go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.1
+go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.8
 gentle-ai version
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,8 +53,8 @@
 # Stable channel (`@latest`, currently v2.3.0)
 go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest
 
-# Opt-in prerelease (v2.4.0-rc.1)
-go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.1
+# Opt-in prerelease (v2.4.0-rc.8)
+go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.8
 ```
 
 Both commands use the `/v2` module path. Go requires that suffix for major
@@ -64,7 +64,7 @@ version 2 and above.
 
 Receipt-Driven Development (RDD) began in `v1.47.0` on 2026-07-10, and `v2.2.0` made it the supported stable path. Those are historical milestones. The negotiated public review contract was published in `v2.1.6`.
 
-The current stable release is [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0). `@latest` explicitly tracks this stable channel. The current opt-in prerelease is [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1). `@main` installs unreleased development changes.
+The current stable release is [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0). `@latest` explicitly tracks this stable channel. The current opt-in prerelease is [`v2.4.0-rc.8`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.8). `@main` installs unreleased development changes.
 
 ### Install the stable channel
 
@@ -76,7 +76,7 @@ gentle-ai version
 ### Install the opt-in prerelease
 
 ```bash
-go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.1
+go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.8
 gentle-ai version
 ```
 

--- a/docs/testing/organic-rdd-testing-guide.md
+++ b/docs/testing/organic-rdd-testing-guide.md
@@ -1,7 +1,7 @@
 # 🧪 How to test — Organic RDD (prerelease 2.2.0-rc.1)
 
 > [!WARNING]
-> **Historical and superseded guide.** This document preserves the candidate-specific validation procedure for `v2.2.0-rc.1` and PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801). It is not current installation or validation guidance for stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0), prerelease [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), or unreleased `main`. Use the [Quickstart version policy](../quickstart.md#version-policy) for current installation channels and validation entry points.
+> **Historical and superseded guide.** This document preserves the candidate-specific validation procedure for `v2.2.0-rc.1` and PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801). It is not current installation or validation guidance for stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0), prerelease [`v2.4.0-rc.8`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.8), or unreleased `main`. Use the [Quickstart version policy](../quickstart.md#version-policy) for current installation channels and validation entry points.
 >
 > Community testing guide for the candidate built from PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801). Every **Expected** here was validated against real output before publication. The guide uses a throwaway HOME precisely so it does not touch your real config — do not skip the setup.
 
@@ -735,7 +735,7 @@ echo "exit=$?"
 
 ## Historical reporting instructions
 
-This section is retained to explain the original candidate procedure. Do not open a current issue or comment on PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801) for results from `v2.2.0-rc.1`; that candidate process is complete. For a current concern, first reproduce it against stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0) or the opt-in prerelease [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), then use the repository's current contribution and issue workflow.
+This section is retained to explain the original candidate procedure. Do not open a current issue or comment on PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801) for results from `v2.2.0-rc.1`; that candidate process is complete. For a current concern, first reproduce it against stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0) or the opt-in prerelease [`v2.4.0-rc.8`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.8), then use the repository's current contribution and issue workflow.
 
 ## What is NOT a bug
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3213

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Update current prerelease guidance from `v2.4.0-rc.1` to `v2.4.0-rc.8`.
- Keep the stable `v2.3.0` guidance and intentional historical `v2.4.0-rc.1` evidence unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md` | Updated the current prerelease release link, channel label, and exact-tag commands. |
| `docs/quickstart.md` | Updated current prerelease policy and installation commands. |
| `docs/testing/organic-rdd-testing-guide.md` | Updated current-channel references inside the superseded historical guide. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with OpenAI GPT-5.6 Sol

**Material scope:** Located the current-channel references, applied the version-only documentation changes, verified preserved historical references, and prepared this submission.

**Verification performed:** Reviewed the complete diff, ran `git diff --check`, confirmed 11 current-guidance references to `v2.4.0-rc.8`, and confirmed exactly two intentional documentation references to `v2.4.0-rc.1` remain.

---

## 🧪 Test Plan

Unit tests, Go formatting, and E2E tests were not run because this PR changes documentation references only and does not modify executable code.

- [ ] Unit tests pass (`go test ./...`) — N/A, documentation-only change
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — N/A, no Go files changed
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A, no runtime behavior changed
- [x] Manually tested locally

Manual verification:

- `git diff --check` passed.
- All 11 current prerelease guidance lines point to `v2.4.0-rc.8`.
- The two intentional historical `v2.4.0-rc.1` references remain unchanged.
- The stable `v2.3.0` references remain unchanged.
- Benchmark validation: N/A, this change does not affect review lifecycle, gates, recovery, delivery, benchmark implementation, corpus, classifiers, or benchmark claims.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — N/A, documentation-only change
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — N/A, no Go files changed
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A, no runtime behavior changed
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained above).
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is a version-only documentation update. Historical release-specific evidence and runtime fixtures remain untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions and version policies to reference prerelease version `v2.4.0-rc.8`.
  - Updated testing guidance and superseded-status notices to reflect the latest prerelease version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->