### PR TITLE
test(review): cross-lane battery with real-host tier

### DIFF
--- a/scripts/cross-lane-battery.sh
+++ b/scripts/cross-lane-battery.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Local cross-lane integration battery. NOT wired into CI on purpose:
+# the optional --with-model lane spends real reviewer model runs on the
+# development subscription, and every lane drives a real gentle-ai binary
+# end to end against live scratch repositories.
+#
+# Usage:
+#   scripts/cross-lane-battery.sh --binary /path/to/gentle-ai [--with-model] [--keep-work]
+#
+# Lanes:
+#   opencode  - drives the REAL OpenCode transport plugin bytes through an
+#               emulated Task hook surface with HOST-assembled binding frames
+#               (lens frame and validator role frame).
+#   claude    - one low-risk full lifecycle to gate allow, plus one medium
+#               candidate consent/v3 round-trip; --with-model additionally
+#               runs the real compiled claude-code reviewer runtime.
+#   schema    - validates every envelope captured above against the published
+#               schemas in contracts/review-integration/.
+#
+# Exit code is non-zero when any check fails. Known-red checks (pending
+# fixes referenced in the output) still fail: red is the battery working.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+exec go run ./scripts/crosslane "$@"

--- a/scripts/cross-lane-battery.sh
+++ b/scripts/cross-lane-battery.sh
@@ -5,9 +5,9 @@
 # end to end against live scratch repositories.
 #
 # Usage:
-#   scripts/cross-lane-battery.sh --binary /path/to/gentle-ai [--with-model] [--keep-work]
+#   scripts/cross-lane-battery.sh --binary /path/to/gentle-ai [--with-model] [--with-host] [--keep-work]
 #
-# Lanes:
+# Deterministic lanes (always run):
 #   opencode  - drives the REAL OpenCode transport plugin bytes through an
 #               emulated Task hook surface with HOST-assembled binding frames
 #               (lens frame and validator role frame).
@@ -16,6 +16,19 @@
 #               runs the real compiled claude-code reviewer runtime.
 #   schema    - validates every envelope captured above against the published
 #               schemas in contracts/review-integration/.
+#
+# --with-host lanes (REAL host applications, dev subscription):
+#   host-codex    - `codex exec` spawned by the compiled codex adapter runs a
+#                   medium reviewer capture (--agent codex) to the receipt.
+#   host-pi       - the INSTALLED gentle-pi review-host-relay code runs a real
+#                   locked-down print-mode `pi` reviewer; refuter/validator
+#                   legs run through the Go-owned pi spawn (--execute).
+#   host-opencode - a real headless `opencode run` session in a sandboxed HOME
+#                   with the real transport plugin: relay start/completion
+#                   frames must flow through the live host hooks.
+# Every with-host lane is bounded, PASS/FAIL/SKIP(reason) per check, sandboxed
+# where a host store would otherwise be touched, and the summary prints the
+# real model runs spent.
 #
 # Exit code is non-zero when any check fails. Known-red checks (pending
 # fixes referenced in the output) still fail: red is the battery working.

