### PR TITLE
fix(review): compact the changed-path manifest encoding

### DIFF
--- a/contracts/review-integration/v1/fixtures/start-v2.fixture.json
+++ b/contracts/review-integration/v1/fixtures/start-v2.fixture.json
@@ -77,16 +77,7 @@
     "byte_size": 226
   },
   "changed_path_manifest": [
-    {
-      "path": "scripts/deploy.sh",
-      "status": "A",
-      "old_mode": "000000",
-      "new_mode": "100644",
-      "deleted": false,
-      "type_changed": false,
-      "mode_only": false,
-      "intended_untracked": false
-    }
+    {"path":"scripts/deploy.sh","status":"A","old_mode":"000000","new_mode":"100644","deleted":false,"type_changed":false,"mode_only":false,"intended_untracked":false}
   ],
   "repository_context": {
     "capability": "review.opaque_repository_context",

--- a/contracts/review-integration/v1/fixtures/start.fixture.json
+++ b/contracts/review-integration/v1/fixtures/start.fixture.json
@@ -31,16 +31,7 @@
     "byte_size": 226
   },
   "changed_path_manifest": [
-    {
-      "path": "scripts/deploy.sh",
-      "status": "A",
-      "old_mode": "000000",
-      "new_mode": "100644",
-      "deleted": false,
-      "type_changed": false,
-      "mode_only": false,
-      "intended_untracked": true
-    }
+    {"path":"scripts/deploy.sh","status":"A","old_mode":"000000","new_mode":"100644","deleted":false,"type_changed":false,"mode_only":false,"intended_untracked":true}
   ],
   "repository_context": {
     "capability": "review.opaque_repository_context",

--- a/contracts/review-integration/v1/fixtures/status-v2.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status-v2.fixture.json
@@ -175,16 +175,7 @@
             "byte_size": 209
           },
           "changed_path_manifest": [
-            {
-              "path": "tracked.txt",
-              "status": "M",
-              "old_mode": "100644",
-              "new_mode": "100644",
-              "deleted": false,
-              "type_changed": false,
-              "mode_only": false,
-              "intended_untracked": false
-            }
+            {"path":"tracked.txt","status":"M","old_mode":"100644","new_mode":"100644","deleted":false,"type_changed":false,"mode_only":false,"intended_untracked":false}
           ]
         }
       ]

--- a/contracts/review-integration/v2/fixtures/start.fixture.json
+++ b/contracts/review-integration/v2/fixtures/start.fixture.json
@@ -73,16 +73,7 @@
     }
   ],
   "changed_path_manifest": [
-    {
-      "path": "scripts/deploy.sh",
-      "status": "A",
-      "old_mode": "000000",
-      "new_mode": "100644",
-      "deleted": false,
-      "type_changed": false,
-      "mode_only": false,
-      "intended_untracked": true
-    }
+    {"path":"scripts/deploy.sh","status":"A","old_mode":"000000","new_mode":"100644","deleted":false,"type_changed":false,"mode_only":false,"intended_untracked":true}
   ],
   "repository_context": {
     "capability": "review.opaque_repository_context",

--- a/contracts/review-integration/v2/fixtures/status.fixture.json
+++ b/contracts/review-integration/v2/fixtures/status.fixture.json
@@ -95,16 +95,7 @@
           "base_tree": "3e21a205dd9b55021aeae87965092623807e455f",
           "candidate_tree": "1c3325617279b38743f073302ba190fc421b5a09",
           "changed_path_manifest": [
-            {
-              "path": "tracked.txt",
-              "status": "M",
-              "old_mode": "100644",
-              "new_mode": "100644",
-              "deleted": false,
-              "type_changed": false,
-              "mode_only": false,
-              "intended_untracked": false
-            }
+            {"path":"tracked.txt","status":"M","old_mode":"100644","new_mode":"100644","deleted":false,"type_changed":false,"mode_only":false,"intended_untracked":false}
           ]
         }
       ]

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -904,8 +905,175 @@ func reviewGateAction(result reviewtransaction.GateResult) string {
 	}
 }
 
