### PR TITLE
fix(review): resolve provider-aware marker for review lens-context

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -404,7 +404,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	}
 	var rawPayload []byte
 	if providerExecution {
-		request, materializeErr := reviewProviderMaterialize(ctx, reviewLensContextDependencies(), contextHandle, *lens)
+		request, materializeErr := reviewProviderMaterialize(ctx, reviewLensContextDependencies(), contextHandle, *lens, providerRuntime)
 		if materializeErr != nil {
 			return reviewPreflightError(materializeErr)
 		}

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -44,13 +44,11 @@ const reviewLensContextByteBudget = reviewtransaction.MaxFrozenCandidateDiffByte
 
 const (
 	reviewLensContextBindingHeader = "GENTLE_AI_REVIEW_BINDING"
-	reviewLensContextContextHeader = "GENTLE_AI_REVIEW_CONTEXT"
 	reviewLensContextNameStatus    = "GENTLE_AI_REVIEW_NAME_STATUS"
 	reviewLensContextNumstat       = "GENTLE_AI_REVIEW_NUMSTAT"
 	reviewLensContextInstruction   = "GENTLE_AI_REVIEW_INSTRUCTION"
 	reviewLensContextResultSchema  = "GENTLE_AI_REVIEW_RESULT_SCHEMA"
 	reviewLensContextPatch         = "GENTLE_AI_REVIEW_PATCH"
-	reviewLensContextTerminator    = "GENTLE_AI_REVIEW_CONTEXT_END"
 )
 
 // reviewLensContextBinding is the machine data a relaying orchestrator used to
@@ -100,6 +98,9 @@ const (
 	reviewLensContextConflictAction = "this frozen lens slot already recorded a reviewer context produced by a different mechanism, and audit history is never rewritten; " +
 		"produce this lens context by the same mechanism that already recorded one, or start a review for a fresh candidate by running " +
 		reviewNextTransitionRefreshCommandV21
+	reviewLensContextAgentAction = "this runtime has no provider-injected reviewer context marker in this release, " +
+		"so no block can be framed for it; re-run with --agent set to a runtime this release generates a reviewer for, " +
+		"or omit --agent to emit the generic marker every relay-agnostic reviewer expects"
 )
 
 // reviewLensContextConflictActionFor names the mechanism the slot really
@@ -187,11 +188,12 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	ctx, cancel := context.WithTimeout(context.Background(), deps.timeout)
 	defer cancel()
 	flags := newReviewFlagSet("review lens-context", help,
-		"Emit the finished reviewer lens context for one selected lens.\n\nForm: --repository-context <handle> --lens <lens> [--delivery provider_command|runtime_interception]\n\nBoth tokens are carried verbatim by the collect transition; nothing else is accepted, and nothing is left for the caller to assemble.")
+		"Emit the finished reviewer lens context for one selected lens.\n\nForm: --repository-context <handle> --lens <lens> [--delivery provider_command|runtime_interception] [--agent <id>]\n\nBoth --repository-context and --lens are carried verbatim by the collect transition; nothing else is accepted, and nothing is left for the caller to assemble.")
 	repositoryContext := flags.String("repository-context", "", "opaque provider-issued repository context")
 	lens := flags.String("lens", "", "exact selected lens")
 	delivery := flags.String("delivery", string(reviewtransaction.ReviewerContextLevelProviderCommand),
 		"how this context reaches the reviewer: provider_command when a caller relays it, runtime_interception when a runtime adapter injects it")
+	agent := flags.String("agent", "", "optional runtime identity whose generated reviewer consumes this block; omitted emits the generic marker")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return nil, err
 	}
@@ -208,6 +210,10 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	if !reviewtransaction.ReviewerContextLevelAccepted(level) {
 		return nil, reviewPreflightError(fmt.Errorf("unknown reviewer context delivery %q; run `gentle-ai review lens-context --help` for the closed command form", *delivery))
 	}
+	marker, ok := reviewtransaction.ReviewerContextMarkerFor(strings.TrimSpace(*agent))
+	if !ok {
+		return nil, reviewLensContextRefusal("lens_context_agent_unknown", reviewLensContextAgentAction)
+	}
 
 	authority, err := resolveReviewLensAuthority(ctx, deps, strings.TrimSpace(*repositoryContext), strings.TrimSpace(*lens))
 	if err != nil {
@@ -216,7 +222,7 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	defer func() {
 		payload, err = reviewLensContextCleanup(ctx, payload, err, func() error { return deps.close(authority.Inspector) })
 	}()
-	block, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen)
+	block, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen, marker)
 	if err != nil {
 		return nil, err
 	}
