### PR TITLE
fix(sdd): judge remediation change against the failed evidence baseline

### DIFF
--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -613,7 +613,7 @@ func runtimeSettleObligation(status RuntimeStatus, reviewDisabled bool) string {
 	}
 	return "this attempt's passing settle is already bound to the chain's unremediated failed verification " +
 		failed.EvidenceRevision + ": settle it passed with `--remediates-evidence-revision \"" + failed.EvidenceRevision +
-		"\"`, and with verification evidence distinct from it, over a candidate this attempt actually changed. " +
+		"\"`, and with verification evidence distinct from it, over a correction candidate that no longer matches the state that failed. " +
 		"An audited reset or an interrupted settlement between that failure and this correction does not release the " +
 		"binding — only a passing settlement that names it does."
 }

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -917,6 +917,9 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			// between the audited reset and the acquire lives inside the begin
 			// snapshot already, so the begin-relative comparison refused a
 			// candidate that genuinely no longer matches the state that failed.
+			// Records committed under this predicate require a reader deciding
+			// the same predicate (applyRuntimeFinishEvent): replay compatibility
+			// is forward-only, the store's standard schema-evolution discipline.
 			if !evidenceOnly && runtimeRemediationCandidateUnchanged(chainFailedAttempt, *active, snapshot.Identity, snapshot.CandidateTree) {
 				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed relative to the state that failed verification, or an audited reset or rescope authorizing this exact unchanged candidate.
 				return runtimeRecord{}, errors.New("unmanaged remediation requires a changed correction candidate")
@@ -2247,16 +2250,10 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		// failing objective against these exact bytes authorizes one evidence-only
 		// retry, so a replayed correction may leave the candidate unchanged.
 		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, chainFailedAttempt, event.FinishCandidateTree)
-		// #3073 lockstep-with-history: the write guard judges "unchanged"
-		// against the failed evidence's candidate snapshot, while records
-		// committed before that fix were judged against the attempt's begin
-		// snapshot. A committed record is valid if it satisfied the guard of
-		// the generation that wrote it, so replay refuses only a record
-		// unchanged under BOTH baselines; judging by the new baseline alone
-		// would make a legitimately committed pre-fix chain unreplayable.
-		unchangedCandidate := runtimeRemediationCandidateUnchanged(chainFailedAttempt, *active, event.FinishCandidateIdentity, event.FinishCandidateTree) &&
-			(event.FinishCandidateIdentity == active.BeginCandidateIdentity ||
-				event.FinishCandidateTree == active.BeginCandidateTree)
+		// #3073 lockstep twin: replay decides the exact write-guard predicate;
+		// the helper falls back to the begin comparison only for a legacy
+		// failed record that carries no finish snapshot.
+		unchangedCandidate := runtimeRemediationCandidateUnchanged(chainFailedAttempt, *active, event.FinishCandidateIdentity, event.FinishCandidateTree)
 		// A binding is deliberately NOT checked here. The write path stopped
 		// treating a leftover binding as a blocker (the kill switch must have
 		// no implications while it is off), and this replay mirror has to agree

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -912,8 +912,13 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		}
 		if unmanagedRemediation {
 			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, status.LastRescope, chainFailedAttempt, snapshot.CandidateTree)
