### PR TITLE
feat(sdd): wire the hidden review-validator OpenCode role

### DIFF
--- a/internal/assets/opencode/sdd-overlay-multi.json
+++ b/internal/assets/opencode/sdd-overlay-multi.json
@@ -28,7 +28,8 @@
             "review-readability": "allow",
             "review-reliability": "allow",
             "review-resilience": "allow",
-            "review-refuter": "allow"
+            "review-refuter": "allow",
+            "review-validator": "allow"
           }
         }
       },
@@ -256,6 +257,13 @@
       "description": "Batched adversarial refuter — evaluates every BLOCKER/CRITICAL candidate through one assigned lens and returns one verdict per finding",
       "prompt": "You are a read-only review refuter. Do NOT delegate and never modify files. Input: the complete merged list of BLOCKER/CRITICAL candidates, with id, location, severity, summary, and evidence per entry, plus exactly one lens: general, correctness, exploitability-impact, or reproducibility. Attempt to refute every candidate through that lens using concrete code evidence; 'seems unlikely' does not refute. Return the assigned lens and a verdicts list with one verdict entry per candidate: finding id, verdict refuted or stands, and evidence. Do not omit candidates or report new findings. Default inconclusive candidates to stands; the orchestrator also treats every malformed or missing per-finding verdict as stands.",
       "tools": { "read": true, "write": false, "edit": false, "bash": false, "task": false }
+    },
+    "review-validator": {
+      "mode": "subagent",
+      "hidden": true,
+      "description": "Targeted read-only validator for provider-issued review checks",
+      "prompt": "You are a targeted validation subagent. Execute only the provider-issued targeted validation in the Go-issued task prompt. Do NOT edit files. Do NOT delegate. Return the exact requested JSON and nothing else.",
+      "tools": { "read": true, "write": false, "edit": false, "bash": true, "task": false }
     }
   }
 }

--- a/internal/assets/opencode/sdd-overlay-single.json
+++ b/internal/assets/opencode/sdd-overlay-single.json
@@ -28,7 +28,8 @@
             "review-readability": "allow",
             "review-reliability": "allow",
             "review-resilience": "allow",
-            "review-refuter": "allow"
+            "review-refuter": "allow",
+            "review-validator": "allow"
           }
         }
       },
@@ -256,6 +257,13 @@
       "description": "Batched adversarial refuter — evaluates every BLOCKER/CRITICAL candidate through one assigned lens and returns one verdict per finding",
       "prompt": "You are a read-only review refuter. Do NOT delegate and never modify files. Input: the complete merged list of BLOCKER/CRITICAL candidates, with id, location, severity, summary, and evidence per entry, plus exactly one lens: general, correctness, exploitability-impact, or reproducibility. Attempt to refute every candidate through that lens using concrete code evidence; 'seems unlikely' does not refute. Return the assigned lens and a verdicts list with one verdict entry per candidate: finding id, verdict refuted or stands, and evidence. Do not omit candidates or report new findings. Default inconclusive candidates to stands; the orchestrator also treats every malformed or missing per-finding verdict as stands.",
       "tools": { "read": true, "write": false, "edit": false, "bash": false, "task": false }