+// reviewManifestArrayKey is the one emitted object key whose array elements are
+// written one per line instead of one field per line.
+//
+// The changed-path manifest is the only field this product emits whose size is
+// proportional to the candidate's changed-file count and whose shape it cannot
+// reduce: the published contract fixes its eight required per-entry fields and
+// forbids additional ones (contracts/review-integration/v2/schemas/
+// start.schema.json#/$defs/changed_path), and every negotiated route that
+// carries reviewer context is required to carry it. What this product does own
+// is how many lines those fixed fields are spread across. Indented per field
+// they cost ten lines per entry, which is how a 149-path candidate reached a
+// 1,505-line payload in a consumer's conversation (issue #3281). One line per
+// entry is the floor that keeps the field intact.
+//
+// This is insignificant whitespace only. The emitted bytes decode to exactly
+// the same value, so every published-schema validation, every artifact-subject
+// digest taken over the manifest, and every consumer that parses rather than
+// pattern-matches the payload are unaffected.
+const reviewManifestArrayKey = `"changed_path_manifest": [`
+
 func encodeReviewJSON(stdout io.Writer, value any) error {
-	encoder := json.NewEncoder(stdout)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(value)
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	// json.Encoder.SetIndent is exactly Marshal followed by Indent, so keeping
+	// both steps explicit leaves every non-manifest envelope byte-identical to
+	// the encoder this product has always used.
+	var indented bytes.Buffer
+	if err := json.Indent(&indented, payload, "", "  "); err != nil {
+		return err
+	}
+	emitted := append(compactReviewChangedPathManifests(indented.Bytes()), '\n')
+	_, err = stdout.Write(emitted)
+	return err
+}
+
+// compactReviewChangedPathManifests rewrites every changed-path manifest array
+// in already-indented JSON so each entry occupies one line. Any array it cannot
+// fully account for is copied through untouched, because emitting a payload
+// this pass only partly understood would be worse than emitting a verbose one.
+func compactReviewChangedPathManifests(indented []byte) []byte {
+	var out bytes.Buffer
+	out.Grow(len(indented))
+	cursor := 0
+	for cursor < len(indented) {
+		key := indexReviewManifestArrayKey(indented, cursor)
+		if key < 0 {
+			break
+		}
+		open := key + len(reviewManifestArrayKey) - 1
+		end := reviewJSONArrayEnd(indented, open)
+		var entries []json.RawMessage
+		if end < 0 || json.Unmarshal(indented[open:end+1], &entries) != nil {
+			out.Write(indented[cursor : open+1])
+			cursor = open + 1
+			continue
+		}
+		compacted, ok := compactReviewManifestEntries(entries, reviewJSONLineIndent(indented, key))
+		if !ok {
+			out.Write(indented[cursor : end+1])
+			cursor = end + 1
+			continue
+		}
+		out.Write(indented[cursor:open])
+		out.Write(compacted)
+		cursor = end + 1
+	}
+	out.Write(indented[cursor:])
+	return out.Bytes()
+}
+
+// compactReviewManifestEntries renders one manifest array in the exact layout
+// json.Indent would use for the array itself, with each entry on a single line.
+func compactReviewManifestEntries(entries []json.RawMessage, indent string) ([]byte, bool) {
+	var out bytes.Buffer
+	out.WriteByte('[')
+	for index, entry := range entries {
+		if index > 0 {
+			out.WriteByte(',')
+		}
+		out.WriteByte('\n')
+		out.WriteString(indent)
+		out.WriteString("  ")
+		if err := json.Compact(&out, entry); err != nil {
+			return nil, false
+		}
+	}
+	if len(entries) > 0 {
+		out.WriteByte('\n')
+		out.WriteString(indent)
+	}
+	out.WriteByte(']')
+	return out.Bytes(), true
+}
+
+// indexReviewManifestArrayKey finds the next manifest array key that is a real
+// object key rather than text inside a string value. Indented JSON always
+// precedes an object key with a line break and its indent, and a raw line break
+// can never appear inside a JSON string, so that prefix is proof of position.
+func indexReviewManifestArrayKey(indented []byte, from int) int {
+	for cursor := from; cursor < len(indented); {
+		offset := bytes.Index(indented[cursor:], []byte(reviewManifestArrayKey))
+		if offset < 0 {
+			return -1
+		}
+		match := cursor + offset
+		if reviewJSONLineStart(indented, match) >= 0 {
+			return match
+		}
+		cursor = match + 1
+	}
+	return -1
+}
+
+// reviewJSONLineStart reports the offset just past the line break preceding
+// position, provided only indent spaces separate them, and -1 otherwise.
+func reviewJSONLineStart(indented []byte, position int) int {
+	for cursor := position - 1; cursor >= 0; cursor-- {
+		switch indented[cursor] {
+		case ' ':
+		case '\n':
+			return cursor + 1
+		default:
+			return -1
+		}
+	}
+	return -1
+}
+
+// reviewJSONLineIndent returns the indent of the line holding position.
+func reviewJSONLineIndent(indented []byte, position int) string {
+	start := reviewJSONLineStart(indented, position)
+	if start < 0 {
+		return ""
+	}
+	return string(indented[start:position])
+}
+
+// reviewJSONArrayEnd returns the offset of the bracket closing the array that
+// opens at open, or -1 when the input is not a balanced array from there.
+func reviewJSONArrayEnd(indented []byte, open int) int {
+	if open >= len(indented) || indented[open] != '[' {
+		return -1
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for cursor := open; cursor < len(indented); cursor++ {
+		character := indented[cursor]
+		switch {
+		case escaped:
+			escaped = false
+		case inString && character == '\\':
+			escaped = true
+		case character == '"':
+			inString = !inString
+		case inString:
+		case character == '[' || character == '{':
+			depth++
+		case character == ']' || character == '}':
+			depth--
+			if depth == 0 {
+				if character != ']' {
+					return -1
+				}
+				return cursor
+			}
+		}
+	}
+	return -1
 }

--- a/internal/cli/review_manifest_line_budget_test.go
+++ b/internal/cli/review_manifest_line_budget_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// reviewManifestLineBudget is the per-entry line cost this product accepts for
+// an emitted changed-path manifest. The published contract fixes the entry's
+// eight required fields and forbids additional ones, so the only cost this
+// product still owns is how many lines those fields are spread across. One
+// entry per line is that floor; the indented-per-field form this pins against
+// cost ten, which is what turned a 149-path candidate into a 1,505-line
+// payload in a consumer's conversation (issue #3281).
+const reviewManifestLineBudget = 1
+
+// manifestEntryLineCost reports how many output lines the emitted
+// "changed_path_manifest" array spends per entry. It is deliberately measured
+// on the real emitted bytes rather than on a re-encoding, because the defect
+// this pins is a property of the bytes a consumer's terminal actually receives.
+func manifestEntryLineCost(t *testing.T, payload []byte, entries int) float64 {
+	t.Helper()
+	if entries == 0 {
+		t.Fatal("manifest line cost is undefined for an empty manifest")
+	}
+	key := reviewManifestArrayKey
+	start := bytes.Index(payload, []byte(key))
+	if start < 0 {
+		t.Fatalf("emitted payload carries no %q array", key)
+	}
+	open := start + len(key) - 1
+	end := reviewJSONArrayEnd(payload, open)
+	if end < 0 {
+		t.Fatalf("emitted %q array is unterminated", key)
+	}
+	// The array body always ends with one line break before its closing
+	// bracket; everything above that is the per-entry cost being measured.
+	return float64(bytes.Count(payload[open:end], []byte("\n"))-1) / float64(entries)
+}
+
+// TestNegotiatedStartBoundsChangedPathManifestLineCost pins the emitted line
+// cost of START's changed-path manifest. START is the route the field report
+// measured: on the reporter's candidate its manifest was 89% of the payload,
+// and it is emitted in full for every candidate regardless of size.
+func TestNegotiatedStartBoundsChangedPathManifestLineCost(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const paths = 40
+	for index := range paths {
+		writeReviewStartCandidate(t, repo,
+			"internal/generated/package"+strconv.Itoa(index)+"/descriptive_source_name.go",
+			"package generated\n\nfunc Exported"+strconv.Itoa(index)+"() bool { return true }\n", 0o644)
+	}
+	var output bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--lineage", "manifest-line-budget",
+	}), &output); err != nil {
+		t.Fatal(negotiatedReviewStartFailure(err, output.String()))
+	}
+	result := decodeNegotiatedReviewStart(t, output.Bytes())
+	if err := result.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if result.ChangedPathManifest == nil || len(*result.ChangedPathManifest) != paths {
+		t.Fatalf("START manifest = %v entries, want %d; the bound must never cost the caller data",
+			result.ChangedPathManifest, paths)
+	}
+	if cost := manifestEntryLineCost(t, output.Bytes(), paths); cost > reviewManifestLineBudget {
+		t.Fatalf("START spends %.2f lines per manifest entry, want at most %d (payload = %d lines, %d bytes)",
+			cost, reviewManifestLineBudget, bytes.Count(output.Bytes(), []byte("\n")), output.Len())
+	}
+}
+
+// TestCapturePreflightBoundsChangedPathManifestLineCost pins the same bound on
+// the capture preflight readback. That route stays reachable for candidates the
+// provider-materialized reviewer route refuses, so it must stay emittable and
+// merely stop spending ten lines on every entry.
+func TestCapturePreflightBoundsChangedPathManifestLineCost(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const paths = 40
+	for index := range paths {
+		writeReviewStartCandidate(t, repo,
+			"internal/generated/package"+strconv.Itoa(index)+"/descriptive_source_name.go",
+			"package generated\n\nfunc Exported"+strconv.Itoa(index)+"() bool { return true }\n", 0o644)
+	}
+	started := runNegotiatedReviewStart(t, repo, "manifest-preflight-line-budget")
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult([]string{
+		"--repository-context", started.RepositoryContext.Handle,
+		"--lineage", started.LineageID, "--target", started.RepositoryContext.TargetIdentity,
+		"--expected-revision", started.RepositoryContext.Revision,
+		"--lens", started.SelectedLenses[0], "--order", "0", "--preflight",
+	}, &output); err != nil {
+		t.Fatalf("capture-result preflight: %v\n%s", err, output.String())
+	}
+	var preflight reviewCapturePreflightResult
+	decodeStrictReviewJSON(t, output.Bytes(), &preflight)
+	if len(preflight.ChangedPathManifest) != paths {
+		t.Fatalf("preflight manifest = %d entries, want %d", len(preflight.ChangedPathManifest), paths)
+	}
+	if cost := manifestEntryLineCost(t, output.Bytes(), paths); cost > reviewManifestLineBudget {
+		t.Fatalf("capture preflight spends %.2f lines per manifest entry, want at most %d (payload = %d lines, %d bytes)",
+			cost, reviewManifestLineBudget, bytes.Count(output.Bytes(), []byte("\n")), output.Len())
+	}
+}
+
+// TestNegotiatedStatusBoundsChangedPathManifestLineCost pins the bound on the
+// negotiated collection transition, which repeats the identical manifest once
+// per uncaptured lens. The repetition itself is fixed by the published schema
+// and is not what this pins; the per-entry line cost of each copy is.
+func TestNegotiatedStatusBoundsChangedPathManifestLineCost(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const paths = reviewProviderMaxEvidenceEntries
+	for index := range paths {
+		writeReviewStartCandidate(t, repo,
+			"internal/generated/package"+strconv.Itoa(index)+"/descriptive_source_name.go",
+			"package generated\n\nfunc Exported"+strconv.Itoa(index)+"() bool { return true }\n", 0o644)
+	}
+	started := runNegotiatedReviewStart(t, repo, "manifest-status-line-budget")
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition",
+		"--lineage", started.LineageID,
+	}, &output); err != nil {
+		t.Fatalf("negotiated status: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) == 0 {
+		t.Fatalf("negotiated status did not offer a collection transition: %s", output.String())
+	}
+	for _, input := range status.NextTransition.Collect.Inputs {
+		if input.ChangedPathManifest == nil || len(*input.ChangedPathManifest) != paths {
+			t.Fatalf("collection input manifest = %v, want %d entries", input.ChangedPathManifest, paths)
+		}
+	}
+	inputs := len(status.NextTransition.Collect.Inputs)
+	if cost := manifestEntryLineCost(t, output.Bytes(), paths); cost > reviewManifestLineBudget {
+		t.Fatalf("negotiated status spends %.2f lines per manifest entry across %d inputs, want at most %d (payload = %d lines, %d bytes)",
+			cost, inputs, reviewManifestLineBudget, bytes.Count(output.Bytes(), []byte("\n")), output.Len())
+	}
+}
+
+// TestEncodeReviewJSONLeavesNonManifestPayloadsByteIdentical is the safety pin
+// for the emitter change: every envelope this product emits that carries no
+// changed-path manifest must still be byte-identical to the indented encoder
+// it has always used. Without this, a whitespace rewrite aimed at one field
+// could silently reshape every other published envelope.
+func TestEncodeReviewJSONLeavesNonManifestPayloadsByteIdentical(t *testing.T) {
+	payloads := []any{
+		nil,
+		map[string]any{},
+		[]any{},
+		map[string]any{"empty_object": map[string]any{}, "empty_array": []any{}, "nested": map[string]any{"deep": []any{1, 2, 3}}},
+		map[string]any{"escaped": "quote \" backslash \\ newline \n tag <b>&</b>", "unicode": "árbol ✅"},
+		ReviewIntegrationFailure{Schema: "gentle-ai.review-integration.failure/v2", Operation: "review.start", Code: "invalid_request"},
+	}
+	for index, payload := range payloads {
+		var emitted, reference bytes.Buffer
+		if err := encodeReviewJSON(&emitted, payload); err != nil {
+			t.Fatalf("payload %d: %v", index, err)
+		}
+		encoder := json.NewEncoder(&reference)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(payload); err != nil {
+			t.Fatalf("payload %d reference: %v", index, err)
+		}
+		if !bytes.Equal(emitted.Bytes(), reference.Bytes()) {
+			t.Fatalf("payload %d emitted bytes drifted from the indented encoder:\n got: %q\nwant: %q",
+				index, emitted.String(), reference.String())
+		}
+	}
+}
+
+// TestEncodeReviewJSONPreservesManifestValue proves the bound is a whitespace
+// property only: the emitted bytes must decode to exactly the manifest that
+// was handed to the emitter, because the artifact subject's digest is taken
+// over that value and a single altered entry would break every binding on it.
+func TestEncodeReviewJSONPreservesManifestValue(t *testing.T) {
+	manifest := []reviewtransaction.ChangedPathManifestEntry{
+		{Path: "docs/removed.md", Status: reviewtransaction.CandidatePathDeleted, OldMode: "100644", NewMode: "000000", Deleted: true},
+		{Path: "internal/auth/session.go", Status: reviewtransaction.CandidatePathAdded, OldMode: "000000", NewMode: "100644"},
+		{Path: "link", Status: reviewtransaction.CandidatePathTypeChanged, OldMode: "120000", NewMode: "100644", TypeChanged: true, IntendedUntracked: true},
+		{Path: "scripts/deploy \"quoted\".sh", Status: reviewtransaction.CandidatePathModified, OldMode: "100644", NewMode: "100755", ModeOnly: true},
+	}
+	digest, err := reviewtransaction.ChangedPathManifestDigest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := struct {
+		Schema              string                                       `json:"schema"`
+		ChangedPathManifest []reviewtransaction.ChangedPathManifestEntry `json:"changed_path_manifest"`
+		Trailing            string                                       `json:"trailing"`
+	}{Schema: "gentle-ai.review-capture-preflight/v1", ChangedPathManifest: manifest, Trailing: "after"}
+
+	var emitted bytes.Buffer
+	if err := encodeReviewJSON(&emitted, source); err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		Schema              string                                       `json:"schema"`
+		ChangedPathManifest []reviewtransaction.ChangedPathManifestEntry `json:"changed_path_manifest"`
+		Trailing            string                                       `json:"trailing"`
+	}
+	if err := json.Unmarshal(emitted.Bytes(), &decoded); err != nil {
+		t.Fatalf("emitted manifest payload is not decodable: %v\n%s", err, emitted.String())
+	}
+	roundTripped, err := reviewtransaction.ChangedPathManifestDigest(decoded.ChangedPathManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if roundTripped != digest {
+		t.Fatalf("emitted manifest digest = %q, want %q", roundTripped, digest)
+	}
+	if decoded.Schema != source.Schema || decoded.Trailing != source.Trailing {
+		t.Fatalf("emitted payload lost sibling fields: %#v", decoded)
+	}
+	if cost := manifestEntryLineCost(t, emitted.Bytes(), len(manifest)); cost > reviewManifestLineBudget {
+		t.Fatalf("emitter spends %.2f lines per manifest entry, want at most %d", cost, reviewManifestLineBudget)
+	}
+	// The compaction must not leak into a sibling array that merely follows it.
+	if !strings.Contains(emitted.String(), "\n  \"trailing\": \"after\"") {
+		t.Fatalf("emitted payload stopped indenting after the manifest array:\n%s", emitted.String())
+	}
+}
+
+// TestEncodeReviewJSONIgnoresManifestKeyInsideStringValues proves the rewrite
+// keys off real object keys rather than off matching text, so a repository path
+// that happens to spell the key never reshapes a payload.
+func TestEncodeReviewJSONIgnoresManifestKeyInsideStringValues(t *testing.T) {
+	source := map[string]any{"note": "\"changed_path_manifest\": [ is only text here", "count": 2}
+	var emitted, reference bytes.Buffer
+	if err := encodeReviewJSON(&emitted, source); err != nil {
+		t.Fatal(err)
+	}
+	encoder := json.NewEncoder(&reference)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(source); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(emitted.Bytes(), reference.Bytes()) {
+		t.Fatalf("a string value spelling the manifest key reshaped the payload:\n got: %q\nwant: %q",
+			emitted.String(), reference.String())
+	}
+}

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -16,13 +16,13 @@ func TestReviewProviderArtifactV1ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v1")
 	want := map[string]string{
 		"fixtures/capabilities-v1.4.fixture.json": "84e0db457b76b97b35c2be772dfc647f9eab66810ea98f64fed85645c3c266ba",
-		"fixtures/start.fixture.json":             "f369160ac26eb3427b57de2dd01c9d8c81e51c8a2bd546446780129d31b1945b",
+		"fixtures/start.fixture.json":             "3b963b221cd1560eb8872cbabbb5407096f593ced2f13eb9cb06eb61e4cca4d1",
 		// issue #2659: start-v2/status-v2 embed a freshly minted target_identity,
 		// and the purified identity domain legitimately changed that hash for
 		// every new snapshot. Deliberate, not drift.
-		"fixtures/start-v2.fixture.json":         "cc229f42781add54a86d904e913bb72e1373f04e7520a28fb3d245674bf703b5",
+		"fixtures/start-v2.fixture.json":         "2699660832c0d944184d5d314f08774ab9a02f5b8a7a4c2a07983440e0e346ad",
 		"fixtures/status.fixture.json":           "555054d8046a896162995dcb117752f9cd1ef903fb9ebaad29af1b7e7f319bb3",
-		"fixtures/status-v2.fixture.json":        "d0dbcddc5bf8947de314f3a9e938b094627b0f01ab3bfaa10a79b3b27fda7a76",
+		"fixtures/status-v2.fixture.json":        "33c5032dcd5d916b4bff73781495640da83893b2f2b334465cbb40c18e1b85f4",
 		"fixtures/status-ambiguous.fixture.json": "ee695fd58ba72adfb3b51dfd16432a177498173a45bfcb594d6bdc53bfa32e6e",
 		"fixtures/status-corrupted.fixture.json": "4cfc0048c28a39cec8a32fecfaad66e56e5c1248263ceb4ce66b6717981880b2",
 		"fixtures/status-recover.fixture.json":   "714f762f72380ce93d567626cafbaa536ab3aae02af73d3d40ca123f1f30d8b0",
@@ -53,7 +53,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 	want := map[string]string{
 		"fixtures/capabilities.fixture.json": "17c150d851c15b3f0c20d18c2e2741eb2232ffa24f35aa71d6d30e90a85e42b7",
 		"fixtures/consent.fixture.json":      "203cc96d5c29ba0f27b5c4db04c2e88566e0a923d3a0cdb317f78d9065349075",
-		"fixtures/status.fixture.json":       "d5438578f2969f17635fecea94c7ef46d14c78fa668e50df48c4254254d5e935",
+		"fixtures/status.fixture.json":       "4cd77906bacdca35d8f99773de147211d2b05fe34dd1b999011ead09e84be7a5",
 		"schemas/capabilities.schema.json":   "7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248",
 		"schemas/consent.schema.json":        "b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858",
 		"schemas/status.schema.json":         "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",


### PR DESCRIPTION
Closes #3281.

Measured the mechanism rather than assuming it. The 50.1 KB / 1505-line payload the reporter saw was `review start`, not `review status` — which is why the commenter could not reproduce it on `status`, the one route already gated by the 32-entry lens-context budget. On a 60-changed-path candidate: start = 18,320 bytes (89.5% of it the manifest, 273 B/entry), capture-result --preflight = 17,663, status = 6,134 with zero manifest entries (it stops on the budget), and finalize --next-transition never reaches the manifest at all.

Fix: compact the manifest encoding at the single sink `encodeReviewJSON`, one entry per line instead of ten. start 649 -> 109 lines, capture preflight 625 -> 85 lines (23% fewer bytes each). No schema, capabilities, or protocol change: the emitted bytes decode to the identical value, and three safety tests pin that non-manifest envelopes stay byte-identical, the manifest round-trips to the same digest, and a string value spelling the key cannot reshape the payload.

Honest limitation stated in the commit: this is a constant-factor reduction, not an asymptotic bound. The 8 required fields cost ~130 B of fixed key text per entry. A true bound needs status/v6 + start/v4 + capabilities/v2.3 with dual-shape emission and coordinated gentle-pi parity, which is a maintainer-level cross-repo decision and was deliberately not taken here.

Rejected alternatives, with reasons: dedupe by digest and make-the-field-optional both break the published schema (`changed_path_manifest` is required per capture-result input, and the capabilities additive_minor_policy is optional-fields-only); truncation silently breaks the changed_path_manifest_sha256 binding; and applying the 32-entry budget to start would destroy the manual/compat route for >32-path candidates.

Separate finding filed as #3367: that 32-entry cap is a hard stop that makes any medium/high candidate with more than 32 changed paths permanently unreviewable.

Note for gentle-pi parity: five published fixture files were regenerated and four pinned digests updated. The bytes changed; the parsed values did not.

RDD receipt: review-d3f58617eb03cd20 (approved, medium, one lens, no blocking findings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Changed-path manifest entries are now compacted to reduce their line usage while preserving all values and semantics.
  * Review output remains valid JSON with unchanged non-manifest content and a trailing newline.

* **Bug Fixes**
  * Improved handling of manifest formatting across start, preflight, and status review workflows.

* **Tests**
  * Added coverage confirming line-budget limits, value preservation, and safe handling of unrelated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->