### PR TITLE
fix(opencode): install and activate Gentleman theme

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -79,6 +79,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 			model.ComponentContext7,
 			model.ComponentPermission,
 			model.ComponentGGA,
+			model.ComponentTheme,
 			model.ComponentClaudeTheme,
 			model.ComponentOpenCodeGentleLogo,
 			model.ComponentPersona,
@@ -131,12 +132,9 @@ func TestNormalizeInstallFlagsFullPresetCustomPersonaKeepsPresetPolish(t *testin
 		if got == model.ComponentPersona {
 			t.Fatalf("components should not include persona for custom persona; got %#v", input.Selection.Components)
 		}
-		if got == model.ComponentTheme {
-			t.Fatalf("components should not include generic theme; got %#v", input.Selection.Components)
-		}
 	}
 
-	for _, want := range []model.ComponentID{model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+	for _, want := range []model.ComponentID{model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
 		found := false
 		for _, got := range input.Selection.Components {
 			if got == want {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2455,8 +2455,12 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			paths = append(paths, gga.ConfigPath(homeDir))
 			paths = append(paths, gga.AgentsTemplatePath(homeDir))
 		case model.ComponentTheme:
-			if p := adapter.SettingsPath(homeDir); p != "" {
-				paths = append(paths, p)
+			if adapter.Agent() == model.AgentOpenCode {
+				configDir := adapter.GlobalConfigDir(homeDir)
+				paths = append(paths,
+					filepath.Join(configDir, "tui.json"),
+					filepath.Join(configDir, "themes", "gentleman.json"),
+				)
 			}
 		case model.ComponentClaudeTheme:
 			paths = append(paths, theme.VisualThemePaths(homeDir, adapter)...)

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,6 +16,20 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
+
+func TestComponentPathsThemeUsesOpenCodeTUIAndThemeFileOnly(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentOpenCode, model.AgentClaudeCode})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentTheme)
+	want := []string{
+		filepath.Join(home, ".config", "opencode", "tui.json"),
+		filepath.Join(home, ".config", "opencode", "themes", "gentleman.json"),
+	}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("componentPaths(theme) = %v, want %v", paths, want)
+	}
+}
 
 func TestComponentPathsSDDIncludesSystemPromptForPromptFileAdapters(t *testing.T) {
 	home := t.TempDir()

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -47,7 +47,7 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	}
 	selection.Preset = preset
 
-	components, err := normalizeComponents(flags.Components, selection.Preset, selection.Persona)
+	components, err := normalizeComponents(flags.Components, selection.Preset, selection.Persona, selection.Agents)
 	if err != nil {
 		return InstallInput{}, err
 	}
@@ -121,9 +121,9 @@ func normalizePreset(value string) (model.PresetID, error) {
 	}
 }
 
-func normalizeComponents(values []string, preset model.PresetID, persona model.PersonaID) ([]model.ComponentID, error) {
+func normalizeComponents(values []string, preset model.PresetID, persona model.PersonaID, agents []model.AgentID) ([]model.ComponentID, error) {
 	if len(values) == 0 {
-		return componentsForPreset(preset, persona), nil
+		return componentsForPreset(preset, persona, agents...), nil
 	}
 
 	allowed := map[model.ComponentID]struct{}{}
@@ -178,8 +178,8 @@ func normalizeSDDMode(value string) (model.SDDModeID, error) {
 	}
 }
 
-func componentsForPreset(preset model.PresetID, persona model.PersonaID) []model.ComponentID {
-	return model.ComponentsForPreset(preset, persona)
+func componentsForPreset(preset model.PresetID, persona model.PersonaID, agents ...model.AgentID) []model.ComponentID {
+	return model.ComponentsForPreset(preset, persona, agents...)
 }
 
 func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentID {

--- a/internal/components/theme/inject.go
+++ b/internal/components/theme/inject.go
@@ -86,18 +86,40 @@ var gentlemanCuteOpenCodeTheme = openCodeTheme{
 	),
 }
 
+func marshalTheme(value any) ([]byte, error) {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(content, '\n'), nil
+}
+
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
-	settingsPath := adapter.SettingsPath(homeDir)
-	if settingsPath == "" {
+	if adapter.Agent() != model.AgentOpenCode {
 		return InjectionResult{}, nil
 	}
 
-	writeResult, err := mergeJSONFile(settingsPath, themeOverlayJSON)
+	configDir := adapter.GlobalConfigDir(homeDir)
+	tuiPath := filepath.Join(configDir, "tui.json")
+	themePath := filepath.Join(configDir, "themes", "gentleman.json")
+	themeContent, err := marshalTheme(gentlemanOpenCodeTheme)
 	if err != nil {
-		return InjectionResult{}, err
+		return InjectionResult{}, fmt.Errorf("marshal OpenCode theme: %w", err)
 	}
 
-	return InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}, nil
+	themeResult, err := filemerge.WriteFileAtomic(themePath, themeContent, 0o644)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("write OpenCode theme: %w", err)
+	}
+	tuiResult, err := mergeJSONFile(tuiPath, themeOverlayJSON)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("merge OpenCode tui theme: %w", err)
+	}
+
+	return InjectionResult{
+		Changed: themeResult.Changed || tuiResult.Changed,
+		Files:   []string{tuiPath, themePath},
+	}, nil
 }
 
 // InjectVisualThemes writes the managed visual theme assets without selecting one