+    },
+    "review-validator": {
+      "mode": "subagent",
+      "hidden": true,
+      "description": "Targeted read-only validator for provider-issued review checks",
+      "prompt": "You are a targeted validation subagent. Execute only the provider-issued targeted validation in the Go-issued task prompt. Do NOT edit files. Do NOT delegate. Return the exact requested JSON and nothing else.",
+      "tools": { "read": true, "write": false, "edit": false, "bash": true, "task": false }
     }
   }
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2124,6 +2124,11 @@ func TestRunSyncAppliesManagedFilesystemChanges(t *testing.T) {
 	if err := os.WriteFile(legacyPluginPath, []byte("legacy background agents plugin"), 0o644); err != nil {
 		t.Fatalf("WriteFile(background-agents.ts) error = %v", err)
 	}
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	seed := `{"theme":"user-theme","agent":{"user-helper":{"mode":"subagent","description":"preserve me"}}}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
 
 	restoreHome := osUserHomeDir
 	restoreBackupHome := backup.UserHomeDirFn
@@ -2151,9 +2156,35 @@ func TestRunSyncAppliesManagedFilesystemChanges(t *testing.T) {
 	}
 
 	// SDD assets should exist.
-	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
 	if _, err := os.Stat(settingsPath); err != nil {
 		t.Errorf("expected SDD inject to create %q: %v", settingsPath, err)
+	}
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(content, &root); err != nil {
+		t.Fatalf("Unmarshal(opencode.json) error = %v", err)
+	}
+	if root["theme"] != "user-theme" {
+		t.Fatalf("sync discarded unrelated theme: %#v", root["theme"])
+	}
+	agentsMap := root["agent"].(map[string]any)
+	if helper, ok := agentsMap["user-helper"].(map[string]any); !ok || helper["description"] != "preserve me" {
+		t.Fatalf("sync discarded unrelated user agent: %#v", agentsMap["user-helper"])
+	}
+	if _, ok := agentsMap["review-validator"].(map[string]any); !ok {
+		t.Fatalf("sync did not add review-validator: %#v", agentsMap)
+	}
+	orchestrator := agentsMap["gentle-orchestrator"].(map[string]any)
+	permission := orchestrator["permission"].(map[string]any)
+	allowlist := permission["task"].(map[string]any)
+	if replacement, ok := allowlist["__replace__"].(map[string]any); ok {
+		allowlist = replacement
+	}
+	if allowlist["review-validator"] != "allow" {
+		t.Fatalf("sync did not authorize gentle-orchestrator -> review-validator: %#v", allowlist)
 	}
 	if _, err := os.Stat(legacyPluginPath); !os.IsNotExist(err) {
 		t.Errorf("expected sync to remove legacy OpenCode plugin %q; stat err = %v", legacyPluginPath, err)

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1739,6 +1739,20 @@ func stripOpenCodeNativeFallbackAgents(overlayBytes []byte) ([]byte, error) {
 	}
 	delete(agents, "general")
 	delete(agents, "explore")
+	// Kilocode does not host the OpenCode provider relay that issues the opaque
+	// validator task, so it must not expose or authorize that OpenCode-only role.
+	delete(agents, opencode.ReviewValidatorAgent)
+	if orchestrator, ok := agents["gentle-orchestrator"].(map[string]any); ok {
+		if permission, ok := orchestrator["permission"].(map[string]any); ok {
+			if task, ok := permission["task"].(map[string]any); ok {
+				if replacement, ok := task["__replace__"].(map[string]any); ok {
+					delete(replacement, opencode.ReviewValidatorAgent)
+				} else {
+					delete(task, opencode.ReviewValidatorAgent)
+				}
+			}
+		}
+	}
 	result, err := json.MarshalIndent(overlay, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal overlay: %w", err)

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -2214,9 +2214,9 @@ func TestInjectOpenCodeMultiMode(t *testing.T) {
 	}
 
 	// Multi overlay must contain gentle-orchestrator + 2 native fallback agents +
-	// 10 SDD sub-agents + 3 JD agents + 4 review agents + 1 batched refuter = 21 agents.
-	if len(agentMap) != 21 {
-		t.Fatalf("agent count = %d, want 21", len(agentMap))
+	// 10 SDD sub-agents + 3 JD agents + 4 review agents + refuter + validator = 22 agents.
+	if len(agentMap) != 22 {
+		t.Fatalf("agent count = %d, want 22", len(agentMap))
 	}
 
 	// Verify gentle-orchestrator is present.
@@ -2240,7 +2240,7 @@ func TestInjectOpenCodeMultiMode(t *testing.T) {
 	}
 
 	// Verify representative sub-agents are present.
-	for _, subAgent := range []string{"sdd-init", "sdd-apply", "sdd-verify", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-archive", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter"} {
+	for _, subAgent := range []string{"sdd-init", "sdd-apply", "sdd-verify", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-archive", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"} {
 		if _, ok := agentMap[subAgent]; !ok {
 			t.Fatalf("missing sub-agent %q", subAgent)
 		}
@@ -2602,12 +2602,12 @@ func TestInjectOpenCodeEmptySDDModeDefaultsSingle(t *testing.T) {
 	}
 
 	// Empty mode defaults to single — gentle-orchestrator + 2 native fallback agents +
-	// 10 SDD sub-agents + 3 JD agents + 4 review agents + 1 batched refuter = 21 agents.
+	// 10 SDD sub-agents + 3 JD agents + 4 review agents + refuter + validator = 22 agents.
 	if _, ok := agentMap["gentle-orchestrator"]; !ok {
 		t.Fatal("missing gentle-orchestrator agent")
 	}
-	if len(agentMap) != 21 {
-		t.Fatalf("agent count = %d, want 21", len(agentMap))
+	if len(agentMap) != 22 {
+		t.Fatalf("agent count = %d, want 22", len(agentMap))
 	}
 
 	// Verify orchestrator mode is "primary".
@@ -2636,7 +2636,7 @@ func TestInjectOpenCodeEmptySDDModeDefaultsSingle(t *testing.T) {
 	}
 
 	// Verify sub-agents are present with mode "subagent".
-	for _, subAgent := range []string{"sdd-init", "sdd-apply", "sdd-verify", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-archive", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter"} {
+	for _, subAgent := range []string{"sdd-init", "sdd-apply", "sdd-verify", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-archive", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"} {
 		raw, ok := agentMap[subAgent]
 		if !ok {
 			t.Fatalf("missing sub-agent %q", subAgent)
@@ -3129,6 +3129,7 @@ func TestInjectOpenCodeMultiModeWithModelAssignments(t *testing.T) {
 		"review-reliability": {ProviderID: "openai", ModelID: "gpt-5"},
 		"review-resilience":  {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		"review-refuter":     {ProviderID: "openai", ModelID: "gpt-5", Effort: "high"},
+		"review-validator":   {ProviderID: "openai", ModelID: "gpt-5-mini"},
 	}
 
 	result, err := Inject(home, opencodeAdapter(), "multi", InjectOptions{OpenCodeModelAssignments: assignments})
@@ -3184,8 +3185,12 @@ func TestInjectOpenCodeMultiModeWithModelAssignments(t *testing.T) {
 		"review-reliability": "openai/gpt-5",
 		"review-resilience":  "anthropic/claude-sonnet-4",
 		"review-refuter":     "openai/gpt-5",
+		"review-validator":   "openai/gpt-5-mini",
 	} {
-		definition := agentMap[agent].(map[string]any)
+		definition, ok := agentMap[agent].(map[string]any)
+		if !ok {
+			t.Fatalf("%s agent definition = %#v, want object", agent, agentMap[agent])
+		}
 		if got := definition["model"]; got != want {
 			t.Fatalf("%s model = %q, want %q", agent, got, want)
 		}
@@ -4395,10 +4400,18 @@ func TestInjectKilocodeKeepsLegacyBackgroundAgentsPluginAndRemovesOpenCodeReview
 	if strings.Contains(string(settings), "codegraph_codegraph_explore") {
 		t.Fatal("Kilocode settings must not receive the OpenCode CodeGraph grant")
 	}
-	for _, fallbackAgent := range []string{"general", "explore"} {
-		if _, exists := agentMap[fallbackAgent]; exists {
-			t.Fatalf("Kilocode settings must not receive OpenCode-only fallback agent %q", fallbackAgent)
+	for _, openCodeOnlyAgent := range []string{"general", "explore", opencodemodel.ReviewValidatorAgent} {
+		if _, exists := agentMap[openCodeOnlyAgent]; exists {
+			t.Fatalf("Kilocode settings must not receive OpenCode-only agent %q", openCodeOnlyAgent)
 		}
+	}
+	orchestrator := agentMap["gentle-orchestrator"].(map[string]any)
+	taskPermissions := orchestrator["permission"].(map[string]any)["task"].(map[string]any)
+	if replacement, ok := taskPermissions["__replace__"].(map[string]any); ok {
+		taskPermissions = replacement
+	}
+	if _, exists := taskPermissions[opencodemodel.ReviewValidatorAgent]; exists {
+		t.Fatalf("Kilocode settings must not authorize OpenCode-only agent %q", opencodemodel.ReviewValidatorAgent)
 	}
 }
 

--- a/internal/components/sdd/prompts_test.go
+++ b/internal/components/sdd/prompts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 )
 
 // TestSharedPromptDir verifies the expected directory path is returned.
@@ -141,13 +142,7 @@ func sddJudgmentDaySubAgentsForCodeGraphTest() []string {
 }
 
 func sddReviewSubAgentsForCodeGraphTest() []string {
-	return []string{
-		"review-risk",
-		"review-readability",
-		"review-reliability",
-		"review-resilience",
-		"review-refuter",
-	}
+	return opencode.ReviewPhases()
 }
 
 func sddShellDisabledSubAgentsForCodeGraphTest() []string {
@@ -546,7 +541,7 @@ func TestInjectOpenCodeSingleModeSubagentPromptsRespectBashCapabilityWhenCodeGra
 	}
 
 	agentsMap := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
-	bashCapableAgents := append(SharedPromptPhases(), "jd-fix-agent")
+	bashCapableAgents := append(SharedPromptPhases(), "jd-fix-agent", opencode.ReviewValidatorAgent)
 	for _, agentName := range bashCapableAgents {
 		prompt := agentPrompt(t, agentsMap, agentName)
 		if !strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(prompt, "gentle-ai codegraph init --cwd <project-root>") {

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -100,6 +100,7 @@ func TestDiscoverCustomAgentsExcludesReservedRolesAndDeduplicates(t *testing.T) 
     "gentle-reviewer": { "model": "openai/gpt-5" },
     "gentle-worker": { "model": "openai/gpt-5-mini" },
     "sdd-orchestrator": { "model": "openai/gpt-5" },
+    "review-validator": { "model": "openai/gpt-5-mini" },
     "a-custom-agent": { "model": "openai/gpt-5-mini" },
     "z-custom-agent": { "model": "openai/gpt-5" },
     "a-custom-agent": { "model": "openai/gpt-5" }
@@ -135,6 +136,7 @@ func TestReadCurrentModelAssignmentsIncludesReviewAgentsFromJSONC(t *testing.T) 
     "review-reliability": { "model": "openai/gpt-5" },
     "review-resilience": { "model": "anthropic/claude-sonnet-4" },
     "review-refuter": { "model": "openai/gpt-5", "variant": "high" },
+    "review-validator": { "model": "openai/gpt-5-mini" },
   },
 }`
 	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
@@ -145,7 +147,7 @@ func TestReadCurrentModelAssignmentsIncludesReviewAgentsFromJSONC(t *testing.T) 
 	if err != nil {
 		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
 	}
-	for _, agent := range []string{"review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter"} {
+	for _, agent := range []string{"review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"} {
 		if got[agent].ProviderID == "" || got[agent].ModelID == "" {
 			t.Errorf("review assignment %q missing: %v", agent, got)
 		}

--- a/internal/components/sdd/review_ledger_contract_test.go
+++ b/internal/components/sdd/review_ledger_contract_test.go
@@ -154,6 +154,7 @@ func TestOpenCodeOverlaysRenderBoundedReadOnlyReviewRoles(t *testing.T) {
 			}
 			agentsMap := root["agent"].(map[string]any)
 			expandOpenCodeBoundedReviewAgents(agentsMap)
+			assertOpenCodeTargetedValidator(t, path, agentsMap)
 			for _, name := range []string{"review-risk", "review-readability", "review-reliability", "review-resilience"} {
 				agent := agentsMap[name].(map[string]any)
 				prompt := agent["prompt"].(string)
@@ -179,6 +180,58 @@ func TestOpenCodeOverlaysRenderBoundedReadOnlyReviewRoles(t *testing.T) {
 			assertNoReviewerLifecycleInstructions(t, path+" refuter", refuterPrompt)
 			assertOpenCodeReadOnlyTools(t, path+" refuter", refuter["tools"].(map[string]any), true, false)
 		})
+	}
+}
+
+func assertOpenCodeTargetedValidator(t *testing.T, label string, agents map[string]any) {
+	t.Helper()
+
+	orchestrator, ok := agents["gentle-orchestrator"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s missing gentle-orchestrator", label)
+	}
+	permission, ok := orchestrator["permission"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s gentle-orchestrator permission = %#v, want object", label, orchestrator["permission"])
+	}
+	task, ok := permission["task"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s gentle-orchestrator permission.task = %#v, want object", label, permission["task"])
+	}
+	allowlist, ok := task["__replace__"].(map[string]any)
+	if !ok || allowlist["review-validator"] != "allow" {
+		t.Fatalf("%s gentle-orchestrator does not allow task review-validator: %#v", label, task)
+	}
+
+	validator, ok := agents["review-validator"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s missing review-validator subagent", label)
+	}
+	if validator["mode"] != "subagent" || validator["hidden"] != true {
+		t.Fatalf("%s review-validator visibility = mode:%#v hidden:%#v, want hidden subagent", label, validator["mode"], validator["hidden"])
+	}
+	prompt, ok := validator["prompt"].(string)
+	if !ok {
+		t.Fatalf("%s review-validator prompt = %#v, want string", label, validator["prompt"])
+	}
+	for _, required := range []string{"provider-issued targeted validation", "Do NOT edit", "Do NOT delegate", "exact requested JSON"} {
+		if !strings.Contains(prompt, required) {
+			t.Errorf("%s review-validator prompt missing %q: %s", label, required, prompt)
+		}
+	}
+
+	tools, ok := validator["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s review-validator tools = %#v, want object", label, validator["tools"])
+	}
+	wantTools := map[string]bool{"read": true, "bash": true, "write": false, "edit": false, "task": false}
+	if len(tools) != len(wantTools) {
+		t.Errorf("%s review-validator tool count = %d, want %d: %#v", label, len(tools), len(wantTools), tools)
+	}
+	for name, want := range wantTools {
+		if got, exists := tools[name]; !exists || got != want {
+			t.Errorf("%s review-validator tool %q = %#v, want %t", label, name, got, want)
+		}
 	}
 }
 

