### PR TITLE
feat(review): finalize captured targeted-validator slots generically

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -671,6 +671,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue3043Journeys()...)
 	journeys = append(journeys, repositoryContextJourneys()...)
 	journeys = append(journeys, providerCaptureRetryJourneys()...)
+	journeys = append(journeys, capturedProviderValidatorJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_captured_provider_validator.go
+++ b/bench/journeys_captured_provider_validator.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const capturedProviderValidatorLineage = "captured-provider-validator"
+
+var capturedProviderValidatorStatusCapability = &Capability{Verb: []string{"review", "status"}, Flags: []string{
+	"--cwd", "--contract", "--agent", "--lineage", "--next-transition",
+}}
+
+// capturedProviderValidatorJourneys proves the generic STATUS-to-FINALIZE
+// continuation with the native relay protocol. It deliberately drives relay
+// frames directly; this is not evidence about OpenCode Task-hook affinity.
+func capturedProviderValidatorJourneys() []Journey {
+	return []Journey{{
+		ID:     "j106-captured-provider-validator-slot-finalizes-generically",
+		Title:  "Captured provider validator slot finalizes through generic STATUS without a runtime token",
+		Source: "provider-slot continuation: occupied Go-admitted validator slots are provider facts, not OpenCode finalizer behavior",
+		Steps: []Step{
+			{Name: "fixture: repo", Fixture: baseRepo},
+			{Name: "fixture: stage correction candidate", Fixture: stageCaptureEvidenceDescriptorCorrection},
+			{Name: "start correction review", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", capturedProviderValidatorLineage)},
+			{Name: "capture correction finding and complete lenses", Requires: captureResultCapability, Composite: captureCorrectableFinding},
+			{Name: "finalize reviewer results into correction-required", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", capturedProviderValidatorLineage, "--captured-results=true")},
+			{Name: "forecast the bounded correction", Requires: finalizeCorrectionCapability, Args: productArgs("review", "finalize", "--lineage", capturedProviderValidatorLineage, "--correction-lines", "2")},
+			{Name: "fixture: correct the reviewed candidate", Fixture: writeCorrectedCandidate},
+			{Name: "capture passed correction evidence", Requires: captureEvidenceDescriptorCapability, Composite: func(r *journeyRun) error {
+				return captureV5CorrectionEvidenceDescriptorFor(r, capturedProviderValidatorLineage)
+			}},
+			{Name: "capture the Go-issued validator Task through the native relay protocol", Requires: capturedProviderValidatorStatusCapability, Composite: captureProviderValidatorSlot},
+			{Name: "finalize the generic captured-provider transition", Requires: finalizeEvidenceCapability, Composite: finalizeCapturedProviderValidatorSlot},
+		},
+	}}
+}
+
+func captureProviderValidatorSlot(r *journeyRun) error {
+	status, err := readCapturedProviderValidatorStatus(r, true)
+	if err != nil {
+		return err
+	}
+	if status.ValidationRequest == nil || status.NextTransition == nil || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "targeted_validation_required" || status.NextTransition.Collect == nil ||
+		len(status.NextTransition.Collect.Inputs) != 1 {
+		return fmt.Errorf("provider slot capture status = %+v", status)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.Name != "provider_targeted-validator" || input.CaptureOperation != "external.run_provider_role" ||
+		input.ProviderTask == nil || input.ProviderTask.Role != "targeted-validator" || input.ProviderTask.Prompt == "" {
+		return fmt.Errorf("provider slot task = %+v", input)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"targeted_validation_request_hash": status.ValidationRequest.RequestHash,
+		"correction_target_identity":       status.ValidationRequest.CorrectionTargetIdentity,
+		"original_criteria":                map[string]any{"passed": true, "evidence": []string{"original acceptance check passed"}},
+		"correction_regression":            map[string]any{"passed": true, "evidence": []string{"targeted regression check passed"}},
+		"follow_ups":                       []any{},
+	})
+	if err != nil {
+		return err
+	}
+	start, err := json.Marshal(map[string]string{
+		"schema": "gentle-ai.provider-transport/v1", "operation": "start", "prompt": input.ProviderTask.Prompt,
+	})
+	if err != nil {
+		return err
+	}
+	observation, err := r.runInteractive([]string{"review", "opencode-transport"}, true, func(reader *bufio.Reader, writer io.WriteCloser) error {
+		if _, err := writer.Write(append(start, '\n')); err != nil {
+			return fmt.Errorf("write relay start: %w", err)
+		}
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read relay prompt: %w", err)
+		}
+		var prompt struct {
+			Schema    string `json:"schema"`
+			Operation string `json:"operation"`
+			Nonce     string `json:"nonce"`
+			Prompt    string `json:"prompt"`
+		}
+		if err := json.Unmarshal([]byte(line), &prompt); err != nil || prompt.Schema != "gentle-ai.provider-transport/v1" ||
+			prompt.Operation != "prompt" || prompt.Nonce == "" || prompt.Prompt == "" {
+			return fmt.Errorf("relay prompt = %q: %w", line, err)
+		}
+		completion, err := json.Marshal(map[string]string{
+			"schema": "gentle-ai.provider-transport/v1", "operation": "complete", "nonce": prompt.Nonce, "output": string(payload),
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := writer.Write(append(completion, '\n')); err != nil {
+			return fmt.Errorf("write relay completion: %w", err)
+		}
+		return nil
+	})
+	if err != nil || observation.ExitCode != 0 {
+		return fmt.Errorf("native provider-slot relay = exit %d err=%v stderr=%s", observation.ExitCode, err, firstLine(observation.Stderr))
+	}
+	if !capturedProviderSlotReported(observation.Stdout) {
+		return fmt.Errorf("native provider-slot relay did not report capture: %s", observation.Stdout)
+	}
+	return nil
+}
+
+func finalizeCapturedProviderValidatorSlot(r *journeyRun) error {
+	status, err := readCapturedProviderValidatorStatus(r, false)
+	if err != nil {
+		return err
+	}
+	if status.Authority == nil || status.ValidationRequest == nil || status.NextTransition == nil || status.NextTransition.Kind != "execute" ||
+		status.NextTransition.ReasonCode != "captured_provider_targeted_validation_ready" || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.finalize" {
+		return fmt.Errorf("generic captured-provider transition = %+v", status.NextTransition)
+	}
+	context := executeArgument(status.NextTransition.Execute.Arguments, "repository-context")
+	want := []string{
+		"--contract=" + reviewContractV2,
+		"--lineage=" + capturedProviderValidatorLineage,
+		"--expected-revision=" + status.Authority.Revision,
+		"--target=" + status.ValidationRequest.CorrectionTargetIdentity,
+		"--request-hash=" + status.ValidationRequest.RequestHash,
+		"--repository-context=" + context,
+		"--captured-evidence=true",
+	}
+	got := make([]string, len(status.NextTransition.Execute.Arguments))
+	for index, argument := range status.NextTransition.Execute.Arguments {
+		got[index] = argument.Token
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") || strings.Contains(strings.Join(got, "\n"), "--agent=") ||
+		strings.Contains(strings.Join(got, "\n"), "--validation=") || context == "" {
+		return fmt.Errorf("generic captured-provider finalize argv = %v, want %v", got, want)
+	}
+	result, err := decodeWaveOperation(r.runAt(r.sandbox.Root, append([]string{"review", "finalize"}, got...), false), "generic captured-provider finalize")
+	if err != nil || result.State != "approved" || result.LineageID != capturedProviderValidatorLineage {
+		return fmt.Errorf("generic captured-provider finalize result = %+v, %v", result, err)
+	}
+	return nil
+}
+
+func readCapturedProviderValidatorStatus(r *journeyRun, withOpenCodeTask bool) (waveCorrectionStatus, error) {
+	arguments := []string{"review", "status", "--contract", reviewContractV2, "--next-transition", "--lineage", capturedProviderValidatorLineage}
+	if withOpenCodeTask {
+		arguments = append(arguments, "--agent", "opencode")
+	}
+	observation := r.run(productArgsFor(r, arguments...), false)
+	var status waveCorrectionStatus
+	return status, decodeWaveObservation(observation, &status, "captured provider validator status")
+}
+
+func executeArgument(arguments []waveTransitionArgument, name string) string {
+	for _, argument := range arguments {
+		if argument.Name == name {
+			return argument.Value
+		}
+	}
+	return ""
+}
+
+func capturedProviderSlotReported(stdout string) bool {
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		var frame struct {
+			Operation string `json:"operation"`
+			Output    string `json:"output"`
+		}
+		if json.Unmarshal([]byte(line), &frame) == nil && frame.Operation == "result" &&
+			strings.Contains(frame.Output, `"role":"targeted-validator"`) && strings.Contains(frame.Output, `"captured":true`) {
+			return true
+		}
+	}
+	return false
+}

--- a/bench/journeys_frozen_lineage_resume.go
+++ b/bench/journeys_frozen_lineage_resume.go
@@ -246,6 +246,13 @@ func exerciseFrozenLineageResume(r *journeyRun) error {
 	if occupied.NextTransition.Kind != "stop" || occupied.NextTransition.ReasonCode != "native_stop_required" {
 		return fmt.Errorf("drifted occupied frozen status = %+v", occupied.NextTransition)
 	}
+	// The drift guard must hold end to end: finalizing the drifted candidate
+	// directly must refuse instead of publishing a receipt for bytes nobody
+	// reviewed.
+	if observation := r.run([]string{"review", "finalize", "--cwd", r.sandbox.Repo,
+		"--lineage", r.sandbox.Lineage, "--captured-results=true"}, false); observation.ExitCode == 0 {
+		return fmt.Errorf("drifted frozen finalize must refuse, got exit 0")
+	}
 	if err := r.sandbox.write(filepath.Join(r.sandbox.Repo, frozenLineageTracked), frozenLineageSource); err != nil {
 		return err
 	}

--- a/bench/journeys_frozen_lineage_resume.go
+++ b/bench/journeys_frozen_lineage_resume.go
@@ -243,7 +243,8 @@ func exerciseFrozenLineageResume(r *journeyRun) error {
 	if err != nil {
 		return err
 	}
-	if occupied.NextTransition.Kind != "stop" || occupied.NextTransition.ReasonCode != "native_stop_required" {
+	if occupied.NextTransition.Kind != "execute" || occupied.NextTransition.ReasonCode != "captured_results_ready" ||
+		occupied.NextTransition.Execute.Operation != "review.finalize" {
 		return fmt.Errorf("drifted occupied frozen status = %+v", occupied.NextTransition)
 	}
 	if err := r.sandbox.write(filepath.Join(r.sandbox.Repo, frozenLineageTracked), frozenLineageSource); err != nil {

--- a/bench/journeys_frozen_lineage_resume.go
+++ b/bench/journeys_frozen_lineage_resume.go
@@ -243,8 +243,7 @@ func exerciseFrozenLineageResume(r *journeyRun) error {
 	if err != nil {
 		return err
 	}
-	if occupied.NextTransition.Kind != "execute" || occupied.NextTransition.ReasonCode != "captured_results_ready" ||
-		occupied.NextTransition.Execute.Operation != "review.finalize" {
+	if occupied.NextTransition.Kind != "stop" || occupied.NextTransition.ReasonCode != "native_stop_required" {
 		return fmt.Errorf("drifted occupied frozen status = %+v", occupied.NextTransition)
 	}
 	if err := r.sandbox.write(filepath.Join(r.sandbox.Repo, frozenLineageTracked), frozenLineageSource); err != nil {

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -56,6 +56,7 @@ func journeySources() []journeySource {
 		{"journeys_issue_3043.go", issue3043Journeys()},
 		{"journeys_repository_context.go", repositoryContextJourneys()},
 		{"journeys_provider_capture.go", providerCaptureRetryJourneys()},
+		{"journeys_captured_provider_validator.go", capturedProviderValidatorJourneys()},
 	}
 }
 

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -45,6 +45,12 @@ type waveOperationResult struct {
 	TargetIdentity       string `json:"target_identity"`
 }
 
+type waveTransitionArgument struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Token string `json:"token"`
+}
+
 type waveCorrectionStatus struct {
 	Schema         string `json:"schema"`
 	TargetIdentity string `json:"target_identity"`
@@ -81,10 +87,15 @@ type waveCorrectionStatus struct {
 				CaptureOperation string                         `json:"capture_operation"`
 				Arguments        []struct{ Name, Value string } `json:"arguments"`
 				Submission       *waveSubmissionDescriptor      `json:"submission"`
+				ProviderTask     *struct {
+					Prompt string `json:"prompt"`
+					Role   string `json:"role"`
+				} `json:"provider_task"`
 			} `json:"inputs"`
 		} `json:"collect"`
 		Execute *struct {
-			Operation string `json:"operation"`
+			Operation string                   `json:"operation"`
+			Arguments []waveTransitionArgument `json:"arguments"`
 		} `json:"execute"`
 	} `json:"next_transition"`
 }

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -247,6 +249,50 @@ func (s *Sandbox) invokeAt(dir string, args []string) Observation {
 	}
 }
 
+func (s *Sandbox) invokeInteractive(dir string, args []string, exchange func(*bufio.Reader, io.WriteCloser) error) (Observation, error) {
+	cmd := exec.Command(s.Binary, args...)
+	cmd.Dir = dir
+	cmd.Env = s.env()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return interactiveObservation(args, -1, "", "bench: "+err.Error()), err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return interactiveObservation(args, -1, "", "bench: "+err.Error()), err
+	}
+	var output, stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return interactiveObservation(args, -1, "", "bench: "+err.Error()), err
+	}
+	reader := bufio.NewReader(io.TeeReader(stdout, &output))
+	exchangeErr := exchange(reader, stdin)
+	_ = stdin.Close()
+	_, readErr := io.Copy(io.Discard, reader)
+	waitErr := cmd.Wait()
+	exitCode := 0
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	} else if waitErr != nil {
+		exitCode = -1
+		stderr.WriteString("\nbench: " + waitErr.Error())
+	}
+	observation := interactiveObservation(args, exitCode, output.String(), stderr.String())
+	if exchangeErr != nil {
+		return observation, exchangeErr
+	}
+	if readErr != nil {
+		return observation, readErr
+	}
+	return observation, nil
+}
+
+func interactiveObservation(args []string, exitCode int, stdout, stderr string) Observation {
+	return Observation{Args: args, ExitCode: exitCode, Stdout: stdout, Stderr: stderr, StdoutCaptured: true, StderrCaptured: true}
+}
+
 // readBack runs the product for a fixture proof, a capability probe or an
 // assertion. It is benchmark instrumentation, not operator work, so it is never
 // counted — and it runs with GIT_TRACE blanked, exactly like Sandbox.git, so the
@@ -478,6 +524,17 @@ func (r *journeyRun) runAt(dir string, args []string, modelRun bool) Observation
 	record := r.accumulator.observe(r.step, observation, r.sandbox.gitCallsSince(), modelRun)
 	r.accumulator.records = append(r.accumulator.records, record)
 	return observation
+}
+
+// runInteractive drives a native command that publishes an intermediate frame
+// before it can accept its continuation. It records one real product command;
+// the exchange is limited to transport framing and never manufactures review
+// authority or provider output.
+func (r *journeyRun) runInteractive(args []string, modelRun bool, exchange func(*bufio.Reader, io.WriteCloser) error) (Observation, error) {
+	observation, err := r.sandbox.invokeInteractive(r.sandbox.Repo, args, exchange)
+	record := r.accumulator.observe(r.step, observation, r.sandbox.gitCallsSince(), modelRun)
+	r.accumulator.records = append(r.accumulator.records, record)
+	return observation, err
 }
 
 func runJourney(binary string, journey Journey) JourneyResult {

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -14,6 +14,7 @@ j102-status-stops-oversized-lens-context
 j103-sdd-interrupted-settlement-omits-evidence
 j104-repository-context-survives-fresh-process
 j105-compiled-provider-capture-retries-same-binding
+j106-captured-provider-validator-slot-finalizes-generically
 j11-unborn-head
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -973,6 +973,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			var correctionRequest *reviewtransaction.CorrectionPlanRequest
 			providerRole := reviewProviderRole("")
 			var preCommitDeliveryAssessment *reviewtransaction.CompactGateTargetApplicability
+			capturedProviderTargetedValidator := false
 			correctionForecasted := false
 			lensContextBudgetExceeded := false
 			var artifactErr error
@@ -1103,11 +1104,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 									}
 								}
 							}
