### PR TITLE
fix(contracts): align published review schemas with live envelopes

### DIFF
--- a/bench/journeys_captured_provider_validator.go
+++ b/bench/journeys_captured_provider_validator.go
@@ -50,7 +50,7 @@ func captureProviderValidatorSlot(r *journeyRun) error {
 		return fmt.Errorf("provider slot capture status = %+v", status)
 	}
 	input := status.NextTransition.Collect.Inputs[0]
-	if input.Name != "provider_targeted-validator" || input.CaptureOperation != "external.run_provider_role" ||
+	if input.Name != "provider_targeted_validator" || input.CaptureOperation != "external.run_provider_role" ||
 		input.ProviderTask == nil || input.ProviderTask.Role != "targeted-validator" || input.ProviderTask.Prompt == "" {
 		return fmt.Errorf("provider slot task = %+v", input)
 	}

--- a/contracts/review-integration/v2/schemas/consent-v3.schema.json
+++ b/contracts/review-integration/v2/schemas/consent-v3.schema.json
@@ -15,7 +15,7 @@
     "contract": {"const": "gentle-ai.review-integration/v2"},
     "operation": {"const": "review.start"},
     "action": {"const": "consent_required"},
-    "agent": {"const": "claude-code"},
+    "agent": {"enum": ["claude-code", "opencode", "codex"]},
     "blocking": {"const": true},
     "target_identity": {"$ref": "#/$defs/sha256"},
     "projection": {"enum": ["workspace", "staged"]},
@@ -56,7 +56,7 @@
         "answer": {"enum": ["granted", "declined"]},
         "label": {"type": "string", "minLength": 1},
         "effect": {"type": "string", "minLength": 1},
-        "invocation": {"type": "string", "pattern": "^gentle-ai review start --contract gentle-ai\\.review-integration/v2 .* --agent claude-code .* --consent (granted|declined)$"}
+        "invocation": {"type": "string", "pattern": "^gentle-ai review start --contract gentle-ai\\.review-integration/v2 .+ --consent (granted|declined)$"}
       }
     },
     "choice_granted": {

--- a/contracts/review-integration/v2/schemas/gate-result.schema.json
+++ b/contracts/review-integration/v2/schemas/gate-result.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gentle-ai.dev/contracts/review-integration/v2/schemas/gate-result.schema.json",
+  "title": "Gentle AI review delivery gate result",
+  "description": "The gentle-ai.review-gate-result/v1 envelope every delivery gate (post-apply, pre-commit, pre-push, pre-pr, release) emits from review validate, including the negotiated review.validate transition. Derived from internal/cli/review.go's ReviewValidateResult and internal/reviewtransaction/receipt.go's GateContext.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "result", "allowed", "action", "reason", "context"],
+  "properties": {
+    "schema": {"const": "gentle-ai.review-gate-result/v1"},
+    "result": {"enum": ["allow", "scope-changed", "invalidated", "escalated"]},
+    "allowed": {"type": "boolean"},
+    "action": {"enum": ["continue", "explicit-maintainer-action", "review.status", "repository-policy"]},
+    "reason": {"type": "string"},
+    "context": {"$ref": "#/$defs/gate_context"},
+    "delivery": {"enum": ["receipt_governed", "disabled/unmanaged", "unmanaged", "candidate_declined/unmanaged"]},
+    "relation": {"enum": ["exact", "compatible_base_advance", "provable_contraction", "changed", "unrelated", "ambiguous", "unknown"]},
+    "next": {
+      "type": "object", "additionalProperties": false,
+      "required": ["reason_code"],
+      "properties": {
+        "transition": {"type": "string", "minLength": 1},
+        "reason_code": {"type": "string", "pattern": "^[a-z0-9_]+$"}
+      }
+    }
+  },
+  "allOf": [
+    {"if": {"properties": {"result": {"const": "allow"}}}, "then": {"properties": {"allowed": {"const": true}}}, "else": {"properties": {"allowed": {"const": false}}}}
+  ],
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "maybe_sha256": {"type": "string", "pattern": "^$|^sha256:[0-9a-f]{64}$"},
+    "maybe_git_object": {"type": "string", "pattern": "^$|^[0-9a-f]{40}([0-9a-f]{24})?$"},
+    "string_array_or_null": {
+      "oneOf": [
+        {"type": "array", "items": {"type": "string", "minLength": 1}},
+        {"type": "null"}
+      ]
+    },
+    "gate_context": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "gate", "lineage_id", "generation", "base_tree", "candidate_tree", "paths_digest",
+        "fix_delta_hash", "policy_hash", "ledger_hash", "evidence_hash", "base_relationship_valid"
+      ],
+      "properties": {
+        "gate": {"enum": ["", "post-apply", "pre-commit", "pre-push", "pre-pr", "release"]},
+        "lineage_id": {"type": "string", "maxLength": 128},
+        "generation": {"type": "integer", "minimum": 0},
+        "store_revision": {"$ref": "#/$defs/sha256"},
+        "genesis_revision": {"$ref": "#/$defs/sha256"},
+        "chain_identity": {"$ref": "#/$defs/sha256"},
+        "bundle_digest": {"$ref": "#/$defs/sha256"},
+        "base_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "candidate_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "paths_digest": {"$ref": "#/$defs/maybe_sha256"},
+        "fix_delta_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "policy_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "ledger_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "evidence_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "base_relationship_valid": {"type": "boolean"},
+        "external_evidence": {"enum": ["invalidating", "escalating"]},
+        "receipt_base_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "base_advanced_compatible": {"$ref": "#/$defs/base_advance_compatibility"},
+        "release": {"$ref": "#/$defs/release_evidence"},
+        "pre_pr_boundary": {"$ref": "#/$defs/pre_pr_boundary"},
+        "denial": {
+          "type": "object", "additionalProperties": false,
+          "required": ["stage", "code"],
+          "properties": {
+            "stage": {"type": "string", "minLength": 1},
+            "code": {"type": "string", "minLength": 1}
+          }
+        },
+        "scope_change": {"$ref": "#/$defs/scope_change"},
+        "base_mismatch": {
+          "type": "object", "additionalProperties": false,
+          "required": ["expected", "actual"],
+          "properties": {
+            "expected": {"type": "string"},
+            "actual": {"type": "string"}
+          }
+        }
+      }
+    },
+    "base_advance_compatibility": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "status", "compatible", "old_base_tree", "new_base_tree", "original_patch_identity",
+        "delivered_patch_identity", "delivered_paths_digest", "base_advance_paths_digest",
+        "paths_disjoint", "merged_result_tree", "ci_attestation_artifact_hash", "ci_attestation_issuer"
+      ],
+      "properties": {
+        "status": {"type": "string"},
+        "compatible": {"type": "boolean"},
+        "old_base_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "new_base_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "original_patch_identity": {"$ref": "#/$defs/maybe_sha256"},
+        "delivered_patch_identity": {"$ref": "#/$defs/maybe_sha256"},
+        "delivered_paths_digest": {"$ref": "#/$defs/maybe_sha256"},
+        "base_advance_paths_digest": {"$ref": "#/$defs/maybe_sha256"},
+        "paths_disjoint": {"type": "boolean"},
+        "merged_result_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "ci_attestation_artifact_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "ci_attestation_issuer": {"type": "string"}
+      }
+    },
+    "release_evidence": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "release_tree", "configuration_hash", "generated_artifact_hash", "provenance_hash",
+        "publication_boundary_hash", "publication_state", "evidence_freshness_hash", "evidence_freshness_state"
+      ],
+      "properties": {
+        "release_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "configuration_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "generated_artifact_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "provenance_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "publication_boundary_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "publication_state": {"enum": ["", "sealed"]},
+        "evidence_freshness_hash": {"$ref": "#/$defs/maybe_sha256"},
+        "evidence_freshness_state": {"enum": ["", "current"]}
+      }
+    },
+    "pre_pr_boundary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "selector", "commit", "merge_base"],
+      "properties": {
+        "source": {"type": "string", "minLength": 1},
+        "selector": {"type": "string"},
+        "commit": {"type": "string"},
+        "merge_base": {"type": "string"},
+        "remote": {"type": "string"},
+        "remote_ref": {"type": "string"},
+        "remote_identity": {"type": "string"}
+      }
+    },
+    "gate_target_evidence": {
+      "type": "object", "additionalProperties": false,
+      "required": ["base_tree", "candidate_tree", "paths_digest", "paths"],
+      "properties": {
+        "base_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "candidate_tree": {"$ref": "#/$defs/maybe_git_object"},
+        "paths_digest": {"$ref": "#/$defs/maybe_sha256"},
+        "paths": {"$ref": "#/$defs/string_array_or_null"}
+      }
+    },
+    "scope_change": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "expected", "actual", "differing_paths", "differing_path_count", "differing_paths_digest",
+        "predecessor_lineage_id", "predecessor_revision", "recovery_operation", "recovery_required_inputs"
+      ],
+      "properties": {
+        "expected": {"$ref": "#/$defs/gate_target_evidence"},
+        "actual": {"$ref": "#/$defs/gate_target_evidence"},
+        "differing_paths": {"$ref": "#/$defs/string_array_or_null"},
+        "differing_path_count": {"type": "integer", "minimum": 0},
+        "differing_paths_digest": {"$ref": "#/$defs/maybe_sha256"},
+        "predecessor_lineage_id": {"type": "string"},
+        "predecessor_revision": {"$ref": "#/$defs/maybe_sha256"},
+        "recovery_operation": {"type": "string"},
+        "recovery_required_inputs": {"$ref": "#/$defs/string_array_or_null"},
+        "recovery_scope": {"type": "string"},
+        "recovery_base_ref": {"type": "string"},
+        "recovery_derived_inputs": {"$ref": "#/$defs/string_array_or_null"}
+      }
+    }
+  }
+}

