### PR TITLE
fix(sdd): classify shared OpenSpec scaffolding as change-neutral

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -672,6 +672,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, repositoryContextJourneys()...)
 	journeys = append(journeys, providerCaptureRetryJourneys()...)
 	journeys = append(journeys, capturedProviderValidatorJourneys()...)
+	journeys = append(journeys, sddSharedScaffoldingJourneys()...)
 	return append(journeys, handoffJourneys()...)
 }
 

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -57,6 +57,7 @@ func journeySources() []journeySource {
 		{"journeys_repository_context.go", repositoryContextJourneys()},
 		{"journeys_provider_capture.go", providerCaptureRetryJourneys()},
 		{"journeys_captured_provider_validator.go", capturedProviderValidatorJourneys()},
+		{"journeys_sdd_shared_scaffolding.go", sddSharedScaffoldingJourneys()},
 	}
 }
 

--- a/bench/journeys_sdd_shared_scaffolding.go
+++ b/bench/journeys_sdd_shared_scaffolding.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// sddSharedScaffoldingJourneys protects the narrow shared OpenSpec allowlist:
+// fresh project scaffolding is not another change payload and must not shadow
+// an approved authority bound to the active change.
+func sddSharedScaffoldingJourneys() []Journey {
+	return []Journey{{
+		ID:     "j107-sdd-approved-active-change-allows-shared-openspec-scaffolding",
+		Title:  "Approved active change remains eligible with exact fresh OpenSpec scaffolding",
+		Source: "shared OpenSpec review-gate policy: config.yaml and empty archive/spec roots are infrastructure, not foreign change payload",
+		Steps: append(sddApprovedAuthoritySteps(sddSharedScaffoldingAuthorityFixture),
+			Step{Name: "sdd-status preserves the approved active-change review gate", Requires: sddStatusCapability,
+				Args: productArgs("sdd-status", sddChange, "--json"), After: sddStatusAssertion("shared OpenSpec scaffolding approval", func(status sddStatusV1) error {
+					if status.ReviewGate == nil || status.ReviewGate.Result != "allow" || status.Dependencies.Archive == "blocked" || status.NextRecommended == "resolve-review" {
+						return fmt.Errorf("shared scaffolding status = %+v", status)
+					}
+					return nil
+				})},
+		),
+	}}
+}
+
+func sddSharedScaffoldingAuthorityFixture(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	if err := sddStageAuthorityChange(sandbox, false); err != nil {
+		return err
+	}
+	for path, content := range map[string]string{
+		filepath.Join(sandbox.Repo, "openspec", "config.yaml"):                    "schema: specification\n",
+		filepath.Join(sandbox.Repo, "openspec", "changes", "archive", ".gitkeep"): "",
+		filepath.Join(sandbox.Repo, "openspec", "specs", ".gitkeep"):              "",
+		filepath.Join(sddChangeRoot(sandbox), "verify-report.md"):                 sddVerifyReport,
+	} {
+		if err := sandbox.write(path, content); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "openspec"); err != nil {
+		return err
+	}
+	return sddFixtureStart(sandbox, sddNewerAuthorityLineage)
+}

--- a/bench/journeys_sdd_test.go
+++ b/bench/journeys_sdd_test.go
@@ -12,6 +12,7 @@ var portableSDDFailClosedAuthorityJourneyIDs = []string{
 	"j55-sdd-mismatched-authority-receipt-fails-closed",
 	"j56-sdd-non-allow-post-apply-gate-fails-closed",
 	"j58-sdd-foreign-openspec-path-fails-closed",
+	"j107-sdd-approved-active-change-allows-shared-openspec-scaffolding",
 	"j80-rescope-authorized-evidence-only-retry",
 	"j81-rc1-consecutive-rescope-repair-executes-printed-command",
 }

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -15,6 +15,7 @@ j103-sdd-interrupted-settlement-omits-evidence
 j104-repository-context-survives-fresh-process
 j105-compiled-provider-capture-retries-same-binding
 j106-captured-provider-validator-slot-finalizes-generically
