### PR TITLE
fix(review): make the clone-scope kill switch reachable on mode-ignoring filesystems

### DIFF
--- a/internal/reviewtransaction/rar_path_safety_create_rollback_unix_test.go
+++ b/internal/reviewtransaction/rar_path_safety_create_rollback_unix_test.go
@@ -88,6 +88,35 @@ func TestCreatePrivateRARDirectoryKeepsTheUnsafePathItNames(t *testing.T) {
 	}
 }
 
+func TestCreatePrivateRARDirectoryNeverRepairsThroughASubstitutedSymlink(t *testing.T) {
+	root := resolvedTempDir(t)
+	path := filepath.Join(root, "v1")
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The race the no-follow walk exists to defeat, and the likeliest reason a
+	// just-created 0700 directory fails on POSIX: it is swapped for a symlink
+	// before validation reads it. A repair that resolved the path would chmod
+	// the attacker's target instead.
+	previous := rarPrivateDirectoryMkdir
+	rarPrivateDirectoryMkdir = func(name string, mode fs.FileMode) error {
+		if err := errors.Join(os.Mkdir(name, mode), os.Remove(name)); err != nil {
+			return err
+		}
+		return os.Symlink(victim, name)
+	}
+	t.Cleanup(func() { rarPrivateDirectoryMkdir = previous })
+
+	created, err := createPrivateRARDirectory(path)
+	if created || err == nil {
+		t.Fatalf("createPrivateRARDirectory over a substituted symlink = (%t, %v), want (false, refusal)", created, err)
+	}
+	if info, statErr := os.Lstat(victim); statErr != nil || info.Mode().Perm() != 0o755 {
+		t.Fatalf("substituted target = %v (%v), want mode 0755; the repair followed the symlink", info, statErr)
+	}
+}
+
 func TestCreatePrivateRARDirectoryNeverRepairsADirectoryItDidNotCreate(t *testing.T) {
 	root := resolvedTempDir(t)
 	path := filepath.Join(root, "v1")

--- a/internal/reviewtransaction/rar_path_safety_create_rollback_unix_test.go
+++ b/internal/reviewtransaction/rar_path_safety_create_rollback_unix_test.go
@@ -115,25 +115,55 @@ func TestCreatePrivateRARDirectoryNeverRepairsThroughASubstitutedSymlink(t *test
 	if info, statErr := os.Lstat(victim); statErr != nil || info.Mode().Perm() != 0o755 {
 		t.Fatalf("substituted target = %v (%v), want mode 0755; the repair followed the symlink", info, statErr)
 	}
+	// Refusing has to be stable: the wrong entry is the operator's to remove,
+	// never this product's, so every later invocation refuses it untouched.
+	if created, err := createPrivateRARDirectory(path); created || err == nil {
+		t.Fatalf("second attempt over a substituted symlink = (%t, %v), want (false, refusal)", created, err)
+	}
+	if info, statErr := os.Lstat(victim); statErr != nil || info.Mode().Perm() != 0o755 {
+		t.Fatalf("substituted target = %v (%v), want mode 0755 after the second refusal", info, statErr)
+	}
 }
 
-func TestCreatePrivateRARDirectoryNeverRepairsADirectoryItDidNotCreate(t *testing.T) {
+func TestCreatePrivateRARDirectoryRepairsWhatAnInterruptedRunLeftBehind(t *testing.T) {
 	root := resolvedTempDir(t)
 	path := filepath.Join(root, "v1")
+	// What a run killed between mkdir(2) and its repair leaves behind -- a CI
+	// timeout, an OOM kill, Ctrl-C, a transient EPERM. mkdir answers every
+	// later attempt with EEXIST, so a `created` gate never repairs it.
 	if err := os.Mkdir(path, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	created, err := createPrivateRARDirectory(path)
-	if created || err == nil {
-		t.Fatalf("createPrivateRARDirectory on a pre-existing unsafe directory = (%t, %v), want (false, refusal)", created, err)
+	if err != nil || created {
+		t.Fatalf("invocation after an interrupted run = (%t, %v), want (false, nil)", created, err)
 	}
 	info, statErr := os.Lstat(path)
-	if statErr != nil {
-		t.Fatalf("stat pre-existing directory: %v", statErr)
+	if statErr != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("directory left by the interrupted run = %v (%v), want it repaired to 0700", info, statErr)
 	}
-	if info.Mode().Perm() != 0o755 {
-		t.Fatalf("pre-existing directory mode = %04o, want it left at 0755; this product does not rewrite permissions it refuses to trust", info.Mode().Perm())
+}
+
+func TestCreatePrivateRARDirectoryNeverRepairsADirectoryHoldingState(t *testing.T) {
+	root := resolvedTempDir(t)
+	path := filepath.Join(root, "v1")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Content is the line between an interrupted creation and an authority
+	// directory somebody weakened. Re-tightening the second one silently would
+	// hide from the operator that anyone could write what is already inside it.
+	if err := os.WriteFile(filepath.Join(path, "state.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := createPrivateRARDirectory(path)
+	if created || err == nil {
+		t.Fatalf("createPrivateRARDirectory over a populated unsafe directory = (%t, %v), want (false, refusal)", created, err)
+	}
+	if info, statErr := os.Lstat(path); statErr != nil || info.Mode().Perm() != 0o755 {
+		t.Fatalf("populated directory = %v (%v), want it left at 0755", info, statErr)
 	}
 }
 

--- a/internal/reviewtransaction/rar_path_safety_create_rollback_unix_test.go
+++ b/internal/reviewtransaction/rar_path_safety_create_rollback_unix_test.go
@@ -1,0 +1,120 @@
+//go:build !windows
+
+package reviewtransaction
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// breakRARPrivateDirectoryMode makes every directory this package creates come
+// back group- and world-readable, the way WSL DrvFS, exFAT, and SMB mounts
+// without POSIX extensions behave: the mode handed to mkdir(2) is accepted and
+// then ignored. No mode argument can produce this on ext4 or tmpfs, because
+// mkdir only ever removes bits, so the primitive is swapped instead.
+func breakRARPrivateDirectoryMode(t *testing.T) {
+	t.Helper()
+	previous := rarPrivateDirectoryMkdir
+	rarPrivateDirectoryMkdir = func(name string, _ fs.FileMode) error {
+		return os.Mkdir(name, 0o755)
+	}
+	t.Cleanup(func() { rarPrivateDirectoryMkdir = previous })
+}
+
+// breakRARPrivateDirectoryChmod completes the simulation for the mounts that
+// also swallow chmod(2): the call reports success and changes nothing, so the
+// directory can never be made safe from inside this process.
+func breakRARPrivateDirectoryChmod(t *testing.T) {
+	t.Helper()
+	previous := rarPrivateDirectoryChmod
+	rarPrivateDirectoryChmod = func(string, fs.FileMode) error { return nil }
+	t.Cleanup(func() { rarPrivateDirectoryChmod = previous })
+}
+
+func TestCreatePrivateRARDirectorySecuresAModeThatDidNotStick(t *testing.T) {
+	root := resolvedTempDir(t)
+	path := filepath.Join(root, "v1")
+	breakRARPrivateDirectoryMode(t)
+
+	created, err := createPrivateRARDirectory(path)
+	if err != nil {
+		t.Fatalf("createPrivateRARDirectory on a filesystem that ignores the mkdir mode = %v, want the directory secured", err)
+	}
+	if !created {
+		t.Fatalf("createPrivateRARDirectory created = false, want true for a directory it made")
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil {
+		t.Fatalf("stat secured directory: %v", statErr)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("secured directory mode = %04o, want 0700", info.Mode().Perm())
+	}
+	if err := validatePrivateRARDirectory(path); err != nil {
+		t.Fatalf("validate secured directory: %v", err)
+	}
+}
+
+func TestCreatePrivateRARDirectoryKeepsTheUnsafePathItNames(t *testing.T) {
+	root := resolvedTempDir(t)
+	path := filepath.Join(root, "v1")
+	breakRARPrivateDirectoryMode(t)
+	breakRARPrivateDirectoryChmod(t)
+
+	created, err := createPrivateRARDirectory(path)
+	if created {
+		t.Fatalf("createPrivateRARDirectory created = true for a directory it could not make safe")
+	}
+	var unsafePath *UnsafeRARPathError
+	if !errors.As(err, &unsafePath) {
+		t.Fatalf("createPrivateRARDirectory on an unrepairable filesystem = %v, want *UnsafeRARPathError", err)
+	}
+	if unsafePath.Path != path || !unsafePath.Directory {
+		t.Fatalf("refusal names %q (directory=%t), want %q (directory=true)", unsafePath.Path, unsafePath.Directory, path)
+	}
+	// The refusal tells the operator to restore the mode on this exact path.
+	// Removing it turned that instruction into "chmod: cannot access ...: No
+	// such file or directory", which is the whole of issue #3285.
+	if _, statErr := os.Lstat(unsafePath.Path); statErr != nil {
+		t.Fatalf("refused path %q is gone, so the printed repair cannot run: %v", unsafePath.Path, statErr)
+	}
+	// Refusing is still the point: an unsafe path that cannot be made safe
+	// must never be reported as usable.
+	if validateErr := validatePrivateRARDirectory(path); validateErr == nil {
+		t.Fatalf("validatePrivateRARDirectory accepted a world-readable directory")
+	}
+}
+
+func TestCreatePrivateRARDirectoryNeverRepairsADirectoryItDidNotCreate(t *testing.T) {
+	root := resolvedTempDir(t)
+	path := filepath.Join(root, "v1")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := createPrivateRARDirectory(path)
+	if created || err == nil {
+		t.Fatalf("createPrivateRARDirectory on a pre-existing unsafe directory = (%t, %v), want (false, refusal)", created, err)
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil {
+		t.Fatalf("stat pre-existing directory: %v", statErr)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("pre-existing directory mode = %04o, want it left at 0755; this product does not rewrite permissions it refuses to trust", info.Mode().Perm())
+	}
+}
+
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	// The private-path walk opens every ancestor with O_NOFOLLOW, so a
+	// symlinked temporary root would fail for a reason unrelated to the mode.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/internal/reviewtransaction/rar_path_safety_export_unix_test.go
+++ b/internal/reviewtransaction/rar_path_safety_export_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package reviewtransaction
+
+import "io/fs"
+
+// SetRARPrivateDirectoryPrimitivesForTest swaps the two filesystem primitives
+// that establish an owner-only RAR directory, so a test can reproduce a mount
+// that ignores the mode it is given. It exists only in the test binary: the
+// production package must never expose a way to change how a security boundary
+// is created.
+//
+// A nil argument keeps the current primitive. The returned function restores
+// both.
+func SetRARPrivateDirectoryPrimitivesForTest(
+	mkdir func(string, fs.FileMode) error,
+	chmod func(string, fs.FileMode) error,
+) func() {
+	previousMkdir, previousChmod := rarPrivateDirectoryMkdir, rarPrivateDirectoryChmod
+	if mkdir != nil {
+		rarPrivateDirectoryMkdir = mkdir
+	}
+	if chmod != nil {
+		rarPrivateDirectoryChmod = chmod
+	}
+	return func() {
+		rarPrivateDirectoryMkdir, rarPrivateDirectoryChmod = previousMkdir, previousChmod
+	}
+}

--- a/internal/reviewtransaction/rar_path_safety_unix.go
+++ b/internal/reviewtransaction/rar_path_safety_unix.go
@@ -17,17 +17,48 @@ func rarPathUnsafe(_ string, info fs.FileInfo) bool {
 	return info == nil || info.Mode()&os.ModeSymlink != 0
 }
 
+// rarPrivateDirectoryMkdir and rarPrivateDirectoryChmod are the only two
+// filesystem primitives that establish an owner-only RAR directory. They are
+// variables so tests can reproduce filesystems that silently ignore the mode
+// they are handed -- WSL DrvFS, exFAT, and SMB mounts without POSIX extensions
+// -- which no mode argument reachable from a test on ext4 or tmpfs can
+// produce. Production always uses the os package.
+var (
+	rarPrivateDirectoryMkdir = os.Mkdir
+	rarPrivateDirectoryChmod = os.Chmod
+)
+
 func createPrivateRARDirectory(path string) (bool, error) {
-	err := os.Mkdir(path, 0o700)
+	err := rarPrivateDirectoryMkdir(path, 0o700)
 	created := err == nil
 	if err != nil && !errors.Is(err, fs.ErrExist) {
 		return false, err
 	}
-	if err := validatePrivateRARDirectory(path); err != nil {
-		if created {
-			_ = os.Remove(path)
+	validateErr := validatePrivateRARDirectory(path)
+	if validateErr != nil && created {
+		// A directory this call just created can still fail its own owner-only
+		// validation, because some filesystems ignore the mode passed to
+		// mkdir(2). Ask for the mode explicitly and revalidate before giving
+		// up: that is the whole failure on WSL DrvFS, and it is the difference
+		// between the kill switch working and the documented self-service
+		// delivery exit being unreachable.
+		//
+		// Only a directory created by this very call is repaired. A directory
+		// that was already there is somebody else's, and rewriting its
+		// permissions is exactly the world-action errUnsafeRARAuthorityPath
+		// refuses to take on the operator's behalf.
+		if chmodErr := rarPrivateDirectoryChmod(path, 0o700); chmodErr == nil {
+			validateErr = validatePrivateRARDirectory(path)
 		}
-		return false, err
+	}
+	if validateErr != nil {
+		// The just-created directory deliberately stays on disk. Removing it
+		// made the refusal name a path that no longer existed, so the repair
+		// this product prints (`chmod 700 <path>`) failed with "cannot access
+		// ...: No such file or directory" and the operator had no runnable way
+		// out. Nothing is trusted by leaving it: every reader revalidates, and
+		// the next attempt takes the already-exists branch and refuses again.
+		return false, validateErr
 	}
 	return created, nil
 }

--- a/internal/reviewtransaction/rar_path_safety_unix.go
+++ b/internal/reviewtransaction/rar_path_safety_unix.go
@@ -22,11 +22,37 @@ func rarPathUnsafe(_ string, info fs.FileInfo) bool {
 // variables so tests can reproduce filesystems that silently ignore the mode
 // they are handed -- WSL DrvFS, exFAT, and SMB mounts without POSIX extensions
 // -- which no mode argument reachable from a test on ext4 or tmpfs can
-// produce. Production always uses the os package.
+// produce. Production always uses the no-follow repair below.
 var (
 	rarPrivateDirectoryMkdir = os.Mkdir
-	rarPrivateDirectoryChmod = os.Chmod
+	rarPrivateDirectoryChmod = repairPrivateRARDirectoryNoFollow
 )
+
+// repairPrivateRARDirectoryNoFollow reapplies the owner-only mode through a
+// descriptor, never the path: os.Chmod resolves symlinks and Linux rejects
+// AT_SYMLINK_NOFOLLOW on fchmodat(2). The validator's own no-follow walk opens
+// the directory, and fchmod(2), the mode check and the uid check all run
+// against that one descriptor -- substituting a symlink for the just-created
+// directory is the attack this walk exists to defeat, and on POSIX it is
+// essentially the only other reason this repair ever runs.
+func repairPrivateRARDirectoryNoFollow(path string, mode fs.FileMode) error {
+	file, err := openRARPathNoFollow(path, true)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if err := file.Chmod(mode); err != nil {
+		return err
+	}
+	repaired, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !repaired.IsDir() || !privateOpenRARPathSafe(file, repaired) {
+		return unsafeRARPathError(path, true)
+	}
+	return nil
+}
 
 func createPrivateRARDirectory(path string) (bool, error) {
 	err := rarPrivateDirectoryMkdir(path, 0o700)
@@ -47,7 +73,7 @@ func createPrivateRARDirectory(path string) (bool, error) {
 		// that was already there is somebody else's, and rewriting its
 		// permissions is exactly the world-action errUnsafeRARAuthorityPath
 		// refuses to take on the operator's behalf.
-		if chmodErr := rarPrivateDirectoryChmod(path, 0o700); chmodErr == nil {
+		if repairErr := rarPrivateDirectoryChmod(path, 0o700); repairErr == nil {
 			validateErr = validatePrivateRARDirectory(path)
 		}
 	}

--- a/internal/reviewtransaction/rar_path_safety_unix.go
+++ b/internal/reviewtransaction/rar_path_safety_unix.go
@@ -41,6 +41,25 @@ func repairPrivateRARDirectoryNoFollow(path string, mode fs.FileMode) error {
 		return err
 	}
 	defer file.Close()
+	// What the entry IS decides, never who created it. O_NOFOLLOW|O_DIRECTORY
+	// already failed the open for a symlink, and an entry owned by anyone else
+	// is refused before the write: euid 0 could otherwise chmod it.
+	before, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if stat, ok := before.Sys().(*syscall.Stat_t); !ok || !before.IsDir() ||
+		stat.Uid != uint32(os.Geteuid()) {
+		return unsafeRARPathError(path, true)
+	}
+	// Only an empty directory is repaired, and emptiness is read from this same
+	// descriptor. An interrupted creation leaves nothing behind, so recovery
+	// works; a populated authority directory whose mode somebody weakened stays
+	// refused, because silently re-tightening it would hide from the operator
+	// that anything inside it was writable by anyone.
+	if names, readErr := file.Readdirnames(-1); readErr != nil || len(names) > 0 {
+		return unsafeRARPathError(path, true)
+	}
 	if err := file.Chmod(mode); err != nil {
 		return err
 	}
@@ -61,18 +80,21 @@ func createPrivateRARDirectory(path string) (bool, error) {
 		return false, err
 	}
 	validateErr := validatePrivateRARDirectory(path)
-	if validateErr != nil && created {
-		// A directory this call just created can still fail its own owner-only
+	if validateErr != nil {
+		// A directory at this path can still fail its own owner-only
 		// validation, because some filesystems ignore the mode passed to
 		// mkdir(2). Ask for the mode explicitly and revalidate before giving
 		// up: that is the whole failure on WSL DrvFS, and it is the difference
 		// between the kill switch working and the documented self-service
 		// delivery exit being unreachable.
 		//
-		// Only a directory created by this very call is repaired. A directory
-		// that was already there is somebody else's, and rewriting its
-		// permissions is exactly the world-action errUnsafeRARAuthorityPath
-		// refuses to take on the operator's behalf.
+		// Do NOT gate this on `created`: a run killed between mkdir(2) and its
+		// repair leaves an unsafe directory that every later mkdir answers with
+		// EEXIST, so that gate makes recovery once-only. The no-follow
+		// descriptor decides instead: tightening an EMPTY directory this euid
+		// already owns is not the world-action errUnsafeRARAuthorityPath
+		// declines. A symlink, somebody else's entry, and a directory already
+		// holding state all still refuse.
 		if repairErr := rarPrivateDirectoryChmod(path, 0o700); repairErr == nil {
 			validateErr = validatePrivateRARDirectory(path)
 		}

--- a/internal/reviewtransaction/rar_path_safety_windows.go
+++ b/internal/reviewtransaction/rar_path_safety_windows.go
@@ -27,6 +27,59 @@ func rarPathUnsafe(path string, info fs.FileInfo) bool {
 	return err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0
 }
 
+// rarPrivateDirectoryCreate and rarPrivateDirectoryRepair mirror the POSIX
+// seam: the only two primitives that establish an owner-only RAR directory,
+// kept as variables so tests can reproduce a filesystem or token that ignores
+// the descriptor it is handed.
+var (
+	rarPrivateDirectoryCreate = windows.CreateDirectory
+	rarPrivateDirectoryRepair = repairPrivateRARDirectoryNoFollow
+)
+
+const rarDirectoryRepairAccess = windows.SYNCHRONIZE | windows.READ_CONTROL |
+	windows.FILE_READ_ATTRIBUTES | windows.WRITE_DAC | windows.WRITE_OWNER
+
+// repairPrivateRARDirectoryNoFollow reapplies the owner-only protected DACL
+// through a handle, never a name: SetNamedSecurityInfo resolves the name it is
+// handed and has no no-follow mode, so a directory swapped for a junction
+// between CreateDirectory and validation would take the repair on the
+// attacker's target. The handle comes from the validator's own OBJ_DONT_REPARSE
+// open, is refused when it is a reparse point, and carries both the write and
+// the owner/DACL readback that clears it.
+func repairPrivateRARDirectoryNoFollow(path string, _ fs.FileMode) error {
+	descriptor, err := ownerOnlyRARSecurityDescriptor(true)
+	if err != nil {
+		return err
+	}
+	owner, _, ownerErr := descriptor.Owner()
+	dacl, _, daclErr := descriptor.DACL()
+	if ownerErr != nil || daclErr != nil || owner == nil || dacl == nil {
+		return errUnsafeRARAuthorityPath
+	}
+	handle, err := openWindowsRARObject(ntPath(path), rarDirectoryRepairAccess, true)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(handle), path)
+	defer file.Close()
+	if openWindowsRARFileUnsafe(file) {
+		return unsafeRARPathError(path, true)
+	}
+	err = windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|
+			windows.PROTECTED_DACL_SECURITY_INFORMATION, owner, nil, dacl, nil)
+	runtime.KeepAlive(descriptor)
+	if err != nil {
+		return err
+	}
+	repaired, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil || !privateRARSecurityDescriptorSafe(repaired, true) {
+		return unsafeRARPathError(path, true)
+	}
+	return nil
+}
+
 func createPrivateRARDirectory(path string) (bool, error) {
 	descriptor, err := ownerOnlyRARSecurityDescriptor(true)
 	if err != nil {
@@ -40,7 +93,7 @@ func createPrivateRARDirectory(path string) (bool, error) {
 		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
 		SecurityDescriptor: descriptor,
 	}
-	err = windows.CreateDirectory(name, &attributes)
+	err = rarPrivateDirectoryCreate(name, &attributes)
 	runtime.KeepAlive(descriptor)
 	created := err == nil
 	if err != nil && !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
@@ -59,20 +112,9 @@ func createPrivateRARDirectory(path string) (bool, error) {
 		// Only a directory created by this very call is repaired. Rewriting the
 		// ACL of a directory that was already there is the world-action
 		// errUnsafeRARAuthorityPath refuses to take on the operator's behalf.
-		if owner, _, ownerErr := descriptor.Owner(); ownerErr == nil && owner != nil {
-			if dacl, _, daclErr := descriptor.DACL(); daclErr == nil && dacl != nil {
-				_ = windows.SetNamedSecurityInfo(
-					path,
-					windows.SE_FILE_OBJECT,
-					windows.OWNER_SECURITY_INFORMATION|
-						windows.DACL_SECURITY_INFORMATION|
-						windows.PROTECTED_DACL_SECURITY_INFORMATION,
-					owner, nil, dacl, nil,
-				)
-				validateErr = validatePrivateRARDirectory(path)
-			}
+		if repairErr := rarPrivateDirectoryRepair(path, 0o700); repairErr == nil {
+			validateErr = validatePrivateRARDirectory(path)
 		}
-		runtime.KeepAlive(descriptor)
 	}
 	if validateErr != nil {
 		// The just-created directory deliberately stays on disk. Removing it
@@ -191,7 +233,7 @@ func rarRepositoryOpenDirectorySafe(file *os.File, info fs.FileInfo) bool {
 }
 
 func openRARPathNoFollow(path string, directory bool) (*os.File, error) {
-	handle, err := openWindowsRARObject(ntPath(path), directory)
+	handle, err := openWindowsRARObject(ntPath(path), windows.FILE_GENERIC_READ|windows.READ_CONTROL, directory)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +254,7 @@ func OpenPhysicalPath(path string, directory bool) (*os.File, error) {
 	return openRARPathNoFollow(absPath, directory)
 }
 
-func openWindowsRARObject(objectPath string, directory bool) (windows.Handle, error) {
+func openWindowsRARObject(objectPath string, access uint32, directory bool) (windows.Handle, error) {
 	open := func(path string) (windows.Handle, error) {
 		objectName, err := windows.NewNTUnicodeString(path)
 		if err != nil {
@@ -233,7 +275,7 @@ func openWindowsRARObject(objectPath string, directory bool) (windows.Handle, er
 		var status windows.IO_STATUS_BLOCK
 		err = windows.NtCreateFile(
 			&handle,
-			windows.FILE_GENERIC_READ|windows.READ_CONTROL,
+			access,
 			attributes,
 			&status,
 			nil,

--- a/internal/reviewtransaction/rar_path_safety_windows.go
+++ b/internal/reviewtransaction/rar_path_safety_windows.go
@@ -46,11 +46,41 @@ func createPrivateRARDirectory(path string) (bool, error) {
 	if err != nil && !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
 		return false, err
 	}
-	if err := validatePrivateRARDirectory(path); err != nil {
-		if created {
-			_ = os.Remove(path)
+	validateErr := validatePrivateRARDirectory(path)
+	if validateErr != nil && created {
+		// Same shape as the POSIX path: a directory this call just created can
+		// still fail its own owner-only validation when the filesystem or the
+		// process token did not honour the descriptor handed to
+		// CreateDirectory. Apply the owner-only, protected DACL explicitly and
+		// revalidate before giving up. This is precisely the repair the CLI
+		// prints, so anything it cannot fix here the operator still cannot fix
+		// there, and the refusal below stays truthful.
+		//
+		// Only a directory created by this very call is repaired. Rewriting the
+		// ACL of a directory that was already there is the world-action
+		// errUnsafeRARAuthorityPath refuses to take on the operator's behalf.
+		if owner, _, ownerErr := descriptor.Owner(); ownerErr == nil && owner != nil {
+			if dacl, _, daclErr := descriptor.DACL(); daclErr == nil && dacl != nil {
+				_ = windows.SetNamedSecurityInfo(
+					path,
+					windows.SE_FILE_OBJECT,
+					windows.OWNER_SECURITY_INFORMATION|
+						windows.DACL_SECURITY_INFORMATION|
+						windows.PROTECTED_DACL_SECURITY_INFORMATION,
+					owner, nil, dacl, nil,
+				)
+				validateErr = validatePrivateRARDirectory(path)
+			}
 		}
-		return false, err
+		runtime.KeepAlive(descriptor)
+	}
+	if validateErr != nil {
+		// The just-created directory deliberately stays on disk. Removing it
+		// made the refusal name a path that no longer existed, so the repair
+		// this product prints could not run at all and the operator had no way
+		// out. Nothing is trusted by leaving it: every reader revalidates, and
+		// the next attempt takes the already-exists branch and refuses again.
+		return false, validateErr
 	}
 	return created, nil
 }

--- a/internal/reviewtransaction/rar_path_safety_windows.go
+++ b/internal/reviewtransaction/rar_path_safety_windows.go
@@ -36,8 +36,11 @@ var (
 	rarPrivateDirectoryRepair = repairPrivateRARDirectoryNoFollow
 )
 
+// FILE_LIST_DIRECTORY is requested because the repair below is allowed only on
+// an empty directory, and a handle that cannot list one cannot establish that.
 const rarDirectoryRepairAccess = windows.SYNCHRONIZE | windows.READ_CONTROL |
-	windows.FILE_READ_ATTRIBUTES | windows.WRITE_DAC | windows.WRITE_OWNER
+	windows.FILE_READ_ATTRIBUTES | windows.FILE_LIST_DIRECTORY |
+	windows.WRITE_DAC | windows.WRITE_OWNER
 
 // repairPrivateRARDirectoryNoFollow reapplies the owner-only protected DACL
 // through a handle, never a name: SetNamedSecurityInfo resolves the name it is
@@ -63,6 +66,29 @@ func repairPrivateRARDirectoryNoFollow(path string, _ fs.FileMode) error {
 	file := os.NewFile(uintptr(handle), path)
 	defer file.Close()
 	if openWindowsRARFileUnsafe(file) {
+		return unsafeRARPathError(path, true)
+	}
+	// What the object IS decides, never who created it. FILE_DIRECTORY_FILE and
+	// OBJ_DONT_REPARSE already refused a non-directory and a junction, and this
+	// same handle answers the owner before the write: only the token user, or
+	// the token owner an elevated shell stamps on its own creations, repairs.
+	existing, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return err
+	}
+	if !rarSecurityDescriptorOwnedByCurrentUser(existing) {
+		owner, _, ownerErr := existing.Owner()
+		tokenOwner, tokenErr := currentRARWindowsTokenOwnerSID()
+		if ownerErr != nil || owner == nil || tokenErr != nil || !owner.Equals(tokenOwner) {
+			return unsafeRARPathError(path, true)
+		}
+	}
+	// Only an empty directory is repaired, read from this same handle. An
+	// interrupted creation leaves nothing behind, so recovery works; a
+	// populated authority directory whose ACL somebody widened stays refused,
+	// because silently re-tightening it would hide the exposure.
+	if names, readErr := file.Readdirnames(-1); readErr != nil || len(names) > 0 {
 		return unsafeRARPathError(path, true)
 	}
 	err = windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT,
@@ -100,8 +126,8 @@ func createPrivateRARDirectory(path string) (bool, error) {
 		return false, err
 	}
 	validateErr := validatePrivateRARDirectory(path)
-	if validateErr != nil && created {
-		// Same shape as the POSIX path: a directory this call just created can
+	if validateErr != nil {
+		// Same shape as the POSIX path: a directory at this path can
 		// still fail its own owner-only validation when the filesystem or the
 		// process token did not honour the descriptor handed to
 		// CreateDirectory. Apply the owner-only, protected DACL explicitly and
@@ -109,9 +135,10 @@ func createPrivateRARDirectory(path string) (bool, error) {
 		// prints, so anything it cannot fix here the operator still cannot fix
 		// there, and the refusal below stays truthful.
 		//
-		// Only a directory created by this very call is repaired. Rewriting the
-		// ACL of a directory that was already there is the world-action
-		// errUnsafeRARAuthorityPath refuses to take on the operator's behalf.
+		// Do NOT gate this on `created`: CreateDirectory answers every later
+		// attempt with ERROR_ALREADY_EXISTS, so that gate makes recovery from
+		// an interrupted run once-only. The handle-verified object decides
+		// instead: an empty directory this process's own principals own.
 		if repairErr := rarPrivateDirectoryRepair(path, 0o700); repairErr == nil {
 			validateErr = validatePrivateRARDirectory(path)
 		}

--- a/internal/reviewtransaction/rar_path_safety_windows_test.go
+++ b/internal/reviewtransaction/rar_path_safety_windows_test.go
@@ -173,6 +173,49 @@ func rarWindowsDescriptorForOwner(
 	return descriptor
 }
 
+// ignoreRequestedRARDescriptor reproduces a filesystem or token that accepts the
+// descriptor handed to CreateDirectory and then ignores it.
+func ignoreRequestedRARDescriptor(t *testing.T) {
+	t.Helper()
+	previous := rarPrivateDirectoryCreate
+	rarPrivateDirectoryCreate = func(name *uint16, _ *windows.SecurityAttributes) error {
+		return windows.CreateDirectory(name, nil)
+	}
+	t.Cleanup(func() { rarPrivateDirectoryCreate = previous })
+}
+
+func TestCreatePrivateRARDirectoryRepairsADescriptorThatDidNotStick(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v1")
+	ignoreRequestedRARDescriptor(t)
+
+	// A nil error is the revalidation: createPrivateRARDirectory only reports
+	// success once validatePrivateRARDirectory accepted the repaired handle.
+	created, err := createPrivateRARDirectory(path)
+	if err != nil || !created {
+		t.Fatalf("createPrivateRARDirectory on a mount that ignored the descriptor = (%t, %v), want (true, nil)", created, err)
+	}
+}
+
+func TestCreatePrivateRARDirectoryKeepsTheUnsafePathItNamesOnWindows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v1")
+	ignoreRequestedRARDescriptor(t)
+	previous := rarPrivateDirectoryRepair
+	// A repair that reports success and changes nothing, the way a mount
+	// without persistent ACL semantics behaves.
+	rarPrivateDirectoryRepair = func(string, fs.FileMode) error { return nil }
+	t.Cleanup(func() { rarPrivateDirectoryRepair = previous })
+
+	created, err := createPrivateRARDirectory(path)
+	var unsafePath *UnsafeRARPathError
+	if created || !errors.As(err, &unsafePath) || unsafePath.Path != path || !unsafePath.Directory {
+		t.Fatalf("createPrivateRARDirectory = (%t, %v), want (false, *UnsafeRARPathError naming %q)", created, err, path)
+	}
+	// Removing the refused directory is what made the printed repair unrunnable.
+	if _, statErr := os.Lstat(path); statErr != nil {
+		t.Fatalf("refused path %q is gone, so the printed repair cannot run: %v", path, statErr)
+	}
+}
+
 // classifierStub records every path it receives and returns a fixed filesystem type.
 type classifierStub struct {
 	calls []string

--- a/internal/reviewtransaction/rar_path_safety_windows_test.go
+++ b/internal/reviewtransaction/rar_path_safety_windows_test.go
@@ -196,6 +196,21 @@ func TestCreatePrivateRARDirectoryRepairsADescriptorThatDidNotStick(t *testing.T
 	}
 }
 
+func TestCreatePrivateRARDirectoryRepairsWhatAnInterruptedRunLeftBehind(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v1")
+	// What a run killed between CreateDirectory and its repair leaves behind: a
+	// directory carrying inherited ACLs. CreateDirectory answers every later
+	// attempt with ERROR_ALREADY_EXISTS, so a `created` gate never repairs it.
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := createPrivateRARDirectory(path)
+	if err != nil || created {
+		t.Fatalf("invocation after an interrupted run = (%t, %v), want (false, nil)", created, err)
+	}
+}
+
 func TestCreatePrivateRARDirectoryKeepsTheUnsafePathItNamesOnWindows(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "v1")
 	ignoreRequestedRARDescriptor(t)

--- a/internal/reviewtransaction/review_mode_disable_guidance_cli_unix_test.go
+++ b/internal/reviewtransaction/review_mode_disable_guidance_cli_unix_test.go
@@ -1,0 +1,132 @@
+//go:build !windows
+
+// This file drives the `gentle-ai review mode disable --scope clone` CLI
+// surface, but it lives beside the package it exercises rather than in
+// internal/cli. The filesystem primitives that reproduce a mount ignoring the
+// mode it is handed are unexported by design, and reaching them from another
+// package would mean exposing a way to change how a security boundary is
+// created in the production build. An external test package keeps the seam
+// inside the test binary and still lets the refusal be read exactly as an
+// operator reads it.
+package reviewtransaction_test
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/cli"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+func TestReviewModeDisableCloneSucceedsWhenTheMkdirModeDoesNotStick(t *testing.T) {
+	repo := initReviewModeGuidanceRepo(t)
+	defer reviewtransaction.SetRARPrivateDirectoryPrimitivesForTest(ignoreRequestedDirectoryMode, nil)()
+
+	var output bytes.Buffer
+	if err := cli.RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output); err != nil {
+		t.Fatalf("review mode disable --scope clone = %v\n%s", err, output.String())
+	}
+	if !strings.Contains(output.String(), `"clone_local": "off"`) {
+		t.Fatalf("review mode disable did not persist the clone-local override:\n%s", output.String())
+	}
+
+	var status bytes.Buffer
+	if err := cli.RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &status); err != nil {
+		t.Fatalf("review mode status = %v\n%s", err, status.String())
+	}
+	if !strings.Contains(status.String(), `"effective": "off"`) {
+		t.Fatalf("review mode did not stay off after disable:\n%s", status.String())
+	}
+}
+
+func TestReviewModeDisableCloneRefusalPrintsARunnableRepair(t *testing.T) {
+	repo := initReviewModeGuidanceRepo(t)
+	defer reviewtransaction.SetRARPrivateDirectoryPrimitivesForTest(
+		ignoreRequestedDirectoryMode,
+		func(string, fs.FileMode) error { return nil },
+	)()
+
+	// The operator loop the product documents: run the command, run the repair
+	// it prints, run the command again. It has to terminate. Before #3285 was
+	// fixed it could not, because the repair named a directory the failing
+	// command had just deleted.
+	const attempts = 12
+	for attempt := 1; ; attempt++ {
+		var output bytes.Buffer
+		err := cli.RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output)
+		if err == nil {
+			if !strings.Contains(output.String(), `"clone_local": "off"`) {
+				t.Fatalf("review mode disable reported success without persisting the override:\n%s", output.String())
+			}
+			return
+		}
+		if attempt == attempts {
+			t.Fatalf("the printed repair never let review mode disable through after %d attempts; last refusal: %v", attempts, err)
+		}
+		repair := repairCommandFrom(t, err.Error())
+		if !strings.HasPrefix(repair, "chmod 700 ") {
+			t.Fatalf("refusal printed %q, want a chmod 700 repair: %v", repair, err)
+		}
+		// The field symptom of #3285 is this exact command failing with
+		// "chmod: cannot access '...': No such file or directory".
+		if combined, runErr := exec.Command("sh", "-c", repair).CombinedOutput(); runErr != nil {
+			t.Fatalf("printed repair %q is not runnable: %v\n%s\nrefusal: %v", repair, runErr, combined, err)
+		}
+	}
+}
+
+// ignoreRequestedDirectoryMode reproduces WSL DrvFS, exFAT, and SMB mounts
+// without POSIX extensions: mkdir(2) accepts the mode and then ignores it.
+func ignoreRequestedDirectoryMode(name string, _ fs.FileMode) error {
+	return os.Mkdir(name, 0o755)
+}
+
+func repairCommandFrom(t *testing.T, message string) string {
+	t.Helper()
+	start := strings.Index(message, "`")
+	if start < 0 {
+		t.Fatalf("refusal %q prints no repair command", message)
+	}
+	rest := message[start+1:]
+	end := strings.Index(rest, "`")
+	if end < 0 {
+		t.Fatalf("refusal %q prints an unterminated repair command", message)
+	}
+	return rest[:end]
+}
+
+func initReviewModeGuidanceRepo(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	repo, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		command := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if output, gitErr := command.CombinedOutput(); gitErr != nil {
+			t.Fatalf("git %v: %v: %s", args, gitErr, output)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "tracked.txt"}, {"commit", "-qm", "base"}} {
+		command := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if output, gitErr := command.CombinedOutput(); gitErr != nil {
+			t.Fatalf("git %v: %v: %s", args, gitErr, output)
+		}
+	}
+	return repo
+}


### PR DESCRIPTION
Closes #3285.

`gentle-ai review mode disable --scope clone` failed with `chmod: cannot access <path>: No such file or directory` and never persisted. On a filesystem that ignores the mode passed to mkdir (WSL/DrvFS), a directory the call had just created failed its own owner-only validation; the code then removed it and printed `chmod 700 <path>` for a path it had just deleted. Re-running repeated the cycle. This is the documented self-service exit named by most terminal stop reason codes, so it failed exactly when it was needed.

The repair now self-heals instead of rolling back, and stays reachable:
- The just-created directory is no longer removed, so the printed repair is runnable and idempotent.
- The mode is repaired in place through a no-follow descriptor (`O_NOFOLLOW|O_DIRECTORY` then `fchmod`), revalidated by `fstat` on that same descriptor so the whole check-and-repair is bound to one inode.
- The repair is no longer gated on who created the directory, so a run interrupted between mkdir and repair is recoverable by a later invocation instead of leaving a permanently unsafe directory.
- Windows had the same rollback shape and the same name-resolution exposure: `SetNamedSecurityInfo` resolves by name with no no-follow variant, so the repair is now bound to an `NtCreateFile` handle opened with `OBJ_DONT_REPARSE`.

Security is unchanged or tighter: repair applies only to an empty directory owned by the effective uid and reached without following a symlink or reparse point. A populated authority directory is still refused (issue #2446), and ownership mismatch is still refused. The previous Windows code would have taken ownership of a pre-existing directory once the create gate came off; it now verifies the owner off the same handle first.

Three review rounds found, in order: a symlink-following chmod after failed validation, once-only recovery on both platforms, and the Windows ownership-taking. A regression test reproduces the symlink substitution and asserts the victim mode is unchanged.

RDD receipt: review-rar-toctou-successor-01 (approved, high, 4R, one bounded correction).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private RAR directory handling by repairing eligible empty directories and revalidating their permissions.
  * Unsafe or populated directories are preserved rather than removed, with clear paths retained for follow-up repair.
  * Prevented repairs from following substituted symlinks or modifying unintended targets.
  * Improved Windows and Unix handling when directory permissions are not applied as requested.
  * `review mode disable --scope clone` now provides a runnable `chmod 700` command when manual repair is required.

* **Tests**
  * Added comprehensive Unix and Windows coverage for interrupted creation, permission repair, symlink safety, and CLI recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->