@@ -118,11 +140,10 @@ func InjectVisualThemes(homeDir string, adapter agents.Adapter) (InjectionResult
 
 	result := InjectionResult{Files: make([]string, 0, len(paths))}
 	for i, path := range paths {
-		content, err := json.MarshalIndent(values[i], "", "  ")
+		content, err := marshalTheme(values[i])
 		if err != nil {
 			return InjectionResult{}, fmt.Errorf("marshal visual theme %q: %w", filepath.Base(path), err)
 		}
-		content = append(content, '\n')
 		writeResult, err := filemerge.WriteFileAtomic(path, content, 0o644)
 		if err != nil {
 			return InjectionResult{}, err

--- a/internal/components/theme/inject_test.go
+++ b/internal/components/theme/inject_test.go
@@ -16,86 +16,133 @@ import (
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 
-func TestInjectMergesThemeOverlayIntoAdapterSettings(t *testing.T) {
+func TestInjectOpenCodeFirstInstallWithoutTUIConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	configDir := opencodeAdapter().GlobalConfigDir(home)
+	tuiPath := filepath.Join(configDir, "tui.json")
+	result, err := Inject(home, opencodeAdapter())
+	if err != nil || !result.Changed {
+		t.Fatalf("Inject() = %#v, %v", result, err)
+	}
+	raw, err := os.ReadFile(tuiPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil || config["theme"] != "gentleman" {
+		t.Fatalf("TUI config = %v, %v", config, err)
+	}
+}
+
+func TestInjectSkipsNonOpenCodeAdapter(t *testing.T) {
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(settings dir) error = %v", err)
 	}
-	if err := os.WriteFile(settingsPath, []byte("{\n  \"permissions\": {\n    \"allow\": [\"Bash(go test ./...)\"]\n  },\n  \"theme\": \"existing-theme\"\n}\n"), 0o644); err != nil {
+	before := []byte("{\n  \"theme\": \"existing-theme\"\n}\n")
+	if err := os.WriteFile(settingsPath, before, 0o644); err != nil {
 		t.Fatalf("WriteFile(settings) error = %v", err)
 	}
 
-	first, err := Inject(home, claudeAdapter())
-	if err != nil {
-		t.Fatalf("Inject() first error = %v", err)
-	}
-	if !first.Changed {
-		t.Fatalf("Inject() first changed = false")
-	}
-
-	second, err := Inject(home, claudeAdapter())
-	if err != nil {
-		t.Fatalf("Inject() second error = %v", err)
-	}
-	if second.Changed {
-		t.Fatalf("Inject() second changed = true")
-	}
-
-	if len(first.Files) != 1 || first.Files[0] != settingsPath {
-		t.Fatalf("files = %#v, want only %q", first.Files, settingsPath)
-	}
-
-	data, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatalf("ReadFile(settings) error = %v", err)
-	}
-	var root struct {
-		Permissions map[string][]string `json:"permissions"`
-		Theme       string              `json:"theme"`
-	}
-	if err := json.Unmarshal(data, &root); err != nil {
-		t.Fatalf("Unmarshal(settings) error = %v", err)
-	}
-	if root.Theme != "gentleman" {
-		t.Fatalf("theme = %q, want gentleman", root.Theme)
-	}
-	if got := root.Permissions["allow"]; len(got) != 1 || got[0] != "Bash(go test ./...)" {
-		t.Fatalf("permissions.allow = %#v, want preserved existing permission", got)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".claude", "themes", "gentleman.json")); !os.IsNotExist(err) {
-		t.Fatalf("Inject() should not write Claude custom theme file; stat error = %v", err)
-	}
-}
-
-func TestInjectCreatesAdapterSettingsWhenMissing(t *testing.T) {
-	home := t.TempDir()
-
-	result, err := Inject(home, opencodeAdapter())
+	result, err := Inject(home, claudeAdapter())
 	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
 	}
-
-	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
-	if !result.Changed {
-		t.Fatalf("Inject() changed = false")
+	if result.Changed || len(result.Files) != 0 {
+		t.Fatalf("Inject() = %#v, want no-op for non-OpenCode adapter", result)
 	}
-	if len(result.Files) != 1 || result.Files[0] != settingsPath {
-		t.Fatalf("files = %#v, want only %q", result.Files, settingsPath)
+	if after, err := os.ReadFile(settingsPath); err != nil || string(after) != string(before) {
+		t.Fatalf("Claude settings changed: content=%q err=%v", after, err)
+	}
+}
+
+func TestInjectInstallsOpenCodeThemeAndMergesTUIConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	configDir := opencodeAdapter().GlobalConfigDir(home)
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(config dir) error = %v", err)
+	}
+	tuiPath := filepath.Join(configDir, "tui.json")
+	if err := os.WriteFile(tuiPath, []byte("{\n  // preserve valid JSONC fields\n  \"$schema\": \"https://opencode.ai/tui.json\",\n  \"plugin\": [\"user-plugin\"],\n}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(tui) error = %v", err)
+	}
+	opencodePath := filepath.Join(configDir, "opencode.json")
+	opencodeBefore := []byte("{\n  \"model\": \"user/model\"\n}\n")
+	if err := os.WriteFile(opencodePath, opencodeBefore, 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode) error = %v", err)
 	}
 
-	data, err := os.ReadFile(settingsPath)
+	first, err := Inject(home, opencodeAdapter())
 	if err != nil {
-		t.Fatalf("ReadFile(settings) error = %v", err)
+		t.Fatalf("Inject() first error = %v", err)
 	}
-	var root struct {
-		Theme string `json:"theme"`
+	themePath := filepath.Join(configDir, "themes", "gentleman.json")
+	if len(first.Files) != 2 || first.Files[0] != tuiPath || first.Files[1] != themePath {
+		t.Fatalf("files = %#v, want [%q %q]", first.Files, tuiPath, themePath)
 	}
-	if err := json.Unmarshal(data, &root); err != nil {
-		t.Fatalf("Unmarshal(settings) error = %v", err)
+
+	tuiData, err := os.ReadFile(tuiPath)
+	if err != nil {
+		t.Fatalf("ReadFile(tui) error = %v", err)
 	}
-	if root.Theme != "gentleman" {
-		t.Fatalf("theme = %q, want gentleman", root.Theme)
+	var tuiConfig struct {
+		Schema string   `json:"$schema"`
+		Plugin []string `json:"plugin"`
+		Theme  string   `json:"theme"`
+	}
+	if err := json.Unmarshal(tuiData, &tuiConfig); err != nil {
+		t.Fatalf("Unmarshal(tui) error = %v", err)
+	}
+	if tuiConfig.Schema != "https://opencode.ai/tui.json" || len(tuiConfig.Plugin) != 1 || tuiConfig.Plugin[0] != "user-plugin" || tuiConfig.Theme != "gentleman" {
+		t.Fatalf("merged tui config = %#v", tuiConfig)
+	}
+	if after, err := os.ReadFile(opencodePath); err != nil || string(after) != string(opencodeBefore) {
+		t.Fatalf("opencode.json changed: content=%q err=%v", after, err)
+	}
+}
+
+func TestInjectThenVisualThemesPreservesGeneratedOpenCodeTheme(t *testing.T) {
+	home := t.TempDir()
+	adapter := opencodeAdapter()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	if result, err := Inject(home, adapter); err != nil || !result.Changed {
+		t.Fatalf("Inject() = %#v, %v", result, err)
+	}
+	paths := VisualThemePaths(home, adapter)
+	before, err := os.Stat(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, err := os.ReadFile(paths[0])
+	if err != nil || !json.Valid(initial) {
+		t.Fatalf("initial Gentleman asset = %q, %v", initial, err)
+	}
+	result, err := InjectVisualThemes(home, adapter)
+	// Files lists managed paths, not changed paths; Cute is newly created.
+	if err != nil || !result.Changed || len(result.Files) != 2 {
+		t.Fatalf("InjectVisualThemes() = %#v, %v", result, err)
+	}
+	if got, err := os.ReadFile(paths[0]); err != nil || !bytes.Equal(got, initial) {
+		t.Fatalf("Gentleman bytes changed: %v", err)
+	}
+	after, err := os.Stat(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) || !before.ModTime().Equal(after.ModTime()) {
+		t.Fatal("Gentleman was rewritten or replaced")
+	}
+	if _, err := os.Stat(paths[1]); err != nil {
+		t.Fatalf("Gentleman Cute missing: %v", err)
+	}
+	if result, err := InjectVisualThemes(home, adapter); err != nil || result.Changed {
+		t.Fatalf("repeated visual injection = %#v, %v", result, err)
+	}
+	if result, err := Inject(home, adapter); err != nil || result.Changed {
+		t.Fatalf("repeated activation = %#v, %v", result, err)
 	}
 }
 

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -837,6 +837,27 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			}
 		}
 	case model.ComponentTheme:
+		if adapter.Agent() == model.AgentOpenCode {
+			configDir := adapter.GlobalConfigDir(homeDir)
+			tuiPath := filepath.Join(configDir, "tui.json")
+			themePath := filepath.Join(configDir, "themes", "gentleman.json")
+			targets = append(targets, tuiPath, themePath)
+			ops = append(ops,
+				rewriteJSONFileWithMutation(tuiPath, func(raw []byte) ([]byte, bool, error) {
+					root, err := unmarshalJSONObject(raw)
+					if err != nil {
+						return nil, false, err
+					}
+					if current, ok := root["theme"].(string); !ok || current != "gentleman" {
+						return raw, false, nil
+					}
+					return removeJSONPaths(raw, jsonPath{"theme"})
+				}),
+				removeFile(themePath),
+				removeDirIfEmpty(filepath.Dir(themePath)),
+			)
+		}
+		// Remove theme keys written by older generic installations.
 		for _, path := range settingsTargets(homeDir, adapter) {
 			targets = append(targets, path)
 			ops = append(ops, rewriteJSONFile(path, jsonPath{"theme"}))
@@ -1164,6 +1185,12 @@ func rewriteMarkdownFile(path string, mutate func(content string) (string, bool)
 }
 
 func rewriteJSONFile(path string, jsonPaths ...jsonPath) operation {
+	return rewriteJSONFileWithMutation(path, func(raw []byte) ([]byte, bool, error) {
+		return removeJSONPaths(raw, jsonPaths...)
+	})
+}
+
+func rewriteJSONFileWithMutation(path string, mutate func([]byte) ([]byte, bool, error)) operation {
 	return operation{
 		typeID: opRewriteFile,
 		path:   path,
@@ -1175,7 +1202,7 @@ func rewriteJSONFile(path string, jsonPaths ...jsonPath) operation {
 				}
 				return false, false, fmt.Errorf("read json file %q: %w", path, err)
 			}
-			updated, changed, err := removeJSONPaths(raw, jsonPaths...)
+			updated, changed, err := mutate(raw)
 			if err != nil {
 				return false, false, fmt.Errorf("clean json file %q: %w", path, err)
 			}

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -26,6 +26,54 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 )
 
+func TestOpenCodeThemeUninstallPreservesUserSelection(t *testing.T) {
+	for _, selection := range []string{`"gentleman"`, `"replacement"`, `"Gentleman"`, `null`, `{"custom":true}`} {
+		t.Run(selection, func(t *testing.T) {
+			home := t.TempDir()
+			svc, err := NewService(home, t.TempDir(), "dev")
+			if err != nil {
+				t.Fatal(err)
+			}
+			adapter, _ := svc.registry.Get(model.AgentOpenCode)
+			configDir := adapter.GlobalConfigDir(home)
+			themePath := filepath.Join(configDir, "themes", "gentleman.json")
+			tuiPath := filepath.Join(configDir, "tui.json")
+			if err := os.MkdirAll(filepath.Dir(themePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			before := []byte("{\n // user config\n \"keep\": true, \"theme\": " + selection + ",\n}\n")
+			for path, raw := range map[string][]byte{tuiPath: before, themePath: []byte(`{"theme":{}}`)} {
+				if err := os.WriteFile(path, raw, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := svc.PartialUninstall([]model.AgentID{model.AgentOpenCode}, []model.ComponentID{model.ComponentTheme}); err != nil {
+				t.Fatal(err)
+			}
+			raw, err := os.ReadFile(tuiPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if selection == `"gentleman"` {
+				root, err := unmarshalJSONObject(raw)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, exists := root["theme"]; exists || root["keep"] != true {
+					t.Fatalf("unexpected config: %s", raw)
+				}
+			} else if string(raw) != string(before) {
+				t.Fatalf("user config changed: %s", raw)
+			}
+			for _, path := range []string{themePath, filepath.Dir(themePath)} {
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatalf("managed path %q remains: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
 type stubSnapshotter struct{}
 
 func TestBuildPlanRemovesOnlyOwnedOpenCodeLaunchers(t *testing.T) {
@@ -569,6 +617,14 @@ func TestPartialUninstallClaudeThemeRemovesOnlyThemeAssets(t *testing.T) {
 	}
 	if err := os.WriteFile(settingsPath, []byte(settings), 0o644); err != nil {
 		t.Fatal(err)
+	}
+
+	themePath := filepath.Join(opencodeAdapter.GlobalConfigDir(homeDir), "themes", "gentleman.json")
+	if err := os.MkdirAll(filepath.Dir(themePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(theme dir) error = %v", err)
+	}
+	if err := os.WriteFile(themePath, []byte(`{"$schema":"https://opencode.ai/theme.json"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(theme) error = %v", err)
 	}
 
 	logoPath := filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx")

--- a/internal/model/presets.go
+++ b/internal/model/presets.go
@@ -1,14 +1,13 @@
 package model
 
 // VisualPolishComponents returns the complete managed visual-polish inventory.
-// Cleanup flows use this inventory, which intentionally includes the generic theme
-// even though presets do not install it.
+// Cleanup flows use the full inventory; preset installs filter theme by agent.
 func VisualPolishComponents() []ComponentID {
 	return []ComponentID{ComponentTheme, ComponentClaudeTheme, ComponentOpenCodeGentleLogo}
 }
 
-// installSafePresetVisualComponents returns only the agent-specific visual
-// components that presets can install without overwriting a generic theme.
+// installSafePresetVisualComponents returns visual components that do not depend
+// on the selected agent.
 func installSafePresetVisualComponents() []ComponentID {
 	return []ComponentID{ComponentClaudeTheme, ComponentOpenCodeGentleLogo}
 }
@@ -16,7 +15,7 @@ func installSafePresetVisualComponents() []ComponentID {
 // ComponentsForPreset returns the managed components implied by a preset/persona
 // pair. PersonaCustom opts out of managed persona only; preset choice still
 // controls visual polish.
-func ComponentsForPreset(preset PresetID, persona PersonaID) []ComponentID {
+func ComponentsForPreset(preset PresetID, persona PersonaID, agents ...AgentID) []ComponentID {
 	var components []ComponentID
 	switch preset {
 	case PresetMinimal:
@@ -33,6 +32,12 @@ func ComponentsForPreset(preset PresetID, persona PersonaID) []ComponentID {
 			ComponentContext7,
 			ComponentPermission,
 			ComponentGGA,
+		}
+		for _, agent := range agents {
+			if agent == AgentOpenCode {
+				components = append(components, ComponentTheme)
+				break
+			}
 		}
 		components = append(components, installSafePresetVisualComponents()...)
 	}

--- a/internal/model/presets_test.go
+++ b/internal/model/presets_test.go
@@ -5,25 +5,28 @@ import (
 	"testing"
 )
 
-func TestComponentsForPresetFullGentlemanUsesInstallSafeVisualInventory(t *testing.T) {
+func TestComponentsForPresetFullGentlemanThemeFollowsOpenCodeSelection(t *testing.T) {
 	tests := []struct {
-		name    string
-		persona PersonaID
+		name      string
+		persona   PersonaID
+		agents    []AgentID
+		wantTheme bool
 	}{
-		{name: "gentleman persona", persona: PersonaGentleman},
-		{name: "custom persona", persona: PersonaCustom},
+		{name: "OpenCode gentleman persona", persona: PersonaGentleman, agents: []AgentID{AgentOpenCode}, wantTheme: true},
+		{name: "OpenCode custom persona", persona: PersonaCustom, agents: []AgentID{AgentOpenCode}, wantTheme: true},
+		{name: "non-OpenCode", persona: PersonaGentleman, agents: []AgentID{AgentClaudeCode}, wantTheme: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ComponentsForPreset(PresetFullGentleman, tt.persona)
+			got := ComponentsForPreset(PresetFullGentleman, tt.persona, tt.agents...)
 
-			if slices.Contains(got, ComponentTheme) {
-				t.Fatalf("ComponentsForPreset() includes generic ComponentTheme: %v", got)
+			if themeIncluded := slices.Contains(got, ComponentTheme); themeIncluded != tt.wantTheme {
+				t.Fatalf("ComponentsForPreset() theme included = %v, want %v: %v", themeIncluded, tt.wantTheme, got)
 			}
 			for _, want := range []ComponentID{ComponentClaudeTheme, ComponentOpenCodeGentleLogo} {
 				if !slices.Contains(got, want) {
-					t.Errorf("ComponentsForPreset() missing safe visual component %q: %v", want, got)
+					t.Errorf("ComponentsForPreset() missing visual component %q: %v", want, got)
 				}
 			}
 		})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -875,7 +875,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		s = installState[0]
 	}
 	agents := preselectedAgents(detection, s)
-	components := componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	components := componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman, agents...)
 	if isPiOnlyAgents(agents) {
 		components = piOnlyComponents()
 	}
@@ -2466,7 +2466,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.Selection.Persona = options[m.Cursor]
 			// Recompute components if a non-custom preset was already chosen
 			if m.Selection.Preset != "" && m.Selection.Preset != model.PresetCustom {
-				m.Selection.Components = componentsForPreset(m.Selection.Preset, m.Selection.Persona)
+				m.Selection.Components = componentsForPreset(m.Selection.Preset, m.Selection.Persona, m.Selection.Agents...)
 			}
 			m.setScreen(ScreenPreset)
 			return m, nil
@@ -2476,7 +2476,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		options := screens.PresetOptions()
 		if m.Cursor < len(options) {
 			m.Selection.Preset = options[m.Cursor]
-			m.Selection.Components = componentsForPreset(options[m.Cursor], m.Selection.Persona)
+			m.Selection.Components = componentsForPreset(options[m.Cursor], m.Selection.Persona, m.Selection.Agents...)
 			// Enter the conditional picker chain through the single source of
 			// truth. pickerNextScreen(ScreenPreset) returns the first chain member
 			// for the current selection (Claude → Kiro → Codex → SDDMode →
@@ -2714,7 +2714,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		return m, nil
 	case ScreenDependencyTree:
 		if m.Selection.Preset == model.PresetCustom {
-			allComps := screens.AllComponents()
+			allComps := screens.AllComponents(m.Selection.Agents...)
 			switch {
 			case m.Cursor < len(allComps):
 				m.toggleCurrentComponent()
@@ -4329,7 +4329,7 @@ func (m Model) optionCount() int {
 		return len(screens.ModelPickerRowsForState(m.ModelPicker)) + 2 // rows + Continue + Back
 	case ScreenDependencyTree:
 		if m.Selection.Preset == model.PresetCustom {
-			return len(screens.AllComponents()) + len(screens.DependencyTreeOptions())
+			return len(screens.AllComponents(m.Selection.Agents...)) + len(screens.DependencyTreeOptions())
 		}
 		return len(screens.DependencyTreeOptions())
 	case ScreenSkillPicker:
@@ -4446,7 +4446,7 @@ func (m *Model) toggleCurrentAgent() {
 }
 
 func (m *Model) toggleCurrentComponent() {
-	allComps := screens.AllComponents()
+	allComps := screens.AllComponents(m.Selection.Agents...)
 	if m.Cursor >= len(allComps) {
 		return
 	}
@@ -5187,8 +5187,8 @@ func (m Model) activePicker() bool {
 	return m.Screen == ScreenModelPicker || (m.Screen == ScreenProfileCreate && m.ProfileCreateStep == 1)
 }
 
-func componentsForPreset(preset model.PresetID, persona model.PersonaID) []model.ComponentID {
-	return model.ComponentsForPreset(preset, persona)
+func componentsForPreset(preset model.PresetID, persona model.PersonaID, agents ...model.AgentID) []model.ComponentID {
+	return model.ComponentsForPreset(preset, persona, agents...)
 }
 
 func hasSelectedComponent(components []model.ComponentID, target model.ComponentID) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4602,7 +4602,7 @@ func TestCustomPresetStrictTDDAppearsAfterComponentSelection(t *testing.T) {
 	// Select SDD component (and Skills so skill picker would show, but StrictTDD must come first).
 	m.Selection.Components = []model.ComponentID{model.ComponentSDD, model.ComponentSkills}
 	// cursor == len(allComps) → "Continue"
-	allComps := screens.AllComponents()
+	allComps := screens.AllComponents(m.Selection.Agents...)
 	m.Cursor = len(allComps)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -4648,7 +4648,7 @@ func TestCustomPresetStrictTDDWithClaudeFlow(t *testing.T) {
 	m2.Selection.Preset = model.PresetCustom
 	m2.Selection.Agents = []model.AgentID{model.AgentClaudeCode}
 	m2.Selection.Components = []model.ComponentID{model.ComponentSDD}
-	allComps := screens.AllComponents()
+	allComps := screens.AllComponents(m2.Selection.Agents...)
 	m2.Cursor = len(allComps) // "Continue"
 
 	updated, _ := m2.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -5672,7 +5672,8 @@ func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
 	m.Screen = ScreenPersona
 	m.Selection.Preset = model.PresetFullGentleman
 	m.Selection.Persona = model.PersonaGentleman
-	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	m.Selection.Agents = []model.AgentID{model.AgentClaudeCode}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman, m.Selection.Agents...)
 
 	// Confirm that managed persona and visual polish are initially included.
 	hasPersonaBefore := false
@@ -8387,7 +8388,7 @@ func TestPickerBackRowRegression(t *testing.T) {
 				m.Selection.Preset = model.PresetCustom
 				m.Selection.Agents = []model.AgentID{model.AgentKiroIDE}
 				m.Selection.Components = sddComponents
-				m.Cursor = len(screens.AllComponents()) // "Continue" row
+				m.Cursor = len(screens.AllComponents(m.Selection.Agents...)) // "Continue" row
 				return m
 			},
 			wantScreen: ScreenKiroModelPicker,
@@ -8401,7 +8402,7 @@ func TestPickerBackRowRegression(t *testing.T) {
 				m.Selection.Preset = model.PresetCustom
 				m.Selection.Agents = []model.AgentID{model.AgentCodex}
 				m.Selection.Components = sddComponents
-				m.Cursor = len(screens.AllComponents()) // "Continue" row
+				m.Cursor = len(screens.AllComponents(m.Selection.Agents...)) // "Continue" row
 				return m
 			},
 			wantScreen: ScreenCodexModelPicker,

--- a/internal/tui/preset_flow_test.go
+++ b/internal/tui/preset_flow_test.go
@@ -182,7 +182,7 @@ func TestCustomPresetPostComponentFlowMatrix(t *testing.T) {
 			m.Selection.Preset = model.PresetCustom
 			m.Selection.Agents = tt.agents
 			m.Selection.Components = tt.components
-			m.Cursor = len(screens.AllComponents())
+			m.Cursor = len(screens.AllComponents(m.Selection.Agents...))
 
 			state := m
 			for _, action := range tt.actions {
@@ -322,7 +322,7 @@ func TestInstallNavigationRoundTrips(t *testing.T) {
 				m.Selection.Preset = model.PresetCustom
 				m.Selection.Agents = []model.AgentID{model.AgentCursor}
 				m.Selection.Components = []model.ComponentID{model.ComponentSDD, model.ComponentSkills}
-				m.Cursor = len(screens.AllComponents())
+				m.Cursor = len(screens.AllComponents(m.Selection.Agents...))
 				return m
 			},
 			forwardActions: []flowAction{
@@ -340,7 +340,7 @@ func TestInstallNavigationRoundTrips(t *testing.T) {
 				m.Selection.Preset = model.PresetCustom
 				m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
 				m.Selection.Components = []model.ComponentID{model.ComponentSDD, model.ComponentSkills}
-				m.Cursor = len(screens.AllComponents())
+				m.Cursor = len(screens.AllComponents(m.Selection.Agents...))
 				return m
 			},
 			forwardActions: []flowAction{
@@ -360,7 +360,7 @@ func TestInstallNavigationRoundTrips(t *testing.T) {
 				m.Selection.Preset = model.PresetCustom
 				m.Selection.Agents = []model.AgentID{model.AgentCursor}
 				m.Selection.Components = []model.ComponentID{model.ComponentEngram}
-				m.Cursor = len(screens.AllComponents())
+				m.Cursor = len(screens.AllComponents(m.Selection.Agents...))
 				return installReviewModeStatusFixture(m)
 			},
 			forwardActions: []flowAction{

--- a/internal/tui/screens/dependency_tree.go
+++ b/internal/tui/screens/dependency_tree.go
@@ -14,9 +14,26 @@ func DependencyTreeOptions() []string {
 	return []string{"Continue", "Back"}
 }
 
-// AllComponents returns the full list of available components for the custom picker.
-func AllComponents() []catalog.Component {
-	return catalog.MVPComponents()
+// AllComponents returns components available to the selected agents. With no
+// agent filter it returns the complete catalog for callers that need inventory.
+func AllComponents(agents ...model.AgentID) []catalog.Component {
+	components := catalog.MVPComponents()
+	for _, agent := range agents {
+		if agent == model.AgentOpenCode {
+			return components
+		}
+	}
+	if len(agents) == 0 {
+		return components
+	}
+
+	available := make([]catalog.Component, 0, len(components)-1)
+	for _, component := range components {
+		if component.ID != model.ComponentTheme {
+			available = append(available, component)
+		}
+	}
+	return available
 }
 
 // RenderDependencyTree shows the install plan. For custom presets, it shows
@@ -128,7 +145,7 @@ func renderCustomPicker(selection model.Selection, cursor int) string {
 	b.WriteString(styles.SubtextStyle.Render("Toggle components with enter or space."))
 	b.WriteString("\n\n")
 
-	allComps := AllComponents()
+	allComps := AllComponents(selection.Agents...)
 	selectedSet := make(map[model.ComponentID]struct{}, len(selection.Components))
 	for _, c := range selection.Components {
 		selectedSet[c] = struct{}{}

--- a/internal/tui/testdata/preset-custom-no-opencode-next.golden
+++ b/internal/tui/testdata/preset-custom-no-opencode-next.golden
@@ -16,8 +16,6 @@ Toggle components with enter or space.
     Security-first defaults and guardrails
   [ ] gga
     Gentleman Guardian Angel — AI provider switcher
-  [ ] theme
-    Visual polish: OpenCode color theme
   [ ] claude-theme
     Visual polish: Gentleman and Gentleman Cute theme assets
   [ ] opencode-gentle-logo

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -256,6 +256,7 @@ func managedAgentBackupPaths(homeDir string, adapter agents.Adapter, diagnostics
 		add(
 			filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx"),
 			filepath.Join(homeDir, ".config", "opencode", "tui.json"),
+			filepath.Join(homeDir, ".config", "opencode", "themes", "gentleman.json"),
 		)
 		for _, phase := range sdd.SharedPromptPhases() {
 			add(filepath.Join(sdd.SharedPromptDir(homeDir), phase+".md"))

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -732,6 +732,7 @@ func TestConfigPathsForBackup_CoversManagedAgentPaths(t *testing.T) {
 		".config/opencode/opencode.json":              `{"model":"claude"}`,
 		".gemini/GEMINI.md":                           "# Gemini",
 		".cursor/rules/gentle-ai.mdc":                 "# Cursor rules",
+		".config/opencode/tui.json":                   `{"theme":"gentleman"}`,
 	}
 	unmanagedFile := filepath.Join(homeDir, ".claude", "conversation-transcript.md")
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2367

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Installs the existing managed Gentleman color theme for OpenCode and activates it through `tui.json` instead of the deprecated `opencode.json` key.
- Makes Full Gentleman and Custom component selection expose the theme only when OpenCode is selected.
- Extends backup, verification, and uninstall coverage to the managed theme asset and TUI configuration.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/theme` | Reuses the managed OpenCode Gentleman palette, installs `themes/gentleman.json`, and merges `theme: gentleman` into `tui.json` while preserving unrelated JSON/JSONC fields. |
| `internal/model`, `internal/tui`, `internal/cli` | Applies OpenCode-aware preset and Custom picker filtering and reports the correct managed paths. |
| `internal/components/uninstall`, `internal/update/upgrade` | Removes and backs up the new managed paths while retaining legacy theme-key cleanup. |
| Focused tests and golden | Covers installation, idempotence, config preservation, applicability, uninstall, and backup behavior. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi / OpenAI Codex GPT-5.6

**Material scope:** Repository investigation, implementation, test updates, theme-schema adaptation, and validation support.

**Verification performed:** The contributor reviewed the scope and provenance, accepted responsibility for the submission, and required focused package tests, Go formatting, LSP diagnostics, and diff-integrity checks before publication.

---

## 🧪 Test Plan

**Focused unit tests**
```bash
go test ./internal/components/theme ./internal/model ./internal/catalog ./internal/tui ./internal/components/uninstall ./internal/update/upgrade -count=1
go test ./internal/cli -run '^(TestNormalizeInstallFlags|TestComponentPathsTheme)' -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Additional checks**
```bash
git diff --check
```

The broader affected-package run passed every listed package except the complete `internal/cli` suite, which reached its existing 10-minute timeout in unrelated review-lifecycle tests. The focused CLI tests covering this change pass. E2E was not run locally. Benchmark validation is not applicable because this change does not affect review lifecycle, gates, recovery, delivery, or benchmark code.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 398 changed lines, within the 400-line review budget |
| Check Issue Reference | ⏳ | PR body contains `Closes #2367` |
| Check Issue Has `status:approved` | ⚠️ | #2367 currently remains `status:needs-review`; this check is expected to remain red until maintainer approval |
| Check PR Has `type:*` Label | ⚠️ | Maintainer action required: the contributor account cannot apply `type:bug` |
| Unit Tests | ⏳ | CI will run the full suite |
| Go Format | ✅ | Passed locally |
| E2E Tests | ⏳ | CI will run required E2E checks |

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — #2367 is linked but not yet approved
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — maintainer action required
- [ ] Unit tests pass (`go test ./...`) — focused affected tests pass; full CI pending
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary — no documentation change is required for the corrected installer behavior
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The implementation reuses the repository's existing generated Gentleman palette for OpenCode, so the activation and visual-theme installation paths write byte-identical `themes/gentleman.json` content using the official `https://opencode.ai/theme.json` schema.

No qualifying security, integrity, admission, repair, governance, or `guard:population` contract changed. The `internal/cli` changes only propagate selected-agent applicability and managed path bookkeeping.

Receipt-driven development was globally disabled in the contributor environment, so delivery is `disabled/unmanaged`; no review receipt is claimed.

Maintainer actions requested:
1. Review and, if accepted, add `status:approved` to #2367.
2. Apply exactly one PR type label: `type:bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenCode installations now configure the TUI and install the Gentleman theme in the appropriate locations.
  - Component selection adapts to the selected agents, showing theme options only when applicable.
- **Bug Fixes**
  - OpenCode theme updates preserve existing settings and user-selected themes.
  - Repeated installations avoid duplicate or conflicting configuration changes.
  - Uninstalling the managed OpenCode theme removes only related assets while preserving unrelated settings.
- **Maintenance**
  - OpenCode theme files are now included in upgrade and installation backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
