### PR TITLE
fix(skills): guard skill-registry refresh against non-project roots

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -382,6 +382,16 @@ func runSkillRegistryRefresh(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	// Startup hooks run refresh from whatever directory the host resolved; a
+	// brand-new non-project directory can resolve to "/", $HOME, or a
+	// markerless folder. Never initialize there: skip silently under --quiet
+	// (a startup hook must not scream) and with a one-line notice otherwise.
+	if reason := skillregistry.RefreshSkip(cwd, home); reason != skillregistry.SkipNone {
+		if !quiet {
+			_, _ = fmt.Fprintf(stdout, "Skill registry refresh skipped (%s): %s is not a project root; run it from a project directory (one containing .git or .atl), or create the project first.\n", reason, cwd)
+		}
+		return nil
+	}
 	if ensureGitignore {
 		if err := skillregistry.EnsureATLIgnored(cwd); err != nil {
 			return err

--- a/internal/app/skill_registry_guard_test.go
+++ b/internal/app/skill_registry_guard_test.go
@@ -1,0 +1,186 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// setFakeHome points os.UserHomeDir at dir for the duration of the test.
+func setFakeHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
+// filesystemRoot returns the platform filesystem root ("/" on POSIX, the
+// volume root on Windows).
+func filesystemRoot() string {
+	if runtime.GOOS == "windows" {
+		return filepath.VolumeName(os.Getenv("SystemDrive")) + `\`
+	}
+	return "/"
+}
+
+func TestSkillRegistryRefreshSkipsFilesystemRootQuietly(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", filesystemRoot()}, &buf)
+	if err != nil {
+		t.Fatalf("refresh --cwd %s must skip quietly, got error: %v", filesystemRoot(), err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("refresh --quiet at filesystem root must print nothing, got %q", buf.String())
+	}
+}
+
+func TestSkillRegistryRefreshSkipsFilesystemRootWithNotice(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--no-gitignore", "--cwd", filesystemRoot()}, &buf)
+	if err != nil {
+		t.Fatalf("refresh --cwd %s must skip with a notice, got error: %v", filesystemRoot(), err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "skipped") {
+		t.Fatalf("non-quiet skip must name the skip, got %q", out)
+	}
+	if !strings.Contains(out, "project") {
+		t.Fatalf("non-quiet skip must name the runnable continuation (run from a project root), got %q", out)
+	}
+	if strings.Count(out, "\n") != 1 {
+		t.Fatalf("non-quiet skip must be a single line, got %q", out)
+	}
+}
+
+func TestSkillRegistryRefreshSkipsHomeDirectoryWithoutRegistry(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", home}, &buf)
+	if err != nil {
+		t.Fatalf("refresh --cwd $HOME must skip, got error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("refresh --quiet at home must print nothing, got %q", buf.String())
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".atl")); !os.IsNotExist(statErr) {
+		t.Fatalf("refresh at home must not create %s: stat err = %v", filepath.Join(home, ".atl"), statErr)
+	}
+}
+
+func TestSkillRegistryRefreshSkipsHomeDirectoryEvenWithExistingRegistry(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+	if err := os.MkdirAll(filepath.Join(home, ".atl"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", home}, &buf)
+	if err != nil {
+		t.Fatalf("refresh --cwd $HOME must always skip, got error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".atl", "skill-registry.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("refresh at home must not write a registry: stat err = %v", statErr)
+	}
+}
+
+func TestSkillRegistryRefreshSkipsFreshNonProjectDirectory(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+	fresh := t.TempDir()
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", fresh}, &buf)
+	if err != nil {
+		t.Fatalf("refresh in a fresh non-project dir must skip, got error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("refresh --quiet in a fresh non-project dir must print nothing, got %q", buf.String())
+	}
+	if _, statErr := os.Stat(filepath.Join(fresh, ".atl")); !os.IsNotExist(statErr) {
+		t.Fatalf("refresh must not create .atl in a non-project dir: stat err = %v", statErr)
+	}
+}
+
+func TestSkillRegistryRefreshProceedsInGitProject(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", project}, &buf)
+	if err != nil {
+		t.Fatalf("refresh in a git project must proceed, got error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(project, ".atl", "skill-registry.md")); statErr != nil {
+		t.Fatalf("refresh in a git project must write the registry: %v", statErr)
+	}
+}
+
+func TestSkillRegistryRefreshProceedsWithGitWorktreeFile(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+	project := t.TempDir()
+	// Git worktrees and submodules use a .git file, not a directory.
+	if err := os.WriteFile(filepath.Join(project, ".git"), []byte("gitdir: /elsewhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", project}, &buf)
+	if err != nil {
+		t.Fatalf("refresh in a git worktree must proceed, got error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(project, ".atl", "skill-registry.md")); statErr != nil {
+		t.Fatalf("refresh in a git worktree must write the registry: %v", statErr)
+	}
+}
+
+func TestSkillRegistryRefreshProceedsWithExistingRegistry(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".atl"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", project}, &buf)
+	if err != nil {
+		t.Fatalf("refresh with an existing .atl must proceed, got error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(project, ".atl", "skill-registry.md")); statErr != nil {
+		t.Fatalf("refresh with an existing .atl must write the registry: %v", statErr)
+	}
+}
+
+func TestSkillRegistryRefreshProceedsWithProjectSkillDir(t *testing.T) {
+	home := t.TempDir()
+	setFakeHome(t, home)
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := runSkillRegistryRefresh([]string{"--quiet", "--no-gitignore", "--cwd", project}, &buf)
+	if err != nil {
+		t.Fatalf("refresh in a skills workspace must proceed, got error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(project, ".atl", "skill-registry.md")); statErr != nil {
+		t.Fatalf("refresh in a skills workspace must write the registry: %v", statErr)
+	}
+}

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -632,6 +632,14 @@ func TestSkillRegistryPluginContract(t *testing.T) {
 		"input.worktree",
 		"timeout: 30_000",
 		"console.error",
+		// Non-project guard: a fresh OpenCode directory can resolve to "/" or
+		// another non-project location; the plugin must skip silently instead
+		// of spawning a refresh that pollutes or fails at startup (#skill-registry-root-guard).
+		"isProjectRoot",
+		"homedir()",
+		".git",
+		".atl",
+		"console.info",
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("skill-registry.ts missing %q", want)
@@ -639,6 +647,9 @@ func TestSkillRegistryPluginContract(t *testing.T) {
 	}
 	if strings.Contains(src, "exec(") {
 		t.Fatal("skill-registry.ts must use execFile, not shell exec")
+	}
+	if guardIdx, spawnIdx := strings.Index(src, "isProjectRoot"), strings.Index(src, "execFileAsync("); guardIdx == -1 || spawnIdx == -1 || guardIdx >= spawnIdx {
+		t.Fatalf("skill-registry.ts must guard before spawning; isProjectRoot@%d execFileAsync(@%d", guardIdx, spawnIdx)
 	}
 	worktreeIdx := strings.Index(src, "input.worktree")
 	directoryIdx := strings.Index(src, "input.directory")

--- a/internal/assets/opencode/plugins/skill-registry.ts
+++ b/internal/assets/opencode/plugins/skill-registry.ts
@@ -16,6 +16,9 @@ import { promisify } from "util"
 
 const execFileAsync = promisify(execFile)
 
+// Mirrors the CLI guard's markers (.git, .atl, and ProjectSkillDirs in internal/skillregistry/registry.go); a Go parity test pins this list.
+const PROJECT_MARKERS = [".git", ".atl", "skills", ".opencode/skills", ".claude/skills", ".gemini/skills", ".cursor/skills", ".github/skills", ".codex/skills", ".qwen/skills", ".kiro/skills", ".openclaw/skills", ".pi/skills", ".agent/skills", ".agents/skills", ".atl/skills", ".hermes/skills"]
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path)
@@ -36,7 +39,8 @@ async function isProjectRoot(cwd: string): Promise<boolean> {
   if (!cwd) return false
   if (cwd === parse(cwd).root) return false
   if (cwd === homedir()) return false
-  return (await pathExists(join(cwd, ".git"))) || (await pathExists(join(cwd, ".atl")))
+  for (const marker of PROJECT_MARKERS) if (await pathExists(join(cwd, ...marker.split("/")))) return true
+  return false
 }
 
 export const SkillRegistryPlugin: Plugin = async (input) => {

--- a/internal/assets/opencode/plugins/skill-registry.ts
+++ b/internal/assets/opencode/plugins/skill-registry.ts
@@ -9,13 +9,46 @@
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { execFile } from "child_process"
+import { access } from "fs/promises"
+import { homedir } from "os"
+import { join, parse } from "path"
 import { promisify } from "util"
 
 const execFileAsync = promisify(execFile)
 
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * OpenCode started in a brand-new non-project directory can resolve the
+ * working directory to "/", the user's home directory, or a markerless
+ * scratch folder. Refreshing there would initialize a stray .atl registry
+ * (or fail loudly on a read-only root) at every startup. The CLI refuses
+ * those locations too; this guard skips the spawn entirely.
+ */
+async function isProjectRoot(cwd: string): Promise<boolean> {
+  if (!cwd) return false
+  if (cwd === parse(cwd).root) return false
+  if (cwd === homedir()) return false
+  return (await pathExists(join(cwd, ".git"))) || (await pathExists(join(cwd, ".atl")))
+}
+
 export const SkillRegistryPlugin: Plugin = async (input) => {
   async function refreshSkillRegistry() {
     const cwd = input.worktree || input.directory || process.cwd()
+
+    if (!(await isProjectRoot(cwd))) {
+      // Startup hooks must not scream: a non-project directory is a normal
+      // situation, not an error.
+      console.info("[skill-registry] skipping refresh: not a project root:", cwd)
+      return
+    }
 
     try {
       await execFileAsync(

--- a/internal/assets/skill_registry_plugin_guard_test.go
+++ b/internal/assets/skill_registry_plugin_guard_test.go
@@ -1,0 +1,72 @@
+package assets
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestSkillRegistryPluginSkipsNonProjectDirectories runs the real plugin
+// under node with a fake `gentle-ai` on PATH that records its argv. OpenCode
+// resolves a brand-new non-project directory to "/" (or another markerless
+// location); the plugin must skip those without spawning, and spawn exactly
+// once for a real project root.
+func TestSkillRegistryPluginSkipsNonProjectDirectories(t *testing.T) {
+	source, err := Read("opencode/plugins/skill-registry.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const harness = `import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import plugin from "./plugin.mts"
+
+const projectDir = mkdtempSync(join(tmpdir(), "skill-registry-project-"))
+mkdirSync(join(projectDir, ".git"))
+const bareDir = mkdtempSync(join(tmpdir(), "skill-registry-bare-"))
+
+await plugin({ worktree: "/", directory: "" })
+await plugin({ worktree: "", directory: "" }) // falls back to process.cwd(): the markerless harness dir
+await plugin({ worktree: bareDir, directory: "" })
+await plugin({ worktree: projectDir, directory: "" })
+
+const logPath = process.env.GENTLE_AI_RELAY_LOG
+const readLines = () => (existsSync(logPath) ? readFileSync(logPath, "utf8").split("\n").filter(Boolean) : [])
+const deadline = Date.now() + 5000
+while (Date.now() < deadline && readLines().length < 1) {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+// Grace period so a wrongly-spawned refresh for a skipped directory can land.
+await new Promise((resolve) => setTimeout(resolve, 300))
+console.log(JSON.stringify({ project: projectDir, lines: readLines() }))
+`
+	const relay = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs"
+appendFileSync(process.env.GENTLE_AI_RELAY_LOG, JSON.stringify(process.argv.slice(2)) + "\n")
+`
+	output, _ := runOpenCodeTransportPluginHarness(t, map[string]string{"plugin.mts": string(source)}, harness, relay)
+	// The plugin's console.info skip notices share stdout with the harness
+	// result; the result is the final line.
+	trimmed := strings.Split(strings.TrimSpace(output), "\n")
+	last := trimmed[len(trimmed)-1]
+	for _, line := range trimmed[:len(trimmed)-1] {
+		if !strings.HasPrefix(line, "[skill-registry] skipping refresh:") {
+			t.Fatalf("unexpected plugin output line %q (skips must be console.info notices, never errors)", line)
+		}
+	}
+	var result struct {
+		Project string   `json:"project"`
+		Lines   []string `json:"lines"`
+	}
+	if err := json.Unmarshal([]byte(last), &result); err != nil {
+		t.Fatalf("decode guard harness output %q: %v", output, err)
+	}
+	if len(result.Lines) != 1 {
+		t.Fatalf("plugin must spawn exactly once (for the project root), got %d spawns: %v", len(result.Lines), result.Lines)
+	}
+	want := fmt.Sprintf(`["skill-registry","refresh","--quiet","--no-gitignore","--cwd",%q]`, result.Project)
+	if result.Lines[0] != want {
+		t.Fatalf("spawn argv = %s, want %s", result.Lines[0], want)
+	}
+}

--- a/internal/assets/skill_registry_plugin_guard_test.go
+++ b/internal/assets/skill_registry_plugin_guard_test.go
@@ -3,8 +3,13 @@ package assets
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/skillregistry"
 )
 
 // TestSkillRegistryPluginSkipsNonProjectDirectories runs the real plugin
@@ -25,21 +30,23 @@ import plugin from "./plugin.mts"
 const projectDir = mkdtempSync(join(tmpdir(), "skill-registry-project-"))
 mkdirSync(join(projectDir, ".git"))
 const bareDir = mkdtempSync(join(tmpdir(), "skill-registry-bare-"))
+const skillsDir = mkdtempSync(join(tmpdir(), "skill-registry-skills-")); mkdirSync(join(skillsDir, ".claude", "skills"), { recursive: true })
 
 await plugin({ worktree: "/", directory: "" })
 await plugin({ worktree: "", directory: "" }) // falls back to process.cwd(): the markerless harness dir
 await plugin({ worktree: bareDir, directory: "" })
 await plugin({ worktree: projectDir, directory: "" })
+await plugin({ worktree: skillsDir, directory: "" }) // no .git/.atl: a skills dir alone is a project marker
 
 const logPath = process.env.GENTLE_AI_RELAY_LOG
 const readLines = () => (existsSync(logPath) ? readFileSync(logPath, "utf8").split("\n").filter(Boolean) : [])
 const deadline = Date.now() + 5000
-while (Date.now() < deadline && readLines().length < 1) {
+while (Date.now() < deadline && readLines().length < 2) {
   await new Promise((resolve) => setTimeout(resolve, 50))
 }
 // Grace period so a wrongly-spawned refresh for a skipped directory can land.
 await new Promise((resolve) => setTimeout(resolve, 300))
-console.log(JSON.stringify({ project: projectDir, lines: readLines() }))
+console.log(JSON.stringify({ project: projectDir, skills: skillsDir, lines: readLines() }))
 `
 	const relay = `#!/usr/bin/env node
 import { appendFileSync } from "node:fs"
@@ -57,16 +64,35 @@ appendFileSync(process.env.GENTLE_AI_RELAY_LOG, JSON.stringify(process.argv.slic
 	}
 	var result struct {
 		Project string   `json:"project"`
+		Skills  string   `json:"skills"`
 		Lines   []string `json:"lines"`
 	}
 	if err := json.Unmarshal([]byte(last), &result); err != nil {
 		t.Fatalf("decode guard harness output %q: %v", output, err)
 	}
-	if len(result.Lines) != 1 {
-		t.Fatalf("plugin must spawn exactly once (for the project root), got %d spawns: %v", len(result.Lines), result.Lines)
+	if len(result.Lines) != 2 {
+		t.Fatalf("plugin must spawn exactly twice (.git project root and skills-dir-only workspace), got %d spawns: %v", len(result.Lines), result.Lines)
 	}
+	sort.Strings(result.Lines) // deterministic: "...-project-*" sorts before "...-skills-*"
 	want := fmt.Sprintf(`["skill-registry","refresh","--quiet","--no-gitignore","--cwd",%q]`, result.Project)
 	if result.Lines[0] != want {
 		t.Fatalf("spawn argv = %s, want %s", result.Lines[0], want)
+	}
+	wantSkills := fmt.Sprintf(`["skill-registry","refresh","--quiet","--no-gitignore","--cwd",%q]`, result.Skills)
+	if result.Lines[1] != wantSkills {
+		t.Fatalf("skills-dir-only workspace spawn argv = %s, want %s", result.Lines[1], wantSkills)
+	}
+}
+
+// TestSkillRegistryPluginMarkersMatchCLIGuard pins the plugin's PROJECT_MARKERS to the CLI guard's set: .git, .atl, and every ProjectSkillDirs workspace skill directory.
+func TestSkillRegistryPluginMarkersMatchCLIGuard(t *testing.T) {
+	list := regexp.MustCompile(`const PROJECT_MARKERS = \[[^\]]*\]`).FindString(MustRead("opencode/plugins/skill-registry.ts"))
+	got := regexp.MustCompile(`"[^"]*"`).FindAllString(list, -1)
+	want := []string{`".git"`, `".atl"`}
+	for _, dir := range skillregistry.ProjectSkillDirs("") {
+		want = append(want, `"`+filepath.ToSlash(dir)+`"`)
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("plugin PROJECT_MARKERS = %v, want the CLI guard's markers %v", got, want)
 	}
 }

--- a/internal/skillregistry/guard.go
+++ b/internal/skillregistry/guard.go
@@ -1,0 +1,69 @@
+package skillregistry
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// SkipReason classifies why `skill-registry refresh` must not initialize a
+// registry at the resolved working directory. Startup hooks (OpenCode plugin,
+// Codex/Claude SessionStart hooks) run the refresh from whatever directory
+// the host resolved — which for a brand-new non-project directory can be "/",
+// the user's home directory, or a markerless scratch folder. Initializing
+// there either fails loudly (mkdir /.atl on a read-only root) or pollutes a
+// directory that is not a project. The guard mirrors the CodeGraph principle:
+// never initialize in the filesystem root, $HOME, or non-project folders.
+type SkipReason string
+
+const (
+	// SkipNone means the directory is a project root and refresh proceeds.
+	SkipNone SkipReason = ""
+	// SkipFilesystemRoot: cwd resolved to the filesystem root. Always refused,
+	// even if markers somehow exist there.
+	SkipFilesystemRoot SkipReason = "filesystem-root"
+	// SkipHomeDirectory: cwd is the user's home directory. Always refused,
+	// even with an existing .atl, so a stray home registry never keeps
+	// startup hooks writing into $HOME.
+	SkipHomeDirectory SkipReason = "home-directory"
+	// SkipNoProjectMarker: cwd carries no project marker (no .git, no
+	// existing .atl, no project skills workspace). Refresh skips without
+	// creating anything.
+	SkipNoProjectMarker SkipReason = "no-project-marker"
+)
+
+// RefreshSkip reports whether a refresh at cwd must be skipped and why.
+// It never writes to the filesystem.
+func RefreshSkip(cwd, home string) SkipReason {
+	cwd = filepath.Clean(cwd)
+	home = filepath.Clean(home)
+	if cwd == filepath.Dir(cwd) {
+		// "/" on POSIX, a volume root on Windows.
+		return SkipFilesystemRoot
+	}
+	if cwd == home {
+		return SkipHomeDirectory
+	}
+	if hasProjectMarker(cwd) {
+		return SkipNone
+	}
+	return SkipNoProjectMarker
+}
+
+// hasProjectMarker reports whether cwd looks like a project root: a Git
+// checkout (.git directory, or the .git file used by worktrees and
+// submodules), an already-initialized registry (.atl), or any workspace
+// skill source directory this registry indexes (ProjectSkillDirs).
+func hasProjectMarker(cwd string) bool {
+	if _, err := os.Lstat(filepath.Join(cwd, ".git")); err == nil {
+		return true
+	}
+	if dirExists(filepath.Join(cwd, ".atl")) {
+		return true
+	}
+	for _, dir := range ProjectSkillDirs(cwd) {
+		if dirExists(dir) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skillregistry/guard_test.go
+++ b/internal/skillregistry/guard_test.go
@@ -1,0 +1,76 @@
+package skillregistry
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRefreshSkipFilesystemRoot(t *testing.T) {
+	root := "/"
+	if runtime.GOOS == "windows" {
+		root = filepath.VolumeName(os.Getenv("SystemDrive")) + `\`
+	}
+	home := t.TempDir()
+	if got := RefreshSkip(root, home); got != SkipFilesystemRoot {
+		t.Fatalf("RefreshSkip(%q) = %q, want %q", root, got, SkipFilesystemRoot)
+	}
+}
+
+func TestRefreshSkipHomeDirectoryEvenWithMarkers(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".atl"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := RefreshSkip(home, home); got != SkipHomeDirectory {
+		t.Fatalf("RefreshSkip(home, home) = %q, want %q", got, SkipHomeDirectory)
+	}
+}
+
+func TestRefreshSkipNoProjectMarker(t *testing.T) {
+	dir := t.TempDir()
+	if got := RefreshSkip(dir, t.TempDir()); got != SkipNoProjectMarker {
+		t.Fatalf("RefreshSkip(markerless dir) = %q, want %q", got, SkipNoProjectMarker)
+	}
+}
+
+func TestRefreshSkipAcceptsProjectMarkers(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+	}{
+		{"git directory", func(t *testing.T, dir string) {
+			if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"git worktree file", func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /elsewhere\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"existing atl registry", func(t *testing.T, dir string) {
+			if err := os.MkdirAll(filepath.Join(dir, ".atl"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"project skills workspace", func(t *testing.T, dir string) {
+			if err := os.MkdirAll(filepath.Join(dir, ".opencode", "skills"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+			if got := RefreshSkip(dir, t.TempDir()); got != SkipNone {
+				t.Fatalf("RefreshSkip(%s) = %q, want SkipNone", tc.name, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3350.

## What

Two-layer guard: the CLI refuses to initialize the filesystem root or $HOME (always, even with a stray `.atl`) and quietly skips marker-less directories (exit 0; silent under --quiet; one-line notice otherwise; `.gitignore` never touched), while real projects (.git incl. worktree files, .atl, or any workspace skills dir) refresh unchanged. The OpenCode plugin validates the resolved cwd before spawning (info-level skip). Codex/Claude hooks are covered by the CLI guard. Review correction: the plugin marker list now mirrors the Go guard exactly, with a parity pin extracting the list from the plugin bytes against a live `ProjectSkillDirs` call.

## RDD

Lineage `review-f854044b23806f9e` (high, 4R): one defect (marker divergence, two lenses), one bounded correction (40/200), targeted validator PASS, state **approved**, pre-pr gate `allow`.

## Verification

RED-first both layers (live repro: fresh dir polluted + root error before; silent clean skip after; 61 skills still refresh in a real project); full `go test ./...` green; vets clean; ratchet clean.

## Size exception

One reviewed unit under an approved receipt; the bulk is guard tests and the node harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skill registry refreshes now safely skip filesystem roots, home directories, and non-project folders.
  * Non-project locations no longer create registry files or start unnecessary refresh processes.
  * Added clear skip notices for non-quiet operation while preserving silent behavior in quiet mode.
  * Refreshes continue to work correctly in recognized project directories, including Git worktrees and skill-enabled workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->