--- a/contracts/review-integration/v2/schemas/opencode-provider-role.schema.json
+++ b/contracts/review-integration/v2/schemas/opencode-provider-role.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gentle-ai.dev/contracts/review-integration/v2/schemas/opencode-provider-role.schema.json",
+  "title": "Gentle AI OpenCode transport provider-role capture acknowledgement",
+  "description": "The gentle-ai.opencode-review-provider-role/v1 envelope the OpenCode review transport returns after natively capturing one provider role result (refuter or targeted-validator). Derived from internal/cli/review_opencode_transport.go's openCodeProviderRoleResultEnvelope.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "role", "captured"],
+  "properties": {
+    "schema": {"const": "gentle-ai.opencode-review-provider-role/v1"},
+    "role": {"enum": ["refuter", "targeted-validator"]},
+    "captured": {"const": true}
+  }
+}

--- a/contracts/review-integration/v2/schemas/start.schema.json
+++ b/contracts/review-integration/v2/schemas/start.schema.json
@@ -66,8 +66,11 @@
         "capability": {"const": "review.opaque_repository_context"},
         "handle": {"type": "string", "pattern": "^rctx1_[0-9a-f]{64}$"},
         "revision": {"$ref": "#/$defs/sha256"},
-        "target_identity": {"$ref": "#/$defs/sha256"}
-      }
+        "target_identity": {"$ref": "#/$defs/sha256"},
+        "event_id": {"$ref": "#/$defs/sha256"},
+        "outcome": {"enum": ["applied", "pending", "blocked_conflict", "durability_limited"]}
+      },
+      "dependentRequired": {"event_id": ["outcome"], "outcome": ["event_id"]}
     }
   },
   "$defs": {

--- a/contracts/review-integration/v2/schemas/status-v5.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v5.schema.json
@@ -29,11 +29,25 @@
     "forecast": {"$ref": "#/$defs/forecast"},
     "next_transition": {"$ref": "#/$defs/next_transition"},
     "validation_request": {"$ref": "../../v1/schemas/targeted-validation-request.schema.json"},
-    "final_verification_retry": {"$ref": "../../v1/schemas/status-v2.schema.json#/properties/final_verification_retry"}
+    "final_verification_retry": {"$ref": "../../v1/schemas/status-v2.schema.json#/properties/final_verification_retry"},
+    "repository_context": {"$ref": "#/$defs/repository_context"}
   },
   "dependentRequired": {"forecast": ["next_transition"]},
   "$defs": {
     "sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "repository_context": {
+      "type": "object", "additionalProperties": false,
+      "required": ["capability", "handle", "revision", "target_identity"],
+      "properties": {
+        "capability": {"const": "review.opaque_repository_context"},
+        "handle": {"type": "string", "pattern": "^rctx1_[0-9a-f]{64}$"},
+        "revision": {"$ref": "#/$defs/sha256"},
+        "target_identity": {"$ref": "#/$defs/sha256"},
+        "event_id": {"$ref": "#/$defs/sha256"},
+        "outcome": {"enum": ["applied", "pending", "blocked_conflict", "durability_limited"]}
+      },
+      "dependentRequired": {"event_id": ["outcome"], "outcome": ["event_id"]}
+    },
     "forecast": {
       "type": "object", "additionalProperties": false, "required": ["horizon", "steps"],
       "properties": {
@@ -57,7 +71,11 @@
         {"if": {"properties": {"kind": {"const": "stop"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["execute"]}, {"required": ["collect"]}]}}},
         {"if": {"properties": {"reason_code": {"enum": ["correction_plan_required", "corrected_candidate_unavailable"]}}, "required": ["reason_code"]}, "then": {"required": ["correction_request"]}, "else": {"not": {"required": ["correction_request"]}}},
         {"if": {"properties": {"reason_code": {"const": "correction_plan_required"}}, "required": ["reason_code"]}, "then": {"properties": {"kind": {"const": "collect"}, "collect": {"properties": {"inputs": {"minItems": 1, "maxItems": 1, "items": {"properties": {"capture_operation": {"const": "external.plan_correction"}}, "required": ["capture_operation", "submission"]}}}}}}},
-        {"if": {"properties": {"reason_code": {"const": "targeted_validation_required"}}, "required": ["reason_code"]}, "then": {"properties": {"kind": {"const": "collect"}, "collect": {"properties": {"inputs": {"minItems": 1, "maxItems": 1, "items": {"properties": {"capture_operation": {"const": "external.run_targeted_validation"}}, "required": ["capture_operation", "submission"]}}}}}}},
+        {"if": {"properties": {"reason_code": {"const": "targeted_validation_required"}}, "required": ["reason_code"]}, "then": {"properties": {"kind": {"const": "collect"}, "collect": {"properties": {"inputs": {"minItems": 1, "maxItems": 1, "items": {"anyOf": [
+          {"properties": {"capture_operation": {"const": "external.run_targeted_validation"}}, "required": ["capture_operation", "submission"]},
+          {"properties": {"capture_operation": {"const": "external.run_provider_role"}}, "required": ["capture_operation", "provider_task"]},
+          {"properties": {"capture_operation": {"const": "review.capture-validation"}}, "required": ["capture_operation", "validation_request"]}
+        ]}}}}}}},
         {"if": {"properties": {"reason_code": {"enum": ["verification_evidence_required", "correction_repository_verification_required"]}}, "required": ["reason_code"]}, "then": {"properties": {"kind": {"const": "collect"}, "collect": {"properties": {"inputs": {"minItems": 1, "maxItems": 1, "items": {"properties": {"capture_operation": {"const": "review.capture-evidence"}}, "required": ["capture_operation", "submission"]}}}}}}}
       ]
     },
