### PR TITLE
fix(contracts): admit pi agent and capture-result submission in published v2 schemas

### DIFF
--- a/contracts/review-integration/v2/schemas/consent-v3.schema.json
+++ b/contracts/review-integration/v2/schemas/consent-v3.schema.json
@@ -15,7 +15,7 @@
     "contract": {"const": "gentle-ai.review-integration/v2"},
     "operation": {"const": "review.start"},
     "action": {"const": "consent_required"},
-    "agent": {"enum": ["claude-code", "opencode", "codex"]},
+    "agent": {"enum": ["claude-code", "opencode", "codex", "pi"]},
     "blocking": {"const": true},
     "target_identity": {"$ref": "#/$defs/sha256"},
     "projection": {"enum": ["workspace", "staged"]},

--- a/contracts/review-integration/v2/schemas/status-v5.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v5.schema.json
@@ -101,7 +101,7 @@
         "schema": {"type": "string", "minLength": 1},
         "capture_operation": {"type": "string", "minLength": 1},
         "arguments": {"type": "array", "minItems": 1, "items": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_argument"}},
-        "submission": {"oneOf": [{"$ref": "#/$defs/submission_descriptor"}, {"$ref": "#/$defs/capture_evidence_submission_descriptor"}]},
+        "submission": {"oneOf": [{"$ref": "#/$defs/submission_descriptor"}, {"$ref": "#/$defs/capture_evidence_submission_descriptor"}, {"$ref": "#/$defs/capture_result_submission_descriptor"}]},
         "artifact_subject": {"$ref": "artifact-subject.schema.json"},
         "base_tree": {"$ref": "#/$defs/git_tree"},
         "candidate_tree": {"$ref": "#/$defs/git_tree"},
@@ -115,8 +115,8 @@
         {"if": {"properties": {"capture_operation": {"not": {"enum": ["external.run_targeted_validation", "review.capture-validation"]}}}, "required": ["capture_operation"]}, "then": {"not": {"required": ["validation_request"]}}},
         {"if": {"properties": {"capture_operation": {"const": "external.plan_correction"}}, "required": ["capture_operation"]}, "then": {"required": ["submission"], "properties": {"schema": {"const": "gentle-ai.review-correction-plan/v1"}}}},
         {"if": {"properties": {"capture_operation": {"const": "review.capture-evidence"}}, "required": ["capture_operation"]}, "then": {"required": ["submission"], "properties": {"schema": {"const": "https://gentle-ai.dev/schema/review/verification-evidence/v1"}, "submission": {"$ref": "#/$defs/capture_evidence_submission_descriptor"}}}},
-        {"if": {"properties": {"capture_operation": {"not": {"enum": ["external.plan_correction", "external.run_targeted_validation", "review.capture-evidence"]}}}, "required": ["capture_operation"]}, "then": {"not": {"required": ["submission"]}}},
-        {"if": {"properties": {"capture_operation": {"const": "review.capture-result"}}, "required": ["capture_operation"]}, "then": {"required": ["artifact_subject", "base_tree", "candidate_tree", "changed_path_manifest"], "properties": {"schema": {"const": "https://gentle-ai.dev/schema/review/reviewer/v1"}}}, "else": {"allOf": [{"not": {"required": ["artifact_subject"]}}, {"not": {"required": ["base_tree"]}}, {"not": {"required": ["candidate_tree"]}}, {"not": {"required": ["changed_path_manifest"]}}]}},
+        {"if": {"properties": {"capture_operation": {"not": {"enum": ["external.plan_correction", "external.run_targeted_validation", "review.capture-evidence", "review.capture-result"]}}}, "required": ["capture_operation"]}, "then": {"not": {"required": ["submission"]}}},
+        {"if": {"properties": {"capture_operation": {"const": "review.capture-result"}}, "required": ["capture_operation"]}, "then": {"required": ["artifact_subject", "base_tree", "candidate_tree", "changed_path_manifest"], "properties": {"schema": {"const": "https://gentle-ai.dev/schema/review/reviewer/v1"}, "submission": {"$ref": "#/$defs/capture_result_submission_descriptor"}}}, "else": {"allOf": [{"not": {"required": ["artifact_subject"]}}, {"not": {"required": ["base_tree"]}}, {"not": {"required": ["candidate_tree"]}}, {"not": {"required": ["changed_path_manifest"]}}]}},
         {"if": {"properties": {"capture_operation": {"const": "external.run_provider_role"}}, "required": ["capture_operation"]}, "then": {"required": ["provider_task"]}, "else": {"not": {"required": ["provider_task"]}}}
       ]
     },