@@ -285,6 +291,11 @@ func reviewLensContextBudgetProbe(
 	if err != nil {
 		return reviewLensContextUnproven, err
 	}
+	// The probe always measures with the generic marker: START has no agent
+	// identity (it is deliberately not persisted), and probing with the
+	// widest registered marker would refuse candidates that review fine
+	// generically.
+	genericMarker, _ := reviewtransaction.ReviewerContextMarkerFor("")
 	for order, lens := range state.SelectedLenses {
 		subject, subjectErr := reviewtransaction.NewArtifactSubject(state, revision, frozen, lens, order, "")
 		if subjectErr != nil {
@@ -293,7 +304,7 @@ func reviewLensContextBudgetProbe(
 		_, assemblyErr := reviewLensContextBlock(assemblyContext, deps, inspector, reviewLensContextBinding{
 			Lineage: state.LineageID, Target: state.InitialSnapshot.Identity, Lens: lens, Order: order,
 			Revision: revision, RepositoryContext: repositoryContext, SubjectHash: subject.SubjectHash,
-		}, subject, frozen)
+		}, subject, frozen, genericMarker)
 		var refusal *reviewLensContextError
 		if errors.As(assemblyErr, &refusal) && refusal.Code == "lens_context_budget_exceeded" {
 			return reviewLensContextOverBudget, nil
@@ -463,6 +474,7 @@ func reviewLensContextSelectedOrder(selected []string, lens string) (int, error)
 func reviewLensContextBlock(
 	ctx context.Context, deps reviewLensContextDeps, inspector reviewLensCandidateInspector,
 	binding reviewLensContextBinding, subject reviewtransaction.ArtifactSubject, frozen reviewtransaction.FrozenCandidateContext,
+	marker reviewtransaction.ReviewerContextMarker,
 ) ([]byte, error) {
 	// RepositoryRoot stays empty: this block is produced only for an opaque
 	// binding, and a reviewer transcript never carries a provider path.
@@ -476,7 +488,7 @@ func reviewLensContextBlock(
 	if err := reviewLensContextWriteLine(&block, reviewLensContextBindingHeader, binding); err != nil {
 		return nil, err
 	}
-	if err := reviewLensContextWriteLine(&block, reviewLensContextContextHeader, preflight); err != nil {
+	if err := reviewLensContextWriteLine(&block, marker.Header, preflight); err != nil {
 		return nil, err
 	}
 
@@ -493,7 +505,7 @@ func reviewLensContextBlock(
 		block.WriteString(rendered)
 		return nil
 	}
-	instruction, err := reviewLensContextInstructionText(binding, len(frozen.ChangedPathManifest))
+	instruction, err := reviewLensContextInstructionText(binding, len(frozen.ChangedPathManifest), marker)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +545,7 @@ func reviewLensContextBlock(
 			return nil, err
 		}
 	}
-	block.WriteString(reviewLensContextTerminator + "\n")
+	block.WriteString(marker.Terminator + "\n")
 	return block.Bytes(), nil
 }
 
@@ -546,7 +558,7 @@ func reviewLensContextBlock(
 // The lens mandate is read from the one canonical source every installed agent
 // definition also renders from, so a reviewer's charge never depends on which
 // surface launched it.
-func reviewLensContextInstructionText(binding reviewLensContextBinding, paths int) (string, error) {
+func reviewLensContextInstructionText(binding reviewLensContextBinding, paths int, marker reviewtransaction.ReviewerContextMarker) (string, error) {
 	title, focus, found := reviewtransaction.LensMandate(binding.Lens)
 	if !found {
 		return "", reviewLensContextRefusal("lens_context_lens_not_selected", reviewLensContextRefreshAction)
@@ -562,7 +574,7 @@ Return. Emit exactly one JSON object and nothing else: no prose before or after 
 Citations. Every finding location, and every path cited inside an evidence string or a proof_refs entry, must be a repository-relative path exactly as it appears in the changed-path manifest, optionally with :line or :start-end. Never cite absolute paths, bare file basenames without their directory, or non-path colon-number shapes such as host:port. Any token shaped like path:line is validated against the frozen repository, and one unknown path rejects the entire result. A finding whose causal_disposition is introduced, behavior-activated, or worsened must anchor its location entirely within lines this candidate changed: every line of a path:start-end span is validated as candidate-changed, one unchanged context line in the span rejects the entire result, and observations about unchanged code belong under pre-existing or base-only instead. When the candidate's own content contains a path-shaped literal that is not a real repository path (for example a traversal or fixture token inside a test), never reproduce that token in evidence or proof_refs: describe it in words and cite the manifest file and line that contain it.
 
 Honesty. If you could not inspect the candidate, say so in evidence and do not return a clean result: an access failure is not a completed inspection, and reporting one as clean is the single outcome this review cannot recover from.`,
-		title, focus, reviewLensContextPatch, paths, reviewLensContextContextHeader,
+		title, focus, reviewLensContextPatch, paths, marker.Header,
 		reviewLensContextResultSchema, binding.SubjectHash), nil
 }
 

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -495,7 +495,7 @@ func reviewLensContextBlock(
 	// The budget bounds the whole delivered block, not only the evidence: at
 	// this level the block IS the reviewer's prompt, so the instruction and the
 	// result schema are part of what has to fit.
-	budget := reviewLensContextByteBudget - block.Len()
+	budget := reviewLensContextByteBudget - block.Len() - len(marker.Terminator) - 1
 	consume := func(header, footer string, body []byte) error {
 		rendered := header + "\n" + string(bytes.TrimSpace(body)) + "\n" + footer + "\n"
 		budget -= len(rendered)

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -210,7 +210,7 @@ func runReviewLensContext(args []string, help io.Writer, deps reviewLensContextD
 	if !reviewtransaction.ReviewerContextLevelAccepted(level) {
 		return nil, reviewPreflightError(fmt.Errorf("unknown reviewer context delivery %q; run `gentle-ai review lens-context --help` for the closed command form", *delivery))
 	}
-	marker, ok := reviewtransaction.ReviewerContextMarkerFor(strings.TrimSpace(*agent))
+	marker, ok := reviewtransaction.ReviewerContextMarkerFor(*agent)
 	if !ok {
 		return nil, reviewLensContextRefusal("lens_context_agent_unknown", reviewLensContextAgentAction)
 	}

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -201,7 +201,7 @@ func TestReviewLensContextAgentOpenCodeIsByteIdenticalToOmittedFlag(t *testing.T
 // a wholly unrecognized string -- fails loudly before any authority mutation,
 // and that a subsequent default-agent run still succeeds afterward.
 func TestReviewLensContextAgentUnknownRefusesWithNoSideEffects(t *testing.T) {
-	for _, agent := range []string{"totally-unknown", "codex"} {
+	for _, agent := range []string{"totally-unknown", "codex", " claude-code "} {
 		t.Run(agent, func(t *testing.T) {
 			_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
 			handle := args[slices.Index(args, "--repository-context")+1]
@@ -550,7 +550,7 @@ func TestReviewLensContextCallersFailClosedOnInspectorCleanupFailure(t *testing.
 			return err, payload == nil
 		}},
 		{"provider materialization", func(deps reviewLensContextDeps, handle, lens string) (error, bool) {
-			request, err := reviewProviderMaterialize(context.Background(), deps, handle, lens)
+			request, err := reviewProviderMaterialize(context.Background(), deps, handle, lens, "")
 			return err, request.Store.Dir == "" && request.Binding == (reviewLensContextBinding{}) && request.Subject == (reviewtransaction.ArtifactSubject{}) && len(request.Invocation.Prompt()) == 0
 		}},
 	} {

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -30,6 +30,18 @@ func lensContextBlock(t *testing.T, handle, lens string) string {
 	return output.String()
 }
 
+// lensContextBlockWithAgent runs `review lens-context --agent <agent>` for one
+// lens and returns the finished reviewer block exactly as a runtime would
+// inject it.
+func lensContextBlockWithAgent(t *testing.T, handle, lens, agent string) string {
+	t.Helper()
+	var output bytes.Buffer
+	if err := RunReview([]string{"lens-context", "--repository-context", handle, "--lens", lens, "--agent", agent}, &output); err != nil {
+		t.Fatalf("lens-context %s --agent %s: %v", lens, agent, err)
+	}
+	return output.String()
+}
+
 // TestReviewLensContextEmitsFinishedReviewerBlockFromTwoTokens is the whole
 // point of the surface: the caller supplies only the two opaque tokens the
 // collect transition already carries, and receives the complete reviewer
@@ -132,6 +144,109 @@ func TestReviewLensContextEmitsFinishedReviewerBlockFromTwoTokens(t *testing.T) 
 	}
 	if !strings.HasSuffix(block, "GENTLE_AI_REVIEW_CONTEXT_END\n") {
 		t.Fatalf("block is not terminated:\n%s", block)
+	}
+}
+
+// TestReviewLensContextAgentClaudeCodeFramesTheClaudeMarker proves that a
+// caller declaring --agent claude-code receives the marker Claude's installed
+// reviewer requires instead of the generic envelope, and that the bare generic
+// header never appears anywhere in the block.
+func TestReviewLensContextAgentClaudeCodeFramesTheClaudeMarker(t *testing.T) {
+	_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	handle := args[slices.Index(args, "--repository-context")+1]
+	lens := args[slices.Index(args, "--lens")+1]
+
+	block := lensContextBlockWithAgent(t, handle, lens, "claude-code")
+
+	if !strings.HasPrefix(block, "GENTLE_AI_REVIEW_BINDING ") {
+		t.Fatalf("first line is not the binding:\n%s", block)
+	}
+	if !strings.Contains(block, "\nGENTLE_AI_CLAUDE_REVIEW_CONTEXT ") {
+		t.Fatalf("block does not frame the Claude marker header:\n%s", block)
+	}
+	if !strings.HasSuffix(block, "GENTLE_AI_CLAUDE_REVIEW_CONTEXT_END\n") {
+		t.Fatalf("block is not terminated with the Claude marker:\n%s", block)
+	}
+	instruction, found := lensContextSection(block, "GENTLE_AI_REVIEW_INSTRUCTION")
+	if !found {
+		t.Fatalf("block carries no reviewer instruction:\n%s", block)
+	}
+	if !strings.Contains(instruction, "GENTLE_AI_CLAUDE_REVIEW_CONTEXT") {
+		t.Fatalf("instruction does not name the Claude marker:\n%s", instruction)
+	}
+	if strings.Contains(block, "\nGENTLE_AI_REVIEW_CONTEXT ") || strings.HasSuffix(block, "GENTLE_AI_REVIEW_CONTEXT_END\n") {
+		t.Fatalf("block still carries a bare generic envelope line alongside the Claude marker:\n%s", block)
+	}
+}
+
+// TestReviewLensContextAgentOpenCodeIsByteIdenticalToOmittedFlag proves
+// OpenCode's marker stays unchanged: declaring --agent opencode must produce
+// exactly the bytes omitting --agent already produces.
+func TestReviewLensContextAgentOpenCodeIsByteIdenticalToOmittedFlag(t *testing.T) {
+	_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	handle := args[slices.Index(args, "--repository-context")+1]
+	lens := args[slices.Index(args, "--lens")+1]
+
+	withAgent := lensContextBlockWithAgent(t, handle, lens, "opencode")
+	// Re-emitting a second time (with the flag omitted) must converge on the
+	// exact same conflict-free mechanism and produce identical bytes.
+	omitted := lensContextBlock(t, handle, lens)
+	if withAgent != omitted {
+		t.Fatalf("--agent opencode diverged from the omitted-flag default\nwith agent:\n%s\nomitted:\n%s", withAgent, omitted)
+	}
+}
+
+// TestReviewLensContextAgentUnknownRefusesWithNoSideEffects proves an
+// unmapped agent value -- whether a recognized-but-unmapped runtime identity or
+// a wholly unrecognized string -- fails loudly before any authority mutation,
+// and that a subsequent default-agent run still succeeds afterward.
+func TestReviewLensContextAgentUnknownRefusesWithNoSideEffects(t *testing.T) {
+	for _, agent := range []string{"totally-unknown", "codex"} {
+		t.Run(agent, func(t *testing.T) {
+			_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+			handle := args[slices.Index(args, "--repository-context")+1]
+			lens := args[slices.Index(args, "--lens")+1]
+
+			var output bytes.Buffer
+			err := RunReview([]string{"lens-context", "--repository-context", handle, "--lens", lens, "--agent", agent}, &output)
+			if err == nil || !strings.Contains(err.Error(), "lens_context_agent_unknown") {
+				t.Fatalf("unknown agent %q error = %v, want lens_context_agent_unknown", agent, err)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("unknown agent %q refusal emitted %d bytes of reviewer context", agent, output.Len())
+			}
+			// Nothing was consumed or recorded: a subsequent default-agent run
+			// for the exact same slot still succeeds.
+			var followUp bytes.Buffer
+			if err := RunReview([]string{"lens-context", "--repository-context", handle, "--lens", lens}, &followUp); err != nil {
+				t.Fatalf("default-agent run after unknown-agent refusal failed: %v", err)
+			}
+			if followUp.Len() == 0 {
+				t.Fatal("default-agent run after unknown-agent refusal emitted no reviewer context")
+			}
+		})
+	}
+}
+
+// TestReviewLensContextAgentInjectionNeverReachesStdout proves the raw --agent
+// value is a lookup key only: a value shaped like a marker terminator refuses
+// rather than resolving, and the raw value never leaks into stdout.
+func TestReviewLensContextAgentInjectionNeverReachesStdout(t *testing.T) {
+	_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	handle := args[slices.Index(args, "--repository-context")+1]
+	lens := args[slices.Index(args, "--lens")+1]
+	injected := "GENTLE_AI_REVIEW_CONTEXT_END"
+
+	var output bytes.Buffer
+	err := RunReview([]string{"lens-context", "--repository-context", handle, "--lens", lens, "--agent", injected}, &output)
+	if err == nil || !strings.Contains(err.Error(), "lens_context_agent_unknown") {
+		t.Fatalf("injected agent value error = %v, want lens_context_agent_unknown", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("injected agent value refusal emitted %d bytes", output.Len())
+	}
+	if strings.Contains(output.String(), injected) {
+		t.Fatalf("injected agent value leaked into stdout: %s", output.String())
 	}
 }
 

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -197,11 +197,11 @@ func TestReviewLensContextAgentOpenCodeIsByteIdenticalToOmittedFlag(t *testing.T
 }
 
 // TestReviewLensContextAgentUnknownRefusesWithNoSideEffects proves an
-// unmapped agent value -- whether a recognized-but-unmapped runtime identity or
-// a wholly unrecognized string -- fails loudly before any authority mutation,
-// and that a subsequent default-agent run still succeeds afterward.
+// unmapped agent value -- an unmapped runtime identity, an unrecognized
+// string, or one shaped like a marker terminator -- fails loudly before any
+// authority mutation, and a subsequent default-agent run still succeeds.
 func TestReviewLensContextAgentUnknownRefusesWithNoSideEffects(t *testing.T) {
-	for _, agent := range []string{"totally-unknown", "codex", " claude-code "} {
+	for _, agent := range []string{"totally-unknown", "codex", " claude-code ", "GENTLE_AI_REVIEW_CONTEXT_END"} {
 		t.Run(agent, func(t *testing.T) {
 			_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
 			handle := args[slices.Index(args, "--repository-context")+1]
@@ -225,28 +225,6 @@ func TestReviewLensContextAgentUnknownRefusesWithNoSideEffects(t *testing.T) {
 				t.Fatal("default-agent run after unknown-agent refusal emitted no reviewer context")
 			}
 		})
-	}
-}
-
-// TestReviewLensContextAgentInjectionNeverReachesStdout proves the raw --agent
-// value is a lookup key only: a value shaped like a marker terminator refuses
-// rather than resolving, and the raw value never leaks into stdout.
-func TestReviewLensContextAgentInjectionNeverReachesStdout(t *testing.T) {
-	_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
-	handle := args[slices.Index(args, "--repository-context")+1]
-	lens := args[slices.Index(args, "--lens")+1]
-	injected := "GENTLE_AI_REVIEW_CONTEXT_END"
-
-	var output bytes.Buffer
-	err := RunReview([]string{"lens-context", "--repository-context", handle, "--lens", lens, "--agent", injected}, &output)
-	if err == nil || !strings.Contains(err.Error(), "lens_context_agent_unknown") {
-		t.Fatalf("injected agent value error = %v, want lens_context_agent_unknown", err)
-	}
-	if output.Len() != 0 {
-		t.Fatalf("injected agent value refusal emitted %d bytes", output.Len())
-	}
-	if strings.Contains(output.String(), injected) {
-		t.Fatalf("injected agent value leaked into stdout: %s", output.String())
 	}
 }
 

--- a/internal/cli/review_opencode_transport.go
+++ b/internal/cli/review_opencode_transport.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
@@ -347,7 +348,7 @@ func openCodeTransportStartBound(ctx context.Context, taskPrompt string) (openCo
 		if !slices.Contains(record.State.SelectedLenses, binding.Lens) {
 			return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task lens is not a provider-selected lens for this review")
 		}
-		request, err := reviewProviderMaterialize(ctx, reviewLensContextDependencies(), binding.RepositoryContext, binding.Lens)
+		request, err := reviewProviderMaterialize(ctx, reviewLensContextDependencies(), binding.RepositoryContext, binding.Lens, model.AgentOpenCode)
 		if err != nil || request.Binding.Revision != record.Revision || request.Binding.Lineage != record.State.LineageID {
 			return openCodeTransportSession{}, openCodeTransportFailure("opencode_review_transport_materialization_unavailable")
 		}

--- a/internal/cli/review_provider.go
+++ b/internal/cli/review_provider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
@@ -60,18 +61,29 @@ type reviewProviderAdmittedResult struct {
 	Admission                 reviewtransaction.ArtifactAdmission
 }
 
+// reviewProviderContextMarkerFor resolves the marker for the exact runtime
+// agent invoking Go-owned provider materialization, falling back to the
+// generic marker for any agent identity with no explicit table entry. This
+// keeps every runtime the shared table has never mapped (for example Codex)
+// on today's byte-identical generic-marker behavior; only an agent with its
+// own table entry (currently Claude Code) changes what it receives.
+func reviewProviderContextMarkerFor(agent model.AgentID) reviewtransaction.ReviewerContextMarker {
+	if marker, ok := reviewtransaction.ReviewerContextMarkerFor(string(agent)); ok {
+		return marker
+	}
+	generic, _ := reviewtransaction.ReviewerContextMarkerFor("")
+	return generic
+}
+
 // reviewProviderMaterialize deliberately delegates to the current lens-context
 // assembly. It does not emit a delivery descriptor or mutate review authority.
-func reviewProviderMaterialize(ctx context.Context, deps reviewLensContextDeps, repositoryContext, lens string) (request reviewProviderRequest, err error) {
+func reviewProviderMaterialize(ctx context.Context, deps reviewLensContextDeps, repositoryContext, lens string, agent model.AgentID) (request reviewProviderRequest, err error) {
 	authority, err := resolveReviewLensAuthority(ctx, deps, repositoryContext, lens)
 	if err != nil {
 		return reviewProviderRequest{}, err
 	}
-	// The Go-owned provider transport is not a caller-declared --agent: it
-	// always frames the generic marker, byte-identical to today, exactly as
-	// every live provider transport already expects.
-	genericMarker, _ := reviewtransaction.ReviewerContextMarkerFor("")
-	prompt, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen, genericMarker)
+	marker := reviewProviderContextMarkerFor(agent)
+	prompt, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen, marker)
 	if err != nil {
 		return reviewLensContextCleanup(ctx, reviewProviderRequest{}, err, func() error { return deps.close(authority.Inspector) })
 	}

--- a/internal/cli/review_provider.go
+++ b/internal/cli/review_provider.go
@@ -67,7 +67,11 @@ func reviewProviderMaterialize(ctx context.Context, deps reviewLensContextDeps, 
 	if err != nil {
 		return reviewProviderRequest{}, err
 	}
-	prompt, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen)
+	// The Go-owned provider transport is not a caller-declared --agent: it
+	// always frames the generic marker, byte-identical to today, exactly as
+	// every live provider transport already expects.
+	genericMarker, _ := reviewtransaction.ReviewerContextMarkerFor("")
+	prompt, err := reviewLensContextBlock(ctx, deps, authority.Inspector, authority.Binding, authority.Subject, authority.Frozen, genericMarker)
 	if err != nil {
 		return reviewLensContextCleanup(ctx, reviewProviderRequest{}, err, func() error { return deps.close(authority.Inspector) })
 	}

--- a/internal/cli/review_provider_test.go
+++ b/internal/cli/review_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestReviewProviderMaterializationMatchesNativeLensContext(t *testing.T) {
 	handle := args[slices.Index(args, "--repository-context")+1]
 	lens := args[slices.Index(args, "--lens")+1]
 
-	request, err := reviewProviderMaterialize(context.Background(), reviewLensContextDependencies(), handle, lens)
+	request, err := reviewProviderMaterialize(context.Background(), reviewLensContextDependencies(), handle, lens, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,6 +54,114 @@ func TestReviewProviderMaterializationMatchesNativeLensContext(t *testing.T) {
 	}
 	if got := request.Invocation.Prompt(); !bytes.Equal(got, native.Bytes()) {
 		t.Fatalf("provider materialization diverged from native lens context\nprovider:\n%s\nnative:\n%s", got, native.Bytes())
+	}
+}
+
+// TestReviewProviderMaterializeResolvesAgentAwareContextMarker proves the
+// compiled-adapter reviewer path (Claude Code's subprocess adapter, routed
+// through reviewProviderMaterialize) frames the marker for the exact runtime
+// agent invoking it, instead of always pinning the generic marker regardless
+// of which agent is running (issue #2777 reproduced through this path).
+// Codex and OpenCode have no explicit reviewerContextMarkers table entry, so
+// they must keep receiving the byte-identical generic marker unchanged.
+func TestReviewProviderMaterializeResolvesAgentAwareContextMarker(t *testing.T) {
+	_, args, _, _ := newCandidateInspectionReview(t, "candidate\n", true)
+	handle := args[slices.Index(args, "--repository-context")+1]
+	lens := args[slices.Index(args, "--lens")+1]
+
+	claudeRequest, err := reviewProviderMaterialize(context.Background(), reviewLensContextDependencies(), handle, lens, model.AgentClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(claudeRequest.Invocation.Prompt(), []byte("GENTLE_AI_CLAUDE_REVIEW_CONTEXT")) {
+		t.Fatalf("claude-code provider materialization did not carry the claude-code marker:\n%s", claudeRequest.Invocation.Prompt())
+	}
+
+	for _, agent := range []model.AgentID{model.AgentCodex, model.AgentOpenCode, ""} {
+		request, err := reviewProviderMaterialize(context.Background(), reviewLensContextDependencies(), handle, lens, agent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(request.Invocation.Prompt(), []byte("GENTLE_AI_CLAUDE_REVIEW_CONTEXT")) {
+			t.Fatalf("agent %q provider materialization unexpectedly carried the claude-code marker:\n%s", agent, request.Invocation.Prompt())
+		}
+		if !bytes.Contains(request.Invocation.Prompt(), []byte("GENTLE_AI_REVIEW_CONTEXT")) {
+			t.Fatalf("agent %q provider materialization did not carry the generic marker:\n%s", agent, request.Invocation.Prompt())
+		}
+	}
+}
+
+// TestReviewProviderNegotiatedCaptureResultCarriesClaudeMarker is the
+// end-to-end proof PR #3398's review requested: it drives the real negotiated
+// v2 STATUS transition with --agent claude-code, runs the exact capture-result
+// invocation that transition hands back through the compiled Claude adapter
+// path, and asserts the prompt the adapter actually receives carries the
+// Claude-specific marker. TestReviewProviderMaterializeResolvesAgentAwareContextMarker
+// above proves reviewProviderMaterialize alone; this proves the full field
+// path -- negotiated collect transition to capture-result to compiled adapter
+// -- because the unit-level proof does not show the rendered transition
+// actually carries --agent through to the adapter that #2777 reports on.
+func TestReviewProviderNegotiatedCaptureResultCarriesClaudeMarker(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, false)
+	lens := record.State.SelectedLenses[0]
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", started.LineageID, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentClaudeCode), "--next-transition",
+	}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) == 0 {
+		t.Fatalf("next transition = %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.CaptureOperation != reviewCaptureResultCaptureOperation {
+		t.Fatalf("capture operation = %q, want %q", input.CaptureOperation, reviewCaptureResultCaptureOperation)
+	}
+	var agentRendered bool
+	var orderValue string
+	args := make([]string, 0, len(input.Arguments))
+	for _, argument := range input.Arguments {
+		if argument.Token == "" {
+			t.Fatalf("collect argument %q carries no runnable token", argument.Name)
+		}
+		if argument.Name == "agent" {
+			agentRendered = argument.Value == string(model.AgentClaudeCode)
+		}
+		if argument.Name == "order" {
+			orderValue = argument.Value
+		}
+		args = append(args, argument.Token)
+	}
+	if !agentRendered {
+		t.Fatalf("negotiated collect transition did not render --agent=%s for capture-result: %#v", model.AgentClaudeCode, input.Arguments)
+	}
+	order, err := strconv.Atoi(orderValue)
+	if err != nil {
+		t.Fatalf("collect transition order argument = %q: %v", orderValue, err)
+	}
+
+	previous := reviewProviderAdapterFor
+	t.Cleanup(func() { reviewProviderAdapterFor = previous })
+	var capturedPrompt []byte
+	reviewProviderAdapterFor = func(_ reviewerprovider.Contract, agent model.AgentID) (reviewerprovider.Adapter, error) {
+		if agent != model.AgentClaudeCode {
+			return nil, errors.New("unexpected runtime")
+		}
+		return providerTestAdapterFunc(func(_ context.Context, invocation reviewerprovider.Invocation) ([]byte, error) {
+			capturedPrompt = invocation.Prompt()
+			return admittedReviewerPayloadForTest(t, repo, record, lens, order), nil
+		}), nil
+	}
+
+	if err := RunReviewCaptureResult(args, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(capturedPrompt, []byte("GENTLE_AI_CLAUDE_REVIEW_CONTEXT")) {
+		t.Fatalf("compiled Claude adapter did not receive the claude-code marker through the negotiated transition:\n%s", capturedPrompt)
 	}
 }
 

--- a/internal/components/sdd/boundedreview.go
+++ b/internal/components/sdd/boundedreview.go
@@ -16,8 +16,6 @@ const boundedReviewContractAsset = "skills/_shared/review-ledger-contract.md"
 // prompt is what lets a reviewer resolve subject_hash from its own instructions
 // instead of depending on whatever context the orchestrator happened to carry.
 const reviewerBindingEnvironmentVariable = "GENTLE_AI_REVIEW_BINDING"
-const claudeReviewerContextMarker = "GENTLE_AI_CLAUDE_REVIEW_CONTEXT"
-const openCodeReviewContextMarker = "GENTLE_AI_REVIEW_CONTEXT"
 
 const nativeReviewerResultSchema = `{"findings":[{"location":"path:line or path:start-end","severity":"CRITICAL","claim":"observable incorrect behavior","evidence_class":"deterministic","causal_disposition":"introduced","proof_refs":["concrete proof"]}],"evidence":["what was inspected"]}`
 const providerReviewerResultSchema = `{"subject_hash":"<artifact_subject.subject_hash>","inspection":{"status":"completed","paths":["<complete unique unordered set>"]},"findings":[{"location":"path:line or path:start-end","severity":"CRITICAL","claim":"observable incorrect behavior","evidence_class":"deterministic","causal_disposition":"introduced","proof_refs":["concrete proof"]}],"evidence":["what was inspected"]}`
@@ -190,8 +188,29 @@ type reviewerTransportInvocation struct {
 	supplier      string
 }
 
+// mustReviewerContextMarker resolves a marker this package compiles a
+// constant reference to. Both keys are part of the closed table in
+// reviewtransaction, so a missing entry here is a build-time programmer
+// error, not a runtime possibility -- it panics at package init rather than
+// silently falling back, exactly like reviewerRoleFor's found check does for
+// an unmapped lens.
+func mustReviewerContextMarker(agent string) reviewtransaction.ReviewerContextMarker {
+	marker, ok := reviewtransaction.ReviewerContextMarkerFor(agent)
+	if !ok {
+		panic("reviewtransaction has no reviewer context marker for " + agent)
+	}
+	return marker
+}
+
+// claudeReviewerContextMarker and openCodeReviewerContextMarker are sourced
+// from the single shared resolver in reviewtransaction, so this file and
+// internal/cli/review_lens_context.go can never carry two independently
+// drifting copies of the same marker pair.
+var claudeReviewerContextMarker = mustReviewerContextMarker("claude-code")
+var openCodeReviewerContextMarker = mustReviewerContextMarker("opencode")
+
 var claudeReviewerInvocation = reviewerTransportInvocation{
-	contextMarker: claudeReviewerContextMarker,
+	contextMarker: claudeReviewerContextMarker.Header,
 	supplier:      "the parent",
 }
 
@@ -199,7 +218,7 @@ var claudeReviewerInvocation = reviewerTransportInvocation{
 // relays a Task to Go, which materializes the canonical context before the
 // reviewer launches. The generated agent holds no bash and no read tool.
 var openCodeReviewerInvocation = reviewerTransportInvocation{
-	contextMarker: openCodeReviewContextMarker,
+	contextMarker: openCodeReviewerContextMarker.Header,
 	supplier:      "the OpenCode host process",
 }
 

--- a/internal/components/sdd/boundedreview.go
+++ b/internal/components/sdd/boundedreview.go
@@ -202,10 +202,8 @@ func mustReviewerContextMarker(agent string) reviewtransaction.ReviewerContextMa
 	return marker
 }
 
-// claudeReviewerContextMarker and openCodeReviewerContextMarker are sourced
-// from the single shared resolver in reviewtransaction, so this file and
-// internal/cli/review_lens_context.go can never carry two independently
-// drifting copies of the same marker pair.
+// Sourced from the single shared resolver so this file and
+// internal/cli/review_lens_context.go can never drift apart.
 var claudeReviewerContextMarker = mustReviewerContextMarker("claude-code")
 var openCodeReviewerContextMarker = mustReviewerContextMarker("opencode")
 

--- a/internal/reviewtransaction/reviewer_context_marker.go
+++ b/internal/reviewtransaction/reviewer_context_marker.go
@@ -1,0 +1,49 @@
+package reviewtransaction
+
+// ReviewerContextMarker names the header and terminator that frame one
+// provider-injected reviewer context block. Header and Terminator are
+// same-typed and used adjacently when framing a block, so they are carried as
+// one value rather than as two independently-passed strings a caller could
+// mismatch.
+type ReviewerContextMarker struct {
+	Header     string
+	Terminator string
+}
+
+// newReviewerContextMarker derives Terminator from Header in one place, so a
+// table entry can never record a terminator that does not actually close its
+// own header.
+func newReviewerContextMarker(header string) ReviewerContextMarker {
+	return ReviewerContextMarker{Header: header, Terminator: header + "_END"}
+}
+
+// reviewerContextMarkers is the closed provider→marker table. It is keyed by
+// plain string rather than model.AgentID so this package never depends on
+// internal/model.
+//
+//   - "" is the omitted-flag default: today's generic marker, kept as an
+//     explicit table entry rather than a caller-side branch so "flag omitted"
+//     is one supported case inside the single resolver.
+//   - "claude-code" resolves to the marker Claude's installed reviewer already
+//     requires.
+//   - "opencode" resolves to the generic marker, verbatim and unchanged, but
+//     now an explicit table entry instead of a coincidence.
+//
+// Every other value -- including recognized-but-unmapped runtime identities --
+// has no entry and therefore resolves to ok=false. Adding a new runtime here
+// must be a deliberate table edit, never an inferred fallback.
+var reviewerContextMarkers = map[string]ReviewerContextMarker{
+	"":            newReviewerContextMarker("GENTLE_AI_REVIEW_CONTEXT"),
+	"claude-code": newReviewerContextMarker("GENTLE_AI_CLAUDE_REVIEW_CONTEXT"),
+	"opencode":    newReviewerContextMarker("GENTLE_AI_REVIEW_CONTEXT"),
+}
+
+// ReviewerContextMarkerFor resolves the header/terminator pair a caller's
+// generated reviewer expects, keyed by the exact agent identity string. It
+// fails closed for any value with no table entry rather than falling back to
+// the generic marker: a runtime this release has never generated a reviewer
+// for gets no guessed marker at all.
+func ReviewerContextMarkerFor(agent string) (ReviewerContextMarker, bool) {
+	marker, found := reviewerContextMarkers[agent]
+	return marker, found
+}

--- a/internal/reviewtransaction/reviewer_context_marker.go
+++ b/internal/reviewtransaction/reviewer_context_marker.go
@@ -39,10 +39,7 @@ var reviewerContextMarkers = map[string]ReviewerContextMarker{
 }
 
 // ReviewerContextMarkerFor resolves the header/terminator pair a caller's
-// generated reviewer expects, keyed by the exact agent identity string. It
-// fails closed for any value with no table entry rather than falling back to
-// the generic marker: a runtime this release has never generated a reviewer
-// for gets no guessed marker at all.
+// generated reviewer expects, keyed by the exact agent identity string.
 func ReviewerContextMarkerFor(agent string) (ReviewerContextMarker, bool) {
 	marker, found := reviewerContextMarkers[agent]
 	return marker, found

--- a/internal/reviewtransaction/reviewer_context_marker_test.go
+++ b/internal/reviewtransaction/reviewer_context_marker_test.go
@@ -1,0 +1,64 @@
+package reviewtransaction
+
+import "testing"
+
+// TestReviewerContextMarkerForResolvesTheClosedThreeKeyTable pins the exact
+// marker every mapped agent identity resolves to, and proves the omitted-agent
+// default stays the generic marker every relay-agnostic reviewer already
+// expects.
+func TestReviewerContextMarkerForResolvesTheClosedThreeKeyTable(t *testing.T) {
+	tests := []struct {
+		name           string
+		agent          string
+		wantHeader     string
+		wantTerminator string
+	}{
+		{name: "omitted agent defaults to the generic marker", agent: "", wantHeader: "GENTLE_AI_REVIEW_CONTEXT", wantTerminator: "GENTLE_AI_REVIEW_CONTEXT_END"},
+		{name: "claude-code resolves its own marker", agent: "claude-code", wantHeader: "GENTLE_AI_CLAUDE_REVIEW_CONTEXT", wantTerminator: "GENTLE_AI_CLAUDE_REVIEW_CONTEXT_END"},
+		{name: "opencode resolves the generic marker verbatim", agent: "opencode", wantHeader: "GENTLE_AI_REVIEW_CONTEXT", wantTerminator: "GENTLE_AI_REVIEW_CONTEXT_END"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			marker, ok := ReviewerContextMarkerFor(test.agent)
+			if !ok {
+				t.Fatalf("ReviewerContextMarkerFor(%q) ok = false, want true", test.agent)
+			}
+			if marker.Header != test.wantHeader || marker.Terminator != test.wantTerminator {
+				t.Fatalf("ReviewerContextMarkerFor(%q) = %+v, want Header=%q Terminator=%q",
+					test.agent, marker, test.wantHeader, test.wantTerminator)
+			}
+		})
+	}
+}
+
+// TestReviewerContextMarkerForRejectsEveryValueOutsideTheClosedTable proves the
+// lookup fails closed: a recognized-but-unmapped model.AgentID, case drift, and
+// incidental whitespace all refuse rather than silently falling back to the
+// generic marker.
+func TestReviewerContextMarkerForRejectsEveryValueOutsideTheClosedTable(t *testing.T) {
+	for _, agent := range []string{"codex", "kilo", "Claude-Code", " claude-code "} {
+		t.Run(agent, func(t *testing.T) {
+			marker, ok := ReviewerContextMarkerFor(agent)
+			if ok {
+				t.Fatalf("ReviewerContextMarkerFor(%q) ok = true, want false (marker=%+v)", agent, marker)
+			}
+			if marker != (ReviewerContextMarker{}) {
+				t.Fatalf("ReviewerContextMarkerFor(%q) returned a non-zero marker on refusal: %+v", agent, marker)
+			}
+		})
+	}
+}
+
+// TestReviewerContextMarkersInvariantTerminatorDerivesFromHeader proves every
+// table entry's terminator is mechanically derived from its header, so the two
+// can never drift apart by hand-editing one and not the other.
+func TestReviewerContextMarkersInvariantTerminatorDerivesFromHeader(t *testing.T) {
+	for agent, marker := range reviewerContextMarkers {
+		if marker.Header == "" {
+			t.Fatalf("agent %q has an empty header", agent)
+		}
+		if marker.Terminator != marker.Header+"_END" {
+			t.Fatalf("agent %q terminator = %q, want %q", agent, marker.Terminator, marker.Header+"_END")
+		}
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2777

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- `gentle-ai review lens-context` hardcoded the generic evidence-block marker (`GENTLE_AI_REVIEW_CONTEXT`/`_END`) regardless of caller provider, while the installed Claude Code reviewer agent requires the Claude-specific marker (`GENTLE_AI_CLAUDE_REVIEW_CONTEXT`/`_END`) — every Claude reviewer launch through `provider_command` delivery was deterministically refused with `inspection.status: "incomplete"`.
- Adds an optional `--agent` flag to `review lens-context`, resolved through one new closed provider→marker table in `internal/reviewtransaction`, shared by both the CLI renderer and `boundedreview.go`'s installed-agent prompt generator (previously two separately hardcoded/duplicated locations).
- An unrecognized `--agent` value fails loud with a typed refusal before any inspector opens; omitting the flag keeps today's generic-marker behavior unchanged (backward compatible for OpenCode / agent-less callers).
- Note on direction: a prior attempt at this issue (PR #3139, `fix/2777-align-claude-review-context`) took the opposite approach — aligning the installed Claude agent to accept the generic marker instead of fixing the renderer. The maintainer closed it 2026-08-12 as the wrong direction ("must not be merged or reused as a compatibility layer"), superseded by #3138's shared-Go-provider-contract refactor. This PR fixes the renderer side that #3138 never wired up, per that guidance.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/reviewer_context_marker.go` | New: closed provider→marker resolver (`claude-code` → Claude marker, `opencode`/omitted → generic marker, unmapped → `ok=false`) |
| `internal/reviewtransaction/reviewer_context_marker_test.go` | New: unit tests for the resolver |
| `internal/cli/review_lens_context.go` | New optional `--agent` flag; resolved marker threaded through all three use sites (block framing + instruction prose); fail-loud typed refusal for an unmapped `--agent` value, raised before the inspector opens |
| `internal/cli/review_lens_context_test.go` | New tests: Claude-agent marker, explicit OpenCode marker, unknown-agent refusal (zero stdout / no side effects); existing generic-marker assertions unchanged |
| `internal/cli/review_provider.go` | Compile-forced update (second caller of the changed signature) — pinned to the generic marker, byte-neutral, no behavior change |
| `internal/components/sdd/boundedreview.go` | Removed two duplicated local marker consts; both now source from the shared resolver — byte-neutral for installed Claude/OpenCode reviewer prompts (guarded by the existing, unmodified `bounded_review_contract_test.go:268`) |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Sonnet 5), via a full local SDD workflow (explore → propose → spec → design → tasks → apply → verify → archive) with strict TDD.

**Material scope:** Root-cause investigation of #2777 against current source, design of the fix (provider→marker table shape, `--agent` flag placement, fail-loud policy), and the full implementation — the new resolver, CLI wiring, `boundedreview.go` rewire, and all new/updated tests.

**Verification performed:** *(contributor — please confirm/adjust before submitting, since this is your attestation, not the tool's)* `go test ./... -count=1`, `go vet ./...`, `go run ./internal/gofmtcheck`, and `./scripts/deadcode-ratchet.sh` all pass, except one pre-existing, unrelated failure (`TestEngramPathGuidanceDefault`, an env/PATH-guidance test with no relationship to any file this PR touches — reproduces identically on unmodified `main`). The byte-neutrality of the `boundedreview.go` rewire was independently confirmed via the existing unmodified guard test at `bounded_review_contract_test.go:268`. An independent `sdd-verify` pass (fresh context) re-derived and traced the marker values, all three use sites, and the fail-loud path against actual source rather than trusting the implementation's own report; verdict `pass_with_warnings` (0 CRITICAL, 2 WARNING — see Notes for Reviewers).

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation** — this touches review-lifecycle code (`internal/cli/review_lens_context.go`, `internal/reviewtransaction`), so benchmark validation applies per the [benchmark guide](../bench/README.md). *Not run locally in this session (no local benchmark corpus run performed) — please run before merge or confirm CI coverage is sufficient.*

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — **not run locally this session**; CI should own this lane.
- [ ] Manually tested locally — *(contributor: check once you've reviewed/exercised this yourself)*

---

## ✅ Contributor Checklist

*(left unchecked intentionally — these are your attestations; please review the diff and check off what you've personally verified before submitting)*

- [ ] PR is linked to an issue with `status:approved`
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [ ] I have updated documentation if necessary
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I understand, reviewed, and take responsibility for the complete submission
- [ ] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [ ] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Two known, non-blocking warnings from `sdd-verify` (0 CRITICAL findings):

1. **Latent doc-wording gap (no live exposure today):** the `review-ledger-contract.md` paragraph telling `provider_command` callers to pass `--agent <id>` renders per installing runtime via `{{GENTLE_AI_RUNTIME_AGENT_ID}}`. For runtimes outside this resolver's closed table (codex, windsurf, cursor, gemini-cli, kiro-ide, vscode-copilot, antigravity), their own rendered doc shows an example that would be refused if actually run. Not exploitable today — none of those runtimes reach a `lens-context` `collect` transition (Codex is Go-materialized; the rest never relay a block at all). A follow-up attempt to scope that paragraph to name only `claude-code`/`opencode` was tried and reverted in this session: it broke two existing invariant tests — `TestRenderedSurfaceNamesOnlyItsOwnRuntime` (`internal/app/documented_provenance_test.go`, requires every `--agent` binding inside a documented `gentle-ai ...` invocation) and `TestGeneratedOrchestratorInstructionsNameTheExecutingRuntime` (`internal/components/sdd/review_runtime_identity_test.go`, forbids a runtime's rendered instructions from naming another runtime's literal identity). Fixing this correctly needs conditional render logic in the Go renderer, not a prose edit — flagging as a separate follow-up rather than scope-creeping this PR.
2. Pre-existing, unrelated `TestEngramPathGuidanceDefault` failure (see Verification performed above) — not this PR's responsibility.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [ ] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [ ] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [ ] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `--agent` option to select context formatting for supported coding agents.
  * Added distinct reviewer context markers for Claude Code and OpenCode, with generic formatting retained by default.
  * Documented the new option and supported command usage.

* **Bug Fixes**
  * Unknown or malformed agent values are rejected safely without producing output or changing state.
  * Standardized reviewer context markers across generated prompts and provider workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->