-			if !evidenceOnly && (snapshot.Identity == active.BeginCandidateIdentity || snapshot.CandidateTree == active.BeginCandidateTree) {
-				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed by the active correction attempt, or an audited reset or rescope authorizing this exact unchanged candidate.
+			// #3073: "changed" is judged against the failed evidence's candidate
+			// snapshot, not the attempt's begin snapshot. A correction applied
+			// between the audited reset and the acquire lives inside the begin
+			// snapshot already, so the begin-relative comparison refused a
+			// candidate that genuinely no longer matches the state that failed.
+			if !evidenceOnly && runtimeRemediationCandidateUnchanged(chainFailedAttempt, *active, snapshot.Identity, snapshot.CandidateTree) {
+				// refusal:by-design operator-knowledge: a remediation claim must name a candidate changed relative to the state that failed verification, or an audited reset or rescope authorizing this exact unchanged candidate.
 				return runtimeRecord{}, errors.New("unmanaged remediation requires a changed correction candidate")
 			}
 			if request.EvidenceRevision == request.RemediatesEvidenceRevision {
@@ -2242,8 +2247,16 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		// failing objective against these exact bytes authorizes one evidence-only
 		// retry, so a replayed correction may leave the candidate unchanged.
 		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, chainFailedAttempt, event.FinishCandidateTree)
-		unchangedCandidate := event.FinishCandidateIdentity == active.BeginCandidateIdentity ||
-			event.FinishCandidateTree == active.BeginCandidateTree
+		// #3073 lockstep-with-history: the write guard judges "unchanged"
+		// against the failed evidence's candidate snapshot, while records
+		// committed before that fix were judged against the attempt's begin
+		// snapshot. A committed record is valid if it satisfied the guard of
+		// the generation that wrote it, so replay refuses only a record
+		// unchanged under BOTH baselines; judging by the new baseline alone
+		// would make a legitimately committed pre-fix chain unreplayable.
+		unchangedCandidate := runtimeRemediationCandidateUnchanged(chainFailedAttempt, *active, event.FinishCandidateIdentity, event.FinishCandidateTree) &&
+			(event.FinishCandidateIdentity == active.BeginCandidateIdentity ||
+				event.FinishCandidateTree == active.BeginCandidateTree)
 		// A binding is deliberately NOT checked here. The write path stopped
 		// treating a leftover binding as a blocker (the kill switch must have
 		// no implications while it is off), and this replay mirror has to agree
@@ -3163,6 +3176,25 @@ func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, rescope *RuntimeRes
 	return rescope != nil && rescope.Actor != "" && rescope.Reason != "" &&
 		rescope.PreviousObjectiveID == failed.ObjectiveID && rescope.PreviousGeneration == failed.ObjectiveGeneration &&
 		rescope.RescopeCandidateTree == candidateTree
+}
+
+// runtimeRemediationCandidateUnchanged judges whether a settling unmanaged
+// remediation still presents the state that FAILED (#3073). The laundering
+// baseline is the remediated failed evidence's candidate snapshot — the exact
+// bytes the failure was recorded over — not the correction attempt's begin
+// snapshot: a correction applied between the audited reset and the acquire is
+// already inside the begin snapshot, so judging against begin refused a
+// genuinely changed candidate, while a revert to the failed bytes after
+// acquire counted as "changed" against begin despite re-presenting exactly
+// what failed. Failed attempts recorded before the finish candidate snapshot
+// existed carry no baseline of their own, so those legacy records fall back
+// to the pre-#3073 begin-relative comparison.
+func runtimeRemediationCandidateUnchanged(failed, active RuntimeAttempt, identity, tree string) bool {
+	baselineIdentity, baselineTree := failed.FinishCandidateIdentity, failed.FinishCandidateTree
+	if baselineIdentity == "" && baselineTree == "" {
+		baselineIdentity, baselineTree = active.BeginCandidateIdentity, active.BeginCandidateTree
+	}
+	return identity == baselineIdentity || tree == baselineTree
 }
 
 func runtimeObjectiveID(change, workUnit, evidenceGoal, candidateIdentity string, generation int) string {

--- a/internal/sddstatus/runtime_ledger_failed_baseline_test.go
+++ b/internal/sddstatus/runtime_ledger_failed_baseline_test.go
@@ -156,6 +156,44 @@ func TestRuntimeRemediationRevertToFailedBytesStaysRefused(t *testing.T) {
 	}
 }
 
+// The replay mirror decides the exact write-guard predicate, and every shape
+// the write guard admits replays cleanly (write-to-replay closure). A
+// two-baseline AND accepted unchanged-vs-failed records the write path refuses.
+func TestRuntimeRemediationReplayDecidesWriteGuardPredicate(t *testing.T) {
+	failedTree, beginTree, failedEvidence := "failedtree", "begintree", runtimeTestHash('a')
+	cases := []struct {
+		name, finishTree string
+		reset            *RuntimeReset
+		wantRefused      bool
+	}{
+		{"unchanged vs failed baseline refuses like the write guard", failedTree, nil, true},
+		{"post-acquire change replays", "correctedtree", nil, false},
+		{"pre-acquire change with finish equal to begin replays", beginTree, nil, false},
+		{"evidence-only waiver shape replays unchanged bytes", failedTree, &RuntimeReset{Actor: "maintainer", Reason: "authorized evidence-only retry", PreviousObjectiveID: "objective", PreviousGeneration: 1, ResetCandidateTree: failedTree}, false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			replay := &runtimeReplay{Status: RuntimeStatus{
+				Objective: &RuntimeObjective{ID: "objective", Generation: 1, MaxAttempts: 3, MaxChangedLines: 10},
+				Attempts: []RuntimeAttempt{
+					{ObjectiveID: "objective", ObjectiveGeneration: 1, Outcome: AttemptFailed, EvidenceRevision: failedEvidence,
+						FinishCandidateIdentity: runtimeTestHash('f'), FinishCandidateTree: failedTree},
+					{Outcome: AttemptRunning},
+				},
+				ActiveAttempt: &RuntimeAttempt{Ordinal: 2, BeginCandidateIdentity: runtimeTestHash('0'), BeginCandidateTree: beginTree},
+				LastReset:     testCase.reset,
+			}}
+			err := applyRuntimeFinishEvent(replay, &runtimeFinishEvent{
+				Ordinal: 2, FinishCandidateIdentity: runtimeTestHash('1'), FinishCandidateTree: testCase.finishTree,
+				Outcome: AttemptPassed, EvidenceRevision: runtimeTestHash('b'), RemediatesEvidenceRevision: failedEvidence,
+			}, true)
+			if (err != nil) != testCase.wantRefused {
+				t.Fatalf("replay refusal = %v, want refused %v", err, testCase.wantRefused)
+			}
+		})
+	}
+}
+
 // Failed attempts recorded before the finish candidate snapshot existed carry
 // no baseline of their own, so the judgment falls back to the correction
 // attempt's begin snapshot — the pre-#3073 comparison — instead of judging