@@ -177,6 +177,25 @@
         "domain": {"const": "artifact_path_or_stdin"},
         "schema": {"const": "https://gentle-ai.dev/schema/review/verification-evidence/v1"},
         "substitution_location": {"const": 5}
+      }
+    },
+    "capture_result_submission_descriptor": {
+      "type": "object", "additionalProperties": false,
+      "required": ["operation_token", "argument_tokens", "value"],
+      "properties": {
+        "operation_token": {"const": "capture-result"},
+        "argument_tokens": {"type": "array", "minItems": 8, "maxItems": 8, "prefixItems": [{"pattern": "^--lineage=\\S+$"}, {"pattern": "^--expected-revision=sha256:[0-9a-f]{64}$"}, {"pattern": "^--target=sha256:[0-9a-f]{64}$"}, {"pattern": "^--repository-context=rctx1_[0-9a-f]{64}$"}, {"pattern": "^--lens=\\S+$"}, {"pattern": "^--order=[0-9]+$"}, {"pattern": "^--subject-hash=sha256:[0-9a-f]{64}$"}, {"const": "--input={{value}}"}], "items": false},
+        "value": {"$ref": "#/$defs/capture_result_submission_value"}
+      }
+    },
+    "capture_result_submission_value": {
+      "type": "object", "additionalProperties": false,
+      "required": ["slot", "domain", "schema", "substitution_location"],
+      "properties": {
+        "slot": {"const": "reviewer_result"},
+        "domain": {"const": "artifact_path_or_stdin"},
+        "schema": {"const": "https://gentle-ai.dev/schema/review/reviewer/v1"},
+        "substitution_location": {"const": 7}
       }
     },
     "git_tree": {"type": "string", "pattern": "^[0-9a-f]{40}([0-9a-f]{24})?$"}

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -84,8 +84,11 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		// agent token when the caller declared no runtime (the pinned fixture
 		// itself carries no --agent), and #2676 binds the declared runtime
 		// (claude-code, opencode, codex) when there is one. The schema now
-		// follows the emitter. Deliberate, not drift.
-		"schemas/consent-v3.schema.json": "2315f1ecda9e798344f0886434316a2cba69e9cc4c1a72eb436bd5fe44c25bb6",
+		// follows the emitter. The agent enum also admits "pi": the Pi host
+		// relay drives consent with its own declared runtime identity, which
+		// the emitter legitimately publishes once the relay handshake is
+		// declared. Deliberate, not drift.
+		"schemas/consent-v3.schema.json": "f56b1809c1bff21713795ef37a095c6ecfdbbb3cf928bcf604b8d5f33be3dea5",
 		"schemas/status.schema.json":     "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
 	}
 	for name, expected := range want {
@@ -112,9 +115,12 @@ func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 		// host-relay (review.capture-validation) shapes, which the schema
 		// rejected as missing the generic submission; and the negotiated-route
 		// disposition preview (ReviewRepairDispositionProviderInputs) is real
-		// optional emitter output the strict schema must admit. Deliberate,
-		// not drift.
-		"schemas/status-v5.schema.json": "5d5170d0c4be0977b640524c6ca9b119e42803a9e8409c43f0053c0c6fbd421e",
+		// optional emitter output the strict schema must admit; and the pi
+		// host-relay materialize path renders the reviewer_result collect
+		// input with a capture-result submission descriptor, which the
+		// submission oneOf and the no-submission allOf rule both rejected.
+		// Deliberate, not drift.
+		"schemas/status-v5.schema.json": "4dd17e863725edb20e9cbb85d9614dfdc07ef6c9257aa789f4c9e8835400483e",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))