--- a/scripts/crosslane/battery.go
+++ b/scripts/crosslane/battery.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	statusPass = "PASS"
+	statusFail = "FAIL"
+	statusSkip = "SKIP"
+
+	reviewContract = "gentle-ai.review-integration/v2"
+)
+
+type check struct {
+	Lane   string
+	Name   string
+	Status string
+	Note   string
+}
+
+type capturedEnvelope struct {
+	Source string
+	Schema string
+	Body   []byte
+}
+
+type battery struct {
+	binary    string
+	repoRoot  string
+	workRoot  string
+	withModel bool
+
+	envelopes []capturedEnvelope
+	checks    []check
+}
+
+func (b *battery) pass(lane, name, note string) {
+	b.checks = append(b.checks, check{lane, name, statusPass, note})
+}
+func (b *battery) fail(lane, name, note string) {
+	b.checks = append(b.checks, check{lane, name, statusFail, note})
+}
+func (b *battery) skip(lane, name, note string) {
+	b.checks = append(b.checks, check{lane, name, statusSkip, note})
+}
+
+// record captures one emitted envelope for the schema conformance lane.
+func (b *battery) record(source string, body []byte) map[string]any {
+	doc := map[string]any{}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil
+	}
+	schema, _ := doc["schema"].(string)
+	if schema != "" {
+		b.envelopes = append(b.envelopes, capturedEnvelope{Source: source, Schema: schema, Body: append([]byte(nil), body...)})
+	}
+	return doc
+}
+
+// run executes the binary under test and returns stdout, stderr, and exit code.
+func (b *battery) run(dir string, args ...string) (string, string, int) {
+	command := exec.Command(b.binary, args...)
+	command.Dir = dir
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	code := 0
+	if err != nil {
+		code = 1
+		if exit, ok := err.(*exec.ExitError); ok {
+			code = exit.ExitCode()
+		}
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// runJSON executes the binary and records + decodes its JSON stdout document.
+func (b *battery) runJSON(source, dir string, args ...string) (map[string]any, string, int) {
+	stdout, stderr, code := b.run(dir, args...)
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return nil, stderr, code
+	}
+	doc := b.record(source, []byte(trimmed))
+	return doc, stderr, code
+}
+
+// status queries the negotiated next transition for one repository.
+func (b *battery) status(repo, agent string, extra ...string) (map[string]any, string, int) {
+	args := []string{"review", "status", "--cwd", repo, "--contract", reviewContract, "--agent", agent, "--next-transition"}
+	args = append(args, extra...)
+	return b.runJSON("status", repo, args...)
+}
+
+// runCommandLine splits a provider-rendered command string and executes it
+// verbatim through the binary under test, from the given directory.
+func (b *battery) runCommandLine(source, dir, command string) (map[string]any, string, int) {
+	fields := strings.Fields(command)
+	if len(fields) < 2 || fields[0] != "gentle-ai" {
+		return nil, fmt.Sprintf("unexpected provider command %q", command), 1
+	}
+	return b.runJSON(source, dir, fields[1:]...)
+}
+
+// scratchRepo creates one initialized scratch git repository.
+func (b *battery) scratchRepo(name string) (string, error) {
+	dir := filepath.Join(b.workRoot, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "crosslane@example.com"},
+		{"config", "user.name", "Cross Lane Battery"},
+		{"commit", "-q", "--allow-empty", "-m", "chore: root"},
+	} {
+		if err := runGit(dir, args...); err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+func runGit(dir string, args ...string) error {
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("git %s: %v: %s", strings.Join(args, " "), err, stderr.String())
+	}
+	return nil
+}
+
+func commitAll(dir, message string) error {
+	if err := runGit(dir, "add", "-A"); err != nil {
+		return err
+	}
+	return runGit(dir, "commit", "-q", "-m", message)
+}
+
+func writeFile(dir, name, content string) error {
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// --- generic JSON navigation helpers ---
+
+func getMap(doc map[string]any, path ...string) map[string]any {
+	current := doc
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = next
+	}
+	return current
+}
+
+func getString(doc map[string]any, path ...string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	parent := getMap(doc, path[:len(path)-1]...)
+	if parent == nil {
+		return ""
+	}
+	value, _ := parent[path[len(path)-1]].(string)
+	return value
+}
+
+func getSlice(doc map[string]any, path ...string) []any {
+	if len(path) == 0 {
+		return nil
+	}
+	parent := getMap(doc, path[:len(path)-1]...)
+	if parent == nil {
+		return nil
+	}
+	value, _ := parent[path[len(path)-1]].([]any)
+	return value
+}
+
+// collectInput returns the first collect input of one status document.
+func collectInput(status map[string]any) map[string]any {
+	inputs := getSlice(status, "next_transition", "collect", "inputs")
+	if len(inputs) == 0 {
+		return nil
+	}
+	input, _ := inputs[0].(map[string]any)
+	return input
+}
+
+// argumentValues maps a collect input's arguments by name, values verbatim.
+func argumentValues(input map[string]any) map[string]string {
+	values := map[string]string{}
+	arguments, _ := input["arguments"].([]any)
+	for _, raw := range arguments {
+		argument, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := argument["name"].(string)
+		value, _ := argument["value"].(string)
+		if name != "" {
+			values[name] = value
+		}
+	}
+	return values
+}
+
+// substituteTokens replaces {{slot}} markers in submission argument tokens.
+func substituteTokens(tokens []any, values map[string]string) []string {
+	out := make([]string, 0, len(tokens))
+	for _, raw := range tokens {
+		token, _ := raw.(string)
+		for slot, value := range values {
+			token = strings.ReplaceAll(token, "{{"+slot+"}}", value)
+		}
+		out = append(out, token)
+	}
+	return out
+}
+
+func (b *battery) captureCapabilities() {
+	if doc, stderr, code := b.runJSON("capabilities", b.workRoot, "review", "capabilities"); doc == nil || code != 0 {
+		b.fail("schema", "capture capabilities v1", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+	}
+	if doc, stderr, code := b.runJSON("capabilities", b.workRoot, "review", "capabilities", "--contract", reviewContract); doc == nil || code != 0 {
+		b.fail("schema", "capture capabilities v2", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+	}
+}
+
+func firstLine(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	return line
+}
+
+func timestamp() string { return time.Now().UTC().Format("2006-01-02T15:04:05Z") }
+
+// operationState reads the finalize state from either the negotiated
+// operation envelope (result.state) or the legacy bare result (state):
+// provider-rendered finalize commands without --contract emit the latter.
+func operationState(doc map[string]any) string {
+	if state := getString(doc, "result", "state"); state != "" {
+		return state
+	}
+	return getString(doc, "state")
+}
+
+// operationLineage mirrors operationState for the lineage identifier.
+func operationLineage(doc map[string]any) string {
+	if lineage := getString(doc, "result", "lineage_id"); lineage != "" {
+		return lineage
+	}
+	return getString(doc, "lineage_id")
+}

--- a/scripts/crosslane/battery.go
+++ b/scripts/crosslane/battery.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,11 @@ import (
 	"strings"
 	"time"
 )
+
+// commandTimeout bounds every non-host command: the --with-model lane drives
+// a real reviewer underneath, so a hung provider must fail the lane with a
+// diagnostic instead of hanging the battery forever.
+const commandTimeout = 20 * time.Minute
 
 const (
 	statusPass = "PASS"
@@ -70,7 +76,10 @@ func (b *battery) record(source string, body []byte) map[string]any {
 
 // run executes the binary under test and returns stdout, stderr, and exit code.
 func (b *battery) run(dir string, args ...string) (string, string, int) {
-	command := exec.Command(b.binary, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, b.binary, args...)
+	command.WaitDelay = 30 * time.Second
 	command.Dir = dir
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout
@@ -81,6 +90,9 @@ func (b *battery) run(dir string, args ...string) (string, string, int) {
 		code = 1
 		if exit, ok := err.(*exec.ExitError); ok {
 			code = exit.ExitCode()
+		}
+		if ctx.Err() != nil {
+			return stdout.String(), fmt.Sprintf("timed out after %s: %s", commandTimeout, stderr.String()), code
 		}
 	}
 	return stdout.String(), stderr.String(), code

--- a/scripts/crosslane/battery.go
+++ b/scripts/crosslane/battery.go
@@ -37,9 +37,12 @@ type battery struct {
 	repoRoot  string
 	workRoot  string
 	withModel bool
+	withHost  bool
 
-	envelopes []capturedEnvelope
-	checks    []check
+	envelopes  []capturedEnvelope
+	checks     []check
+	hostCosts  []string
+	piRelayDir string
 }
 
 func (b *battery) pass(lane, name, note string) {

--- a/scripts/crosslane/claude.go
+++ b/scripts/crosslane/claude.go
@@ -23,7 +23,8 @@ func (b *battery) runClaudeLowLifecycle() {
 		b.fail(claudeLane, "low lifecycle scratch repository", err.Error())
 		return
 	}
-	if err := writeFile(repo, "docs/ordinary-guide.md", "# Ordinary guide\n\nline one\n"); err == nil {
+	err = writeFile(repo, "docs/ordinary-guide.md", "# Ordinary guide\n\nline one\n")
+	if err == nil {
 		err = commitAll(repo, "docs: guide")
 	}
 	if err != nil {
@@ -91,7 +92,8 @@ func (b *battery) runClaudeMediumConsent() {
 		return
 	}
 	base := "export function mul(a, b) {\n  return a * b;\n}\n"
-	if err := writeFile(repo, "src/mul.js", base); err == nil {
+	err = writeFile(repo, "src/mul.js", base)
+	if err == nil {
 		err = commitAll(repo, "feat: mul")
 	}
 	if err != nil {

--- a/scripts/crosslane/claude.go
+++ b/scripts/crosslane/claude.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const claudeLane = "claude"
+
+// runClaudeLane drives one low-risk full lifecycle to a gate allow and one
+// medium-candidate consent/v3 round-trip with the claude-code runtime.
+// With --with-model it additionally runs the real compiled claude-code
+// reviewer runtime over the medium lineage (dev subscription).
+func (b *battery) runClaudeLane() {
+	b.runClaudeLowLifecycle()
+	b.runClaudeMediumConsent()
+}
+
+func (b *battery) runClaudeLowLifecycle() {
+	repo, err := b.scratchRepo("claude-low")
+	if err != nil {
+		b.fail(claudeLane, "low lifecycle scratch repository", err.Error())
+		return
+	}
+	if err := writeFile(repo, "docs/ordinary-guide.md", "# Ordinary guide\n\nline one\n"); err == nil {
+		err = commitAll(repo, "docs: guide")
+	}
+	if err != nil {
+		b.fail(claudeLane, "low lifecycle scratch repository", err.Error())
+		return
+	}
+	if err := writeFile(repo, "docs/ordinary-guide.md", "# Ordinary guide\n\nline one\nline two, purely passive documentation\n"); err != nil {
+		b.fail(claudeLane, "low lifecycle scratch repository", err.Error())
+		return
+	}
+
+	statusDoc, stderr, code := b.status(repo, "claude-code")
+	target := getString(statusDoc, "target_identity")
+	if target == "" || getString(statusDoc, "next_transition", "execute", "operation") != "review.start" {
+		b.fail(claudeLane, "low lifecycle: negotiated start", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+		return
+	}
+	startDoc, stderr, code := b.runCommandLine("start", repo, getString(statusDoc, "next_transition", "execute", "command"))
+	if code != 0 || getString(startDoc, "risk_level") != "low" || getString(startDoc, "state") != "reviewing" {
+		b.fail(claudeLane, "low lifecycle: start", fmt.Sprintf("exit=%d risk=%q state=%q %s", code, getString(startDoc, "risk_level"), getString(startDoc, "state"), firstLine(stderr)))
+		return
+	}
+	if lensesRequired, _ := startDoc["lenses_required"].(bool); lensesRequired {
+		b.fail(claudeLane, "low lifecycle: start", "low-risk start unexpectedly selected lenses")
+		return
+	}
+
+	statusDoc, stderr, _ = b.status(repo, "claude-code")
+	if getString(statusDoc, "next_transition", "execute", "operation") != "review.finalize" {
+		b.fail(claudeLane, "low lifecycle: finalize", fmt.Sprintf("expected finalize transition, got %s/%s %s",
+			getString(statusDoc, "next_transition", "kind"), getString(statusDoc, "next_transition", "reason_code"), firstLine(stderr)))
+		return
+	}
+	finalize, stderr, code := b.runCommandLine("operation", repo, getString(statusDoc, "next_transition", "execute", "command"))
+	if code != 0 || operationState(finalize) != "approved" {
+		b.fail(claudeLane, "low lifecycle: finalize", fmt.Sprintf("exit=%d state=%q %s", code, operationState(finalize), firstLine(stderr)))
+		return
+	}
+	lineage := operationLineage(finalize)
+
+	// Stage the reviewed candidate exactly as reviewed, then gate.
+	if err := runGit(repo, "add", "-A"); err != nil {
+		b.fail(claudeLane, "low lifecycle: gate allow", err.Error())
+		return
+	}
+	statusDoc, stderr, _ = b.status(repo, "claude-code", "--lineage", lineage, "--projection", "staged", "--gate", "pre-commit")
+	if getString(statusDoc, "next_transition", "execute", "operation") != "review.validate" {
+		b.fail(claudeLane, "low lifecycle: gate allow", fmt.Sprintf("expected validate transition, got %s/%s %s",
+			getString(statusDoc, "next_transition", "kind"), getString(statusDoc, "next_transition", "reason_code"), firstLine(stderr)))
+		return
+	}
+	gate, stderr, code := b.runCommandLine("gate", repo, getString(statusDoc, "next_transition", "execute", "command"))
+	allowed, _ := gate["allowed"].(bool)
+	if code != 0 || getString(gate, "result") != "allow" || !allowed {
+		b.fail(claudeLane, "low lifecycle: gate allow", fmt.Sprintf("exit=%d result=%q %s", code, getString(gate, "result"), firstLine(stderr)))
+		return
+	}
+	b.pass(claudeLane, "low lifecycle to gate allow", "start (low, zero lenses) -> finalize approved -> pre-commit validate allow")
+}
+
+func (b *battery) runClaudeMediumConsent() {
+	repo, err := b.scratchRepo("claude-medium")
+	if err != nil {
+		b.fail(claudeLane, "medium consent scratch repository", err.Error())
+		return
+	}
+	base := "export function mul(a, b) {\n  return a * b;\n}\n"
+	if err := writeFile(repo, "src/mul.js", base); err == nil {
+		err = commitAll(repo, "feat: mul")
+	}
+	if err != nil {
+		b.fail(claudeLane, "medium consent scratch repository", err.Error())
+		return
+	}
+	if err := writeFile(repo, "src/mul.js", base+"export function twice(a) {\n  return a + a;\n}\n"); err != nil {
+		b.fail(claudeLane, "medium consent scratch repository", err.Error())
+		return
+	}
+
+	statusDoc, stderr, code := b.status(repo, "claude-code")
+	target := getString(statusDoc, "target_identity")
+	if target == "" {
+		b.fail(claudeLane, "medium consent: negotiated status", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+		return
+	}
+	consent, stderr, _ := b.runJSON("consent", repo,
+		"review", "start", "--contract", reviewContract, "--cwd", repo,
+		"--target", target, "--projection", "workspace", "--agent", "claude-code", "--consent", "relay")
+	if getString(consent, "schema") != "gentle-ai.review-integration.consent/v3" || getString(consent, "action") != "consent_required" {
+		b.fail(claudeLane, "medium consent: envelope surfaced", fmt.Sprintf("schema=%q action=%q %s", getString(consent, "schema"), getString(consent, "action"), firstLine(stderr)))
+		return
+	}
+	granted := grantedInvocation(consent)
+	if granted == "" {
+		b.fail(claudeLane, "medium consent: envelope surfaced", "no granted choice invocation in envelope")
+		return
+	}
+	startDoc, stderr, code := b.runCommandLine("start", repo, granted)
+	lenses := getSlice(startDoc, "selected_lenses")
+	if code != 0 || getString(startDoc, "state") != "reviewing" || getString(startDoc, "risk_level") != "medium" || len(lenses) != 1 {
+		b.fail(claudeLane, "medium consent: granted round-trip", fmt.Sprintf("exit=%d state=%q risk=%q lenses=%d %s",
+			code, getString(startDoc, "state"), getString(startDoc, "risk_level"), len(lenses), firstLine(stderr)))
+		return
+	}
+	b.pass(claudeLane, "medium consent: granted round-trip", "consent/v3 surfaced; granted invocation created a reviewing medium lineage with one lens")
+
+	if !b.withModel {
+		b.skip(claudeLane, "medium reviewer model run", "pass --with-model to run the real claude-code reviewer (dev subscription)")
+		return
+	}
+	b.runClaudeModelReview(repo)
+}
+
+// runClaudeModelReview lets the compiled claude-code reviewer runtime execute
+// the provider-owned request for the pending lens slot, then follows the
+// native transitions to the approved receipt and a post-apply allow.
+func (b *battery) runClaudeModelReview(repo string) {
+	statusDoc, stderr, _ := b.status(repo, "claude-code")
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-result" {
+		b.fail(claudeLane, "medium reviewer model run", fmt.Sprintf("no capture-result collect input; %s", firstLine(stderr)))
+		return
+	}
+	args := argumentValues(input)
+	capture, stderr, code := b.runJSON("result-artifact", repo,
+		"review", "capture-result",
+		"--lineage", args["lineage"],
+		"--expected-revision", args["expected-revision"],
+		"--target", args["target"],
+		"--repository-context", args["repository-context"],
+		"--lens", args["lens"],
+		"--order", args["order"],
+		"--subject-hash", args["subject-hash"],
+		"--agent", "claude-code")
+	if code != 0 || getString(capture, "schema") != "gentle-ai.review-result-artifact/v2" {
+		b.fail(claudeLane, "medium reviewer model run", fmt.Sprintf("exit=%d schema=%q %s", code, getString(capture, "schema"), firstLine(stderr)))
+		return
+	}
+	b.pass(claudeLane, "medium reviewer model run", "compiled claude-code reviewer runtime captured a native result artifact")
+
+	// Follow the native transitions to the terminal receipt, bounded.
+	evidencePath := filepath.Join(b.workRoot, "claude-evidence.txt")
+	evidence := fmt.Sprintf("crosslane battery %s: node --check src/mul.js passed on the frozen candidate\n", timestamp())
+	if err := os.WriteFile(evidencePath, []byte(evidence), 0o644); err != nil {
+		b.fail(claudeLane, "medium lifecycle after model run", err.Error())
+		return
+	}
+	for step := 0; step < 8; step++ {
+		statusDoc, stderr, _ = b.status(repo, "claude-code")
+		kind := getString(statusDoc, "next_transition", "kind")
+		switch {
+		case kind == "execute":
+			operation := getString(statusDoc, "next_transition", "execute", "operation")
+			doc, execStderr, code := b.runCommandLine("operation", repo, getString(statusDoc, "next_transition", "execute", "command"))
+			if code != 0 {
+				b.fail(claudeLane, "medium lifecycle after model run", fmt.Sprintf("%s exit=%d %s", operation, code, firstLine(execStderr)))
+				return
+			}
+			if operationState(doc) == "approved" {
+				b.pass(claudeLane, "medium lifecycle after model run", "model-reviewed lineage reached the approved receipt")
+				return
+			}
+			if operationState(doc) == "correction_required" {
+				// A real model finding against scratch code is a legitimate
+				// outcome; the battery treats reaching correction as success
+				// for the model lane and stops here.
+				b.pass(claudeLane, "medium lifecycle after model run", "model review reported candidate-causal findings (correction_required)")
+				return
+			}
+		case kind == "collect":
+			input = collectInput(statusDoc)
+			if input == nil || input["capture_operation"] != "review.capture-evidence" {
+				b.fail(claudeLane, "medium lifecycle after model run", fmt.Sprintf("unsupported collect input %v", input["capture_operation"]))
+				return
+			}
+			tokens := substituteTokens(getSlice(input, "submission", "argument_tokens"), map[string]string{"outcome": "passed", "input": evidencePath})
+			captureArgs := append([]string{"review", getString(input, "submission", "operation_token")}, tokens...)
+			if record, captureStderr, code := b.runJSON("verification-evidence", b.workRoot, captureArgs...); code != 0 || getString(record, "outcome") != "passed" {
+				b.fail(claudeLane, "medium lifecycle after model run", fmt.Sprintf("evidence capture exit=%d %s", code, firstLine(captureStderr)))
+				return
+			}
+		default:
+			b.fail(claudeLane, "medium lifecycle after model run", fmt.Sprintf("unexpected transition %s/%s %s", kind, getString(statusDoc, "next_transition", "reason_code"), firstLine(stderr)))
+			return
+		}
+	}
+	b.fail(claudeLane, "medium lifecycle after model run", "did not reach a terminal state within the step budget")
+}

--- a/scripts/crosslane/harness.mts
+++ b/scripts/crosslane/harness.mts
@@ -1,0 +1,61 @@
+// Cross-lane battery hook harness.
+//
+// Emulates ONLY the OpenCode Task hook surface (tool.execute.before /
+// tool.execute.after) around the REAL transport plugin bytes copied next to
+// this file as plugin.mts. The binding frame is assembled HERE, on the host
+// side, with the host's own JSON serialization - exactly the seam where
+// opencode_review_transport_binding_invalid escaped to the field.
+//
+// Input: one case config JSON path as argv[2]:
+//   {
+//     "name": string,
+//     "subagent": string,                     // e.g. review-reliability
+//     "binding_pairs": [[key, value], ...],   // host-assembled lens binding
+//     "body": string,                         // prompt body after the binding
+//     "prompt": string,                       // OR a verbatim prompt (role frames)
+//     "task_output": string                   // raw reviewer/validator output
+//   }
+// Output: one JSON result line on stdout:
+//   { name, before_ok, after_ok, child_prompt, output, error }
+import { readFileSync } from "node:fs"
+import plugin from "./plugin.mts"
+
+interface CaseConfig {
+  name: string
+  subagent: string
+  binding_pairs?: [string, unknown][]
+  body?: string
+  prompt?: string
+  task_output: string
+}
+
+const config = JSON.parse(readFileSync(process.argv[2], "utf8")) as CaseConfig
+const prompt =
+  config.prompt ??
+  "GENTLE_AI_REVIEW_BINDING " + JSON.stringify(Object.fromEntries(config.binding_pairs ?? [])) + "\n" + (config.body ?? "")
+
+const hooks = await plugin({
+  directory: process.cwd(),
+  worktree: process.cwd(),
+} as never)
+
+const result = { name: config.name, before_ok: false, after_ok: false, child_prompt: "", output: "", error: "" }
+const before = { args: { subagent_type: config.subagent, prompt } }
+try {
+  await hooks["tool.execute.before"]!(
+    { tool: "task", sessionID: "battery", callID: config.name } as never,
+    before as never,
+  )
+  result.before_ok = true
+  result.child_prompt = before.args.prompt
+  const after = { output: config.task_output, metadata: {} }
+  await hooks["tool.execute.after"]!(
+    { tool: "task", sessionID: "battery", callID: config.name, args: { subagent_type: config.subagent } } as never,
+    after as never,
+  )
+  result.after_ok = true
+  result.output = after.output
+} catch (cause) {
+  result.error = cause instanceof Error ? cause.message : String(cause)
+}
+console.log(JSON.stringify(result))

--- a/scripts/crosslane/host.go
+++ b/scripts/crosslane/host.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// hostCommandTimeout bounds every command a --with-host lane runs: real
+// reviewer model processes (codex exec, pi print mode, an OpenCode session)
+// are spawned underneath these commands, so a stalled provider must surface
+// as a bounded lane failure instead of hanging the battery.
+const hostCommandTimeout = 12 * time.Minute
+
+// hostStepBudget bounds the negotiated transition follower. A full medium
+// lifecycle is start -> capture -> finalize -> evidence -> finalize; the
+// budget leaves room for refuter/validator legs without permitting a loop.
+const hostStepBudget = 10
+
+// mergeEnvironment overlays overrides onto the inherited environment,
+// replacing any variable both define so no consumer-dependent duplicate-key
+// resolution can leak the inherited value through.
+func mergeEnvironment(overrides []string) []string {
+	overridden := make(map[string]bool, len(overrides))
+	for _, entry := range overrides {
+		if name, _, found := strings.Cut(entry, "="); found {
+			overridden[name] = true
+		}
+	}
+	merged := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		if name, _, found := strings.Cut(entry, "="); found && overridden[name] {
+			continue
+		}
+		merged = append(merged, entry)
+	}
+	return append(merged, overrides...)
+}
+
+// runEnv mirrors run with a bounded timeout and per-lane environment
+// overrides replacing their inherited counterparts.
+func (b *battery) runEnv(dir string, env []string, args ...string) (string, string, int) {
+	ctx, cancel := context.WithTimeout(context.Background(), hostCommandTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, b.binary, args...)
+	command.Dir = dir
+	if len(env) > 0 {
+		command.Env = mergeEnvironment(env)
+	}
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	code := 0
+	if err != nil {
+		code = 1
+		if exit, ok := err.(*exec.ExitError); ok {
+			code = exit.ExitCode()
+		}
+		if ctx.Err() != nil {
+			return stdout.String(), fmt.Sprintf("timed out after %s: %s", hostCommandTimeout, stderr.String()), code
+		}
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// runJSONEnv mirrors runJSON over runEnv.
+func (b *battery) runJSONEnv(source, dir string, env []string, args ...string) (map[string]any, string, int) {
+	stdout, stderr, code := b.runEnv(dir, env, args...)
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return nil, stderr, code
+	}
+	doc := b.record(source, []byte(trimmed))
+	return doc, stderr, code
+}
+
+// statusEnv queries the negotiated next transition with lane environment.
+func (b *battery) statusEnv(repo, agent string, env []string) (map[string]any, string, int) {
+	return b.runJSONEnv("status", repo, env,
+		"review", "status", "--cwd", repo, "--contract", reviewContract, "--agent", agent, "--next-transition")
+}
+
+// runCommandLineEnv mirrors runCommandLine over runEnv.
+func (b *battery) runCommandLineEnv(source, dir string, env []string, command string) (map[string]any, string, int) {
+	fields := strings.Fields(command)
+	if len(fields) < 2 || fields[0] != "gentle-ai" {
+		return nil, fmt.Sprintf("unexpected provider command %q", command), 1
+	}
+	return b.runJSONEnv(source, dir, env, fields[1:]...)
+}
+
+// argumentTokens returns a collect input's provider-rendered argument tokens
+// verbatim ("--name=value"), the exact argv the negotiated contract binds.
+func argumentTokens(input map[string]any) []string {
+	tokens := make([]string, 0)
+	arguments, _ := input["arguments"].([]any)
+	for _, raw := range arguments {
+		argument, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if token, _ := argument["token"].(string); token != "" {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
+}
+
+func hasArgument(input map[string]any, name string) bool {
+	arguments, _ := input["arguments"].([]any)
+	for _, raw := range arguments {
+		if argument, ok := raw.(map[string]any); ok && argument["name"] == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hostNegotiatedMediumStart drives status -> provider-rendered review.start
+// -> consent/v3 granted round-trip for one host runtime, asserting the frozen
+// medium tier. Returns false after recording the failing check.
+func (b *battery) hostNegotiatedMediumStart(lane, repo, agent string, env []string) bool {
+	statusDoc, stderr, code := b.statusEnv(repo, agent, env)
+	command := getString(statusDoc, "next_transition", "execute", "command")
+	if getString(statusDoc, "next_transition", "execute", "operation") != "review.start" || command == "" {
+		b.fail(lane, "negotiated start", fmt.Sprintf("exit=%d %s/%s %s", code,
+			getString(statusDoc, "next_transition", "kind"), getString(statusDoc, "next_transition", "reason_code"), firstLine(stderr)))
+		return false
+	}
+	consent, stderr, _ := b.runCommandLineEnv("consent", repo, env, command)
+	if getString(consent, "schema") != "gentle-ai.review-integration.consent/v3" || getString(consent, "action") != "consent_required" {
+		b.fail(lane, "consent envelope surfaced", fmt.Sprintf("schema=%q action=%q %s", getString(consent, "schema"), getString(consent, "action"), firstLine(stderr)))
+		return false
+	}
+	granted := grantedInvocation(consent)
+	if granted == "" {
+		b.fail(lane, "consent envelope surfaced", "no granted choice invocation in envelope")
+		return false
+	}
+	startDoc, stderr, code := b.runCommandLineEnv("start", repo, env, granted)
+	if code != 0 || getString(startDoc, "state") != "reviewing" || getString(startDoc, "risk_level") != "medium" {
+		b.fail(lane, "consent granted round-trip", fmt.Sprintf("exit=%d state=%q risk=%q %s",
+			code, getString(startDoc, "state"), getString(startDoc, "risk_level"), firstLine(stderr)))
+		return false
+	}
+	b.pass(lane, "consent granted round-trip", "consent/v3 surfaced; granted invocation created a reviewing medium lineage")
+	return true
+}
+
+// hostMediumCandidate writes the shared clean medium-risk candidate: a small
+// committed module plus one uncommitted additive function. Real reviewers
+// usually approve it, keeping the with-host lanes deterministic in practice
+// while a genuine finding still exercises the same transport honestly.
+func (b *battery) hostMediumCandidate(lane, name string) (string, bool) {
+	repo, err := b.scratchRepo(name)
+	if err != nil {
+		b.fail(lane, "scratch repository", err.Error())
+		return "", false
+	}
+	base := "export function add(a, b) {\n  return a + b;\n}\n"
+	if err := writeFile(repo, "src/add.js", base); err == nil {
+		err = commitAll(repo, "feat: add")
+	}
+	if err != nil {
+		b.fail(lane, "scratch repository", err.Error())
+		return "", false
+	}
+	extended := base + "export function double(a) {\n  return add(a, a);\n}\n"
+	if err := writeFile(repo, "src/add.js", extended); err != nil {
+		b.fail(lane, "scratch repository", err.Error())
+		return "", false
+	}
+	return repo, true
+}
+
+// hostCaptureLens satisfies one review.capture-result collect input for a
+// host lane. Compiled runtimes (codex) run the provider-rendered argv, which
+// makes Go spawn the real reviewer process; the pi host relay routes through
+// the installed gentle-pi relay implementation instead.
+func (b *battery) hostCaptureLens(lane, repo string, env []string, input map[string]any) bool {
+	if hasArgument(input, "materialize") {
+		return b.runPiRelaySlot(lane, repo, input)
+	}
+	b.noteHostCost(lane, "1 compiled reviewer subprocess run (capture-result --agent)")
+	capture, stderr, code := b.runJSONEnv("result-artifact", repo, env,
+		append([]string{"review", "capture-result"}, argumentTokens(input)...)...)
+	if code != 0 || getString(capture, "schema") != "gentle-ai.review-result-artifact/v2" {
+		b.fail(lane, "reviewer capture admitted", fmt.Sprintf("exit=%d schema=%q %s", code, getString(capture, "schema"), firstLine(stderr)))
+		return false
+	}
+	b.pass(lane, "reviewer capture admitted", "real reviewer process produced a native result artifact")
+	return true
+}
+
+// hostFollowToReceipt follows negotiated transitions to the terminal receipt.
+// A correction_required terminal is a legitimate real-model outcome and is
+// reported as such, mirroring the claude --with-model lane.
+func (b *battery) hostFollowToReceipt(lane, repo, agent string, env []string) {
+	const check = "lifecycle to approved receipt"
+	evidencePath := filepath.Join(b.workRoot, lane+"-evidence.txt")
+	evidence := fmt.Sprintf("crosslane battery %s: node --check passed on the frozen candidate\n", timestamp())
+	if err := os.WriteFile(evidencePath, []byte(evidence), 0o644); err != nil {
+		b.fail(lane, check, err.Error())
+		return
+	}
+	for step := 0; step < hostStepBudget; step++ {
+		statusDoc, statusStderr, _ := b.statusEnv(repo, agent, env)
+		kind := getString(statusDoc, "next_transition", "kind")
+		switch kind {
+		case "execute":
+			operation := getString(statusDoc, "next_transition", "execute", "operation")
+			doc, execStderr, code := b.runCommandLineEnv("operation", repo, env, getString(statusDoc, "next_transition", "execute", "command"))
+			if code != 0 {
+				b.fail(lane, check, fmt.Sprintf("%s exit=%d %s", operation, code, firstLine(execStderr)))
+				return
+			}
+			switch operationState(doc) {
+			case "approved":
+				b.pass(lane, check, "real-host reviewed lineage reached the approved receipt")
+				return
+			case "correction_required":
+				// A real model finding against scratch code is a legitimate
+				// outcome; transport, admission, and lifecycle are proven, and
+				// the bounded correction flow is not automated in this tier.
+				b.pass(lane, check, "real reviewer reported candidate-causal findings (correction_required); transport and admission proven")
+				return
+			}
+		case "collect":
+			input := collectInput(statusDoc)
+			operation, _ := input["capture_operation"].(string)
+			switch operation {
+			case "review.capture-result":
+				if !b.hostCaptureLens(lane, repo, env, input) {
+					return
+				}
+			case "review.capture-evidence":
+				tokens := substituteTokens(getSlice(input, "submission", "argument_tokens"), map[string]string{"outcome": "passed", "input": evidencePath})
+				captureArgs := append([]string{"review", getString(input, "submission", "operation_token")}, tokens...)
+				record, captureStderr, code := b.runJSONEnv("verification-evidence", repo, env, captureArgs...)
+				if code != 0 || getString(record, "outcome") != "passed" {
+					b.fail(lane, check, fmt.Sprintf("evidence capture exit=%d %s", code, firstLine(captureStderr)))
+					return
+				}
+			case "review.capture-refuter", "review.capture-validation":
+				// The provider-rendered argv carries --execute: Go itself spawns
+				// the real locked-down pi role process on the materialized request.
+				b.noteHostCost(lane, "1 Go-owned pi role process run ("+operation+")")
+				roleDoc, roleStderr, code := b.runJSONEnv("provider-role", repo, env,
+					append([]string{"review", strings.TrimPrefix(operation, "review.")}, argumentTokens(input)...)...)
+				captured, _ := roleDoc["captured"].(bool)
+				if code != 0 || !captured {
+					b.fail(lane, check, fmt.Sprintf("%s exit=%d captured=%v %s", operation, code, captured, firstLine(roleStderr)))
+					return
+				}
+			default:
+				b.fail(lane, check, fmt.Sprintf("unsupported collect input %q for the with-host tier", operation))
+				return
+			}
+		default:
+			b.fail(lane, check, fmt.Sprintf("unexpected transition %s/%s %s", kind, getString(statusDoc, "next_transition", "reason_code"), firstLine(statusStderr)))
+			return
+		}
+	}
+	b.fail(lane, check, "did not reach a terminal state within the step budget")
+}
+
+// noteHostCost records one real model-spend event for the summary.
+func (b *battery) noteHostCost(lane, note string) {
+	b.hostCosts = append(b.hostCosts, lane+": "+note)
+}
+
+// runHostLanes drives the three real host applications end to end.
+func (b *battery) runHostLanes() {
+	if !b.withHost {
+		b.skip(hostCodexLane, "real codex host tier", "pass --with-host to spawn real host applications (dev subscription)")
+		b.skip(hostPiLane, "real pi host tier", "pass --with-host to spawn real host applications (dev subscription)")
+		b.skip(hostOpenCodeLane, "real opencode host tier", "pass --with-host to spawn real host applications (dev subscription)")
+		return
+	}
+	b.runHostCodexLane()
+	b.runHostPiLane()
+	b.runHostOpenCodeLane()
+}

--- a/scripts/crosslane/host.go
+++ b/scripts/crosslane/host.go
@@ -48,6 +48,9 @@ func (b *battery) runEnv(dir string, env []string, args ...string) (string, stri
 	ctx, cancel := context.WithTimeout(context.Background(), hostCommandTimeout)
 	defer cancel()
 	command := exec.CommandContext(ctx, b.binary, args...)
+	// Force Wait to close the stdout/stderr pipes after kill so grandchild
+	// processes holding them open cannot block past the context cancel.
+	command.WaitDelay = 30 * time.Second
 	command.Dir = dir
 	if len(env) > 0 {
 		command.Env = mergeEnvironment(env)
@@ -164,7 +167,8 @@ func (b *battery) hostMediumCandidate(lane, name string) (string, bool) {
 		return "", false
 	}
 	base := "export function add(a, b) {\n  return a + b;\n}\n"
-	if err := writeFile(repo, "src/add.js", base); err == nil {
+	err = writeFile(repo, "src/add.js", base)
+	if err == nil {
 		err = commitAll(repo, "feat: add")
 	}
 	if err != nil {
@@ -190,8 +194,9 @@ func (b *battery) hostCaptureLens(lane, repo string, env []string, input map[str
 	b.noteHostCost(lane, "1 compiled reviewer subprocess run (capture-result --agent)")
 	capture, stderr, code := b.runJSONEnv("result-artifact", repo, env,
 		append([]string{"review", "capture-result"}, argumentTokens(input)...)...)
-	if code != 0 || getString(capture, "schema") != "gentle-ai.review-result-artifact/v2" {
-		b.fail(lane, "reviewer capture admitted", fmt.Sprintf("exit=%d schema=%q %s", code, getString(capture, "schema"), firstLine(stderr)))
+	if code != 0 || getString(capture, "schema") != "gentle-ai.review-result-artifact/v2" || getString(capture, "admission_decision") != "completed" {
+		b.fail(lane, "reviewer capture admitted", fmt.Sprintf("exit=%d schema=%q admission=%q %s",
+			code, getString(capture, "schema"), getString(capture, "admission_decision"), firstLine(stderr)))
 		return false
 	}
 	b.pass(lane, "reviewer capture admitted", "real reviewer process produced a native result artifact")

--- a/scripts/crosslane/hostcodex.go
+++ b/scripts/crosslane/hostcodex.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// hostCodexLane drives the REAL Codex host application: gentle-ai's compiled
+// codex adapter spawns `codex exec --skip-git-repo-check --ignore-user-config
+// --sandbox read-only -C <empty scratch> --output-last-message <result>` with
+// the Go-materialized opaque provider prompt on stdin, exactly the transport
+// the compiled boundary admits for the codex runtime identity.
+const hostCodexLane = "host-codex"
+
+// runHostCodexLane runs one medium candidate review where the reviewer
+// capture executes with --agent codex: real codex process, prompt-carried
+// evidence, native admission, lifecycle to the approved receipt.
+func (b *battery) runHostCodexLane() {
+	if _, err := exec.LookPath("codex"); err != nil {
+		b.skip(hostCodexLane, "codex host lane", "codex binary is not on PATH")
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err == nil {
+		if _, statErr := os.Stat(filepath.Join(home, ".codex", "auth.json")); statErr != nil {
+			b.skip(hostCodexLane, "codex host lane", "no codex credentials (~/.codex/auth.json); the real reviewer spawn would fail without them")
+			return
+		}
+	}
+
+	repo, ok := b.hostMediumCandidate(hostCodexLane, "host-codex")
+	if !ok {
+		return
+	}
+	if !b.hostNegotiatedMediumStart(hostCodexLane, repo, "codex", nil) {
+		return
+	}
+	statusDoc, stderr, _ := b.statusEnv(repo, "codex", nil)
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-result" || !hasArgument(input, "agent") {
+		b.fail(hostCodexLane, "reviewer capture admitted", "no capture-result collect input carrying an agent argument; "+firstLine(stderr))
+		return
+	}
+	if !b.hostCaptureLens(hostCodexLane, repo, nil, input) {
+		return
+	}
+	b.hostFollowToReceipt(hostCodexLane, repo, "codex", nil)
+}

--- a/scripts/crosslane/hostopencode.go
+++ b/scripts/crosslane/hostopencode.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// hostOpenCodeLane drives the REAL OpenCode host application headlessly:
+// `opencode run` in a sandboxed HOME with the real gentle-ai transport plugin
+// installed globally, a real driver model invoking one review Task, the real
+// tool.execute.before/after hooks relaying the start and completion frames
+// through a live `gentle-ai review opencode-transport` child, and a real
+// reviewer subagent model producing the captured verdict. This is the lane
+// that catches host-app behavior (like swallowed hook throws) the emulated
+// deterministic opencode lane cannot see.
+const hostOpenCodeLane = "host-opencode"
+
+// runHostOpenCodeLane sandboxes an OpenCode installation, prepares a scratch
+// lineage under that sandbox HOME (the transport child inherits it, so the
+// opaque repository-context store must live there too), and asserts through
+// the authority store that the relay frames flowed through the real hooks.
+func (b *battery) runHostOpenCodeLane() {
+	openCodeBinary, err := exec.LookPath("opencode")
+	if err != nil {
+		b.skip(hostOpenCodeLane, "opencode host lane", "opencode binary is not on PATH")
+		return
+	}
+	realHome, err := os.UserHomeDir()
+	if err != nil {
+		b.skip(hostOpenCodeLane, "opencode host lane", "cannot resolve the real home directory")
+		return
+	}
+	authPath := filepath.Join(realHome, ".local", "share", "opencode", "auth.json")
+	if _, err := os.Stat(authPath); err != nil {
+		b.skip(hostOpenCodeLane, "opencode host lane", "no OpenCode credentials ("+authPath+"); the real session would have no model")
+		return
+	}
+	reviewAgents, err := realOpenCodeReviewAgents(realHome)
+	if err != nil {
+		b.skip(hostOpenCodeLane, "opencode host lane", "no synced review agents in the real OpenCode config: "+err.Error())
+		return
+	}
+
+	sandboxHome, env, err := b.prepareOpenCodeSandbox(authPath, reviewAgents)
+	if err != nil {
+		b.fail(hostOpenCodeLane, "sandbox HOME setup", err.Error())
+		return
+	}
+
+	repo, ok := b.hostMediumCandidate(hostOpenCodeLane, "host-opencode")
+	if !ok {
+		return
+	}
+	// The whole lane, gentle-ai included, runs under the sandbox HOME: the
+	// plugin's transport child inherits OpenCode's environment, so lineage
+	// authority, opaque contexts, and the RDD switch all live in the sandbox.
+	// The enable runs from the scratch repo because mode resolution also
+	// records the clone identity of its working directory.
+	if _, stderr, code := b.runEnv(repo, env, "review", "mode", "enable"); code != 0 {
+		b.fail(hostOpenCodeLane, "sandbox HOME setup", "enable sandbox RDD switch: "+firstLine(stderr))
+		return
+	}
+	if !b.hostNegotiatedMediumStart(hostOpenCodeLane, repo, "opencode", env) {
+		return
+	}
+	statusDoc, stderr, _ := b.statusEnv(repo, "opencode", env)
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-result" {
+		b.fail(hostOpenCodeLane, "reviewer collect slot", "no review.capture-result collect input; "+firstLine(stderr))
+		return
+	}
+	args := argumentValues(input)
+
+	// The binding uses the Go-typed order (JSON number). The host-faithful
+	// string serialization is the deterministic lane's known-red
+	// (fix/opencode-host-binding); this lane isolates host-app behavior, not
+	// that serialization defect.
+	binding, err := json.Marshal(map[string]any{
+		"lineage":            args["lineage"],
+		"target":             args["target"],
+		"lens":               args["lens"],
+		"order":              0,
+		"revision":           args["expected-revision"],
+		"repository_context": args["repository-context"],
+		"subject_hash":       args["subject-hash"],
+	})
+	if err != nil {
+		b.fail(hostOpenCodeLane, "binding assembly", err.Error())
+		return
+	}
+	prompt := "GENTLE_AI_REVIEW_BINDING " + string(binding) + "\nReview this frozen candidate through the assigned lens."
+	message := "You are driving a review transport integration test. Call the task tool exactly once with " +
+		"subagent_type set to \"" + args["lens"] + "\" and the prompt argument set to EXACTLY the text between " +
+		"the BEGIN and END marker lines below (marker lines excluded), byte for byte: preserve the JSON exactly " +
+		"as written, do not reformat, reorder, or add whitespace. After the task tool returns, reply with exactly: RELAY DONE\n" +
+		"BEGIN\n" + prompt + "\nEND\n"
+
+	b.noteHostCost(hostOpenCodeLane, "1 real opencode session (driver model + reviewer subagent model)")
+	ctx, cancel := context.WithTimeout(context.Background(), hostCommandTimeout)
+	defer cancel()
+	session := exec.CommandContext(ctx, openCodeBinary, "run", "--dir", repo, message)
+	session.Dir = b.workRoot
+	session.Env = openCodeSandboxSessionEnvironment(sandboxHome, b.hostShimPath())
+	output, sessionErr := session.CombinedOutput()
+	logPath := filepath.Join(b.workRoot, "host-opencode-run.log")
+	_ = os.WriteFile(logPath, output, 0o644)
+
+	// Ground truth lives in the authority store, not the session transcript:
+	// the captured lens artifact exists only if the before hook relayed the
+	// start frame, the Go transport materialized, the real subagent reviewed,
+	// and the after hook relayed the completion frame into native admission.
+	statusDoc, stderr, _ = b.statusEnv(repo, "opencode", env)
+	reason := getString(statusDoc, "next_transition", "reason_code")
+	if getString(statusDoc, "next_transition", "execute", "operation") != "review.finalize" || reason != "captured_results_ready" {
+		note := fmt.Sprintf("no captured lens artifact after the real session (transition %s/%s)", getString(statusDoc, "next_transition", "kind"), reason)
+		if sessionErr != nil {
+			note += fmt.Sprintf("; opencode run: %v", sessionErr)
+		}
+		b.fail(hostOpenCodeLane, "relay frames through real hooks", note+"; session log kept at "+logPath+" "+firstLine(stderr))
+		return
+	}
+	b.pass(hostOpenCodeLane, "relay frames through real hooks",
+		"real opencode session: before hook relayed the start frame, after hook relayed the completion, capture admitted")
+	b.hostFollowToReceipt(hostOpenCodeLane, repo, "opencode", env)
+}
+
+// realOpenCodeReviewAgents extracts the gentle-ai-synced review-* subagent
+// definitions from the user's real OpenCode configuration.
+func realOpenCodeReviewAgents(realHome string) (map[string]any, error) {
+	payload, err := os.ReadFile(filepath.Join(realHome, ".config", "opencode", "opencode.json"))
+	if err != nil {
+		return nil, err
+	}
+	var config map[string]any
+	if err := json.Unmarshal(payload, &config); err != nil {
+		return nil, err
+	}
+	agents, _ := config["agent"].(map[string]any)
+	review := map[string]any{}
+	for name, definition := range agents {
+		if !strings.HasPrefix(name, "review-") {
+			continue
+		}
+		if body, ok := definition.(map[string]any); ok {
+			// The sandbox driver must be able to name the subagent in a task
+			// call, so the synced hidden flag is dropped inside the sandbox.
+			copied := map[string]any{}
+			for key, value := range body {
+				copied[key] = value
+			}
+			delete(copied, "hidden")
+			review[name] = copied
+		}
+	}
+	if len(review) == 0 {
+		return nil, fmt.Errorf("no review-* agents; run gentle-ai sync for OpenCode first")
+	}
+	return review, nil
+}
+
+// prepareOpenCodeSandbox seeds a sandboxed HOME: the REAL transport plugin
+// bytes installed globally, the real synced review agents, and a copy of the
+// user's OpenCode credentials (removed with the work directory).
+func (b *battery) prepareOpenCodeSandbox(authPath string, reviewAgents map[string]any) (string, []string, error) {
+	sandboxHome := filepath.Join(b.workRoot, "opencode-home")
+	configDir := filepath.Join(sandboxHome, ".config", "opencode")
+	dataDir := filepath.Join(sandboxHome, ".local", "share", "opencode")
+	for _, dir := range []string{filepath.Join(configDir, "plugins"), dataDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", nil, err
+		}
+	}
+	plugin, err := os.ReadFile(filepath.Join(b.repoRoot, pluginSourcePath))
+	if err != nil {
+		return "", nil, fmt.Errorf("read real plugin bytes: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "plugins", filepath.Base(pluginSourcePath)), plugin, 0o644); err != nil {
+		return "", nil, err
+	}
+	auth, err := os.ReadFile(authPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "auth.json"), auth, 0o600); err != nil {
+		return "", nil, err
+	}
+	driverModel := ""
+	for _, definition := range reviewAgents {
+		if body, ok := definition.(map[string]any); ok {
+			if model, _ := body["model"].(string); model != "" {
+				driverModel = model
+				break
+			}
+		}
+	}
+	config := map[string]any{
+		"share":      "disabled",
+		"autoupdate": false,
+		"agent":      reviewAgents,
+		"permission": map[string]any{"task": "allow", "read": "allow"},
+	}
+	if driverModel != "" {
+		config["model"] = driverModel
+	}
+	payload, err := json.MarshalIndent(config, "", " ")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "opencode.json"), payload, 0o644); err != nil {
+		return "", nil, err
+	}
+	env := openCodeSandboxGentleEnvironment(sandboxHome)
+	return sandboxHome, env, nil
+}
+
+// openCodeSandboxGentleEnvironment is the override set for gentle-ai
+// invocations belonging to the sandboxed lane.
+func openCodeSandboxGentleEnvironment(sandboxHome string) []string {
+	return []string{
+		"HOME=" + sandboxHome,
+		"XDG_CONFIG_HOME=" + filepath.Join(sandboxHome, ".config"),
+		"XDG_DATA_HOME=" + filepath.Join(sandboxHome, ".local", "share"),
+		"XDG_CACHE_HOME=" + filepath.Join(sandboxHome, ".cache"),
+		"XDG_STATE_HOME=" + filepath.Join(sandboxHome, ".local", "state"),
+	}
+}
+
+// openCodeSandboxSessionEnvironment is the complete environment for the real
+// OpenCode session process itself: sandbox HOME, no autoupdate, and a PATH
+// whose first entry resolves `gentle-ai` to the binary under test.
+func openCodeSandboxSessionEnvironment(sandboxHome, shimPath string) []string {
+	return mergeEnvironment(append(openCodeSandboxGentleEnvironment(sandboxHome),
+		"OPENCODE_DISABLE_AUTOUPDATE=1", "PATH="+shimPath))
+}
+
+// hostShimPath builds a PATH whose first entry resolves `gentle-ai` to the
+// binary under test, so the real plugin's transport spawn hits it.
+func (b *battery) hostShimPath() string {
+	shimDir := filepath.Join(b.workRoot, "host-shim-bin")
+	if err := os.MkdirAll(shimDir, 0o755); err == nil {
+		shim := "#!/bin/sh\nexec \"" + b.binary + "\" \"$@\"\n"
+		_ = os.WriteFile(filepath.Join(shimDir, "gentle-ai"), []byte(shim), 0o755)
+	}
+	return shimDir + string(os.PathListSeparator) + os.Getenv("PATH")
+}

--- a/scripts/crosslane/hostpi.go
+++ b/scripts/crosslane/hostpi.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed pirelay.mts
+var piRelayDriver string
+
+// hostPiLane drives the REAL Pi host: the lens capture runs through the
+// INSTALLED gentle-pi review-host-relay implementation (byte-identical lib
+// copy) which spawns a brand-new locked-down print-mode `pi` subprocess, and
+// any refuter/validator leg runs through `--execute`, where Go itself spawns
+// the real pi role process. Every reviewer verdict in this lane comes out of
+// a real pi process over the dev subscription.
+const hostPiLane = "host-pi"
+
+// piRelayContractEnv is the exact handshake gentle-ai requires before the pi
+// runtime identity becomes eligible for immutable review transport.
+var piRelayContractEnv = []string{"GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1"}
+
+// piPackageDir returns the installed gentle-pi package root.
+func piPackageDir() string {
+	if override := os.Getenv("CROSSLANE_GENTLE_PI_DIR"); override != "" {
+		return override
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pi", "agent", "npm", "node_modules", "gentle-pi")
+}
+
+// runHostPiLane probes the real pi surface, documents the print-mode
+// extension evidence, and drives one medium candidate review to the receipt.
+//
+// Print-mode extension note, verified against `pi --help`: pi discovers and
+// loads extensions in print mode too (`--no-extensions` exists to turn that
+// off, and extension-registered CLI flags appear in the help output). What
+// stays out of this battery is driving gentle-pi's ORCHESTRATOR review flow
+// through a live print-mode model session: that is an unbounded multi-turn
+// agentic run answering consent envelopes, not a boundable lane. The bounded
+// real-host coverage is this host-relay reviewer lane: the exact seam where
+// gentle-pi's launcher meets the Go facade, with real pi processes at every
+// reviewer, refuter, and validator leg.
+func (b *battery) runHostPiLane() {
+	if _, err := exec.LookPath("pi"); err != nil {
+		b.skip(hostPiLane, "pi host lane", "pi binary is not on PATH")
+		return
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		b.skip(hostPiLane, "pi host lane", "node is unavailable for the gentle-pi relay driver")
+		return
+	}
+	packageDir := piPackageDir()
+	if packageDir == "" || !piRelayClosurePresent(packageDir) {
+		b.skip(hostPiLane, "pi host lane", "installed gentle-pi package with lib/review-host-relay.ts not found under "+packageDir)
+		return
+	}
+
+	b.probePiPrintModeExtensions()
+
+	relayDir, err := b.preparePiRelayDriver(packageDir)
+	if err != nil {
+		b.fail(hostPiLane, "gentle-pi relay driver setup", err.Error())
+		return
+	}
+	b.piRelayDir = relayDir
+
+	repo, ok := b.hostMediumCandidate(hostPiLane, "host-pi")
+	if !ok {
+		return
+	}
+	if !b.hostNegotiatedMediumStart(hostPiLane, repo, "pi", piRelayContractEnv) {
+		return
+	}
+	statusDoc, stderr, _ := b.statusEnv(repo, "pi", piRelayContractEnv)
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-result" || !hasArgument(input, "materialize") || getMap(input, "submission") == nil {
+		b.fail(hostPiLane, "relay capture admitted", "no materialize+submission capture-result collect input; "+firstLine(stderr))
+		return
+	}
+	if !b.runPiRelaySlot(hostPiLane, repo, input) {
+		return
+	}
+	b.hostFollowToReceipt(hostPiLane, repo, "pi", piRelayContractEnv)
+}
+
+// probePiPrintModeExtensions records the probe evidence for pi's print-mode
+// extension surface from `pi --help` output.
+func (b *battery) probePiPrintModeExtensions() {
+	output, err := exec.Command("pi", "--help").CombinedOutput()
+	if err != nil {
+		b.fail(hostPiLane, "print-mode extension probe", fmt.Sprintf("pi --help failed: %v", err))
+		return
+	}
+	help := string(output)
+	if strings.Contains(help, "Extension CLI Flags") && strings.Contains(help, "--no-extensions") {
+		b.pass(hostPiLane, "print-mode extension probe",
+			"pi loads extensions in print mode (extension-registered CLI flags in --help; --no-extensions is the opt-out); the full extension-driven review flow is an unbounded agentic session, so this lane drives the bounded host relay instead")
+		return
+	}
+	b.pass(hostPiLane, "print-mode extension probe",
+		"pi --help shows no extension-registered flags; extension loading in print mode unproven, lane drives the host relay")
+}
+
+func piRelayClosurePresent(packageDir string) bool {
+	_, err := os.Stat(filepath.Join(packageDir, "lib", "review-host-relay.ts"))
+	return err == nil
+}
+
+// preparePiRelayDriver copies the installed gentle-pi lib/ and scripts/
+// sources byte-identical into the work directory (relocated out of
+// node_modules only so Node can type-strip them) next to the battery driver.
+func (b *battery) preparePiRelayDriver(packageDir string) (string, error) {
+	relayDir := filepath.Join(b.workRoot, "gentle-pi-relay")
+	for _, sub := range []string{"lib", "scripts"} {
+		if err := os.MkdirAll(filepath.Join(relayDir, sub), 0o755); err != nil {
+			return "", err
+		}
+		entries, err := os.ReadDir(filepath.Join(packageDir, sub))
+		if err != nil {
+			return "", fmt.Errorf("read installed gentle-pi %s/: %w", sub, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			payload, err := os.ReadFile(filepath.Join(packageDir, sub, entry.Name()))
+			if err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(filepath.Join(relayDir, sub, entry.Name()), payload, 0o644); err != nil {
+				return "", err
+			}
+		}
+	}
+	if err := os.WriteFile(filepath.Join(relayDir, "driver.mts"), []byte(piRelayDriver), 0o644); err != nil {
+		return "", err
+	}
+	return relayDir, nil
+}
+
+type piRelayResult struct {
+	PromptBytes int    `json:"prompt_bytes"`
+	ResultBytes int    `json:"result_bytes"`
+	Submission  string `json:"submission"`
+}
+
+// runPiRelaySlot satisfies one materialize+submission capture-result collect
+// input through the installed gentle-pi relay: materialize -> real locked-down
+// pi subprocess -> provider-owned submission, all owned by gentle-pi's code.
+func (b *battery) runPiRelaySlot(lane, repo string, input map[string]any) bool {
+	const check = "relay capture admitted"
+	if b.piRelayDir == "" {
+		b.fail(lane, check, "gentle-pi relay driver is not prepared")
+		return false
+	}
+	caseConfig := map[string]any{
+		"capture_argument_tokens": argumentTokens(input),
+		"submission":              input["submission"],
+		"gentle_ai_executable":    b.binary,
+		"pi_executable":           "pi",
+	}
+	payload, err := json.Marshal(caseConfig)
+	if err != nil {
+		b.fail(lane, check, err.Error())
+		return false
+	}
+	casePath := filepath.Join(b.piRelayDir, "case.json")
+	if err := os.WriteFile(casePath, payload, 0o644); err != nil {
+		b.fail(lane, check, err.Error())
+		return false
+	}
+	b.noteHostCost(lane, "1 real pi print-mode reviewer run (gentle-pi host relay)")
+	ctx, cancel := context.WithTimeout(context.Background(), hostCommandTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, "node", "driver.mts", casePath)
+	command.Dir = b.piRelayDir
+	command.Env = append(os.Environ(), piRelayContractEnv...)
+	output, err := command.Output()
+	if err != nil {
+		detail := ""
+		if exit, ok := err.(*exec.ExitError); ok {
+			detail = string(exit.Stderr)
+		}
+		b.fail(lane, check, fmt.Sprintf("gentle-pi relay driver failed: %v %s", err, firstLine(detail)))
+		return false
+	}
+	var result piRelayResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &result); err != nil {
+		b.fail(lane, check, fmt.Sprintf("decode relay driver output %q: %v", firstLine(string(output)), err))
+		return false
+	}
+	manifest := b.record("result-artifact", []byte(result.Submission))
+	if getString(manifest, "schema") != "gentle-ai.review-result-artifact/v2" {
+		b.fail(lane, check, "relay submission did not round-trip a native result artifact")
+		return false
+	}
+	b.pass(lane, check, fmt.Sprintf("installed gentle-pi relay ran a real pi process (%d prompt bytes -> %d result bytes) and the capture was admitted", result.PromptBytes, result.ResultBytes))
+	return true
+}

--- a/scripts/crosslane/hostpi.go
+++ b/scripts/crosslane/hostpi.go
@@ -107,7 +107,7 @@ func (b *battery) probePiPrintModeExtensions() {
 			"pi loads extensions in print mode (extension-registered CLI flags in --help; --no-extensions is the opt-out); the full extension-driven review flow is an unbounded agentic session, so this lane drives the bounded host relay instead")
 		return
 	}
-	b.pass(hostPiLane, "print-mode extension probe",
+	b.skip(hostPiLane, "print-mode extension probe",
 		"pi --help shows no extension-registered flags; extension loading in print mode unproven, lane drives the host relay")
 }
 

--- a/scripts/crosslane/main.go
+++ b/scripts/crosslane/main.go
@@ -1,0 +1,105 @@
+// Command crosslane is the local cross-lane integration battery.
+//
+// It drives one real gentle-ai binary (--binary) end to end across the
+// integration boundaries where host runtimes meet the Go facade:
+//
+//   - opencode lane: the REAL OpenCode transport plugin bytes
+//     (internal/assets/opencode/plugins/opencode-review-transport.ts) driven
+//     through an emulated Task hook surface with HOST-assembled binding
+//     frames, against a live scratch-repo lineage. Covers the lens frame and
+//     the validator role frame, in both host-shaped and Go-shaped variants.
+//   - claude lane: one low-risk full lifecycle (start -> finalize -> validate
+//     gate allow) and one medium-candidate consent/v3 round-trip (granted).
+//     With --with-model it additionally runs the real compiled claude-code
+//     reviewer runtime, which is why this battery lives outside CI.
+//   - schema lane: every envelope captured along the way is validated
+//     against the published schemas in contracts/review-integration/.
+//     Any emitter/schema divergence fails the battery.
+//
+// The battery is intentionally honest: known-red checks (host binding frames
+// pending fix/opencode-host-binding, schema gaps) FAIL and are annotated,
+// because red at the exact seam where field defects escaped is the battery
+// proving its worth.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	binary := flag.String("binary", "", "path to the gentle-ai binary under test (required)")
+	withModel := flag.Bool("with-model", false, "include the real reviewer model run (uses the dev subscription)")
+	keepWork := flag.Bool("keep-work", false, "keep the scratch working directory for inspection")
+	flag.Parse()
+
+	if *binary == "" {
+		fmt.Fprintln(os.Stderr, "crosslane: --binary <path> is required")
+		os.Exit(2)
+	}
+	resolved, err := filepath.Abs(*binary)
+	if err == nil {
+		_, err = os.Stat(resolved)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crosslane: binary %q is not usable: %v\n", *binary, err)
+		os.Exit(2)
+	}
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crosslane: %v\n", err)
+		os.Exit(2)
+	}
+	workRoot, err := os.MkdirTemp("", "gentle-ai-crosslane-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crosslane: %v\n", err)
+		os.Exit(2)
+	}
+
+	b := &battery{
+		binary:    resolved,
+		repoRoot:  repoRoot,
+		workRoot:  workRoot,
+		withModel: *withModel,
+	}
+	if !*keepWork {
+		defer os.RemoveAll(workRoot)
+	} else {
+		defer fmt.Printf("\nwork directory kept: %s\n", workRoot)
+	}
+
+	b.captureCapabilities()
+	b.runOpenCodeLane()
+	b.runClaudeLane()
+	b.runSchemaLane()
+
+	failed := b.printTable()
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func (b *battery) printTable() int {
+	fmt.Println()
+	fmt.Println("cross-lane battery results")
+	fmt.Printf("binary: %s\n", b.binary)
+	fmt.Println()
+	laneWidth, nameWidth := len("lane"), len("check")
+	for _, c := range b.checks {
+		laneWidth = max(laneWidth, len(c.Lane))
+		nameWidth = max(nameWidth, len(c.Name))
+	}
+	fmt.Printf("%-*s  %-*s  %-6s  %s\n", laneWidth, "lane", nameWidth, "check", "status", "note")
+	failed := 0
+	for _, c := range b.checks {
+		fmt.Printf("%-*s  %-*s  %-6s  %s\n", laneWidth, c.Lane, nameWidth, c.Name, c.Status, c.Note)
+		if c.Status == statusFail {
+			failed++
+		}
+	}
+	fmt.Println()
+	fmt.Printf("total: %d checks, %d failed\n", len(b.checks), failed)
+	return failed
+}

--- a/scripts/crosslane/main.go
+++ b/scripts/crosslane/main.go
@@ -30,6 +30,12 @@ import (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+// run holds the battery body so deferred cleanup (work-root removal or the
+// --keep-work banner) always executes before the process exits nonzero.
+func run() int {
 	binary := flag.String("binary", "", "path to the gentle-ai binary under test (required)")
 	withModel := flag.Bool("with-model", false, "include the real reviewer model run (uses the dev subscription)")
 	withHost := flag.Bool("with-host", false, "spawn REAL host applications (codex exec, pi print mode, an opencode session) end to end (uses the dev subscription)")
@@ -38,7 +44,7 @@ func main() {
 
 	if *binary == "" {
 		fmt.Fprintln(os.Stderr, "crosslane: --binary <path> is required")
-		os.Exit(2)
+		return 2
 	}
 	resolved, err := filepath.Abs(*binary)
 	if err == nil {
@@ -46,17 +52,17 @@ func main() {
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "crosslane: binary %q is not usable: %v\n", *binary, err)
-		os.Exit(2)
+		return 2
 	}
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "crosslane: %v\n", err)
-		os.Exit(2)
+		return 2
 	}
 	workRoot, err := os.MkdirTemp("", "gentle-ai-crosslane-")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "crosslane: %v\n", err)
-		os.Exit(2)
+		return 2
 	}
 
 	b := &battery{
@@ -80,8 +86,9 @@ func main() {
 
 	failed := b.printTable()
 	if failed > 0 {
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 func (b *battery) printTable() int {

--- a/scripts/crosslane/main.go
+++ b/scripts/crosslane/main.go
@@ -32,6 +32,7 @@ import (
 func main() {
 	binary := flag.String("binary", "", "path to the gentle-ai binary under test (required)")
 	withModel := flag.Bool("with-model", false, "include the real reviewer model run (uses the dev subscription)")
+	withHost := flag.Bool("with-host", false, "spawn REAL host applications (codex exec, pi print mode, an opencode session) end to end (uses the dev subscription)")
 	keepWork := flag.Bool("keep-work", false, "keep the scratch working directory for inspection")
 	flag.Parse()
 
@@ -63,6 +64,7 @@ func main() {
 		repoRoot:  repoRoot,
 		workRoot:  workRoot,
 		withModel: *withModel,
+		withHost:  *withHost,
 	}
 	if !*keepWork {
 		defer os.RemoveAll(workRoot)
@@ -73,6 +75,7 @@ func main() {
 	b.captureCapabilities()
 	b.runOpenCodeLane()
 	b.runClaudeLane()
+	b.runHostLanes()
 	b.runSchemaLane()
 
 	failed := b.printTable()
@@ -101,5 +104,12 @@ func (b *battery) printTable() int {
 	}
 	fmt.Println()
 	fmt.Printf("total: %d checks, %d failed\n", len(b.checks), failed)
+	if len(b.hostCosts) > 0 {
+		fmt.Println()
+		fmt.Println("token cost (real model runs on the dev subscription):")
+		for _, cost := range b.hostCosts {
+			fmt.Printf("  %s\n", cost)
+		}
+	}
 	return failed
 }

--- a/scripts/crosslane/opencode.go
+++ b/scripts/crosslane/opencode.go
@@ -51,7 +51,8 @@ func (b *battery) runOpenCodeLane() {
 		return
 	}
 	base := "export function greet(name) {\n  return \"hi \" + name;\n}\n"
-	if err := writeFile(repo, "src/greet.js", base); err == nil {
+	err = writeFile(repo, "src/greet.js", base)
+	if err == nil {
 		err = commitAll(repo, "feat: greet")
 	}
 	if err != nil {

--- a/scripts/crosslane/opencode.go
+++ b/scripts/crosslane/opencode.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed harness.mts
+var hookHarness string
+
+const openCodeLane = "opencode"
+
+// pluginSourcePath is the real transport plugin the battery drives. The bytes
+// are read from the repository at run time so the battery always exercises
+// the current plugin, never an embedded copy.
+const pluginSourcePath = "internal/assets/opencode/plugins/opencode-review-transport.ts"
+
+const bindingInvalid = "opencode_review_transport_binding_invalid"
+
+type harnessResult struct {
+	Name        string `json:"name"`
+	BeforeOK    bool   `json:"before_ok"`
+	AfterOK     bool   `json:"after_ok"`
+	ChildPrompt string `json:"child_prompt"`
+	Output      string `json:"output"`
+	Error       string `json:"error"`
+}
+
+type harnessCase struct {
+	Name         string   `json:"name"`
+	Subagent     string   `json:"subagent"`
+	BindingPairs [][2]any `json:"binding_pairs,omitempty"`
+	Body         string   `json:"body,omitempty"`
+	Prompt       string   `json:"prompt,omitempty"`
+	TaskOutput   string   `json:"task_output"`
+}
+
+// runOpenCodeLane drives the real plugin bytes through host-assembled binding
+// frames against a live medium-risk lineage: consent round-trip, lens frame
+// (host-faithful and Go-typed), correction flow, and validator role frame
+// (host-serialized and exact relay).
+func (b *battery) runOpenCodeLane() {
+	repo, err := b.scratchRepo("opencode-lane")
+	if err != nil {
+		b.fail(openCodeLane, "scratch repository", err.Error())
+		return
+	}
+	base := "export function greet(name) {\n  return \"hi \" + name;\n}\n"
+	if err := writeFile(repo, "src/greet.js", base); err == nil {
+		err = commitAll(repo, "feat: greet")
+	}
+	if err != nil {
+		b.fail(openCodeLane, "scratch repository", err.Error())
+		return
+	}
+	unsafe := base + "export function shout(name) {\n  return name.toUpperCase() + \"!\";\n}\n"
+	if err := writeFile(repo, "src/greet.js", unsafe); err != nil {
+		b.fail(openCodeLane, "scratch repository", err.Error())
+		return
+	}
+
+	// Consent round-trip with the opencode runtime identity.
+	statusDoc, stderr, code := b.status(repo, "opencode")
+	target := getString(statusDoc, "target_identity")
+	if target == "" {
+		b.fail(openCodeLane, "negotiated status", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+		return
+	}
+	consent, stderr, _ := b.runJSON("consent", repo,
+		"review", "start", "--contract", reviewContract, "--cwd", repo,
+		"--target", target, "--projection", "workspace", "--agent", "opencode", "--consent", "relay")
+	if getString(consent, "action") != "consent_required" || getString(consent, "schema") != "gentle-ai.review-integration.consent/v3" {
+		b.fail(openCodeLane, "consent envelope surfaced", fmt.Sprintf("schema=%q action=%q %s", getString(consent, "schema"), getString(consent, "action"), firstLine(stderr)))
+		return
+	}
+	granted := grantedInvocation(consent)
+	if granted == "" {
+		b.fail(openCodeLane, "consent envelope surfaced", "no granted choice invocation in envelope")
+		return
+	}
+	startDoc, stderr, code := b.runCommandLine("start", repo, granted)
+	if code != 0 || getString(startDoc, "state") != "reviewing" || getString(startDoc, "risk_level") != "medium" {
+		b.fail(openCodeLane, "consent granted round-trip", fmt.Sprintf("exit=%d state=%q risk=%q %s", code, getString(startDoc, "state"), getString(startDoc, "risk_level"), firstLine(stderr)))
+		return
+	}
+	b.pass(openCodeLane, "consent granted round-trip", "consent/v3 surfaced; granted invocation created a reviewing medium lineage")
+
+	// Reviewer collect slot: this is where the host assembles the binding.
+	statusDoc, stderr, _ = b.status(repo, "opencode")
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-result" {
+		b.fail(openCodeLane, "reviewer collect slot", fmt.Sprintf("no review.capture-result collect input; %s", firstLine(stderr)))
+		return
+	}
+	args := argumentValues(input)
+	node, err := b.prepareHookHarness(repo)
+	if err != nil {
+		b.fail(openCodeLane, "hook harness setup", err.Error())
+		return
+	}
+
+	reviewer := map[string]any{
+		"subject_hash": args["subject-hash"],
+		"inspection":   map[string]any{"status": "completed", "paths": []string{"src/greet.js"}},
+		"evidence":     []string{"shout calls toUpperCase without a nullish guard; introduced by the candidate hunk"},
+		"findings": []map[string]any{{
+			"claim":              "shout calls toUpperCase on its argument without a null/undefined guard",
+			"severity":           "BLOCKER",
+			"evidence_class":     "deterministic",
+			"causal_disposition": "introduced",
+			"lens":               "review-reliability",
+			"location":           "src/greet.js:5",
+			"proof_refs":         []string{"src/greet.js:4-6 calls name.toUpperCase() with no nullish guard in the candidate tree"},
+		}},
+	}
+	reviewerJSON, err := json.Marshal(reviewer)
+	if err != nil {
+		b.fail(openCodeLane, "reviewer manifest", err.Error())
+		return
+	}
+
+	// Host-faithful lens frame: the binding values come verbatim from the
+	// collect input arguments, exactly as the orchestration contract tells a
+	// host to assemble them. The provider delivers order as the string "0",
+	// so a faithful host serializes "order":"0".
+	hostPairs := [][2]any{
+		{"lineage", args["lineage"]},
+		{"target", args["target"]},
+		{"lens", args["lens"]},
+		{"order", args["order"]},
+		{"revision", args["expected-revision"]},
+		{"repository_context", args["repository-context"]},
+		{"subject_hash", args["subject-hash"]},
+	}
+	hostCase := harnessCase{
+		Name:         "lens-host-faithful",
+		Subagent:     args["lens"],
+		BindingPairs: hostPairs,
+		Body:         "Review this frozen candidate through the assigned lens.",
+		TaskOutput:   string(reviewerJSON),
+	}
+	hostResult, err := b.runHookCase(node, hostCase)
+	lensCaptured := false
+	switch {
+	case err != nil:
+		b.fail(openCodeLane, "lens frame: host-assembled", err.Error())
+	case hostResult.AfterOK:
+		lensCaptured = true
+		b.pass(openCodeLane, "lens frame: host-assembled", "host-serialized binding accepted end to end (fix merged)")
+		b.skip(openCodeLane, "lens frame: Go-typed control", "host frame already captured the slot; control unnecessary")
+	case strings.Contains(hostResult.Error, bindingInvalid):
+		b.fail(openCodeLane, "lens frame: host-assembled",
+			"known-red pending fix/opencode-host-binding: Go transport rejects the host-serialized binding (order delivered as collect-argument string): "+firstLine(hostResult.Error))
+	default:
+		b.fail(openCodeLane, "lens frame: host-assembled", "unexpected failure: "+firstLine(hostResult.Error))
+	}
+
+	if !lensCaptured {
+		// Go-typed control: identical binding but with order as a JSON number.
+		// Proves the slot itself is healthy, isolating the failure above to
+		// the host serialization.
+		goPairs := append([][2]any(nil), hostPairs...)
+		goPairs[3] = [2]any{"order", 0}
+		controlResult, err := b.runHookCase(node, harnessCase{
+			Name:         "lens-go-typed",
+			Subagent:     args["lens"],
+			BindingPairs: goPairs,
+			Body:         "Review this frozen candidate through the assigned lens.",
+			TaskOutput:   string(reviewerJSON),
+		})
+		switch {
+		case err != nil:
+			b.fail(openCodeLane, "lens frame: Go-typed control", err.Error())
+			return
+		case !controlResult.AfterOK:
+			b.fail(openCodeLane, "lens frame: Go-typed control", firstLine(controlResult.Error))
+			return
+		case !strings.HasPrefix(controlResult.ChildPrompt, "GENTLE_AI_REVIEW_PROVIDER_MATERIALIZATION "):
+			b.fail(openCodeLane, "lens frame: Go-typed control", "child prompt is not the Go-issued materialization")
+			return
+		default:
+			manifest := b.record("result-artifact", []byte(controlResult.Output))
+			if getString(manifest, "schema") != "gentle-ai.review-result-artifact/v2" || getString(manifest, "admission_decision") != "completed" {
+				b.fail(openCodeLane, "lens frame: Go-typed control", "completion did not round-trip a completed result artifact")
+				return
+			}
+			b.pass(openCodeLane, "lens frame: Go-typed control", "session started, child received Go-canonical bytes, completion round-tripped")
+		}
+	}
+
+	// Correction flow to reach a live validator role slot.
+	if !b.driveCorrectionToValidation(repo, base) {
+		return
+	}
+
+	statusDoc, stderr, _ = b.status(repo, "opencode")
+	input = collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "external.run_provider_role" {
+		b.fail(openCodeLane, "validator role slot", fmt.Sprintf("no provider role collect input; %s", firstLine(stderr)))
+		return
+	}
+	providerPrompt := getString(input, "provider_task", "prompt")
+	validationRequest := getMap(statusDoc, "validation_request")
+	if providerPrompt == "" || validationRequest == nil {
+		b.fail(openCodeLane, "validator role slot", "provider task prompt or validation request missing from status")
+		return
+	}
+	validator := map[string]any{
+		"targeted_validation_request_hash": validationRequest["request_hash"],
+		"correction_target_identity":       validationRequest["correction_target_identity"],
+		"original_criteria": map[string]any{
+			"passed":   true,
+			"evidence": []string{"frozen correction tree guards name == null before toUpperCase per the embedded diff"},
+		},
+		"correction_regression": map[string]any{
+			"passed":   true,
+			"evidence": []string{"greet() is untouched by the correction diff; only shout gained the guard"},
+		},
+		"follow_ups": []any{},
+	}
+	validatorJSON, err := json.Marshal(validator)
+	if err != nil {
+		b.fail(openCodeLane, "validator manifest", err.Error())
+		return
+	}
+
+	// Host-serialized role frame: same semantic binding, re-serialized by the
+	// host (sorted keys). The Go transport currently requires the byte-exact
+	// provider-issued prompt.
+	hostRolePrompt, err := reserializeBindingLine(providerPrompt)
+	if err != nil {
+		b.fail(openCodeLane, "validator frame: host-serialized", err.Error())
+		return
+	}
+	validatorCaptured := false
+	hostRole, err := b.runHookCase(node, harnessCase{
+		Name:       "validator-host-serialized",
+		Subagent:   "review-validator",
+		Prompt:     hostRolePrompt,
+		TaskOutput: string(validatorJSON),
+	})
+	switch {
+	case err != nil:
+		b.fail(openCodeLane, "validator frame: host-serialized", err.Error())
+	case hostRole.AfterOK:
+		validatorCaptured = true
+		b.pass(openCodeLane, "validator frame: host-serialized", "host-serialized role binding accepted end to end (fix merged)")
+		b.skip(openCodeLane, "validator frame: exact relay control", "host frame already captured the slot; control unnecessary")
+	case strings.Contains(hostRole.Error, bindingInvalid):
+		b.fail(openCodeLane, "validator frame: host-serialized",
+			"known-red pending fix/opencode-host-binding: Go transport requires byte-exact provider prompt; host re-serialization refused: "+firstLine(hostRole.Error))
+	default:
+		b.fail(openCodeLane, "validator frame: host-serialized", "unexpected failure: "+firstLine(hostRole.Error))
+	}
+
+	if !validatorCaptured {
+		exact, err := b.runHookCase(node, harnessCase{
+			Name:       "validator-exact-relay",
+			Subagent:   "review-validator",
+			Prompt:     providerPrompt,
+			TaskOutput: string(validatorJSON),
+		})
+		switch {
+		case err != nil:
+			b.fail(openCodeLane, "validator frame: exact relay control", err.Error())
+			return
+		case !exact.AfterOK:
+			b.fail(openCodeLane, "validator frame: exact relay control", firstLine(exact.Error))
+			return
+		default:
+			roleResult := b.record("provider-role", []byte(exact.Output))
+			if captured, _ := roleResult["captured"].(bool); !captured {
+				b.fail(openCodeLane, "validator frame: exact relay control", "role completion did not report captured=true")
+				return
+			}
+			b.pass(openCodeLane, "validator frame: exact relay control", "exact Go-issued role prompt round-tripped and captured")
+		}
+	}
+
+	// Terminal: finalize the captured validation to the approved receipt.
+	statusDoc, stderr, _ = b.status(repo, "opencode")
+	command := getString(statusDoc, "next_transition", "execute", "command")
+	if getString(statusDoc, "next_transition", "execute", "operation") != "review.finalize" || command == "" {
+		b.fail(openCodeLane, "correction lifecycle approved", fmt.Sprintf("expected finalize transition, got %s/%s %s",
+			getString(statusDoc, "next_transition", "kind"), getString(statusDoc, "next_transition", "reason_code"), firstLine(stderr)))
+		return
+	}
+	finalize, stderr, code := b.runCommandLine("operation", repo, command)
+	if code != 0 || operationState(finalize) != "approved" {
+		b.fail(openCodeLane, "correction lifecycle approved", fmt.Sprintf("exit=%d state=%q %s", code, operationState(finalize), firstLine(stderr)))
+		return
+	}
+	b.pass(openCodeLane, "correction lifecycle approved", "plan, fix, evidence, and captured validation reached the approved receipt")
+}
+
+// driveCorrectionToValidation walks finalize -> correction plan -> fix edit ->
+// evidence capture, leaving the lineage waiting on targeted validation.
+func (b *battery) driveCorrectionToValidation(repo, fixedBase string) bool {
+	statusDoc, stderr, _ := b.status(repo, "opencode")
+	command := getString(statusDoc, "next_transition", "execute", "command")
+	if getString(statusDoc, "next_transition", "execute", "operation") != "review.finalize" || command == "" {
+		b.fail(openCodeLane, "correction: finalize captured results", fmt.Sprintf("expected finalize transition; %s", firstLine(stderr)))
+		return false
+	}
+	finalize, stderr, code := b.runCommandLine("operation", repo, command)
+	if code != 0 || operationState(finalize) != "correction_required" {
+		b.fail(openCodeLane, "correction: finalize captured results", fmt.Sprintf("exit=%d state=%q %s", code, operationState(finalize), firstLine(stderr)))
+		return false
+	}
+
+	// Correction plan forecast is submitted BEFORE editing.
+	statusDoc, stderr, _ = b.status(repo, "opencode")
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "external.plan_correction" {
+		b.fail(openCodeLane, "correction: plan forecast", fmt.Sprintf("no plan_correction collect input; %s", firstLine(stderr)))
+		return false
+	}
+	tokens := substituteTokens(getSlice(input, "submission", "argument_tokens"), map[string]string{"value": "2"})
+	planArgs := append([]string{"review", getString(input, "submission", "operation_token")}, tokens...)
+	plan, stderr, code := b.runJSON("operation", b.workRoot, planArgs...)
+	if code != 0 || operationState(plan) != "correction_required" {
+		b.fail(openCodeLane, "correction: plan forecast", fmt.Sprintf("exit=%d state=%q %s", code, operationState(plan), firstLine(stderr)))
+		return false
+	}
+
+	// Bounded fix edit.
+	fixed := fixedBase + "export function shout(name) {\n  if (name == null) return \"!\";\n  return name.toUpperCase() + \"!\";\n}\n"
+	if err := writeFile(repo, "src/greet.js", fixed); err != nil {
+		b.fail(openCodeLane, "correction: bounded fix edit", err.Error())
+		return false
+	}
+
+	// Correction verification evidence.
+	statusDoc, stderr, _ = b.status(repo, "opencode")
+	input = collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-evidence" {
+		b.fail(openCodeLane, "correction: evidence capture", fmt.Sprintf("no capture-evidence collect input; %s", firstLine(stderr)))
+		return false
+	}
+	evidencePath := filepath.Join(b.workRoot, "opencode-evidence.txt")
+	evidence := fmt.Sprintf("crosslane battery %s: node --check src/greet.js passed; shout(null) now returns \"!\" instead of throwing\n", timestamp())
+	if err := os.WriteFile(evidencePath, []byte(evidence), 0o644); err != nil {
+		b.fail(openCodeLane, "correction: evidence capture", err.Error())
+		return false
+	}
+	tokens = substituteTokens(getSlice(input, "submission", "argument_tokens"), map[string]string{"outcome": "passed", "input": evidencePath})
+	captureArgs := append([]string{"review", getString(input, "submission", "operation_token")}, tokens...)
+	record, stderr, code := b.runJSON("verification-evidence", b.workRoot, captureArgs...)
+	if code != 0 || getString(record, "outcome") != "passed" {
+		b.fail(openCodeLane, "correction: evidence capture", fmt.Sprintf("exit=%d outcome=%q %s", code, getString(record, "outcome"), firstLine(stderr)))
+		return false
+	}
+	b.pass(openCodeLane, "correction: plan, fix, evidence", "forecast before edit, bounded fix, and passed evidence captured")
+	return true
+}
+
+// prepareHookHarness materializes the node harness directory: the REAL plugin
+// bytes, the hook emulator, and a PATH shim so the plugin's spawn("gentle-ai")
+// resolves to the binary under test.
+func (b *battery) prepareHookHarness(repo string) (string, error) {
+	if _, err := exec.LookPath("node"); err != nil {
+		return "", fmt.Errorf("node is unavailable: %w", err)
+	}
+	plugin, err := os.ReadFile(filepath.Join(b.repoRoot, pluginSourcePath))
+	if err != nil {
+		return "", fmt.Errorf("read real plugin bytes: %w", err)
+	}
+	dir := filepath.Join(b.workRoot, "hook-harness")
+	if err := os.MkdirAll(filepath.Join(dir, "bin"), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plugin.mts"), plugin, 0o644); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "harness.mts"), []byte(hookHarness), 0o644); err != nil {
+		return "", err
+	}
+	shim := "#!/bin/sh\nexec \"" + b.binary + "\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "bin", "gentle-ai"), []byte(shim), 0o755); err != nil {
+		return "", err
+	}
+	_ = repo
+	return dir, nil
+}
+
+// runHookCase executes one hook case in a fresh node process so every case
+// gets an isolated relay registry, exactly like a fresh host session.
+func (b *battery) runHookCase(harnessDir string, c harnessCase) (harnessResult, error) {
+	configPath := filepath.Join(harnessDir, c.Name+".case.json")
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return harnessResult{}, err
+	}
+	if err := os.WriteFile(configPath, payload, 0o644); err != nil {
+		return harnessResult{}, err
+	}
+	command := exec.Command("node", "harness.mts", configPath)
+	command.Dir = harnessDir
+	command.Env = append(os.Environ(), "PATH="+filepath.Join(harnessDir, "bin")+string(os.PathListSeparator)+os.Getenv("PATH"))
+	output, err := command.Output()
+	if err != nil {
+		detail := ""
+		if exit, ok := err.(*exec.ExitError); ok {
+			detail = string(exit.Stderr)
+		}
+		return harnessResult{}, fmt.Errorf("hook harness crashed: %v %s", err, firstLine(detail))
+	}
+	var result harnessResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &result); err != nil {
+		return harnessResult{}, fmt.Errorf("decode hook harness output %q: %w", firstLine(string(output)), err)
+	}
+	return result, nil
+}
+
+// grantedInvocation extracts the provider-owned granted choice invocation.
+func grantedInvocation(consent map[string]any) string {
+	for _, raw := range getSlice(consent, "choices") {
+		choice, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if choice["answer"] == "granted" {
+			invocation, _ := choice["invocation"].(string)
+			return invocation
+		}
+	}
+	return ""
+}
+
+// reserializeBindingLine re-serializes the role binding line of a Go-issued
+// provider task prompt with the host's own JSON encoding (sorted keys),
+// preserving the binding semantics byte-for-byte at the field level.
+func reserializeBindingLine(prompt string) (string, error) {
+	line, rest, hasRest := strings.Cut(prompt, "\n")
+	const header = "GENTLE_AI_REVIEW_PROVIDER_TASK "
+	encoded, found := strings.CutPrefix(line, header)
+	if !found {
+		return "", fmt.Errorf("provider task prompt has no role binding header")
+	}
+	var binding map[string]any
+	if err := json.Unmarshal([]byte(encoded), &binding); err != nil {
+		return "", fmt.Errorf("decode role binding: %w", err)
+	}
+	reserialized, err := json.Marshal(binding) // Go maps marshal with sorted keys
+	if err != nil {
+		return "", err
+	}
+	if string(reserialized) == encoded {
+		return "", fmt.Errorf("re-serialized role binding is byte-identical; perturbation void")
+	}
+	out := header + string(reserialized)
+	if hasRest {
+		out += "\n" + rest
+	}
+	return out, nil
+}

--- a/scripts/crosslane/pirelay.mts
+++ b/scripts/crosslane/pirelay.mts
@@ -1,0 +1,68 @@
+// Cross-lane battery pi host-relay driver.
+//
+// Feeds one provider-issued review.capture-result collect input to the
+// INSTALLED gentle-pi review-host-relay implementation: the lib/ sources are
+// copied byte-identical next to this file, relocated out of node_modules only
+// because Node refuses type-stripping under node_modules. The relay itself is
+// the real production code path: materialize prelude -> brand-new locked-down
+// print-mode `pi` subprocess in an empty scratch directory (REVIEW_HOST_RELAY_PI_ARGV)
+// -> submission of the raw final bytes through the provider-owned form.
+//
+// The wire submission (snake_case) is decoded into the relay's typed form
+// exactly as gentle-pi's status decoder does; both the current `value` object
+// and the decoder-era `values` array wire forms are accepted.
+//
+// Input: one case config JSON path as argv[2]:
+//   {
+//     "capture_argument_tokens": ["--lineage=...", ...],
+//     "submission": { "operation_token", "argument_tokens", "value"|"values" },
+//     "gentle_ai_executable": "/abs/path/gentle-ai",
+//     "pi_executable": "pi"
+//   }
+// Output: one JSON result line on stdout:
+//   { prompt_bytes, result_bytes, submission }
+import { readFileSync } from "node:fs"
+import { runReviewHostRelaySlot } from "./lib/review-host-relay.ts"
+
+interface WireSubmissionValue {
+  slot: string
+  domain: string
+  substitution_location: number
+}
+
+interface CaseConfig {
+  capture_argument_tokens: string[]
+  submission: {
+    operation_token: string
+    argument_tokens: string[]
+    value?: WireSubmissionValue
+    values?: WireSubmissionValue[]
+  }
+  gentle_ai_executable: string
+  pi_executable: string
+}
+
+const config = JSON.parse(readFileSync(process.argv[2], "utf8")) as CaseConfig
+const wire = config.submission
+const rows = wire.values ?? (wire.value ? [wire.value] : [])
+const submission = {
+  operationToken: wire.operation_token,
+  argumentTokens: wire.argument_tokens,
+  values: rows.map((row) => ({
+    slot: row.slot,
+    domain: row.domain,
+    substitutionLocation: row.substitution_location,
+  })),
+}
+const result = await runReviewHostRelaySlot({
+  captureArgumentTokens: config.capture_argument_tokens,
+  submission,
+  gentleAiExecutable: config.gentle_ai_executable,
+  piExecutable: config.pi_executable,
+  environment: { ...process.env, GENTLE_PI_REVIEW_RELAY_CONTRACT: "gentle-pi.review-relay/v1" },
+})
+console.log(JSON.stringify({
+  prompt_bytes: result.promptByteLength,
+  result_bytes: result.resultByteLength,
+  submission: result.submission,
+}))

--- a/scripts/crosslane/schema.go
+++ b/scripts/crosslane/schema.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const schemaLane = "schema"
+
+// runSchemaLane validates every envelope the battery captured against the
+// published schemas in contracts/review-integration/. An envelope whose
+// declared schema identity has no published schema file, or whose bytes fail
+// its published schema, is an emitter/schema divergence and fails the lane.
+func (b *battery) runSchemaLane() {
+	compiled, index, err := b.compilePublishedSchemas()
+	if err != nil {
+		b.fail(schemaLane, "compile published schemas", err.Error())
+		return
+	}
+
+	type outcome struct {
+		total    int
+		failures []string
+	}
+	outcomes := map[string]*outcome{}
+	for _, envelope := range b.envelopes {
+		state := outcomes[envelope.Schema]
+		if state == nil {
+			state = &outcome{}
+			outcomes[envelope.Schema] = state
+		}
+		state.total++
+		schema, published := compiled[envelope.Schema]
+		if !published {
+			if len(state.failures) == 0 {
+				state.failures = append(state.failures, "no published schema in contracts/ covers this emitted envelope")
+			}
+			continue
+		}
+		document, err := jsonschema.UnmarshalJSON(strings.NewReader(string(envelope.Body)))
+		if err != nil {
+			state.failures = append(state.failures, fmt.Sprintf("%s: %v", envelope.Source, err))
+			continue
+		}
+		if err := schema.Validate(document); err != nil {
+			detail := err.Error()
+			if validation, ok := err.(*jsonschema.ValidationError); ok {
+				detail = flattenValidationError(validation)
+			}
+			state.failures = append(state.failures, fmt.Sprintf("%s: %s", envelope.Source, detail))
+		}
+	}
+
+	identities := make([]string, 0, len(outcomes))
+	for identity := range outcomes {
+		identities = append(identities, identity)
+	}
+	sort.Strings(identities)
+	for _, identity := range identities {
+		state := outcomes[identity]
+		name := "conformance: " + identity
+		if len(state.failures) == 0 {
+			b.pass(schemaLane, name, fmt.Sprintf("%d captured envelope(s) match the published schema", state.total))
+			continue
+		}
+		unique := dedupe(state.failures)
+		note := fmt.Sprintf("%d/%d envelope(s) diverge: %s", len(state.failures), state.total, strings.Join(unique, " | "))
+		b.fail(schemaLane, name, note)
+	}
+	_ = index
+}
+
+// compilePublishedSchemas compiles every schema under
+// contracts/review-integration/{v1,v2}/schemas and indexes them by the
+// envelope identity each one validates (properties.schema.const).
+func (b *battery) compilePublishedSchemas() (map[string]*jsonschema.Schema, []string, error) {
+	compiler := jsonschema.NewCompiler()
+	compiler.UseRegexpEngine(crosslaneRegexpEngine)
+	type pending struct {
+		identity string
+		id       string
+	}
+	var pendings []pending
+	for _, version := range []string{"v1", "v2"} {
+		paths, err := filepath.Glob(filepath.Join(b.repoRoot, "contracts", "review-integration", version, "schemas", "*.schema.json"))
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, path := range paths {
+			payload, err := os.ReadFile(path)
+			if err != nil {
+				return nil, nil, err
+			}
+			document, err := jsonschema.UnmarshalJSON(strings.NewReader(string(payload)))
+			if err != nil {
+				return nil, nil, fmt.Errorf("%s: %w", path, err)
+			}
+			body, ok := document.(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("%s: schema document is not an object", path)
+			}
+			id, _ := body["$id"].(string)
+			if id == "" {
+				return nil, nil, fmt.Errorf("%s: schema document has no $id", path)
+			}
+			if err := compiler.AddResource(id, document); err != nil {
+				return nil, nil, fmt.Errorf("%s: %w", path, err)
+			}
+			identity := getString(map[string]any{"root": body}, "root", "properties", "schema", "const")
+			if identity != "" {
+				pendings = append(pendings, pending{identity: identity, id: id})
+			}
+		}
+	}
+	compiled := map[string]*jsonschema.Schema{}
+	var identities []string
+	for _, p := range pendings {
+		schema, err := compiler.Compile(p.id)
+		if err != nil {
+			return nil, nil, fmt.Errorf("compile %s: %w", p.id, err)
+		}
+		// Later contract versions win when two files share an identity
+		// (they do not today; keep the first compiled otherwise).
+		if _, exists := compiled[p.identity]; !exists {
+			compiled[p.identity] = schema
+		}
+		identities = append(identities, p.identity)
+	}
+	return compiled, identities, nil
+}
+
+func flattenValidationError(err *jsonschema.ValidationError) string {
+	leaf := err
+	for len(leaf.Causes) > 0 {
+		leaf = leaf.Causes[0]
+	}
+	location := "/" + strings.Join(leaf.InstanceLocation, "/")
+	detail := firstLine(leaf.Error())
+	if index := strings.Index(detail, ": "); index >= 0 {
+		detail = detail[index+2:]
+	}
+	return fmt.Sprintf("%s: %s", location, detail)
+}
+
+func dedupe(values []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, value := range values {
+		if !seen[value] {
+			seen[value] = true
+			out = append(out, value)
+		}
+	}
+	if len(out) > 3 {
+		out = append(out[:3], fmt.Sprintf("(+%d more)", len(out)-3))
+	}
+	return out
+}
+
+// crosslaneRegexpEngine mirrors the repository's schema test engine: Go
+// regexp cannot compile the one negative-lookahead path pattern used by the
+// published schemas, so that exact pattern gets a semantic matcher.
+func crosslaneRegexpEngine(pattern string) (jsonschema.Regexp, error) {
+	if pattern == `^(?!/)(?!.*(?:^|/)\.\.(?:/|$)).+$` {
+		return crosslaneRegexp{pattern: pattern}, nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return crosslaneRegexp{pattern: pattern, re: re}, nil
+}
+
+type crosslaneRegexp struct {
+	pattern string
+	re      *regexp.Regexp
+}
+
+func (r crosslaneRegexp) String() string { return r.pattern }
+
+func (r crosslaneRegexp) MatchString(value string) bool {
+	if r.re == nil {
+		return value != "" && !strings.HasPrefix(value, "/") && !strings.Contains(value, "\n") && !slices.Contains(strings.Split(value, "/"), "..")
+	}
+	return r.re.MatchString(value)
+}

--- a/scripts/crosslane/schema.go
+++ b/scripts/crosslane/schema.go
@@ -126,11 +126,9 @@ func (b *battery) compilePublishedSchemas() (map[string]*jsonschema.Schema, []st
 		if err != nil {
 			return nil, nil, fmt.Errorf("compile %s: %w", p.id, err)
 		}
-		// Later contract versions win when two files share an identity
-		// (they do not today; keep the first compiled otherwise).
-		if _, exists := compiled[p.identity]; !exists {
-			compiled[p.identity] = schema
-		}
+		// Later contract versions win when two files share an identity:
+		// the walk visits v1 before v2, so the last assignment is newest.
+		compiled[p.identity] = schema
 		identities = append(identities, p.identity)
 	}
 	return compiled, identities, nil


### PR DESCRIPTION
Closes #3361.

Local cross-lane battery: deterministic host-frame/lifecycle/schema tiers plus --with-model (real reviewer) and --with-host (real codex exec, pi print-mode relay, headless opencode run in sandboxed HOME). Includes the bounded 61-line correction from its own RDD review: work-root cleanup on failing exits (credential retention), WaitDelay/timeout bounds for host and model lanes, err-shadow fixes, newest-schema precedence, admission assertion, and a fail-able pi probe.

RDD receipt: review-f934ba904c3037ec (approved, 4R, one bounded correction).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-lane integration battery for validating capabilities, review workflows, consent, corrections, evidence, and approvals.
  * Added optional integrations with Claude, Codex, Pi, and OpenCode, including automatic prerequisite checks and skip handling.
  * Added schema conformance checks for published envelope formats.
  * Added deterministic local execution with optional model and real-host runs, timeout protection, result reporting, and token-cost tracking.
  * Added JSON-based harnesses for capturing and validating transport and review results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->