--- a/internal/sddstatus/runtime_ledger_failed_baseline_test.go
+++ b/internal/sddstatus/runtime_ledger_failed_baseline_test.go
@@ -1,0 +1,190 @@
+package sddstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #3073 (residual shape, Flow C): the "changed correction candidate"
+// judgment compared the settling snapshot only against the correction
+// attempt's BEGIN snapshot. When the correction bytes land AFTER the audited
+// reset but BEFORE the correction attempt acquires, the begin snapshot
+// already contains them, so a candidate genuinely changed relative to the
+// state that FAILED was refused as unchanged — and the attempt stuck with no
+// recovery transition. The judgment must compare against the remediated
+// failed evidence's candidate snapshot: the state the failure was recorded
+// over is the laundering baseline, not whatever the retry happened to begin
+// from.
+func TestRuntimeRemediationSettlesWhenCorrectionPredatesAcquire(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "correction-predates-acquire")
+	store.ReviewDisabled = true
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "predates-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 1, MaxChangedLines: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "predates-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failed.DecisionRequired || failed.NextAction != RuntimeActionReset {
+		t.Fatalf("exhausted failed verification = %#v", failed)
+	}
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "predates-audited-reset",
+		Reason: "maintainer decision: authorize a focused remediation of the failed verification",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// THE TRIGGER: the real tracked correction is applied after the reset and
+	// before the correction attempt acquires, so the begin snapshot already
+	// carries the corrected bytes.
+	appendRuntimeLedgerFile(t, repo, "expect(emptyState).toBeVisible()\n")
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: reset.Revision, RequestID: "predates-begin-correction", WorkUnit: "correction",
+		EvidenceGoal: "focused remediation", MaxAttempts: 1, MaxChangedLines: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "predates-finish-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "focused and full verification passed against the corrected candidate",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatalf("correction changed against the failed evidence was refused: %v", err)
+	}
+	if !completed.Complete || completed.ActiveAttempt != nil || completed.Binding != nil {
+		t.Fatalf("pre-acquire correction settle = %#v", completed)
+	}
+	last := completed.Attempts[len(completed.Attempts)-1]
+	if last.RemediatesEvidenceRevision != failedEvidence {
+		t.Fatalf("correction did not link the failed evidence: %#v", last)
+	}
+	// The candidate really did change relative to the state that failed, even
+	// though it never changed during the correction attempt itself.
+	if last.FinishCandidateTree != last.BeginCandidateTree ||
+		last.FinishCandidateTree == completed.Attempts[0].FinishCandidateTree {
+		t.Fatalf("pre-acquire correction candidate provenance = %#v vs failed %#v", last, completed.Attempts[0])
+	}
+	// The replay twin must admit exactly what the write guard admitted.
+	reopened := mustRuntimeStore(t, repo, "correction-predates-acquire")
+	replayed, err := reopened.Status()
+	if err != nil || replayed.Revision != completed.Revision || !replayed.Complete {
+		t.Fatalf("full-chain replay of the pre-acquire correction = %#v err=%v", replayed, err)
+	}
+}
+
+// The failed-evidence baseline cuts both ways: a candidate reverted to the
+// exact bytes that failed is unchanged relative to the failure no matter how
+// much it differs from the correction attempt's begin snapshot, and the
+// audited reset taken over DIFFERENT bytes does not authorize it either. The
+// begin-relative judgment used to accept this laundering shape.
+func TestRuntimeRemediationRevertToFailedBytesStaysRefused(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "revert-to-failed-bytes")
+	store.ReviewDisabled = true
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "revert-begin-verification", WorkUnit: "verify",
+		EvidenceGoal: "independent verification", MaxAttempts: 1, MaxChangedLines: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "revert-finish-verification", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "independent verification found a correctable defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification cleanup completed",
+		ProcessEvidence: "verification process scan completed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drift the candidate BEFORE the reset so the reset's audited authority is
+	// bound to different bytes than the ones that failed.
+	appendRuntimeLedgerFile(t, repo, "unrelated drift\n")
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "revert-audited-reset",
+		Reason: "maintainer decision: authorize a focused remediation of the failed verification",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: reset.Revision, RequestID: "revert-begin-correction", WorkUnit: "correction",
+		EvidenceGoal: "focused remediation", MaxAttempts: 1, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Revert to the exact bytes the failed verification was recorded over.
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := countRuntimeRecords(t, store.Dir)
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: active.Revision, RequestID: "revert-finish-correction", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "reverted candidate claims a correction of the bytes that failed",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "correction cleanup completed",
+		ProcessEvidence: "correction process scan completed", RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unmanaged remediation requires a changed correction candidate") {
+		t.Fatalf("revert to the failed bytes = %v, want the changed-candidate refusal", err)
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil || status.Revision != active.Revision || status.ActiveAttempt == nil ||
+		countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("revert refusal mutated runtime: status=%#v err=%v records=%d", status, statusErr, countRuntimeRecords(t, store.Dir))
+	}
+}
+
+// Failed attempts recorded before the finish candidate snapshot existed carry
+// no baseline of their own, so the judgment falls back to the correction
+// attempt's begin snapshot — the pre-#3073 comparison — instead of judging
+// every candidate as changed.
+func TestRuntimeRemediationCandidateBaselineFallsBackToBeginSnapshot(t *testing.T) {
+	failedTree, failedIdentity := "failedtree", runtimeTestHash('f')
+	beginTree, beginIdentity := "begintree", runtimeTestHash('0')
+	active := RuntimeAttempt{BeginCandidateIdentity: beginIdentity, BeginCandidateTree: beginTree}
+	snapshotFailed := RuntimeAttempt{FinishCandidateIdentity: failedIdentity, FinishCandidateTree: failedTree}
+	legacyFailed := RuntimeAttempt{}
+	cases := []struct {
+		name           string
+		failed         RuntimeAttempt
+		identity, tree string
+		wantUnchanged  bool
+	}{
+		{"matches the failed baseline", snapshotFailed, failedIdentity, failedTree, true},
+		{"failed tree alone marks unchanged", snapshotFailed, runtimeTestHash('1'), failedTree, true},
+		{"matches only the begin snapshot", snapshotFailed, beginIdentity, beginTree, false},
+		{"differs from the failed baseline", snapshotFailed, runtimeTestHash('1'), "othertree", false},
+		{"legacy failed record falls back to begin", legacyFailed, beginIdentity, beginTree, true},
+		{"legacy fallback admits a changed candidate", legacyFailed, runtimeTestHash('1'), "othertree", false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := runtimeRemediationCandidateUnchanged(testCase.failed, active, testCase.identity, testCase.tree)
+			if got != testCase.wantUnchanged {
+				t.Fatalf("runtimeRemediationCandidateUnchanged = %v, want %v", got, testCase.wantUnchanged)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3073.

## What

The "changed correction candidate" judgment for a remediation settle now compares against the REMEDIATED FAILED attempt's finish snapshot (what actually failed) instead of the acquire-time begin snapshot — fixing the still-reproducing shape where a correction written between the audited reset and the acquire was refused as unchanged and the attempt stuck. Legacy records without a finish snapshot keep the begin-snapshot fallback.

Bonus hardening: reverting to the exact failed bytes now refuses (the old begin-relative check accepted that laundering shape). Review correction: the replay mirror decides the exact write-guard predicate (shared helper + write→replay closure test), with forward-only reader compatibility pinned at the write guard.

## RDD

Lineage `review-d95f2e360e8f148d` (high, 4R): two CRITICAL findings, one bounded correction (55/116), targeted validator PASS, state **approved**, pre-pr gate `allow`.

## Verification

RED-first (Flow C blocked→complete end-to-end); full `go test ./...` green; `go vet` + `GOOS=windows go vet` clean; deadcode ratchet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remediation validation to reject correction candidates that remain identical to the failed state.
  * Accepted valid corrections made before acquisition when they differ from the recorded failure evidence.
  * Preserved compatibility with legacy records while applying consistent validation during writes and replay.
  * Prevented rejected corrections from mutating application state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->