### PR TITLE
fix(cli): make successful negotiated review operations silent on stderr

### DIFF
--- a/e2e/organicruntime/organic_lifecycle_hardening_test.go
+++ b/e2e/organicruntime/organic_lifecycle_hardening_test.go
@@ -1210,20 +1210,19 @@ func TestOrganicReviewStoreRobustness(t *testing.T) {
 	})
 }
 
-// TestOrganicReviewNarrationPairedRecoverableVersusTerminal proves spec
-// "Three-Tier Narration Contract"'s paired scenario for organic-dx Phase 4:
-// one underlying machinery condition -- no existing review record matches
-// this target (reviewtransaction.TargetApplicabilityUnrelated) -- with two
-// caller-selector shapes. The ordinary shape reaches an executable next step
-// with uninterrupted Tier-A behavior (stdout carries the machine envelope,
-// stderr carries zero Tier-B/Tier-C output). The same missing-record
-// condition, requested through the one selector combination that is
-// recovery-only for a fresh target (--workspace-overlay --projection
-// staged), is genuinely terminal here and produces exactly one Tier C
-// statement on stderr, naming the decision
-// (internal/cli/review_narration.go's registered
-// staged_workspace_overlay_recovery_unavailable statement) -- never on
-// stdout, which stays byte-for-byte the same JSON envelope contract either way.
+// TestOrganicReviewNarrationPairedRecoverableVersusTerminal keeps the paired
+// scenario from organic-dx Phase 4 -- one underlying machinery condition (no
+// existing review record matches this target,
+// reviewtransaction.TargetApplicabilityUnrelated) with two caller-selector
+// shapes -- under the negotiated-silence contract: a successful negotiated
+// (--contract) STATUS is machine-readable end to end, so BOTH shapes keep
+// stdout as the byte-for-byte JSON envelope and write zero bytes to stderr.
+// The terminal shape's decision stays structural in
+// next_transition.reason_code (staged_workspace_overlay_recovery_unavailable)
+// instead of being narrated: gentle-pi's adapter fails closed
+// (UNEXPECTED_STDERR) on any stderr a successful native process writes, and
+// the registered Tier C statement remains in internal/cli/review_narration.go
+// as vocabulary only.
 func TestOrganicReviewNarrationPairedRecoverableVersusTerminal(t *testing.T) {
 	t.Run("issue-organic-dx-phase4-paired-narration", func(t *testing.T) {
 		harness := newOrganicHarness(t)
@@ -1266,14 +1265,8 @@ func TestOrganicReviewNarrationPairedRecoverableVersusTerminal(t *testing.T) {
 			if status.NextTransition == nil || status.NextTransition.Kind != "stop" || status.NextTransition.ReasonCode != "staged_workspace_overlay_recovery_unavailable" {
 				t.Fatalf("terminal next-transition on the same fresh target = %#v, want the staged_workspace_overlay_recovery_unavailable stop", status.NextTransition)
 			}
-			lines := strings.Split(strings.TrimRight(stderr, "\n"), "\n")
-			if len(lines) != 1 || strings.TrimSpace(lines[0]) == "" {
-				t.Fatalf("terminal shape did not emit exactly one Tier C statement on stderr: %q", stderr)
-			}
-			const wantStatement = "Pass `--lineage <id>` to continue the review you already started, " +
-				"or drop `--workspace-overlay` and run `gentle-ai review start --projection staged` to start fresh."
-			if lines[0] != wantStatement {
-				t.Fatalf("terminal Tier C statement = %q, want %q", lines[0], wantStatement)
+			if stderr != "" {
+				t.Fatalf("stop-shaped negotiated STATUS wrote stderr, want zero bytes: %q", stderr)
 			}
 		})
 	})

--- a/internal/cli/review_consent_relay_test.go
+++ b/internal/cli/review_consent_relay_test.go
@@ -363,9 +363,12 @@ func TestRelayedConsentDeclineIsScopedToTheCandidate(t *testing.T) {
 
 // TestNegotiatedStartWithoutConsentDeclarationKeepsTodaysEnvelope pins the
 // no-declaration path: the negotiated envelope carries no consent fields (the
-// strict decoder refuses unknown fields), the start completes, and the
-// skip-and-notice behavior stays on the console. Byte-identity of the envelope
-// itself is pinned by TestNegotiatedReviewStartMatchesVersionedFixture.
+// strict decoder refuses unknown fields), the start completes in the
+// fail-safe direction, and the console stays byte-silent — the skip notices
+// are a human surface reserved for plain (non-negotiated) starts, because a
+// successful negotiated operation writes zero bytes to stderr. Byte-identity
+// of the envelope itself is pinned by
+// TestNegotiatedReviewStartMatchesVersionedFixture.
 func TestNegotiatedStartWithoutConsentDeclarationKeepsTodaysEnvelope(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -383,8 +386,8 @@ func TestNegotiatedStartWithoutConsentDeclarationKeepsTodaysEnvelope(t *testing.
 	if strings.Contains(output.String(), "consent") {
 		t.Fatalf("undeclared negotiated START leaked consent fields:\n%s", output.String())
 	}
-	if !strings.Contains(console.String(), reviewConsentSkippedNotice) {
-		t.Fatalf("undeclared headless START must keep the skip notice:\n%s", console.String())
+	if console.Len() != 0 {
+		t.Fatalf("undeclared negotiated START must stay silent on the console:\n%s", console.String())
 	}
 }
 

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1137,26 +1137,25 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 				transition.ReasonCode != "correction_repository_tooling_failed" {
 				result.ValidationRequest = nil
 			}
-			// The stdout JSON envelope is the machine surface and stays
-			// byte-for-byte unchanged; this is the additive Tier C human
-			// surface (spec "Three-Tier Narration Contract"), written to
-			// stderr only, never mixed into the parsed stream.
-			if transition.Kind == reviewNextTransitionStop {
-				continuation := ""
-				if transition.ReasonCode == "rdd_disabled" {
-					continuation = reviewRDDDisabledNarration(result.rddMode, root, args)
-				}
-				reviewNarrateStopReason(transition.ReasonCode, runtime, continuation)
-			}
+			// A negotiated invocation is the machine surface end to end: the
+			// stdout JSON envelope carries every routing fact (kind,
+			// reason_code, forecast), and a successful operation writes zero
+			// bytes to stderr. gentle-pi fails closed (UNEXPECTED_STDERR) on
+			// any stderr a successful native process writes, so the Tier C
+			// stop narration that used to print here was removed rather than
+			// allowlisted downstream. The registered Tier C statements remain
+			// in review_narration.go as the human-surface vocabulary source.
 		}
 		if intendedScope.NeedsSelection && (result.NextTransition == nil || result.NextTransition.Kind != reviewNextTransitionStop || result.NextTransition.ReasonCode != "rdd_disabled") {
 			transition := reviewIntendedUntrackedCollection(result, intendedScope)
 			result.NextTransition = &transition
 		}
 		if *contract == ReviewIntegrationContractV2 && result.NextTransition != nil {
+			// The forecast is structural only: it rides the v2 envelope's
+			// `forecast` field and is never narrated to stderr, because a
+			// successful negotiated operation must stay byte-silent there.
 			forecast := newReviewForecast(*result.NextTransition)
 			result.Forecast = &forecast
-			reviewNarrateForecast(forecast)
 		}
 		var validationErr error
 		if compactAuthority != nil {
@@ -1776,7 +1775,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	// point where the kill switch can stop a start and consent can name the real
 	// reason. Nothing has been persisted yet, so refusing here leaves no
 	// authority behind.
-	if err := authorizeReviewStart(ctx, root, assessment, consentMode); err != nil {
+	if err := authorizeReviewStart(ctx, root, assessment, consentMode, negotiated); err != nil {
 		if errors.Is(err, errReviewConsentQuestionRequired) {
 			// The caller declared it can relay a blocking question, so the
 			// typed question IS this start's response. Nothing has been

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -630,8 +630,9 @@ func reviewConsoleTerminal(file *os.File) bool {
 // A consent declaration selects candidate-scoped negotiated semantics: relay
 // always returns the typed question, while granted and declined apply only to
 // the exact frozen candidate and never touch the legacy clone-wide latch. An
-// undeclared START keeps the one-time console behavior unchanged.
-func authorizeReviewStart(ctx context.Context, repo string, assessment reviewtransaction.RiskAssessment, consent reviewStartConsentMode) error {
+// undeclared plain START keeps the one-time console behavior unchanged; an
+// undeclared negotiated START authorizes silently (see below).
+func authorizeReviewStart(ctx context.Context, repo string, assessment reviewtransaction.RiskAssessment, consent reviewStartConsentMode, negotiated bool) error {
 	global, err := readGlobalRDDMode()
 	if err != nil {
 		return err
@@ -666,6 +667,19 @@ func authorizeReviewStart(ctx context.Context, repo string, assessment reviewtra
 	case reviewConsentModeGranted:
 		// The exact target binding was revalidated before this call. Authorize
 		// only that candidate; later candidates must receive their own question.
+		return nil
+	}
+	if negotiated {
+		// A negotiated invocation is machine-readable end to end: stdout
+		// carries the typed envelope and a successful operation writes zero
+		// bytes to stderr (gentle-pi fails closed on any stderr a successful
+		// START writes). Negotiated consent is carried by the typed consent
+		// envelope (--consent relay/granted/declined), so the legacy one-time
+		// console ceremony — the prompt and every skip notice — is a human
+		// surface this route never touches. The review proceeds in the same
+		// fail-safe direction as a headless start, and neither the one-time
+		// consent latch nor the once-per-clone notice marker is consumed, so
+		// a later plain start in this clone can still ask and still announce.
 		return nil
 	}
 	console := reviewConsole()

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -669,20 +669,21 @@ func authorizeReviewStart(ctx context.Context, repo string, assessment reviewtra
 		// only that candidate; later candidates must receive their own question.
 		return nil
 	}
-	if negotiated {
-		// A negotiated invocation is machine-readable end to end: stdout
-		// carries the typed envelope and a successful operation writes zero
-		// bytes to stderr (gentle-pi fails closed on any stderr a successful
-		// START writes). Negotiated consent is carried by the typed consent
-		// envelope (--consent relay/granted/declined), so the legacy one-time
-		// console ceremony — the prompt and every skip notice — is a human
-		// surface this route never touches. The review proceeds in the same
-		// fail-safe direction as a headless start, and neither the one-time
-		// consent latch nor the once-per-clone notice marker is consumed, so
-		// a later plain start in this clone can still ask and still announce.
+	console := reviewConsole()
+	if negotiated && !console.Interactive {
+		// A non-interactive negotiated invocation is machine-readable end to
+		// end: stdout carries the typed envelope and a successful operation
+		// writes zero bytes to stderr (gentle-pi fails closed on any stderr a
+		// successful START writes), and machine listeners only ever spawn
+		// non-interactive processes. Negotiated consent is carried by the
+		// typed consent envelope (--consent relay/granted/declined), so this
+		// route returns before the latch read: neither the one-time consent
+		// latch nor the once-per-clone notice marker is consumed, and a later
+		// plain start in this clone can still ask and still announce. A human
+		// at a real terminal falls through to the unchanged one-time ceremony
+		// below and keeps the power to refuse.
 		return nil
 	}
-	console := reviewConsole()
 	asked, err := reviewtransaction.RDDConsentAsked(ctx, repo)
 	if err != nil {
 		// A damaged latch must neither block the review nor silently disable it:

--- a/internal/cli/review_narration.go
+++ b/internal/cli/review_narration.go
@@ -219,12 +219,12 @@ func reviewNarrationContainsWord(lowered, word string) bool {
 	return pattern.MatchString(lowered)
 }
 
-// There is deliberately no stderr emission machinery here anymore. Every
-// production caller of the old reviewNarrateStopReason/reviewNarrateForecast
-// pair was a negotiated (--contract) invocation, and a successful negotiated
-// operation is machine-readable end to end: stdout carries every routing fact
-// (kind, reason_code, forecast) and stderr stays byte-silent, because
-// gentle-pi's adapter fails closed (UNEXPECTED_STDERR) on any stderr a
-// successful native process writes. The registered statements above remain
-// the single vocabulary source for the Tier A/C narration contract tests and
-// for any future genuinely-human surface.
+// There is deliberately no stderr emission machinery here anymore: a
+// successful negotiated operation is machine-readable end to end (gentle-pi
+// fails closed on any stderr a successful native process writes). The
+// registered statements above stay live two ways. The Tier C stop statements
+// are contract data cross-validated against the live stop-code emitter in
+// review_next_transition.go by review_narration_test.go (the bijection test).
+// The Tier A consent prompt remains production-emitted through the
+// interactive console ceremony in review_mode.go, proven reachable by
+// TestNegotiatedStartUndeclaredInteractiveKeepsConsentCeremony.

--- a/internal/cli/review_narration.go
+++ b/internal/cli/review_narration.go
@@ -2,13 +2,8 @@ package cli
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"regexp"
-	"strings"
 
-	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
-	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/sddstatus"
 )
 
@@ -224,86 +219,12 @@ func reviewNarrationContainsWord(lowered, word string) bool {
 	return pattern.MatchString(lowered)
 }
 
-// reviewNarrationOutput is the human-surface stream Tier C statements print
-// to. It is a var, like reviewConsole, so tests can capture it without a
-// real terminal; production always writes to stderr, never stdout, because
-// stdout carries the machine-readable JSON envelope and a narration line
-// mixed into it would corrupt every caller that parses it.
-var reviewNarrationOutput io.Writer = os.Stderr
-
-// reviewStopReasonStatement looks up the registered Tier C statement for a
-// review_next_transition.go stop reason code. The second result is false for
-// a code with no registry entry — TestReviewNarrationRegistryCoversEveryStopReasonCode
-// is what keeps that from happening for any code the source actually emits.
-func reviewStopReasonStatement(reason string) (string, bool) {
-	emission, ok := reviewNarrationRegistry["stop:"+strings.TrimSpace(reason)]
-	if !ok {
-		return "", false
-	}
-	return emission.Statement, true
-}
-
-// reviewNarrateStopReason writes exactly one Tier C statement to the human
-// surface for a stop-kind next transition. It never touches stdout, so the
-// negotiated JSON envelope (the machine surface) is byte-for-byte unchanged;
-// it is the additive half of spec "Three-Tier Narration Contract"'s "Tier C
-// terminal state emits exactly one statement" scenario. A reason with no
-// registry entry prints nothing: TestReviewNarrationRegistryCoversEveryStopReasonCode
-// is the fail-closed proof that should never happen for a code the source emits.
-func reviewNarrateStopReason(reason string, runtimeAgent model.AgentID, continuation string) {
-	statement, ok := reviewStopReasonStatement(reason)
-	if !ok {
-		return
-	}
-	if strings.TrimSpace(continuation) != "" {
-		statement = continuation
-	}
-	_, _ = fmt.Fprintln(reviewNarrationOutput, bindNarrationRuntimeIdentity(statement, runtimeAgent))
-}
-
-func reviewRDDDisabledNarration(mode reviewtransaction.RDDModeStatus, root string, statusArgs []string) string {
-	enable := "gentle-ai review mode enable --scope=global"
-	if mode.Source == reviewtransaction.RDDModeSourceCloneLocal {
-		enable = "gentle-ai review mode enable --scope=clone --cwd=" + reviewTransitionShellWord(root)
-	}
-	parts := []string{reviewTransitionCommandTool, "review", "status", reviewTransitionShellWord("--cwd=" + root)}
-	for index := 0; index < len(statusArgs); index++ {
-		argument := statusArgs[index]
-		if argument == "--cwd" {
-			index++
-			continue
-		}
-		if strings.HasPrefix(argument, "--cwd=") {
-			continue
-		}
-		parts = append(parts, reviewTransitionShellWord(argument))
-	}
-	return "Review mode is disabled. Run `" + enable + "`, then re-run `" + strings.Join(parts, " ") + "`."
-}
-
-// reviewNarrateForecast keeps the v2 machine envelope on stdout while showing
-// its descriptive, non-routing head to a human on stderr.
-func reviewNarrateForecast(forecast ReviewForecast) {
-	_, _ = fmt.Fprintf(reviewNarrationOutput, "Forecast horizon: %s\n", forecast.Horizon)
-	for _, step := range forecast.Steps {
-		_, _ = fmt.Fprintf(reviewNarrationOutput, "step %d: %s; reason_code=%s; description=%s\n", step.Step, step.Kind, step.ReasonCode, step.Description)
-	}
-	if forecast.Horizon == ForecastHorizonPartial {
-		_, _ = fmt.Fprintln(reviewNarrationOutput, "Re-query STATUS after completing this partial head.")
-	}
-}
-
-// bindNarrationRuntimeIdentity fills the runtime-identity slot in a registered
-// statement with the identity the caller declared on this very invocation. The
-// registry is a package-level map with no caller context, so the statements
-// carry a slot rather than a constant: a narration that told every runtime to
-// rerun as `claude-code` would invite a Codex or OpenCode reader to declare a
-// false identity and pass the transport admission check under another runtime's
-// capability profile. An undeclared caller omits the entire optional segment.
-func bindNarrationRuntimeIdentity(statement string, runtimeAgent model.AgentID) string {
-	identity := strings.TrimSpace(string(runtimeAgent))
-	if identity == "" {
-		return strings.ReplaceAll(statement, " --agent "+reviewUndeclaredRuntimeIdentitySlot, "")
-	}
-	return strings.ReplaceAll(statement, reviewUndeclaredRuntimeIdentitySlot, identity)
-}
+// There is deliberately no stderr emission machinery here anymore. Every
+// production caller of the old reviewNarrateStopReason/reviewNarrateForecast
+// pair was a negotiated (--contract) invocation, and a successful negotiated
+// operation is machine-readable end to end: stdout carries every routing fact
+// (kind, reason_code, forecast) and stderr stays byte-silent, because
+// gentle-pi's adapter fails closed (UNEXPECTED_STDERR) on any stderr a
+// successful native process writes. The registered statements above remain
+// the single vocabulary source for the Tier A/C narration contract tests and
+// for any future genuinely-human surface.

--- a/internal/cli/review_negotiated_stderr_silence_test.go
+++ b/internal/cli/review_negotiated_stderr_silence_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -230,6 +231,63 @@ func TestNegotiatedLifecycleOperationsAreByteSilentOnStderr(t *testing.T) {
 
 	if got := stderr(); got != "" {
 		t.Fatalf("negotiated lifecycle wrote stderr, want zero bytes:\n%q", got)
+	}
+}
+
+// TestNegotiatedStartUndeclaredInteractiveKeepsConsentCeremony pins the human
+// half of the negotiated-silence contract: an undeclared negotiated START at a
+// real interactive terminal keeps the exact plain-start one-time ceremony —
+// the Tier A consent prompt is written to the console and answer 2 refuses
+// this candidate. This is also the production-reachability proof for the
+// human narration surface: the prompt bytes below are the registered Tier A
+// vocabulary reaching a real console through authorizeReviewStart.
+func TestNegotiatedStartUndeclaredInteractiveKeepsConsentCeremony(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	console := stubReviewConsole(t, true, "2\n")
+	writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+
+	var output bytes.Buffer
+	err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--lineage", "review-negotiated-interactive",
+	}), &output)
+	if !errors.Is(err, errReviewDeclinedForCandidate) {
+		t.Fatalf("interactive negotiated refusal = %v, want errReviewDeclinedForCandidate\n%s", err, output.String())
+	}
+	assertReviewConsentPrompt(t, console.String(), "scripts/deploy.sh")
+}
+
+// TestNegotiatedStartUndeclaredAskedLatchProceedsSilently proves the machine
+// half stays intact: a non-interactive negotiated START with the one-time
+// question already answered proceeds, writes nothing to the console, and
+// leaves both the consent latch and the once-per-clone notice marker exactly
+// as it found them.
+func TestNegotiatedStartUndeclaredAskedLatchProceedsSilently(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	console := stubReviewConsole(t, false, "")
+	writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+	if err := recordReviewConsentAsked(context.Background(), repo); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--lineage", "review-negotiated-asked-latch",
+	}))
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	if started.Action != string(reviewtransaction.CompactStartCreated) {
+		t.Fatalf("asked-latch negotiated START = %#v", started)
+	}
+	if console.Len() != 0 {
+		t.Fatalf("asked-latch negotiated START wrote to the console:\n%s", console.String())
+	}
+	if asked, err := reviewtransaction.RDDConsentAsked(context.Background(), repo); err != nil || !asked {
+		t.Fatalf("negotiated START changed the consent latch: asked=%v err=%v", asked, err)
+	}
+	if shown, err := reviewConsentNoticeAlreadyShown(context.Background(), repo); err != nil || shown {
+		t.Fatalf("negotiated START burned the notice marker: shown=%v err=%v", shown, err)
 	}
 }
 

--- a/internal/cli/review_negotiated_stderr_silence_test.go
+++ b/internal/cli/review_negotiated_stderr_silence_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// captureReviewProcessStderr swaps the process stderr for a pipe so a test can
+// assert the machine-readable (negotiated) surface stays byte-silent. It
+// catches every writer that resolves os.Stderr at call time: the consent
+// console (defaultReviewConsole) and any direct fmt.Fprint(os.Stderr, ...)
+// site. The returned function restores stderr and yields the captured bytes.
+func captureReviewProcessStderr(t *testing.T) func() string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stderr
+	os.Stderr = write
+	var once sync.Once
+	var captured string
+	stop := func() string {
+		once.Do(func() {
+			os.Stderr = previous
+			_ = write.Close()
+			data, readErr := io.ReadAll(read)
+			_ = read.Close()
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			captured = string(data)
+		})
+		return captured
+	}
+	t.Cleanup(func() { _ = stop() })
+	return stop
+}
+
+// TestNegotiatedStatusSuccessIsByteSilentOnStderr pins the pi compatibility
+// contract: a successful negotiated STATUS (exit 0, valid JSON on stdout)
+// writes zero bytes to stderr. The forecast is carried structurally in the
+// JSON `forecast` field, never narrated (gentle-pi fails closed with
+// UNEXPECTED_STDERR on any stderr byte a successful operation writes).
+func TestNegotiatedStatusSuccessIsByteSilentOnStderr(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/notes.md", "silent status\n", 0o644)
+	stderr := captureReviewProcessStderr(t)
+
+	var stdout bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code", "--next-transition",
+	}, &stdout); err != nil {
+		t.Fatalf("negotiated STATUS: %v\n%s", err, stdout.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, stdout.Bytes(), &status)
+	if status.NextTransition == nil || status.Forecast == nil || len(status.Forecast.Steps) == 0 {
+		t.Fatalf("forecast must stay structural on stdout: %#v", status.Forecast)
+	}
+	if got := stderr(); got != "" {
+		t.Fatalf("successful negotiated STATUS wrote stderr, want zero bytes:\n%q", got)
+	}
+}
+
+// TestNegotiatedStatusStopIsByteSilentOnStderr covers the stop-shaped success:
+// a negotiated STATUS answering `stop` (here rdd_disabled) still exits 0 with
+// a valid envelope, so its Tier C stop narration and the rendered enable
+// continuation must not reach stderr either. The reason code stays structural
+// in next_transition.reason_code.
+func TestNegotiatedStatusStopIsByteSilentOnStderr(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/notes.md", "disabled stop\n", 0o644)
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "global"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	stderr := captureReviewProcessStderr(t)
+
+	var stdout bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code", "--next-transition",
+	}, &stdout); err != nil {
+		t.Fatalf("negotiated STATUS while disabled: %v\n%s", err, stdout.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, stdout.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionStop ||
+		status.NextTransition.ReasonCode != "rdd_disabled" {
+		t.Fatalf("disabled transition = %#v", status.NextTransition)
+	}
+	if got := stderr(); got != "" {
+		t.Fatalf("stop-shaped negotiated STATUS wrote stderr, want zero bytes:\n%q", got)
+	}
+}
+
+// TestNegotiatedStartUndeclaredConsentIsByteSilentOnStderr pins the START half
+// of the same contract: a negotiated START without a --consent declaration
+// reviews the candidate in the fail-safe direction, exactly like a headless
+// start, but announces nothing — the consent-skip notices are a human surface
+// and negotiated consent is carried by the typed consent envelope instead.
+// Neither the one-time consent latch nor the once-per-clone notice marker is
+// consumed, so a later plain (non-negotiated) start still shows the notice.
+func TestNegotiatedStartUndeclaredConsentIsByteSilentOnStderr(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	console := stubReviewConsole(t, false, "")
+	writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+	stderr := captureReviewProcessStderr(t)
+
+	output := runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--lineage", "review-negotiated-silent",
+	}))
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	if started.Action != string(reviewtransaction.CompactStartCreated) || len(started.SelectedLenses) != 4 {
+		t.Fatalf("undeclared negotiated START stopped reviewing: %#v", started)
+	}
+	if console.Len() != 0 {
+		t.Fatalf("undeclared negotiated START wrote to the console, want silence:\n%s", console.String())
+	}
+	if got := stderr(); got != "" {
+		t.Fatalf("undeclared negotiated START wrote stderr, want zero bytes:\n%q", got)
+	}
+	if asked, err := reviewtransaction.RDDConsentAsked(context.Background(), repo); err != nil || asked {
+		t.Fatalf("negotiated START consumed the one-time question: asked=%v err=%v", asked, err)
+	}
+	if shown, err := reviewConsentNoticeAlreadyShown(context.Background(), repo); err != nil || shown {
+		t.Fatalf("negotiated START burned the once-per-clone notice marker: shown=%v err=%v", shown, err)
+	}
+}
+
+// TestNegotiatedStartConsentAnswersStayByteSilentOnStderr proves the three
+// declared consent shapes stay silent on success: relay answers with the typed
+// question envelope, granted starts the review, and neither touches stderr.
+func TestNegotiatedStartConsentAnswersStayByteSilentOnStderr(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	console := stubReviewConsole(t, false, "")
+	writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+	stderr := captureReviewProcessStderr(t)
+
+	relay := runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--lineage", "review-negotiated-consents", "--consent", "relay",
+	}))
+	question := decodeConsentQuestion(t, relay.Bytes())
+	if question.Action != "consent_required" || !question.Blocking {
+		t.Fatalf("relay did not answer with the typed question: %#v", question)
+	}
+
+	granted := runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--lineage", "review-negotiated-consents", "--consent", "granted",
+	}))
+	started := decodeNegotiatedReviewStart(t, granted.Bytes())
+	if started.Action != string(reviewtransaction.CompactStartCreated) {
+		t.Fatalf("granted START = %#v", started)
+	}
+
+	if console.Len() != 0 {
+		t.Fatalf("declared negotiated consent wrote to the console:\n%s", console.String())
+	}
+	if got := stderr(); got != "" {
+		t.Fatalf("declared negotiated consent wrote stderr, want zero bytes:\n%q", got)
+	}
+}
+
+// TestNegotiatedLifecycleOperationsAreByteSilentOnStderr walks a complete
+// low-risk negotiated lifecycle — STATUS, START, FINALIZE, staged VALIDATE —
+// and requires zero stderr bytes from every successful operation, the exact
+// sequence gentle-pi drives fail-closed.
+func TestNegotiatedLifecycleOperationsAreByteSilentOnStderr(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stubReviewConsole(t, false, "")
+	writeReviewStartCandidate(t, repo, "docs/notes.md", "lifecycle\n", 0o644)
+	stderr := captureReviewProcessStderr(t)
+
+	status := negotiatedStartStatusForContract(t, repo, ReviewIntegrationContractV2, "--agent", "claude-code")
+	started := executeStartTransition(t, repo, status)
+	if started.RiskLevel != reviewtransaction.RiskLow || len(started.SelectedLenses) != 0 {
+		t.Fatalf("low-risk negotiated START = %#v", started)
+	}
+
+	var finalizeStatus bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code", "--next-transition",
+	}, &finalizeStatus); err != nil {
+		t.Fatalf("post-start STATUS: %v", err)
+	}
+	var ready ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, finalizeStatus.Bytes(), &ready)
+	if ready.NextTransition == nil || ready.NextTransition.Execute == nil ||
+		ready.NextTransition.Execute.Operation != "review.finalize" {
+		t.Fatalf("post-start transition = %#v", ready.NextTransition)
+	}
+
+	var finalized bytes.Buffer
+	if err := RunReview([]string{
+		"finalize", "--cwd", repo, "--lineage", started.LineageID,
+		"--captured-results=true", "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code",
+	}, &finalized); err != nil {
+		t.Fatalf("negotiated FINALIZE: %v\n%s", err, finalized.String())
+	}
+
+	runReviewCLIGit(t, repo, "add", "--", "docs/notes.md")
+	var validated bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV2, "--gate", "pre-commit", "--cwd", repo,
+	}, &validated); err != nil {
+		t.Fatalf("negotiated VALIDATE: %v\n%s", err, validated.String())
+	}
+	if !strings.Contains(validated.String(), `"result": "allow"`) &&
+		!strings.Contains(validated.String(), `"result":"allow"`) {
+		t.Fatalf("pre-commit gate did not allow: %s", validated.String())
+	}
+
+	if got := stderr(); got != "" {
+		t.Fatalf("negotiated lifecycle wrote stderr, want zero bytes:\n%q", got)
+	}
+}
+
+// TestPlainStartConsentNoticeStaysByteIdentical pins requirement 3 of the
+// negotiated-silence contract: non-negotiated (human) invocations keep their
+// narration byte-identical. A fresh headless clone with the default mode
+// source prints exactly the skip notice and the default-provenance line, each
+// as its own line, and nothing else.
+func TestPlainStartConsentNoticeStaysByteIdentical(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	console := stubReviewConsole(t, false, "")
+	writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-plain-notice"}, &output); err != nil {
+		t.Fatalf("plain headless start: %v\n%s", err, output.String())
+	}
+	want := reviewConsentSkippedNotice + "\n" + reviewConsentSkippedDefaultProvenance + "\n"
+	if console.String() != want {
+		t.Fatalf("plain start notice drifted:\n got %q\nwant %q", console.String(), want)
+	}
+}

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -970,15 +970,12 @@ func TestReviewStatusValidateRejectsMalformedForecast(t *testing.T) {
 	}
 }
 