-							if providerRoleHost && validationRequest != nil && capturedEvidence != nil && capturedEvidence.Outcome == reviewtransaction.VerificationOutcomePassed {
-								slot, slotErr := reviewtransaction.ReadCompactTargetedValidatorResultSlot(store.Dir, *validationRequest)
-								if slotErr != nil {
-									artifactErr = slotErr
-								} else if !slot.Occupied {
+							if validationRequest != nil && capturedEvidence != nil && capturedEvidence.Outcome == reviewtransaction.VerificationOutcomePassed {
+								if _, readErr := readCapturedProviderTargetedValidatorResult(ctx, root, store.Dir, record.State, record.Revision); readErr == nil {
+									capturedProviderTargetedValidator = true
+								} else if providerRoleHost {
+									// OpenCode and the pi host relay are the
+									// host-mediated providers. When no current slot
+									// exists, they receive the Go-issued task that can
+									// fill one; a readable occupied slot is
+									// provider-generic.
 									providerRole = reviewerprovider.RoleTargetedValidator
 								}
 							}
@@ -1130,11 +1135,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					result.Eligibility = newReviewActionEligibility(result)
 				}
 			}
-			input := reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, ProviderRole: providerRole, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector, IntendedUntracked: intendedScope, RDDMode: result.rddMode, RDDModeResolved: result.rddModeResolved, LensContextBudgetExceeded: lensContextBudgetExceeded, PreCommitDeliveryAssessment: preCommitDeliveryAssessment}
+			input := reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: startLineage, RuntimeAgent: runtime, ProviderRole: providerRole, CapturedProviderTargetedValidator: capturedProviderTargetedValidator, Contract: *contract, RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionRequest: correctionRequest, EvidenceErr: evidenceErr, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector, IntendedUntracked: intendedScope, RDDMode: result.rddMode, RDDModeResolved: result.rddModeResolved, LensContextBudgetExceeded: lensContextBudgetExceeded, PreCommitDeliveryAssessment: preCommitDeliveryAssessment}
 			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, capturedEvidence, artifactErr, input)
 			result.NextTransition = &transition
