### PR TITLE
fix(review): replay the authorized untracked selection in recovery transitions

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1231,6 +1231,11 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	committedOnly := flags.Bool("committed-only", false, "acknowledge that --base-ref excludes dirty tracked changes")
 	workspaceOverlay := flags.Bool("workspace-overlay", false, "recover an approved base-diff into the exact staged index over --base-ref")
 	releaseScope := flags.Bool("release-scope", false, "recover an approved current-changes review into the immutable HEAD first-parent release scope")
+	var untrackedScope, expectedUntrackedInventory reviewSingleValueFlag
+	var intendedUntracked reviewRepeatedPathFlag
+	flags.Var(&untrackedScope, "untracked-scope", "explicit untracked scope for a current-changes successor: exclude or select (default: inherit the predecessor's frozen declaration)")
+	flags.Var(&intendedUntracked, "intended-untracked", "repo-relative untracked path to include; repeat for each path")
+	flags.Var(&expectedUntrackedInventory, "expected-untracked-inventory", "sha256 inventory digest from review status")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -1301,10 +1306,27 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	// the authority being recovered, and dropping them silently rebinds the
 	// successor to a partial candidate. Only the current-changes successor
 	// carries the declaration forward; base-diff, overlay, and release
-	// scopes never hold intended-untracked paths.
+	// scopes never hold intended-untracked paths. Issue #1972: an explicit
+	// recovery-time declaration (the same flags START and STATUS accept)
+	// overrides inheritance, so the successor target derives from the exact
+	// selection STATUS authorized rather than from the predecessor alone.
+	declaredSelection := reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory)
+	currentChangesSuccessor := !*releaseScope && !*committedOnly && !stagedScopeOverlay && !overlay
+	if declaredSelection && !currentChangesSuccessor {
+		return errors.New("intended-untracked selection requires a current-changes recovery; rerun `gentle-ai review recover` without --untracked-scope, --intended-untracked, and --expected-untracked-inventory")
+	}
+	if declaredSelection && projection == reviewtransaction.ProjectionStaged {
+		return errors.New("staged projection does not accept intended-untracked selection; remove those flags and rerun `gentle-ai review recover --projection staged`")
+	}
 	intended := []string{}
-	if !*releaseScope && !*committedOnly && !stagedScopeOverlay && !overlay &&
-		predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetCurrentChanges {
+	switch {
+	case declaredSelection:
+		scope, scopeErr := reviewIntendedUntrackedScopeForTarget(context.Background(), reviewtransaction.SnapshotBuilder{Repo: root}, untrackedScope, intendedUntracked, expectedUntrackedInventory)
+		if scopeErr != nil {
+			return scopeErr
+		}
+		intended = append(intended, scope.Intended...)
+	case currentChangesSuccessor && predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetCurrentChanges:
 		intended = append(intended, predecessorRecord.State.InitialSnapshot.IntendedUntracked...)
 	}
 	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
@@ -2263,6 +2285,9 @@ func validateReviewTransitionSelectorFlagCounts(args []string, operation string)
 			"policy":                        reviewIntegrationValueFlag,
 			"focus":                         reviewIntegrationValueFlag,
 			"base-ref":                      reviewIntegrationValueFlag,
+			"untracked-scope":               reviewIntegrationValueFlag,
+			"intended-untracked":            reviewIntegrationValueFlag,
+			"expected-untracked-inventory":  reviewIntegrationValueFlag,
 			"committed-only":                reviewIntegrationBoolFlag,
 			"workspace-overlay":             reviewIntegrationBoolFlag,
 			"release-scope":                 reviewIntegrationBoolFlag,

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -929,7 +929,7 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 			return reviewStopTransition("recovery_scope_unchanged")
 		}
 		var representable bool
-		selectorArguments, representable = input.Selector.recoveryArguments()
+		selectorArguments, representable = input.Selector.recoveryArguments(input.IntendedUntracked)
 		if !representable {
 			// Root 7 (#2471): the selector the caller supplied cannot be
 			// represented as a recovery target, so the missing thing is a
@@ -954,7 +954,7 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 	})
 }
 
