### PR TITLE
fix(review): name retry-safe causes in gate receipt discovery

### DIFF
--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -872,6 +872,22 @@ func reviewGateContentionError(evaluation reviewtransaction.NativeGateEvaluation
 	)
 }
 
+// reviewRetrySafeDenialAction overrides the result-derived gate action for
+// the two retry-safe receipt-discovery denials (issue #3342). Both stay
+// denied (allowed=false), but their action is "retry": the reason already
+// names the runnable continuation, and routing either to
+// explicit-maintainer-action escalated conditions that clear themselves.
+func reviewRetrySafeDenialAction(denial *reviewtransaction.GateDenial) string {
+	if denial == nil || denial.Stage != "receipt-discovery" {
+		return ""
+	}
+	switch ReviewReceiptDiscoveryKind(denial.Code) {
+	case ReviewGateRemoteFetchRequired, ReviewAuthorityInventoryBusy:
+		return "retry"
+	}
+	return ""
+}
+
 func reviewGateAction(result reviewtransaction.GateResult) string {
 	switch result {
 	case reviewtransaction.GateAllow:

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -264,6 +264,10 @@ const (
 	// recorded holder, and the retry continuation, never maintainer
 	// escalation for a condition that clears itself.
 	ReviewAuthorityInventoryBusy ReviewReceiptDiscoveryKind = "inventory_busy"
+	// ReviewAuthorityLockUnverifiable names shared store-lock residue whose
+	// recorded holder is neither flock-held nor verifiably dead on this
+	// host; no event terminates a retry, so it is NOT retry-safe.
+	ReviewAuthorityLockUnverifiable ReviewReceiptDiscoveryKind = "lock_holder_unverifiable"
 )
 
 type ReviewReceiptDiscoveryError struct {
@@ -351,6 +355,8 @@ func (err *ReviewReceiptDiscoveryError) Error() string {
 		message = "advertised publication base commit is not available locally"
 	case ReviewAuthorityInventoryBusy:
 		message = "review authority store is busy"
+	case ReviewAuthorityLockUnverifiable:
+		message = "review authority store lock records a holder this host cannot verify"
 	}
 	if err.Detail != "" {
 		return message + ": " + err.Detail
@@ -3737,11 +3743,9 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 		receipt, parseErr := reviewtransaction.ParseCompactReceipt(payload)
 		derived, deriveErr := record.State.Receipt()
 		if parseErr != nil || deriveErr != nil || !reviewtransaction.CompactReceiptEqual(receipt, derived) {
-			if parseErr != nil {
-				if busy := reviewInventoryBusyFromStoreRead(ctx, repo, parseErr); busy != nil {
-					return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, busy
-				}
-			}
+			// A receipt that EXISTS but fails to parse or match is integrity
+			// damage: a held shared lock never downgrades it to busy; only
+			// the clean absence/read-race windows above may.
 			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 		}
 		terminalCount++
@@ -4110,7 +4114,28 @@ func reviewInventoryBusyFromLockResidue(ctx context.Context, repo string, report
 	if err != nil || !evidence.Exists || (!evidence.Held && !evidence.HolderRecorded) {
 		return nil
 	}
+	if !evidence.Held && !evidence.HolderVerifiedDeadOnThisHost {
+		return reviewLockHolderUnverifiableError(evidence)
+	}
 	return reviewInventoryBusyError(ctx, repo, &evidence)
+}
+
+// reviewLockHolderUnverifiableError renders the not-retry-safe disposition
+// for lock residue whose recorded holder this host can neither prove live
+// (kernel advisory ownership is the only liveness truth, and the flock is
+// not held) nor prove dead: "retry once it finishes" would never terminate.
+func reviewLockHolderUnverifiableError(evidence reviewtransaction.CompactSharedStoreLockEvidence) *ReviewReceiptDiscoveryError {
+	why := fmt.Sprintf("pid %d cannot be attributed to a live review operation from this host", evidence.HolderPID)
+	if host, err := os.Hostname(); err == nil && host != evidence.HolderHost {
+		why = fmt.Sprintf("it was recorded on host %s, not this host (%s)", evidence.HolderHost, host)
+	}
+	return &ReviewReceiptDiscoveryError{
+		Kind: ReviewAuthorityLockUnverifiable,
+		Detail: fmt.Sprintf(
+			"the store lock %s under the repository Git common directory records holder pid %d on host %s, which is neither flock-held nor verifiably dead: %s; verify that holder on the recorded host, or remove the LOCK file only if that machine is known idle",
+			evidence.DisplayPath, evidence.HolderPID, evidence.HolderHost, why,
+		),
+	}
 }
 
 // reviewInventoryBusyError renders the inventory_busy denial. The reason
@@ -4142,11 +4167,6 @@ func reviewInventoryBusyError(ctx context.Context, repo string, evidence *review
 			detail = fmt.Sprintf(
 				"the store lock %s under the repository Git common directory records holder pid %d, which is no longer running on this host; remove the stale LOCK file, then retry the same gate",
 				evidence.DisplayPath, evidence.HolderPID,
-			)
-		case evidence.HolderRecorded:
-			detail = fmt.Sprintf(
-				"the store lock %s under the repository Git common directory records holder pid %d on host %s; retry once that operation finishes",
-				evidence.DisplayPath, evidence.HolderPID, evidence.HolderHost,
 			)
 		}
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -248,6 +248,22 @@ const (
 	// unmanaged-while-disabled classification with a missing, scope-changed,
 	// or unrelated receipt.
 	ReviewReceiptTargetUnresolvable ReviewReceiptDiscoveryKind = "target_unresolvable"
+	// ReviewGateRemoteFetchRequired (issue #3342) names the one assessment
+	// failure class the local repository resolves by itself: every unknown
+	// assessment failed because the advertised publication tip is not in the
+	// local object store. The authority store is healthy; `git fetch
+	// <remote>` followed by the identical gate resolves it. The gate stays
+	// denied (fail-closed), but the denial is retry-safe, never maintainer
+	// escalation.
+	ReviewGateRemoteFetchRequired ReviewReceiptDiscoveryKind = "remote_fetch_required"
+	// ReviewAuthorityInventoryBusy (issue #3342) names transient shared-store
+	// coordination instead of damage: the shared compact store lock is held
+	// by a live concurrent review operation, a store read lost a bounded lock
+	// wait, or the lock file carries readable interrupted-holder residue. The
+	// gate stays denied (fail-closed), but the denial names the lock, its
+	// recorded holder, and the retry continuation, never maintainer
+	// escalation for a condition that clears itself.
+	ReviewAuthorityInventoryBusy ReviewReceiptDiscoveryKind = "inventory_busy"
 )
 
 type ReviewReceiptDiscoveryError struct {
@@ -331,6 +347,10 @@ func (err *ReviewReceiptDiscoveryError) Error() string {
 		message = "complete review authority inventory is unavailable or corrupted"
 	case ReviewReceiptTargetUnresolvable:
 		message = "review gate target could not be resolved"
+	case ReviewGateRemoteFetchRequired:
+		message = "advertised publication base commit is not available locally"
+	case ReviewAuthorityInventoryBusy:
+		message = "review authority store is busy"
 	}
 	if err.Detail != "" {
 		return message + ": " + err.Detail
@@ -3614,6 +3634,11 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	}
 	report, err := reviewtransaction.InventoryAuthority(ctx, repo)
 	if (err != nil || !report.Complete || !report.Authoritative) && !reviewAuthorityCorruptionConfinedToLegacyEntries(report, err) {
+		// issue #3342: an inventory whose only completeness breakers are
+		// readable shared-lock residue is coordination evidence, not damage.
+		if busy := reviewInventoryBusyFromLockResidue(ctx, repo, report, err); busy != nil {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, busy
+		}
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{
 			Kind: ReviewAuthorityCorrupted, Category: reviewAuthorityCauseCategory(report, err),
 			Detail: reviewAuthorityCorruptionDetail(ctx, repo),
@@ -3621,6 +3646,9 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	}
 	stores, err := reviewtransaction.CompactAuthorityLeaves(ctx, repo)
 	if err != nil {
+		if busy := reviewInventoryBusyFromStoreRead(ctx, repo, err); busy != nil {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, busy
+		}
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{
 			Kind: ReviewAuthorityCorrupted, Category: "record_or_graph_invalid",
 			Detail: reviewAuthorityCorruptionDetail(ctx, repo),
@@ -3635,7 +3663,15 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	exact := []candidate{}
 	scopeChanged := []candidate{}
 	scopeWithoutContext := []string{}
-	assessmentUnknown := []string{}
+	// assessmentUnknown keeps each lineage's underlying assessment failure
+	// (issue #3342): when every unknown assessment shares one recognized
+	// retry-safe cause class, the fail-closed exit below names that class and
+	// its runnable continuation instead of collapsing into corruption.
+	type unknownAssessment struct {
+		lineage string
+		cause   error
+	}
+	assessmentUnknown := []unknownAssessment{}
 	// deliveryShape collects receipts whose assessment failed only on the
 	// deterministic pre-push one-commit delivery rule: a typed statement about
 	// candidate shape versus the reviewed receipt, made over an inventory the
@@ -3679,6 +3715,9 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	for _, store := range stores {
 		record, loadErr := store.Load()
 		if loadErr != nil {
+			if busy := reviewInventoryBusyFromStoreRead(ctx, repo, loadErr); busy != nil {
+				return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, busy
+			}
 			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 		}
 		if !facadeTerminalState(record.State.State) {
@@ -3686,11 +3725,23 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 		}
 		payload, readErr := os.ReadFile(store.ReceiptPath())
 		if readErr != nil {
+			// issue #3342 occurrence 1: a terminal record whose receipt is
+			// not yet published is the concurrent writer's own window while
+			// the shared store lock is held; without a live holder it stays
+			// the fail-closed corruption verdict.
+			if busy := reviewInventoryBusyFromStoreRead(ctx, repo, readErr); busy != nil {
+				return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, busy
+			}
 			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 		}
 		receipt, parseErr := reviewtransaction.ParseCompactReceipt(payload)
 		derived, deriveErr := record.State.Receipt()
 		if parseErr != nil || deriveErr != nil || !reviewtransaction.CompactReceiptEqual(receipt, derived) {
+			if parseErr != nil {
+				if busy := reviewInventoryBusyFromStoreRead(ctx, repo, parseErr); busy != nil {
+					return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, busy
+				}
+			}
 			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 		}
 		terminalCount++
@@ -3777,7 +3828,7 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 				})
 				continue
 			}
-			assessmentUnknown = append(assessmentUnknown, record.State.LineageID)
+			assessmentUnknown = append(assessmentUnknown, unknownAssessment{lineage: record.State.LineageID, cause: assessErr})
 			continue
 		}
 		switch assessment.Applicability {
@@ -3826,7 +3877,9 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 		for index := range deliveryShape {
 			lineages = append(lineages, deliveryShape[index].lineage)
 		}
-		lineages = append(lineages, assessmentUnknown...)
+		for _, unknown := range assessmentUnknown {
+			lineages = append(lineages, unknown.lineage)
+		}
 		for _, failure := range targetResolution {
 			lineages = append(lineages, failure.lineage)
 		}
@@ -3856,6 +3909,19 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 		}
 	}
 	if len(scopeWithoutContext) > 0 || len(assessmentUnknown) > 0 {
+		// issue #3342: when EVERY unknown assessment shares one recognized
+		// retry-safe cause class, the denial names that class and its
+		// runnable continuation. Mixed or unrecognized causes keep the exact
+		// fail-closed corruption verdict below.
+		if len(scopeWithoutContext) == 0 {
+			causes := make([]error, len(assessmentUnknown))
+			for index := range assessmentUnknown {
+				causes[index] = assessmentUnknown[index].cause
+			}
+			if retrySafe := reviewRetrySafeUnknownAssessments(ctx, repo, causes); retrySafe != nil {
+				return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, retrySafe
+			}
+		}
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 	}
 	if len(targetResolution) == terminalCount {
@@ -3940,6 +4006,151 @@ func reviewAuthorityCauseCategory(report reviewtransaction.AuthorityStatusReport
 		}
 	}
 	return "inventory_incomplete"
+}
+
+// reviewLockContentionCause reports whether cause is one of the typed
+// shared-store coordination refusals a store read produces under a held lock
+// (issue #3342): the non-blocking acquisition sentinel or an exhausted
+// bounded lock wait. Both prove nothing about the store's content.
+func reviewLockContentionCause(cause error) bool {
+	var lockTimeout *reviewtransaction.AuthorityLockTimeoutError
+	return errors.Is(cause, reviewtransaction.ErrStoreLockContended) || errors.As(cause, &lockTimeout)
+}
+
+// reviewRetrySafeUnknownAssessments classifies the fail-closed unknown-
+// assessment exit of discoverCompactFacadeGateReview (issue #3342). It
+// answers non-nil only when EVERY unknown assessment failed with the SAME
+// recognized retry-safe cause class:
+//
+//   - fetch staleness: every assessment failed because the advertised
+//     publication tip is absent from the local object store
+//     (GateRemoteFetchRequiredError). The continuation is `git fetch
+//     <remote>`, then the identical gate.
+//   - lock contention: every assessment lost shared-store coordination. The
+//     continuation is retrying once the concurrent operation finishes.
+//
+// Mixed or unrecognized causes answer nil, keeping the caller's exact
+// authority_corrupted verdict.
+func reviewRetrySafeUnknownAssessments(ctx context.Context, repo string, causes []error) *ReviewReceiptDiscoveryError {
+	fetchStale, contended, remote := 0, 0, ""
+	for _, cause := range causes {
+		var fetchErr *reviewtransaction.GateRemoteFetchRequiredError
+		if errors.As(cause, &fetchErr) {
+			fetchStale++
+			if remote == "" {
+				remote = strings.TrimSpace(fetchErr.Remote)
+			}
+			continue
+		}
+		if reviewLockContentionCause(cause) {
+			contended++
+			continue
+		}
+		return nil
+	}
+	if fetchStale > 0 && fetchStale == len(causes) {
+		if remote == "" {
+			remote = "origin"
+		}
+		return &ReviewReceiptDiscoveryError{
+			Kind:   ReviewGateRemoteFetchRequired,
+			Detail: fmt.Sprintf("run `git fetch %s`, then re-run the same gate", remote),
+		}
+	}
+	if contended > 0 && contended == len(causes) {
+		return reviewInventoryBusyError(ctx, repo, nil)
+	}
+	return nil
+}
+
+// reviewInventoryBusyFromStoreRead classifies one store-read failure inside
+// receipt discovery (issue #3342). A typed lock-contention cause is
+// retry-safe on its own; any other read anomaly is retry-safe only while the
+// shared compact store lock is verifiably held by a live concurrent writer,
+// whose mid-write window the anomaly then belongs to. Everything else answers
+// nil and keeps the caller's fail-closed corruption verdict.
+func reviewInventoryBusyFromStoreRead(ctx context.Context, repo string, cause error) *ReviewReceiptDiscoveryError {
+	if reviewLockContentionCause(cause) {
+		return reviewInventoryBusyError(ctx, repo, nil)
+	}
+	evidence, err := reviewtransaction.InspectCompactSharedStoreLock(ctx, repo)
+	if err != nil || !evidence.Held {
+		return nil
+	}
+	return reviewInventoryBusyError(ctx, repo, &evidence)
+}
+
+// reviewInventoryBusyFromLockResidue classifies the one incomplete-inventory
+// shape that is coordination evidence rather than damage (issue #3342
+// occurrence 2): no inventory error, no diagnostics, and every ambiguous lock
+// either already confined to an invalid legacy entry or the shared compact
+// store lock itself carrying readable interrupted-holder residue. Unreadable
+// residue answers nil and keeps the exact authority_corrupted verdict.
+func reviewInventoryBusyFromLockResidue(ctx context.Context, repo string, report reviewtransaction.AuthorityStatusReport, inventoryErr error) *ReviewReceiptDiscoveryError {
+	if inventoryErr != nil || len(report.Diagnostics) > 0 {
+		return nil
+	}
+	sharedResidue := false
+	for _, lock := range report.Locks {
+		if lock.Status != reviewtransaction.AuthorityLockAmbiguous {
+			continue
+		}
+		if reviewAmbiguousLockConfinedToInvalidLegacyEntry(report, lock) {
+			continue
+		}
+		if lock.Version != reviewtransaction.AuthorityVersionCompact || strings.TrimSpace(lock.LineageID) != "" {
+			return nil
+		}
+		sharedResidue = true
+	}
+	if !sharedResidue {
+		return nil
+	}
+	evidence, err := reviewtransaction.InspectCompactSharedStoreLock(ctx, repo)
+	if err != nil || !evidence.Exists || (!evidence.Held && !evidence.HolderRecorded) {
+		return nil
+	}
+	return reviewInventoryBusyError(ctx, repo, &evidence)
+}
+
+// reviewInventoryBusyError renders the inventory_busy denial. The reason
+// names the lock (relative to the repository Git common directory, so no
+// absolute path leaks into gate envelopes), the recorded holder when
+// readable, and the runnable continuation. Stale-lock removal guidance
+// appears ONLY when the recorded pid is verifiably dead on this host; the
+// lock schema records pid and host precisely to make that decidable.
+func reviewInventoryBusyError(ctx context.Context, repo string, evidence *reviewtransaction.CompactSharedStoreLockEvidence) *ReviewReceiptDiscoveryError {
+	if evidence == nil {
+		if inspected, err := reviewtransaction.InspectCompactSharedStoreLock(ctx, repo); err == nil {
+			evidence = &inspected
+		}
+	}
+	detail := "a concurrent review operation is using the review authority store; retry once it finishes"
+	if evidence != nil && evidence.Exists {
+		switch {
+		case evidence.Held && evidence.HolderRecorded:
+			detail = fmt.Sprintf(
+				"a concurrent review operation holds the store lock %s under the repository Git common directory (recorded holder pid %d on host %s); retry once it finishes",
+				evidence.DisplayPath, evidence.HolderPID, evidence.HolderHost,
+			)
+		case evidence.Held:
+			detail = fmt.Sprintf(
+				"a concurrent review operation holds the store lock %s under the repository Git common directory; retry once it finishes",
+				evidence.DisplayPath,
+			)
+		case evidence.HolderRecorded && evidence.HolderVerifiedDeadOnThisHost:
+			detail = fmt.Sprintf(
+				"the store lock %s under the repository Git common directory records holder pid %d, which is no longer running on this host; remove the stale LOCK file, then retry the same gate",
+				evidence.DisplayPath, evidence.HolderPID,
+			)
+		case evidence.HolderRecorded:
+			detail = fmt.Sprintf(
+				"the store lock %s under the repository Git common directory records holder pid %d on host %s; retry once that operation finishes",
+				evidence.DisplayPath, evidence.HolderPID, evidence.HolderHost,
+			)
+		}
+	}
+	return &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityInventoryBusy, Detail: detail}
 }
 
 func legacyExactFacadeGateLineages(ctx context.Context, repo string, input reviewtransaction.NativeGateRequestInput) int {
@@ -4553,9 +4764,13 @@ func emitFacadeGateEvaluationNegotiated(stdout io.Writer, evaluation reviewtrans
 	if err := reviewGateContentionError(evaluation); err != nil {
 		return err
 	}
+	action := reviewGateAction(evaluation.Result)
+	if override := reviewRetrySafeDenialAction(evaluation.Context.Denial); override != "" {
+		action = override
+	}
 	result := ReviewValidateResult{
 		Schema: ReviewValidateSchema, Result: evaluation.Result, Allowed: evaluation.Result == reviewtransaction.GateAllow,
-		Action: reviewGateAction(evaluation.Result), Reason: evaluation.Reason, Context: evaluation.Context,
+		Action: action, Reason: evaluation.Reason, Context: evaluation.Context,
 		Relation: evaluation.Relation, Next: evaluation.Next,
 	}
 	if err := encodeReviewIntegrationOperation(stdout, negotiated, ReviewIntegrationOperationValidate, result, result, contract); err != nil {

--- a/internal/cli/review_gate_retry_safe_denial_test.go
+++ b/internal/cli/review_gate_retry_safe_denial_test.go
@@ -200,6 +200,21 @@ func TestGateDiscoveryNamesLiveLockContentionAsInventoryBusy(t *testing.T) {
 		t.Fatalf("negotiated live-contention failure = %#v, want inventory_busy/retry_safe/retry", failure)
 	}
 
+	// A receipt that EXISTS but fails to parse is integrity damage, never
+	// inventory_busy, even while the shared lock is verifiably held.
+	if err := os.WriteFile(receipt, []byte("{tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output.Reset()
+	gateErr = RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output)
+	tampered := decodeDeniedGateResult(t, gateErr, output.Bytes())
+	if tampered.Context.Denial == nil || tampered.Context.Denial.Code != "authority_corrupted" || tampered.Action == "retry" {
+		t.Fatalf("held-lock tampered-receipt result = %#v, want authority_corrupted without a retry promise", tampered)
+	}
+	if err := os.Remove(receipt); err != nil {
+		t.Fatal(err)
+	}
+
 	// The same anomaly WITHOUT a live holder is genuine damage and keeps
 	// today's fail-closed corruption verdict, byte for byte.
 	if err := held.Release(); err != nil {
@@ -303,32 +318,47 @@ func TestGateDiscoveryNamesDeadOwnerStaleLockResidue(t *testing.T) {
 		}
 	})
 
-	t.Run("live recorded holder never gets the removal continuation", func(t *testing.T) {
+	t.Run("recorded holder without the flock is unverifiable even when its pid runs here", func(t *testing.T) {
 		writeReviewCLIStoreLockResidue(t, lockPath, os.Getpid(), host)
 		t.Cleanup(func() { _ = os.Remove(lockPath) })
 		output, gateErr := validate()
 		result := decodeDeniedGateResult(t, gateErr, output.Bytes())
-		if result.Context.Denial == nil || result.Context.Denial.Code != "inventory_busy" {
-			t.Fatalf("live-owner denial = %#v, want inventory_busy", result.Context.Denial)
+		if result.Context.Denial == nil || result.Context.Denial.Code != "lock_holder_unverifiable" || result.Action == "retry" {
+			t.Fatalf("live-pid result = %#v, want lock_holder_unverifiable without a retry promise", result)
 		}
 		if !strings.Contains(result.Reason, strconv.Itoa(os.Getpid())) {
-			t.Fatalf("live-owner reason does not name the recorded holder pid: %q", result.Reason)
+			t.Fatalf("live-pid reason does not name the recorded holder pid: %q", result.Reason)
 		}
-		if strings.Contains(result.Reason, "remove the stale") {
-			t.Fatalf("live-owner reason suggests removing a lock whose recorded holder is running: %q", result.Reason)
+		if strings.Contains(result.Reason, "remove the stale") || strings.Contains(result.Reason, "retry once") {
+			t.Fatalf("live-pid reason promises removal or a terminating retry: %q", result.Reason)
 		}
 	})
 
-	t.Run("foreign-host recorded holder never gets the removal continuation", func(t *testing.T) {
-		writeReviewCLIStoreLockResidue(t, lockPath, reviewCLIDeadPID(t), host+"-elsewhere")
+	t.Run("foreign-host recorded holder is unverifiable, never a retry promise", func(t *testing.T) {
+		pid := reviewCLIDeadPID(t)
+		writeReviewCLIStoreLockResidue(t, lockPath, pid, host+"-elsewhere")
 		t.Cleanup(func() { _ = os.Remove(lockPath) })
 		output, gateErr := validate()
 		result := decodeDeniedGateResult(t, gateErr, output.Bytes())
-		if result.Context.Denial == nil || result.Context.Denial.Code != "inventory_busy" {
-			t.Fatalf("foreign-host denial = %#v, want inventory_busy", result.Context.Denial)
+		if result.Context.Denial == nil || result.Context.Denial.Code != "lock_holder_unverifiable" || result.Action == "retry" {
+			t.Fatalf("foreign-host result = %#v, want lock_holder_unverifiable without a retry promise", result)
 		}
-		if strings.Contains(result.Reason, "remove the stale") {
-			t.Fatalf("liveness is not verifiable across hosts, yet the reason suggests removal: %q", result.Reason)
+		for _, token := range []string{reviewSharedStoreLockToken, strconv.Itoa(pid), host + "-elsewhere", "known idle"} {
+			if !strings.Contains(result.Reason, token) {
+				t.Fatalf("foreign-host reason misses %q: %q", token, result.Reason)
+			}
+		}
+		if strings.Contains(result.Reason, "remove the stale") || strings.Contains(result.Reason, "retry once") {
+			t.Fatalf("foreign-host reason promises removal or a terminating retry: %q", result.Reason)
+		}
+
+		var negotiated bytes.Buffer
+		if err := RunReview([]string{"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &negotiated); err == nil {
+			t.Fatalf("negotiated foreign-host gate unexpectedly allowed:\n%s", negotiated.String())
+		}
+		failure := decodeReviewIntegrationFailure(t, negotiated.Bytes())
+		if failure.Code != "lock_holder_unverifiable" || failure.RetrySafe || failure.NextAction == "retry" {
+			t.Fatalf("negotiated foreign-host failure = %#v, want lock_holder_unverifiable and not retry-safe", failure)
 		}
 	})
 
@@ -346,6 +376,25 @@ func TestGateDiscoveryNamesDeadOwnerStaleLockResidue(t *testing.T) {
 			t.Fatalf("unreadable-lock control reason changed: %q", result.Reason)
 		}
 	})
+}
+
+// TestInventoryBusyProducersRequireProvablySelfClearingContention pins the
+// producer set behind reviewInventoryBusyError after the narrowing: (1) a
+// typed in-flight lock-contention cause, here and in the all-contended
+// aggregate (pinned below); (2) a read anomaly under a verifiably held flock
+// (pinned end-to-end above); (3) residue with a held flock or a holder
+// verifiably dead on this host (pinned above). Nothing else is ever busy.
+func TestInventoryBusyProducersRequireProvablySelfClearingContention(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-busy-producers", "docs/busy.md", "reviewed\n")
+	ctx := context.Background()
+	contention := fmt.Errorf("read authority: %w", reviewtransaction.ErrStoreLockContended)
+	if busy := reviewInventoryBusyFromStoreRead(ctx, repo, contention); busy == nil || busy.Kind != ReviewAuthorityInventoryBusy {
+		t.Fatalf("typed in-flight contention = %#v, want inventory_busy", busy)
+	}
+	if busy := reviewInventoryBusyFromStoreRead(ctx, repo, errors.New("parse compact receipt: unexpected end of JSON input")); busy != nil {
+		t.Fatalf("anomaly without a held flock = %#v, want nil (fail-closed corruption)", busy)
+	}
 }
 
 // TestGateDiscoveryMixedOrUnrecognizedUnknownCausesStayCorrupted pins the

--- a/internal/cli/review_gate_retry_safe_denial_test.go
+++ b/internal/cli/review_gate_retry_safe_denial_test.go
@@ -1,0 +1,426 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// This file is issue #3342: read-only delivery gates collapsed EVERY
+// assessment or inventory failure into `authority_corrupted` /
+// "complete review authority inventory is unavailable or corrupted" /
+// explicit-maintainer-action, even when the underlying cause was retry-safe
+// and self-describing (a publication remote the local clone has not fetched,
+// or shared store-lock contention). The denial stays a denial (allowed=false,
+// fail-closed), but it must name the actual cause and its runnable
+// continuation instead of routing every transient condition to a maintainer.
+
+const reviewSharedStoreLockToken = "review-transactions/v2/LOCK"
+
+func reviewCLICommonDir(t *testing.T, repo string) string {
+	t.Helper()
+	return filepath.Clean(strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir")))
+}
+
+func reviewCLISharedStoreLockPath(t *testing.T, repo string) string {
+	t.Helper()
+	return filepath.Join(reviewCLICommonDir(t, repo), "gentle-ai", "review-transactions", "v2", "LOCK")
+}
+
+func decodeDeniedGateResult(t *testing.T, gateErr error, payload []byte) ReviewValidateResult {
+	t.Helper()
+	if gateErr == nil {
+		t.Fatalf("gate unexpectedly allowed:\n%s", payload)
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, payload, &result)
+	if result.Allowed || result.Result != reviewtransaction.GateInvalidated {
+		t.Fatalf("denied gate result = %#v", result)
+	}
+	return result
+}
+
+// TestPrePRGateNamesFetchStalenessAsRetrySafeDenial reproduces occurrence 3 of
+// issue #3342: with the local clone behind the advertised remote tip, pre-PR
+// boundary selection fails every terminal lineage with "advertised base commit
+// is not available locally; fetch before validation", and discovery collapsed
+// that into authority_corrupted although nothing in the store is damaged --
+// `git fetch origin` alone flips the identical gate to allow.
+func TestPrePRGateNamesFetchStalenessAsRetrySafeDenial(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "-q", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	approveDiscoveryMarkdown(t, repo, "review-fetch-staleness", "docs/single.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed change")
+
+	// Advance the remote past the local clone's fetched state, exactly as a
+	// teammate's merge does: the advertised tip is now absent locally.
+	seed := filepath.Join(t.TempDir(), "seed")
+	runReviewCLIGit(t, repo, "clone", "-q", remote, seed)
+	runReviewCLIGit(t, seed, "config", "user.email", "test@example.com")
+	runReviewCLIGit(t, seed, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(seed, "remote-advance.txt"), []byte("remote advance\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, seed, "add", "remote-advance.txt")
+	runReviewCLIGit(t, seed, "commit", "-qm", "advance remote")
+	runReviewCLIGit(t, seed, "push", "-q", "origin", "HEAD:refs/heads/"+branch)
+
+	validate := func() (*bytes.Buffer, error) {
+		var output bytes.Buffer
+		err := RunReviewFacadeValidate([]string{
+			"--cwd", repo, "--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+		}, &output)
+		return &output, err
+	}
+
+	output, gateErr := validate()
+	result := decodeDeniedGateResult(t, gateErr, output.Bytes())
+	if result.Context.Denial == nil || result.Context.Denial.Stage != "receipt-discovery" || result.Context.Denial.Code != "remote_fetch_required" {
+		t.Fatalf("fetch-staleness denial = %#v, want receipt-discovery/remote_fetch_required", result.Context.Denial)
+	}
+	if result.Action != "retry" {
+		t.Fatalf("fetch-staleness action = %q, want retry", result.Action)
+	}
+	if !strings.Contains(result.Reason, "git fetch origin") {
+		t.Fatalf("fetch-staleness reason does not name the runnable continuation: %q", result.Reason)
+	}
+	if strings.Contains(result.Reason, "unavailable or corrupted") {
+		t.Fatalf("fetch-staleness reason still claims corruption: %q", result.Reason)
+	}
+
+	var negotiated bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+	}, &negotiated); err == nil {
+		t.Fatalf("negotiated fetch-staleness gate unexpectedly allowed:\n%s", negotiated.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, negotiated.Bytes())
+	if failure.Code != "remote_fetch_required" || !failure.RetrySafe || failure.NextAction != "retry" {
+		t.Fatalf("negotiated fetch-staleness failure = %#v, want remote_fetch_required/retry_safe/retry", failure)
+	}
+	if failure.AuthorityApplicability == "corrupted" {
+		t.Fatalf("negotiated fetch-staleness failure still classifies authority as corrupted: %#v", failure)
+	}
+	if !strings.Contains(failure.Cause, "git fetch origin") {
+		t.Fatalf("negotiated fetch-staleness cause does not name the runnable continuation: %q", failure.Cause)
+	}
+
+	// The named continuation, and nothing else, flips the identical gate.
+	runReviewCLIGit(t, repo, "fetch", "-q", "origin")
+	output, gateErr = validate()
+	if gateErr != nil {
+		t.Fatalf("gate still denied after the named continuation: %v\n%s", gateErr, output.String())
+	}
+	var allowed ReviewValidateResult
+	decodeStrictReviewJSON(t, output.Bytes(), &allowed)
+	if !allowed.Allowed {
+		t.Fatalf("gate after fetch = %#v", allowed)
+	}
+}
+
+// TestGateDiscoveryNamesLiveLockContentionAsInventoryBusy reproduces
+// occurrence 1 of issue #3342: while a concurrent review operation holds the
+// shared compact store lock, a transient per-lineage read anomaly (here: a
+// terminal record whose receipt is not yet published) was reported as
+// authority corruption requiring explicit maintainer action, although the
+// identical gate allows once the concurrent writer finishes.
+func TestGateDiscoveryNamesLiveLockContentionAsInventoryBusy(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	_, store := approveDiscoveryMarkdown(t, repo, "review-lock-live", "docs/live.md", "reviewed\n")
+	lockPath := reviewCLISharedStoreLockPath(t, repo)
+
+	held, err := reviewtransaction.AcquireAuthorityFileLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			_ = held.Release()
+		}
+	}()
+
+	receipt := store.ReceiptPath()
+	hidden := receipt + ".hidden"
+	if err := os.Rename(receipt, hidden); err != nil {
+		t.Fatal(err)
+	}
+	restored := false
+	defer func() {
+		if !restored {
+			_ = os.Rename(hidden, receipt)
+		}
+	}()
+
+	var output bytes.Buffer
+	gateErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output)
+	result := decodeDeniedGateResult(t, gateErr, output.Bytes())
+	if result.Context.Denial == nil || result.Context.Denial.Stage != "receipt-discovery" || result.Context.Denial.Code != "inventory_busy" {
+		t.Fatalf("live-contention denial = %#v, want receipt-discovery/inventory_busy", result.Context.Denial)
+	}
+	if result.Action != "retry" {
+		t.Fatalf("live-contention action = %q, want retry", result.Action)
+	}
+	if !strings.Contains(result.Reason, reviewSharedStoreLockToken) {
+		t.Fatalf("live-contention reason does not name the lock: %q", result.Reason)
+	}
+	if !strings.Contains(result.Reason, strconv.Itoa(os.Getpid())) {
+		t.Fatalf("live-contention reason does not name the recorded holder pid %d: %q", os.Getpid(), result.Reason)
+	}
+	if strings.Contains(result.Reason, "remove the stale") {
+		t.Fatalf("live-contention reason suggests removing a lock whose holder is alive: %q", result.Reason)
+	}
+	if strings.Contains(result.Reason, "unavailable or corrupted") {
+		t.Fatalf("live-contention reason still claims corruption: %q", result.Reason)
+	}
+
+	var negotiated bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &negotiated); err == nil {
+		t.Fatalf("negotiated live-contention gate unexpectedly allowed:\n%s", negotiated.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, negotiated.Bytes())
+	if failure.Code != "inventory_busy" || !failure.RetrySafe || failure.NextAction != "retry" {
+		t.Fatalf("negotiated live-contention failure = %#v, want inventory_busy/retry_safe/retry", failure)
+	}
+
+	// The same anomaly WITHOUT a live holder is genuine damage and keeps
+	// today's fail-closed corruption verdict, byte for byte.
+	if err := held.Release(); err != nil {
+		t.Fatal(err)
+	}
+	released = true
+	output.Reset()
+	gateErr = RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output)
+	control := decodeDeniedGateResult(t, gateErr, output.Bytes())
+	if control.Context.Denial == nil || control.Context.Denial.Code != "authority_corrupted" {
+		t.Fatalf("uncontended missing-receipt control = %#v, want authority_corrupted", control.Context.Denial)
+	}
+	if control.Reason != "complete review authority inventory is unavailable or corrupted" {
+		t.Fatalf("uncontended missing-receipt control reason changed: %q", control.Reason)
+	}
+
+	// Restoring the receipt (the concurrent writer finishing) allows.
+	if err := os.Rename(hidden, receipt); err != nil {
+		t.Fatal(err)
+	}
+	restored = true
+	output.Reset()
+	if gateErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output); gateErr != nil {
+		t.Fatalf("gate still denied after contention cleared: %v\n%s", gateErr, output.String())
+	}
+}
+
+// reviewCLIDeadPID returns a pid that verifiably belonged to a process that
+// has already exited on this host.
+func reviewCLIDeadPID(t *testing.T) int {
+	t.Helper()
+	command := exec.Command(os.Args[0], "-test.run", "^TestNothingMatchesThisNamePattern$", "-test.count=1")
+	command.Stdout, command.Stderr = nil, nil
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	_ = command.Wait()
+	return command.Process.Pid
+}
+
+func writeReviewCLIStoreLockResidue(t *testing.T, lockPath string, pid int, host string) {
+	t.Helper()
+	owner := fmt.Sprintf(
+		`{"schema":"gentle-ai.review-store-lock/v1","owner_id":"deadbeefdeadbeefdeadbeefdeadbeef","pid":%d,"host":%q,"acquired_at":"2026-08-16T00:00:00Z"}`,
+		pid, host,
+	)
+	// The trailing partial record is the interrupted-rewrite residue an
+	// abruptly terminated holder leaves behind: the recorded owner is intact,
+	// but the lock file no longer parses as exactly one owner document.
+	if err := os.WriteFile(lockPath, []byte(owner+"\n{\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGateDiscoveryNamesDeadOwnerStaleLockResidue reproduces occurrence 2 of
+// issue #3342: a process killed mid-operation left the shared store LOCK
+// carrying its owner record, and every subsequent gate reported authority
+// corruption until the stale lock was removed by hand. The lock schema records
+// owner pid and host precisely so this situation is decidable: when the
+// recorded pid is verifiably dead on this host, the denial must say so and
+// name the removal continuation.
+func TestGateDiscoveryNamesDeadOwnerStaleLockResidue(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-lock-dead", "docs/dead.md", "reviewed\n")
+	lockPath := reviewCLISharedStoreLockPath(t, repo)
+	host, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validate := func() (*bytes.Buffer, error) {
+		var output bytes.Buffer
+		err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePostApply)}, &output)
+		return &output, err
+	}
+
+	t.Run("dead recorded holder on this host names the removal continuation", func(t *testing.T) {
+		deadPID := reviewCLIDeadPID(t)
+		writeReviewCLIStoreLockResidue(t, lockPath, deadPID, host)
+		output, gateErr := validate()
+		result := decodeDeniedGateResult(t, gateErr, output.Bytes())
+		if result.Context.Denial == nil || result.Context.Denial.Code != "inventory_busy" {
+			t.Fatalf("dead-owner denial = %#v, want inventory_busy", result.Context.Denial)
+		}
+		if result.Action != "retry" {
+			t.Fatalf("dead-owner action = %q, want retry", result.Action)
+		}
+		for _, token := range []string{reviewSharedStoreLockToken, strconv.Itoa(deadPID), "no longer running", "remove the stale"} {
+			if !strings.Contains(result.Reason, token) {
+				t.Fatalf("dead-owner reason misses %q: %q", token, result.Reason)
+			}
+		}
+
+		// The named continuation, and nothing else, flips the identical gate.
+		if err := os.Remove(lockPath); err != nil {
+			t.Fatal(err)
+		}
+		output, gateErr = validate()
+		if gateErr != nil {
+			t.Fatalf("gate still denied after removing the stale lock: %v\n%s", gateErr, output.String())
+		}
+	})
+
+	t.Run("live recorded holder never gets the removal continuation", func(t *testing.T) {
+		writeReviewCLIStoreLockResidue(t, lockPath, os.Getpid(), host)
+		t.Cleanup(func() { _ = os.Remove(lockPath) })
+		output, gateErr := validate()
+		result := decodeDeniedGateResult(t, gateErr, output.Bytes())
+		if result.Context.Denial == nil || result.Context.Denial.Code != "inventory_busy" {
+			t.Fatalf("live-owner denial = %#v, want inventory_busy", result.Context.Denial)
+		}
+		if !strings.Contains(result.Reason, strconv.Itoa(os.Getpid())) {
+			t.Fatalf("live-owner reason does not name the recorded holder pid: %q", result.Reason)
+		}
+		if strings.Contains(result.Reason, "remove the stale") {
+			t.Fatalf("live-owner reason suggests removing a lock whose recorded holder is running: %q", result.Reason)
+		}
+	})
+
+	t.Run("foreign-host recorded holder never gets the removal continuation", func(t *testing.T) {
+		writeReviewCLIStoreLockResidue(t, lockPath, reviewCLIDeadPID(t), host+"-elsewhere")
+		t.Cleanup(func() { _ = os.Remove(lockPath) })
+		output, gateErr := validate()
+		result := decodeDeniedGateResult(t, gateErr, output.Bytes())
+		if result.Context.Denial == nil || result.Context.Denial.Code != "inventory_busy" {
+			t.Fatalf("foreign-host denial = %#v, want inventory_busy", result.Context.Denial)
+		}
+		if strings.Contains(result.Reason, "remove the stale") {
+			t.Fatalf("liveness is not verifiable across hosts, yet the reason suggests removal: %q", result.Reason)
+		}
+	})
+
+	t.Run("unreadable lock residue keeps the fail-closed corruption verdict", func(t *testing.T) {
+		if err := os.WriteFile(lockPath, []byte("not-json\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Remove(lockPath) })
+		output, gateErr := validate()
+		result := decodeDeniedGateResult(t, gateErr, output.Bytes())
+		if result.Context.Denial == nil || result.Context.Denial.Code != "authority_corrupted" {
+			t.Fatalf("unreadable-lock control = %#v, want authority_corrupted", result.Context.Denial)
+		}
+		if result.Reason != "complete review authority inventory is unavailable or corrupted" {
+			t.Fatalf("unreadable-lock control reason changed: %q", result.Reason)
+		}
+	})
+}
+
+// TestGateDiscoveryMixedOrUnrecognizedUnknownCausesStayCorrupted pins the
+// control of issue #3342: the retry-safe classification exists only when
+// EVERY unknown assessment shares one recognized retry-safe cause class.
+// Mixed or unrecognized causes keep today's fail-closed corruption verdict.
+func TestGateDiscoveryMixedOrUnrecognizedUnknownCausesStayCorrupted(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-mixed-first", "docs/mixed-first.md", "first\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver first")
+	approveDiscoveryMarkdown(t, repo, "review-mixed-second", "docs/mixed-second.md", "second\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver second")
+
+	original := assessCompactGateTargetForDiscovery
+	t.Cleanup(func() { assessCompactGateTargetForDiscovery = original })
+	stub := func(errs map[string]error) {
+		assessCompactGateTargetForDiscovery = func(ctx context.Context, repo string, state reviewtransaction.CompactState, input reviewtransaction.NativeGateRequestInput) (reviewtransaction.CompactGateTargetAssessment, error) {
+			if err, stubbed := errs[state.LineageID]; stubbed {
+				return reviewtransaction.CompactGateTargetAssessment{}, err
+			}
+			return original(ctx, repo, state, input)
+		}
+	}
+	discover := func() error {
+		_, _, err := discoverCompactFacadeGateReview(context.Background(), repo, "", reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply})
+		return err
+	}
+	discoveryKind := func(t *testing.T, err error) ReviewReceiptDiscoveryKind {
+		t.Helper()
+		var discovery *ReviewReceiptDiscoveryError
+		if !errors.As(err, &discovery) {
+			t.Fatalf("discovery error = %v", err)
+		}
+		return discovery.Kind
+	}
+
+	t.Run("all fetch-stale assessments classify retry-safe", func(t *testing.T) {
+		stub(map[string]error{
+			"review-mixed-first":  fmt.Errorf("derive compact gate target: %w", &reviewtransaction.GateRemoteFetchRequiredError{Remote: "origin"}),
+			"review-mixed-second": fmt.Errorf("derive compact gate target: %w", &reviewtransaction.GateRemoteFetchRequiredError{Remote: "origin"}),
+		})
+		if kind := discoveryKind(t, discover()); kind != ReviewGateRemoteFetchRequired {
+			t.Fatalf("all-fetch-stale discovery kind = %q, want %q", kind, ReviewGateRemoteFetchRequired)
+		}
+	})
+
+	t.Run("all lock-contended assessments classify retry-safe", func(t *testing.T) {
+		stub(map[string]error{
+			"review-mixed-first":  fmt.Errorf("read authority: %w", reviewtransaction.ErrStoreLockContended),
+			"review-mixed-second": &reviewtransaction.AuthorityLockTimeoutError{Timeout: 0},
+		})
+		if kind := discoveryKind(t, discover()); kind != ReviewAuthorityInventoryBusy {
+			t.Fatalf("all-lock-contended discovery kind = %q, want %q", kind, ReviewAuthorityInventoryBusy)
+		}
+	})
+
+	t.Run("mixed retry-safe causes stay corrupted", func(t *testing.T) {
+		stub(map[string]error{
+			"review-mixed-first":  fmt.Errorf("derive compact gate target: %w", &reviewtransaction.GateRemoteFetchRequiredError{Remote: "origin"}),
+			"review-mixed-second": fmt.Errorf("read authority: %w", reviewtransaction.ErrStoreLockContended),
+		})
+		if kind := discoveryKind(t, discover()); kind != ReviewAuthorityCorrupted {
+			t.Fatalf("mixed-cause discovery kind = %q, want %q", kind, ReviewAuthorityCorrupted)
+		}
+	})
+
+	t.Run("unrecognized cause stays corrupted", func(t *testing.T) {
+		stub(map[string]error{
+			"review-mixed-first":  fmt.Errorf("derive compact gate target: %w", &reviewtransaction.GateRemoteFetchRequiredError{Remote: "origin"}),
+			"review-mixed-second": errors.New("assessment exploded"),
+		})
+		if kind := discoveryKind(t, discover()); kind != ReviewAuthorityCorrupted {
+			t.Fatalf("unrecognized-cause discovery kind = %q, want %q", kind, ReviewAuthorityCorrupted)
+		}
+	})
+}

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -989,6 +989,22 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		case ReviewAuthorityCorrupted:
 			failure.AuthorityApplicability = "corrupted"
 			failure.CauseCategory = discovery.Category
+		case ReviewGateRemoteFetchRequired:
+			// issue #3342: the local clone is behind the advertised remote
+			// tip; nothing about the authority store was evaluated, and the
+			// cause names the runnable `git fetch <remote>` continuation.
+			failure.Message = "The advertised publication base commit is not available locally; fetch the publication remote, then retry the same gate."
+			failure.AuthorityApplicability = "not_evaluated"
+			failure.RetrySafe = true
+			failure.NextAction = "retry"
+		case ReviewAuthorityInventoryBusy:
+			// issue #3342: transient shared-store coordination, never damage;
+			// the cause names the lock, its recorded holder, and the
+			// continuation.
+			failure.Message = "The review authority store is busy with a concurrent review operation; retry the same gate."
+			failure.AuthorityApplicability = "not_evaluated"
+			failure.RetrySafe = true
+			failure.NextAction = "retry"
 		}
 		return failure
 	}

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -1005,6 +1005,12 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 			failure.AuthorityApplicability = "not_evaluated"
 			failure.RetrySafe = true
 			failure.NextAction = "retry"
+		case ReviewAuthorityLockUnverifiable:
+			// Neither provably live nor provably dead: no event terminates a
+			// retry, so the continuation is manual and stays not retry-safe.
+			failure.Message = "The review authority store lock records a holder this host cannot verify; verify it on the recorded host, or remove the lock only if that machine is known idle."
+			failure.AuthorityApplicability = "not_evaluated"
+			failure.NextAction = "explicit-maintainer-action"
 		}
 		return failure
 	}

--- a/internal/reviewtransaction/compact_shared_lock.go
+++ b/internal/reviewtransaction/compact_shared_lock.go
@@ -1,0 +1,91 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// sharedStoreLockReadLimit bounds how much lock-file residue inspection is
+// willing to read; a healthy owner record is a few hundred bytes.
+const sharedStoreLockReadLimit int64 = 64 << 10
+
+// CompactSharedStoreLockEvidence describes the live coordination state of the
+// shared compact store lock (v2/LOCK) for retry-safe gate classification
+// (issue #3342). Inspection is read-only: it never creates, truncates, or
+// removes the lock file, and a probe that momentarily acquires the advisory
+// flock releases it before returning.
+type CompactSharedStoreLockEvidence struct {
+	// DisplayPath names the lock for humans without leaking an absolute
+	// filesystem path into gate envelopes: it is the lock's path relative to
+	// the repository Git common directory.
+	DisplayPath string
+	Exists      bool
+	// Held reports that the advisory flock is currently held, which is proof
+	// of a live concurrent review operation on this store.
+	Held bool
+	// HolderRecorded reports that the lock file carries a readable owner
+	// record; HolderPID and HolderHost are meaningful only when it is true.
+	// The record is decoded tolerantly (interrupted-holder residue may leave
+	// trailing bytes after the owner document), because it feeds guidance,
+	// never authorization: kernel advisory ownership remains the only
+	// liveness truth.
+	HolderRecorded bool
+	HolderPID      int
+	HolderHost     string
+	// HolderVerifiedDeadOnThisHost is true only when the flock is not held,
+	// the recorded host is this host, and the recorded pid verifiably names
+	// no running process. Only this proof may back stale-lock removal
+	// guidance.
+	HolderVerifiedDeadOnThisHost bool
+}
+
+// InspectCompactSharedStoreLock reports the shared compact store lock's
+// coordination evidence for the repository owning repo.
+func InspectCompactSharedStoreLock(ctx context.Context, repo string) (CompactSharedStoreLockEvidence, error) {
+	root, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactSharedStoreLockEvidence{}, err
+	}
+	evidence := CompactSharedStoreLockEvidence{
+		DisplayPath: path.Join("gentle-ai", "review-transactions", "v2", "LOCK"),
+	}
+	file, err := os.OpenFile(filepath.Join(root, "v2", "LOCK"), os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return evidence, nil
+		}
+		return evidence, err
+	}
+	defer file.Close()
+	evidence.Exists = true
+	if payload, readErr := io.ReadAll(io.LimitReader(file, sharedStoreLockReadLimit)); readErr == nil {
+		var owner storeLockOwner
+		if decodeErr := json.NewDecoder(bytes.NewReader(payload)).Decode(&owner); decodeErr == nil &&
+			owner.Schema == storeLockSchema && owner.PID > 0 && strings.TrimSpace(owner.Host) != "" {
+			evidence.HolderRecorded = true
+			evidence.HolderPID = owner.PID
+			evidence.HolderHost = owner.Host
+		}
+	}
+	locked, probeErr := tryLockFile(file)
+	if probeErr != nil {
+		return evidence, probeErr
+	}
+	if !locked {
+		evidence.Held = true
+		return evidence, nil
+	}
+	_ = unlockFile(file)
+	if evidence.HolderRecorded {
+		if host, hostErr := os.Hostname(); hostErr == nil && host == evidence.HolderHost {
+			evidence.HolderVerifiedDeadOnThisHost = processVerifiedDead(evidence.HolderPID)
+		}
+	}
+	return evidence, nil
+}

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -630,6 +630,21 @@ func (err *GateTargetResolutionError) Unwrap() error {
 	return err.Err
 }
 
+// GateRemoteFetchRequiredError reports that boundary selection resolved an
+// advertised remote tip whose commit is absent from the local object store
+// (issue #3342). The review authority store is untouched by this condition:
+// the local clone is merely behind the remote it publishes to, and
+// `git fetch <remote>` followed by re-running the identical gate resolves it.
+// It is typed so receipt discovery can classify the denial as retry-safe
+// instead of collapsing it into authority corruption.
+type GateRemoteFetchRequiredError struct {
+	Remote string
+}
+
+func (err *GateRemoteFetchRequiredError) Error() string {
+	return "advertised base commit is not available locally; fetch before validation"
+}
+
 // baseRefTargetResolutionError types a publication-boundary failure the caller
 // resolves by supplying --base-ref <remote>/<branch>. Every producer of that
 // sentence types itself here: an untyped one is classified downstream as an
@@ -739,7 +754,7 @@ func resolveAdvertisedSelector(ctx context.Context, repo, selector string, sourc
 	}
 	local, err := resolveCommit(ctx, repo, matches[0].Commit)
 	if err != nil || local != matches[0].Commit {
-		return PrePRBoundarySelection{}, errors.New("advertised base commit is not available locally; fetch before validation")
+		return PrePRBoundarySelection{}, &GateRemoteFetchRequiredError{Remote: matches[0].Remote}
 	}
 	return matches[0], nil
 }
@@ -768,7 +783,7 @@ func advertisedRemoteRef(ctx context.Context, repo, remote, ref, selector string
 	}
 	local, err := resolveCommit(ctx, repo, fields[0])
 	if err != nil || local != fields[0] {
-		return PrePRBoundarySelection{}, errors.New("advertised base commit is not available locally; fetch before validation")
+		return PrePRBoundarySelection{}, &GateRemoteFetchRequiredError{Remote: remote}
 	}
 	return PrePRBoundarySelection{Source: source, Selector: selector, Commit: fields[0], Remote: remote, RemoteRef: ref, RemoteIdentity: identity}, nil
 }

--- a/internal/reviewtransaction/process_liveness_unix.go
+++ b/internal/reviewtransaction/process_liveness_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package reviewtransaction
+
+import (
+	"errors"
+	"syscall"
+)
+
+// processVerifiedDead reports whether pid verifiably does not name a running
+// process on this host. Only a definitive "no such process" answer counts:
+// permission refusals and every other ambiguity report false, so stale-lock
+// removal guidance is only ever derived from proof (issue #3342).
+func processVerifiedDead(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+}

--- a/internal/reviewtransaction/process_liveness_windows.go
+++ b/internal/reviewtransaction/process_liveness_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package reviewtransaction
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// processVerifiedDead reports whether pid verifiably does not name a running
+// process on this host. Only a definitive answer counts: access refusals and
+// every other ambiguity report false, so stale-lock removal guidance is only
+// ever derived from proof (issue #3342).
+func processVerifiedDead(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		// OpenProcess answers ERROR_INVALID_PARAMETER for a pid that names no
+		// process at all; anything else (access denied, transient fault) is
+		// not proof of death.
+		return errors.Is(err, windows.ERROR_INVALID_PARAMETER)
+	}
+	defer windows.CloseHandle(handle)
+	// STILL_ACTIVE (259): GetExitCodeProcess answers it for a running
+	// process; any real exit code proves the recorded holder exited.
+	const stillActive = 259
+	var code uint32
+	if err := windows.GetExitCodeProcess(handle, &code); err != nil {
+		return false
+	}
+	return code != stillActive
+}


### PR DESCRIPTION
Closes #3342.

## What

Gate receipt discovery no longer collapses every unknown assessment into `authority_corrupted / explicit-maintainer-action`. Recognized retry-safe causes now speak for themselves:

- Fetch staleness → `remote_fetch_required`, action retry, reason naming `git fetch <remote>` (the buried per-lineage error finally surfaces).
- Provably self-clearing contention → `inventory_busy` (kernel-verified live flock holder or in-flight read race only).
- Dead-owner stale LOCK (verified dead on this host) → stale-lock guidance with the removal continuation.
- Unverifiable holders (foreign host, unattributable pid — kernel flock is the only liveness truth) → `lock_holder_unverifiable`, NOT retry-safe, naming why and the manual continuation.
- Receipt integrity failures stay `authority_corrupted` regardless of lock state; mixed/unrecognized causes byte-identical fail-closed.

No contract bump: the closed `result` enum is untouched; new codes land in open vocabulary.

## RDD

Lineage `review-2966226764c17763` (high, 4R): three CRITICAL findings (busy masking receipt integrity; nonterminating retry hint; non-self-clearing busy class) fixed in one bounded correction (119/200), targeted validator PASS, state **approved**, pre-pr gate `allow`.

## Verification

All three field occurrences reproduced hermetically RED then fixed; full `go test ./...` green; vets clean; ratchet clean; 103 core + 134 damaged-store/real-world axis journeys zero failures.

## Size exception

One reviewed unit under an approved receipt; the bulk is the hermetic occurrence reproductions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review gates now distinguish retryable remote-fetch issues and temporary authority-store contention from integrity failures.
  * Retry-safe denials provide clear retry actions and continuation guidance.
  * Lock and process-state checks improve detection of stale or active review locks.

* **Bug Fixes**
  * Ambiguous, malformed, or unverifiable failures continue to fail safely rather than being incorrectly marked retryable.
  * Missing remote boundary data now produces clearer fetch-required feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->