-func TestNegotiatedStatusForecastStaysOnStderrAndV1StaysFrozen(t *testing.T) {
+func TestNegotiatedStatusForecastStaysStructuralAndV1StaysFrozen(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("forecast\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	previous := reviewNarrationOutput
-	var stderr bytes.Buffer
-	reviewNarrationOutput = &stderr
-	t.Cleanup(func() { reviewNarrationOutput = previous })
+	stderr := captureReviewProcessStderr(t)
 
 	var stdout bytes.Buffer
 	if err := RunReviewStatus([]string{"--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition"}, &stdout); err != nil {
@@ -998,10 +995,11 @@ func TestNegotiatedStatusForecastStaysOnStderrAndV1StaysFrozen(t *testing.T) {
 	if status.Forecast.Horizon != ForecastHorizonPartial || step.Step != 1 || step.Kind != status.NextTransition.Kind || step.ReasonCode != status.NextTransition.ReasonCode || strings.TrimSpace(step.Description) == "" {
 		t.Fatalf("status forecast = %#v, transition = %#v", status.Forecast, status.NextTransition)
 	}
-	for _, want := range []string{"Forecast horizon: partial", "step 1", step.Kind, step.ReasonCode, step.Description, "Re-query STATUS"} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Errorf("stderr forecast missing %q:\n%s", want, stderr.String())
-		}
+	// The forecast is structural only: a successful negotiated STATUS writes
+	// zero bytes to stderr (gentle-pi fails closed on any stderr a successful
+	// native process writes).
+	if got := stderr(); got != "" {
+		t.Errorf("negotiated STATUS narrated the forecast to stderr, want zero bytes:\n%q", got)
 	}
 
 	var legacy bytes.Buffer

--- a/internal/cli/review_reopen_admitted_test.go
+++ b/internal/cli/review_reopen_admitted_test.go
@@ -221,10 +221,11 @@ func TestReviewReopenResultsRecoversContaminatedAdmittedReviewFromCorrectionRequ
 	if transition == nil || transition.Kind != reviewNextTransitionStop || transition.ReasonCode != "corrected_candidate_unavailable" {
 		t.Fatalf("post-forecast transition = %#v, want corrected_candidate_unavailable stop", transition)
 	}
-	statement, ok := reviewStopReasonStatement("corrected_candidate_unavailable")
+	emission, ok := reviewNarrationRegistry["stop:corrected_candidate_unavailable"]
 	if !ok {
 		t.Fatal("corrected_candidate_unavailable has no narration statement")
 	}
+	statement := emission.Statement
 	if !strings.Contains(statement, "Change the candidate content") {
 		t.Fatalf("narration lost the real-findings truth: %q", statement)
 	}

--- a/internal/cli/review_start_runtime_identity_test.go
+++ b/internal/cli/review_start_runtime_identity_test.go
@@ -150,30 +150,27 @@ func TestNegotiatedStartCommandEchoesTheCallersOwnRuntime(t *testing.T) {
 	}
 }
 
-func TestTierCRecoveryNarrationBindsOnlyDeclaredRuntimeIdentity(t *testing.T) {
+// TestTierCRecoveryStatementsCarryOnlyTheIdentitySlot keeps the issue #2440
+// property on the registered Tier C statements themselves: they never bake a
+// compiled runtime identity into a printed command, only the neutral
+// placeholder slot. The old runtime-binding renderer was removed along with
+// all Tier C stderr emission (successful negotiated operations are byte-silent
+// on stderr), so the registry data is the surface that remains to guard.
+func TestTierCRecoveryStatementsCarryOnlyTheIdentitySlot(t *testing.T) {
 	t.Parallel()
 
 	for _, reason := range []string{"corrected_candidate_unavailable", "correction_repository_verification_failed"} {
-		statement, ok := reviewStopReasonStatement(reason)
+		emission, ok := reviewNarrationRegistry["stop:"+reason]
 		if !ok {
 			t.Fatalf("Tier C reason %q has no narration", reason)
 		}
-		for _, runtime := range []model.AgentID{"", model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
-			t.Run(reason+"/"+string(runtime), func(t *testing.T) {
-				rendered := bindNarrationRuntimeIdentity(statement, runtime)
-				if strings.Contains(rendered, reviewUndeclaredRuntimeIdentitySlot) {
-					t.Fatalf("Tier C narration retained the runtime placeholder: %s", rendered)
-				}
-				if runtime == "" {
-					if strings.Contains(rendered, "--agent") {
-						t.Fatalf("unbound Tier C narration emitted an agent segment: %s", rendered)
-					}
-					return
-				}
-				if strings.Count(rendered, "--agent "+string(runtime)) != 1 {
-					t.Fatalf("bound Tier C narration does not contain one exact runtime identity: %s", rendered)
-				}
-			})
+		if !strings.Contains(emission.Statement, "--agent "+reviewUndeclaredRuntimeIdentitySlot) {
+			t.Fatalf("Tier C statement lost the neutral runtime-identity slot: %s", emission.Statement)
+		}
+		for _, identity := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
+			if strings.Contains(emission.Statement, "--agent "+string(identity)) {
+				t.Fatalf("Tier C statement baked in compiled identity %q: %s", identity, emission.Statement)
+			}
 		}
 	}
 }

--- a/internal/cli/review_status_rdd_mode_test.go
+++ b/internal/cli/review_status_rdd_mode_test.go
@@ -42,10 +42,8 @@ func TestNegotiatedStatusMatchesReviewStartRDDMode(t *testing.T) {
 			if tt.cloneOff {
 				disableReviewForClone(t, repo)
 			}
-			var narration, output bytes.Buffer
-			previousNarrationOutput := reviewNarrationOutput
-			reviewNarrationOutput = &narration
-			t.Cleanup(func() { reviewNarrationOutput = previousNarrationOutput })
+			var output bytes.Buffer
+			stderr := captureReviewProcessStderr(t)
 			if err := RunReview([]string{
 				"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--agent", "opencode",
 				"--action-eligibility", "--next-transition",
@@ -71,19 +69,12 @@ func TestNegotiatedStatusMatchesReviewStartRDDMode(t *testing.T) {
 				if status.NextTransition.Kind != reviewNextTransitionStop || status.NextTransition.ReasonCode != "rdd_disabled" {
 					t.Fatalf("disabled transition = %#v", status.NextTransition)
 				}
-				for _, want := range []string{
-					"gentle-ai review mode enable --scope=" + tt.wantScope,
-					"gentle-ai review status", "--cwd=" + repo,
-					"--contract", ReviewIntegrationContractV2,
-					"--agent", "opencode", "--action-eligibility", "--next-transition",
-				} {
-					if !strings.Contains(narration.String(), want) {
-						t.Fatalf("disabled STATUS continuation is incomplete; missing %q:\n%s", want, narration.String())
-					}
-				}
-				if tt.wantScope == "clone" && (!strings.Contains(narration.String(), "--cwd") || !strings.Contains(narration.String(), repo)) {
-					t.Fatalf("clone continuation is not repository-bound:\n%s", narration.String())
-				}
+			}
+			// A successful negotiated STATUS is byte-silent on stderr in
+			// every mode: the rdd_disabled continuation is not narrated, the
+			// reason code stays structural in next_transition.reason_code.
+			if got := stderr(); got != "" {
+				t.Fatalf("negotiated STATUS wrote stderr, want zero bytes:\n%q", got)
 			}
 			startErr := RunReview([]string{
 				"start", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--agent", "opencode",
@@ -147,7 +138,11 @@ func TestNegotiatedStatusKeepsRDDDisabledStopWhenUntrackedSelectionIsNeeded(t *t
 	}
 }
 
-func TestDisabledStatusNarrationCanonicalizesCWD(t *testing.T) {
+// TestDisabledStatusStaysSilentForEveryCWDSpelling replaces the old
+// narration-canonicalization test: the rdd_disabled continuation is no longer
+// narrated at all, because a successful negotiated STATUS must write zero
+// bytes to stderr regardless of how the caller spelled --cwd.
+func TestDisabledStatusStaysSilentForEveryCWDSpelling(t *testing.T) {
 	for _, cwd := range [][]string{{"--cwd=."}, {"--cwd", "."}} {
 		t.Run(strings.Join(cwd, " "), func(t *testing.T) {
 			reviewModeHome(t)
@@ -157,20 +152,22 @@ func TestDisabledStatusNarrationCanonicalizesCWD(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var narration, output bytes.Buffer
-			previous := reviewNarrationOutput
-			reviewNarrationOutput = &narration
-			t.Cleanup(func() { reviewNarrationOutput = previous })
+			var output bytes.Buffer
+			stderr := captureReviewProcessStderr(t)
 			args := append([]string{"status"}, cwd...)
 			args = append(args, "--contract", ReviewIntegrationContractV2, "--agent", "opencode", "--next-transition")
 			if err := RunReview(args, &output); err != nil {
 				t.Fatalf("STATUS: %v\n%s", err, output.String())
 			}
-			if !strings.Contains(narration.String(), "--cwd="+repo) {
-				t.Fatalf("STATUS retry is not bound to the resolved root:\n%s", narration.String())
+			var status ReviewTargetStatusResult
+			if err := json.Unmarshal(output.Bytes(), &status); err != nil {
+				t.Fatalf("decode STATUS: %v\n%s", err, output.String())
 			}
-			if strings.Contains(narration.String(), "--cwd=. --contract") || strings.Contains(narration.String(), "--cwd . --contract") {
-				t.Fatalf("STATUS retry retained caller cwd %q:\n%s", strings.Join(cwd, " "), narration.String())
+			if status.NextTransition == nil || status.NextTransition.ReasonCode != "rdd_disabled" {
+				t.Fatalf("disabled transition = %#v", status.NextTransition)
+			}
+			if got := stderr(); got != "" {
+				t.Fatalf("disabled negotiated STATUS wrote stderr, want zero bytes:\n%q", got)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #3303.

## What

A successful negotiated (`--contract`) review operation now writes zero bytes to stderr, closing the compatibility hole gentle-pi needs: its adapter fails closed (`UNEXPECTED_STDERR`) on any stderr a successful native process writes.

Suppressed on the negotiated route only (facts stay structural in the JSON envelope):
- forecast narration (`forecast` field), stop-reason narration (`reason_code`), the `rdd_disabled` rendered enable-command continuation (derivable from `review mode status --json`), and the consent notices on undeclared negotiated START.

Preserved byte-identical (test-pinned):
- every non-negotiated (plain) invocation, including both consent notices;
- the interactive one-time consent ceremony: an undeclared negotiated START on an interactive terminal still asks and can still refuse (`errReviewDeclinedForCandidate`) exactly like a plain start — only non-interactive (machine) listeners get the silent path, and neither the consent latch nor the once-per-clone notice marker is consumed there.

## RDD

Lineage `review-cde8c4c813cf7dff`, high risk, canonical 4R. Two CRITICAL reliability findings (interactive-refusal bypass unproved; Tier C surface deleted without reachability proof) fixed in one bounded correction (101/200 lines): console-aware negotiated guard + interactive-ceremony parity tests + honest narration proof-chain comment. Targeted validator PASS on both axes; state **approved**, pre-push gate validated.

## Verification

- RED-first tests; `go test ./...` 67 packages ok; `go vet` + `GOOS=windows go vet` clean; gofmt clean.
- deadcode ratchet: no new unreachable functions; refusal-resolution ratchet green.
- Driven journey corpus: 99/99 completed, dead_end 0.
- Smoke on a fixed binary: full negotiated lifecycle (STATUS→START→FINALIZE→VALIDATE) with `stderr_bytes=0` at every step; plain start still prints both notices byte-identically.
- OpenCode transport unaffected (collects stderr only for error messages on failed relays).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Negotiated STATUS, START, FINALIZE, and VALIDATE operations now keep stderr silent on successful execution.
  - Machine-readable JSON remains available on stdout, including recoverable and terminal status responses.
  - Undeclared negotiated starts complete quietly in fail-safe mode without unnecessary notices.
  - Interactive consent prompts continue to work, while previously completed consent flows proceed silently.
  - Plain, non-negotiated starts retain their existing consent notices and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Size exception

Committed candidate is 546 lines plus a 101-line RDD-bounded correction; the suppression, its byte-identical plain-route pins, and the interactive-ceremony parity tests form one indivisible reviewed unit under an approved RDD receipt (lineage `review-cde8c4c813cf7dff`). Splitting would separate the behavior change from the tests that pin its non-regression surface.