-func (selector reviewTransitionSelector) recoveryArguments() ([]ReviewTransitionArgument, bool) {
+func (selector reviewTransitionSelector) recoveryArguments(scope reviewIntendedUntrackedScope) ([]ReviewTransitionArgument, bool) {
 	if selector.Recovery == nil {
 		return nil, false
 	}
@@ -967,6 +967,26 @@ func (selector reviewTransitionSelector) recoveryArguments() ([]ReviewTransition
 	case reviewtransaction.TargetCurrentChanges:
 		if target.Projection == reviewtransaction.ProjectionStaged {
 			arguments = append(arguments, ReviewTransitionArgument{Name: "projection", Value: string(target.Projection)})
+			break
+		}
+		// Issue #1972: STATUS authorized a target derived from the caller's
+		// declared untracked selection, so the rendered RECOVER must replay
+		// that exact selection. Without it, `review recover` re-derives the
+		// successor target from predecessor inheritance alone and refuses
+		// its own authorization whenever the recovery-time selection
+		// diverges from the predecessor's frozen declaration. A declared
+		// selection without its validated inventory digest cannot be
+		// replayed and fails closed instead of rendering a partial selector.
+		if scope.Declared {
+			if scope.Digest == "" {
+				return nil, false
+			}
+			arguments = append(arguments,
+				ReviewTransitionArgument{Name: "untracked-scope", Value: map[bool]string{true: "select", false: "exclude"}[len(target.IntendedUntracked) != 0]},
+				ReviewTransitionArgument{Name: "expected-untracked-inventory", Value: scope.Digest})
+			for _, path := range target.IntendedUntracked {
+				arguments = append(arguments, ReviewTransitionArgument{Name: "intended-untracked", Value: path})
+			}
 		}
 	case reviewtransaction.TargetBaseDiff:
 		if target.BaseRef == "" || target.Projection != reviewtransaction.ProjectionWorkspace {

--- a/internal/cli/review_recover_selector_replay_test.go
+++ b/internal/cli/review_recover_selector_replay_test.go
@@ -1,0 +1,339 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// escalatedSelectionReplayFixture is the #1972 predecessor: an escalated
+// current-changes authority whose frozen snapshot declared ONLY notes-a.txt,
+// while notes-b.txt stayed an eligible-but-unselected untracked path. The
+// recovery-time selection can then legitimately diverge from the predecessor's
+// frozen declaration.
+func escalatedSelectionReplayFixture(t *testing.T, lineage string) (string, reviewtransaction.CompactRecord) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"notes-a.txt", "notes-b.txt"} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte("untracked but explicitly eligible\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage,
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest,
+		"--intended-untracked", "notes-a.txt"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{
+		Findings: []facadeFinding{{
+			Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "candidate regression",
+			ProofRefs:     []string{"differential test fails only on candidate"},
+			EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+		}}, Evidence: []string{"focused differential test failed"},
+	})
+	if err := finalizeReviewCLIArgs(t, repo, []string{"--cwd", repo, "--lineage", lineage,
+		"--result", resultPath, "--correction-lines", "1000"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if predecessor.State.State != reviewtransaction.StateEscalated ||
+		len(predecessor.State.InitialSnapshot.IntendedUntracked) != 1 {
+		t.Fatalf("fixture did not reach an escalated authority declaring only notes-a.txt: %#v", predecessor.State.InitialSnapshot)
+	}
+	return repo, predecessor
+}
+
+// TestRecoveryTransitionReplaysAuthorizedUntrackedSelection is #1972 end to
+// end. STATUS accepts a recovery-time intended-untracked selection that
+// diverges from the predecessor's frozen declaration, authorizes recovery for
+// the selection-derived target, and renders the RECOVER transition. Executing
+// that exact provider-returned command must create the successor for the SAME
+// target STATUS authorized; before the fix the transition carried
+// selector_arguments: [] and `review recover` re-derived the target from
+// predecessor inheritance alone, refusing its own authorization.
+func TestRecoveryTransitionReplaysAuthorizedUntrackedSelection(t *testing.T) {
+	repo, predecessor := escalatedSelectionReplayFixture(t, "recover-1972")
+
+	// The bounded correction the escalation asked for.
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection := []string{
+		"--untracked-scope=select",
+		"--intended-untracked", "notes-a.txt", "--intended-untracked", "notes-b.txt",
+		"--expected-untracked-inventory", digest,
+	}
+	probe := selectorTransitionStatus(t, repo, selection...)
+	if probe.Action != reviewtransaction.TargetStatusActionRecover ||
+		probe.ActionDisposition != reviewtransaction.RecoveryEscalated || probe.Authority == nil {
+		t.Fatalf("selection-bearing recovery probe = %#v", probe)
+	}
+	const successor, actor, reason = "successor-1972", "maintainer", "recover the complete authorized candidate"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + predecessor.State.LineageID +
+		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
+		"\nsuccessor_lineage=" + successor + "\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo, append(append([]string{}, selection...),
+		"--recovery-successor-lineage", successor, "--recovery-reason", reason,
+		"--recovery-actor", actor, "--recovery-authorization", authorization)...)
+	if status.NextTransition == nil || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.recover" ||
+		status.NextTransition.ReasonCode != "recovery_authorized" {
+		t.Fatalf("selection-bearing recovery transition = %#v", status.NextTransition)
+	}
+
+	// Execute the exact provider-returned RECOVER command, verbatim.
+	executeSelectorTransition(t, repo, status)
+
+	// The rendered transition must replay the authorized selection.
+	selectors := status.NextTransition.Execute.SelectorArguments
+	if selectors == nil || len(*selectors) == 0 {
+		t.Fatalf("selection-bearing recovery rendered selector_arguments = %#v, want the authorized untracked selection", selectors)
+	}
+	want := []ReviewTransitionArgument{
+		{Name: "untracked-scope", Value: "select"},
+		{Name: "expected-untracked-inventory", Value: digest},
+		{Name: "intended-untracked", Value: "notes-a.txt"},
+		{Name: "intended-untracked", Value: "notes-b.txt"},
+	}
+	if !reflect.DeepEqual(*selectors, want) {
+		t.Fatalf("selection-bearing recovery selectors = %#v, want %#v", *selectors, want)
+	}
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, successor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.State.InitialSnapshot.Identity != probe.TargetIdentity {
+		t.Fatalf("successor identity %s does not bind the authorized target %s",
+			recovered.State.InitialSnapshot.Identity, probe.TargetIdentity)
+	}
+	if got := recovered.State.InitialSnapshot.IntendedUntracked; strings.Join(got, ",") != "notes-a.txt,notes-b.txt" {
+		t.Fatalf("successor intended-untracked = %v, want the authorized selection", got)
+	}
+}
+
+// TestRecoveryArgumentsReplayUntrackedSelection pins the rendering seam: a
+// workspace current-changes recovery with a declared selection replays the
+// exact untracked-scope flags, and the inheritance-only case (no declaration)
+// still renders no selector arguments at all.
+func TestRecoveryArgumentsReplayUntrackedSelection(t *testing.T) {
+	t.Parallel()
+
+	selector := reviewTransitionSelector{Recovery: &reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{"notes-a.txt", "notes-b.txt"},
+	}}
+	scope := reviewIntendedUntrackedScope{
+		Intended: []string{"notes-a.txt", "notes-b.txt"}, Digest: "sha256:0123", Declared: true,
+	}
+	arguments, representable := selector.recoveryArguments(scope)
+	if !representable {
+		t.Fatalf("declared workspace selection is unrepresentable")
+	}
+	want := []ReviewTransitionArgument{
+		{Name: "untracked-scope", Value: "select"},
+		{Name: "expected-untracked-inventory", Value: "sha256:0123"},
+		{Name: "intended-untracked", Value: "notes-a.txt"},
+		{Name: "intended-untracked", Value: "notes-b.txt"},
+	}
+	if !reflect.DeepEqual(arguments, want) {
+		t.Fatalf("declared selection arguments = %#v, want %#v", arguments, want)
+	}
+
+	exclude := reviewTransitionSelector{Recovery: &reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+	}}
+	arguments, representable = exclude.recoveryArguments(reviewIntendedUntrackedScope{Digest: "sha256:0123", Declared: true})
+	if !representable || !reflect.DeepEqual(arguments, []ReviewTransitionArgument{
+		{Name: "untracked-scope", Value: "exclude"},
+		{Name: "expected-untracked-inventory", Value: "sha256:0123"},
+	}) {
+		t.Fatalf("declared exclude arguments = %#v representable=%v", arguments, representable)
+	}
+
+	inherited := reviewTransitionSelector{Recovery: &reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+	}}
+	arguments, representable = inherited.recoveryArguments(reviewIntendedUntrackedScope{})
+	if !representable || len(arguments) != 0 {
+		t.Fatalf("inheritance-only recovery arguments = %#v representable=%v, want none", arguments, representable)
+	}
+
+	// A declared selection without its validated inventory digest cannot be
+	// replayed; the transition must fail closed rather than render a partial
+	// selector.
+	if _, representable = selector.recoveryArguments(reviewIntendedUntrackedScope{
+		Intended: []string{"notes-a.txt"}, Declared: true,
+	}); representable {
+		t.Fatal("declared selection without an inventory digest was rendered")
+	}
+}
+
+// TestReviewRecoverAcceptsDeclaredUntrackedSelection drives `review recover`
+// directly with the mirrored START/STATUS untracked selection flags: the
+// successor target must derive from the declared selection, not from
+// predecessor inheritance.
+func TestReviewRecoverAcceptsDeclaredUntrackedSelection(t *testing.T) {
+	repo, predecessor := escalatedSelectionReplayFixture(t, "recover-1972-flags")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	_, digest, err := builder.IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	complete, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{"notes-a.txt", "notes-b.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision,
+		complete.Identity, "maintainer", "recover the complete authorized candidate")
+
+	var output bytes.Buffer
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "recover-1972-flags-successor", "--disposition", "escalated",
+		"--reason", "recover the complete authorized candidate", "--actor", "maintainer",
+		"--maintainer-authorization", authorization,
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest,
+		"--intended-untracked", "notes-a.txt", "--intended-untracked", "notes-b.txt",
+	}, &output); err != nil {
+		t.Fatalf("recovery with the declared selection was refused: %v\n%s", err, output.String())
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "recover-1972-flags-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if successor.State.InitialSnapshot.Identity != complete.Identity ||
+		strings.Join(successor.State.InitialSnapshot.IntendedUntracked, ",") != "notes-a.txt,notes-b.txt" {
+		t.Fatalf("successor snapshot = %#v, want the declared selection target %s", successor.State.InitialSnapshot, complete.Identity)
+	}
+}
+
+// TestReviewRecoverExcludeSelectionOverridesInheritance: an explicit exclude
+// declaration is a real recovery-time decision, so it must override the
+// predecessor's frozen declaration exactly the way a fresh START would.
+func TestReviewRecoverExcludeSelectionOverridesInheritance(t *testing.T) {
+	repo, predecessor := escalatedSelectionReplayFixture(t, "recover-1972-exclude")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	_, digest, err := builder.IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	trackedOnly, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision,
+		trackedOnly.Identity, "maintainer", "recover the tracked-only candidate")
+
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "recover-1972-exclude-successor", "--disposition", "escalated",
+		"--reason", "recover the tracked-only candidate", "--actor", "maintainer",
+		"--maintainer-authorization", authorization,
+		"--untracked-scope=exclude", "--expected-untracked-inventory=" + digest,
+	}, io.Discard); err != nil {
+		t.Fatalf("recovery with an explicit exclude declaration was refused: %v", err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "recover-1972-exclude-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if successor.State.InitialSnapshot.Identity != trackedOnly.Identity ||
+		len(successor.State.InitialSnapshot.IntendedUntracked) != 0 {
+		t.Fatalf("successor snapshot = %#v, want the tracked-only target %s", successor.State.InitialSnapshot, trackedOnly.Identity)
+	}
+}
+
+// TestReviewRecoverDivergentSelectionStillRefused: the exact maintainer
+// authorization keeps binding the selection-derived target, so an invocation
+// whose declared selection does not match the authorized identity refuses
+// exactly as before.
+func TestReviewRecoverDivergentSelectionStillRefused(t *testing.T) {
+	repo, predecessor := escalatedSelectionReplayFixture(t, "recover-1972-divergent")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	_, digest, err := builder.IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	complete, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{"notes-a.txt", "notes-b.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision,
+		complete.Identity, "maintainer", "recover the complete authorized candidate")
+
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "recover-1972-divergent-successor", "--disposition", "escalated",
+		"--reason", "recover the complete authorized candidate", "--actor", "maintainer",
+		"--maintainer-authorization", authorization,
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest,
+		"--intended-untracked", "notes-a.txt",
+	}, io.Discard); err == nil {
+		t.Fatal("recovery whose declared selection diverges from the authorized target was admitted")
+	}
+	if _, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "recover-1972-divergent-successor"); err == nil {
+		if _, loadErr := os.Stat(filepath.Join(repo, ".git")); loadErr != nil {
+			t.Fatal(loadErr)
+		}
+	}
+}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -1030,7 +1030,7 @@ func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
 	if execution == nil || (execution.Operation != "review.validate" && execution.Operation != "review.recover") {
 		return nil
 	}
