### PR TITLE
fix(review): admit contract-shaped host bindings by value, not bytes

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -492,7 +492,13 @@ func TestOpenCodeReviewTransportPluginContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`gentle-ai.provider-transport/v1`, `"review", "opencode-transport"`, `RELAY_REGISTRY_KEY`, `reviewRelayRegistry()`, `output.args.prompt = (await relay.prompt).prompt`, `output.output = await registration.relay.complete(output.output)`, `"tool.execute.before"`, `"tool.execute.after"`} {
+	for _, want := range []string{`gentle-ai.provider-transport/v1`, `"review", "opencode-transport"`, `RELAY_REGISTRY_KEY`, `reviewRelayRegistry()`, `output.args.prompt = (await relay.prompt).prompt`, `output.output = await registration.relay.complete(output.output)`, `"tool.execute.before"`, `"tool.execute.after"`,
+		// A refused relay start must fail the Task loudly and never launch an
+		// unbound child: the before hook poisons the Task prompt and the after
+		// hook replaces child output with the typed refusal, so a host runtime
+		// that swallows hook errors still cannot deliver an unbound child's
+		// prose as a reviewer completion.
+		`opencode_review_transport_relay_refused`, `refused.set(key, reason)`, `output.args.prompt = relayRefusedPrompt(reason)`, `output.output = relayRefusedOutput(refusal)`} {
 		if !strings.Contains(source, want) {
 			t.Fatalf("transport plugin missing %q", want)
 		}

--- a/internal/assets/opencode/plugins/opencode-review-transport.ts
+++ b/internal/assets/opencode/plugins/opencode-review-transport.ts
@@ -56,6 +56,32 @@ function taskKey(sessionID: string, callID: string): string {
   return `${sessionID}:${callID}`
 }
 
+// A refused relay must fail the Task loudly and never launch an unbound
+// child. Throwing from the before hook is the primary refusal; these two
+// projections keep the refusal authoritative even in a host runtime that
+// swallows hook errors and launches the Task anyway: the child receives only
+// this refusal prompt (never the semi-bound original), and the after hook
+// replaces the child's raw output with the typed transport refusal so an
+// unbound child's prose can never masquerade as a captured reviewer result.
+const RELAY_REFUSED_CODE = "opencode_review_transport_relay_refused"
+
+function relayRefusedReason(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+function relayRefusedPrompt(reason: string): string {
+  return (
+    `${RELAY_REFUSED_CODE}: the Go review relay refused this Task before launch: ${reason}\n` +
+    `You have no review binding and no frozen candidate evidence. Do not inspect anything, ` +
+    `do not fabricate findings, and do not return a review result. ` +
+    `Reply with exactly: ${RELAY_REFUSED_CODE}`
+  )
+}
+
+function relayRefusedOutput(reason: string): string {
+  return `${RELAY_REFUSED_CODE}: ${reason}`
+}
+
 function decodeTransportFrame(line: string): TransportFrame {
   const frame = JSON.parse(line) as unknown
   if (!frame || typeof frame !== "object" || Array.isArray(frame)) throw new Error("invalid Go transport response")
@@ -141,6 +167,10 @@ const OpenCodeReviewTransportPlugin: Plugin = async ({ directory, worktree }) =>
   // deferral is the only tolerated silent completion path; every other
   // unmatched completion refuses loudly.
   const deferred = new Map<string, RelayRegistration>()
+  // Keys whose relay start this instance refused. Their Tasks must never
+  // deliver child output as a completion, even if the host runtime swallowed
+  // the before hook's thrown refusal and launched the Task anyway.
+  const refused = new Map<string, string>()
   const cwd = () => worktree || directory
   const clearOwned = (key: string) => {
     const registration = relays.get(key)
@@ -159,10 +189,12 @@ const OpenCodeReviewTransportPlugin: Plugin = async ({ directory, worktree }) =>
       registration.relay.close()
     }
     for (const key of deferred.keys()) if (key.startsWith(prefix)) deferred.delete(key)
+    for (const key of refused.keys()) if (key.startsWith(prefix)) refused.delete(key)
   }
   return {
     dispose: async () => {
       deferred.clear()
+      refused.clear()
       for (const [key, registration] of relays) if (registration.owner === owner) clearOwned(key)
     },
     event: async ({ event }) => {
@@ -189,12 +221,21 @@ const OpenCodeReviewTransportPlugin: Plugin = async ({ directory, worktree }) =>
         output.args.prompt = (await relay.prompt).prompt
       } catch (cause) {
         clearOwned(key)
+        const reason = relayRefusedReason(cause)
+        refused.set(key, reason)
+        output.args.prompt = relayRefusedPrompt(reason)
         throw cause
       }
     },
     "tool.execute.after": async (input, output) => {
       if (input.tool !== "task" || typeof input.args?.subagent_type !== "string" || !REVIEW_AGENTS.has(input.args.subagent_type)) return
       const key = taskKey(input.sessionID, input.callID)
+      const refusal = refused.get(key)
+      if (refusal !== undefined) {
+        refused.delete(key)
+        output.output = relayRefusedOutput(refusal)
+        throw new Error(relayRefusedOutput(refusal))
+      }
       // Owner-scoped dedup tolerance: this instance saw the before hook for
       // this task but another instance owns the relay, so that owner's after
       // hook delivers the completion and this one passes through untouched.

--- a/internal/cli/review_opencode_host_binding_test.go
+++ b/internal/cli/review_opencode_host_binding_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// hostLensBindingJSON assembles the binding one-liner exactly the way the
+// orchestration contract instructs a live host to: the contract's own field
+// order (which differs from Go's marshal order only by host choice), values
+// copied verbatim from the collect input -- including `order`, which that
+// input delivers as a decimal string argument -- and host-owned whitespace.
+func hostLensBindingJSON(lineage, target, lens, order, revision, repositoryContext, subjectHash string) string {
+	return fmt.Sprintf(
+		`{"lineage": %q, "target": %q, "lens": %q, "order": %s, "revision": %q, "repository_context": %q, "subject_hash": %q}`,
+		lineage, target, lens, order, revision, repositoryContext, subjectHash,
+	)
+}
+
+func hostLensReviewFixture(t *testing.T) (repo string, store reviewtransaction.CompactStore, record reviewtransaction.CompactRecord, lens, contextHandle string, subject reviewtransaction.ArtifactSubject) {
+	t.Helper()
+	repo, _, store, record = newArtifactReview(t, false)
+	lens = record.State.SelectedLenses[0]
+	contextHandle, err := reviewtransaction.PublishReviewRepositoryContext(context.Background(), repo, reviewtransaction.ReviewRepositoryContextBinding{
+		LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity, Revision: record.Revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, store, record, lens, contextHandle, mustArtifactSubject(t, repo, record, lens, 0)
+}
+
+// TestOpenCodeReviewTransportAdmitsContractShapedHostLensFrame is the live
+// defect reproduction: a real OpenCode host assembles the lens binding from
+// the collect input per the orchestration contract -- `order` arrives as the
+// input's string argument, `subject_hash` is populated, whitespace and key
+// treatment are host-owned, and reviewer instructions follow the binding
+// line. That first-contact frame must be admitted by field value, start the
+// session, and hand the child only Go-rebuilt canonical bytes.
+func TestOpenCodeReviewTransportAdmitsContractShapedHostLensFrame(t *testing.T) {
+	repo, store, record, lens, contextHandle, subject := hostLensReviewFixture(t)
+	const injected = "You are the reliability reviewer. Inspect the frozen candidate trees and return one JSON object."
+	binding := hostLensBindingJSON(record.State.LineageID, record.State.InitialSnapshot.Identity, lens, `"0"`,
+		record.Revision, contextHandle, subject.SubjectHash)
+	relay := startOpenCodeTransportRelay(t, openCodeTransportEnvelope{
+		Schema: openCodeReviewTransportSchema, Operation: "start",
+		Prompt: reviewLensContextBindingHeader + " " + binding + "\n" + injected,
+	})
+	if strings.Contains(relay.prompt.Prompt, injected) {
+		t.Fatalf("host-authored prompt bytes reached the provider Task: %q", relay.prompt.Prompt)
+	}
+	taskPrompt, reintercepted, err := decodeOpenCodeTransportMaterialization(relay.prompt.Prompt)
+	if err != nil || !reintercepted {
+		t.Fatalf("materialization = %q, reintercepted=%v, err=%v", taskPrompt, reintercepted, err)
+	}
+	canonical, err := json.Marshal(reviewLensContextBinding{
+		Lineage: record.State.LineageID, Target: record.State.InitialSnapshot.Identity, Lens: lens, Order: 0,
+		Revision: record.Revision, RepositoryContext: contextHandle, SubjectHash: subject.SubjectHash,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if taskPrompt != reviewLensContextBindingHeader+" "+string(canonical) {
+		t.Fatalf("materialized task prompt = %q, want the Go-rebuilt canonical binding line", taskPrompt)
+	}
+	raw := admittedReviewerPayloadForTest(t, repo, record, lens, 0)
+	hostOutput := string(raw)
+	completed, err := relay.complete(openCodeTransportEnvelope{
+		Schema: openCodeReviewTransportSchema, Operation: "complete", Nonce: relay.prompt.Nonce, Output: &hostOutput,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var artifact reviewResultArtifact
+	decodeStrictReviewJSON(t, []byte(*completed.Output), &artifact)
+	if artifact.AdmissionDecision != reviewtransaction.ArtifactAdmissionCompleted {
+		t.Fatalf("transport artifact = %#v", artifact)
+	}
+	if _, found, err := store.ResolveAdmittedReviewerResult(context.Background(), record.Revision, record.State.InitialSnapshot.Identity,
+		mustFrozenContext(t, repo, record), subject); err != nil || !found {
+		t.Fatalf("captured host-frame result found=%v err=%v", found, err)
+	}
+}
+
+// TestOpenCodeReviewTransportAdmitsHostLensFrameWithNumericOrderAndShuffledKeys
+// covers the other legitimate host serialization: numeric order and a key
+// order different from both the contract listing and Go's marshal order.
+func TestOpenCodeReviewTransportAdmitsHostLensFrameWithNumericOrderAndShuffledKeys(t *testing.T) {
+	repo, _, record, lens, contextHandle, subject := hostLensReviewFixture(t)
+	binding := fmt.Sprintf(
+		`{"subject_hash": %q, "repository_context": %q, "revision": %q, "order": 0, "lens": %q, "target": %q, "lineage": %q}`,
+		subject.SubjectHash, contextHandle, record.Revision, lens, record.State.InitialSnapshot.Identity, record.State.LineageID,
+	)
+	relay := startOpenCodeTransportRelay(t, openCodeTransportEnvelope{
+		Schema: openCodeReviewTransportSchema, Operation: "start",
+		Prompt: reviewLensContextBindingHeader + " " + binding + "\nReviewer instructions follow.",
+	})
+	if !strings.HasPrefix(relay.prompt.Prompt, openCodeTransportMaterializationHeader+" ") {
+		t.Fatalf("relay prompt = %q", relay.prompt.Prompt)
+	}
+	if err := relay.closeWithoutCompletion(); err == nil {
+		t.Fatal("relay without completion unexpectedly succeeded")
+	}
+	_ = repo
+}
+
+// TestOpenCodeReviewTransportRefusesHostLensFrameValueTampering verifies the
+// semantic admission stays fail-closed: every contract field value is checked
+// against the Go-resolved authority, unknown keys refuse, and missing
+// required fields refuse. No tampered frame may release a provider prompt.
+func TestOpenCodeReviewTransportRefusesHostLensFrameValueTampering(t *testing.T) {
+	repo, store, record, lens, contextHandle, subject := hostLensReviewFixture(t)
+	valid := func() map[string]any {
+		return map[string]any{
+			"lineage": record.State.LineageID, "target": record.State.InitialSnapshot.Identity, "lens": lens,
+			"order": 0, "revision": record.Revision, "repository_context": contextHandle, "subject_hash": subject.SubjectHash,
+		}
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "unknown key", mutate: func(binding map[string]any) { binding["note"] = "host extension" }},
+		{name: "tampered subject hash", mutate: func(binding map[string]any) {
+			binding["subject_hash"] = differentOpenCodeTransportTestSHA(subject.SubjectHash)
+		}},
+		{name: "tampered order", mutate: func(binding map[string]any) { binding["order"] = 3 }},
+		{name: "non-numeric order", mutate: func(binding map[string]any) { binding["order"] = "first" }},
+		{name: "tampered lens", mutate: func(binding map[string]any) { binding["lens"] = "review-unselected" }},
+		{name: "tampered revision", mutate: func(binding map[string]any) {
+			binding["revision"] = differentOpenCodeTransportTestSHA(record.Revision)
+		}},
+		{name: "tampered target", mutate: func(binding map[string]any) {
+			binding["target"] = differentOpenCodeTransportTestSHA(record.State.InitialSnapshot.Identity)
+		}},
+		{name: "tampered lineage", mutate: func(binding map[string]any) { binding["lineage"] = "different-live-lineage" }},
+		{name: "missing revision", mutate: func(binding map[string]any) { delete(binding, "revision") }},
+		{name: "missing lineage", mutate: func(binding map[string]any) { delete(binding, "lineage") }},
+		{name: "missing target", mutate: func(binding map[string]any) { delete(binding, "target") }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			before := discoverOpenCodeRelayRecord(t, repo, record.State.LineageID)
+			binding := valid()
+			test.mutate(binding)
+			encoded, err := json.Marshal(binding)
+			if err != nil {
+				t.Fatal(err)
+			}
+			start, err := json.Marshal(openCodeTransportEnvelope{
+				Schema: openCodeReviewTransportSchema, Operation: "start",
+				Prompt: reviewLensContextBindingHeader + " " + string(encoded) + "\nReviewer instructions follow.",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			transportErr := runReviewOpenCodeTransport(nil, bytes.NewReader(start), &output)
+			var bindingErr *openCodeTransportBindingError
+			if !errors.As(transportErr, &bindingErr) {
+				t.Fatalf("transport error = %v, want typed binding refusal", transportErr)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("tampered host frame released a provider prompt: %q", output.String())
+			}
+			assertOpenCodeRelayAuthorityUnchanged(t, repo, record.State.LineageID, store, before)
+		})
+	}
+}
+
+// TestOpenCodeReviewTransportAdmitsHostExpandedProviderRoleTask covers the
+// role lane a real host drives: the Go-issued provider task binding line
+// followed by host-authored task instructions. The frame is admitted by field
+// value against the resolved authority, and the child receives only the
+// Go-rebuilt materialization -- never the host-authored trailing bytes.
+func TestOpenCodeReviewTransportAdmitsHostExpandedProviderRoleTask(t *testing.T) {
+	repo, lineage, _ := providerCorrectionReady(t)
+	task := openCodeTargetedValidatorTask(t, repo, lineage)
+	const injected = "Input:\nmaterialized validator payload"
+	relay := startOpenCodeTransportRelay(t, openCodeTransportEnvelope{
+		Schema: openCodeReviewTransportSchema, Operation: "start", Prompt: task.Prompt + "\n\n" + injected,
+	})
+	if strings.Contains(relay.prompt.Prompt, injected) {
+		t.Fatalf("host-authored prompt bytes reached the provider Task: %q", relay.prompt.Prompt)
+	}
+	taskPrompt, reintercepted, err := decodeOpenCodeTransportMaterialization(relay.prompt.Prompt)
+	if err != nil || !reintercepted {
+		t.Fatalf("materialization = %q, reintercepted=%v, err=%v", taskPrompt, reintercepted, err)
+	}
+	if taskPrompt != task.Prompt {
+		t.Fatalf("materialized task prompt = %q, want the exact Go-issued role binding line", taskPrompt)
+	}
+	if err := relay.closeWithoutCompletion(); err == nil {
+		t.Fatal("relay without completion unexpectedly succeeded")
+	}
+}
+
+// TestOpenCodeReviewTransportRefusesHostRoleFrameTampering keeps the role
+// lane fail-closed under semantic admission: unknown keys and same-line
+// trailing JSON still refuse before any provider launch.
+func TestOpenCodeReviewTransportRefusesHostRoleFrameTampering(t *testing.T) {
+	repo, lineage, _ := providerCorrectionReady(t)
+	task := openCodeTargetedValidatorTask(t, repo, lineage)
+	line, _, _ := strings.Cut(task.Prompt, "\n")
+	encoded, found := strings.CutPrefix(line, reviewProviderTaskBindingHeader+" ")
+	if !found {
+		t.Fatalf("provider task prompt has no binding: %q", task.Prompt)
+	}
+	for _, test := range []struct {
+		name   string
+		prompt string
+	}{
+		{name: "unknown key", prompt: reviewProviderTaskBindingHeader + " " + strings.TrimSuffix(encoded, "}") + `,"note":"host extension"}`},
+		{name: "trailing JSON on the binding line", prompt: reviewProviderTaskBindingHeader + " " + encoded + " {}"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			start, err := json.Marshal(openCodeTransportEnvelope{
+				Schema: openCodeReviewTransportSchema, Operation: "start", Prompt: test.prompt,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			transportErr := runReviewOpenCodeTransport(nil, bytes.NewReader(start), &output)
+			var bindingErr *openCodeTransportBindingError
+			if !errors.As(transportErr, &bindingErr) {
+				t.Fatalf("transport error = %v, want typed binding refusal", transportErr)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("tampered role frame released a provider prompt: %q", output.String())
+			}
+		})
+	}
+	_ = lineage
+}
+
+func discoverOpenCodeRelayRecord(t *testing.T, repo, lineage string) reviewtransaction.CompactRecord {
+	t.Helper()
+	_, record, err := discoverCompactFacadeReview(context.Background(), repo, lineage, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record
+}

--- a/internal/cli/review_opencode_transport.go
+++ b/internal/cli/review_opencode_transport.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -59,7 +61,68 @@ type openCodeTransportTaskBinding struct {
 	TargetIdentity    string
 	RepositoryContext string
 	Lens              string
+	Order             openCodeHostBindingOrder
+	SubjectHash       string
 	Role              reviewProviderRole
+	// canonicalTaskPrompt is the Go-rebuilt binding line for a provider role
+	// task. It replaces the host-authored prompt before materialization so no
+	// caller-authored byte can ride the relay into the reviewer child.
+	canonicalTaskPrompt string
+}
+
+// openCodeHostBindingOrder admits the contract's host-owned order field. The
+// collect input delivers `order` as a decimal string argument and the
+// orchestration contract tells the host to assemble the binding JSON from
+// exactly that input, so the JSON number 0 and the string "0" identify the
+// same frozen slot. Presence is tracked so a provider-omitted order skips the
+// value check instead of masquerading as slot 0.
+type openCodeHostBindingOrder struct {
+	value    int
+	provided bool
+}
+
+func (order *openCodeHostBindingOrder) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if string(trimmed) == "null" {
+		// A JSON null is an omitted field, not slot 0: the value check must
+		// not bind an absent order to the first lens slot by accident.
+		return nil
+	}
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var text string
+		if err := json.Unmarshal(trimmed, &text); err != nil {
+			return err
+		}
+		value, err := strconv.Atoi(strings.TrimSpace(text))
+		if err != nil {
+			return errors.New("order is not a decimal integer") // refusal:by-design world-action: the collect input delivers order as a decimal slot index
+		}
+		order.value, order.provided = value, true
+		return nil
+	}
+	var value int
+	if err := json.Unmarshal(trimmed, &value); err != nil {
+		return err
+	}
+	order.value, order.provided = value, true
+	return nil
+}
+
+// openCodeHostLensBinding is the semantic admission shape for a first-contact
+// host-assembled lens frame. The orchestration contract makes key order and
+// whitespace host-owned, so admission accepts the contract's exact field set
+// in any serialization the strict decoder recognizes and verifies every field
+// value against the Go-resolved authority instead of comparing bytes. Unknown
+// keys still refuse, missing required fields still refuse, and the reviewer
+// child only ever receives Go-rebuilt canonical bytes.
+type openCodeHostLensBinding struct {
+	Lineage           string                   `json:"lineage"`
+	Target            string                   `json:"target"`
+	Lens              string                   `json:"lens"`
+	Order             openCodeHostBindingOrder `json:"order"`
+	Revision          string                   `json:"revision"`
+	RepositoryContext string                   `json:"repository_context"`
+	SubjectHash       string                   `json:"subject_hash"`
 }
 
 // openCodeTransportMaterialization carries the original, Go-issued Task
@@ -257,21 +320,33 @@ func openCodeTransportStartBound(ctx context.Context, taskPrompt string) (openCo
 	if err := authorizeReviewAuthorityMutation(ctx, root); err != nil {
 		return openCodeTransportSession{}, openCodeTransportAuthorityUnavailable(err)
 	}
-	// For a role task decodeOpenCodeTransportBinding already proved taskPrompt
-	// is byte-identical to the Go-issued prompt. The lens branch below replaces
-	// it with the Go-rebuilt canonical binding line, so no caller-authored
-	// bytes can ride the materialization envelope into the reviewer Task.
+	// Both branches replace the host-authored task prompt with Go-rebuilt
+	// canonical bytes -- the role branch with the Go-issued binding line, the
+	// lens branch with the Go-marshaled authority binding -- so no
+	// caller-authored byte can ride the materialization envelope into the
+	// reviewer Task. Host frames are admitted by field value only; every
+	// value below is checked against the Go-resolved authority, fail-closed.
 	session := openCodeTransportSession{binding: binding, root: root, store: store, record: record, taskPrompt: taskPrompt}
 	if binding.Role != "" {
+		session.taskPrompt = binding.canonicalTaskPrompt
 		invocation, err := reviewProviderRoleTaskRequest(ctx, root, store.Dir, record.State, record.Revision, binding.Role)
 		if err != nil {
 			return openCodeTransportSession{}, openCodeTransportFailure("opencode_review_transport_materialization_unavailable")
 		}
 		session.providerPrompt = invocation.Prompt()
 	} else {
+		if !slices.Contains(record.State.SelectedLenses, binding.Lens) {
+			return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task lens is not a provider-selected lens for this review")
+		}
 		request, err := reviewProviderMaterialize(ctx, reviewLensContextDependencies(), binding.RepositoryContext, binding.Lens)
 		if err != nil || request.Binding.Revision != record.Revision || request.Binding.Lineage != record.State.LineageID {
 			return openCodeTransportSession{}, openCodeTransportFailure("opencode_review_transport_materialization_unavailable")
+		}
+		if binding.Order.provided && binding.Order.value != request.Binding.Order {
+			return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task order does not match the provider-selected lens slot")
+		}
+		if binding.SubjectHash != "" && binding.SubjectHash != request.Binding.SubjectHash {
+			return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task subject hash does not match the provider-issued artifact subject")
 		}
 		encoded, err := json.Marshal(request.Binding)
 		if err != nil {
@@ -348,6 +423,14 @@ func openCodeTransportComplete(ctx context.Context, session openCodeTransportSes
 	return openCodeTransportEnvelope{Schema: openCodeReviewTransportSchema, Operation: "result", Output: &output}, nil
 }
 
+// decodeOpenCodeTransportBinding admits the first line of a host Task prompt
+// semantically: the exact contract field set in host-owned key order and
+// whitespace, unknown keys refused, missing required fields refused. Field
+// values are verified against the Go-resolved authority by the caller; bytes
+// are never compared for a first-contact host-assembled frame, because the
+// orchestration contract makes the binding serialization host-owned. Trailing
+// prompt lines are host-authored task prose and never reach the reviewer
+// child, which only ever receives the Go-rebuilt materialization.
 func decodeOpenCodeTransportBinding(prompt string) (openCodeTransportTaskBinding, error) {
 	line, _, _ := strings.Cut(prompt, "\n")
 	if encoded, found := strings.CutPrefix(line, reviewProviderTaskBindingHeader+" "); found {
@@ -365,12 +448,13 @@ func decodeOpenCodeTransportBinding(prompt string) (openCodeTransportTaskBinding
 			LineageID: binding.LineageID, Revision: binding.Revision, TargetIdentity: binding.TargetIdentity,
 			RepositoryContext: binding.RepositoryContext,
 		})
-		if err != nil || prompt != issued.Prompt {
-			return openCodeTransportTaskBinding{}, openCodeTransportBindingInvalid("Task prompt is not the exact provider-issued binding")
+		if err != nil {
+			return openCodeTransportTaskBinding{}, openCodeTransportBindingInvalid("Task prompt binding is not a Go-issuable provider role binding")
 		}
 		return openCodeTransportTaskBinding{
 			LineageID: binding.LineageID, Revision: binding.Revision, TargetIdentity: binding.TargetIdentity,
 			RepositoryContext: binding.RepositoryContext, Role: reviewProviderRole(binding.Role),
+			canonicalTaskPrompt: issued.Prompt,
 		}, nil
 	}
 	encoded, found := strings.CutPrefix(line, reviewLensContextBindingHeader+" ")
@@ -379,17 +463,18 @@ func decodeOpenCodeTransportBinding(prompt string) (openCodeTransportTaskBinding
 	}
 	decoder := json.NewDecoder(strings.NewReader(encoded))
 	decoder.DisallowUnknownFields()
-	var binding reviewLensContextBinding
+	var binding openCodeHostLensBinding
 	if err := decoder.Decode(&binding); err != nil {
 		return openCodeTransportTaskBinding{}, openCodeTransportBindingInvalid("Task prompt binding is not provider-issued JSON")
 	}
 	var extra any
-	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) || binding.RepositoryContext == "" || binding.Lens == "" {
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) || binding.Lineage == "" || binding.Target == "" ||
+		binding.Revision == "" || binding.RepositoryContext == "" || binding.Lens == "" {
 		return openCodeTransportTaskBinding{}, openCodeTransportBindingInvalid("Task prompt binding is incomplete")
 	}
 	return openCodeTransportTaskBinding{
 		LineageID: binding.Lineage, Revision: binding.Revision, TargetIdentity: binding.Target,
-		RepositoryContext: binding.RepositoryContext, Lens: binding.Lens,
+		RepositoryContext: binding.RepositoryContext, Lens: binding.Lens, Order: binding.Order, SubjectHash: binding.SubjectHash,
 	}, nil
 }
 

--- a/internal/cli/review_opencode_transport_test.go
+++ b/internal/cli/review_opencode_transport_test.go
@@ -196,12 +196,6 @@ func TestOpenCodeReviewTransportRefusesNonCanonicalProviderTaskBeforeProviderLau
 			},
 		},
 		{
-			name: "expanded provider binding",
-			prompt: func(binding string) string {
-				return binding + "\n\nInput:\nmaterialized validator payload"
-			},
-		},
-		{
 			name: "forged materialization marker",
 			prompt: func(binding string) string {
 				payload, err := json.Marshal(openCodeTransportMaterialization{TaskPrompt: binding})
@@ -763,9 +757,13 @@ func startOpenCodeTransportRelay(t *testing.T, start openCodeTransportEnvelope) 
 		_ = output.CloseWithError(err)
 		done <- err
 	}()
-	if err := json.NewEncoder(input).Encode(start); err != nil {
-		t.Fatal(err)
-	}
+	// The start frame is written concurrently because io.Pipe is synchronous:
+	// when the encoded frame lands exactly on the decoder's read-chunk
+	// boundary, the relay decodes the envelope and answers with its prompt
+	// frame before consuming the trailing newline, and a same-goroutine
+	// writer would deadlock against the unread prompt frame. Any write
+	// failure surfaces through the prompt decode below.
+	go func() { _ = json.NewEncoder(input).Encode(start) }()
 	decoder := json.NewDecoder(bufio.NewReader(outputReader))
 	var prompt openCodeTransportEnvelope
 	if err := decoder.Decode(&prompt); err != nil {


### PR DESCRIPTION
Closes #3343.

## What

- Lens lane: semantic admission of host-assembled binding frames (any key order/whitespace; `order` as number or decimal string; unknown keys refuse) with value verification against Go-resolved authority including three checks the byte path never had (lens ∈ selected, order == slot, subject_hash == provider-issued).
- Role lane: byte equality dropped; strict decode + authority validation; the session prompt is replaced with the Go-issued canonical binding line.
- #3317 invariant intact on both lanes: the child only receives Go-rebuilt bytes; Go-reissued materializations still compare byte-exact.
- Plugin: a refused relay start poisons the Task prompt with a typed refusal and replaces unbound child output before throwing — no silent unbound launches.

## RDD

Lineage `review-b151096192d8fb83` (high, 4R): approved with zero corrections; pre-pr gate `allow`.

## Verification

RED transcript against the real contract shape (string order + trailing prose → binding_invalid; post-fix accepted with Go-canonical child bytes); full `go test ./...` green; vets clean; ratchet clean; driven journey j106 completed; cross-lane battery host-frame lanes designed to flip green on this merge.

## Size exception

One reviewed unit under an approved receipt; the bulk is the new host-binding acceptance/refusal test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added robust handling for relay startup failures, including clear refusal responses when review tasks cannot be started.
  * Improved validation and reconstruction of review prompts from host-provided task details.
  * Added support for numeric task ordering and flexible input formatting while maintaining integrity checks.

* **Bug Fixes**
  * Prevented tampered or malformed task data from being accepted.
  * Improved transport behavior to avoid startup communication deadlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->