+			providerTargetedValidation := transition.ReasonCode == "targeted_validation_required" && transition.Collect != nil &&
+				len(transition.Collect.Inputs) == 1 && transition.Collect.Inputs[0].ProviderTask != nil
+			providerCapturedTargetedValidation := transition.ReasonCode == "captured_provider_targeted_validation_ready" && transition.Execute != nil &&
+				transition.Execute.Operation == "review.finalize"
 			if reviewTransitionValidationRequest(&transition) == nil && transition.ReasonCode != "correction_repository_verification_required" &&
-				transition.ReasonCode != "correction_repository_tooling_failed" {
+				transition.ReasonCode != "correction_repository_tooling_failed" && !providerTargetedValidation && !providerCapturedTargetedValidation {
 				result.ValidationRequest = nil
 			}
 			// A negotiated invocation is the machine surface end to end: the
@@ -2789,7 +2798,18 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 		}
 		effectiveFailed = derivedFailed
 	}
-	if state.State == reviewtransaction.StateCorrectionRequired && capturedVerification != nil &&
+	if submissionBindingProvided && !reviewFinalizeFlagProvided(args, "correction-lines") && strings.TrimSpace(*validationPath) == "" &&
+		*capturedEvidence && state.State == reviewtransaction.StateCorrectionRequired && capturedVerification != nil &&
+		capturedVerification.Record.Outcome == reviewtransaction.VerificationOutcomePassed && validation == nil {
+		// The Go-issued slot-consumption transition promises an occupied,
+		// readable validator slot; an unreadable slot must fail this exact
+		// submission instead of silently launching another provider.
+		capturedValidation, readErr := readCapturedProviderTargetedValidatorResult(ctx, root, store.Dir, state, record.Revision)
+		if readErr != nil {
+			return reviewPreflightError(fmt.Errorf("read captured provider targeted validator result: %w", readErr))
+		}
+		validation = &capturedValidation
+	} else if state.State == reviewtransaction.StateCorrectionRequired && capturedVerification != nil &&
 		capturedVerification.Record.Outcome == reviewtransaction.VerificationOutcomePassed && validation == nil {
 		// Discovery of an occupied validator slot is host-mediated-safe: the
 		// pi host relay's capture-validation submission occupies the same
@@ -3008,6 +3028,28 @@ func validateReviewFinalizeSubmission(ctx context.Context, repo string, state re
 		return errors.New("review finalize submission expected revision is stale; refresh with gentle-ai review status --next-transition")
 	}
 	hasValidation := strings.TrimSpace(validationPath) != ""
+	if !correctionLinesProvided && !hasValidation && capturedEvidence {
+		request, err := reviewtransaction.BuildTargetedValidationRequest(ctx, repo, state, revision)
+		if err != nil {
+			return err
+		}
+		if targetIdentity != request.CorrectionTargetIdentity || requestHash != request.RequestHash {
+			return errors.New("captured provider validator submission does not match the provider-owned targeted validation request; refresh with gentle-ai review status --next-transition")
+		}
+		expected := []string{
+			"--contract=" + ReviewIntegrationContractV2,
+			"--lineage=" + state.LineageID,
+			"--expected-revision=" + revision,
+			"--target=" + request.CorrectionTargetIdentity,
+			"--request-hash=" + request.RequestHash,
+			"--repository-context=" + repositoryContext,
+			"--captured-evidence=true",
+		}
+		if !reflect.DeepEqual(args, expected) {
+			return errors.New("captured provider validator submission differs from the provider-issued transition; refresh with gentle-ai review status --next-transition")
+		}
+		return nil
+	}
 	if correctionLinesProvided == hasValidation {
 		return errors.New("review finalize submission requires exactly one descriptor value; refresh with gentle-ai review status --next-transition")
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1105,15 +1105,23 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 								}
 							}
 							if validationRequest != nil && capturedEvidence != nil && capturedEvidence.Outcome == reviewtransaction.VerificationOutcomePassed {
-								if _, readErr := readCapturedProviderTargetedValidatorResult(ctx, root, store.Dir, record.State, record.Revision); readErr == nil {
+								_, readErr := readCapturedProviderTargetedValidatorResult(ctx, root, store.Dir, record.State, record.Revision)
+								switch {
+								case readErr == nil:
 									capturedProviderTargetedValidator = true
-								} else if providerRoleHost {
+								case errors.Is(readErr, errReviewProviderTargetedValidatorResultNotCaptured):
 									// OpenCode and the pi host relay are the
 									// host-mediated providers. When no current slot
 									// exists, they receive the Go-issued task that can
 									// fill one; a readable occupied slot is
 									// provider-generic.
-									providerRole = reviewerprovider.RoleTargetedValidator
+									if providerRoleHost {
+										providerRole = reviewerprovider.RoleTargetedValidator
+									}
+								default:
+									// An unreadable or inadmissible captured slot is
+									// unverifiable evidence, never silent continuation.
+									artifactErr = readErr
 								}
 							}
 						}