-	arguments, err := reviewTransitionArgumentMap(execution.Arguments)
+	arguments, err := reviewTransitionArgumentMap(execution.Arguments, execution.Operation)
 	if err != nil {
 		return err
 	}
@@ -1039,8 +1039,15 @@ func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
 	if selectorsPresent {
 		selectors = *execution.SelectorArguments
 	}
+	// intended-untracked legitimately repeats on a selection-replaying
+	// RECOVER (#1972), so echo membership is checked pairwise against the
+	// executable arguments rather than through the deduplicating map.
+	argumentPairs := make(map[ReviewTransitionArgument]bool, len(execution.Arguments))
+	for _, argument := range execution.Arguments {
+		argumentPairs[ReviewTransitionArgument{Name: argument.Name, Value: argument.Value}] = true
+	}
 	for _, selector := range selectors {
-		if arguments[selector.Name] != selector.Value {
+		if !argumentPairs[ReviewTransitionArgument{Name: selector.Name, Value: selector.Value}] {
 			return errors.New("negotiated transition changed its normalized selector")
 		}
 	}
@@ -1048,7 +1055,11 @@ func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
 	_, hasCommitted := arguments["committed-only"]
 	projection, hasProjection := arguments["projection"]
 	workspaceOverlay, hasWorkspaceOverlay := arguments["workspace-overlay"]
-	if !selectorsPresent && (hasBase || hasCommitted || hasProjection || hasWorkspaceOverlay) {
+	_, hasUntrackedScope := arguments["untracked-scope"]
+	_, hasUntrackedInventory := arguments["expected-untracked-inventory"]
+	_, hasIntendedUntracked := arguments["intended-untracked"]
+	if !selectorsPresent && (hasBase || hasCommitted || hasProjection || hasWorkspaceOverlay ||
+		hasUntrackedScope || hasUntrackedInventory || hasIntendedUntracked) {
 		return errors.New("negotiated transition omitted its normalized selector")
 	}
 	if hasWorkspaceOverlay && workspaceOverlay != "true" {
@@ -1067,11 +1078,11 @@ func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
 			return errors.New("current-changes RECOVER transition invented target selectors")
 		}
 	case reviewtransaction.TargetBaseDiff:
-		if !hasBase || !hasCommitted || hasWorkspaceOverlay {
+		if !hasBase || !hasCommitted || hasWorkspaceOverlay || hasUntrackedScope || hasUntrackedInventory || hasIntendedUntracked {
 			return errors.New("base-diff RECOVER transition lacks exact target selectors")
 		}
 	case reviewtransaction.TargetBaseWorkspaceOverlay:
-		if !hasBase || hasCommitted {
+		if !hasBase || hasCommitted || hasUntrackedScope || hasUntrackedInventory || hasIntendedUntracked {
 			return errors.New("workspace-overlay RECOVER transition has incompatible target selectors")
 		}
 		if result.Projection.Projection == reviewtransaction.ProjectionStaged &&
@@ -1560,7 +1571,7 @@ func (submission ReviewTransitionSubmission) validateFinalize() error {
 }
 
 func reviewTransitionArgumentMap(arguments []ReviewTransitionArgument, operation ...string) (map[string]string, error) {
-	allowIntendedUntracked := len(operation) == 1 && operation[0] == "review.start"
+	allowIntendedUntracked := len(operation) == 1 && (operation[0] == "review.start" || operation[0] == "review.recover")
 	values := make(map[string]string, len(arguments))
 	for _, argument := range arguments {
 		if previous, duplicate := values[argument.Name]; duplicate && (!allowIntendedUntracked || argument.Name != "intended-untracked" || previous == argument.Value) {
@@ -1609,16 +1620,38 @@ func validateReviewTransitionExecution(execution ReviewTransitionExecution, argu
 			return errors.New("review validate transition selectors are invalid")
 		}
 	case "review.recover":
+		// intended-untracked repeats once per selected path (#1972), so the
+		// selector echo is rebuilt from the ordered executable arguments and
+		// the argument-count check uses distinct selector names because the
+		// argument map deduplicates the repeats.
+		recoverSelectorNames := map[string]bool{
+			"base-ref": true, "committed-only": true, "projection": true, "workspace-overlay": true,
+			"untracked-scope": true, "expected-untracked-inventory": true, "intended-untracked": true,
+		}
 		wantSelectors := []ReviewTransitionArgument{}
-		for _, name := range []string{"base-ref", "committed-only", "projection", "workspace-overlay"} {
-			if value, present := arguments[name]; present {
-				wantSelectors = append(wantSelectors, ReviewTransitionArgument{Name: name, Value: value})
+		distinctSelectors := map[string]bool{}
+		intendedPaths := []string{}
+		for _, argument := range execution.Arguments {
+			if !recoverSelectorNames[argument.Name] {
+				continue
+			}
+			wantSelectors = append(wantSelectors, ReviewTransitionArgument{Name: argument.Name, Value: argument.Value})
+			distinctSelectors[argument.Name] = true
+			if argument.Name == "intended-untracked" {
+				intendedPaths = append(intendedPaths, argument.Value)
 			}
 		}
 		if execution.SelectorArguments != nil && !reflect.DeepEqual(*execution.SelectorArguments, wantSelectors) {
 			return errors.New("review recover transition selectors are invalid")
 		}
-		if !exact([]string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition", "reason", "actor", "maintainer-authorization"}, wantSelectors) ||
+		required := []string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition", "reason", "actor", "maintainer-authorization"}
+		requiredPresent := true
+		for _, name := range required {
+			if _, present := arguments[name]; !present {
+				requiredPresent = false
+			}
+		}
+		if !requiredPresent || len(arguments) != len(required)+len(distinctSelectors) ||
 			arguments["predecessor-lineage"] != execution.Binding.LineageID ||
 			arguments["expected-predecessor-revision"] != execution.Binding.Revision ||
 			!validReviewIntegrationLineage(arguments["successor-lineage"]) ||
@@ -1640,6 +1673,9 @@ func validateReviewTransitionExecution(execution ReviewTransitionExecution, argu
 		committed, hasCommitted := arguments["committed-only"]
 		projection, hasProjection := arguments["projection"]
 		workspaceOverlay, hasWorkspaceOverlay := arguments["workspace-overlay"]
+		untrackedScope, hasUntrackedScope := arguments["untracked-scope"]
+		inventory, hasInventory := arguments["expected-untracked-inventory"]
+		hasIntended := distinctSelectors["intended-untracked"]
 		if arguments["maintainer-authorization"] != wantAuthorization ||
 			hasBase && !validReviewTransitionSelector(base) ||
 			hasCommitted && (!hasBase || committed != "true") ||
@@ -1649,6 +1685,23 @@ func validateReviewTransitionExecution(execution ReviewTransitionExecution, argu
 				projection != string(reviewtransaction.ProjectionStaged) || workspaceOverlay != "true") {
 			return errors.New("review recover transition selectors are invalid")
 		}
+		// The untracked selection replay (#1972) is only meaningful for a
+		// workspace current-changes successor: scope and inventory travel
+		// together, select carries at least one path, exclude carries none,
+		// and every path is a plain repository-relative spelling.
+		if hasUntrackedScope != hasInventory ||
+			hasIntended && untrackedScope != "select" ||
+			hasUntrackedScope && untrackedScope == "select" && !hasIntended ||
+			hasUntrackedScope && untrackedScope != "select" && untrackedScope != "exclude" ||
+			hasUntrackedScope && (hasBase || hasCommitted || hasWorkspaceOverlay || hasProjection) ||
+			hasInventory && strings.TrimSpace(inventory) == "" {
+			return errors.New("review recover transition selectors are invalid")
+		}
+		for _, path := range intendedPaths {
+			if !validReviewIntendedUntrackedPath(path) {
+				return errors.New("review recover transition selectors are invalid")
+			}
+		}
 	}
 	return nil
 }
@@ -1657,6 +1710,16 @@ func validReviewTransitionSelector(value string) bool {
 	fields := strings.Fields(value)
 	return len(fields) == 1 && fields[0] == value && !path.IsAbs(value) &&
 		!strings.HasPrefix(value, "-") && !strings.ContainsRune(value, 0)
+}
+
+// validReviewIntendedUntrackedPath admits the repository-relative spellings an
+// intended-untracked declaration may carry. Unlike a target selector, a path
+// may contain interior spaces, so only the shapes that would break argv
+// replay or escape the repository are rejected.
+func validReviewIntendedUntrackedPath(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && !path.IsAbs(value) &&
+		!strings.HasPrefix(value, "-") && !strings.ContainsRune(value, 0) &&
+		!strings.ContainsAny(value, "\n\r")
 }
 
 func (eligibility ReviewActionEligibility) Validate(status ReviewTargetStatusResult) error {


### PR DESCRIPTION
Closes #1972.

## What

An escalated workspace candidate with an intended-untracked selection could get a maintainer authorization that RECOVER was guaranteed to reject: STATUS authorized the selection-derived target but rendered the RECOVER transition with `selector_arguments: []`, and `review recover` derived its target from predecessor inheritance alone.

- `review recover` gains the untracked selection flags (mirroring START/STATUS); a declared selection overrides #3159 inheritance, no-flags inheritance unchanged.
- `recoveryArguments` replays the authorized selection into the rendered transition (scope + inventory digest + per-path flags), failing closed without the digest.
- Transition validators admit the replay pairwise; divergent manual invocations still refuse.

## RDD

Lineage `review-c0fee9d02a8470ec` (high, 4R): approved with zero corrections; pre-pr gate `allow`.

## Verification

RED via the live repro; GREEN executing the rendered RECOVER verbatim → successor created for the authorized target; full `go test ./...` green; vets clean; ratchet clean; driven journeys j32/j33/j46/j48/j76/j81/j94 completed.

## Size exception

One reviewed unit under an approved receipt; the bulk is the selector-replay validation matrix and e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `review recover` now supports explicitly selecting untracked paths for recovery.
  * Added validation for untracked scope, inventory state, selected paths, and repository-relative path formats.
  * Repeated untracked-path selections are supported.

* **Bug Fixes**
  * Prevented invalid or incomplete recovery selections from proceeding.
  * Ensured recovery selections match the authorized target and avoid unintended path inheritance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->