### PR TITLE
fix(sdd): exclude exploration-only directories from active change selection

### DIFF
--- a/internal/sddstatus/exploration_only_selection_test.go
+++ b/internal/sddstatus/exploration_only_selection_test.go
@@ -1,0 +1,120 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #3278 claim C: a directory holding only an exploration artifact is not
+// an active change, yet listActiveOpenSpecChanges counted it as one. With one
+// genuinely active change plus one stale sdd-explore directory, auto-selection
+// reported "Change selection is ambiguous" and the SDD task-failure
+// continuation (which carries no selector) could never resolve it.
+//
+// The contract these tests pin: a directory whose only SDD artifacts are
+// exploration artifacts (exploration.md and nothing among proposal.md,
+// design.md, tasks.md, specs/) is not a candidate for auto-selection or
+// ambiguity, but remains addressable when explicitly named. Directories with
+// no SDD artifacts at all (empty scaffolds) keep their historical behavior and
+// stay candidates.
+
+func TestExplorationOnlyDirectoryDoesNotMakeSelectionAmbiguous(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "add-widget", "- [ ] 1.1 Wire widget\n")
+	write(t, filepath.Join(root, "openspec", "changes", "explore-widget-idea", "exploration.md"), "# Exploration\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.ChangeName == nil || *status.ChangeName != "add-widget" {
+		t.Fatalf("ChangeName = %v, want add-widget auto-selected beside an exploration-only directory", ptrValue(status.ChangeName))
+	}
+	if status.NextRecommended == "select-change" {
+		t.Fatalf("NextRecommended = select-change; an exploration-only directory must not make selection ambiguous.\nBlockedReasons: %v", status.BlockedReasons)
+	}
+	if status.NextRecommended != "apply" {
+		t.Fatalf("NextRecommended = %q, want apply for the one genuinely active change", status.NextRecommended)
+	}
+}
+
+func TestTwoFullChangesStayAmbiguousBesideExplorationOnlyDirectory(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "first", "- [ ] 1.1 Work\n")
+	seedReadyChange(t, root, "second", "- [ ] 1.1 Work\n")
+	write(t, filepath.Join(root, "openspec", "changes", "explore-widget-idea", "exploration.md"), "# Exploration\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended != "select-change" {
+		t.Fatalf("NextRecommended = %q, want select-change with two full changes", status.NextRecommended)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if !strings.Contains(reasons, "ambiguous: first, second.") {
+		t.Fatalf("ambiguity must list exactly the two full changes.\ngot:\n%s", reasons)
+	}
+	if strings.Contains(reasons, "explore-widget-idea") {
+		t.Fatalf("exploration-only directory leaked into the ambiguity candidates.\ngot:\n%s", reasons)
+	}
+}
+
+func TestExplorationOnlyDirectoryStillResolvesWhenExplicitlyNamed(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "add-widget", "- [ ] 1.1 Wire widget\n")
+	write(t, filepath.Join(root, "openspec", "changes", "explore-widget-idea", "exploration.md"), "# Exploration\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "explore-widget-idea"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.ChangeName == nil || *status.ChangeName != "explore-widget-idea" {
+		t.Fatalf("ChangeName = %v, want explore-widget-idea when explicitly named", ptrValue(status.ChangeName))
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if strings.Contains(reasons, "not found") {
+		t.Fatalf("explicitly naming an exploration-only directory must keep resolving it.\ngot:\n%s", reasons)
+	}
+	if status.NextRecommended != "propose" {
+		t.Fatalf("NextRecommended = %q, want propose for an exploration-only change", status.NextRecommended)
+	}
+}
+
+func TestAllExplorationOnlyDirectoriesBlockAsNoActiveChanges(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "openspec", "changes", "explore-widget-idea", "exploration.md"), "# Exploration\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended != "sdd-new" {
+		t.Fatalf("NextRecommended = %q, want sdd-new when every directory is exploration-only", status.NextRecommended)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if !strings.Contains(reasons, "No active OpenSpec changes") {
+		t.Fatalf("BlockedReasons = %v, want the no-active-changes refusal", status.BlockedReasons)
+	}
+	if !strings.Contains(reasons, "explore-widget-idea") {
+		t.Fatalf("the refusal must name the exploration-only directory so the operator can address it explicitly.\ngot:\n%s", reasons)
+	}
+}
+
+func TestExplorationBesideRealArtifactsStaysASelectionCandidate(t *testing.T) {
+	root := t.TempDir()
+	// exploration.md beside a proposal is a change that finished exploring;
+	// it must keep counting as active.
+	changeRoot := filepath.Join(root, "openspec", "changes", "add-widget")
+	write(t, filepath.Join(changeRoot, "exploration.md"), "# Exploration\n")
+	write(t, filepath.Join(changeRoot, "proposal.md"), "# Proposal\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.ChangeName == nil || *status.ChangeName != "add-widget" {
+		t.Fatalf("ChangeName = %v, want add-widget: exploration.md beside real artifacts stays selectable", ptrValue(status.ChangeName))
+	}
+}