@@ -82,7 +100,9 @@
         "provider_task": {"$ref": "#/$defs/provider_task"}
       },
       "allOf": [
-        {"if": {"properties": {"capture_operation": {"const": "external.run_targeted_validation"}}, "required": ["capture_operation"]}, "then": {"required": ["validation_request", "submission"], "properties": {"schema": {"const": "gentle-ai.review-targeted-validation-request/v1"}}}, "else": {"not": {"required": ["validation_request"]}}},
+        {"if": {"properties": {"capture_operation": {"const": "external.run_targeted_validation"}}, "required": ["capture_operation"]}, "then": {"required": ["validation_request", "submission"], "properties": {"schema": {"const": "gentle-ai.review-targeted-validation-request/v1"}}}},
+        {"if": {"properties": {"capture_operation": {"const": "review.capture-validation"}}, "required": ["capture_operation"]}, "then": {"required": ["validation_request"]}},
+        {"if": {"properties": {"capture_operation": {"not": {"enum": ["external.run_targeted_validation", "review.capture-validation"]}}}, "required": ["capture_operation"]}, "then": {"not": {"required": ["validation_request"]}}},
         {"if": {"properties": {"capture_operation": {"const": "external.plan_correction"}}, "required": ["capture_operation"]}, "then": {"required": ["submission"], "properties": {"schema": {"const": "gentle-ai.review-correction-plan/v1"}}}},
         {"if": {"properties": {"capture_operation": {"const": "review.capture-evidence"}}, "required": ["capture_operation"]}, "then": {"required": ["submission"], "properties": {"schema": {"const": "https://gentle-ai.dev/schema/review/verification-evidence/v1"}, "submission": {"$ref": "#/$defs/capture_evidence_submission_descriptor"}}}},
         {"if": {"properties": {"capture_operation": {"not": {"enum": ["external.plan_correction", "external.run_targeted_validation", "review.capture-evidence"]}}}, "required": ["capture_operation"]}, "then": {"not": {"required": ["submission"]}}},

--- a/contracts/review-integration/v2/schemas/status-v5.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v5.schema.json
@@ -30,7 +30,17 @@
     "next_transition": {"$ref": "#/$defs/next_transition"},
     "validation_request": {"$ref": "../../v1/schemas/targeted-validation-request.schema.json"},
     "final_verification_retry": {"$ref": "../../v1/schemas/status-v2.schema.json#/properties/final_verification_retry"},
-    "repository_context": {"$ref": "#/$defs/repository_context"}
+    "repository_context": {"$ref": "#/$defs/repository_context"},
+    "disposition": {
+      "type": "object", "additionalProperties": false,
+      "required": ["plan_digest", "authority_inventory_revision"],
+      "properties": {
+        "plan_digest": {"$ref": "#/$defs/sha256"},
+        "authority_inventory_revision": {"$ref": "#/$defs/sha256"},
+        "seed_lineage_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "seed_expected_revision": {"$ref": "#/$defs/sha256"}
+      }
+    }
   },
   "dependentRequired": {"forecast": ["next_transition"]},
   "$defs": {

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -397,6 +397,17 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 	}
 }
 
