### PR TITLE
fix(review): bound reviewer context by bytes so large candidates stay reviewable

### DIFF
--- a/bench/journeys_lens_context_budget.go
+++ b/bench/journeys_lens_context_budget.go
@@ -3,14 +3,20 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
-const lensContextBudgetCandidatePaths = 33
+// lensContextBudgetCandidatePaths is two paths, not thirty-three. Path count
+// stopped deciding representability with issue #3367: the bound is the
+// aggregate byte budget the reviewer block has to fit inside, so an
+// unrepresentable candidate is made of bytes now.
+const lensContextBudgetCandidatePaths = 2
 
 func oversizedLensContextCandidate(sandbox *Sandbox) error {
+	body := strings.Repeat("oversized evidence line\n", 100_000)
 	for index := range lensContextBudgetCandidatePaths {
-		path := filepath.Join(sandbox.Repo, fmt.Sprintf("candidate/path-%02d.txt", index))
-		if err := sandbox.write(path, "candidate evidence\n"); err != nil {
+		path := filepath.Join(sandbox.Repo, fmt.Sprintf("candidate/bulk-%02d.txt", index))
+		if err := sandbox.write(path, body); err != nil {
 			return err
 		}
 		if err := sandbox.git(sandbox.Repo, "add", "--", path); err != nil {
@@ -42,17 +48,23 @@ func stopOversizedLensContextReview(r *journeyRun) error {
 		return fmt.Errorf("oversized candidate START did not request consent: %q", start.NextTransition.Execute.Command)
 	}
 	started := r.run(args, false)
-	if started.ExitCode != 0 {
-		return fmt.Errorf("printed oversized candidate START exited %d: %s", started.ExitCode, firstLine(started.Stderr))
+	if started.ExitCode == 0 {
+		return fmt.Errorf("oversized candidate START succeeded and left authority STATUS could only refuse: %s", firstLine(started.Stdout))
+	}
+	if !strings.Contains(started.Stdout+started.Stderr, "lens_context_budget_exceeded") {
+		return fmt.Errorf("oversized candidate START refused without naming its budget: %s", firstLine(started.Stderr))
 	}
 
+	// Nothing was persisted, so the repository is exactly where it was: STATUS
+	// still offers the same start, rather than a permanent stop on a lineage
+	// no reviewer action can ever advance.
 	status, err := readStatusForContract(r, reviewContractV2)
 	if err != nil {
 		return err
 	}
-	if status.Authority.State != "reviewing" || len(status.Projection.Paths) != lensContextBudgetCandidatePaths ||
-		status.NextTransition.Kind != "stop" || status.NextTransition.ReasonCode != "lens_context_budget_exceeded" {
-		return fmt.Errorf("oversized candidate STATUS = authority=%+v paths=%d transition=%+v", status.Authority, len(status.Projection.Paths), status.NextTransition)
+	if status.Authority.LineageID != "" || status.NextTransition.Kind != "execute" ||
+		status.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("refused oversized candidate STATUS = authority=%+v transition=%+v", status.Authority, status.NextTransition)
 	}
 	return nil
 }
@@ -60,13 +72,13 @@ func stopOversizedLensContextReview(r *journeyRun) error {
 func lensContextBudgetJourneys() []Journey {
 	return []Journey{{
 		ID:     "j102-status-stops-oversized-lens-context",
-		Title:  "Oversized immutable reviewer context stops instead of reoffering an impossible reviewer slot",
-		Source: "issue #2773: a frozen candidate exceeding the native evidence capacity must end STATUS with lens_context_budget_exceeded",
+		Title:  "An unrepresentable immutable reviewer context is refused by START instead of becoming a dead lineage",
+		Source: "issues #2773 and #3367: a frozen candidate whose complete reviewer evidence exceeds the native budget must be refused before any authority is created",
 		Steps: []Step{
 			{Name: "fixture: repository", Fixture: baseRepo},
-			{Name: "fixture: 33 staged reviewer-evidence paths", Fixture: oversizedLensContextCandidate},
+			{Name: "fixture: staged reviewer evidence beyond the byte budget", Fixture: oversizedLensContextCandidate},
 			{Name: "enable review mode only in the disposable journey clone", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--scope", "clone", "--json")},
-			{Name: "negotiated STATUS starts the review then stops the oversized frozen reviewer context", Requires: frozenLineageStatusCapability, Composite: stopOversizedLensContextReview},
+			{Name: "negotiated START refuses the oversized frozen reviewer context without persisting authority", Requires: frozenLineageStatusCapability, Composite: stopOversizedLensContextReview},
 		},
 	}}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1110,7 +1110,10 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 						if record.State.State == reviewtransaction.StateReviewing {
 							artifacts, artifactErr = discoverCapturedReviewerArtifacts(ctx, root, store.Dir, record.State, record.Revision)
 							if artifactErr == nil && len(artifacts) != len(record.State.SelectedLenses) {
-								lensContextBudgetExceeded, artifactErr = reviewLensContextStatusBudgetExhausted(ctx, root, record.State, record.Revision)
+								// Only the probe's deterministic verdict stops STATUS: an unproven
+								// probe says nothing about artifacts that just verified, so it must
+								// never become a terminal captured-artifact failure (issue #3367).
+								lensContextBudgetExceeded = reviewLensContextStatusBudgetExhausted(ctx, root, record.State, record.Revision)
 							}
 							if artifactErr == nil && !lensContextBudgetExceeded {
 								if hasRepositoryContextIntent(record.EffectIntents) {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1110,7 +1110,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 						if record.State.State == reviewtransaction.StateReviewing {
 							artifacts, artifactErr = discoverCapturedReviewerArtifacts(ctx, root, store.Dir, record.State, record.Revision)
 							if artifactErr == nil && len(artifacts) != len(record.State.SelectedLenses) {
-								lensContextBudgetExceeded = reviewLensContextStatusBudgetExhausted(ctx, root, record.State, record.Revision)
+								lensContextBudgetExceeded, artifactErr = reviewLensContextStatusBudgetExhausted(ctx, root, record.State, record.Revision)
 							}
 							if artifactErr == nil && !lensContextBudgetExceeded {
 								if hasRepositoryContextIntent(record.EffectIntents) {
@@ -2093,6 +2093,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	var requestedFrozenContext *reviewtransaction.FrozenCandidateContext
 	var requestedRepositoryContext *ReviewRepositoryContextReference
 	var requestedContextErr error
+	var requestedLensBudgetErr error
 	// Selecting lenses is a promise that reviewer work can be handed out, and
 	// the frozen candidate context is the whole of what a reviewer is handed.
 	// Rendering it here -- for every START that selects lenses, negotiated or
@@ -2109,6 +2110,14 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		contextResult, contextErr := renderReviewStartFrozenCandidateContext(ctx, contextBuilder, state.InitialSnapshot)
 		if contextErr == nil && *contract == ReviewIntegrationContractV1 {
 			contextResult, contextErr = contextBuilder.WithLegacyCandidateDiff(ctx, state.InitialSnapshot, contextResult)
+		}
+		// Rendering the frozen context proves the candidate's trees and manifest
+		// exist; it does not prove the reviewer evidence built from them fits.
+		// That second proof belongs here too, for the same reason, and keeps its
+		// own typed refusal rather than being reshaped into a render failure it
+		// is not (issue #3367).
+		if contextErr == nil {
+			requestedLensBudgetErr = reviewLensContextStartBudgetRefusal(ctx, root, state)
 		}
 		if contextErr != nil {
 			requestedContextErr = &reviewStartContextError{LineageID: state.LineageID, Cause: contextErr}
@@ -2149,6 +2158,9 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	beforeCreate := func() error {
 		if requestedContextErr != nil {
 			return requestedContextErr
+		}
+		if requestedLensBudgetErr != nil {
+			return requestedLensBudgetErr
 		}
 		if intendedScope.Declared {
 			if _, err := (reviewtransaction.SnapshotBuilder{Repo: root}).ValidateIntendedUntrackedSelection(ctx, intendedScope.Digest, intendedScope.Intended); err != nil {

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -31,11 +31,16 @@ const reviewLensContextTimeout = 120 * time.Second
 // It is enforced by outright refusal. Truncating would hand a reviewer a
 // partial view of the candidate while still letting it report a clean result,
 // which is the one failure this surface exists to make impossible.
+//
+// It is also the *only* bound this surface applies. A separate 32-entry cap
+// used to sit beside it, inherited unchanged from the deleted advisory-review
+// adapter's request validator, where it carried no rationale of its own. A
+// count is not a measure of what a reviewer's context costs: it refused 33
+// one-line files whose complete evidence was a few kilobytes while admitting
+// 32 files that filled this entire budget. Counting entries also made the
+// refusal unfixable rather than merely large, because path count is the one
+// property splitting a candidate barely changes (issue #3367).
 const reviewLensContextByteBudget = reviewtransaction.MaxFrozenCandidateDiffBytes
-
-// reviewProviderMaxEvidenceEntries bounds every provider-owned role request.
-// It is shared native policy, never adapter-owned configuration.
-const reviewProviderMaxEvidenceEntries = 32
 
 const (
 	reviewLensContextBindingHeader = "GENTLE_AI_REVIEW_BINDING"
@@ -83,6 +88,10 @@ const (
 	reviewLensContextBudgetAction = "immutable candidate evidence is never truncated and retrying this candidate cannot succeed; " +
 		"split the candidate into a chained sequence of smaller reviewable commits, each under the budget, then refresh the exact native next transition by running " +
 		reviewNextTransitionRefreshCommandV21 + " and execute the returned transition for the reduced scope"
+	reviewLensContextStartBudgetAction = "no review authority was created, so nothing has to be abandoned or repaired; " +
+		"immutable candidate evidence is never truncated and retrying this exact candidate cannot succeed, so split it into a chained sequence of smaller reviewable commits, each under the budget, " +
+		"then refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 +
+		" and execute the returned transition for the reduced scope"
 	reviewLensContextEmptyPatchAction = "one content-changing path produced no patch bytes at all, which no legitimate candidate does; " +
 		"refresh the exact native next transition by running " + reviewNextTransitionRefreshCommandV21 +
 		" and run this operation again, and if the same path keeps producing no patch treat it as a native inspection defect and stop retrying"
@@ -207,7 +216,7 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	defer func() {
 		payload, err = reviewLensContextCleanup(ctx, payload, err, func() error { return deps.close(authority.Inspector) })
 	}()
-	block, err := reviewLensContextAssemble(ctx, deps, authority.Binding, authority.Subject, authority.Frozen, authority.Inspector)
+	block, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen)
 	if err != nil {
 		return nil, err
 	}
@@ -238,32 +247,27 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	return block, nil
 }
 
-// reviewLensContextAssemble is the one immutable evidence representability
-// check. STATUS reuses it before publishing a collection transition, while the
-// launch path records an emission only after this function returns a block.
-func reviewLensContextAssemble(
-	ctx context.Context, deps reviewLensContextDeps, binding reviewLensContextBinding,
-	subject reviewtransaction.ArtifactSubject, frozen reviewtransaction.FrozenCandidateContext,
-	inspector reviewLensCandidateInspector,
-) ([]byte, error) {
-	if len(frozen.ChangedPathManifest) > reviewProviderMaxEvidenceEntries {
-		return nil, reviewLensContextRefusal("lens_context_budget_exceeded", reviewLensContextCapacityAction(len(frozen.ChangedPathManifest)))
-	}
-	return reviewLensContextBlock(ctx, deps, inspector, binding, subject, frozen)
-}
-
-// reviewLensContextStatusBudgetExhausted proves only the deterministic budget
-// refusal for the frozen slots STATUS would otherwise reoffer. It derives the
-// same opaque handle without publishing it and never records an emission.
-// Every other assembly failure remains a launch-time failure so fresh STATUS
-// preserves the existing negotiated collection continuity.
-func reviewLensContextStatusBudgetExhausted(ctx context.Context, repo string, state reviewtransaction.CompactState, revision string) bool {
-	assemblyContext, cancel := context.WithTimeout(ctx, reviewLensContextTimeout)
+// reviewLensContextBudgetProbe assembles the complete immutable evidence for
+// every lens a review selected and reports whether any of them exceeds the
+// byte budget. It derives the opaque handle without publishing it, records no
+// emission, and writes nothing. Every other assembly failure is left to the
+// launch path so fresh STATUS preserves the existing negotiated collection
+// continuity.
+//
+// The third outcome is the one that matters. A probe that never reached the
+// budget returns its cause rather than "under budget": before issue #3367 a
+// preparation failure here read exactly like a candidate that fits, which let
+// a caller be handed a reviewer slot nothing had verified was fillable. That
+// is the same shape the budget itself exists to prevent, one layer up.
+func reviewLensContextBudgetProbe(
+	ctx context.Context, deps reviewLensContextDeps, repo string,
+	state reviewtransaction.CompactState, revision string,
+) (bool, error) {
+	assemblyContext, cancel := context.WithTimeout(ctx, deps.timeout)
 	defer cancel()
-	deps := reviewLensContextDependencies()
 	inspector, err := deps.prepare(reviewtransaction.SnapshotBuilder{Repo: repo}, assemblyContext, state.InitialSnapshot)
 	if err != nil {
-		return false
+		return false, err
 	}
 	defer deps.close(inspector)
 	frozen := inspector.FrozenCandidateContext()
@@ -271,23 +275,81 @@ func reviewLensContextStatusBudgetExhausted(ctx context.Context, repo string, st
 		LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: revision,
 	})
 	if err != nil {
-		return false
+		return false, err
 	}
 	for order, lens := range state.SelectedLenses {
 		subject, subjectErr := reviewtransaction.NewArtifactSubject(state, revision, frozen, lens, order, "")
 		if subjectErr != nil {
-			continue
+			return false, subjectErr
 		}
-		_, assemblyErr := reviewLensContextAssemble(assemblyContext, deps, reviewLensContextBinding{
+		_, assemblyErr := reviewLensContextBlock(assemblyContext, deps, inspector, reviewLensContextBinding{
 			Lineage: state.LineageID, Target: state.InitialSnapshot.Identity, Lens: lens, Order: order,
 			Revision: revision, RepositoryContext: repositoryContext, SubjectHash: subject.SubjectHash,
-		}, subject, frozen, inspector)
+		}, subject, frozen)
 		var refusal *reviewLensContextError
 		if errors.As(assemblyErr, &refusal) && refusal.Code == "lens_context_budget_exceeded" {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+// reviewLensContextStatusBudgetExhausted proves the deterministic budget
+// refusal for the frozen slots STATUS would otherwise reoffer.
+//
+// Since START refuses an unrepresentable candidate before persisting anything,
+// the only lineages this can still classify as exhausted are ones an older
+// build created, so it stays as the upgrade path's defence rather than the
+// primary guard.
+func reviewLensContextStatusBudgetExhausted(ctx context.Context, repo string, state reviewtransaction.CompactState, revision string) (bool, error) {
+	return reviewLensContextBudgetProbe(ctx, reviewLensContextDependencies(), repo, state, revision)
+}
+
+// reviewLensContextStartBudgetRefusal is START's representability check: it
+// proves the complete immutable evidence for every selected lens can actually
+// be assembled, before any durable authority exists.
+//
+// This is what makes the facade's stated invariant true rather than merely
+// intended -- "a candidate that starts here is a candidate STATUS can answer".
+// The same budget was previously discovered only by STATUS, after START had
+// already persisted authority, so an over-budget candidate became a permanent
+// dead lineage whose only exits were abandoning review for the clone or
+// splitting the candidate anyway (issue #3367). Refusing here reports that
+// once, at the point of decision, with nothing to clean up afterwards.
+//
+// It fails closed: a probe that could not reach the budget refuses too, since
+// nothing is persisted and re-running START costs a caller nothing.
+func reviewLensContextStartBudgetRefusal(ctx context.Context, repo string, state reviewtransaction.CompactState) error {
+	if len(state.SelectedLenses) == 0 {
+		return nil
+	}
+	revision, err := reviewtransaction.CompactRevisionForState(state)
+	if err != nil {
+		return err
+	}
+	exceeded, err := reviewLensContextBudgetProbe(ctx, reviewLensContextDependencies(), repo, state, revision)
+	if err != nil {
+		return err
+	}
+	if exceeded {
+		return reviewPreflightRefusal(reviewLensContextStartBudgetReason,
+			&reviewLensContextError{Code: "lens_context_budget_exceeded", Action: reviewLensContextStartBudgetAction})
+	}
+	return nil
+}
+
+// reviewLensContextStartBudgetReason classifies START's budget refusal. The
+// default "correct the request you sent" shape would be an actively wrong
+// instruction here: no flag, projection, or lineage makes an over-budget
+// candidate representable, and raising the bound would only move the cliff.
+// The contract message stays inside the published 240-character bound and says
+// the two things a caller acts on -- that nothing was created, and that the
+// change has to be reviewed as smaller candidates. The exact runnable
+// continuation travels with the cause.
+var reviewLensContextStartBudgetReason = reviewPreflightReason{
+	Code:       "lens_context_budget_exceeded",
+	Message:    "The candidate's complete reviewer evidence exceeds the native context budget, so no review authority was created; review this change as smaller candidates that each fit under it.",
+	NextAction: "stop",
 }
 
 // reviewLensAuthority is the resolved provider-owned binding, subject, and
@@ -534,8 +596,4 @@ func reviewLensContextDeadline(ctx context.Context, err error) error {
 		return reviewLensContextRefusal("lens_context_canceled", reviewLensContextRefreshAction)
 	}
 	return nil
-}
-
-func reviewLensContextCapacityAction(entries int) string {
-	return fmt.Sprintf("immutable candidate evidence has %d paths but provider-owned reviewer context accepts at most %d evidence entries; retrying this candidate cannot succeed; split the candidate into a chained sequence of smaller reviewable commits, then refresh the exact native next transition by running %s and execute the returned transition for the reduced scope", entries, reviewProviderMaxEvidenceEntries, reviewNextTransitionRefreshCommandV21)
 }

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -247,27 +247,35 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	return block, nil
 }
 
+// reviewLensContextProbeOutcome is what a representability probe learned. The
+// first two are verdicts about the candidate; the third is a fact about the
+// probe, and the type exists so they never collapse into each other.
+type reviewLensContextProbeOutcome int
+
+const (
+	reviewLensContextRepresentable reviewLensContextProbeOutcome = iota // every lens assembled in full, inside the budget
+	reviewLensContextOverBudget                                         // one lens exceeded it: deterministic and permanent
+	reviewLensContextUnproven                                           // never decided: the candidate may fit perfectly well
+)
+
 // reviewLensContextBudgetProbe assembles the complete immutable evidence for
-// every lens a review selected and reports whether any of them exceeds the
-// byte budget. It derives the opaque handle without publishing it, records no
-// emission, and writes nothing. Every other assembly failure is left to the
-// launch path so fresh STATUS preserves the existing negotiated collection
-// continuity.
+// every lens a review selected and classifies the candidate. It derives the
+// opaque handle without publishing it, records no emission, and writes nothing.
 //
-// The third outcome is the one that matters. A probe that never reached the
-// budget returns its cause rather than "under budget": before issue #3367 a
-// preparation failure here read exactly like a candidate that fits, which let
-// a caller be handed a reviewer slot nothing had verified was fillable. That
-// is the same shape the budget itself exists to prevent, one layer up.
+// The third outcome is the one that matters. Every stop that is not the budget
+// refusal -- an unreachable tree, an expired deadline, any other typed refusal
+// -- ends the probe and returns its cause, because before issue #3367 those
+// failures read exactly like a candidate that fits, which let a caller be
+// handed a reviewer slot nothing had verified was fillable.
 func reviewLensContextBudgetProbe(
 	ctx context.Context, deps reviewLensContextDeps, repo string,
 	state reviewtransaction.CompactState, revision string,
-) (bool, error) {
+) (reviewLensContextProbeOutcome, error) {
 	assemblyContext, cancel := context.WithTimeout(ctx, deps.timeout)
 	defer cancel()
 	inspector, err := deps.prepare(reviewtransaction.SnapshotBuilder{Repo: repo}, assemblyContext, state.InitialSnapshot)
 	if err != nil {
-		return false, err
+		return reviewLensContextUnproven, err
 	}
 	defer deps.close(inspector)
 	frozen := inspector.FrozenCandidateContext()
@@ -275,12 +283,12 @@ func reviewLensContextBudgetProbe(
 		LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Revision: revision,
 	})
 	if err != nil {
-		return false, err
+		return reviewLensContextUnproven, err
 	}
 	for order, lens := range state.SelectedLenses {
 		subject, subjectErr := reviewtransaction.NewArtifactSubject(state, revision, frozen, lens, order, "")
 		if subjectErr != nil {
-			return false, subjectErr
+			return reviewLensContextUnproven, subjectErr
 		}
 		_, assemblyErr := reviewLensContextBlock(assemblyContext, deps, inspector, reviewLensContextBinding{
 			Lineage: state.LineageID, Target: state.InitialSnapshot.Identity, Lens: lens, Order: order,
@@ -288,26 +296,37 @@ func reviewLensContextBudgetProbe(
 		}, subject, frozen)
 		var refusal *reviewLensContextError
 		if errors.As(assemblyErr, &refusal) && refusal.Code == "lens_context_budget_exceeded" {
-			return true, nil
+			return reviewLensContextOverBudget, nil
+		}
+		if assemblyErr != nil {
+			return reviewLensContextUnproven, assemblyErr
 		}
 	}
-	return false, nil
+	return reviewLensContextRepresentable, nil
 }
 
 // reviewLensContextStatusBudgetExhausted proves the deterministic budget
-// refusal for the frozen slots STATUS would otherwise reoffer.
+// refusal for the frozen slots STATUS would otherwise reoffer, and only that.
+//
+// An unproven probe answers false rather than degrading STATUS: this runs only
+// after the captured artifacts verified, so reporting its cause as that
+// discovery's failure would turn a transient hiccup into a terminal
+// captured-artifact verdict about something that never happened. The launch
+// this keeps offering re-runs the same assembly against the same frozen trees
+// and refuses with its own typed, refreshable cause.
 //
 // Since START refuses an unrepresentable candidate before persisting anything,
 // the only lineages this can still classify as exhausted are ones an older
 // build created, so it stays as the upgrade path's defence rather than the
 // primary guard.
-func reviewLensContextStatusBudgetExhausted(ctx context.Context, repo string, state reviewtransaction.CompactState, revision string) (bool, error) {
-	return reviewLensContextBudgetProbe(ctx, reviewLensContextDependencies(), repo, state, revision)
+func reviewLensContextStatusBudgetExhausted(ctx context.Context, repo string, state reviewtransaction.CompactState, revision string) bool {
+	outcome, _ := reviewLensContextBudgetProbe(ctx, reviewLensContextDependencies(), repo, state, revision)
+	return outcome == reviewLensContextOverBudget
 }
 
 // reviewLensContextStartBudgetRefusal is START's representability check: it
-// proves the complete immutable evidence for every selected lens can actually
-// be assembled, before any durable authority exists.
+// refuses a candidate whose complete immutable evidence is proven not to fit,
+// before any durable authority exists.
 //
 // This is what makes the facade's stated invariant true rather than merely
 // intended -- "a candidate that starts here is a candidate STATUS can answer".
@@ -317,25 +336,27 @@ func reviewLensContextStatusBudgetExhausted(ctx context.Context, repo string, st
 // splitting the candidate anyway (issue #3367). Refusing here reports that
 // once, at the point of decision, with nothing to clean up afterwards.
 //
-// It fails closed: a probe that could not reach the budget refuses too, since
-// nothing is persisted and re-running START costs a caller nothing.
+// It refuses on the proven verdict and only that, and never hands back the
+// untyped error a consumer cannot route on. An unproven probe classified the
+// probe rather than the candidate, and refusing on it would block candidates
+// that review perfectly well whenever one inspection read refuses -- while
+// telling their author to split a change nothing ever measured. The launch
+// path re-runs this same assembly and answers with its own typed, refreshable
+// refusal, which is where an undecided budget belongs.
 func reviewLensContextStartBudgetRefusal(ctx context.Context, repo string, state reviewtransaction.CompactState) error {
 	if len(state.SelectedLenses) == 0 {
 		return nil
 	}
-	revision, err := reviewtransaction.CompactRevisionForState(state)
-	if err != nil {
-		return err
+	// An underivable revision is one more way the budget stays undecided.
+	outcome := reviewLensContextUnproven
+	if revision, err := reviewtransaction.CompactRevisionForState(state); err == nil {
+		outcome, _ = reviewLensContextBudgetProbe(ctx, reviewLensContextDependencies(), repo, state, revision)
 	}
-	exceeded, err := reviewLensContextBudgetProbe(ctx, reviewLensContextDependencies(), repo, state, revision)
-	if err != nil {
-		return err
+	if outcome != reviewLensContextOverBudget {
+		return nil
 	}
-	if exceeded {
-		return reviewPreflightRefusal(reviewLensContextStartBudgetReason,
-			&reviewLensContextError{Code: "lens_context_budget_exceeded", Action: reviewLensContextStartBudgetAction})
-	}
-	return nil
+	return reviewPreflightRefusal(reviewLensContextStartBudgetReason,
+		&reviewLensContextError{Code: "lens_context_budget_exceeded", Action: reviewLensContextStartBudgetAction})
 }
 
 // reviewLensContextStartBudgetReason classifies START's budget refusal. The

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -824,8 +824,8 @@ func deriveLensContextHandle(t *testing.T, repo string, record reviewtransaction
 
 // TestReviewLensContextBudgetProbeReportsFailureInsteadOfUnderBudget pins the
 // third outcome. A probe that never reached the budget used to return the same
-// false a comfortably-small candidate returns, so STATUS published a reviewer
-// slot nothing had verified was fillable (issue #3367 property 2).
+// false a comfortably-small candidate returns, so no caller could tell "fits"
+// apart from "never measured" (issue #3367 property 2).
 func TestReviewLensContextBudgetProbeReportsFailureInsteadOfUnderBudget(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
@@ -840,9 +840,15 @@ func TestReviewLensContextBudgetProbeReportsFailureInsteadOfUnderBudget(t *testi
 		t.Fatal(err)
 	}
 
-	exhausted, err := reviewLensContextStatusBudgetExhausted(t.Context(), repo, record.State, record.Revision)
-	if err != nil || exhausted {
-		t.Fatalf("reachable small candidate probe = (%v, %v), want (false, nil)", exhausted, err)
+	if reviewLensContextStatusBudgetExhausted(t.Context(), repo, record.State, record.Revision) {
+		t.Fatal("reachable small candidate was classified as over budget")
+	}
+
+	// START routes the proven verdict only: an unproven probe defers to the
+	// launch path that can establish the truth, rather than refusing a
+	// candidate nothing measured or raising an untyped failure.
+	if startErr := reviewLensContextStartBudgetRefusal(t.Context(), filepath.Join(t.TempDir(), "absent"), record.State); startErr != nil {
+		t.Fatalf("START refused a candidate its probe never classified: %v", startErr)
 	}
 
 	for _, test := range []struct {
@@ -867,12 +873,12 @@ func TestReviewLensContextBudgetProbeReportsFailureInsteadOfUnderBudget(t *testi
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			exhausted, err := reviewLensContextBudgetProbe(t.Context(), test.deps(reviewLensContextDependencies()), repo, record.State, record.Revision)
+			outcome, err := reviewLensContextBudgetProbe(t.Context(), test.deps(reviewLensContextDependencies()), repo, record.State, record.Revision)
 			if err == nil {
-				t.Fatalf("probe answered exhausted=%v with no cause after it never evaluated the budget", exhausted)
+				t.Fatalf("probe answered outcome=%v with no cause after it never evaluated the budget", outcome)
 			}
-			if exhausted {
-				t.Fatalf("probe that failed to evaluate the budget reported it exhausted, inventing a refusal reason: %v", err)
+			if outcome != reviewLensContextUnproven {
+				t.Fatalf("probe that failed to evaluate the budget answered %v, inventing a verdict about the candidate: %v", outcome, err)
 			}
 		})
 	}

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
@@ -170,30 +171,64 @@ func TestReviewLensContextRefusesUnboundInput(t *testing.T) {
 	}
 }
 
-// TestReviewLensContextRefusesOverBudgetCandidateWithoutTruncating proves the
-// budget is enforced by outright refusal. Truncated candidate evidence could
-// fabricate a false-clean lens result, so there is no partial outcome.
-func TestReviewLensContextRefusesOverBudgetCandidateWithoutTruncating(t *testing.T) {
-	// Two paths that each read well inside the per-command cap but together
-	// exceed the whole-context budget: this is the aggregate the surface owns
-	// and no single native read would ever catch.
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", os.Getenv("HOME"))
-	repo := initReviewCLIRepo(t)
+// writeOverByteBudgetLensContextCandidate writes two paths that each read well
+// inside the per-command cap but together exceed the whole-context byte budget.
+// That aggregate is what this surface owns, and no single native read catches
+// it.
+func writeOverByteBudgetLensContextCandidate(t *testing.T, repo string) {
+	t.Helper()
 	body := strings.Repeat("oversized evidence line\n", 100_000)
 	for _, name := range []string{"bulk-one.txt", "bulk-two.txt"} {
 		writeReviewStartCandidate(t, repo, name, body, 0o644)
 	}
-	started := runNegotiatedReviewStart(t, repo, "lens-context-budget")
+}
+
+// TestNegotiatedStartRefusesOverBudgetCandidateWithoutPersistingAuthority
+// proves the budget is enforced by outright refusal at the point of decision.
+// Truncated candidate evidence could fabricate a false-clean lens result, so
+// there is no partial outcome; and because START refuses before creating
+// authority, there is no dead lineage to abandon afterwards either (#3367).
+func TestNegotiatedStartRefusesOverBudgetCandidateWithoutPersistingAuthority(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	writeOverByteBudgetLensContextCandidate(t, repo)
+	authorityRoot := reviewCLIAuthorityRoot(t, repo)
+	homeBefore := readLegacyAuthorityTree(t, home)
+
 	var output bytes.Buffer
-	err := RunReview([]string{
-		"lens-context", "--repository-context", started.RepositoryContext.Handle, "--lens", started.SelectedLenses[0],
-	}, &output)
+	err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--lineage", "lens-context-budget",
+	}), &output)
 	if err == nil || !strings.Contains(err.Error(), "lens_context_budget_exceeded") {
-		t.Fatalf("over-budget error = %v", err)
+		t.Fatalf("over-budget START error = %v\n%s", err, output.String())
 	}
-	if output.Len() != 0 {
-		t.Fatalf("over-budget refusal emitted %d bytes of truncated evidence", output.Len())
+	if !strings.Contains(err.Error(), "no review authority was created") {
+		t.Fatalf("over-budget START does not say that nothing was persisted: %v", err)
+	}
+	var failure *ReviewIntegrationFailureError
+	if !errors.As(err, &failure) {
+		t.Fatalf("over-budget START did not emit a typed negotiated failure: %T", err)
+	}
+	if failure.Failure.MutationOutcome != ReviewMutationNotStarted || failure.Failure.Phase != "preflight" ||
+		failure.Failure.NextAction != "stop" || failure.Failure.Code != "lens_context_budget_exceeded" {
+		t.Fatalf("over-budget START envelope does not report a refusal that wrote nothing: %#v", failure.Failure)
+	}
+	if !strings.Contains(failure.Failure.Cause, "chained sequence of smaller reviewable commits") ||
+		!strings.Contains(failure.Failure.Cause, "gentle-ai review status") {
+		t.Fatalf("over-budget START cause does not name the runnable continuation: %q", failure.Failure.Cause)
+	}
+	if strings.Contains(output.String(), "GENTLE_AI_REVIEW_") {
+		t.Fatalf("over-budget START refusal emitted reviewer evidence:\n%s", output.String())
+	}
+	// A store LOCK file is bookkeeping the refusal itself takes out; durable
+	// authority is a persisted record, and there must be none.
+	for path := range readLegacyAuthorityTree(t, authorityRoot) {
+		if filepath.Base(path) != "LOCK" {
+			t.Fatalf("over-budget START persisted authority STATUS could only refuse: %s", path)
+		}
+	}
+	if after := readLegacyAuthorityTree(t, home); !reflect.DeepEqual(homeBefore, after) {
+		t.Fatalf("over-budget START persisted an artifact: before=%#v after=%#v", homeBefore, after)
 	}
 }
 
@@ -248,64 +283,31 @@ func TestReviewLensContextCarriesAggregateDeadline(t *testing.T) {
 	}
 }
 
-func TestReviewLensContextRefusesManifestOverAdvisoryCapacityBeforePatchInspection(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", os.Getenv("HOME"))
-	repo := initReviewCLIRepo(t)
-	for index := range 33 {
-		writeReviewStartCandidate(t, repo, fmt.Sprintf("path-%02d.txt", index), "candidate\n", 0o644)
-	}
-	started := runNegotiatedReviewStart(t, repo, "lens-context-entry-capacity")
-	deps := reviewLensContextDependencies()
-	inspect := deps.inspect
-	patchReads := 0
-	deps.inspect = func(ctx context.Context, inspector reviewLensCandidateInspector, operation string, pathIndex int, side string) ([]byte, error) {
-		if operation == "patch" {
-			patchReads++
-		}
-		return inspect(ctx, inspector, operation, pathIndex, side)
-	}
-	block, err := runReviewLensContext([]string{
-		"--repository-context", started.RepositoryContext.Handle, "--lens", started.SelectedLenses[0],
-	}, io.Discard, deps)
-	if err == nil || !strings.Contains(err.Error(), "lens_context_budget_exceeded") {
-		t.Fatalf("entry-capacity error = %v", err)
-	}
-	if strings.Contains(err.Error(), "advisory review") || !strings.Contains(err.Error(), "provider-owned reviewer context accepts at most") ||
-		!strings.Contains(err.Error(), "33") || !strings.Contains(err.Error(), "32") || !strings.Contains(err.Error(), "retrying this candidate cannot succeed") ||
-		!strings.Contains(err.Error(), "chained sequence of smaller reviewable commits") || !strings.Contains(err.Error(), reviewNextTransitionRefreshCommandV21) {
-		t.Fatalf("entry-capacity guidance does not name its limit and runnable continuation: %q", err)
-	}
-	if patchReads != 0 {
-		t.Fatalf("patch inspections before entry-capacity refusal = %d, want 0", patchReads)
-	}
-	if len(block) != 0 {
-		t.Fatalf("entry-capacity refusal emitted %d bytes of reviewer context", len(block))
-	}
-}
-
+// TestNegotiatedStatusStopsDeterministicLensContextBudgetWithoutMutation keeps
+// STATUS's deterministic budget classification honest for a lineage that
+// already exists over budget. Its candidate changed with issue #3367: the
+// 33-path fixture it used to carry is now reviewable, because path count no
+// longer decides anything, so the over-budget candidate has to be one whose
+// evidence genuinely exceeds the byte budget.
+//
+// Its authority is created through StartCompactAuthority rather than the
+// facade, which is exactly the shape a build without START's representability
+// check leaves behind. That upgrade path is the only way this stop is still
+// reachable, and it is why the classification is kept rather than deleted
+// along with the count. Every no-mutation assertion below is unchanged.
 func TestNegotiatedStatusStopsDeterministicLensContextBudgetWithoutMutation(t *testing.T) {
 	home := reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
-	for index := range reviewProviderMaxEvidenceEntries + 1 {
-		writeReviewStartCandidate(t, repo, "path-"+strconv.Itoa(index)+".txt", "candidate\n", 0o644)
-	}
-	started := runNegotiatedReviewStart(t, repo, "lens-context-status-budget")
-	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, started.LineageID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	record, err := store.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
+	writeOverByteBudgetLensContextCandidate(t, repo)
+	record := startCompactAuthorityWithoutFacadeChecks(t, repo, "lens-context-status-budget")
+	handle := deriveLensContextHandle(t, repo, record)
 	before := readLegacyAuthorityTree(t, reviewCLIAuthorityRoot(t, repo))
 	homeBefore := readLegacyAuthorityTree(t, home)
 	worktreeBefore := runReviewCLIGit(t, repo, "status", "--porcelain=v2", "--untracked-files=all")
 
 	var context bytes.Buffer
-	err = RunReview([]string{
-		"lens-context", "--repository-context", started.RepositoryContext.Handle, "--lens", started.SelectedLenses[0],
+	err := RunReview([]string{
+		"lens-context", "--repository-context", handle, "--lens", record.State.SelectedLenses[0],
 	}, &context)
 	if err == nil || !strings.Contains(err.Error(), "lens_context_budget_exceeded") {
 		t.Fatalf("lens-context refusal = %v, want deterministic budget exhaustion", err)
@@ -320,7 +322,7 @@ func TestNegotiatedStatusStopsDeterministicLensContextBudgetWithoutMutation(t *t
 		t.Fatalf("lens-context budget refusal persisted an artifact: before=%#v after=%#v", homeBefore, after)
 	}
 
-	status := explicitFrozenReviewingStatus(t, repo, started.LineageID)
+	status := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
 	if status.Action != reviewtransaction.TargetStatusActionStop ||
 		status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionStop ||
 		status.NextTransition.ReasonCode != "lens_context_budget_exceeded" ||
@@ -373,7 +375,7 @@ func TestReviewLensContextRecoveryGuidanceRefreshesThenExecutesNextTransition(t 
 		action string
 	}{
 		{name: "evidence capacity", action: reviewLensContextBudgetAction},
-		{name: "entry capacity", action: reviewLensContextCapacityAction(reviewProviderMaxEvidenceEntries + 1)},
+		{name: "start capacity", action: reviewLensContextStartBudgetAction},
 		{name: "deadline", action: reviewLensContextDeadlineAction},
 	}
 	for _, test := range tests {
@@ -701,4 +703,177 @@ func lensContextSection(block, header string) (string, bool) {
 	}
 	body, _, found := strings.Cut(after, "\n"+header+"_END\n")
 	return body, found
+}
+
+// writeLensContextPathFixture writes `paths` small, distinct source files so a
+// candidate's path count and its evidence byte size can be varied
+// independently. Every file is a few dozen bytes, which is what makes the
+// difference between counting entries and measuring bytes observable.
+func writeLensContextPathFixture(t *testing.T, repo string, paths int) {
+	t.Helper()
+	for index := range paths {
+		writeReviewStartCandidate(t, repo,
+			fmt.Sprintf("internal/candidate/path%02d/source.go", index),
+			"package path"+strconv.Itoa(index)+"\n\nfunc Exported"+strconv.Itoa(index)+"() bool { return true }\n", 0o644)
+	}
+}
+
+// TestNegotiatedStartLeavesNoAuthorityStatusCanOnlyRefuse pins the documented
+// START invariant from review_facade.go: "a candidate that starts here is a
+// candidate STATUS can answer". A candidate whose only excess is its path count
+// costs a few kilobytes of evidence, so START must not persist durable
+// authority whose STATUS is a permanent stop (issue #3367 property 1).
+func TestNegotiatedStartLeavesNoAuthorityStatusCanOnlyRefuse(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	writeLensContextPathFixture(t, repo, 60)
+	started := runNegotiatedReviewStart(t, repo, "large-candidate-reviewable")
+	if len(started.SelectedLenses) == 0 {
+		t.Fatal("60-path candidate selected no lenses; the fixture no longer exercises reviewer evidence")
+	}
+	status := explicitFrozenReviewingStatus(t, repo, started.LineageID)
+	if status.NextTransition == nil {
+		t.Fatal("STATUS published no next transition for a durable authority START created")
+	}
+	if status.NextTransition.Kind == reviewNextTransitionStop {
+		t.Fatalf("START persisted authority STATUS can only refuse: stop(%s) for a %d-path candidate",
+			status.NextTransition.ReasonCode, len(started.SelectedLenses))
+	}
+}
+
+// TestReviewLensContextAdmitsManyPathsFarUnderByteBudget pins that the limit
+// tracks the thing that actually costs reviewer context. Thirty-three one-line
+// files are a rounding error against a 4 MiB budget, so refusing them while
+// admitting a much larger 32-path candidate is a count masquerading as a
+// budget (issue #3367 property 3).
+func TestReviewLensContextAdmitsManyPathsFarUnderByteBudget(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	writeLensContextPathFixture(t, repo, 33)
+	started := runNegotiatedReviewStart(t, repo, "lens-context-small-paths")
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"lens-context", "--repository-context", started.RepositoryContext.Handle, "--lens", started.SelectedLenses[0],
+	}, &output); err != nil {
+		t.Fatalf("33 one-line paths were refused: %v", err)
+	}
+	if output.Len() > reviewLensContextByteBudget/8 {
+		t.Fatalf("fixture is not far under budget: block = %d bytes of %d", output.Len(), reviewLensContextByteBudget)
+	}
+	t.Logf("33-path reviewer block = %d bytes of the %d byte budget", output.Len(), reviewLensContextByteBudget)
+}
+
+// startCompactAuthorityWithoutFacadeChecks persists reviewing authority the way
+// a build predating START's representability check did: the same native state
+// and the same store write, with none of the facade's pre-create refusals. It
+// is the only remaining way to reach a lineage whose reviewer evidence cannot
+// be assembled, which is exactly the upgrade path STATUS still has to classify.
+func startCompactAuthorityWithoutFacadeChecks(t *testing.T, repo, lineage string) reviewtransaction.CompactRecord {
+	t.Helper()
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(t.Context(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := builder.AssessSnapshotRisk(t.Context(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lenses, err := facadeSelectedLenses(assessment, "reliability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lenses) == 0 {
+		t.Fatal("fixture selected no lenses; it no longer exercises reviewer evidence")
+	}
+	policy, err := facadePolicyBytes("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: lineage, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1,
+		Snapshot: snapshot, PolicyHash: facadePayloadHash(policy), RiskLevel: assessment.Level,
+		SelectedLenses: lenses, OriginalChangedLines: &assessment.ChangedLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := reviewtransaction.StartCompactAuthority(t.Context(), repo, reviewtransaction.CompactStartRequest{
+		State: state, ExplicitLineage: true, RepositoryContext: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return started.Record
+}
+
+// deriveLensContextHandle recovers the opaque repository context a collect
+// transition would have carried for an already-persisted record.
+func deriveLensContextHandle(t *testing.T, repo string, record reviewtransaction.CompactRecord) string {
+	t.Helper()
+	handle, err := reviewtransaction.PublishReviewRepositoryContext(t.Context(), repo, reviewtransaction.ReviewRepositoryContextBinding{
+		LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity, Revision: record.Revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle
+}
+
+// TestReviewLensContextBudgetProbeReportsFailureInsteadOfUnderBudget pins the
+// third outcome. A probe that never reached the budget used to return the same
+// false a comfortably-small candidate returns, so STATUS published a reviewer
+// slot nothing had verified was fillable (issue #3367 property 2).
+func TestReviewLensContextBudgetProbeReportsFailureInsteadOfUnderBudget(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	writeLensContextPathFixture(t, repo, 4)
+	started := runNegotiatedReviewStart(t, repo, "budget-probe-failure")
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exhausted, err := reviewLensContextStatusBudgetExhausted(t.Context(), repo, record.State, record.Revision)
+	if err != nil || exhausted {
+		t.Fatalf("reachable small candidate probe = (%v, %v), want (false, nil)", exhausted, err)
+	}
+
+	for _, test := range []struct {
+		name string
+		deps func(reviewLensContextDeps) reviewLensContextDeps
+	}{
+		{
+			name: "candidate preparation fails",
+			deps: func(deps reviewLensContextDeps) reviewLensContextDeps {
+				deps.prepare = func(reviewtransaction.SnapshotBuilder, context.Context, reviewtransaction.Snapshot) (reviewLensCandidateInspector, error) {
+					return nil, errors.New("frozen trees are unreachable")
+				}
+				return deps
+			},
+		},
+		{
+			name: "repository context is unreachable",
+			deps: func(deps reviewLensContextDeps) reviewLensContextDeps {
+				deps.timeout = time.Nanosecond
+				return deps
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			exhausted, err := reviewLensContextBudgetProbe(t.Context(), test.deps(reviewLensContextDependencies()), repo, record.State, record.Revision)
+			if err == nil {
+				t.Fatalf("probe answered exhausted=%v with no cause after it never evaluated the budget", exhausted)
+			}
+			if exhausted {
+				t.Fatalf("probe that failed to evaluate the budget reported it exhausted, inventing a refusal reason: %v", err)
+			}
+		})
+	}
 }

--- a/internal/cli/review_manifest_line_budget_test.go
+++ b/internal/cli/review_manifest_line_budget_test.go
@@ -117,7 +117,10 @@ func TestCapturePreflightBoundsChangedPathManifestLineCost(t *testing.T) {
 func TestNegotiatedStatusBoundsChangedPathManifestLineCost(t *testing.T) {
 	reviewModeHome(t)
 	repo := initReviewCLIRepo(t)
-	const paths = reviewProviderMaxEvidenceEntries
+	// Forty paths, matching the START and preflight fixtures above. This used
+	// to be pinned to the retired 32-entry evidence cap, which was the largest
+	// candidate STATUS would answer at all before issue #3367.
+	const paths = 40
 	for index := range paths {
 		writeReviewStartCandidate(t, repo,
 			"internal/generated/package"+strconv.Itoa(index)+"/descriptive_source_name.go",

--- a/internal/cli/review_provider.go
+++ b/internal/cli/review_provider.go
@@ -67,7 +67,7 @@ func reviewProviderMaterialize(ctx context.Context, deps reviewLensContextDeps, 
 	if err != nil {
 		return reviewProviderRequest{}, err
 	}
-	prompt, err := reviewLensContextAssemble(ctx, deps, authority.Binding, authority.Subject, authority.Frozen, authority.Inspector)
+	prompt, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen)
 	if err != nil {
 		return reviewLensContextCleanup(ctx, reviewProviderRequest{}, err, func() error { return deps.close(authority.Inspector) })
 	}

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -251,9 +251,9 @@ func reviewProviderMaterializeEvidence(ctx context.Context, repo string, snapsho
 	}
 	defer deps.close(inspector)
 	frozen := inspector.FrozenCandidateContext()
-	if len(frozen.ChangedPathManifest) > reviewProviderMaxEvidenceEntries {
-		return nil, reviewLensContextRefusal("lens_context_budget_exceeded", reviewLensContextCapacityAction(len(frozen.ChangedPathManifest)))
-	}
+	// The aggregate byte budget is the whole bound. The 32-entry cap that used
+	// to sit above it measured the wrong thing and is gone (issue #3367); this
+	// role request is additionally bounded by its contract's prompt limit.
 	budget := reviewLensContextByteBudget
 	evidence := make([]reviewProviderEvidence, 0, len(frozen.ChangedPathManifest))
 	for index, entry := range frozen.ChangedPathManifest {


### PR DESCRIPTION
Closes #3367.

A medium or high-risk candidate with more than 32 changed paths was permanently unreviewable: START created durable authority and STATUS then refused it forever with `lens_context_budget_exceeded`.

The cap turned out to be a vestige. `git log -S` traces `reviewProviderMaxEvidenceEntries = 32` to the commit that deleted `internal/advisoryreview`, where it was lifted verbatim from that package. Its sibling `maxEvidenceBytes` carries a five-line rationale explaining it mirrors the budget the CLI already enforces; the entry count carries none. It validated an evidence array for an adapter that no longer exists and was promoted to native policy by transplant. Nothing downstream needs it: the published schemas set no `maxItems` on the manifest, and provider role prompts are separately bounded by bytes.

The aggregate byte budget is now the only bound, and START runs the representability check before persisting authority, so an unrepresentable candidate is refused with nothing created. Measured end to end at 686 bytes per path against the 4 MiB budget: 6,000 paths start and advance; 6,200 are refused at START with a typed preflight envelope and `mutation_outcome: not_started`.

The budget probe no longer fails open. It returns a typed three-valued outcome — representable, over budget, or unproven-with-cause — and one rule routes both callers: only a proven verdict acts, an unproven probe defers to the actor that can establish the truth. Previously any non-budget failure read as "under budget".

One deliberate non-change, forced by measurement: START does not fail closed on an unproven probe. `reviewLensContextByteBudget` and the per-read git limit are the same 4 MiB constant, so a single oversized patch fails the read before any accounting happens. Failing closed there would refuse a 110k-line candidate the product starts today and tell its author to split a change nothing measured. Verified by a counterfactual build during targeted validation.

RDD receipt: review-e01b0ad3b2bb4ea6 (approved, high, 4R, one bounded correction of 118 lines).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reviewer context is now governed by an aggregate size budget rather than a fixed file-count limit.
  * Reviews can include many small files when the combined context remains within the allowed budget.
* **Bug Fixes**
  * Review starts now detect oversized context before creating review authority.
  * Oversized candidates are clearly refused with guidance to reduce the review scope.
  * Status correctly identifies existing reviews whose context exceeds the current budget.
  * Failed starts leave no partial authority or lineage behind and remain available for retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->