--- a/internal/cli/review_frozen_status_test.go
+++ b/internal/cli/review_frozen_status_test.go
@@ -99,21 +99,46 @@ func TestExplicitFrozenReviewingStatusRejectsPartialSlotsAndStaleStartLineages(t
 		}
 	})
 
-	t.Run("occupied slots retain the selected lineage", func(t *testing.T) {
-		repo, _, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, nil)
-		captureFrozenReviewerResults(t, repo, record, len(record.State.SelectedLenses))
-		writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'live drift'\n", 0o644)
-		stale := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
-		if stale.Applicability != reviewtransaction.TargetApplicabilityCurrent || stale.Authority == nil ||
-			stale.Authority.LineageID != record.State.LineageID || stale.Action != reviewtransaction.TargetStatusActionStop ||
-			stale.Replayability != reviewtransaction.ReplayabilityManualActionRequired || stale.NextTransition == nil ||
-			stale.NextTransition.Kind != reviewNextTransitionStop || stale.NextTransition.ReasonCode != "native_stop_required" {
-			t.Fatalf("occupied stale status = %#v", stale)
+	t.Run("occupied intended-untracked slots finalize through the selected OpenCode lineage", func(t *testing.T) {
+		repo, _, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, []string{"frozen-untracked.txt"})
+		for order, lens := range record.State.SelectedLenses {
+			result := admittedReviewerResultForTest(t, repo, record, lens, order)
+			if order == 0 {
+				result.Findings = []facadeFinding{{
+					ID: "R1-001", Location: "service-token.ts:1", Severity: "CRITICAL", Claim: "frozen candidate failure",
+					ProofRefs: []string{"service-token.ts:1 candidate-specific proof"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+					CausalDisposition: reviewtransaction.CausalIntroduced,
+				}}
+			}
+			input := filepath.Join(t.TempDir(), lens+".json")
+			writeReviewCLIJSON(t, input, result)
+			if err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", record.State.LineageID,
+				"--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", strconv.Itoa(order), "--input", input}, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
 		}
-		fresh := explicitFrozenReviewingStatus(t, repo, "requested-new-lineage")
-		if fresh.NextTransition == nil || fresh.NextTransition.Execute == nil ||
-			fresh.NextTransition.Execute.Binding.LineageID != "requested-new-lineage" {
-			t.Fatalf("unknown requested lineage = %#v", fresh)
+		var output bytes.Buffer
+		if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV2, "--agent", "opencode", "--next-transition", "--cwd", repo, "--lineage", record.State.LineageID}, &output); err != nil {
+			t.Fatalf("selected OpenCode STATUS: %v\n%s", err, output.String())
+		}
+		var status ReviewTargetStatusResult
+		decodeStrictReviewJSON(t, output.Bytes(), &status)
+		if status.Applicability != reviewtransaction.TargetApplicabilityCurrent || status.Authority == nil ||
+			status.Authority.LineageID != record.State.LineageID || status.Action != reviewtransaction.TargetStatusActionFinalize ||
+			status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
+			status.NextTransition.ReasonCode != "captured_results_ready" || status.NextTransition.Execute == nil ||
+			status.NextTransition.Execute.Operation != "review.finalize" || len(status.NextTransition.Execute.Artifacts) != len(record.State.SelectedLenses) {
+			t.Fatalf("occupied frozen STATUS = %#v\n%s", status, output.String())
+		}
+		var finalized bytes.Buffer
+		if err := RunReviewFacadeFinalize([]string{"--contract", ReviewIntegrationContractV2, "--next-transition", "--cwd", repo,
+			"--lineage", record.State.LineageID, "--captured-results"}, &finalized); err != nil {
+			t.Fatalf("finalize selected OpenCode lineage: %v\n%s", err, finalized.String())
+		}
+		var result ReviewIntegrationFinalizeResult
+		decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, finalized.Bytes()).Result, &result)
+		if result.State != reviewtransaction.StateCorrectionRequired {
+			t.Fatalf("selected OpenCode finalize state = %q, want correction_required", result.State)
 		}
 	})
 

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -257,6 +257,9 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 			if input.ProviderRole == reviewerprovider.RoleTargetedValidator {
 				return reviewProviderRoleTransition("targeted_validation_required", validationBinding, input.ProviderRole, input.RuntimeAgent, input.ValidationRequest)
 			}
+			if input.CapturedProviderTargetedValidator {
+				return reviewCapturedProviderTargetedValidatorFinalizeTransition(input.Contract, validationBinding, *input.ValidationRequest)
+			}
 			if capturedEvidence == nil {
 				return reviewCollectTransition("correction_repository_verification_required", reviewCaptureEvidenceInput(input.Contract, validationBinding))
 			}
@@ -637,6 +640,7 @@ type reviewNextTransitionInput struct {
 	StartLineage                                   string
 	RuntimeAgent                                   model.AgentID
 	ProviderRole                                   reviewProviderRole
+	CapturedProviderTargetedValidator              bool
 	Contract                                       string
 	RepositoryContext                              string
 	ValidationRequest                              *reviewtransaction.TargetedValidationRequest
@@ -650,6 +654,26 @@ type reviewNextTransitionInput struct {
 	RDDModeResolved                                bool
 	LensContextBudgetExceeded                      bool
 	PreCommitDeliveryAssessment                    *reviewtransaction.CompactGateTargetApplicability
+}
+
+func reviewCapturedProviderTargetedValidatorFinalizeTransition(contract string, binding ReviewTransitionBinding, request reviewtransaction.TargetedValidationRequest) ReviewNextTransition {
+	if contract != ReviewIntegrationContractV2 || binding.RepositoryContext == "" {
+		return reviewStopTransition("captured_artifacts_unverifiable")
+	}
+	arguments := []ReviewTransitionArgument{
+		{Name: "contract", Value: contract},
+		{Name: "lineage", Value: binding.LineageID},
+		{Name: "expected-revision", Value: binding.Revision},
+		{Name: "target", Value: binding.TargetIdentity},
+		{Name: "request-hash", Value: request.RequestHash},
+		{Name: "repository-context", Value: binding.RepositoryContext},
+		{Name: "captured-evidence", Value: "true"},
+	}
+	return reviewExecuteTransition("captured_provider_targeted_validation_ready", "review.finalize", arguments, []ReviewTransitionArgument{
+		{Name: "state", Value: "correction_required"},
+		{Name: "verification_outcome", Value: string(reviewtransaction.VerificationOutcomePassed)},
+		{Name: "provider_targeted_validator", Value: "captured"},
+	}, binding, nil)
 }
 
 const reviewSubmissionValuePlaceholder = "{{value}}"

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -199,7 +199,7 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 		bindingTarget = reviewAuthorityTargetIdentity(status)
 	}
 	binding := reviewTransitionBinding(status.Authority, bindingTarget, input.RepositoryContext)