--- a/internal/sddstatus/exploration_only_selection_test.go
+++ b/internal/sddstatus/exploration_only_selection_test.go
@@ -1,7 +1,9 @@
 package sddstatus
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -99,6 +101,34 @@ func TestAllExplorationOnlyDirectoriesBlockAsNoActiveChanges(t *testing.T) {
 	}
 	if !strings.Contains(reasons, "explore-widget-idea") {
 		t.Fatalf("the refusal must name the exploration-only directory so the operator can address it explicitly.\ngot:\n%s", reasons)
+	}
+}
+
+func TestUnstatableMarkerKeepsChangeAnActiveCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX symlink semantics to force a non-ErrNotExist stat error")
+	}
+	root := t.TempDir()
+	seedReadyChange(t, root, "add-widget", "- [ ] 1.1 Wire widget\n")
+	changeRoot := filepath.Join(root, "openspec", "changes", "explore-broken")
+	write(t, filepath.Join(changeRoot, "exploration.md"), "# Exploration\n")
+	// A self-referential symlink makes os.Stat fail with ELOOP, not
+	// ErrNotExist. The classification is unprovable, so the directory must
+	// stay an active-change candidate (surfacing as ambiguity), never drop
+	// out of selection silently.
+	if err := os.Symlink("proposal.md", filepath.Join(changeRoot, "proposal.md")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended != "select-change" {
+		t.Fatalf("NextRecommended = %q, want select-change: an unprovable exploration-only classification must fail toward ambiguity, not silent exclusion", status.NextRecommended)
+	}
+	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "explore-broken") {
+		t.Fatalf("the unprovable directory must stay visible as a candidate.\ngot: %v", status.BlockedReasons)
 	}
 }
 