--- a/internal/cli/review_published_schema_conformance_test.go
+++ b/internal/cli/review_published_schema_conformance_test.go
@@ -197,11 +197,17 @@ func TestConsentFixtureMatchesPublishedConsentSchemaV3(t *testing.T) {
 // TestConsentEnvelopeWithDeclaredRuntimeMatchesPublishedConsentSchemaV3 drives
 // the live relay-declared START with each runtime the consent validator
 // accepts and validates the emitted envelope, so the published agent domain
-// covers every identity the emitter can actually publish (#2676).
+// covers every identity the emitter can actually publish (#2676). Pi joins
+// the domain through its host-relay handshake: the emitter legitimately
+// publishes agent "pi" once the relay contract is declared, so the published
+// schema must admit it (cross-lane battery conformance finding).
 func TestConsentEnvelopeWithDeclaredRuntimeMatchesPublishedConsentSchemaV3(t *testing.T) {
 	schema := compileWholePublishedReviewSchema(t, "v2", "consent-v3.schema.json")
-	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
+	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex, model.AgentPi} {
 		t.Run(string(agent), func(t *testing.T) {
+			if agent == model.AgentPi {
+				t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+			}
 			reviewModeHome(t)
 			repo := initReviewCLIRepo(t)
 			stubReviewConsole(t, false, "")
@@ -219,6 +225,39 @@ func TestConsentEnvelopeWithDeclaredRuntimeMatchesPublishedConsentSchemaV3(t *te
 			validatePublishedReviewSchema(t, schema, output.Bytes())
 		})
 	}
+}
+
+// TestPiHostRelayStatusEnvelopeMatchesPublishedStatusSchemaV5 pins the whole
+// live negotiated STATUS envelope the Pi host relay receives: the materialize
+// branch (review_next_transition.go's reviewCaptureInput) renders the
+// reviewer_result collect input with a capture-result submission descriptor,
+// real emitter output the published status-v5 schema must admit (cross-lane
+// battery conformance finding).
+func TestPiHostRelayStatusEnvelopeMatchesPublishedStatusSchemaV5(t *testing.T) {
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, _, record, _ := newCandidateInspectionReview(t, "candidate\n", true)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", record.State.LineageID, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentPi), "--next-transition",
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("pi host relay transition = %#v", status.NextTransition)
+	}
+	// The divergence needs the capture-result submission present, so this
+	// test proves the live emitter really publishes it before validating.
+	submission := status.NextTransition.Collect.Inputs[0].Submission
+	if submission == nil || submission.OperationToken != "capture-result" {
+		t.Fatalf("pi host relay submission = %#v", submission)
+	}
+	schema := compileWholePublishedReviewSchema(t, "v2", "status-v5.schema.json")
+	validatePublishedReviewSchema(t, schema, output.Bytes())
 }
 
 // TestReviewGateResultEnvelopeMatchesPublishedSchema walks one low-risk


### PR DESCRIPTION
Closes #3363.

Admit the pi agent in consent/v3 and the pi host-relay capture-result submission descriptor in status/v5, with RED-first regression tests driving the real emission paths and validating full envelopes against the published schemas. Both defects were caught by the cross-lane battery conformance tier from #3362.

RDD receipt: review-e656321ae665c4bd (approved, medium, one lens, no findings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Pi as a recognized review agent.
  * Added `capture-result` submissions for review transitions, including reviewer-result artifact metadata and validated command arguments.

* **Bug Fixes**
  * Updated schema validation to correctly accept and enforce the new review submission format.

* **Tests**
  * Expanded conformance coverage for Pi host-relay status messages and capture-result submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->