--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -503,7 +503,10 @@ func JDPhases() []string {
 	}
 }
 
-const ReviewRefuterAgent = "review-refuter"
+const (
+	ReviewRefuterAgent   = "review-refuter"
+	ReviewValidatorAgent = "review-validator"
+)
 
 // ReviewLensPhases returns the ordered native bounded-review lens agents.
 func ReviewLensPhases() []string {
@@ -518,7 +521,7 @@ func ReviewLensPhases() []string {
 // ReviewPhases returns every agent invoked by the native review lifecycle.
 func ReviewPhases() []string {
 	phases := ReviewLensPhases()
-	return append(phases, ReviewRefuterAgent)
+	return append(phases, ReviewRefuterAgent, ReviewValidatorAgent)
 }
 
 // ConfigurableAgentPhases returns all agent names that support per-agent

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -379,6 +379,7 @@ func TestReviewPhasesCompleteRuntimeSet(t *testing.T) {
 		"review-reliability",
 		"review-resilience",
 		"review-refuter",
+		"review-validator",
 	}
 	if got := ReviewPhases(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("ReviewPhases() = %v, want %v", got, want)

--- a/testdata/golden/sdd-opencode-multi-settings.golden
+++ b/testdata/golden/sdd-opencode-multi-settings.golden
@@ -44,6 +44,7 @@
           "review-reliability": "allow",
           "review-resilience": "allow",
           "review-risk": "allow",
+          "review-validator": "allow",
           "sdd-apply": "allow",
           "sdd-archive": "allow",
           "sdd-design": "allow",
@@ -188,6 +189,19 @@
         "bash": false,
         "edit": false,
         "read": false,
+        "task": false,
+        "write": false
+      }
+    },
+    "review-validator": {
+      "description": "Targeted read-only validator for provider-issued review checks",
+      "hidden": true,
+      "mode": "subagent",
+      "prompt": "You are a targeted validation subagent. Execute only the provider-issued targeted validation in the Go-issued task prompt. Do NOT edit files. Do NOT delegate. Return the exact requested JSON and nothing else.\n\n\u003c!-- gentle-ai:agent-language-contract --\u003e\n## Artifact Language Contract\n\nGenerated artifacts (code, comments, UI copy, docs, specs, tests, commit messages, memory entries) default to English. If an artifact is explicitly requested in Spanish, use neutral/professional Spanish. Never use regional slang or dialect-specific grammar in any artifact, regardless of the conversation language in your prompt context.\n\nBefore any Write/Edit whose content is an artifact, re-verify these artifact language rules.\n\u003c!-- /gentle-ai:agent-language-contract --\u003e\n",
+      "tools": {
+        "bash": true,
+        "edit": false,
+        "read": true,
         "task": false,
         "write": false
       }


### PR DESCRIPTION
Closes #3333.

## What

Unit 5 (final) of the recovered-units train: `ReviewValidatorAgent` in `ReviewPhases`, both sdd-overlay JSONs (hidden read-only bash-capable subagent + orchestrator allowlist), Kilocode stripping, golden regenerated via the documented flow, and sync user-settings preservation tests.

## RDD

Lineage `review-4bf7c49c0c2aafa7` (medium risk, focus lens): approved with zero corrections; pre-pr gate `allow`.

## Verification

Full `go test ./...` green; `go vet` + `GOOS=windows go vet` clean; deadcode ratchet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only review validator that performs provider-requested checks and returns structured results.
  * Expanded review workflows to include targeted validation alongside existing review phases.
* **Bug Fixes**
  * Improved configuration synchronization so existing theme and agent settings are preserved while managed review settings are added.
  * Prevented provider-specific review agents and permissions from appearing in incompatible configurations.
* **Validation**
  * Added coverage for validator configuration, permissions, tool access, model assignment, and cross-provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->