+// reviewProviderRoleInputName renders the published collection-input name for
+// one provider role. Input names are contract identifiers, not role tokens:
+// the published transition_input schema (status-v5.schema.json) and gentle-pi's
+// runtime decoder both pin them to ^[a-z0-9_]+$, so the hyphen the
+// targeted-validator role token carries must project to an underscore here
+// (cross-lane battery finding; the completed-input echo already published
+// "provider_targeted_validator").
+func reviewProviderRoleInputName(role reviewProviderRole) string {
+	return "provider_" + strings.ReplaceAll(string(role), "-", "_")
+}
+
 func reviewProviderRoleTransition(reason string, binding ReviewTransitionBinding, role reviewProviderRole, runtime model.AgentID, validation *reviewtransaction.TargetedValidationRequest) ReviewNextTransition {
 	if reviewProviderHostRelayMaterializeRuntime(runtime) {
 		input, err := reviewProviderHostRelayRoleInput(binding, role, runtime, validation)
@@ -410,7 +421,7 @@ func reviewProviderRoleTransition(reason string, binding ReviewTransitionBinding
 		return reviewStopTransition("captured_artifacts_unverifiable")
 	}
 	return reviewCollectTransition(reason, ReviewTransitionInput{
-		Name: "provider_" + string(role), Schema: reviewProviderRoleTaskSchema(role), CaptureOperation: "external.run_provider_role",
+		Name: reviewProviderRoleInputName(role), Schema: reviewProviderRoleTaskSchema(role), CaptureOperation: "external.run_provider_role",
 		Arguments: append(reviewBindingArguments(binding),
 			ReviewTransitionArgument{Name: "repository-context", Value: binding.RepositoryContext},
 			ReviewTransitionArgument{Name: "agent", Value: string(model.AgentOpenCode)},
@@ -442,7 +453,7 @@ func reviewProviderHostRelayRoleInput(binding ReviewTransitionBinding, role revi
 	}
 	arguments := append(reviewBindingArguments(binding),
 		ReviewTransitionArgument{Name: "repository-context", Value: binding.RepositoryContext})
-	input := ReviewTransitionInput{Name: "provider_" + string(role)}
+	input := ReviewTransitionInput{Name: reviewProviderRoleInputName(role)}
 	switch role {
 	case reviewerprovider.RoleRefuter:
 		input.Schema, input.CaptureOperation = reviewRefuterSchemaID, reviewCaptureRefuterCaptureOperation

--- a/internal/cli/review_opencode_transport.go
+++ b/internal/cli/review_opencode_transport.go
@@ -358,6 +358,14 @@ func openCodeTransportStartBound(ctx context.Context, taskPrompt string) (openCo
 	return session, nil
 }
 
+// openCodeProviderRoleResultEnvelope renders the exact published
+// gentle-ai.opencode-review-provider-role/v1 envelope for a captured provider
+// role result. It is the single wording source for those bytes, so the
+// transport and the published-schema conformance test cannot drift apart.
+func openCodeProviderRoleResultEnvelope(role reviewProviderRole) string {
+	return `{"schema":"gentle-ai.opencode-review-provider-role/v1","role":"` + string(role) + `","captured":true}`
+}
+
 func openCodeTransportComplete(ctx context.Context, session openCodeTransportSession, envelope openCodeTransportEnvelope) (openCodeTransportEnvelope, error) {
 	if envelope.Error != "" {
 		return openCodeTransportEnvelope{}, openCodeTransportFailure("opencode_task_transport_failed")
@@ -381,7 +389,7 @@ func openCodeTransportComplete(ctx context.Context, session openCodeTransportSes
 		if err := openCodeTransportCaptureRole(ctx, session.root, store, record, session.binding.Role, hostOutput); err != nil {
 			return openCodeTransportEnvelope{}, openCodeTransportFailure("opencode_provider_role_result_refused")
 		}
-		output := `{"schema":"gentle-ai.opencode-review-provider-role/v1","role":"` + string(session.binding.Role) + `","captured":true}`
+		output := openCodeProviderRoleResultEnvelope(session.binding.Role)
 		return openCodeTransportEnvelope{Schema: openCodeReviewTransportSchema, Operation: "result", Output: &output}, nil
 	}
 	admitted, err := reviewProviderAdmitRaw(ctx, session.root, record.State, record.Revision, session.lensRequest.Frozen, session.lensRequest.Subject, hostOutput)

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -110,8 +110,11 @@ func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 		// which the schema did not admit; and targeted_validation_required also
 		// arrives as the provider-task (external.run_provider_role) and pi
 		// host-relay (review.capture-validation) shapes, which the schema
-		// rejected as missing the generic submission. Deliberate, not drift.
-		"schemas/status-v5.schema.json": "e0d7687c40c242d2d2c64690d3e9fb5c0ad88bcd18df2d7dd50702102149020c",
+		// rejected as missing the generic submission; and the negotiated-route
+		// disposition preview (ReviewRepairDispositionProviderInputs) is real
+		// optional emitter output the strict schema must admit. Deliberate,
+		// not drift.
+		"schemas/status-v5.schema.json": "5d5170d0c4be0977b640524c6ca9b119e42803a9e8409c43f0053c0c6fbd421e",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -79,8 +79,14 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		// Deliberate, not drift.
 		"fixtures/consent-v3.fixture.json":      "feb1dc7705f7da6490698ef48021bb7730de154ae23ec73d033d8d96fa996a21",
 		"schemas/capabilities-v2.1.schema.json": "9ede8ebbe3e169cf6ca4f4a6882c9c4e588a6d1073d8e22a155649cd41d38cd0",
-		"schemas/consent-v3.schema.json":        "80915f5f4f43a494826253d1e7251fc463989f41d2cf163a6a52a8b4328c023c",
-		"schemas/status.schema.json":            "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+		// Cross-lane battery conformance fix: the schema pinned the choice
+		// invocations to `--agent claude-code`, but the live emitter omits the
+		// agent token when the caller declared no runtime (the pinned fixture
+		// itself carries no --agent), and #2676 binds the declared runtime
+		// (claude-code, opencode, codex) when there is one. The schema now
+		// follows the emitter. Deliberate, not drift.
+		"schemas/consent-v3.schema.json": "2315f1ecda9e798344f0886434316a2cba69e9cc4c1a72eb436bd5fe44c25bb6",
+		"schemas/status.schema.json":     "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -98,7 +104,37 @@ func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/status-v5.fixture.json": "1a6d002c9691c87e50687f8d5f3e59013e9229d93004028f746bfcda7947d5fc",
-		"schemas/status-v5.schema.json":   "fac52b56d7ec927e3b7e0f41d5af2ea4c2a221e4912b0b4d4f70485d3bf2b60b",
+		// Cross-lane battery conformance fix: live negotiated STATUS publishes
+		// the top-level repository_context reference (review_status_contract.go's
+		// ReviewTargetStatusResult, populated since the recovered-units merges),
+		// which the schema did not admit; and targeted_validation_required also
+		// arrives as the provider-task (external.run_provider_role) and pi
+		// host-relay (review.capture-validation) shapes, which the schema
+		// rejected as missing the generic submission. Deliberate, not drift.
+		"schemas/status-v5.schema.json": "e0d7687c40c242d2d2c64690d3e9fb5c0ad88bcd18df2d7dd50702102149020c",
+	}
+	for name, expected := range want {
+		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		digest := sha256.Sum256(payload)
+		if actual := hex.EncodeToString(digest[:]); actual != expected {
+			t.Fatalf("%s digest = %s, want %s", name, actual, expected)
+		}
+	}
+}
+
+// TestReviewProviderArtifactConformanceSchemasArePinned pins the schemas the
+// cross-lane battery conformance work first published: the delivery gate
+// result (gentle-ai.review-gate-result/v1) and the OpenCode provider-role
+// capture acknowledgement (gentle-ai.opencode-review-provider-role/v1). Both
+// envelopes already shipped on the wire; only their published schemas are new.
+func TestReviewProviderArtifactConformanceSchemasArePinned(t *testing.T) {
+	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
+	want := map[string]string{
+		"schemas/gate-result.schema.json":            "38aa37bdea8bdc8ea664d888f7c7217beac7e34c43a95a3ed7d9354bf76709ed",
+		"schemas/opencode-provider-role.schema.json": "c6b9f216f89c044f8e844b55e7200114850cfbc16642bca0677f30a399d8aa9b",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -220,6 +256,8 @@ func TestReviewProviderArtifactSchemasAreStrictAndBound(t *testing.T) {
 		{name: "failure.schema.json", id: ReviewIntegrationFailureSchemaIDV2},
 		{name: "operation.schema.json", id: ReviewIntegrationOperationSchemaIDV2},
 		{name: "repair.schema.json", id: ReviewIntegrationRepairSchemaIDV2},
+		{name: "gate-result.schema.json", id: "https://gentle-ai.dev/contracts/review-integration/v2/schemas/gate-result.schema.json"},
+		{name: "opencode-provider-role.schema.json", id: "https://gentle-ai.dev/contracts/review-integration/v2/schemas/opencode-provider-role.schema.json"},
 	}
 	v2Documents := make(map[string]map[string]any, len(v2Schemas))
 	for _, tt := range v2Schemas {

--- a/internal/cli/review_provider_role_input_name_test.go
+++ b/internal/cli/review_provider_role_input_name_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestProviderRoleCollectInputNamesObeyPublishedPattern pins every provider
+// role collection input name to the published transition_input name pattern
+// (^[a-z0-9_]+$, status-v5.schema.json and gentle-pi's own decoder). The
+// battery found the targeted-validator slot publishing the raw hyphenated
+// role token, which no published consumer can admit.
+func TestProviderRoleCollectInputNamesObeyPublishedPattern(t *testing.T) {
+	t.Parallel()
+	pattern := regexp.MustCompile("^[a-z0-9_]+$")
+	binding := ReviewTransitionBinding{
+		LineageID:         "published-schema-role",
+		Revision:          "sha256:" + strings.Repeat("a", 64),
+		TargetIdentity:    "sha256:" + strings.Repeat("b", 64),
+		RepositoryContext: "rctx1_" + strings.Repeat("c", 64),
+	}
+
+	transition := reviewProviderRoleTransition("provider_refuter_required", binding, reviewerprovider.RoleTargetedValidator, model.AgentOpenCode, nil)
+	if transition.Kind != "collect" || transition.Collect == nil || len(transition.Collect.Inputs) != 1 {
+		t.Fatalf("targeted-validator transition = %#v", transition)
+	}
+	input := transition.Collect.Inputs[0]
+	if !pattern.MatchString(input.Name) {
+		t.Fatalf("targeted-validator collect input name %q violates the published ^[a-z0-9_]+$ pattern", input.Name)
+	}
+	if input.Name != "provider_targeted_validator" {
+		t.Fatalf("targeted-validator collect input name = %q, want provider_targeted_validator", input.Name)
+	}
+
+	refuter := reviewProviderRoleTransition("provider_refuter_required", binding, reviewerprovider.RoleRefuter, model.AgentOpenCode, nil)
+	if refuter.Collect == nil || len(refuter.Collect.Inputs) != 1 || refuter.Collect.Inputs[0].Name != "provider_refuter" {
+		t.Fatalf("refuter transition = %#v", refuter)
+	}
+
+	validation := &reviewtransaction.TargetedValidationRequest{RequestHash: "sha256:" + strings.Repeat("d", 64)}
+	relay, err := reviewProviderHostRelayRoleInput(binding, reviewerprovider.RoleTargetedValidator, model.AgentPi, validation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pattern.MatchString(relay.Name) || relay.Name != "provider_targeted_validator" {
+		t.Fatalf("host-relay targeted-validator input name = %q, want provider_targeted_validator", relay.Name)
+	}
+}

--- a/internal/cli/review_provider_test.go
+++ b/internal/cli/review_provider_test.go
@@ -273,13 +273,22 @@ func TestReviewProviderOpenCodeStatusIssuesBoundTargetedValidatorTask(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if input.Name != "provider_"+string(reviewerprovider.RoleTargetedValidator) || input.CaptureOperation != "external.run_provider_role" ||
+	if input.Name != "provider_targeted_validator" || input.CaptureOperation != "external.run_provider_role" ||
 		input.Submission != nil || input.ValidationRequest != nil || input.ProviderTask == nil ||
 		input.ProviderTask.Agent != "review-validator" || input.ProviderTask.Role != string(reviewerprovider.RoleTargetedValidator) ||
 		arguments["lineage"] != status.Authority.LineageID || arguments["expected-revision"] != status.Authority.Revision ||
 		arguments["target"] != request.CorrectionTargetIdentity || arguments["target"] != status.ValidationRequest.CorrectionTargetIdentity {
 		t.Fatalf("OpenCode targeted-validator task = %#v", input)
 	}
+	// The provider-task validator slot is one of the shapes the published
+	// status-v5 schema admits for targeted_validation_required (cross-lane
+	// battery finding: the schema used to force the generic
+	// external.run_targeted_validation submission shape onto this input).
+	transitionPayload, err := json.Marshal(status.NextTransition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateAgainstPublishedNextTransitionSchemaV5(t, transitionPayload)
 
 	cloneInput := func() (ReviewTargetStatusResult, *ReviewTransitionInput) {
 		malformed := status

--- a/internal/cli/review_published_schema_conformance_test.go
+++ b/internal/cli/review_published_schema_conformance_test.go
@@ -131,6 +131,44 @@ func TestNegotiatedStatusEnvelopeMatchesPublishedStatusSchemaV5(t *testing.T) {
 	validatePublishedReviewSchema(t, schema, output.Bytes())
 }
 
+// TestStatusDispositionProjectionMatchesPublishedStatusSchemaV5 ties the
+// emitter bytes of the negotiated-route disposition preview
+// (ReviewRepairDispositionProviderInputs, populated by STATUS when a closed
+// closure disposition plan derives) to the published status-v5 schema. Like
+// the top-level repository_context the battery caught, this optional
+// projection is real emitter output the strict schema must admit.
+func TestStatusDispositionProjectionMatchesPublishedStatusSchemaV5(t *testing.T) {
+	t.Parallel()
+	fixture, err := os.ReadFile(filepath.Join("..", "..", "contracts", "review-integration", "v2", "fixtures", "status-v5.fixture.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(fixture, &document); err != nil {
+		t.Fatal(err)
+	}
+	disposition, err := json.Marshal(ReviewRepairDispositionProviderInputs{
+		PlanDigest:                 "sha256:" + strings.Repeat("a", 64),
+		AuthorityInventoryRevision: "sha256:" + strings.Repeat("b", 64),
+		SeedLineageID:              "review-disposition-seed",
+		SeedExpectedRevision:       "sha256:" + strings.Repeat("c", 64),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dispositionDocument map[string]any
+	if err := json.Unmarshal(disposition, &dispositionDocument); err != nil {
+		t.Fatal(err)
+	}
+	document["disposition"] = dispositionDocument
+	payload, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := compileWholePublishedReviewSchema(t, "v2", "status-v5.schema.json")
+	validatePublishedReviewSchema(t, schema, payload)
+}
+
 // TestConsentFixtureMatchesPublishedConsentSchemaV3 compiles the published
 // consent-v3 schema against the pinned consent-v3 fixture — the exact live
 // bytes TestConsentQuestionMatchesVersionedFixture captures from the emitter.

--- a/internal/cli/review_published_schema_conformance_test.go
+++ b/internal/cli/review_published_schema_conformance_test.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// This file is the published-schema conformance suite for live envelopes: it
+// drives the real CLI (or the exact envelope constructors) and validates the
+// emitted bytes against the schemas published in contracts/review-integration/.
+// Every test here is the pin that keeps one emitter and its published schema
+// from drifting apart, the exact divergence class the cross-lane battery found.
+
+// compileWholePublishedReviewSchema compiles one published schema file with
+// every contract schema (v1 and v2) registered, so cross-file $refs resolve
+// exactly as an external consumer compiling the published artifacts would.
+func compileWholePublishedReviewSchema(t *testing.T, version, name string) *jsonschema.Schema {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", "contracts", "review-integration"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.UseRegexpEngine(reviewSchemaRegexpEngine)
+	for _, contractVersion := range []string{"v1", "v2"} {
+		paths, err := filepath.Glob(filepath.Join(root, contractVersion, "schemas", "*.schema.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range paths {
+			payload, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var document map[string]any
+			if err := json.Unmarshal(payload, &document); err != nil {
+				t.Fatal(err)
+			}
+			if err := compiler.AddResource(document["$id"].(string), document); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	schema, err := compiler.Compile("https://gentle-ai.dev/contracts/review-integration/" + version + "/schemas/" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+func validatePublishedReviewSchema(t *testing.T, schema *jsonschema.Schema, payload []byte) {
+	t.Helper()
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("live envelope diverges from its published schema: %v\nenvelope: %s", err, payload)
+	}
+}
+
+// TestNegotiatedStartEnvelopeMatchesPublishedStartSchemaV3 pins the whole live
+// negotiated START envelope to the published start/v3 schema. The battery
+// found the live emitter publishing repository_context.event_id and .outcome
+// (real, load-bearing fields validated by
+// validateReviewRepositoryContextReference) that the schema did not admit.
+func TestNegotiatedStartEnvelopeMatchesPublishedStartSchemaV3(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc conformance() {}\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
+		"--lineage", "published-schema-start",
+	}), &output); err != nil {
+		t.Fatal(err)
+	}
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	if started.Schema != ReviewIntegrationStartSchema {
+		t.Fatalf("negotiated START schema = %q, want %q", started.Schema, ReviewIntegrationStartSchema)
+	}
+	// The divergence needs the reconciled event identity present, so this
+	// test proves the live emitter really publishes it before validating.
+	if started.RepositoryContext == nil || started.RepositoryContext.EventID == "" || started.RepositoryContext.Outcome == "" {
+		t.Fatalf("negotiated START repository context carries no event identity: %#v", started.RepositoryContext)
+	}
+	schema := compileWholePublishedReviewSchema(t, "v2", "start.schema.json")
+	validatePublishedReviewSchema(t, schema, output.Bytes())
+}
+
+// TestNegotiatedStatusEnvelopeMatchesPublishedStatusSchemaV5 pins the whole
+// live negotiated STATUS envelope, including the top-level repository_context
+// reference the battery found missing from status-v5.schema.json.
+func TestNegotiatedStatusEnvelopeMatchesPublishedStatusSchemaV5(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc conformance() {}\n", 0o644)
+	runNegotiatedReviewStart(t, repo, "published-schema-status")
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentClaudeCode), "--next-transition",
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.Schema != ReviewIntegrationStatusSchemaV5 {
+		t.Fatalf("negotiated STATUS schema = %q, want %q", status.Schema, ReviewIntegrationStatusSchemaV5)
+	}
+	// The divergence needs the top-level repository context present, so this
+	// test proves the live emitter really publishes it before validating.
+	if status.RepositoryContext == nil {
+		t.Fatalf("negotiated STATUS carries no top-level repository context: %s", output.String())
+	}
+	schema := compileWholePublishedReviewSchema(t, "v2", "status-v5.schema.json")
+	validatePublishedReviewSchema(t, schema, output.Bytes())
+}
+
+// TestConsentFixtureMatchesPublishedConsentSchemaV3 compiles the published
+// consent-v3 schema against the pinned consent-v3 fixture — the exact live
+// bytes TestConsentQuestionMatchesVersionedFixture captures from the emitter.
+// The battery found the schema pinning `--agent claude-code` inside the choice
+// invocations while the emitter (and therefore the fixture) omits the agent
+// token whenever the caller declared no runtime.
+func TestConsentFixtureMatchesPublishedConsentSchemaV3(t *testing.T) {
+	t.Parallel()
+	payload, err := os.ReadFile(filepath.Join("..", "..", "contracts", "review-integration", "v2", "fixtures", "consent-v3.fixture.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var question ReviewIntegrationConsentResult
+	if err := json.Unmarshal(payload, &question); err != nil {
+		t.Fatal(err)
+	}
+	for _, choice := range question.Choices {
+		if strings.Contains(choice.Invocation, "--agent") {
+			t.Fatalf("fixture invocation unexpectedly declares a runtime agent: %q", choice.Invocation)
+		}
+	}
+	schema := compileWholePublishedReviewSchema(t, "v2", "consent-v3.schema.json")
+	validatePublishedReviewSchema(t, schema, payload)
+}
+
+// TestConsentEnvelopeWithDeclaredRuntimeMatchesPublishedConsentSchemaV3 drives
+// the live relay-declared START with each runtime the consent validator
+// accepts and validates the emitted envelope, so the published agent domain
+// covers every identity the emitter can actually publish (#2676).
+func TestConsentEnvelopeWithDeclaredRuntimeMatchesPublishedConsentSchemaV3(t *testing.T) {
+	schema := compileWholePublishedReviewSchema(t, "v2", "consent-v3.schema.json")
+	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
+		t.Run(string(agent), func(t *testing.T) {
+			reviewModeHome(t)
+			repo := initReviewCLIRepo(t)
+			stubReviewConsole(t, false, "")
+			writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+
+			output := runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+				"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
+				"--agent", string(agent),
+				"--lineage", "published-schema-consent", "--consent", "relay",
+			}))
+			question := decodeConsentQuestion(t, output.Bytes())
+			if question.Agent != string(agent) {
+				t.Fatalf("consent agent = %q, want %q", question.Agent, agent)
+			}
+			validatePublishedReviewSchema(t, schema, output.Bytes())
+		})
+	}
+}
+
+// TestReviewGateResultEnvelopeMatchesPublishedSchema walks one low-risk
+// lifecycle to its approved receipt, runs the delivery gate, and validates the
+// emitted gentle-ai.review-gate-result/v1 envelope against its published
+// schema — the envelope the battery found had no published schema at all.
+func TestReviewGateResultEnvelopeMatchesPublishedSchema(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	// Compiled before the printed-command execution below changes the working
+	// directory, because the contracts/ tree is addressed repo-relative.
+	schema := compileWholePublishedReviewSchema(t, "v2", "gate-result.schema.json")
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/guide.md", "# Guide\n\npurely passive documentation\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
+		"--lineage", "published-schema-gate",
+	}), &output); err != nil {
+		t.Fatal(err)
+	}
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	if started.RiskLevel != reviewtransaction.RiskLow || started.LensesRequired {
+		t.Fatalf("low candidate start = risk %q lenses_required %v", started.RiskLevel, started.LensesRequired)
+	}
+
+	output.Reset()
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentClaudeCode), "--next-transition",
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.finalize" {
+		t.Fatalf("next transition = %#v", status.NextTransition)
+	}
+	words := reviewShellWords(t, status.NextTransition.Execute.Command)
+	if len(words) < 3 || words[0] != "gentle-ai" || words[1] != "review" {
+		t.Fatalf("finalize command = %q", status.NextTransition.Execute.Command)
+	}
+	// The provider-rendered finalize command runs from the repository it was
+	// issued for, exactly as the negotiated protocol prescribes.
+	t.Chdir(repo)
+	output.Reset()
+	if err := RunReview(words[2:], &output); err != nil {
+		t.Fatalf("finalize: %v\n%s", err, output.String())
+	}
+
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output); err != nil {
+		t.Fatalf("post-apply gate: %v\n%s", err, output.String())
+	}
+	assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
+	var gate ReviewValidateResult
+	decodeStrictReviewJSON(t, output.Bytes(), &gate)
+	if gate.Schema != ReviewValidateSchema {
+		t.Fatalf("gate result schema = %q, want %q", gate.Schema, ReviewValidateSchema)
+	}
+	validatePublishedReviewSchema(t, schema, output.Bytes())
+}
+
+// TestOpenCodeProviderRoleEnvelopeMatchesPublishedSchema validates the exact
+// bytes the OpenCode transport publishes for a captured provider role result
+// against its published schema — the second envelope the battery found had no
+// published schema.
+func TestOpenCodeProviderRoleEnvelopeMatchesPublishedSchema(t *testing.T) {
+	t.Parallel()
+	schema := compileWholePublishedReviewSchema(t, "v2", "opencode-provider-role.schema.json")
+	for _, role := range []reviewerprovider.Role{reviewerprovider.RoleRefuter, reviewerprovider.RoleTargetedValidator} {
+		payload := openCodeProviderRoleResultEnvelope(role)
+		var decoded struct {
+			Schema   string `json:"schema"`
+			Role     string `json:"role"`
+			Captured bool   `json:"captured"`
+		}
+		if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+			t.Fatal(err)
+		}
+		if decoded.Schema != "gentle-ai.opencode-review-provider-role/v1" || decoded.Role != string(role) || !decoded.Captured {
+			t.Fatalf("provider role envelope = %s", payload)
+		}
+		validatePublishedReviewSchema(t, schema, []byte(payload))
+	}
+}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -877,7 +877,7 @@ func validateReviewProviderTaskInput(input ReviewTransitionInput, arguments map[
 
 func (result ReviewTargetStatusResult) validateTargetedValidatorProviderTaskInput(input ReviewTransitionInput) error {
 	if result.Schema != ReviewIntegrationStatusSchemaV5 || result.Authority == nil || result.ValidationRequest == nil ||
-		input.Name != "provider_"+string(reviewerprovider.RoleTargetedValidator) || input.ProviderTask == nil ||
+		input.Name != reviewProviderRoleInputName(reviewerprovider.RoleTargetedValidator) || input.ProviderTask == nil ||
 		input.ProviderTask.Role != string(reviewerprovider.RoleTargetedValidator) || input.Submission != nil {
 		return errors.New("targeted validator provider task is not bound to the correction authority") // refusal:by-design world-action: only Go may issue a targeted validator task for the current correction authority
 	}

--- a/internal/reviewtransaction/verification_evidence.go
+++ b/internal/reviewtransaction/verification_evidence.go
@@ -86,7 +86,12 @@ func NewVerificationEvidenceRecord(lineageID, authorityRevision string, target S
 		Schema: VerificationEvidenceRecordSchema, Version: VerificationEvidenceRecordVersion,
 		LineageID: lineageID, AuthorityRevision: authorityRevision, TargetIdentity: target.Identity,
 		CandidateTree: target.CandidateTree, PathsDigest: target.PathsDigest,
-		Paths: append([]string(nil), target.Paths...), LedgerIDs: append([]string(nil), target.LedgerIDs...),
+		// LedgerIDs stays a JSON array even on the clean path (no correction,
+		// so no ledger): the published verification-evidence/v2 schema types
+		// it as an array, and a nil slice here marshaled as `null` (cross-lane
+		// battery finding). Records persisted by older binaries keep parsing:
+		// their canonical bytes round-trip through the nil slice unchanged.
+		Paths: append([]string(nil), target.Paths...), LedgerIDs: append([]string{}, target.LedgerIDs...),
 		RawPayloadSHA256: finalVerificationPayloadDigest(payload), RawPayloadBytes: int64(len(payload)), Outcome: outcome,
 	}
 	record.RecordDigest = verificationEvidenceRecordDigest(record)

--- a/internal/reviewtransaction/verification_evidence.go
+++ b/internal/reviewtransaction/verification_evidence.go
@@ -89,8 +89,13 @@ func NewVerificationEvidenceRecord(lineageID, authorityRevision string, target S
 		// LedgerIDs stays a JSON array even on the clean path (no correction,
 		// so no ledger): the published verification-evidence/v2 schema types
 		// it as an array, and a nil slice here marshaled as `null` (cross-lane
-		// battery finding). Records persisted by older binaries keep parsing:
-		// their canonical bytes round-trip through the nil slice unchanged.
+		// battery finding). This also shifts the record DIGEST domain: a
+		// ledger-free record now canonicalizes as `"ledger_ids":[]`, so this
+		// binary's digest for the same logical record differs from the
+		// null-form digest an older binary produced. That is safe because
+		// each digest validates over its OWN record's persisted canonical
+		// bytes: legacy null-form records round-trip byte-identical through
+		// the nil slice and keep their original digests.
 		Paths: append([]string(nil), target.Paths...), LedgerIDs: append([]string{}, target.LedgerIDs...),
 		RawPayloadSHA256: finalVerificationPayloadDigest(payload), RawPayloadBytes: int64(len(payload)), Outcome: outcome,
 	}

--- a/internal/reviewtransaction/verification_evidence_encoding_test.go
+++ b/internal/reviewtransaction/verification_evidence_encoding_test.go
@@ -1,0 +1,106 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// newLedgerFreeEvidenceSnapshot builds a valid frozen snapshot whose target
+// carries no correction ledger — the ordinary clean-path candidate every
+// non-corrected review captures final verification evidence for.
+func newLedgerFreeEvidenceSnapshot(t *testing.T) Snapshot {
+	t.Helper()
+	snapshot := Snapshot{
+		Kind:                   TargetCurrentChanges,
+		BaseTree:               strings.Repeat("1", 40),
+		CandidateTree:          strings.Repeat("2", 40),
+		Paths:                  []string{"docs/guide.md"},
+		IntendedUntracked:      []string{},
+		IntendedUntrackedProof: hashCanonical("gentle-ai.intended-untracked/v1"),
+	}
+	snapshot.PathsDigest = digestPaths(snapshot.Paths)
+	snapshot.Identity = snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree,
+		snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+	return snapshot
+}
+
+// TestVerificationEvidenceRecordEncodesLedgerFreeCleanPathAsEmptyArray is the
+// RED-first proof for the cross-lane battery's verification-evidence finding:
+// the published gentle-ai.review-verification-evidence/v2 schema requires
+// ledger_ids to be an array, but the clean-path emitter (no correction, so no
+// ledger) marshaled the nil slice as `"ledger_ids":null`.
+func TestVerificationEvidenceRecordEncodesLedgerFreeCleanPathAsEmptyArray(t *testing.T) {
+	t.Parallel()
+	snapshot := newLedgerFreeEvidenceSnapshot(t)
+	record, err := NewVerificationEvidenceRecord("clean-path-lineage", "sha256:"+strings.Repeat("a", 64),
+		snapshot, []byte("go test ./...: pass\n"), VerificationOutcomePassed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := CanonicalVerificationEvidenceRecord(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(payload, []byte(`"ledger_ids":null`)) {
+		t.Fatalf("clean-path evidence record encodes ledger_ids as null, the published schema requires an array:\n%s", payload)
+	}
+	if !bytes.Contains(payload, []byte(`"ledger_ids":[]`)) {
+		t.Fatalf("clean-path evidence record does not encode ledger_ids as the empty array:\n%s", payload)
+	}
+	// A record captured with a correction ledger keeps its exact IDs.
+	ledgered := snapshot
+	ledgered.LedgerIDs = []string{"ledger-1"}
+	ledgered.Identity = snapshotIdentityForProjection(ledgered.Kind, ledgered.Projection, ledgered.BaseTree,
+		ledgered.CandidateTree, ledgered.PathsDigest, ledgered.IntendedUntrackedProof, ledgered.IntendedUntracked, ledgered.LedgerIDs)
+	withLedger, err := NewVerificationEvidenceRecord("clean-path-lineage", "sha256:"+strings.Repeat("a", 64),
+		ledgered, []byte("go test ./...: pass\n"), VerificationOutcomePassed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgeredPayload, err := CanonicalVerificationEvidenceRecord(withLedger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(ledgeredPayload, []byte(`"ledger_ids":["ledger-1"]`)) {
+		t.Fatalf("ledgered evidence record lost its ledger IDs:\n%s", ledgeredPayload)
+	}
+}
+
+// TestVerificationEvidenceRecordWithNullLedgerHistoryStaysReadable pins the
+// compatibility half of the fix: records persisted by an older binary encoded
+// the missing ledger as `null`, and those immutable bytes must keep parsing
+// (canonical-form validation re-marshals the decoded record, so the historical
+// null round-trips through the nil slice unchanged).
+func TestVerificationEvidenceRecordWithNullLedgerHistoryStaysReadable(t *testing.T) {
+	t.Parallel()
+	snapshot := newLedgerFreeEvidenceSnapshot(t)
+	record, err := NewVerificationEvidenceRecord("clean-path-lineage", "sha256:"+strings.Repeat("a", 64),
+		snapshot, []byte("go test ./...: pass\n"), VerificationOutcomePassed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := CanonicalVerificationEvidenceRecord(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	historical := bytes.Replace(payload, []byte(`"ledger_ids":[]`), []byte(`"ledger_ids":null`), 1)
+	if bytes.Equal(historical, payload) {
+		t.Fatal("historical payload substitution did not apply")
+	}
+	// The digest domain is the marshaled record, so the historical bytes carry
+	// the digest an older binary computed over the null encoding.
+	legacy := record
+	legacy.LedgerIDs = nil
+	legacy.RecordDigest = verificationEvidenceRecordDigest(legacy)
+	historical = bytes.Replace(historical,
+		[]byte(`"record_digest":"`+record.RecordDigest+`"`),
+		[]byte(`"record_digest":"`+legacy.RecordDigest+`"`), 1)
+	parsed, err := ParseVerificationEvidenceRecord(historical)
+	if err != nil {
+		t.Fatalf("historical null-ledger record no longer parses: %v\n%s", err, historical)
+	}
+	if parsed.LedgerIDs != nil {
+		t.Fatalf("historical record decoded ledger IDs = %#v, want nil", parsed.LedgerIDs)
+	}
+}

--- a/internal/reviewtransaction/verification_evidence_encoding_test.go
+++ b/internal/reviewtransaction/verification_evidence_encoding_test.go
@@ -2,6 +2,8 @@ package reviewtransaction
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -102,5 +104,48 @@ func TestVerificationEvidenceRecordWithNullLedgerHistoryStaysReadable(t *testing
 	}
 	if parsed.LedgerIDs != nil {
 		t.Fatalf("historical record decoded ledger IDs = %#v, want nil", parsed.LedgerIDs)
+	}
+}
+
+// TestVerificationEvidenceDigestDomainIsPinnedToEachRecordsOwnEncoding pins
+// the documented digest-domain shift: the same logical ledger-free record
+// digests differently under the historical `null` encoding and the published
+// `[]` encoding, and the digest-keyed evidence store accepts each form
+// validated against its own persisted canonical bytes, never the other's.
+func TestVerificationEvidenceDigestDomainIsPinnedToEachRecordsOwnEncoding(t *testing.T) {
+	t.Parallel()
+	snapshot, revision := newLedgerFreeEvidenceSnapshot(t), "sha256:"+strings.Repeat("a", 64)
+	lineage, payload := "clean-path-lineage", []byte("go test ./...: pass\n")
+	newStore, legacyStore := t.TempDir(), t.TempDir()
+	captured, err := PublishCapturedVerificationEvidence(CaptureVerificationEvidenceRequest{
+		StoreDir: newStore, LineageID: lineage, AuthorityRevision: revision,
+		Target: snapshot, Payload: payload, Outcome: VerificationOutcomePassed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := captured.Record
+	legacy.LedgerIDs = nil
+	legacy.RecordDigest = verificationEvidenceRecordDigest(legacy)
+	if legacy.RecordDigest == captured.Record.RecordDigest {
+		t.Fatal("digest domain shift: null and empty-array encodings must digest differently")
+	}
+	legacyBytes, err := CanonicalVerificationEvidenceRecord(legacy)
+	if err != nil || !bytes.Contains(legacyBytes, []byte(`"ledger_ids":null`)) {
+		t.Fatalf("null-form record does not validate against its own digest: %v\n%s", err, legacyBytes)
+	}
+	dir, err := compactFinalEvidenceCandidateDir(legacyStore, revision, snapshot.Identity)
+	if err != nil || os.MkdirAll(dir, 0o700) != nil {
+		t.Fatal(err)
+	}
+	if os.WriteFile(filepath.Join(dir, CompactFinalEvidenceFile), payload, 0o600) != nil ||
+		os.WriteFile(filepath.Join(dir, CompactFinalEvidenceRecordFile), legacyBytes, 0o600) != nil {
+		t.Fatal("write legacy evidence artifacts")
+	}
+	for storeDir, digest := range map[string]string{newStore: captured.Record.RecordDigest, legacyStore: legacy.RecordDigest} {
+		loaded, err := ReadCapturedVerificationEvidence(storeDir, lineage, revision, snapshot)
+		if err != nil || loaded.Record.RecordDigest != digest {
+			t.Fatalf("evidence store read = %#v, %v; want record digest %s", loaded.Record, err, digest)
+		}
 	}
 }


### PR DESCRIPTION
Closes #3346.

## What

Schema-emitter conformance across the review contract surface (emitter authoritative where the field is real; emitter fixed where the schema was right):

- status/v5: top-level `repository_context`, anyOf for the live targeted-validation submission shapes, `disposition` preview admitted.
- start/v3: `repository_context.event_id`/`outcome` (dependent pair).
- consent-v3: `--agent` invocation pin dropped (emitter omits it); `agent` widened to the enum Validate() accepts.
- Emitter fixes (RED-first): collect input renamed `provider_targeted_validator` (the hyphen violated the schema's own pattern; gentle-pi's decoder rejects hyphens; single projection helper for both provider paths), `ledger_ids` emits `[]` on the clean path (legacy null-form records keep parsing byte-identically; digest-domain shift documented and dual-acceptance PINNED per review correction, all digest consumers audited within-form).
- New published schemas: `gate-result.schema.json`, `opencode-provider-role.schema.json` (emitter extracted so bytes and schema share one source); hash pins updated per the documented flow.
- New live-envelope conformance suite driving the real CLI and validating whole stdout envelopes against compiled published schemas.

## RDD

Lineage `review-2706fc99dd040ddf` (high, 4R): two CRITICAL findings on the digest-domain consequence, one bounded correction (54/200), targeted validator PASS, state **approved**, pre-pr gate `allow`.

## Verification

Full `go test ./...` green; vets clean; bench green; ratchet clean; battery schema lane 10/10 (25 envelopes).

## Size exception

One reviewed unit under an approved receipt; the bulk is the conformance suite and two new schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenCode and Codex consent workflows alongside Claude Code.
  - Added published schemas for review gate results and OpenCode provider-role acknowledgements.
  - Expanded review status data with repository context, disposition details, and validation retry support.

- **Bug Fixes**
  - Standardized provider-role input names for reliable validation.
  - Verification evidence without ledger IDs now serializes as `[]` instead of `null`, while preserving legacy records.

- **Tests**
  - Added comprehensive conformance coverage for review envelopes, schemas, provider-role workflows, and legacy evidence compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->