--- a/internal/sddstatus/selection_continuation_test.go
+++ b/internal/sddstatus/selection_continuation_test.go
@@ -1,0 +1,105 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Issue #3278 (secondary defect, tracked as #2790's ambiguity half): the
+// ambiguity continuations emitted by ambiguousChangeSelectionReasons rendered
+// `gentle-ai sdd-status --cwd <repo> --change <name>`, but ParseCommandArgs
+// has no --change flag — the change selector is positional. Every command the
+// refusal told the operator to run was rejected by the very parser it targets,
+// so following our own guidance burned the operator's single sanctioned
+// observation on a syntax error.
+//
+// The guard: every runnable `gentle-ai sdd-status ...` continuation emitted in
+// BlockedReasons must parse through ParseCommandArgs, and ambiguity
+// continuations must carry the change selector through to the parsed result.
+
+var sddStatusContinuationRe = regexp.MustCompile("`gentle-ai sdd-status ([^`]+)`")
+
+// parseEmittedContinuations extracts every backticked sdd-status invocation
+// from the blocked reasons and feeds its arguments to ParseCommandArgs,
+// returning the parsed selectors. Placeholder tokens like <change-name> are
+// parseable positionals by design, so no filtering is needed.
+func parseEmittedContinuations(t *testing.T, reasons []string) []string {
+	t.Helper()
+	selectors := []string{}
+	found := false
+	for _, reason := range reasons {
+		for _, match := range sddStatusContinuationRe.FindAllStringSubmatch(reason, -1) {
+			found = true
+			args := strings.Fields(match[1])
+			parsed, err := ParseCommandArgs(args)
+			if err != nil {
+				t.Fatalf("emitted continuation does not parse through ParseCommandArgs: %q\nerror: %v", "gentle-ai sdd-status "+match[1], err)
+			}
+			selectors = append(selectors, parsed.ChangeName)
+		}
+	}
+	if !found {
+		t.Fatalf("no runnable sdd-status continuation found in blocked reasons: %v", reasons)
+	}
+	return selectors
+}
+
+func TestOpenSpecAmbiguityContinuationsParseAndCarryTheSelector(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "first", "- [ ] 1.1 Work\n")
+	seedReadyChange(t, root, "second", "- [ ] 1.1 Work\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended != "select-change" {
+		t.Fatalf("NextRecommended = %q, want select-change", status.NextRecommended)
+	}
+
+	selectors := parseEmittedContinuations(t, status.BlockedReasons)
+	want := []string{"first", "second"}
+	if strings.Join(selectors, ",") != strings.Join(want, ",") {
+		t.Fatalf("parsed change selectors = %v, want %v: each continuation must select the change it names", selectors, want)
+	}
+}
+
+func TestEngramAmbiguityContinuationsParseAndCarryTheSelector(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".engram"))
+	runRuntimeLedgerGit(t, root, "init", "-q")
+	runRuntimeLedgerGit(t, root, "remote", "add", "origin", "git@github.com:Gentleman-Programming/gentle-ai.git")
+
+	restore := stubEngramExport(t, []engramObservation{
+		{Title: "sdd/add-auth/proposal", Content: "# Proposal\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/add-billing/proposal", Content: "# Proposal\n", Project: "gentle-ai", Scope: "project"},
+	})
+	defer restore()
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended != "select-change" {
+		t.Fatalf("NextRecommended = %q, want select-change", status.NextRecommended)
+	}
+
+	selectors := parseEmittedContinuations(t, status.BlockedReasons)
+	want := []string{"add-auth", "add-billing"}
+	if strings.Join(selectors, ",") != strings.Join(want, ",") {
+		t.Fatalf("parsed change selectors = %v, want %v: each continuation must select the change it names", selectors, want)
+	}
+}
+
+func TestExplorationOnlyRefusalContinuationParses(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "openspec", "changes", "explore-widget-idea", "exploration.md"), "# Exploration\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	parseEmittedContinuations(t, status.BlockedReasons)
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1631,13 +1631,21 @@ func absOrCWD(path string) (string, error) {
 // that listed options and named no command. The list stays first because it is
 // what a human scanning the refusal wants; the commands follow because that is
 // what makes the refusal runnable.
+//
+// The selector is positional: ParseCommandArgs has no --change flag, so the
+// emitted spelling must be `gentle-ai sdd-status <change> --cwd <root>`. The
+// first shipped spelling used `--change` and every emitted command was
+// rejected by the very parser it targets (#3278, #2790), burning the
+// operator's single sanctioned observation on a syntax error. The guard test
+// in selection_continuation_test.go feeds every emitted continuation back
+// through ParseCommandArgs so the spelling cannot drift from the parser again.
 func ambiguousChangeSelectionReasons(subject, workspaceRoot string, changes []string) []string {
 	reasons := make([]string, 0, len(changes)+1)
 	reasons = append(reasons, fmt.Sprintf("%s selection is ambiguous: %s.", subject, strings.Join(changes, ", ")))
 	for _, change := range changes {
 		reasons = append(reasons, fmt.Sprintf(
-			"Run `gentle-ai sdd-status --cwd %s --change %s` to continue with %s.",
-			workspaceRoot, change, change,
+			"Run `gentle-ai sdd-status %s --cwd %s` to continue with %s.",
+			change, workspaceRoot, change,
 		))
 	}
 	return reasons

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -3,6 +3,7 @@ package sddstatus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -428,13 +429,16 @@ func selectableOpenSpecChanges(changesDir string, changes []string) []string {
 
 // explorationOnlyChangeDir reports whether the change directory's only SDD
 // artifact is an exploration artifact: exploration.md is present and none of
-// proposal.md, design.md, tasks.md, or specs/ exist.
+// proposal.md, design.md, tasks.md, or specs/ exist. Only os.ErrNotExist
+// proves a marker absent; any other stat error makes the classification
+// unprovable, so the directory stays an active-change candidate (failing
+// toward visibility, never toward silent exclusion from selection).
 func explorationOnlyChangeDir(changeRoot string) bool {
 	if _, err := os.Stat(filepath.Join(changeRoot, "exploration.md")); err != nil {
 		return false
 	}
 	for _, marker := range []string{"proposal.md", "design.md", "tasks.md", "specs"} {
-		if _, err := os.Stat(filepath.Join(changeRoot, marker)); err == nil {
+		if _, err := os.Stat(filepath.Join(changeRoot, marker)); !errors.Is(err, os.ErrNotExist) {
 			return false
 		}
 	}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -406,6 +406,41 @@ func listActiveOpenSpecChanges(workspaceRoot string) ([]string, error) {
 	return changes, nil
 }
 
+// selectableOpenSpecChanges filters exploration-only directories out of the
+// auto-selection candidates (#3278 claim C). A stale sdd-explore directory
+// holding only exploration.md is not an active change: counting it made
+// selection ambiguous beside the one genuinely active change, and the SDD
+// task-failure continuation (which carries no selector) could never resolve
+// that ambiguity. Exploration-only directories stay addressable when
+// explicitly named — listActiveOpenSpecChanges still returns them — and
+// directories with no SDD artifacts at all keep their historical behavior as
+// candidates.
+func selectableOpenSpecChanges(changesDir string, changes []string) []string {
+	selectable := make([]string, 0, len(changes))
+	for _, change := range changes {
+		if explorationOnlyChangeDir(filepath.Join(changesDir, change)) {
+			continue
+		}
+		selectable = append(selectable, change)
+	}
+	return selectable
+}
+
+// explorationOnlyChangeDir reports whether the change directory's only SDD
+// artifact is an exploration artifact: exploration.md is present and none of
+// proposal.md, design.md, tasks.md, or specs/ exist.
+func explorationOnlyChangeDir(changeRoot string) bool {
+	if _, err := os.Stat(filepath.Join(changeRoot, "exploration.md")); err != nil {
+		return false
+	}
+	for _, marker := range []string{"proposal.md", "design.md", "tasks.md", "specs"} {
+		if _, err := os.Stat(filepath.Join(changeRoot, marker)); err == nil {
+			return false
+		}
+	}
+	return true
+}
+
 func Resolve(options ResolveOptions) (Status, error) {
 	workspaceRoot, err := resolveWorkspaceRoot(options)
 	if err != nil {
@@ -427,16 +462,30 @@ func Resolve(options ResolveOptions) (Status, error) {
 
 	changeName := strings.TrimSpace(options.ChangeName)
 	if changeName == "" {
-		switch len(activeChanges) {
+		candidates := selectableOpenSpecChanges(changesDir, activeChanges)
+		switch len(candidates) {
 		case 0:
+			if len(activeChanges) > 0 {
+				// Every directory is exploration-only. This is an OpenSpec
+				// workspace mid-exploration, not an empty one, so do not fall
+				// through to Engram: report it honestly and keep the
+				// directories addressable by explicit name.
+				return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, nil, "sdd-new", []string{
+					"No active OpenSpec changes found under openspec/changes.",
+					fmt.Sprintf(
+						"Exploration-only directories are not active changes: %s. Run `gentle-ai sdd-status <change-name> --cwd %s` to inspect one explicitly.",
+						strings.Join(activeChanges, ", "), workspaceRoot,
+					),
+				}, options.IncludeInstructions), nil
+			}
 			if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, reviewDisabled); ok || err != nil {
 				return status, err
 			}
 			return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, nil, "sdd-new", []string{"No active OpenSpec changes found under openspec/changes."}, options.IncludeInstructions), nil
 		case 1:
-			changeName = activeChanges[0]
+			changeName = candidates[0]
 		default:
-			return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, nil, "select-change", ambiguousChangeSelectionReasons("Change", workspaceRoot, activeChanges), options.IncludeInstructions), nil
+			return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, nil, "select-change", ambiguousChangeSelectionReasons("Change", workspaceRoot, candidates), options.IncludeInstructions), nil
 		}
 	}
 

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -165,7 +165,9 @@ func TestAmbiguousChangeSelectionNamesARunnableCommandPerChange(t *testing.T) {
 
 	reasons := strings.Join(status.BlockedReasons, "\n")
 	for _, change := range []string{"first", "second"} {
-		want := "gentle-ai sdd-status --cwd " + root + " --change " + change
+		// The selector is positional: ParseCommandArgs has no --change flag
+		// (#3278, #2790), so this is the only runnable spelling.
+		want := "gentle-ai sdd-status " + change + " --cwd " + root
 		if !strings.Contains(reasons, want) {
 			t.Fatalf("blocked reasons named no runnable command for %q; a refusal that lists options and no command is the shape this project does not ship.\ngot:\n%s", change, reasons)
 		}


### PR DESCRIPTION
Closes #3278. Also carries #2790 (the emitted continuation now parses).

## What

Claim C of #3278 plus two adjacent defects found while fixing it:

- A directory whose only artifact is `exploration.md` no longer counts as an active change for auto-selection or ambiguity (it stays addressable when explicitly named; all-exploration-only blocks `sdd-new` naming the dirs).
- Ambiguity continuations now emit the valid positional spelling (`gentle-ai sdd-status <change> --cwd <root>`) — the previous `--change` suggestion was rejected by the parser; a guard test asserts every emitted `sdd-status` continuation parses and selects the change it names.
- Review correction: a non-ENOENT stat error no longer classifies a change as exploration-only — unprovable classification fails toward visibility, never silent exclusion (RED via ELOOP symlink).

Claim routing for #3278: claim B (phase mislabel) was already fixed by e57bcbb5 (v2.4.0-rc.7+); claim A (empty child result with workspace mutation) remains tracked by #2855.

## RDD

Lineage `review-38986721363451c1` (high, 4R): one CRITICAL finding, one bounded correction (38/148), targeted validator PASS, state **approved**, pre-pr gate `allow`.

## Verification

RED-first throughout; full `go test ./...` green; `go vet` + `GOOS=windows go vet` clean; deadcode ratchet clean; live smoke: original ambiguous layout auto-selects, emitted continuation executed verbatim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Exploration-only workspaces are no longer treated as active changes during automatic selection.
  - Explicitly named exploration directories remain accessible.
  - Workspaces containing only exploration directories now correctly report that no active changes are available.
  - Selection ambiguity handling now provides runnable continuation commands with the correct change name.
- **Tests**
  - Added coverage for exploration-only selection, ambiguity scenarios, explicit resolution, and continuation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->