+j107-sdd-approved-active-change-allows-shared-openspec-scaffolding
 j11-unborn-head
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -918,7 +918,7 @@ func TestCompactAuthorityPathBindingRejectsForeignAndTraversalOpenSpecPaths(t *t
 		{name: "traversal", paths: []string{"openspec/changes/thin/../other/tasks.md"}, wantReason: true},
 		{name: "dot segment", paths: []string{"openspec/changes/thin/./tasks.md"}, wantReason: true},
 		{name: "duplicate separator", paths: []string{"openspec/changes/thin//tasks.md"}, wantReason: true},
-		{name: "mixed foreign path", paths: []string{"openspec/changes/thin/tasks.md", "openspec/config.yaml"}, wantReason: true},
+		{name: "mixed unexpected config", paths: []string{"openspec/changes/thin/tasks.md", "openspec/config.yml"}, wantReason: true},
 		{name: "mixed foreign change", paths: []string{"openspec/changes/thin/tasks.md", "openspec/changes/other/tasks.md"}, wantReason: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1787,6 +1787,10 @@ func writeApprovedCompactAuthorityForChange(t *testing.T, repo, changeRoot, line
 }
 
 func writeApprovedCompactAuthorityForChangeWithTasks(t *testing.T, repo, changeRoot, lineage, tasks string) {
+	writeApprovedCompactAuthorityForChangeWithCandidate(t, repo, changeRoot, lineage, tasks, nil)
+}
+
+func writeApprovedCompactAuthorityForChangeWithCandidate(t *testing.T, repo, changeRoot, lineage, tasks string, prepareCandidate func()) {
 	t.Helper()
 	runSDDStatusGit(t, repo, "init", "-q")
 	runSDDStatusGit(t, repo, "config", "user.email", "status@example.com")
@@ -1794,6 +1798,9 @@ func writeApprovedCompactAuthorityForChangeWithTasks(t *testing.T, repo, changeR
 	runSDDStatusGit(t, repo, "add", ".")
 	runSDDStatusGit(t, repo, "commit", "-qm", "base")
 	write(t, filepath.Join(changeRoot, "tasks.md"), tasks)
+	if prepareCandidate != nil {
+		prepareCandidate()
+	}
 	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -123,20 +123,27 @@ func compactAuthorityPathsBound(state reviewtransaction.CompactState, changeName
 	if !sameCanonicalPaths(state.GenesisPaths, state.InitialSnapshot.Paths) {
 		return false, "path-bound compact authority has inconsistent immutable paths"
 	}
+	if !validReviewBindingChange(changeName) {
+		return false, "path-bound compact authority contains a non-canonical OpenSpec path"
+	}
 	prefix := "openspec/changes/" + changeName + "/"
 	matched := false
 	foreignOpenSpec := false
 	for _, raw := range state.GenesisPaths {
 		path := filepath.ToSlash(raw)
-		if filepath.IsAbs(raw) || path != filepath.ToSlash(filepath.Clean(raw)) {
+		if filepath.IsAbs(raw) || path != filepath.ToSlash(filepath.Clean(raw)) || path == "openspec" || strings.HasPrefix(path, "openspec\\") {
 			return false, "path-bound compact authority contains a non-canonical OpenSpec path"
 		}
 		if strings.HasPrefix(path, "openspec/") {
-			if !strings.HasPrefix(path, prefix) {
+			switch {
+			case strings.HasPrefix(path, prefix):
+				matched = true
+			case path == "openspec/config.yaml", path == "openspec/changes/archive/.gitkeep", path == "openspec/specs/.gitkeep":
+				// Fresh repositories need these exact OpenSpec scaffolding files;
+				// they are not change payloads and cannot name another capability.
+			default:
 				foreignOpenSpec = true
-				continue
 			}
-			matched = true
 		}
 	}
 	if matched && foreignOpenSpec {

--- a/internal/sddstatus/review_gate_receipt_test.go
+++ b/internal/sddstatus/review_gate_receipt_test.go
@@ -136,3 +136,79 @@ func TestBoundReviewArchiveGateIgnoresStaleGateContextViaReDerivation(t *testing
 		t.Fatalf("status still routed through the retired stored-GateContext-comparison rejection: %#v", status)
 	}
 }
+
+func TestCompactAuthorityPathsBoundAllowsExactFreshOpenSpecInfrastructure(t *testing.T) {
+	const change = "add-webhook-signature-verifier"
+	paths := []string{
+		".gitignore",
+		"internal/webhook/signature.go",
+		"openspec/config.yaml",
+		"openspec/changes/archive/.gitkeep",
+		"openspec/specs/.gitkeep",
+		"openspec/changes/" + change + "/proposal.md",
+		"openspec/changes/" + change + "/design.md",
+		"openspec/changes/" + change + "/tasks.md",
+		"openspec/changes/" + change + "/specs/auth/spec.md",
+	}
+	state := reviewtransaction.CompactState{
+		GenesisPaths:    append([]string(nil), paths...),
+		InitialSnapshot: reviewtransaction.Snapshot{Paths: append([]string(nil), paths...)},
+	}
+	if bound, reason := compactAuthorityPathsBound(state, change); !bound || reason != "" {
+		t.Fatalf("fresh shared OpenSpec infrastructure bound=%t reason=%q, want true, empty", bound, reason)
+	}
+
+	for _, test := range []struct {
+		name string
+		path string
+	}{
+		{name: "other active change", path: "openspec/changes/other-change/tasks.md"},
+		{name: "archived change payload", path: "openspec/changes/archive/previous-change/proposal.md"},
+		{name: "canonical capability spec", path: "openspec/specs/webhooks/spec.md"},
+		{name: "unexpected config", path: "openspec/config.yml"},
+		{name: "traversal", path: "openspec/changes/" + change + "/../other-change/tasks.md"},
+		{name: "ambiguous separator", path: "openspec\\changes\\other-change\\tasks.md"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			forged := state
+			forged.GenesisPaths = append(append([]string(nil), paths...), test.path)
+			forged.InitialSnapshot.Paths = append([]string(nil), forged.GenesisPaths...)
+			if bound, reason := compactAuthorityPathsBound(forged, change); bound || reason == "" {
+				t.Fatalf("foreign path %q bound=%t reason=%q, want false with refusal", test.path, bound, reason)
+			}
+		})
+	}
+}
+
+func TestResolveAllowsApprovedFreshOpenSpecInfrastructureForActiveChange(t *testing.T) {
+	const change = "add-webhook-signature-verifier"
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, change, "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChangeWithCandidate(t, root, changeRoot, "approved-webhook", "- [x] 1.1 Done\n", func() {
+		write(t, filepath.Join(root, ".gitignore"), ".env\n")
+		write(t, filepath.Join(root, "internal", "webhook", "signature.go"), "package webhook\n")
+		write(t, filepath.Join(root, "openspec", "config.yaml"), "schema: specification\n")
+		write(t, filepath.Join(root, "openspec", "changes", "archive", ".gitkeep"), "")
+		write(t, filepath.Join(root, "openspec", "specs", ".gitkeep"), "")
+		write(t, filepath.Join(changeRoot, "proposal.md"), "# Proposal\nFresh infrastructure included\n")
+		write(t, filepath.Join(changeRoot, "design.md"), "# Design\nFresh infrastructure included\n")
+		write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Fresh infrastructure\n")
+		write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("a"), "pass"))
+	})
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: change})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow ||
+		status.Dependencies.Archive == DependencyBlocked || status.NextRecommended == "resolve-review" {
+		t.Fatalf("fresh OpenSpec infrastructure status = %#v", status)
+	}
+	projected, err := ProjectStatusV1(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projected.ReviewGate == nil || projected.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("fresh OpenSpec infrastructure projected review gate = %#v", projected.ReviewGate)
+	}
+}


### PR DESCRIPTION
Closes #3327.

## What

Unit 3 of the recovered-units train: `config.yaml` and the two legitimate `.gitkeep` scaffold files no longer classify as foreign payload blocking SDD (`validReviewBindingChange` + backslash/bare-`openspec` hardening), with the j107 driven journey.

## RDD

Lineage `review-83270063f2f6ac2e` (high risk, 4R): approved with zero corrections; pre-pr gate `allow`.

## Verification

Full `go test ./...` green; `go vet` + `GOOS=windows go vet` clean; bench green; deadcode ratchet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approved active changes now remain valid when accompanied by the exact supported OpenSpec infrastructure files.
  * Improved validation rejects unexpected configuration paths, traversal attempts, ambiguous separators, and files belonging to other changes or archives.

* **Tests**
  * Added coverage for shared OpenSpec scaffolding, authority resolution, project status checks, and path collision detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->