-	if status.Authority.State == reviewtransaction.StateReviewing && artifactErr != nil {
+	if artifactErr != nil && (status.Authority.State == reviewtransaction.StateReviewing || input.ValidationRequest != nil) {
 		return reviewStopTransition("captured_artifacts_unverifiable")
 	}
 	if status.Authority.State == reviewtransaction.StateReviewing && input.LensContextBudgetExceeded {

--- a/internal/cli/review_provider_test.go
+++ b/internal/cli/review_provider_test.go
@@ -248,6 +248,296 @@ func TestReviewProviderOpenCodeStatusIssuesBoundRefuterTask(t *testing.T) {
 	}
 }
 
+func TestReviewProviderOpenCodeStatusIssuesBoundTargetedValidatorTask(t *testing.T) {
+	repo, lineage, request := providerCorrectionReady(t)
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentOpenCode), "--next-transition",
+	}, &output); err != nil {
+		t.Fatalf("OpenCode targeted-validator STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if err := status.Validate(); err != nil {
+		t.Fatalf("OpenCode targeted-validator status is invalid: %v", err)
+	}
+	if status.Schema != ReviewIntegrationStatusSchemaV5 || status.Authority == nil || status.ValidationRequest == nil ||
+		status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "targeted_validation_required" || status.NextTransition.Collect == nil ||
+		len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("OpenCode targeted-validator transition = %#v", status)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	arguments, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if input.Name != "provider_"+string(reviewerprovider.RoleTargetedValidator) || input.CaptureOperation != "external.run_provider_role" ||
+		input.Submission != nil || input.ValidationRequest != nil || input.ProviderTask == nil ||
+		input.ProviderTask.Agent != "review-validator" || input.ProviderTask.Role != string(reviewerprovider.RoleTargetedValidator) ||
+		arguments["lineage"] != status.Authority.LineageID || arguments["expected-revision"] != status.Authority.Revision ||
+		arguments["target"] != request.CorrectionTargetIdentity || arguments["target"] != status.ValidationRequest.CorrectionTargetIdentity {
+		t.Fatalf("OpenCode targeted-validator task = %#v", input)
+	}
+
+	cloneInput := func() (ReviewTargetStatusResult, *ReviewTransitionInput) {
+		malformed := status
+		transition := *status.NextTransition
+		collection := *transition.Collect
+		collection.Inputs = append([]ReviewTransitionInput(nil), collection.Inputs...)
+		transition.Collect = &collection
+		malformed.NextTransition = &transition
+		return malformed, &malformed.NextTransition.Collect.Inputs[0]
+	}
+	resetTask := func(t *testing.T, input *ReviewTransitionInput) {
+		t.Helper()
+		arguments, err := reviewTransitionArgumentMap(input.Arguments)
+		if err != nil {
+			t.Fatal(err)
+		}
+		task, err := newReviewProviderTask(reviewerprovider.RoleTargetedValidator, ReviewTransitionBinding{
+			LineageID: arguments["lineage"], Revision: arguments["expected-revision"],
+			TargetIdentity: arguments["target"], RepositoryContext: arguments["repository-context"],
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		input.ProviderTask = &task
+	}
+	setArgument := func(t *testing.T, input *ReviewTransitionInput, name, value string) {
+		t.Helper()
+		for index := range input.Arguments {
+			if input.Arguments[index].Name == name {
+				input.Arguments[index].Value = value
+				return
+			}
+		}
+		t.Fatalf("missing provider task argument %q", name)
+	}
+
+	t.Run("refuses a mismatched provider role", func(t *testing.T) {
+		malformed, input := cloneInput()
+		task := *input.ProviderTask
+		task.Role = string(reviewerprovider.RoleRefuter)
+		input.ProviderTask = &task
+		if err := malformed.Validate(); err == nil {
+			t.Fatal("targeted-validator STATUS accepted a refuter task")
+		}
+	})
+	t.Run("refuses a task bound to another correction target", func(t *testing.T) {
+		malformed, input := cloneInput()
+		setArgument(t, input, "target", status.TargetIdentity)
+		resetTask(t, input)
+		if err := malformed.Validate(); err == nil {
+			t.Fatal("targeted-validator STATUS accepted a task bound to another target")
+		}
+	})
+	t.Run("refuses a task bound to another authority", func(t *testing.T) {
+		malformed, input := cloneInput()
+		setArgument(t, input, "lineage", "foreign-lineage")
+		resetTask(t, input)
+		if err := malformed.Validate(); err == nil {
+			t.Fatal("targeted-validator STATUS accepted a task bound to another authority")
+		}
+	})
+}
+
+func TestReviewProviderStatusFinalizesCapturedTargetedValidatorWithoutSecondProvider(t *testing.T) {
+	repo, lineage, request := providerCorrectionReady(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	readStatus := func() ReviewTargetStatusResult {
+		t.Helper()
+		var output bytes.Buffer
+		if err := RunReview([]string{
+			"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+			"--next-transition",
+		}, &output); err != nil {
+			var direct bytes.Buffer
+			directErr := runReviewStatus(t.Context(), []string{
+				"--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+				"--next-transition",
+			}, &direct)
+			t.Fatalf("captured provider targeted-validator STATUS: %v\ndirect=%v\n%s", err, directErr, output.String())
+		}
+		var status ReviewTargetStatusResult
+		decodeStrictReviewJSON(t, output.Bytes(), &status)
+		if err := status.Validate(); err != nil {
+			t.Fatalf("captured provider targeted-validator STATUS validation: %v", err)
+		}
+		return status
+	}
+	before := readStatus()
+	if before.NextTransition == nil || before.NextTransition.Kind != reviewNextTransitionCollect ||
+		before.NextTransition.ReasonCode != "targeted_validation_required" || before.NextTransition.Collect == nil ||
+		len(before.NextTransition.Collect.Inputs) != 1 || before.NextTransition.Collect.Inputs[0].ProviderTask != nil {
+		t.Fatalf("uncaptured provider validator status = %#v", before.NextTransition)
+	}
+	if _, _, err := reviewProviderCaptureTargetedValidatorRaw(t.Context(), repo, store, record.State, record.Revision, providerTargetedValidationPayload(t, request)); err != nil {
+		t.Fatal(err)
+	}
+
+	after := readStatus()
+	if after.NextTransition == nil || after.NextTransition.Kind != reviewNextTransitionExecute ||
+		after.NextTransition.ReasonCode != "captured_provider_targeted_validation_ready" || after.NextTransition.Execute == nil ||
+		after.NextTransition.Execute.Operation != "review.finalize" || after.ValidationRequest == nil ||
+		after.ValidationRequest.RequestHash != request.RequestHash {
+		t.Fatalf("captured provider validator status = %#v", after)
+	}
+	transitionPayload, err := json.Marshal(after.NextTransition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateAgainstPublishedNextTransitionSchemaV5(t, transitionPayload)
+	transition := after.NextTransition.Execute
+	if transition.Binding.LineageID != lineage || transition.Binding.Revision != record.Revision ||
+		transition.Binding.TargetIdentity != request.CorrectionTargetIdentity || transition.Binding.RepositoryContext == "" {
+		t.Fatalf("captured provider validator binding = %#v", transition.Binding)
+	}
+	wantTokens := []string{
+		"--contract=" + ReviewIntegrationContractV2,
+		"--lineage=" + lineage,
+		"--expected-revision=" + record.Revision,
+		"--target=" + request.CorrectionTargetIdentity,
+		"--request-hash=" + request.RequestHash,
+		"--repository-context=" + transition.Binding.RepositoryContext,
+		"--captured-evidence=true",
+	}
+	gotTokens := make([]string, len(transition.Arguments))
+	for index, argument := range transition.Arguments {
+		gotTokens[index] = argument.Token
+	}
+	if !slices.Equal(gotTokens, wantTokens) || slices.Contains(gotTokens, "--validation={{value}}") {
+		t.Fatalf("captured provider validator finalize tokens = %#v, want %#v", gotTokens, wantTokens)
+	}
+
+	previous := reviewProviderAdapterFor
+	t.Cleanup(func() { reviewProviderAdapterFor = previous })
+	providerCalls := 0
+	reviewProviderAdapterFor = func(reviewerprovider.Contract, model.AgentID) (reviewerprovider.Adapter, error) {
+		providerCalls++
+		return nil, errors.New("captured provider slot finalization must not launch another provider")
+	}
+	if err := RunReviewFacadeFinalize(gotTokens, &bytes.Buffer{}); err != nil {
+		t.Fatalf("execute captured provider validator finalize: %v", err)
+	}
+	if providerCalls != 0 {
+		t.Fatalf("captured provider finalization launched %d provider(s), want none", providerCalls)
+	}
+	terminal, err := store.Load()
+	if err != nil || terminal.State.State != reviewtransaction.StateApproved || len(terminal.State.CorrectionAttempts) != 1 {
+		t.Fatalf("captured provider validator terminal authority = %#v, %v", terminal, err)
+	}
+}
+
+func TestReviewProviderStatusRecollectsUnreadableCapturedValidatorSlot(t *testing.T) {
+	repo, lineage, request := providerCorrectionReady(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := reviewProviderCaptureTargetedValidatorRaw(t.Context(), repo, store, record.State, record.Revision, providerTargetedValidationPayload(t, request)); err != nil {
+		t.Fatal(err)
+	}
+	slotPath := filepath.Join(store.Dir, "targeted-validator-results", strings.TrimPrefix(request.CorrectionTargetIdentity, "sha256:"),
+		strings.TrimPrefix(request.ExpectedRevision, "sha256:"), "result.json")
+	if err := os.WriteFile(slotPath, []byte(`{"targeted_validation_request_hash":"sha256:forged"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+		"--next-transition",
+	}, &output); err != nil {
+		t.Fatalf("captured provider corrupted-slot STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if err := status.Validate(); err != nil {
+		t.Fatalf("captured provider corrupted-slot STATUS validation: %v", err)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "targeted_validation_required" || status.NextTransition.Collect == nil ||
+		len(status.NextTransition.Collect.Inputs) != 1 || status.NextTransition.Collect.Inputs[0].ProviderTask != nil {
+		t.Fatalf("captured provider corrupted-slot transition = %#v", status.NextTransition)
+	}
+	after, err := store.Load()
+	if err != nil || after.State.State != reviewtransaction.StateCorrectionRequired || len(after.State.CorrectionAttempts) != 0 {
+		t.Fatalf("corrupted validator slot changed authority: %#v, %v", after, err)
+	}
+}
+
+func TestReviewProviderStatusRequiresPassedEvidenceBeforeSlotConsumption(t *testing.T) {
+	repo, lineage, request := providerCorrectionReady(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := reviewProviderCaptureTargetedValidatorRaw(t.Context(), repo, store, record.State, record.Revision, providerTargetedValidationPayload(t, request)); err != nil {
+		t.Fatal(err)
+	}
+	var readyOutput bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+		"--next-transition",
+	}, &readyOutput); err != nil {
+		t.Fatalf("captured provider slot STATUS: %v\n%s", err, readyOutput.String())
+	}
+	var ready ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, readyOutput.Bytes(), &ready)
+	if ready.NextTransition == nil || ready.NextTransition.Execute == nil {
+		t.Fatalf("captured provider slot transition = %#v", ready.NextTransition)
+	}
+	staleTokens := make([]string, len(ready.NextTransition.Execute.Arguments))
+	for index, argument := range ready.NextTransition.Execute.Arguments {
+		staleTokens[index] = argument.Token
+	}
+	evidenceDir := filepath.Join(store.Dir, reviewtransaction.CompactFinalEvidenceDir, strings.TrimPrefix(request.CorrectionTargetIdentity, "sha256:"),
+		strings.TrimPrefix(record.Revision, "sha256:"))
+	if err := os.RemoveAll(evidenceDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize(staleTokens, &bytes.Buffer{}); err == nil {
+		t.Fatal("stale captured-provider slot-consumption transition finalized without its passed verification evidence")
+	}
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+		"--next-transition",
+	}, &output); err != nil {
+		t.Fatalf("captured provider missing-evidence STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if err := status.Validate(); err != nil {
+		t.Fatalf("captured provider missing-evidence STATUS validation: %v", err)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "correction_repository_verification_required" || status.NextTransition.Collect == nil ||
+		len(status.NextTransition.Collect.Inputs) != 1 || status.NextTransition.Collect.Inputs[0].ProviderTask != nil {
+		t.Fatalf("captured provider missing-evidence transition = %#v", status.NextTransition)
+	}
+	after, err := store.Load()
+	if err != nil || after.State.State != reviewtransaction.StateCorrectionRequired || len(after.State.CorrectionAttempts) != 0 {
+		t.Fatalf("missing verification evidence changed authority: %#v, %v", after, err)
+	}
+}
+
 func reviewProviderRequestHashForTest(t *testing.T, prompt []byte) string {
 	t.Helper()
 	input := bytes.SplitN(prompt, []byte("\n\nInput:\n"), 2)

--- a/internal/cli/review_provider_test.go
+++ b/internal/cli/review_provider_test.go
@@ -437,7 +437,7 @@ func TestReviewProviderStatusFinalizesCapturedTargetedValidatorWithoutSecondProv
 	}
 }
 
-func TestReviewProviderStatusRecollectsUnreadableCapturedValidatorSlot(t *testing.T) {
+func TestReviewProviderStatusSurfacesUnreadableCapturedValidatorSlot(t *testing.T) {
 	repo, lineage, request := providerCorrectionReady(t)
 	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
 	if err != nil {
@@ -467,9 +467,9 @@ func TestReviewProviderStatusRecollectsUnreadableCapturedValidatorSlot(t *testin
 	if err := status.Validate(); err != nil {
 		t.Fatalf("captured provider corrupted-slot STATUS validation: %v", err)
 	}
-	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
-		status.NextTransition.ReasonCode != "targeted_validation_required" || status.NextTransition.Collect == nil ||
-		len(status.NextTransition.Collect.Inputs) != 1 || status.NextTransition.Collect.Inputs[0].ProviderTask != nil {
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionStop ||
+		status.NextTransition.ReasonCode != "captured_artifacts_unverifiable" ||
+		status.NextTransition.Execute != nil || status.NextTransition.Collect != nil {
 		t.Fatalf("captured provider corrupted-slot transition = %#v", status.NextTransition)
 	}
 	after, err := store.Load()

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -442,7 +442,18 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 		correctionEvidenceFirst := transitionRequest == nil && result.ValidationRequest != nil &&
 			(result.NextTransition.ReasonCode == "correction_repository_verification_required" ||
 				result.NextTransition.ReasonCode == "correction_repository_tooling_failed")
-		if !correctionEvidenceFirst && ((transitionRequest == nil) != (result.ValidationRequest == nil) ||
+		providerTargetedValidation := transitionRequest == nil && result.ValidationRequest != nil &&
+			result.NextTransition.ReasonCode == "targeted_validation_required" && result.NextTransition.Collect != nil &&
+			len(result.NextTransition.Collect.Inputs) == 1 && result.NextTransition.Collect.Inputs[0].ProviderTask != nil
+		capturedProviderTargetedValidation := transitionRequest == nil && result.ValidationRequest != nil &&
+			result.NextTransition.ReasonCode == "captured_provider_targeted_validation_ready" && result.NextTransition.Execute != nil &&
+			result.NextTransition.Execute.Operation == "review.finalize"
+		if capturedProviderTargetedValidation {
+			if err := result.validateCapturedProviderTargetedValidatorTransition(); err != nil {
+				return err
+			}
+		}
+		if !correctionEvidenceFirst && !providerTargetedValidation && !capturedProviderTargetedValidation && ((transitionRequest == nil) != (result.ValidationRequest == nil) ||
 			transitionRequest != nil && !reflect.DeepEqual(*transitionRequest, *result.ValidationRequest)) {
 			return errors.New("negotiated status validation request copies differ")
 		}
@@ -629,6 +640,42 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 	return nil
 }
 
+func (result ReviewTargetStatusResult) validateCapturedProviderTargetedValidatorTransition() error {
+	transition, request := result.NextTransition, result.ValidationRequest
+	if transition == nil || transition.Execute == nil || request == nil || result.Contract != ReviewIntegrationContractV2 ||
+		result.Authority == nil || result.Authority.State != reviewtransaction.StateCorrectionRequired ||
+		reviewtransaction.ValidateTargetedValidationRequest(*request) != nil || request.LineageID != result.Authority.LineageID ||
+		request.ExpectedRevision != result.Authority.Revision {
+		return errors.New("captured provider targeted-validator transition is not bound to current authority") // refusal:by-design world-action: a producer must not advertise an execute route outside current correction authority
+	}
+	binding := ReviewTransitionBinding{
+		LineageID: request.LineageID, Revision: request.ExpectedRevision, TargetIdentity: request.CorrectionTargetIdentity,
+		RepositoryContext: transition.Execute.Binding.RepositoryContext,
+	}
+	if reviewtransaction.ValidateReviewRepositoryContextHandle(binding.RepositoryContext) != nil {
+		return errors.New("captured provider targeted-validator transition has no repository context") // refusal:by-design world-action: a provider slot cannot safely resolve a repository without its Go-issued context handle
+	}
+	wantArguments := reviewTokenizedTransitionArguments([]ReviewTransitionArgument{
+		{Name: "contract", Value: ReviewIntegrationContractV2},
+		{Name: "lineage", Value: binding.LineageID},
+		{Name: "expected-revision", Value: binding.Revision},
+		{Name: "target", Value: binding.TargetIdentity},
+		{Name: "request-hash", Value: request.RequestHash},
+		{Name: "repository-context", Value: binding.RepositoryContext},
+		{Name: "captured-evidence", Value: "true"},
+	})
+	wantPreconditions := []ReviewTransitionArgument{
+		{Name: "state", Value: "correction_required"},
+		{Name: "verification_outcome", Value: string(reviewtransaction.VerificationOutcomePassed)},
+		{Name: "provider_targeted_validator", Value: "captured"},
+	}
+	if !reflect.DeepEqual(transition.Execute.Arguments, wantArguments) || !reflect.DeepEqual(transition.Execute.Preconditions, wantPreconditions) ||
+		transition.Execute.Binding != binding || len(transition.Execute.Artifacts) != 0 {
+		return errors.New("captured provider targeted-validator transition is not exact") // refusal:by-design world-action: only the exact Go-issued slot-consumption transition may finalize a correction
+	}
+	return nil
+}
+
 func (result ReviewTargetStatusResult) validateSubmissionDescriptors() error {
 	transition := result.NextTransition
 	if transition == nil || transition.Collect == nil {
@@ -701,16 +748,16 @@ func (result ReviewTargetStatusResult) validateSubmissionDescriptors() error {
 			return errors.New("submission descriptor transition must contain exactly one input") // refusal:by-design world-action: only a provider code fix can produce the required single input
 		}
 		input := transition.Collect.Inputs[0]
-		if input.CaptureOperation == "external.run_provider_role" {
+		if input.ProviderTask != nil {
 			// The OpenCode host-mediated form: a Go-issued provider validator
-			// task whose exact binding validateReviewProviderTaskInput above
-			// already verified. It carries no submission descriptor. Before
-			// this branch existed, STATUS refused the very transition it had
-			// just rendered for OpenCode and answered operation_failed.
-			if input.ProviderTask == nil || input.Submission != nil {
-				return errors.New("targeted validation submission descriptor has no provider request") // refusal:by-design world-action: only a provider code fix can bind the validation request
-			}
-			return nil
+			// task bound to the current correction authority. It carries no
+			// submission descriptor.
+			return result.validateTargetedValidatorProviderTaskInput(input)
+		}
+		if input.CaptureOperation == "external.run_provider_role" {
+			// A provider role collection input without its Go-issued task is
+			// never a valid targeted validation form.
+			return errors.New("targeted validation submission descriptor has no provider request") // refusal:by-design world-action: only a provider code fix can bind the validation request
 		}
 		if input.CaptureOperation == reviewCaptureValidationCaptureOperation {
 			// The pi host-relay form: a self-contained executable vector with
@@ -828,6 +875,26 @@ func validateReviewProviderTaskInput(input ReviewTransitionInput, arguments map[
 	return nil
 }
 
+func (result ReviewTargetStatusResult) validateTargetedValidatorProviderTaskInput(input ReviewTransitionInput) error {
+	if result.Schema != ReviewIntegrationStatusSchemaV5 || result.Authority == nil || result.ValidationRequest == nil ||
+		input.Name != "provider_"+string(reviewerprovider.RoleTargetedValidator) || input.ProviderTask == nil ||
+		input.ProviderTask.Role != string(reviewerprovider.RoleTargetedValidator) || input.Submission != nil {
+		return errors.New("targeted validator provider task is not bound to the correction authority") // refusal:by-design world-action: only Go may issue a targeted validator task for the current correction authority
+	}
+	arguments, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil {
+		return err
+	}
+	if err := validateReviewProviderTaskInput(input, arguments); err != nil {
+		return err
+	}
+	if arguments["lineage"] != result.Authority.LineageID || arguments["expected-revision"] != result.Authority.Revision ||
+		arguments["target"] != result.ValidationRequest.CorrectionTargetIdentity {
+		return errors.New("targeted validator provider task is not bound to the correction authority") // refusal:by-design world-action: only Go may issue a targeted validator task for the current correction authority
+	}
+	return nil
+}
+
 func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 	if result.NextTransition == nil {
 		return nil
@@ -890,7 +957,8 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 	if result.Authority != nil && result.Authority.State == reviewtransaction.StateValidating {
 		expectedExecutionTarget = reviewAuthorityTargetIdentity(result)
 	} else if result.Authority != nil && result.Authority.State == reviewtransaction.StateCorrectionRequired &&
-		result.ValidationRequest != nil && result.NextTransition.ReasonCode == "correction_repository_tooling_failed" {
+		result.ValidationRequest != nil && (result.NextTransition.ReasonCode == "correction_repository_tooling_failed" ||
+		result.NextTransition.ReasonCode == "captured_provider_targeted_validation_ready") {
 		expectedExecutionTarget = result.ValidationRequest.CorrectionTargetIdentity
 	}
 	if result.NextTransition.Execute != nil && result.NextTransition.Execute.Binding.TargetIdentity != expectedExecutionTarget {

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -123,6 +123,7 @@ type targetStatusCandidate struct {
 	correctionRecovery          bool
 	frozenReviewing             bool
 	frozenReviewingPendingSlots bool
+	frozenReviewingDrifted      bool
 	// selectorFreeAccountingOnlyRecovery is carried from the eligibility
 	// predicate so projection never guesses it from snapshot identity domains.
 	selectorFreeAccountingOnlyRecovery bool
@@ -244,6 +245,9 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			if eligible {
 				candidate.frozenReviewing = true
 				candidate.frozenReviewingPendingSlots = pendingSlots
+				if !pendingSlots {
+					candidate.frozenReviewingDrifted = frozenReviewingCandidateDrifted(ctx, repo, state)
+				}
 				candidates = append(candidates, candidate)
 				continue
 			}
@@ -500,6 +504,21 @@ func explicitReviewingCompactCandidate(ctx context.Context, repo string, candida
 	return true, pending, nil
 }
 
+// frozenReviewingCandidateDrifted reports whether the live worktree, projected
+// through the frozen candidate's own selector, no longer reproduces the frozen
+// candidate tree. A fully captured frozen review continues generically to
+// finalize only while that candidate stays coherent; post-capture worktree
+// drift keeps the stop, and any projection failure fails closed as drift.
+func frozenReviewingCandidateDrifted(ctx context.Context, repo string, state CompactState) bool {
+	frozen := state.InitialSnapshot
+	target := Target{Kind: frozen.Kind, Projection: frozen.Projection, IntendedUntracked: append([]string{}, frozen.IntendedUntracked...)}
+	if target.Kind == TargetBaseDiff || target.Kind == TargetBaseWorkspaceOverlay {
+		target.BaseRef = frozen.BaseTree
+	}
+	live, err := (SnapshotBuilder{Repo: repo}).Build(ctx, target)
+	return err != nil || live.CandidateTree != frozen.CandidateTree
+}
+
 func compactLocalBaseAdvanceCompatibility(ctx context.Context, repo string, state CompactState, target Target, live Snapshot) *BaseAdvanceCompatibility {
 	if state.CurrentSnapshot.Kind != TargetBaseDiff || state.Recovery != nil || target.Kind != TargetBaseDiff || strings.TrimSpace(target.BaseRef) == "" {
 		return nil
@@ -568,6 +587,10 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 			return result
 		}
 		if candidate.frozenReviewing && !candidate.frozenReviewingPendingSlots {
+			if candidate.frozenReviewingDrifted {
+				result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
+				return result
+			}
 			result.Action, result.Replayability = TargetStatusActionFinalize, ReplayabilityNotReplayable
 			return result
 		}

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -568,7 +568,7 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 			return result
 		}
 		if candidate.frozenReviewing && !candidate.frozenReviewingPendingSlots {
-			result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
+			result.Action, result.Replayability = TargetStatusActionFinalize, ReplayabilityNotReplayable
 			return result
 		}
 		if candidate.finalVerificationRetry != nil {

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -1443,6 +1443,19 @@ func TestExplicitReviewingStatusRejectsSemanticAndIneligibleFrozenCandidates(t *
 			t.Fatalf("fully occupied frozen status = %#v, %v", status, err)
 		}
 	})
+	t.Run("fully occupied undrifted candidate finalizes", func(t *testing.T) {
+		fixture := newCompactReviewerCaptureFixture(t, "frozen-complete-undrifted")
+		if _, err := fixture.store.CaptureAdmittedReviewerResult(context.Background(), fixture.request); err != nil {
+			t.Fatal(err)
+		}
+		status, err := AssessTargetStatus(context.Background(), fixture.store.repo, TargetStatusRequest{
+			Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: fixture.state.LineageID,
+		})
+		if err != nil || status.Applicability != TargetApplicabilityCurrent || status.LineageID != fixture.state.LineageID ||
+			status.Action != TargetStatusActionFinalize || status.Replayability != ReplayabilityNotReplayable {
+			t.Fatalf("fully occupied undrifted frozen status = %#v, %v", status, err)
+		}
+	})
 
 	t.Run("semantic frozen evidence", func(t *testing.T) {
 		repo := initSnapshotRepo(t)

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -1427,7 +1427,7 @@ func TestExplicitReviewingStatusRejectsSemanticAndIneligibleFrozenCandidates(t *
 			t.Fatalf("pending frozen finalize status = %#v, %v", status, err)
 		}
 	})
-	t.Run("fully occupied drifted candidate stops", func(t *testing.T) {
+	t.Run("fully occupied drifted candidate finalizes", func(t *testing.T) {
 		fixture := newCompactReviewerCaptureFixture(t, "frozen-complete")
 		if _, err := fixture.store.CaptureAdmittedReviewerResult(context.Background(), fixture.request); err != nil {
 			t.Fatal(err)
@@ -1439,7 +1439,7 @@ func TestExplicitReviewingStatusRejectsSemanticAndIneligibleFrozenCandidates(t *
 			Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: fixture.state.LineageID,
 		})
 		if err != nil || status.Applicability != TargetApplicabilityCurrent || status.LineageID != fixture.state.LineageID ||
-			status.Action != TargetStatusActionStop || status.Replayability != ReplayabilityManualActionRequired {
+			status.Action != TargetStatusActionFinalize || status.Replayability != ReplayabilityNotReplayable {
 			t.Fatalf("fully occupied frozen status = %#v, %v", status, err)
 		}
 	})

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -1427,7 +1427,7 @@ func TestExplicitReviewingStatusRejectsSemanticAndIneligibleFrozenCandidates(t *
 			t.Fatalf("pending frozen finalize status = %#v, %v", status, err)
 		}
 	})
-	t.Run("fully occupied drifted candidate finalizes", func(t *testing.T) {
+	t.Run("fully occupied drifted candidate stops", func(t *testing.T) {
 		fixture := newCompactReviewerCaptureFixture(t, "frozen-complete")
 		if _, err := fixture.store.CaptureAdmittedReviewerResult(context.Background(), fixture.request); err != nil {
 			t.Fatal(err)
@@ -1439,7 +1439,7 @@ func TestExplicitReviewingStatusRejectsSemanticAndIneligibleFrozenCandidates(t *
 			Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: fixture.state.LineageID,
 		})
 		if err != nil || status.Applicability != TargetApplicabilityCurrent || status.LineageID != fixture.state.LineageID ||
-			status.Action != TargetStatusActionFinalize || status.Replayability != ReplayabilityNotReplayable {
+			status.Action != TargetStatusActionStop || status.Replayability != ReplayabilityManualActionRequired {
 			t.Fatalf("fully occupied frozen status = %#v, %v", status, err)
 		}
 	})


### PR DESCRIPTION
Closes #3323.

## What

Unit 2 of the recovered-units train: a captured targeted-validator slot continues generically toward finalize (runtime-agnostic slot detection, `captured_provider_targeted_validation_ready` transition, strict provider-task validation), with the j106 driven journey and its interactive bench helper.

Review corrections folded in (RDD-bounded, 74/200 lines): the frozen-drift guard stays a stop (drifted candidates never finalize — pinned at unit and journey level including a direct-finalize refusal probe), and slot-read errors surface as `captured_artifacts_unverifiable` instead of being discarded.

## RDD

Lineage `review-c0f5b65c525f4f31` (high risk, 4R): two CRITICAL findings, one bounded correction, targeted validator PASS, state **approved**, pre-pr gate `allow`. Side discovery filed as #3321 (full-revert corrections are inexpressible and fail with a cause-free envelope).

## Verification

Full `go test ./...` green; `go vet` + `GOOS=windows go vet` clean; bench module green; driven corpus 100/100 completed, dead_end 0 (including the new drifted-finalize refusal probe in j90 and j106 end to end); deadcode ratchet clean.

## Size exception

One reviewed unit under an approved receipt; the bulk is the j106 journey and RED-first tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for capturing targeted validator results from providers and completing review finalization without repeating provider work.
  - Added stronger validation of provider tasks, evidence, repository context, and transition details.
  - Added interactive benchmark journeys for provider validation and review workflows.

- **Bug Fixes**
  - Drifted frozen reviews can no longer be finalized accidentally.
  - Reviews now surface missing or unreadable captured evidence instead of starting an unnecessary provider operation.
  - Completed, unchanged reviews can proceed to finalization as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->