### PR TITLE
fix(review): classify prior-schema snapshot identities and offer a fresh start

### DIFF
--- a/internal/cli/review_prior_schema_status_test.go
+++ b/internal/cli/review_prior_schema_status_test.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// These tests pin the negotiated contract surface for prior-schema authority:
+// a stored lineage whose snapshot identities were minted by the retired
+// pre-fbb55080 formula is inert history, so STATUS naming it must route to
+// the ordinary fresh-start transition for the live candidate — and that START
+// must actually succeed, creating a new lineage alongside the untouched
+// historical record — while a record matching neither formula keeps the
+// terminal corrupted_or_unverifiable_authority stop.
+
+// retiredSnapshotIdentityForCLITest reproduces the exact pre-fbb55080
+// snapshot-identity formula (verbatim from fbb55080^): v1/v2/
+// base-workspace-overlay/v1 domain tags, the untracked-replay proof folded
+// into the hashed values, and the intended-untracked paths hashed after them.
+// Fixture-only; the fixture below additionally proves the production forensic
+// classifier accepts its output before any assertion runs.
+func retiredSnapshotIdentityForCLITest(snapshot reviewtransaction.Snapshot) string {
+	digest := sha256.New()
+	writeLengthPrefixed := func(value string) {
+		_, _ = digest.Write([]byte(strconv.Itoa(len(value))))
+		_, _ = digest.Write([]byte{0})
+		_, _ = digest.Write([]byte(value))
+		_, _ = digest.Write([]byte{0})
+	}
+	if snapshot.Kind == reviewtransaction.TargetBaseWorkspaceOverlay {
+		digest.Write([]byte("gentle-ai.review-snapshot/base-workspace-overlay/v1\x00"))
+	} else if snapshot.Projection == reviewtransaction.ProjectionStaged {
+		digest.Write([]byte("gentle-ai.review-snapshot/v2\x00"))
+	} else {
+		digest.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
+	}
+	values := []string{string(snapshot.Kind), snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof}
+	if snapshot.Projection == reviewtransaction.ProjectionStaged {
+		values = []string{string(snapshot.Kind), string(snapshot.Projection), snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof}
+	}
+	for _, value := range values {
+		writeLengthPrefixed(value)
+	}
+	for _, value := range snapshot.IntendedUntracked {
+		writeLengthPrefixed(value)
+	}
+	for _, value := range snapshot.LedgerIDs {
+		writeLengthPrefixed(value)
+	}
+	return "sha256:" + hex.EncodeToString(digest.Sum(nil))
+}
+
+// relocateCompactRecordWithIdentities rewrites a persisted compact record
+// under a NEW lineage directory with re-minted snapshot identities, exactly
+// like a store written by another release: the historical directory name was
+// derived from the historical identity, so it never collides with the lineage
+// a fresh START of the same candidate derives today.
+func relocateCompactRecordWithIdentities(t *testing.T, repo, fromLineage, toLineage string, mint func(reviewtransaction.Snapshot) string) reviewtransaction.CompactStore {
+	t.Helper()
+	root := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2")
+	payload, err := os.ReadFile(filepath.Join(root, fromLineage, "review-state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record reviewtransaction.CompactRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	record.State.LineageID = toLineage
+	record.State.InitialSnapshot.Identity = mint(record.State.InitialSnapshot)
+	record.State.CurrentSnapshot.Identity = mint(record.State.CurrentSnapshot)
+	revision, err := reviewtransaction.CompactRevisionForState(record.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.Revision = revision
+	rewritten, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, toLineage), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, toLineage, "review-state.json"), rewritten, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, fromLineage)); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, toLineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestStatusOffersFreshStartForPriorSchemaLineageAndStartSucceeds(t *testing.T) {
+	repo, started, _, _ := newArtifactReview(t, false)
+	store := relocateCompactRecordWithIdentities(t, repo, started.LineageID, "prior-schema-history", retiredSnapshotIdentityForCLITest)
+
+	// The fixture must be what the production forensic classifier calls
+	// prior-schema; anything else would test the wrong record class.
+	_, loadErr := store.Load()
+	var semantic *reviewtransaction.CompactSemanticStateError
+	if loadErr == nil || !errors.As(loadErr, &semantic) || !semantic.OutdatedIdentity {
+		t.Fatalf("prior-schema fixture load error = %v, want an outdated-identity semantic failure", loadErr)
+	}
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", "prior-schema-history"}, &output); err != nil {
+		t.Fatalf("status naming a prior-schema lineage: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.Applicability != reviewtransaction.TargetApplicabilityUnrelated {
+		t.Fatalf("prior-schema lineage applicability = %q, want unrelated (fresh start)", status.Applicability)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
+		status.NextTransition.ReasonCode != "fresh_target_ready" || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.start" {
+		t.Fatalf("prior-schema lineage transition = %#v, want the fresh review.start execute", status.NextTransition)
+	}
+
+	// An explicit lineage argument appears only when the derived name is
+	// occupied; the fixture freed the derived name, so the transition may
+	// legitimately omit it and let START derive the fresh lineage itself.
+	freshLineage := ""
+	for _, argument := range status.NextTransition.Execute.Arguments {
+		if argument.Name == "lineage" {
+			freshLineage = argument.Value
+		}
+	}
+	if freshLineage == "prior-schema-history" {
+		t.Fatalf("fresh start transition renamed the prior-schema lineage itself: %#v", status.NextTransition.Execute.Arguments)
+	}
+	startArgs := []string{"--cwd", repo}
+	if freshLineage != "" {
+		startArgs = append(startArgs, "--lineage", freshLineage)
+	}
+	var startOutput bytes.Buffer
+	if err := RunReviewFacadeStart(startArgs, &startOutput); err != nil {
+		t.Fatalf("fresh start alongside prior-schema history: %v\n%s", err, startOutput.String())
+	}
+	var restarted ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, startOutput.Bytes(), &restarted)
+	if restarted.LineageID == "" || restarted.LineageID == "prior-schema-history" {
+		t.Fatalf("fresh start lineage = %q", restarted.LineageID)
+	}
+	if freshLineage != "" && restarted.LineageID != freshLineage {
+		t.Fatalf("fresh start created lineage %q, want the rendered %q", restarted.LineageID, freshLineage)
+	}
+	after, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("fresh start mutated the prior-schema historical record")
+	}
+	freshStore, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, restarted.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := freshStore.Load(); err != nil {
+		t.Fatalf("fresh lineage alongside prior-schema history does not load: %v", err)
+	}
+}
+
+func TestStatusKeepsTerminalStopForUnrecognizedIdentityLineage(t *testing.T) {
+	repo, started, _, _ := newArtifactReview(t, false)
+	store := relocateCompactRecordWithIdentities(t, repo, started.LineageID, "unrecognized-history", func(snapshot reviewtransaction.Snapshot) string {
+		sum := sha256.Sum256([]byte("unrecognized identity domain " + snapshot.Identity))
+		return "sha256:" + hex.EncodeToString(sum[:])
+	})
+
+	_, loadErr := store.Load()
+	var semantic *reviewtransaction.CompactSemanticStateError
+	if loadErr == nil || !errors.As(loadErr, &semantic) || semantic.OutdatedIdentity {
+		t.Fatalf("unrecognized-identity fixture load error = %v, want a non-outdated semantic failure", loadErr)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", "unrecognized-history"}, &output); err != nil {
+		t.Fatalf("status naming a corrupted lineage: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.Applicability != reviewtransaction.TargetApplicabilityCorrupted {
+		t.Fatalf("unrecognized-identity lineage applicability = %q, want corrupted", status.Applicability)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionStop ||
+		status.NextTransition.ReasonCode != "corrupted_or_unverifiable_authority" {
+		t.Fatalf("unrecognized-identity lineage transition = %#v, want the terminal corrupted stop", status.NextTransition)
+	}
+}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -55,6 +55,12 @@ type CompactSemanticStateError struct {
 	// damaged: diagnostics classify it historical instead of malformed, and
 	// no scoped walk lets it block another lineage's operation.
 	OutdatedIdentity bool
+	// PriorSchemaPredecessorLineageID names the recovery predecessor an
+	// OutdatedIdentity record froze, recovered through the same read-only
+	// forensic parse that proved the prior-schema classification. It lets a
+	// scoped ancestry audit keep walking past inert prior-schema history; it
+	// is forensic classification only and never live authority.
+	PriorSchemaPredecessorLineageID string
 }
 
 func (err *CompactSemanticStateError) Error() string {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -170,7 +170,13 @@ type CompactRecord struct {
 }
 
 // historicalCompactForensicRecord is raw-byte identity, never authority.
-type historicalCompactForensicRecord struct{ RawDigest string }
+// PredecessorLineageID carries the recovery predecessor the prior-schema
+// record names, recovered through the same read-only forensic parse, so
+// scoped ancestry audits can keep walking past inert prior-schema history.
+type historicalCompactForensicRecord struct {
+	RawDigest            string
+	PredecessorLineageID string
+}
 
 type CompactStore struct {
 	Dir                 string
@@ -2393,9 +2399,9 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 		return CompactRecord{}, errors.New("invalid compact review state record")
 	}
 	if err := record.State.Validate(); err != nil {
-		_, historical := forensicHistoricalCompactRecord(payload, lineageID)
+		forensic, historical := forensicHistoricalCompactRecord(payload, lineageID)
 		return CompactRecord{}, &CompactSemanticStateError{LineageID: record.State.LineageID, State: record.State.State, Problem: err.Error(),
-			OutdatedIdentity: historical}
+			OutdatedIdentity: historical, PriorSchemaPredecessorLineageID: forensic.PredecessorLineageID}
 	}
 	if err := validateCompactEffectIntents(record); err != nil {
 		return CompactRecord{}, err
@@ -2475,17 +2481,58 @@ func forensicHistoricalCompactRecord(payload []byte, lineageID string) (historic
 		return historicalCompactForensicRecord{}, false
 	}
 	state := record.State
+	// The proof is a coherent re-mint of the retired identity domain: every
+	// snapshot identity the record froze must equal the retired formula's own
+	// recomputation (Initial/Current unconditionally; correction snapshots may
+	// already carry a current-formula identity and then stay untouched), and
+	// every binding that pins one of those identities — the verification
+	// evidence target and each correction attempt's frozen correction target —
+	// is remapped through the exact same bijection, never invented. A record
+	// that still fails validation after that is not prior-schema.
+	reminted := map[string]string{}
+	remint := func(snapshot *Snapshot) {
+		minted := snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+		reminted[snapshot.Identity] = minted
+		snapshot.Identity = minted
+	}
 	for _, snapshot := range []*Snapshot{&state.InitialSnapshot, &state.CurrentSnapshot} {
 		if snapshot.Identity != retiredCompactSnapshotIdentity(*snapshot) {
 			return historicalCompactForensicRecord{}, false
 		}
-		snapshot.Identity = snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+		remint(snapshot)
+	}
+	for index := range state.CorrectionAttempts {
+		snapshot := &state.CorrectionAttempts[index].Snapshot
+		if minted, seen := reminted[snapshot.Identity]; seen {
+			snapshot.Identity = minted
+		} else if snapshot.Identity == retiredCompactSnapshotIdentity(*snapshot) {
+			remint(snapshot)
+		}
+	}
+	if target := state.CorrectionVerificationTarget; target != nil {
+		if minted, seen := reminted[target.Identity]; seen {
+			target.Identity = minted
+		} else if target.Identity == retiredCompactSnapshotIdentity(*target) {
+			remint(target)
+		}
+	}
+	if minted, seen := reminted[state.EvidenceTargetIdentity]; seen {
+		state.EvidenceTargetIdentity = minted
+	}
+	for index := range state.CorrectionAttempts {
+		if minted, seen := reminted[state.CorrectionAttempts[index].CorrectionTargetIdentity]; seen {
+			state.CorrectionAttempts[index].CorrectionTargetIdentity = minted
+		}
 	}
 	if state.Validate() != nil {
 		return historicalCompactForensicRecord{}, false
 	}
+	predecessor := ""
+	if state.Recovery != nil {
+		predecessor = state.Recovery.PredecessorLineageID
+	}
 	sum := sha256.Sum256(payload)
-	return historicalCompactForensicRecord{RawDigest: "sha256:" + hex.EncodeToString(sum[:])}, true
+	return historicalCompactForensicRecord{RawDigest: "sha256:" + hex.EncodeToString(sum[:]), PredecessorLineageID: predecessor}, true
 }
 
 func retiredCompactSnapshotIdentity(snapshot Snapshot) string {

--- a/internal/reviewtransaction/prior_schema_authority_test.go
+++ b/internal/reviewtransaction/prior_schema_authority_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -309,6 +310,49 @@ func TestExplicitLineageStatusOffersFreshStartForWholePriorSchemaAncestry(t *tes
 	}
 	if status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart {
 		t.Fatalf("whole prior-schema ancestry did not reclassify to fresh start: %#v", status)
+	}
+}
+
+// TestExplicitLineageStatusKeepsLiveAuthorityOverPriorSchemaPredecessor pins
+// the fresh-start exit to the NAMED lineage: a current-schema lineage whose
+// recovery predecessor is prior-schema still owns live authority, so
+// candidate loading must keep it instead of answering with the empty map
+// that routes STATUS to fresh start.
+func TestExplicitLineageStatusKeepsLiveAuthorityOverPriorSchemaPredecessor(t *testing.T) {
+	repo, predecessorStore, _, successorLineage := priorSchemaRecoveryChain(t, "live-over-prior")
+	outdateCompactSnapshotIdentity(t, predecessorStore)
+
+	candidates, err := loadCompactTargetStatusCandidates(context.Background(), repo, successorLineage)
+	if err != nil {
+		t.Fatalf("candidates for a live lineage over a prior-schema predecessor = %v", err)
+	}
+	if _, held := candidates[successorLineage]; !held {
+		t.Fatalf("live named lineage lost its authority to its prior-schema predecessor: %#v", candidates)
+	}
+}
+
+// TestPriorSchemaToleranceIsViolationScoped pins the suppression to the one
+// dangling-predecessor violation the prior-schema gap explains. A second
+// co-present violation on the same lineage is unconstructible through
+// compactAuthorityGraphViolations (it records at most one violation per
+// lineage and the dangling check short-circuits first), so the scoping is
+// proven at the unit level of the filtering predicate.
+func TestPriorSchemaToleranceIsViolationScoped(t *testing.T) {
+	record := CompactRecord{State: CompactState{LineageID: "successor",
+		Recovery: &CompactRecoveryProvenance{PredecessorLineageID: "gone"}}}
+	priorSchema := map[string]bool{"gone": true}
+	dangling := fmt.Errorf("dangling predecessor for %q", "successor")
+	if !compactPriorSchemaToleratedViolation("successor", dangling, record, priorSchema) {
+		t.Fatal("the dangling-predecessor violation a prior-schema gap explains must be tolerated")
+	}
+	for _, violation := range []error{fmt.Errorf("fork at %q", "gone"), errors.New("recovery cycle"),
+		fmt.Errorf("predecessor revision mismatch for %q", "successor")} {
+		if compactPriorSchemaToleratedViolation("successor", violation, record, priorSchema) {
+			t.Fatalf("unrelated violation %v must keep blocking", violation)
+		}
+	}
+	if compactPriorSchemaToleratedViolation("successor", dangling, record, map[string]bool{}) {
+		t.Fatal("a missing predecessor without prior-schema proof must keep blocking")
 	}
 }
 

--- a/internal/reviewtransaction/prior_schema_authority_test.go
+++ b/internal/reviewtransaction/prior_schema_authority_test.go
@@ -1,0 +1,333 @@
+package reviewtransaction
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// These tests pin the prior-schema classification contract: a compact record
+// whose frozen snapshot identities were minted by the retired pre-fbb55080
+// formula is PRIOR-SCHEMA — provably written by an older release and still
+// self-consistent under that formula — never generic corruption. Discovery
+// blocked exclusively by prior-schema history must reclassify the live target
+// through the ordinary fresh-start route instead of the terminal
+// corrupted_or_unverifiable_authority stop, while any record matching neither
+// formula keeps today's fail-closed behavior.
+
+// TestRetiredCompactSnapshotIdentityMatchesVerbatimRetiredFormula proves the
+// production forensic formula (retiredCompactSnapshotIdentity) reproduces the
+// exact pre-fbb55080 snapshotIdentityForProjection body — domain tags v1/v2/
+// base-workspace-overlay/v1, the untracked-replay proof folded into the
+// values, and the length-prefixed intended entries — for every domain-tag
+// shape, and that it always differs from the current formula.
+func TestRetiredCompactSnapshotIdentityMatchesVerbatimRetiredFormula(t *testing.T) {
+	tree := func(seed string) string {
+		sum := sha256.Sum256([]byte(seed))
+		return hex.EncodeToString(sum[:])[:40]
+	}
+	digest := func(seed string) string {
+		sum := sha256.Sum256([]byte(seed))
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	snapshots := []Snapshot{
+		{Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, BaseTree: tree("base"), CandidateTree: tree("candidate"),
+			PathsDigest: digest("paths"), IntendedUntrackedProof: digest("proof"),
+			IntendedUntracked: []string{"a.txt", "b.txt"}, LedgerIDs: []string{}},
+		{Kind: TargetCurrentChanges, Projection: ProjectionStaged, BaseTree: tree("base"), CandidateTree: tree("candidate"),
+			PathsDigest: digest("paths"), IntendedUntrackedProof: digest("proof"),
+			IntendedUntracked: []string{}, LedgerIDs: []string{"R1-001"}},
+		{Kind: TargetBaseWorkspaceOverlay, Projection: ProjectionWorkspace, BaseTree: tree("base"), CandidateTree: tree("candidate"),
+			PathsDigest: digest("paths"), IntendedUntrackedProof: digest("proof"),
+			IntendedUntracked: []string{"overlay.txt"}, LedgerIDs: []string{}},
+		{Kind: TargetFixDiff, Projection: ProjectionWorkspace, BaseTree: tree("base"), CandidateTree: tree("fix"),
+			PathsDigest: digest("paths"), IntendedUntrackedProof: digest("proof"),
+			IntendedUntracked: []string{}, LedgerIDs: []string{"R3-001", "R3-002"}},
+	}
+	for index, snapshot := range snapshots {
+		retired := retiredCompactSnapshotIdentity(snapshot)
+		if verbatim := retiredSnapshotIdentity(snapshot); retired != verbatim {
+			t.Fatalf("snapshot %d: production retired formula %q != verbatim pre-fbb55080 formula %q", index, retired, verbatim)
+		}
+		current := snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree,
+			snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+		if retired == current {
+			t.Fatalf("snapshot %d: retired formula reproduced the current identity %q; the domains would be indistinguishable", index, retired)
+		}
+	}
+}
+
+// retireCompactStateIdentities rewrites every snapshot identity in the state
+// to the retired pre-fbb55080 formula and coherently retires the evidence and
+// correction-target bindings that pin those identities, exactly as a 2.2.x
+// release froze them. It returns nothing: callers persist the state
+// themselves and assert on the load classification.
+func retireCompactStateIdentities(state *CompactState) {
+	retired := map[string]string{}
+	mint := func(snapshot *Snapshot) {
+		value := retiredSnapshotIdentity(*snapshot)
+		retired[snapshot.Identity] = value
+		snapshot.Identity = value
+	}
+	mint(&state.InitialSnapshot)
+	mint(&state.CurrentSnapshot)
+	for index := range state.CorrectionAttempts {
+		mint(&state.CorrectionAttempts[index].Snapshot)
+	}
+	if state.CorrectionVerificationTarget != nil {
+		mint(state.CorrectionVerificationTarget)
+	}
+	if value, seen := retired[state.EvidenceTargetIdentity]; seen {
+		state.EvidenceTargetIdentity = value
+	}
+	for index := range state.CorrectionAttempts {
+		if value, seen := retired[state.CorrectionAttempts[index].CorrectionTargetIdentity]; seen {
+			state.CorrectionAttempts[index].CorrectionTargetIdentity = value
+		}
+	}
+}
+
+// persistCompactStateBytes writes a record for the state exactly as the store
+// serializes one, without any write-path validation, so fixtures can persist
+// historical shapes the current release refuses to mint.
+func persistCompactStateBytes(t *testing.T, repo string, state CompactState) CompactStore {
+	t.Helper()
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+// correctedApprovedCompactState builds the exact record shape 32 of the 36
+// previously unclassifiable real-store records carry: approved through one
+// bounded correction, so the evidence record binding and the correction
+// attempt both pin snapshot identities.
+func correctedApprovedCompactState(t *testing.T, repo, lineage string) CompactState {
+	t.Helper()
+	state, fix := pendingCompactCorrection(t, repo, lineage)
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := bindTargetedValidationForTest(ScopedValidationResult{
+		LedgerIDs: append([]string(nil), state.FixFindingIDs...), FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+		OriginalCriteria:     ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: true},
+	}, fix)
+	payload := []byte("repository verification passed\n")
+	passed, err := NewVerificationEvidenceRecord(state.LineageID, hash("a"), fix, payload, VerificationOutcomePassed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteCorrectionVerification(fix, 1, validation, passed, payload); err != nil {
+		t.Fatal(err)
+	}
+	if state.State != StateApproved || len(state.CorrectionAttempts) != 1 || state.EvidenceTargetIdentity == "" {
+		t.Fatalf("corrected approved fixture state = %#v", state)
+	}
+	return state
+}
+
+// TestCorrectedApprovedPriorSchemaRecordClassifiesOutdated pins the forensic
+// classification for the evidence-bound, correction-carrying shape: the
+// retired identities thread through the correction attempt, the correction
+// target binding, and the verification evidence binding, and the record must
+// still classify as prior-schema (OutdatedIdentity), never generic damage.
+func TestCorrectedApprovedPriorSchemaRecordClassifiesOutdated(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := correctedApprovedCompactState(t, repo, "prior-schema-corrected")
+	retireCompactStateIdentities(&state)
+	store := persistCompactStateBytes(t, repo, state)
+
+	_, loadErr := store.Load()
+	var semantic *CompactSemanticStateError
+	if loadErr == nil || !errors.As(loadErr, &semantic) {
+		t.Fatalf("prior-schema corrected record load error = %v, want a semantic state error", loadErr)
+	}
+	if !semantic.OutdatedIdentity {
+		t.Fatalf("prior-schema corrected record classified as generic damage: %v", loadErr)
+	}
+}
+
+// priorSchemaLineage plants one lineage whose record is byte-faithful to a
+// pre-fbb55080 release: a plain approved review with every identity minted by
+// the retired formula. The worktree residue is removed so the fixture never
+// changes what any live snapshot sees.
+func priorSchemaLineage(t *testing.T, repo, lineage string) CompactStore {
+	t.Helper()
+	planted := quarantineFixtureHealthyLineage(t, repo, lineage, "prior-schema candidate content\n")
+	if err := os.Remove(filepath.Join(repo, planted+".txt")); err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, planted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outdateCompactSnapshotIdentity(t, store)
+	return store
+}
+
+// corruptSnapshotIdentityBeyondRecognition rewrites a persisted record so its
+// snapshot identities match NEITHER the current nor the retired formula —
+// genuine corruption, the control shape that must keep failing closed.
+func corruptSnapshotIdentityBeyondRecognition(t *testing.T, store CompactStore) {
+	t.Helper()
+	record := mustLoadCompactRecord(t, store)
+	for _, snapshot := range []*Snapshot{&record.State.InitialSnapshot, &record.State.CurrentSnapshot} {
+		sum := sha256.Sum256([]byte("unrecognized identity domain " + snapshot.Identity))
+		snapshot.Identity = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	_, payload, err := makeCompactRecord(record.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, loadErr := store.Load()
+	var semantic *CompactSemanticStateError
+	if loadErr == nil || !errors.As(loadErr, &semantic) || semantic.OutdatedIdentity {
+		t.Fatalf("unrecognized-identity fixture load error = %v, want a non-outdated semantic failure", loadErr)
+	}
+}
+
+// TestExplicitLineageStatusOffersFreshStartForPriorSchemaAuthority is the
+// classification fix itself: STATUS naming a lineage whose record is provably
+// prior-schema must answer with the ordinary fresh-start shape for the live
+// candidate — the prior-schema authority stays untouched on disk as inert
+// history — instead of the terminal corrupted classification.
+func TestExplicitLineageStatusOffersFreshStartForPriorSchemaAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	store := priorSchemaLineage(t, repo, "prior-schema-only")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfresh live work\n")
+
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: store.lineageID,
+	})
+	if err != nil {
+		t.Fatalf("status naming a prior-schema lineage = %v", err)
+	}
+	if status.Applicability == TargetApplicabilityCorrupted {
+		t.Fatalf("prior-schema authority still classifies corrupted: %#v", status)
+	}
+	if status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart {
+		t.Fatalf("prior-schema authority did not reclassify to the fresh-start shape: %#v", status)
+	}
+	after, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("read-only status mutated the prior-schema record")
+	}
+}
+
+// TestExplicitLineageStatusKeepsCorruptedForUnrecognizedIdentity is the
+// fail-closed control: a record whose identities match neither formula is
+// genuine corruption and keeps today's terminal classification.
+func TestExplicitLineageStatusKeepsCorruptedForUnrecognizedIdentity(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	lineage := quarantineFixtureHealthyLineage(t, repo, "unrecognized-identity", "corrupted candidate content\n")
+	if err := os.Remove(filepath.Join(repo, lineage+".txt")); err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corruptSnapshotIdentityBeyondRecognition(t, store)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfresh live work\n")
+
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: lineage,
+	})
+	if err != nil {
+		t.Fatalf("status naming a corrupted lineage = %v", err)
+	}
+	if status.Applicability != TargetApplicabilityCorrupted || status.Action != TargetStatusActionRepairAuthority {
+		t.Fatalf("unrecognized-identity record lost its fail-closed classification: %#v", status)
+	}
+}
+
+// priorSchemaRecoveryChain builds a real recovery chain (predecessor plus a
+// recovered successor) so ancestry-walk classification can be pinned, then
+// hands both stores back for per-test mutation.
+func priorSchemaRecoveryChain(t *testing.T, prefix string) (string, CompactStore, CompactStore, string) {
+	t.Helper()
+	repo, predecessor, predecessorStore, predecessorRecord := correctionScopeRecoveryFixture(t, prefix+"-predecessor")
+	writeSnapshotFile(t, repo, "process_helper.go", "package processhelper\n")
+	successor := newCompactTestStateWithIntended(t, repo, prefix+"-successor", []string{"process_helper.go"})
+	successor.Generation = predecessor.Generation + 1
+	request := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRecord.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "correction requires a process helper",
+		Actor: "maintainer", RecoveredAt: time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC),
+	}
+	request.MaintainerAuthorization = recoveryAuthorizationFixture(request)
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorStore, err := CompactAuthoritativeStore(context.Background(), repo, recovered.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, predecessorStore, successorStore, recovered.State.LineageID
+}
+
+// TestExplicitLineageStatusOffersFreshStartForWholePriorSchemaAncestry: when
+// EVERY record blocking the named lineage is prior-schema, the whole chain is
+// inert history and the live target reclassifies to fresh start.
+func TestExplicitLineageStatusOffersFreshStartForWholePriorSchemaAncestry(t *testing.T) {
+	repo, predecessorStore, successorStore, successorLineage := priorSchemaRecoveryChain(t, "prior-chain")
+	outdateCompactSnapshotIdentity(t, successorStore)
+	outdateCompactSnapshotIdentity(t, predecessorStore)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfresh live work\n")
+
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: successorLineage,
+	})
+	if err != nil {
+		t.Fatalf("status naming a whole prior-schema chain = %v", err)
+	}
+	if status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart {
+		t.Fatalf("whole prior-schema ancestry did not reclassify to fresh start: %#v", status)
+	}
+}
+
+// TestExplicitLineageStatusKeepsCorruptedForMixedAncestry: a prior-schema
+// record recovering from genuinely corrupted authority is a mixed blocking
+// set, and mixed keeps today's fail-closed behavior.
+func TestExplicitLineageStatusKeepsCorruptedForMixedAncestry(t *testing.T) {
+	repo, predecessorStore, successorStore, successorLineage := priorSchemaRecoveryChain(t, "mixed-chain")
+	outdateCompactSnapshotIdentity(t, successorStore)
+	corruptSnapshotIdentityBeyondRecognition(t, predecessorStore)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfresh live work\n")
+
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: successorLineage,
+	})
+	if err != nil {
+		t.Fatalf("status naming a mixed prior-schema/corrupt chain = %v", err)
+	}
+	if status.Applicability != TargetApplicabilityCorrupted {
+		t.Fatalf("mixed ancestry lost its fail-closed classification: %#v", status)
+	}
+}

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -83,13 +83,34 @@ func loadCompactTargetStatusCandidates(ctx context.Context, repo, lineageID stri
 		// validating every recovery edge in the selected lineage's ancestry.
 		cursor := store
 		selected = append(selected, store)
+		priorSchema := map[string]bool{}
 		for {
-			if _, seen := records[cursor.lineageID]; seen {
+			if _, seen := records[cursor.lineageID]; seen || priorSchema[cursor.lineageID] {
 				return nil, errors.New("invalid compact authority graph: recovery cycle")
 			}
 			record, loadErr := cursor.LoadContext(ctx)
 			if loadErr != nil {
-				return nil, loadErr
+				semantic, priorSchemaRecord := compactPriorSchemaLoadFailure(loadErr)
+				if !priorSchemaRecord {
+					return nil, loadErr
+				}
+				// A prior-schema record — provably frozen by an earlier
+				// release under the retired snapshot-identity formula and
+				// still self-consistent under it — is inert history, not
+				// damage. It cannot govern this target, so it never fails the
+				// selection closed by itself; the walk keeps auditing the
+				// rest of the ancestry so any genuinely corrupted deeper
+				// record still does.
+				priorSchema[cursor.lineageID] = true
+				if semantic.PriorSchemaPredecessorLineageID == "" {
+					break
+				}
+				predecessor, exists := storeByLineage[semantic.PriorSchemaPredecessorLineageID]
+				if !exists {
+					return nil, fmt.Errorf("invalid compact authority graph: dangling predecessor for %q", cursor.lineageID)
+				}
+				cursor = predecessor
+				continue
 			}
 			records[record.State.LineageID] = record
 			if record.State.Recovery == nil {
@@ -105,8 +126,26 @@ func loadCompactTargetStatusCandidates(ctx context.Context, repo, lineageID stri
 		// Scoping the refusal is not relaxing it: what changes is whose
 		// business a defect is, never whether a defect is tolerated.
 		violations, _ := compactAuthorityGraphViolations(records)
+		for lineage, record := range records {
+			// Tolerate exactly the one edge a prior-schema gap explains: a
+			// loaded successor whose recovery predecessor is a proven
+			// prior-schema record can only carry the dangling-predecessor
+			// violation for that absence. Every other defect keeps blocking.
+			if _, carried := violations[lineage]; carried && record.State.Recovery != nil && priorSchema[record.State.Recovery.PredecessorLineageID] {
+				delete(violations, lineage)
+			}
+		}
 		if carrier, cause := compactAuthorityBlockingCause(records, violations, lineageID); cause != nil {
 			return nil, compactBlockedLineageError(lineageID, carrier, cause)
+		}
+		if len(priorSchema) > 0 {
+			// The named lineage is blocked exclusively by prior-schema
+			// history, so it owns no live authority: report no candidate and
+			// let status reclassify the live target through its one
+			// lifted-restriction recursion (#2645), which lands on the same
+			// fresh-start route any unrelated target takes. The prior-schema
+			// records stay untouched on disk as inert history.
+			return map[string]targetStatusCandidate{}, nil
 		}
 	}
 
@@ -348,6 +387,20 @@ func classifyCompactCorrectionTargetForStatus(ctx context.Context, repo string, 
 	requested := existing
 	requested.InitialSnapshot = live
 	return classifyCompactCorrectionTarget(ctx, repo, existing, requested, true)
+}
+
+// compactPriorSchemaLoadFailure classifies one load failure as provably
+// prior-schema: parseCompactRecord's forensic pass (#2743) confirmed the
+// stored snapshot identities equal the retired pre-fbb55080 formula's own
+// recomputation and the state validates once coherently re-minted. Anything
+// else — unrecognized identities, structural damage, IO failure — is not
+// prior schema and keeps failing closed exactly as before.
+func compactPriorSchemaLoadFailure(err error) (*CompactSemanticStateError, bool) {
+	var semantic *CompactSemanticStateError
+	if !errors.As(err, &semantic) || !semantic.OutdatedIdentity {
+		return nil, false
+	}
+	return semantic, true
 }
 
 func targetStatusFailure(base TargetStatusResult, err error) (TargetStatusResult, error) {

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -127,24 +127,25 @@ func loadCompactTargetStatusCandidates(ctx context.Context, repo, lineageID stri
 		// business a defect is, never whether a defect is tolerated.
 		violations, _ := compactAuthorityGraphViolations(records)
 		for lineage, record := range records {
-			// Tolerate exactly the one edge a prior-schema gap explains: a
-			// loaded successor whose recovery predecessor is a proven
-			// prior-schema record can only carry the dangling-predecessor
-			// violation for that absence. Every other defect keeps blocking.
-			if _, carried := violations[lineage]; carried && record.State.Recovery != nil && priorSchema[record.State.Recovery.PredecessorLineageID] {
+			// Tolerate exactly the one violation a prior-schema gap explains:
+			// the dangling-predecessor defect for that proven absence. Every
+			// other violation on the same lineage keeps blocking.
+			if violation, carried := violations[lineage]; carried && compactPriorSchemaToleratedViolation(lineage, violation, record, priorSchema) {
 				delete(violations, lineage)
 			}
 		}
 		if carrier, cause := compactAuthorityBlockingCause(records, violations, lineageID); cause != nil {
 			return nil, compactBlockedLineageError(lineageID, carrier, cause)
 		}
-		if len(priorSchema) > 0 {
-			// The named lineage is blocked exclusively by prior-schema
-			// history, so it owns no live authority: report no candidate and
-			// let status reclassify the live target through its one
-			// lifted-restriction recursion (#2645), which lands on the same
-			// fresh-start route any unrelated target takes. The prior-schema
-			// records stay untouched on disk as inert history.
+		if priorSchema[lineageID] {
+			// The named lineage ITSELF is prior-schema history, so it owns no
+			// live authority: report no candidate and let status reclassify
+			// the live target through its one lifted-restriction recursion
+			// (#2645), which lands on the same fresh-start route any
+			// unrelated target takes. A live current-schema lineage whose
+			// ancestors are prior-schema falls through and keeps its
+			// authority. The prior-schema records stay untouched on disk as
+			// inert history.
 			return map[string]targetStatusCandidate{}, nil
 		}
 	}
@@ -401,6 +402,19 @@ func compactPriorSchemaLoadFailure(err error) (*CompactSemanticStateError, bool)
 		return nil, false
 	}
 	return semantic, true
+}
+
+// compactPriorSchemaToleratedViolation reports whether one carried violation
+// is exactly the dangling-predecessor defect a proven prior-schema gap
+// explains: the record's recovery predecessor is prior-schema, and the
+// violation is the one compactAuthorityGraphViolations records for that
+// missing predecessor. Any other violation on the same lineage keeps
+// blocking.
+func compactPriorSchemaToleratedViolation(lineage string, violation error, record CompactRecord, priorSchema map[string]bool) bool {
+	if record.State.Recovery == nil || !priorSchema[record.State.Recovery.PredecessorLineageID] {
+		return false
+	}
+	return violation != nil && violation.Error() == fmt.Sprintf("dangling predecessor for %q", lineage)
 }
 
 func targetStatusFailure(base TargetStatusResult, err error) (TargetStatusResult, error) {


### PR DESCRIPTION
Closes #3306.

## What

The 227 pre-fbb55080 lineages in any long-lived store classified as `corrupted_or_unverifiable_authority` (terminal) because `validateCompactSnapshot` recomputes today's identity formula over records frozen under the retired one. This change classifies them instead as **prior-schema: inert history**, and routes the target to the ordinary fresh-start exit — new work ignores retired-schema lineages instead of dying on them.

- Forensic fidelity: `retiredCompactSnapshotIdentity` pinned against the verbatim pre-fbb55080 formula (tags v1/v2/overlay-v1, proof in values, length-prefixed intended entries).
- `forensicHistoricalCompactRecord` extended to coherently re-mint correction attempts and evidence/correction target identities through the retired→current bijection (36 of the 227 previously failed re-mint validation as generic damage).
- Explicit-lineage walk treats prior-schema records as inert history: keeps auditing ancestry, tolerates ONLY the exact dangling-predecessor violation a prior-schema gap explains, and offers fresh start only when the named lineage itself is prior-schema. Mixed/unrecognized ancestry keeps today's terminal behavior (control-pinned).
- Contract surface reused (`fresh_target_ready`/`review.start`): no new reason code, zero golden churn.

## RDD

Lineage `review-63a08be6e7034c61`, high risk, 4R. Seven CRITICAL findings (all four lenses converging on two real defects: live authority discarded when any ancestor was prior-schema; violation suppression not scoped to the explained edge) fixed in one bounded correction (82/200 lines) — the early return is now scoped to the named lineage and the tolerance is violation-content-gated. Targeted validator PASS; state **approved**, pre-push gate validated.

## Verification

- RED-first throughout; full `go test ./...` green; `go vet` + `GOOS=windows go vet` clean; deadcode ratchet clean.
- Driven journey corpus: 99/99 completed, dead_end 0.
- Real-world smoke (read-only, 256-lineage store): before — 191 outdated + 36 unclassifiable, explicit STATUS `corrupted`; after — all 227 prior-schema, 0 unclassifiable, 8 ok untouched, same STATUS offers `fresh_target_ready` → `review.start`, historical records byte-identical, store not mutated.

## Size exception

The forensic re-mint coverage, the prior-schema walk, and the RDD-bounded correction (82 lines) form one reviewed unit under an approved receipt (lineage `review-63a08be6e7034c61`); the bulk is RED-first tests over real-store shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status handling for records created under earlier schema versions.
  * Valid historical records can now recover with a clean start without altering historical records.
  * Preserved detection of unknown, mixed, or genuinely corrupted records.
  * Improved ancestry validation, including recovery-cycle detection and safe handling of outdated predecessor records.

* **Tests**
  * Added comprehensive coverage for legacy compatibility, recovery behavior, corruption handling, and historical authority scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->