### PR TITLE
fix(review): companion test paths, cross-version kill switch, advisory disposition

### DIFF
--- a/contracts/review-integration/v1/schemas/operation.schema.json
+++ b/contracts/review-integration/v1/schemas/operation.schema.json
@@ -89,6 +89,9 @@
           "$comment": "Present only when the authority is escalated. Carries the accounting sentence with spent, remaining and total correction lines, so a caller learns the numbers without a second call.",
           "type": "string",
           "minLength": 1
+        },
+        "advisory_findings": {
+          "$ref": "#/$defs/advisory_findings"
         }
       },
       "allOf": [
@@ -105,8 +108,81 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "required": [
+              "advisory_findings"
+            ]
+          },
+          "then": {
+            "properties": {
+              "state": {
+                "const": "approved"
+              }
+            }
+          }
         }
       ]
+    },
+    "advisory_findings": {
+      "$comment": "Additive and optional. Present only on an approved lineage that froze at least one non-blocking finding, it names the disposition that lineage's routing already decided (outcome plus absence from the correction ledger) instead of leaving a consumer to infer it from a bare severity string. It changes nothing about which findings block: a corrected blocker is excluded rather than relabelled, and the statement says the approval stands and that no correction transition is offered.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "statement",
+        "findings"
+      ],
+      "properties": {
+        "statement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "findings": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "severity",
+              "disposition"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "lens": {
+                "type": "string",
+                "minLength": 1
+              },
+              "location": {
+                "type": "string",
+                "minLength": 1
+              },
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "BLOCKER",
+                  "CRITICAL",
+                  "WARNING",
+                  "SUGGESTION"
+                ]
+              },
+              "disposition": {
+                "$comment": "informational: a non-severe finding that never entered classification and requires no action. follow_up: a severe finding proved to originate outside the frozen candidate, recorded for separate later work. refuted: a severe inferential finding the refuter knocked down.",
+                "enum": [
+                  "informational",
+                  "follow_up",
+                  "refuted"
+                ]
+              }
+            }
+          }
+        }
+      }
     },
     "validate": {
       "type": "object",

--- a/contracts/review-integration/v2/schemas/operation.schema.json
+++ b/contracts/review-integration/v2/schemas/operation.schema.json
@@ -33,12 +33,17 @@
         "eligibility": {"$ref": "status.schema.json#/properties/eligibility"},
         "next_transition": {"$ref": "status.schema.json#/$defs/next_transition"},
         "validation_request": {"$ref": "../../v1/schemas/targeted-validation-request.schema.json"},
-        "escalation": {"type": "string", "minLength": 1}
+        "escalation": {"type": "string", "minLength": 1},
+        "advisory_findings": {"$ref": "../../v1/schemas/operation.schema.json#/$defs/advisory_findings"}
       },
       "allOf": [
         {
           "if": {"required": ["validation_request"]},
           "then": {"properties": {"state": {"const": "correction_required"}}}
+        },
+        {
+          "if": {"required": ["advisory_findings"]},
+          "then": {"properties": {"state": {"const": "approved"}}}
         }
       ]
     }

--- a/internal/cli/review_advisory_disposition_test.go
+++ b/internal/cli/review_advisory_disposition_test.go
@@ -1,0 +1,299 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// approveTrackedGoChangeWithAdvisoryFindings persists an approved compact
+// authority whose completed review froze one WARNING and one SUGGESTION.
+// Neither severity is candidate-causal-severe, so both route to the
+// informational outcome, follow_ups stays empty, and the approval stands --
+// exactly the shape of the field incident this file covers.
+func approveTrackedGoChangeWithAdvisoryFindings(t *testing.T, repo, lineage string) reviewtransaction.CompactState {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "feature.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add feature base")
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n\nfunc Feature() int { return 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: lineage, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1, Snapshot: snapshot,
+		PolicyHash: "sha256:" + hexDigest("advisory-policy"), RiskLevel: risk,
+		SelectedLenses: []string{reviewtransaction.LensReliability}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := []reviewtransaction.Finding{
+		{
+			ID: "R3-001", Lens: "reliability", Location: "feature.go:3", Severity: "WARNING",
+			Claim: "Feature() has no covering assertion", ProofRefs: []string{"feature.go:3 has no differential test"},
+		},
+		{
+			ID: "R3-002", Lens: "reliability", Location: "feature.go:3", Severity: "SUGGESTION",
+			Claim: "Feature() could return a named constant", ProofRefs: []string{"feature.go:3 returns a bare literal"},
+		},
+	}
+	results := []reviewtransaction.LensResult{{
+		Lens: reviewtransaction.LensReliability, Findings: findings, Evidence: []string{"review completed"},
+	}}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{
+		LensResults: results, Classifications: []reviewtransaction.FindingEvidence{}, RefuterOutcomes: []reviewtransaction.EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	if state.State != reviewtransaction.StateApproved || len(state.FollowUps) != 0 || len(state.FixFindingIDs) != 0 {
+		t.Fatalf("advisory fixture must approve with no follow-up and no correction: %#v", state)
+	}
+	return state
+}
+
+// TestApprovedFinalizeDeclaresAdvisoryFindings is the regression for the field
+// incident: an approved receipt carried a WARNING, the consumer had only the
+// severity string to reason from, inferred it had to act, and re-ran a full
+// review on an already-approved candidate. The approved payload must say the
+// disposition out loud instead.
+func TestApprovedFinalizeDeclaresAdvisoryFindings(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	state := approveTrackedGoChangeWithAdvisoryFindings(t, repo, "advisory-legacy")
+
+	var stdout bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", state.LineageID}, &stdout); err != nil {
+		t.Fatalf("finalize approved lineage: %v", err)
+	}
+	var result ReviewFacadeFinalizeResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode finalize result %q: %v", stdout.String(), err)
+	}
+	if result.State != reviewtransaction.StateApproved {
+		t.Fatalf("finalize state = %q, want approved", result.State)
+	}
+	if result.AdvisoryFindings == nil {
+		t.Fatalf("approved finalize payload carries no advisory_findings block: %s", stdout.String())
+	}
+	statement := result.AdvisoryFindings.Statement
+	for _, want := range []string{"approved", "non-blocking", "no correction"} {
+		if !strings.Contains(strings.ToLower(statement), want) {
+			t.Fatalf("advisory statement %q must state %q", statement, want)
+		}
+	}
+	got := map[string]string{}
+	for _, finding := range result.AdvisoryFindings.Findings {
+		got[finding.ID] = string(finding.Disposition)
+		if finding.Severity == "" {
+			t.Fatalf("advisory finding %q must keep its severity: %#v", finding.ID, finding)
+		}
+	}
+	want := map[string]string{
+		"R3-001": string(reviewtransaction.AdvisoryInformational),
+		"R3-002": string(reviewtransaction.AdvisoryInformational),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("advisory findings = %#v, want %#v", got, want)
+	}
+	for id, disposition := range want {
+		if got[id] != disposition {
+			t.Fatalf("advisory disposition for %q = %q, want %q", id, got[id], disposition)
+		}
+	}
+}
+
+// TestApprovedFinalizeAdvisoryFindingsSurfaceOnNegotiatedContract proves the
+// same disposition reaches the negotiated v2 consumers (gentle-pi and every
+// other host reading the published operation envelope), not only the legacy
+// bare result.
+func TestApprovedFinalizeAdvisoryFindingsSurfaceOnNegotiatedContract(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	state := approveTrackedGoChangeWithAdvisoryFindings(t, repo, "advisory-negotiated")
+
+	var stdout bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{
+		"--cwd", repo, "--lineage", state.LineageID, "--contract", ReviewIntegrationContractV2,
+	}, &stdout); err != nil {
+		t.Fatalf("negotiated finalize approved lineage: %v", err)
+	}
+	// gentle-pi and every other host vendor these schemas byte-pinned, so the
+	// live envelope carrying the new block must validate against the published
+	// contract, not only against the Go struct.
+	validatePublishedReviewSchema(t, compileWholePublishedReviewSchema(t, "v2", "operation.schema.json"), stdout.Bytes())
+
+	var envelope ReviewIntegrationOperationResult
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode negotiated envelope %q: %v", stdout.String(), err)
+	}
+	var result ReviewIntegrationFinalizeResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		t.Fatalf("decode negotiated finalize result %q: %v", string(envelope.Result), err)
+	}
+	if result.State != reviewtransaction.StateApproved || result.AdvisoryFindings == nil {
+		t.Fatalf("negotiated approved payload carries no advisory_findings block: %s", stdout.String())
+	}
+	if len(result.AdvisoryFindings.Findings) != 2 {
+		t.Fatalf("negotiated advisory findings = %#v, want both frozen non-blocking findings", result.AdvisoryFindings.Findings)
+	}
+	for _, finding := range result.AdvisoryFindings.Findings {
+		if finding.Disposition != reviewtransaction.AdvisoryInformational {
+			t.Fatalf("negotiated advisory disposition for %q = %q, want informational", finding.ID, finding.Disposition)
+		}
+	}
+
+	// The negative half of the contract: nothing about an advisory finding may
+	// offer a way back into review. No correction request, no validation
+	// request, and the routed next transition is the delivery gate.
+	if result.ValidationRequest != nil {
+		t.Fatalf("approved advisory payload offers a validation request: %#v", result.ValidationRequest)
+	}
+	if result.NextTransition != nil && result.NextTransition.CorrectionRequest != nil {
+		t.Fatalf("approved advisory payload offers a correction request: %#v", result.NextTransition.CorrectionRequest)
+	}
+
+	runReviewCLIGit(t, repo, "add", "-A")
+	var statusOut bytes.Buffer
+	if err := RunReviewStatus([]string{
+		"--cwd", repo, "--contract", ReviewIntegrationContractV2, "--agent", "claude-code", "--next-transition",
+		"--lineage", state.LineageID, "--projection", "staged", "--gate", "pre-commit",
+	}, &statusOut); err != nil {
+		t.Fatalf("negotiated status after advisory approval: %v", err)
+	}
+	var status struct {
+		NextTransition *ReviewNextTransition `json:"next_transition"`
+	}
+	if err := json.Unmarshal(statusOut.Bytes(), &status); err != nil {
+		t.Fatalf("decode status %q: %v", statusOut.String(), err)
+	}
+	if status.NextTransition == nil {
+		t.Fatalf("status after advisory approval returned no next transition: %s", statusOut.String())
+	}
+	if status.NextTransition.CorrectionRequest != nil || strings.Contains(status.NextTransition.ReasonCode, "correction") {
+		t.Fatalf("advisory approval routed back into correction: %#v", status.NextTransition)
+	}
+	if status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.validate" {
+		t.Fatalf("advisory approval next transition = %#v, want the review.validate delivery gate", status.NextTransition)
+	}
+}
+
+// TestApprovedFinalizeWithoutFindingsOmitsAdvisoryBlock keeps the addition
+// additive: a clean approval's bytes are unchanged, so byte-pinned consumers
+// see nothing new until a review actually produces a non-blocking finding.
+func TestApprovedFinalizeWithoutFindingsOmitsAdvisoryBlock(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	state := approveTrackedGoChangeWithNoFindings(t, repo, "advisory-clean")
+
+	var stdout bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", state.LineageID}, &stdout); err != nil {
+		t.Fatalf("finalize clean approved lineage: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("advisory_findings")) {
+		t.Fatalf("clean approval must not carry an advisory block: %s", stdout.String())
+	}
+}
+
+// approveTrackedGoChangeWithNoFindings is the clean-path twin of the advisory
+// fixture: identical lifecycle, zero frozen findings.
+func approveTrackedGoChangeWithNoFindings(t *testing.T, repo, lineage string) reviewtransaction.CompactState {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "feature.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add feature base")
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n\nfunc Feature() int { return 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: lineage, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1, Snapshot: snapshot,
+		PolicyHash: "sha256:" + hexDigest("advisory-policy"), RiskLevel: risk,
+		SelectedLenses: []string{reviewtransaction.LensReliability}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := []reviewtransaction.LensResult{{
+		Lens: reviewtransaction.LensReliability, Findings: []reviewtransaction.Finding{}, Evidence: []string{"review completed"},
+	}}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{
+		LensResults: results, Classifications: []reviewtransaction.FindingEvidence{}, RefuterOutcomes: []reviewtransaction.EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return state
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -229,9 +229,14 @@ type ReviewFacadeFinalizeResult struct {
 	// reviewtransaction.EscalationAccountingReasonTemplate. It is present only
 	// when the authority actually escalated with a derivable cause, so every
 	// other finalize shape keeps its exact existing output.
-	Escalation    string `json:"escalation,omitempty"`
-	StoreRevision string `json:"store_revision"`
-	ReceiptPath   string `json:"receipt_path,omitempty"`
+	Escalation string `json:"escalation,omitempty"`
+	// AdvisoryFindings names the disposition of every non-blocking frozen
+	// finding on a terminally approved lineage, plus the sentence saying the
+	// approval stands. It is present only when an approved lineage actually
+	// froze such a finding, so a clean approval's bytes are unchanged.
+	AdvisoryFindings *reviewtransaction.AdvisoryFindingSet `json:"advisory_findings,omitempty"`
+	StoreRevision    string                                `json:"store_revision"`
+	ReceiptPath      string                                `json:"receipt_path,omitempty"`
 }
 
 type ReviewReceiptDiscoveryKind string
@@ -4825,10 +4830,18 @@ func encodeCompactFacadeFinalize(stdout io.Writer, negotiated bool, contract str
 		result.Escalation = fmt.Sprintf(reviewtransaction.EscalationAccountingReasonTemplate,
 			accounting.Cause, accounting.Spent, accounting.Remaining, accounting.Total)
 	}
+	// The disposition of a non-blocking finding is already decided by the time
+	// this lineage is approved -- it lives in state.Outcomes and its absence
+	// from state.FixFindingIDs. Saying it out loud changes no routing and
+	// blocks nothing new; it removes the inference a consumer previously had
+	// to make from a bare severity string, which is what let an approved
+	// WARNING be "fixed" and re-reviewed in the field.
+	result.AdvisoryFindings = reviewtransaction.AdvisoryFindingSetFor(state)
 	public := ReviewIntegrationFinalizeResult{
 		Operation: result.Operation, LineageID: result.LineageID, State: result.State,
-		Action: result.Action, Escalation: result.Escalation, StoreRevision: result.StoreRevision,
-		Eligibility: eligibility, NextTransition: transition, ValidationRequest: validationRequest,
+		Action: result.Action, Escalation: result.Escalation, AdvisoryFindings: result.AdvisoryFindings,
+		StoreRevision: result.StoreRevision,
+		Eligibility:   eligibility, NextTransition: transition, ValidationRequest: validationRequest,
 	}
 	return encodeReviewIntegrationOperation(stdout, negotiated, ReviewIntegrationOperationFinalize, result, public, contract)
 }

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -428,6 +428,17 @@ func emitReviewMode(stdout io.Writer, result ReviewModeResult, emitJSON bool) er
 		reviewModeLabel(result.Status.Global),
 		reviewModeLabel(result.Status.CloneLocal),
 	)
+	if err != nil || result.Status.Reach != reviewtransaction.RDDModeReachThisBuild {
+		return err
+	}
+	// The switch is machine state. A write that reached only this build has to
+	// say so on the surface the operator actually reads, or it reports a
+	// working kill switch to someone half of whose gentle-ai installations are
+	// still enforcing review.
+	_, err = fmt.Fprint(
+		stdout,
+		"  note:        applied for this gentle-ai only; a gentle-ai installed before the switch moved reads a location this command could not open, and keeps enforcing the value it holds there\n",
+	)
 	return err
 }
 

--- a/internal/cli/review_mode_cross_version_test.go
+++ b/internal/cli/review_mode_cross_version_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestCloneScopeDisableReportsHowFarItReached is #3284 at the surface the
+// operator reads.
+//
+// The clone-scope switch is machine state: a modern gentle-ai publishes it
+// under the relocated switch root, and every gentle-ai installed before that
+// relocation reads its own location. The disable used to report plain success
+// either way, so an operator who had turned reviews off kept being blocked by
+// another build on the same machine with nothing in the output to explain it.
+func TestCloneScopeDisableReportsHowFarItReached(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output); err != nil {
+		t.Fatalf("clone-scoped disable failed: %v", err)
+	}
+	if result := decodeReviewModeResult(t, output.Bytes()); result.Status.Reach != reviewtransaction.RDDModeReachMachine {
+		t.Fatalf("disable reported reach %q, want %q", result.Status.Reach, reviewtransaction.RDDModeReachMachine)
+	}
+}
+
+// TestCloneScopeDisableSaysWhenItReachedOnlyThisBuild keeps #2882's exit open
+// and stops it lying at the same time. A damaged review authority tree may not
+// make the documented clone-scoped disable refuse, and it may not let the
+// command report a machine-wide switch it did not publish machine-wide.
+func TestCloneScopeDisableSaysWhenItReachedOnlyThisBuild(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	damageReviewAuthorityTree(t, repo)
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone", "--json"}, &output); err != nil {
+		t.Fatalf("clone-scoped disable failed while authority was damaged: %v", err)
+	}
+	result := decodeReviewModeResult(t, output.Bytes())
+	if result.Status.Effective != reviewtransaction.RDDModeOff {
+		t.Fatalf("disable reported %#v, want off", result.Status)
+	}
+	if result.Status.Reach != reviewtransaction.RDDModeReachThisBuild {
+		t.Fatalf("disable reported reach %q, want %q", result.Status.Reach, reviewtransaction.RDDModeReachThisBuild)
+	}
+
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", repo}, &output); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if strings.Contains(output.String(), "note:") {
+		t.Fatalf("read-only status invented a reach it never verified:\n%s", output.String())
+	}
+
+	output.Reset()
+	if err := RunReviewMode([]string{"disable", "--cwd", repo, "--scope", "clone"}, &output); err != nil {
+		t.Fatalf("repeated clone-scoped disable failed: %v", err)
+	}
+	if !strings.Contains(output.String(), "note:") ||
+		!strings.Contains(output.String(), "applied for this gentle-ai only") {
+		t.Fatalf("the human-readable disable claimed a machine-wide switch it did not publish:\n%s", output.String())
+	}
+}

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -145,6 +145,13 @@ func TestReviewModeCloneScopeEnableMigratesLegacyRevision(t *testing.T) {
 		t.Fatalf("read current record: %v", err)
 	}
 	legacyRoot := filepath.Join(repo, ".git", "gentle-ai", "review-transactions")
+	// The seeding write publishes into both locations, because the switch is
+	// machine state rather than build state (#3284). This fixture is the clone
+	// that only ever had the pre-relocation one, so its mirror is dropped
+	// before the relocated root takes that name.
+	if err := os.RemoveAll(legacyRoot); err != nil {
+		t.Fatalf("drop the mirrored fixture copy: %v", err)
+	}
 	if err := os.Rename(filepath.Join(repo, ".git", "gentle-ai", "review-mode"), legacyRoot); err != nil {
 		t.Fatalf("relocate secure legacy fixture: %v", err)
 	}

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -1527,7 +1527,12 @@ type ReviewIntegrationFinalizeResult struct {
 	// Escalation carries the same correction-budget accounting sentence as
 	// ReviewFacadeFinalizeResult.Escalation, so the negotiated and legacy
 	// finalize surfaces explain a terminal escalation identically.
-	Escalation        string                                       `json:"escalation,omitempty"`
+	Escalation string `json:"escalation,omitempty"`
+	// AdvisoryFindings mirrors ReviewFacadeFinalizeResult.AdvisoryFindings so
+	// a negotiated consumer learns the same explicit non-blocking disposition
+	// the legacy surface reports. Additive and optional: it appears only on an
+	// approved lineage that froze at least one non-blocking finding.
+	AdvisoryFindings  *reviewtransaction.AdvisoryFindingSet        `json:"advisory_findings,omitempty"`
 	StoreRevision     string                                       `json:"store_revision"`
 	Eligibility       *ReviewActionEligibility                     `json:"eligibility,omitempty"`
 	NextTransition    *ReviewNextTransition                        `json:"next_transition,omitempty"`

--- a/internal/reviewtransaction/advisory_disposition.go
+++ b/internal/reviewtransaction/advisory_disposition.go
@@ -1,0 +1,111 @@
+package reviewtransaction
+
+import "sort"
+
+// AdvisoryDisposition names, out loud, why one frozen finding on an approved
+// lineage did not block. The routing itself is not new: it is already recorded
+// in CompactState.Outcomes and CompactState.FixFindingIDs, and this vocabulary
+// changes none of it. What was missing is that a consumer reading an approved
+// receipt saw only the severity string and had to infer the consequence from
+// it -- the exact inference a field incident got wrong, "fixing" a WARNING on
+// an approved candidate and burning a second full review cycle on it.
+type AdvisoryDisposition string
+
+const (
+	// AdvisoryInformational is a non-severe finding (WARNING or SUGGESTION).
+	// It never entered classification, never opened a follow-up, and requires
+	// no action of any kind.
+	AdvisoryInformational AdvisoryDisposition = "informational"
+	// AdvisoryFollowUp is a severe finding whose cause was proved to lie
+	// outside the frozen candidate (pre-existing or base-only). It is recorded
+	// as a follow-up for separate later work and never reopens this review.
+	AdvisoryFollowUp AdvisoryDisposition = "follow_up"
+	// AdvisoryRefuted is a severe inferential finding the refuter knocked
+	// down. It carries no residual obligation at all.
+	AdvisoryRefuted AdvisoryDisposition = "refuted"
+)
+
+// AdvisoryStatement is the one sentence that answers the question the
+// disposition vocabulary alone still leaves open: what a consumer should do
+// next. It is deliberately explicit that the approval stands and that no
+// correction transition exists to take.
+const AdvisoryStatement = "This review is approved and its receipt stands. Every finding listed here is non-blocking: none opened a correction, none reopens this review, and no correction transition is offered for this candidate. Treat them as separate later work, never as a reason to re-run review on this candidate."
+
+// AdvisoryFinding is one frozen non-blocking finding projected with its
+// explicit disposition. It carries identity, severity, and location so a
+// consumer can locate the finding it already read, and nothing else: the claim
+// and proof refs stay where they were captured.
+type AdvisoryFinding struct {
+	ID          string              `json:"id"`
+	Lens        string              `json:"lens,omitempty"`
+	Location    string              `json:"location,omitempty"`
+	Severity    string              `json:"severity"`
+	Disposition AdvisoryDisposition `json:"disposition"`
+}
+
+// AdvisoryFindingSet is the whole projection: the findings plus the sentence
+// that says the approval stands.
+type AdvisoryFindingSet struct {
+	Statement string            `json:"statement"`
+	Findings  []AdvisoryFinding `json:"findings"`
+}
+
+// AdvisoryFindings projects every non-blocking frozen finding of a terminally
+// approved lineage, sorted by finding ID for a deterministic payload.
+//
+// It is a pure read of already-decided state and decides nothing itself: a
+// finding listed in FixFindingIDs blocked and was corrected, so it is excluded
+// rather than relabelled, and a lineage that is not StateApproved yields
+// nothing at all because its dispositions are not yet settled.
+func AdvisoryFindings(state CompactState) []AdvisoryFinding {
+	if state.State != StateApproved {
+		return nil
+	}
+	corrected := stringSet(state.FixFindingIDs)
+	advisory := make([]AdvisoryFinding, 0, len(state.Findings))
+	for _, finding := range state.Findings {
+		if _, blocked := corrected[finding.ID]; blocked {
+			continue
+		}
+		disposition, ok := advisoryDisposition(finding, state.Outcomes[finding.ID])
+		if !ok {
+			continue
+		}
+		advisory = append(advisory, AdvisoryFinding{
+			ID: finding.ID, Lens: finding.Lens, Location: finding.Location,
+			Severity: finding.Severity, Disposition: disposition,
+		})
+	}
+	if len(advisory) == 0 {
+		return nil
+	}
+	sort.Slice(advisory, func(left, right int) bool { return advisory[left].ID < advisory[right].ID })
+	return advisory
+}
+
+// AdvisoryFindingSetFor pairs the projection with its statement, or reports
+// nothing when the lineage has no non-blocking finding to explain.
+func AdvisoryFindingSetFor(state CompactState) *AdvisoryFindingSet {
+	findings := AdvisoryFindings(state)
+	if len(findings) == 0 {
+		return nil
+	}
+	return &AdvisoryFindingSet{Statement: AdvisoryStatement, Findings: findings}
+}
+
+// advisoryDisposition maps one already-recorded outcome to its named
+// disposition. An outcome this function does not recognize is skipped rather
+// than guessed: an unnamed routing must never be announced as harmless.
+func advisoryDisposition(finding Finding, outcome EvidenceOutcome) (AdvisoryDisposition, bool) {
+	switch outcome {
+	case OutcomeInfo:
+		if isSevereSeverity(finding.Severity) {
+			return AdvisoryFollowUp, true
+		}
+		return AdvisoryInformational, true
+	case OutcomeRefuted:
+		return AdvisoryRefuted, true
+	default:
+		return "", false
+	}
+}

--- a/internal/reviewtransaction/advisory_disposition_test.go
+++ b/internal/reviewtransaction/advisory_disposition_test.go
@@ -1,0 +1,100 @@
+package reviewtransaction
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAdvisoryFindingsDeclareNonBlockingRouting pins the disposition every
+// non-blocking frozen finding already carries internally (Outcomes[id] and its
+// absence from FixFindingIDs) as an explicit, named value. The field incident
+// this covers: a consumer read a WARNING off an approved receipt, inferred
+// from the severity string alone that it had to act, and burned a review cycle
+// re-running an already-approved candidate.
+func TestAdvisoryFindingsDeclareNonBlockingRouting(t *testing.T) {
+	state := CompactState{
+		State: StateApproved,
+		Findings: []Finding{
+			{ID: "R3-001", Lens: "reliability", Location: "feature.go:3", Severity: "WARNING", Claim: "no covering assertion"},
+			{ID: "R3-002", Lens: "reliability", Location: "feature.go:5", Severity: "SUGGESTION", Claim: "could reuse the helper"},
+			{ID: "R1-003", Lens: "risk", Location: "legacy.go:9", Severity: "CRITICAL", Claim: "pre-existing injection"},
+			{ID: "R1-004", Lens: "risk", Location: "feature.go:7", Severity: "BLOCKER", Claim: "inferential claim the refuter knocked down"},
+		},
+		Outcomes: map[string]EvidenceOutcome{
+			"R3-001": OutcomeInfo,
+			"R3-002": OutcomeInfo,
+			"R1-003": OutcomeInfo,
+			"R1-004": OutcomeRefuted,
+		},
+		FixFindingIDs: []string{},
+	}
+	want := []AdvisoryFinding{
+		{ID: "R1-003", Lens: "risk", Location: "legacy.go:9", Severity: "CRITICAL", Disposition: AdvisoryFollowUp},
+		{ID: "R1-004", Lens: "risk", Location: "feature.go:7", Severity: "BLOCKER", Disposition: AdvisoryRefuted},
+		{ID: "R3-001", Lens: "reliability", Location: "feature.go:3", Severity: "WARNING", Disposition: AdvisoryInformational},
+		{ID: "R3-002", Lens: "reliability", Location: "feature.go:5", Severity: "SUGGESTION", Disposition: AdvisoryInformational},
+	}
+	got := AdvisoryFindings(state)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AdvisoryFindings(approved) = %#v, want %#v", got, want)
+	}
+}
+
+// TestAdvisoryFindingsExcludeCorrectedAndUnapprovedLineages keeps the new
+// projection strictly descriptive: it never claims a corrected (blocking)
+// finding was advisory, and it says nothing at all about a lineage that is not
+// terminally approved.
+func TestAdvisoryFindingsExcludeCorrectedAndUnapprovedLineages(t *testing.T) {
+	corrected := CompactState{
+		State: StateApproved,
+		Findings: []Finding{
+			{ID: "R1-001", Lens: "risk", Location: "feature.go:3", Severity: "BLOCKER", Claim: "candidate-caused"},
+			{ID: "R3-002", Lens: "reliability", Location: "feature.go:5", Severity: "WARNING", Claim: "advisory only"},
+		},
+		Outcomes:      map[string]EvidenceOutcome{"R1-001": OutcomeCorroborated, "R3-002": OutcomeInfo},
+		FixFindingIDs: []string{"R1-001"},
+	}
+	got := AdvisoryFindings(corrected)
+	if len(got) != 1 || got[0].ID != "R3-002" || got[0].Disposition != AdvisoryInformational {
+		t.Fatalf("AdvisoryFindings(corrected approved) = %#v, want only the informational finding", got)
+	}
+
+	reviewing := corrected
+	reviewing.State = StateReviewing
+	if got := AdvisoryFindings(reviewing); len(got) != 0 {
+		t.Fatalf("AdvisoryFindings(reviewing) = %#v, want none: only a terminal approval settles disposition", got)
+	}
+}
+
+// TestAdvisoryStatementSaysApprovalStands makes the sentence itself testable:
+// a consumer must not have to infer "nothing to do" from a severity string.
+func TestAdvisoryStatementSaysApprovalStands(t *testing.T) {
+	for _, want := range []string{"approved", "non-blocking", "no correction"} {
+		if !containsFold(AdvisoryStatement, want) {
+			t.Fatalf("AdvisoryStatement %q must state %q", AdvisoryStatement, want)
+		}
+	}
+}
+
+func containsFold(haystack, needle string) bool {
+	return len(needle) == 0 || indexFold(haystack, needle) >= 0
+}
+
+func indexFold(haystack, needle string) int {
+	lower := func(value string) string {
+		out := []rune(value)
+		for index, char := range out {
+			if char >= 'A' && char <= 'Z' {
+				out[index] = char + ('a' - 'A')
+			}
+		}
+		return string(out)
+	}
+	lowerHaystack, lowerNeedle := lower(haystack), lower(needle)
+	for index := 0; index+len(lowerNeedle) <= len(lowerHaystack); index++ {
+		if lowerHaystack[index:index+len(lowerNeedle)] == lowerNeedle {
+			return index
+		}
+	}
+	return -1
+}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -970,7 +970,17 @@ func validateCompactRecoveredCorrection(state CompactState, evidence CompactReco
 		attempt.Snapshot.CandidateTree != state.InitialSnapshot.CandidateTree ||
 		attempt.Snapshot.Projection != state.InitialSnapshot.Projection ||
 		!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) ||
-		pathsAreSubset(attempt.Snapshot.Paths, state.CorrectionScopePaths()) != nil ||
+		// The imported attempt is measured the way every other attempt-facing
+		// check measures one (validateCompactCorrection, correctionTargetFrozen,
+		// targetedValidationRequestForCorrection): against the frozen genesis
+		// manifest THROUGH the correction admission, not against the delivery
+		// scope. The delivery scope is rolled back when a correction escalates,
+		// and an accounting-only escalation is exactly what this recovery
+		// imports, so measuring against it would refuse a companion test path
+		// the correction was entitled to add and leave the attempt with no way
+		// to be revalidated. Admission still refuses everything a correction
+		// could not have added, so nothing unreviewed enters here.
+		correctionScopeRefused(attempt.Snapshot.Paths, state.GenesisPaths) ||
 		attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) || state.FixDeltaHash != attempt.FixDeltaHash ||
 		state.OriginalCriteria == nil || state.CorrectionRegression == nil ||
 		*state.OriginalCriteria != attempt.OriginalCriteria || *state.CorrectionRegression != attempt.CorrectionRegression ||

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -502,7 +502,11 @@ func (state CompactState) Validate() error {
 	if err := validateCompactCorrectionAddedPaths(state); err != nil {
 		return err
 	}
-	if err := pathsAreSubset(state.CurrentSnapshot.Paths, state.CorrectionScopePaths()); err != nil {
+	candidateScope, err := compactCorrectionCandidateScope(state)
+	if err != nil {
+		return err
+	}
+	if err := pathsAreSubset(state.CurrentSnapshot.Paths, candidateScope); err != nil {
 		return err
 	}
 	if !validSHA256(state.PolicyHash) || !validSHA256(state.FixDeltaHash) {
@@ -808,10 +812,14 @@ func validateCompactCorrection(state CompactState) error {
 		return errors.New("compact cumulative correction lines require persisted attempts")
 	}
 	if len(state.CorrectionAttempts) > 0 {
+		candidateScope, scopeErr := compactCorrectionCandidateScope(state)
+		if scopeErr != nil {
+			return errors.New("compact correction attempt is outside frozen scope")
+		}
 		base, cumulative := state.InitialSnapshot.CandidateTree, 0
 		for _, attempt := range state.CorrectionAttempts {
 			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.Projection != state.InitialSnapshot.Projection || attempt.Snapshot.BaseTree != base ||
-				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.CorrectionScopePaths()) != nil ||
+				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, candidateScope) != nil ||
 				validateCompactSnapshot(attempt.Snapshot) != nil || validateCompactSnapshotMetadata(attempt.Snapshot) != nil ||
 				attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) {
 				return errors.New("compact correction attempt is outside frozen scope")
@@ -928,11 +936,15 @@ func validateCompactCorrection(state CompactState) error {
 
 func validateCompactCorrectedCandidate(state CompactState, correction Snapshot) error {
 	current, initial := state.CurrentSnapshot, state.InitialSnapshot
+	candidateScope, scopeErr := compactCorrectionCandidateScope(state)
+	if scopeErr != nil {
+		return errors.New("terminal correction authority does not preserve the complete reviewed candidate") // refusal:by-design world-action: contradictory persisted authority requires code or storage repair
+	}
 	if current.Kind != initial.Kind || current.Projection != initial.Projection || current.UnbornHead != correction.UnbornHead ||
 		current.BaseTree != initial.BaseTree || current.CandidateTree != correction.CandidateTree ||
 		current.IntendedUntrackedProof != correction.IntendedUntrackedProof ||
 		!equalStrings(current.IntendedUntracked, initial.IntendedUntracked) || !equalStrings(current.LedgerIDs, initial.LedgerIDs) ||
-		pathsAreSubset(current.Paths, state.CorrectionScopePaths()) != nil {
+		pathsAreSubset(current.Paths, candidateScope) != nil {
 		return errors.New("terminal correction authority does not preserve the complete reviewed candidate") // refusal:by-design world-action: contradictory persisted authority requires code or storage repair
 	}
 	return nil
@@ -1456,9 +1468,6 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 		OriginalCriteria: validation.OriginalCriteria, CorrectionRegression: validation.CorrectionRegression,
 		TargetedValidationRequestHash: validation.TargetedValidationRequestHash, CorrectionTargetIdentity: validation.CorrectionTargetIdentity}
 	state.CorrectionAttempts = append(state.CorrectionAttempts, attempt)
-	if len(added) > 0 {
-		state.CorrectionAddedPaths = added
-	}
 	state.CumulativeCorrectionLines += actual
 	state.CurrentSnapshot = snapshot
 	state.FollowUps = append(state.FollowUps, validation.FollowUps...)
@@ -1466,9 +1475,18 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	original, regression := validation.OriginalCriteria, validation.CorrectionRegression
 	state.OriginalCriteria, state.CorrectionRegression = &original, &regression
 	if state.CumulativeCorrectionLines > state.CorrectionBudget || !original.Passed || !regression.Passed {
+		// The correction did not complete, so it never earned the widened
+		// delivery scope. The attempt stays on record -- it consumed the one
+		// correction, and its snapshot still names every path it touched --
+		// but CorrectionScopePaths keeps the frozen reviewed manifest, so a
+		// companion path an escalated correction merely attempted can never
+		// ride out through a delivery gate.
 		state.State = StateEscalated
 	} else {
 		state.State = StateValidating
+		if len(added) > 0 {
+			state.CorrectionAddedPaths = added
+		}
 	}
 	return state.Validate()
 }

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -97,6 +97,7 @@ type CompactState struct {
 	InitialSnapshot              Snapshot                     `json:"initial_snapshot"`
 	CurrentSnapshot              Snapshot                     `json:"current_snapshot"`
 	GenesisPaths                 []string                     `json:"genesis_paths"`
+	CorrectionAddedPaths         []string                     `json:"correction_added_paths,omitempty"`
 	PolicyHash                   string                       `json:"policy_hash"`
 	RiskLevel                    RiskLevel                    `json:"risk_level"`
 	SelectedLenses               []string                     `json:"selected_lenses"`
@@ -300,14 +301,23 @@ type CompactRecoveredEvidence struct {
 }
 
 type CompactReceipt struct {
-	Schema                    string              `json:"schema"`
-	LineageID                 string              `json:"lineage_id"`
-	Projection                Projection          `json:"projection,omitempty"`
-	Generation                int                 `json:"generation"`
-	BaseTree                  string              `json:"base_tree"`
-	InitialReviewTree         string              `json:"initial_review_tree"`
-	FinalCandidateTree        string              `json:"final_candidate_tree"`
-	PathsDigest               string              `json:"paths_digest"`
+	Schema             string     `json:"schema"`
+	LineageID          string     `json:"lineage_id"`
+	Projection         Projection `json:"projection,omitempty"`
+	Generation         int        `json:"generation"`
+	BaseTree           string     `json:"base_tree"`
+	InitialReviewTree  string     `json:"initial_review_tree"`
+	FinalCandidateTree string     `json:"final_candidate_tree"`
+	PathsDigest        string     `json:"paths_digest"`
+	// CorrectionAddedPaths discloses the companion test paths one admitted
+	// bounded correction added beyond the reviewed genesis manifest (issue
+	// #3375). PathsDigest already covers them, so delivery works; this field
+	// exists so an auditor can see WHICH delivered paths no lens inspected
+	// rather than having to infer it. It is omitempty, and absence means the
+	// correction stayed inside the reviewed manifest — which is every receipt
+	// issued before this field existed, so each of those stays byte-identical
+	// under re-derivation.
+	CorrectionAddedPaths      []string            `json:"correction_added_paths,omitempty"`
 	FixDeltaHash              string              `json:"fix_delta_hash"`
 	PolicyHash                string              `json:"policy_hash"`
 	EvidenceHash              string              `json:"evidence_hash"`
@@ -489,7 +499,10 @@ func (state CompactState) Validate() error {
 	if err != nil || !equalStrings(paths, state.GenesisPaths) || !equalStrings(state.GenesisPaths, state.InitialSnapshot.Paths) {
 		return errors.New("compact genesis paths must exactly match the canonical initial scope")
 	}
-	if err := pathsAreSubset(state.CurrentSnapshot.Paths, state.GenesisPaths); err != nil {
+	if err := validateCompactCorrectionAddedPaths(state); err != nil {
+		return err
+	}
+	if err := pathsAreSubset(state.CurrentSnapshot.Paths, state.CorrectionScopePaths()); err != nil {
 		return err
 	}
 	if !validSHA256(state.PolicyHash) || !validSHA256(state.FixDeltaHash) {
@@ -798,7 +811,7 @@ func validateCompactCorrection(state CompactState) error {
 		base, cumulative := state.InitialSnapshot.CandidateTree, 0
 		for _, attempt := range state.CorrectionAttempts {
 			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.Projection != state.InitialSnapshot.Projection || attempt.Snapshot.BaseTree != base ||
-				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.GenesisPaths) != nil ||
+				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.CorrectionScopePaths()) != nil ||
 				validateCompactSnapshot(attempt.Snapshot) != nil || validateCompactSnapshotMetadata(attempt.Snapshot) != nil ||
 				attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) {
 				return errors.New("compact correction attempt is outside frozen scope")
@@ -846,7 +859,7 @@ func validateCompactCorrection(state CompactState) error {
 			state.OriginalCriteria != nil || state.CorrectionRegression != nil || state.FixDeltaHash != EmptyFixDeltaHash ||
 			target.Kind != TargetFixDiff || target.Projection != state.InitialSnapshot.Projection ||
 			target.BaseTree != state.CurrentSnapshot.CandidateTree || !equalStrings(target.LedgerIDs, state.FixFindingIDs) ||
-			pathsAreSubset(target.Paths, state.GenesisPaths) != nil {
+			correctionScopeRefused(target.Paths, state.GenesisPaths) {
 			return errors.New("procedural correction verification target is invalid") // refusal:by-design world-action: persisted terminal evidence targets an invalid correction snapshot and cannot authorize continuation
 		}
 		if err := validateCompactSnapshot(*target); err != nil {
@@ -919,7 +932,7 @@ func validateCompactCorrectedCandidate(state CompactState, correction Snapshot) 
 		current.BaseTree != initial.BaseTree || current.CandidateTree != correction.CandidateTree ||
 		current.IntendedUntrackedProof != correction.IntendedUntrackedProof ||
 		!equalStrings(current.IntendedUntracked, initial.IntendedUntracked) || !equalStrings(current.LedgerIDs, initial.LedgerIDs) ||
-		pathsAreSubset(current.Paths, state.GenesisPaths) != nil {
+		pathsAreSubset(current.Paths, state.CorrectionScopePaths()) != nil {
 		return errors.New("terminal correction authority does not preserve the complete reviewed candidate") // refusal:by-design world-action: contradictory persisted authority requires code or storage repair
 	}
 	return nil
@@ -945,7 +958,7 @@ func validateCompactRecoveredCorrection(state CompactState, evidence CompactReco
 		attempt.Snapshot.CandidateTree != state.InitialSnapshot.CandidateTree ||
 		attempt.Snapshot.Projection != state.InitialSnapshot.Projection ||
 		!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) ||
-		pathsAreSubset(attempt.Snapshot.Paths, state.GenesisPaths) != nil ||
+		pathsAreSubset(attempt.Snapshot.Paths, state.CorrectionScopePaths()) != nil ||
 		attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) || state.FixDeltaHash != attempt.FixDeltaHash ||
 		state.OriginalCriteria == nil || state.CorrectionRegression == nil ||
 		*state.OriginalCriteria != attempt.OriginalCriteria || *state.CorrectionRegression != attempt.CorrectionRegression ||
@@ -1422,7 +1435,8 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	if snapshot.CandidateTree == snapshot.BaseTree {
 		return errors.New("compact correction has an unchanged candidate tree")
 	}
-	if err := pathsAreSubset(snapshot.Paths, state.GenesisPaths); err != nil {
+	added, err := admitCorrectionScope(snapshot.Paths, state.GenesisPaths)
+	if err != nil {
 		return err
 	}
 	if actual < 0 {
@@ -1442,6 +1456,9 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 		OriginalCriteria: validation.OriginalCriteria, CorrectionRegression: validation.CorrectionRegression,
 		TargetedValidationRequestHash: validation.TargetedValidationRequestHash, CorrectionTargetIdentity: validation.CorrectionTargetIdentity}
 	state.CorrectionAttempts = append(state.CorrectionAttempts, attempt)
+	if len(added) > 0 {
+		state.CorrectionAddedPaths = added
+	}
 	state.CumulativeCorrectionLines += actual
 	state.CurrentSnapshot = snapshot
 	state.FollowUps = append(state.FollowUps, validation.FollowUps...)
@@ -1501,7 +1518,7 @@ func (state *CompactState) EscalateCorrectionVerification(snapshot Snapshot, rec
 	}
 	if snapshot.Kind != TargetFixDiff || snapshot.Projection != state.InitialSnapshot.Projection ||
 		snapshot.BaseTree != state.CurrentSnapshot.CandidateTree || !equalStrings(snapshot.LedgerIDs, state.FixFindingIDs) ||
-		pathsAreSubset(snapshot.Paths, state.GenesisPaths) != nil {
+		correctionScopeRefused(snapshot.Paths, state.GenesisPaths) {
 		return errors.New("procedural correction verification target is outside the open correction transaction") // refusal:by-design world-action: candidate mutation invalidated the captured correction target and requires a fresh stable evidence capture
 	}
 	if err := record.ValidatePayload(payload); err != nil {
@@ -1651,14 +1668,23 @@ func (state CompactState) Receipt() (CompactReceipt, error) {
 	}
 	pathsDigest := state.CurrentSnapshot.PathsDigest
 	if state.CurrentSnapshot.Kind == TargetFixDiff {
+		// A fix diff names only the correction's own paths, so the reviewed
+		// manifest is the authority for what was delivered. When an admitted
+		// correction widened that manifest, the digest must cover the widened
+		// scope or delivery would refuse the very file the correction was
+		// granted. With no added paths the two expressions are identical.
 		pathsDigest = state.InitialSnapshot.PathsDigest
+		if len(state.CorrectionAddedPaths) > 0 {
+			pathsDigest = digestPaths(state.CorrectionScopePaths())
+		}
 	}
 	receipt := CompactReceipt{
 		Schema: CompactReceiptSchema, LineageID: state.LineageID, Generation: state.Generation,
 		Projection: state.InitialSnapshot.Projection,
 		BaseTree:   state.InitialSnapshot.BaseTree, InitialReviewTree: state.InitialSnapshot.CandidateTree,
 		FinalCandidateTree: state.CurrentSnapshot.CandidateTree, PathsDigest: pathsDigest,
-		FixDeltaHash: state.FixDeltaHash, PolicyHash: state.PolicyHash, EvidenceHash: evidence,
+		CorrectionAddedPaths: append([]string(nil), state.CorrectionAddedPaths...),
+		FixDeltaHash:         state.FixDeltaHash, PolicyHash: state.PolicyHash, EvidenceHash: evidence,
 		EvidenceRecordDigest: state.EvidenceRecordDigest, EvidenceOutcome: state.EvidenceOutcome,
 		EvidenceTargetIdentity: state.EvidenceTargetIdentity, EvidenceAuthorityRevision: state.EvidenceAuthorityRevision,
 		RiskLevel: state.RiskLevel, SelectedLenses: append([]string{}, state.SelectedLenses...),
@@ -1741,6 +1767,13 @@ func (receipt CompactReceipt) Validate() error {
 	ids, err := canonicalStrings(receipt.ResolvedFindingIDs, "resolved finding id")
 	if err != nil || !equalStrings(ids, receipt.ResolvedFindingIDs) {
 		return errors.New("compact receipt resolved finding IDs must be canonical")
+	}
+	if len(receipt.CorrectionAddedPaths) > 0 {
+		added, addedErr := canonicalPaths(receipt.CorrectionAddedPaths)
+		if addedErr != nil || !equalStrings(added, receipt.CorrectionAddedPaths) {
+			// refusal:by-design world-action: an immutably published receipt carrying non-canonical bytes requires storage repair, not an operator command
+			return errors.New("compact receipt correction added paths must be canonical")
+		}
 	}
 	if receipt.TerminalState != TerminalApproved && receipt.TerminalState != TerminalEscalated {
 		return errors.New("compact receipt terminal state is invalid")

--- a/internal/reviewtransaction/compact_correction_added_path_test.go
+++ b/internal/reviewtransaction/compact_correction_added_path_test.go
@@ -454,3 +454,58 @@ func TestCompactCorrectionEscalationRollsBackTheWidenedScope(t *testing.T) {
 		})
 	}
 }
+
+// TestCompactAddedPathDeliversThroughThePrePRGate is the gate-level proof for
+// R3-widened-scope-no-gate-proof. Admitting a companion test path into the
+// bounded correction is only half the feature. Every delivery gate re-proves
+// the delivered paths against the scope the receipt authorizes, so a gate
+// still measuring the frozen reviewed manifest refuses the very file the
+// correction was granted -- the whole point of the change -- at the last step
+// before it ships. The candidate here goes all the way through: correction,
+// independent verification, receipt, published delivery, pre-PR gate.
+func TestCompactAddedPathDeliversThroughThePrePRGate(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-gate", 3)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "internal/widget/widget_windows_test.go", "package widget\n\nimport \"testing\"\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/widget_windows_test.go")
+	if err := state.CompleteCorrection(fix, 3, passingCoverageValidation(state, fix)); err != nil {
+		t.Fatalf("CompleteCorrection: %v", err)
+	}
+	if err := state.CompleteVerification([]byte("go test ./internal/widget/ passes\n"), true); err != nil {
+		t.Fatalf("CompleteVerification: %v", err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCompactFixtureRecord(t, store, state)
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "deliver the corrected candidate")
+	// The delivered set genuinely exceeds the frozen reviewed manifest, so the
+	// allow below can only come from the widened correction scope.
+	delivered := []string{"internal/widget/widget.go", "internal/widget/widget_windows_test.go"}
+	if pathsAreSubset(delivered, state.GenesisPaths) == nil || pathsAreSubset(delivered, state.CorrectionScopePaths()) != nil {
+		t.Fatalf("fixture does not exercise the widened scope: genesis=%v scope=%v", state.GenesisPaths, state.CorrectionScopePaths())
+	}
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/" + branch,
+	})
+	if got.Result != GateAllow {
+		t.Fatalf("pre-PR delivery of a correction that added a companion test = %#v, want allow", got)
+	}
+	if !equalStrings(receipt.CorrectionAddedPaths, []string{"internal/widget/widget_windows_test.go"}) {
+		t.Fatalf("the authorized receipt must disclose the added path, got %v", receipt.CorrectionAddedPaths)
+	}
+}

--- a/internal/reviewtransaction/compact_correction_added_path_test.go
+++ b/internal/reviewtransaction/compact_correction_added_path_test.go
@@ -403,3 +403,54 @@ func TestCompactCorrectionRefusesCompiledSourceInATestDirectory(t *testing.T) {
 		t.Fatalf("a refused correction must not mutate the authority: %q", state.State)
 	}
 }
+
+// TestCompactCorrectionEscalationRollsBackTheWidenedScope is the reproduction
+// of R4-escalated-scope-not-rolled-back. A correction that escalates did not
+// complete, so the companion path it tried to add never earned a place in the
+// scope an approved candidate may deliver. The attempt itself stays on record,
+// and the single-correction rule still binds.
+func TestCompactCorrectionEscalationRollsBackTheWidenedScope(t *testing.T) {
+	requireSnapshotGit(t)
+	for _, tt := range []struct {
+		name    string
+		overrun int
+		passing bool
+	}{
+		{name: "over-budget", overrun: 1, passing: true},
+		{name: "failed-targeted-check", overrun: 0, passing: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			state := coverageCorrectionFixture(t, repo, "coverage-escalated-"+tt.name, 1)
+			writeSnapshotFile(t, repo, "internal/widget/widget_windows_test.go", "package widget\n\nimport \"testing\"\n")
+			fix := buildCoverageFix(t, repo, state, "internal/widget/widget_windows_test.go")
+			validation := passingCoverageValidation(state, fix)
+			actual := 1
+			if tt.overrun > 0 {
+				actual = state.CorrectionBudget + tt.overrun
+			}
+			if !tt.passing {
+				validation.CorrectionRegression.Passed = false
+			}
+			if err := state.CompleteCorrection(fix, actual, validation); err != nil {
+				t.Fatalf("CompleteCorrection: %v", err)
+			}
+			if state.State != StateEscalated {
+				t.Fatalf("state after a failed path-adding correction = %q, want escalated", state.State)
+			}
+			if len(state.CorrectionAddedPaths) != 0 {
+				t.Fatalf("a correction that did not complete kept its widened scope: %v", state.CorrectionAddedPaths)
+			}
+			if !equalStrings(state.CorrectionScopePaths(), state.GenesisPaths) {
+				t.Fatalf("delivery scope after a failed correction = %v, want the frozen reviewed manifest %v",
+					state.CorrectionScopePaths(), state.GenesisPaths)
+			}
+			if err := state.Validate(); err != nil {
+				t.Fatalf("the escalated authority must still be a valid record of its attempt: %v", err)
+			}
+			if len(state.CorrectionAttempts) != 1 || !state.CorrectionAttemptConsumed() {
+				t.Fatalf("a failed path-adding correction must still consume the one attempt: %d attempts", len(state.CorrectionAttempts))
+			}
+		})
+	}
+}

--- a/internal/reviewtransaction/compact_correction_added_path_test.go
+++ b/internal/reviewtransaction/compact_correction_added_path_test.go
@@ -1,0 +1,299 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// coverageCorrectionFixture freezes the exact lineage shape issue #3375
+// reports: a small candidate over one reviewed production file, whose only
+// blocking finding is a CRITICAL saying the changed behaviour has no test
+// able to execute it. The returned state sits in correction_required with a
+// forecast already open, so a caller only has to write the correction and
+// build its fix-diff snapshot.
+func coverageCorrectionFixture(t *testing.T, repo, lineage string, forecast int) CompactState {
+	t.Helper()
+	writeSnapshotFile(t, repo, "internal/widget/widget.go", "package widget\n\nfunc Widget() string {\n\treturn \"posix\"\n}\n")
+	gitSnapshot(t, repo, "add", "--", "internal/widget/widget.go")
+	gitSnapshot(t, repo, "commit", "-m", "widget")
+	// Six changed lines: the issue's small candidate, and the exact shape of
+	// the observed defect (a platform-specific branch nothing can execute).
+	writeSnapshotFile(t, repo, "internal/widget/widget.go",
+		"package widget\n\nimport \"runtime\"\n\nfunc Widget() string {\n\tif runtime.GOOS == \"windows\" {\n\t\treturn \"windows\"\n\t}\n\treturn \"posix\"\n}\n")
+	state := newCompactTestState(t, repo, lineage)
+	if !equalStrings(state.GenesisPaths, []string{"internal/widget/widget.go"}) {
+		t.Fatalf("fixture genesis scope = %v, want the single reviewed production file", state.GenesisPaths)
+	}
+	if len(state.SelectedLenses) == 0 {
+		t.Fatalf("fixture risk %q selected no lens, so it cannot carry a blocking finding", state.RiskLevel)
+	}
+	finding := Finding{
+		ID: "R3-001", Lens: state.SelectedLenses[0], Location: "internal/widget/widget.go:6", Severity: "CRITICAL",
+		Claim:     "the new windows branch has no test able to execute it",
+		ProofRefs: []string{"no test file in internal/widget exercises the windows branch"},
+	}
+	results := make([]LensResult, 0, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		result := LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"inspected the frozen candidate"}}
+		if index == 0 {
+			result.Findings = []Finding{finding}
+		}
+		results = append(results, result)
+	}
+	if err := state.CompleteReview(CompactReviewInput{
+		LensResults: results,
+		Classifications: []FindingEvidence{{
+			FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced,
+			Proof: "the changed hunk introduces the untested branch",
+		}},
+		RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatalf("CompleteReview: %v", err)
+	}
+	if state.State != StateCorrectionRequired {
+		t.Fatalf("fixture state = %q, want correction_required", state.State)
+	}
+	if err := state.BeginCorrection(forecast); err != nil {
+		t.Fatalf("BeginCorrection(%d): %v", forecast, err)
+	}
+	return state
+}
+
+// buildCoverageFix stages the correction's files and freezes the fix-diff
+// snapshot bound to the reviewed candidate.
+func buildCoverageFix(t *testing.T, repo string, state CompactState, paths ...string) Snapshot {
+	t.Helper()
+	gitSnapshot(t, repo, append([]string{"add", "--"}, paths...)...)
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree,
+		IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs,
+	})
+	if err != nil {
+		t.Fatalf("build fix-diff snapshot: %v", err)
+	}
+	return fix
+}
+
+func passingCoverageValidation(state CompactState, fix Snapshot) ScopedValidationResult {
+	fixHash := FixDeltaHashForSnapshot(fix)
+	return bindTargetedValidationForTest(ScopedValidationResult{
+		LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+		OriginalCriteria:     ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: true},
+	}, fix)
+}
+
+// TestCompactCorrectionAdmitsCompanionTestPathForCoverageFinding is the
+// behaviour-first reproduction for issue #3375. The single bounded correction
+// the lifecycle grants must be able to satisfy the most common class of
+// blocking finding: "this behaviour has no test coverage", whose only remedy
+// is a new test file. The correction here stays well inside the frozen line
+// budget and adds exactly one companion test file for the reviewed
+// production path, so it must complete instead of forcing a scope_changed
+// recovery plus a second full review.
+func TestCompactCorrectionAdmitsCompanionTestPathForCoverageFinding(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-correction", 3)
+	budget := state.CorrectionBudget
+	writeSnapshotFile(t, repo, "internal/widget/widget_windows_test.go", "package widget\n\nimport \"testing\"\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/widget_windows_test.go")
+	if equalStrings(fix.Paths, state.GenesisPaths) {
+		t.Fatalf("fixture correction did not add a path: %v", fix.Paths)
+	}
+	actual := 3
+	if actual > budget {
+		t.Fatalf("fixture correction of %d lines does not fit the frozen budget of %d", actual, budget)
+	}
+	if err := state.CompleteCorrection(fix, actual, passingCoverageValidation(state, fix)); err != nil {
+		t.Fatalf("bounded correction adding a companion test file for a coverage finding must complete: %v", err)
+	}
+	if state.State != StateValidating {
+		t.Fatalf("state after admitted correction = %q, want validating", state.State)
+	}
+	if !equalStrings(state.CorrectionAddedPaths, []string{"internal/widget/widget_windows_test.go"}) {
+		t.Fatalf("CorrectionAddedPaths = %v, want the one added companion test path", state.CorrectionAddedPaths)
+	}
+	if !equalStrings(state.GenesisPaths, []string{"internal/widget/widget.go"}) {
+		t.Fatalf("genesis scope must stay frozen, got %v", state.GenesisPaths)
+	}
+	if state.CorrectionBudget != budget || state.CumulativeCorrectionLines != actual {
+		t.Fatalf("budget accounting = %d/%d, want %d/%d", state.CumulativeCorrectionLines, state.CorrectionBudget, actual, budget)
+	}
+	if err := state.Validate(); err != nil {
+		t.Fatalf("validate admitted correction state: %v", err)
+	}
+	// The single-correction rule still holds.
+	if !state.CorrectionAttemptConsumed() {
+		t.Fatal("an admitted path-adding correction must still consume the one correction attempt")
+	}
+	// The authority round-trips through its store byte-stably.
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCompactFixtureRecord(t, store, state)
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(loaded.State.CorrectionAddedPaths, state.CorrectionAddedPaths) {
+		t.Fatalf("persisted CorrectionAddedPaths = %v, want %v", loaded.State.CorrectionAddedPaths, state.CorrectionAddedPaths)
+	}
+}
+
+// TestCompactCorrectionRefusesAddedProductionPath proves the widened scope is
+// not a hole: a correction may not introduce a production source file that no
+// lens ever inspected, even when it fits the budget.
+func TestCompactCorrectionRefusesAddedProductionPath(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-production", 3)
+	writeSnapshotFile(t, repo, "internal/widget/helper.go", "package widget\n\nfunc helper() {}\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/helper.go")
+	before := state
+	err := state.CompleteCorrection(fix, 3, passingCoverageValidation(state, fix))
+	if err == nil || !strings.Contains(err.Error(), "internal/widget/helper.go") {
+		t.Fatalf("CompleteCorrection(added production path) = %v, want a refusal naming the path", err)
+	}
+	if state.State != before.State || len(state.CorrectionAttempts) != 0 || len(state.CorrectionAddedPaths) != 0 {
+		t.Fatalf("a refused correction must not mutate the authority: %q", state.State)
+	}
+}
+
+// TestCompactCorrectionRefusesUnrelatedTestPath proves the addition must be a
+// companion of an already-reviewed path. A test file dropped somewhere else
+// in the tree is not evidence about the reviewed candidate.
+func TestCompactCorrectionRefusesUnrelatedTestPath(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-unrelated", 3)
+	writeSnapshotFile(t, repo, "cmd/other/main_test.go", "package main\n\nimport \"testing\"\n")
+	fix := buildCoverageFix(t, repo, state, "cmd/other/main_test.go")
+	if err := state.CompleteCorrection(fix, 3, passingCoverageValidation(state, fix)); err == nil ||
+		!strings.Contains(err.Error(), "cmd/other/main_test.go") {
+		t.Fatalf("CompleteCorrection(unrelated test path) = %v, want a refusal naming the path", err)
+	}
+}
+
+// TestCompactCorrectionAddedPathStillBindsLineBudget proves the frozen line
+// budget keeps binding an admitted path-adding correction: the added file's
+// lines are correction lines like any other.
+func TestCompactCorrectionAddedPathStillBindsLineBudget(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-budget", 1)
+	budget := state.CorrectionBudget
+	writeSnapshotFile(t, repo, "internal/widget/widget_windows_test.go", "package widget\n\nimport \"testing\"\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/widget_windows_test.go")
+	if err := state.CompleteCorrection(fix, budget+1, passingCoverageValidation(state, fix)); err != nil {
+		t.Fatalf("CompleteCorrection(over budget): %v", err)
+	}
+	if state.State != StateEscalated {
+		t.Fatalf("state after an over-budget path-adding correction = %q, want escalated", state.State)
+	}
+	if !state.CorrectionAttemptConsumed() {
+		t.Fatal("an over-budget path-adding correction must still consume the one correction attempt")
+	}
+	if err := state.BeginCorrection(1); !errors.Is(err, ErrCompactCorrectionConsumed) {
+		t.Fatalf("second correction = %v, want ErrCompactCorrectionConsumed", err)
+	}
+}
+
+// TestCompactCorrectionAddedPathIsDisclosedInReceipt proves an added path that
+// no lens ever saw is disclosed rather than hidden: the terminal receipt names
+// it, and its paths digest covers the delivered scope instead of claiming the
+// narrower reviewed one.
+func TestCompactCorrectionAddedPathIsDisclosedInReceipt(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-receipt", 3)
+	writeSnapshotFile(t, repo, "internal/widget/widget_windows_test.go", "package widget\n\nimport \"testing\"\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/widget_windows_test.go")
+	if err := state.CompleteCorrection(fix, 3, passingCoverageValidation(state, fix)); err != nil {
+		t.Fatalf("CompleteCorrection: %v", err)
+	}
+	if err := state.CompleteVerification([]byte("go test ./internal/widget/ passes\n"), true); err != nil {
+		t.Fatalf("CompleteVerification: %v", err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatalf("Receipt: %v", err)
+	}
+	if !equalStrings(receipt.CorrectionAddedPaths, []string{"internal/widget/widget_windows_test.go"}) {
+		t.Fatalf("receipt CorrectionAddedPaths = %v, want the disclosed added path", receipt.CorrectionAddedPaths)
+	}
+	want := digestPaths([]string{"internal/widget/widget.go", "internal/widget/widget_windows_test.go"})
+	if receipt.PathsDigest != want {
+		t.Fatalf("receipt paths digest = %s, want the delivered union %s", receipt.PathsDigest, want)
+	}
+	if err := receipt.Validate(); err != nil {
+		t.Fatalf("validate disclosing receipt: %v", err)
+	}
+}
+
+// TestCompactStateRejectsForgedCorrectionAddedPaths proves the new field
+// cannot be used to widen an authority's scope without an actual admitted
+// correction.
+func TestCompactStateRejectsForgedCorrectionAddedPaths(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "internal/widget/widget.go", "package widget\n")
+	gitSnapshot(t, repo, "add", "--", "internal/widget/widget.go")
+	state := newCompactTestState(t, repo, "forged-added-paths")
+	if len(state.GenesisPaths) == 0 {
+		t.Fatal("fixture genesis scope is empty")
+	}
+	for _, tt := range []struct {
+		name  string
+		paths []string
+	}{
+		{name: "no correction at all", paths: []string{"tracked_test.txt"}},
+		{name: "path already inside genesis", paths: state.GenesisPaths},
+		{name: "non-canonical", paths: []string{"b_test.go", "a_test.go"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			forged := state
+			forged.CorrectionAddedPaths = tt.paths
+			if err := forged.Validate(); err == nil {
+				t.Fatalf("forged CorrectionAddedPaths %v validated", tt.paths)
+			}
+		})
+	}
+}
+
+// TestCorrectionAddedPathAdmission pins the closed convention table that
+// decides which added paths a bounded correction may carry.
+func TestCorrectionAddedPathAdmission(t *testing.T) {
+	genesis := []string{"internal/widget/widget.go", "src/app/service.ts", "lib/calc.py"}
+	for _, tt := range []struct {
+		path string
+		want bool
+	}{
+		{path: "internal/widget/widget_windows_test.go", want: true},
+		{path: "internal/widget/testdata_test.go", want: true},
+		{path: "internal/widget/tests/widget_test.go", want: true},
+		{path: "internal/tests/widget_test.go", want: true},
+		{path: "src/app/service.spec.ts", want: true},
+		{path: "src/app/__tests__/service.ts", want: true},
+		{path: "lib/test_calc.py", want: true},
+		{path: "lib/CalcTests.cs", want: true},
+		// Not a test file.
+		{path: "internal/widget/helper.go", want: false},
+		{path: "internal/widget/latest.go", want: false},
+		{path: "internal/widget/testable.go", want: false},
+		{path: "internal/widget/protest.go", want: false},
+		{path: "src/app/service.ts", want: false},
+		// A test file, but no reviewed path it could be evidence about.
+		{path: "cmd/other/main_test.go", want: false},
+		{path: "internal/widget/deep/nested/widget_test.go", want: false},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := correctionAddedPathAdmissible(tt.path, genesis); got != tt.want {
+				t.Fatalf("correctionAddedPathAdmissible(%q) = %t, want %t", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reviewtransaction/compact_correction_added_path_test.go
+++ b/internal/reviewtransaction/compact_correction_added_path_test.go
@@ -277,15 +277,26 @@ func TestCorrectionAddedPathAdmission(t *testing.T) {
 		{path: "internal/widget/tests/widget_test.go", want: true},
 		{path: "internal/tests/widget_test.go", want: true},
 		{path: "src/app/service.spec.ts", want: true},
-		{path: "src/app/__tests__/service.ts", want: true},
+		{path: "src/app/service.test.ts", want: true},
 		{path: "lib/test_calc.py", want: true},
-		{path: "lib/CalcTests.cs", want: true},
+		{path: "lib/calc_test.py", want: true},
 		// Not a test file.
 		{path: "internal/widget/helper.go", want: false},
 		{path: "internal/widget/latest.go", want: false},
 		{path: "internal/widget/testable.go", want: false},
 		{path: "internal/widget/protest.go", want: false},
 		{path: "src/app/service.ts", want: false},
+		// Compilable production source the old table admitted: the pytest
+		// prefix on a Go file, and any name at all inside a directory called
+		// tests. Both ship inside the ordinary package.
+		{path: "internal/widget/test_helper.go", want: false},
+		{path: "internal/widget/tests/helper.go", want: false},
+		{path: "internal/tests/helper.go", want: false},
+		{path: "src/app/__tests__/service.ts", want: false},
+		{path: "lib/tests/helper.py", want: false},
+		// An extension whose toolchain this table cannot decide from a path.
+		{path: "lib/CalcTests.cs", want: false},
+		{path: "internal/widget/tests/notes.md", want: false},
 		// A test file, but no reviewed path it could be evidence about.
 		{path: "cmd/other/main_test.go", want: false},
 		{path: "internal/widget/deep/nested/widget_test.go", want: false},
@@ -295,5 +306,100 @@ func TestCorrectionAddedPathAdmission(t *testing.T) {
 				t.Fatalf("correctionAddedPathAdmissible(%q) = %t, want %t", tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestCorrectionTestFileNameIsLanguageAware pins the property the whole guard
+// rests on: a name counts as a test only under the discovery rule of the
+// toolchain that owns that exact extension. A convention borrowed from another
+// ecosystem is how compilable production source got in -- test_helper.go
+// carries pytest's prefix and is compiled into the ordinary Go package, and
+// _test.go is the only spelling the Go toolchain itself excludes.
+func TestCorrectionTestFileNameIsLanguageAware(t *testing.T) {
+	for _, tt := range []struct {
+		base string
+		want bool
+	}{
+		// Go: the compiler keys on the _test.go suffix and nothing else.
+		{base: "widget_test.go", want: true},
+		{base: "test_helper.go", want: false},
+		{base: "TestHelper.go", want: false},
+		{base: "helper_spec.go", want: false},
+		{base: "_test.go", want: false},
+		{base: "widget_Test.go", want: false},
+		// Python: pytest discovers test_*.py and *_test.py.
+		{base: "test_calc.py", want: true},
+		{base: "calc_test.py", want: true},
+		{base: "conftest.py", want: false},
+		{base: "calc.spec.py", want: false},
+		// The JS/TS family: the .test/.spec infix every runner defaults to.
+		{base: "service.test.ts", want: true},
+		{base: "service.spec.tsx", want: true},
+		{base: "service.test.mjs", want: true},
+		{base: "service-test.js", want: false},
+		{base: "service.ts", want: false},
+		// Ruby and Elixir.
+		{base: "calc_test.rb", want: true},
+		{base: "calc_spec.rb", want: true},
+		{base: "calc_test.exs", want: true},
+		{base: "calc_test.ex", want: false},
+		// Extensions this table cannot decide from a name: the suffix says
+		// test, the build system ships the file anyway.
+		{base: "CalcTests.cs", want: false},
+		{base: "WidgetTest.java", want: false},
+		{base: "WidgetTest.kt", want: false},
+		{base: "widget_test.rs", want: false},
+		{base: "widget_test.txt", want: false},
+		{base: "widget_test", want: false},
+	} {
+		t.Run(tt.base, func(t *testing.T) {
+			if got := correctionTestFileName(tt.base); got != tt.want {
+				t.Fatalf("correctionTestFileName(%q) = %t, want %t", tt.base, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCompactCorrectionRefusesGoSourceWithAPytestPrefix is the behaviour-first
+// reproduction of R1-correction-scope-test-prefix. internal/widget/test_helper.go
+// is an ordinary member of package widget: the Go toolchain compiles it into
+// the shipped binary, and only the _test.go SUFFIX excludes a file from that
+// build. Admitting it as a "test file" ships production source no lens
+// inspected inside an approved candidate.
+func TestCompactCorrectionRefusesGoSourceWithAPytestPrefix(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-pytest-prefix", 3)
+	writeSnapshotFile(t, repo, "internal/widget/test_helper.go",
+		"package widget\n\n// Helper ships inside the ordinary package.\nfunc Helper() string {\n\treturn \"shipped\"\n}\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/test_helper.go")
+	before := state
+	err := state.CompleteCorrection(fix, 3, passingCoverageValidation(state, fix))
+	if err == nil || !strings.Contains(err.Error(), "internal/widget/test_helper.go") {
+		t.Fatalf("CompleteCorrection(compiled Go source named test_helper.go) = %v, want a refusal naming the path", err)
+	}
+	if state.State != before.State || len(state.CorrectionAttempts) != 0 || len(state.CorrectionAddedPaths) != 0 {
+		t.Fatalf("a refused correction must not mutate the authority: %q", state.State)
+	}
+}
+
+// TestCompactCorrectionRefusesCompiledSourceInATestDirectory is the
+// behaviour-first reproduction of R1-correction-scope-test-directory. A Go
+// directory named tests is an ordinary compiled package, so the file's own
+// name has to decide; a reserved directory segment may never answer for it.
+func TestCompactCorrectionRefusesCompiledSourceInATestDirectory(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	state := coverageCorrectionFixture(t, repo, "coverage-test-directory", 3)
+	writeSnapshotFile(t, repo, "internal/widget/tests/helper.go",
+		"package tests\n\n// Helper is compiled and importable from production code.\nfunc Helper() string {\n\treturn \"shipped\"\n}\n")
+	fix := buildCoverageFix(t, repo, state, "internal/widget/tests/helper.go")
+	before := state
+	err := state.CompleteCorrection(fix, 3, passingCoverageValidation(state, fix))
+	if err == nil || !strings.Contains(err.Error(), "internal/widget/tests/helper.go") {
+		t.Fatalf("CompleteCorrection(compiled Go source under tests/) = %v, want a refusal naming the path", err)
+	}
+	if state.State != before.State || len(state.CorrectionAttempts) != 0 || len(state.CorrectionAddedPaths) != 0 {
+		t.Fatalf("a refused correction must not mutate the authority: %q", state.State)
 	}
 }

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -94,7 +94,7 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	if compatibility != nil {
 		proofExpected := state.CurrentSnapshot
 		proofExpected.Projection = snapshot.Projection
-		if classifyCompactTargetRelation(proofExpected, snapshot, state.GenesisPaths,
+		if classifyCompactTargetRelation(proofExpected, snapshot, state.CorrectionScopePaths(),
 			compactTargetRelationEvidence{CompatibleAdvance: compatibility}).Kind == compactTargetCompatibleAdvance {
 			assessment.Applicability = CompactGateTargetExact
 			return assessment, nil
@@ -111,7 +111,7 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	squashedFixDelivery := compactSquashedFixDelivery(request.Gate, state, snapshot, resolvedPrePR, state.CurrentSnapshot.CandidateTree)
 	strictBinding := request.Gate == GatePostApply || request.Gate == GatePreCommit ||
 		request.Gate == GatePrePush && state.InitialSnapshot.Kind != TargetCurrentChanges
-	pathsMatch := pathsAreSubset(snapshot.Paths, state.GenesisPaths) == nil
+	pathsMatch := pathsAreSubset(snapshot.Paths, state.CorrectionScopePaths()) == nil
 	baseMatches := snapshot.BaseTree == state.CurrentSnapshot.BaseTree || request.Target.Kind == TargetFixDiff || squashedFixDelivery
 	if strictBinding {
 		pathsMatch = snapshot.PathsDigest == state.CurrentSnapshot.PathsDigest || squashedFixDelivery
@@ -149,7 +149,7 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	// relation algebra compares content/scope inside the selected gate
 	// projection rather than treating the gate's own staged view as unrelated.
 	relationExpected.Projection = snapshot.Projection
-	relation := classifyCompactTargetRelation(relationExpected, snapshot, state.GenesisPaths, compactTargetRelationEvidence{})
+	relation := classifyCompactTargetRelation(relationExpected, snapshot, state.CorrectionScopePaths(), compactTargetRelationEvidence{})
 	if relation.Kind != compactTargetUnsafe {
 		assessment.Applicability = CompactGateTargetScopeChanged
 		return assessment, nil
@@ -161,7 +161,7 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 func compactSquashedFixDelivery(gate GateKind, state CompactState, snapshot Snapshot, refs *resolvedPrePRRefs, finalCandidateTree string) bool {
 	return gate == GatePrePush && state.CurrentSnapshot.Kind == TargetFixDiff && refs != nil && refs.DeliveredCommitCount == 1 &&
 		snapshot.CandidateTree == finalCandidateTree && snapshot.BaseTree == state.InitialSnapshot.BaseTree &&
-		equalStrings(snapshot.Paths, state.GenesisPaths) && snapshot.PathsDigest == digestPaths(state.GenesisPaths)
+		equalStrings(snapshot.Paths, state.CorrectionScopePaths()) && snapshot.PathsDigest == digestPaths(state.CorrectionScopePaths())
 }
 
 func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceipt, input NativeGateRequestInput) NativeGateEvaluation {

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -347,7 +347,11 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	validatePublicationRange := request.Gate == GatePrePush && (record.State.InitialSnapshot.Kind == TargetBaseDiff || bootstrapPublication) ||
 		record.State.InitialSnapshot.Kind == TargetBaseWorkspaceOverlay && (request.Gate == GatePrePush || request.Gate == GatePrePR)
 	if validatePublicationRange && !subsetProof.Allowed {
-		publicationGenesis := record.State.GenesisPaths
+		// "Nothing unreviewed rides along" is stated against the delivered
+		// scope, the same set prepr.go measures the boundary-compatible range
+		// against, so an admitted companion test path is not treated as a
+		// stowaway in the intermediate commits that carry it.
+		publicationGenesis := record.State.CorrectionScopePaths()
 		if record.State.Recovery != nil {
 			if chain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, record.State); chainErr == nil && ok {
 				publicationGenesis = chain.GenesisPaths
@@ -440,7 +444,12 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		boundary := resolvedPrePR.Selection
 		gateContext.PrePRBoundary = &boundary
 	}
-	pathsMismatch := pathsAreSubset(snapshot.Paths, record.State.GenesisPaths) != nil && !compatibleAdvance
+	// The delivered paths are proven against the scope the receipt authorizes,
+	// which is the reviewed manifest plus whatever one admitted correction
+	// added. Measuring the frozen manifest here would refuse the companion test
+	// file the correction was granted -- the exact delivery the widened scope
+	// exists to permit -- at the last step before it ships.
+	pathsMismatch := pathsAreSubset(snapshot.Paths, record.State.CorrectionScopePaths()) != nil && !compatibleAdvance
 	if strictBinding {
 		pathsMismatch = snapshot.PathsDigest != binding.PathsDigest && !squashedFixDelivery && !compatibleAdvance
 	}

--- a/internal/reviewtransaction/compact_gate_discovery_baseline.go
+++ b/internal/reviewtransaction/compact_gate_discovery_baseline.go
@@ -69,5 +69,5 @@ func CompactLeafProvablyUnrelatedToPreCommitBaseline(state CompactState, baselin
 	if current.CandidateTree == baseline.HeadTree || current.CandidateTree == baseline.CandidateTree {
 		return false
 	}
-	return classifyCompactPathSetRelation(state.GenesisPaths, baseline.Paths) == compactPathsDisjoint
+	return classifyCompactPathSetRelation(state.CorrectionScopePaths(), baseline.Paths) == compactPathsDisjoint
 }

--- a/internal/reviewtransaction/correction_scope.go
+++ b/internal/reviewtransaction/correction_scope.go
@@ -34,7 +34,8 @@ import (
 // This file narrows the guard instead of removing it. A correction may add a
 // path only when that path is BOTH:
 //
-//  1. recognized as a test path under the closed convention table below, and
+//  1. named the way the toolchain that owns its extension names a test, under
+//     the closed convention table below, and
 //  2. a companion of an already-reviewed genesis path — living in a reviewed
 //     directory, or in a test directory immediately inside or immediately
 //     beside one.
@@ -47,14 +48,34 @@ import (
 // terminal receipt, so an auditor can always see exactly which delivered
 // paths no lens inspected.
 //
-// The honest limit of rule 1 is that "is a test file" is a naming convention
-// in every ecosystem except Go, where the compiler enforces it. The table is
-// deliberately closed and conservative: an unrecognized name is refused, not
-// guessed at, so the failure mode is the status quo (recovery) rather than an
-// unreviewed file slipping into an approved candidate.
+// Rule 1 answers one question and refuses everything it cannot answer: does
+// the toolchain that owns THIS extension treat THIS name as a test, rather
+// than as source it compiles into the shipped package? Two properties follow,
+// and both are load-bearing:
+//
+//   - A convention is never borrowed across ecosystems. pytest's test_ prefix
+//     says nothing about a Go file: only the _test.go suffix keeps a file out
+//     of the ordinary build, so test_helper.go is production source and is
+//     refused. That refusal is the whole point of the guard.
+//   - A directory name never decides for a file. A Go package under a
+//     directory called tests is compiled and importable exactly like any
+//     other, so an ancestor segment may not answer a question about the file.
+//     The reserved directory names below still describe where a test may
+//     LIVE relative to the code it covers (rule 2), never what a file IS.
+//
+// Where the path alone cannot decide the answer, the extension is absent from
+// the table and the addition is refused. Java, Kotlin, C#, and Rust are the
+// deliberate omissions: their test sources are separated by build
+// configuration (a test source root, a separate project, a cargo target)
+// rather than by a name a path can be checked against, so FooTest.java under
+// src/main/java and widget_test.rs under src/ both compile into the shipped
+// artifact. Refusing them costs a recovery, which is the status quo; admitting
+// them would ship unreviewed production code inside an approved candidate.
 
 // correctionTestDirectoryNames is the closed set of directory names a
-// repository conventionally reserves for tests.
+// repository conventionally reserves for tests. It decides only WHERE an
+// admitted test file may live relative to the reviewed code it covers; it
+// never decides whether a file is a test.
 var correctionTestDirectoryNames = map[string]struct{}{
 	"test": {}, "tests": {}, "__tests__": {}, "spec": {}, "specs": {},
 }
@@ -64,49 +85,73 @@ func correctionTestDirectoryName(segment string) bool {
 	return ok
 }
 
-// correctionTestFileName reports whether one base name is a test file under
-// the closed convention table.
+// correctionTestFileConvention is one extension's discovery rule: the stem
+// prefixes and suffixes the toolchain that owns that extension uses to tell a
+// test apart from source it builds into the shipped package.
+type correctionTestFileConvention struct {
+	prefixes []string
+	suffixes []string
+}
+
+// correctionJavaScriptTestConvention is shared by every extension the JS/TS
+// runners treat alike.
+var correctionJavaScriptTestConvention = correctionTestFileConvention{suffixes: []string{".test", ".spec"}}
+
+// correctionTestFileConventions is the closed table. Matching is
+// case-sensitive and extension-exact because every toolchain here matches that
+// way: the go tool ignores a file called widget_Test.go as a test and a file
+// called widget.GO as Go source at all, so anything looser would admit names
+// the toolchain does not.
+var correctionTestFileConventions = map[string]correctionTestFileConvention{
+	// Go: the compiler itself excludes _test.go from the ordinary build. This
+	// is the only entry in the table that is enforced rather than conventional.
+	".go": {suffixes: []string{"_test"}},
+	// Python: pytest's default python_files, test_*.py and *_test.py.
+	".py": {prefixes: []string{"test_"}, suffixes: []string{"_test"}},
+	// Ruby: minitest's test/*_test.rb and RSpec's spec/*_spec.rb.
+	".rb": {suffixes: []string{"_test", "_spec"}},
+	// Elixir: mix test loads *_test.exs, and .exs is never compiled into a
+	// release the way .ex is.
+	".exs": {suffixes: []string{"_test"}},
+	// The JS/TS family: the .test/.spec infix in the default Jest and Vitest
+	// patterns. A -test or -spec dash is deliberately absent: no default
+	// configuration collects it, so those files are bundled as ordinary
+	// modules.
+	".js":  correctionJavaScriptTestConvention,
+	".jsx": correctionJavaScriptTestConvention,
+	".mjs": correctionJavaScriptTestConvention,
+	".cjs": correctionJavaScriptTestConvention,
+	".ts":  correctionJavaScriptTestConvention,
+	".tsx": correctionJavaScriptTestConvention,
+	".mts": correctionJavaScriptTestConvention,
+	".cts": correctionJavaScriptTestConvention,
+}
+
+// correctionTestFileName reports whether one base name is a test file to the
+// toolchain that owns its extension. An unrecognized extension is refused
+// rather than guessed at, so the failure mode is the status quo (recovery)
+// rather than an unreviewed file slipping into an approved candidate.
 func correctionTestFileName(base string) bool {
-	stem := strings.TrimSuffix(base, path.Ext(base))
-	if stem == "" {
+	extension := path.Ext(base)
+	convention, recognized := correctionTestFileConventions[extension]
+	if !recognized {
 		return false
 	}
-	lower := strings.ToLower(stem)
-	// pytest and unittest: test_calc.py.
-	if strings.HasPrefix(lower, "test_") {
-		return true
-	}
-	// Go, Rust, Ruby, Elixir, and the JS/TS family: widget_test.go,
-	// calc_spec.rb, service.test.ts, service.spec.ts, service-test.js.
-	for _, marker := range []string{"_test", "_spec", ".test", ".spec", "-test", "-spec"} {
-		if strings.HasSuffix(lower, marker) {
+	// A stem no longer than the marker it matches is that marker and nothing
+	// else: _test.go names no unit under test, and the go tool ignores a
+	// leading underscore outright.
+	stem := strings.TrimSuffix(base, extension)
+	for _, prefix := range convention.prefixes {
+		if len(stem) > len(prefix) && strings.HasPrefix(stem, prefix) {
 			return true
 		}
 	}
-	// .NET, Java, and Kotlin: CalcTests.cs, WidgetTest.java. The capital T is
-	// load-bearing rather than incidental: it is the CamelCase word boundary
-	// that separates a real suffix from an ordinary word merely ending in the
-	// same letters, so "latest.go" and "protest.go" stay production files.
-	for _, marker := range []string{"Test", "Tests"} {
-		if strings.HasSuffix(stem, marker) && len(stem) > len(marker) {
+	for _, suffix := range convention.suffixes {
+		if len(stem) > len(suffix) && strings.HasSuffix(stem, suffix) {
 			return true
 		}
 	}
 	return false
-}
-
-// correctionTestPath reports whether a repository-relative path is a test
-// path, either by its own name or by living under a recognized test
-// directory.
-func correctionTestPath(candidate string) bool {
-	if directory := path.Dir(candidate); directory != "." {
-		for _, segment := range strings.Split(directory, "/") {
-			if correctionTestDirectoryName(segment) {
-				return true
-			}
-		}
-	}
-	return correctionTestFileName(path.Base(candidate))
 }
 
 // correctionCompanionDirectory reports whether a test living in addedDir is
@@ -128,7 +173,7 @@ func correctionCompanionDirectory(addedDir, genesisDir string) bool {
 // correctionAddedPathAdmissible reports whether one path a correction adds
 // beyond the frozen genesis scope may enter the reviewed candidate.
 func correctionAddedPathAdmissible(added string, genesis []string) bool {
-	if !correctionTestPath(added) {
+	if !correctionTestFileName(path.Base(added)) {
 		return false
 	}
 	directory := path.Dir(added)

--- a/internal/reviewtransaction/correction_scope.go
+++ b/internal/reviewtransaction/correction_scope.go
@@ -1,0 +1,233 @@
+package reviewtransaction
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// Correction scope admission (issue #3375).
+//
+// A bounded correction used to be confined to the frozen genesis manifest:
+// every path it touched had to already be one the lenses reviewed. That rule
+// is not arbitrary. It is what keeps three separate invariants true at once:
+//
+//   - Reviewers only ever inspected the genesis paths, so a path outside them
+//     entered the approved candidate having been judged by nobody. The same
+//     principle already demotes an out-of-genesis severe finding to
+//     CausalUnknown (findingLocationInGenesis, compact.go).
+//   - The receipt's PathsDigest is derived from that manifest, and every
+//     delivery gate re-proves the delivered paths against it. A path that
+//     entered behind the manifest's back would either be refused at delivery
+//     or, worse, ride along inside a receipt that never named it.
+//   - The pre-PR publication range check ("nothing unreviewed rides along in
+//     intermediate commits", prepr.go) is stated in the same terms.
+//
+// So the guard cannot simply be deleted. But it also made the single bounded
+// correction structurally unable to satisfy the single most common blocking
+// finding a reviewer produces: "this behaviour has no test able to execute
+// it". The only remedy for that finding is a new test file, a new path, and
+// therefore a scope_changed recovery plus a second full review — a cascade
+// caused by the rule rather than by the code.
+//
+// This file narrows the guard instead of removing it. A correction may add a
+// path only when that path is BOTH:
+//
+//  1. recognized as a test path under the closed convention table below, and
+//  2. a companion of an already-reviewed genesis path — living in a reviewed
+//     directory, or in a test directory immediately inside or immediately
+//     beside one.
+//
+// Everything else keeps today's exact behaviour and still requires recovery.
+// The line budget is untouched: an added file's lines are correction lines
+// like any other, so the blast radius stays bounded by the same number. The
+// single-correction rule is untouched. And an added path is never silent: it
+// is persisted on the authority as CorrectionAddedPaths and disclosed on the
+// terminal receipt, so an auditor can always see exactly which delivered
+// paths no lens inspected.
+//
+// The honest limit of rule 1 is that "is a test file" is a naming convention
+// in every ecosystem except Go, where the compiler enforces it. The table is
+// deliberately closed and conservative: an unrecognized name is refused, not
+// guessed at, so the failure mode is the status quo (recovery) rather than an
+// unreviewed file slipping into an approved candidate.
+
+// correctionTestDirectoryNames is the closed set of directory names a
+// repository conventionally reserves for tests.
+var correctionTestDirectoryNames = map[string]struct{}{
+	"test": {}, "tests": {}, "__tests__": {}, "spec": {}, "specs": {},
+}
+
+func correctionTestDirectoryName(segment string) bool {
+	_, ok := correctionTestDirectoryNames[strings.ToLower(segment)]
+	return ok
+}
+
+// correctionTestFileName reports whether one base name is a test file under
+// the closed convention table.
+func correctionTestFileName(base string) bool {
+	stem := strings.TrimSuffix(base, path.Ext(base))
+	if stem == "" {
+		return false
+	}
+	lower := strings.ToLower(stem)
+	// pytest and unittest: test_calc.py.
+	if strings.HasPrefix(lower, "test_") {
+		return true
+	}
+	// Go, Rust, Ruby, Elixir, and the JS/TS family: widget_test.go,
+	// calc_spec.rb, service.test.ts, service.spec.ts, service-test.js.
+	for _, marker := range []string{"_test", "_spec", ".test", ".spec", "-test", "-spec"} {
+		if strings.HasSuffix(lower, marker) {
+			return true
+		}
+	}
+	// .NET, Java, and Kotlin: CalcTests.cs, WidgetTest.java. The capital T is
+	// load-bearing rather than incidental: it is the CamelCase word boundary
+	// that separates a real suffix from an ordinary word merely ending in the
+	// same letters, so "latest.go" and "protest.go" stay production files.
+	for _, marker := range []string{"Test", "Tests"} {
+		if strings.HasSuffix(stem, marker) && len(stem) > len(marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// correctionTestPath reports whether a repository-relative path is a test
+// path, either by its own name or by living under a recognized test
+// directory.
+func correctionTestPath(candidate string) bool {
+	if directory := path.Dir(candidate); directory != "." {
+		for _, segment := range strings.Split(directory, "/") {
+			if correctionTestDirectoryName(segment) {
+				return true
+			}
+		}
+	}
+	return correctionTestFileName(path.Base(candidate))
+}
+
+// correctionCompanionDirectory reports whether a test living in addedDir is
+// plausibly evidence about a reviewed file in genesisDir. The three accepted
+// shapes are the ones every mainstream layout uses: the same directory
+// (Go, JS/TS co-located), a test directory immediately inside the reviewed
+// one, and a test directory immediately beside it.
+func correctionCompanionDirectory(addedDir, genesisDir string) bool {
+	if addedDir == genesisDir {
+		return true
+	}
+	if !correctionTestDirectoryName(path.Base(addedDir)) {
+		return false
+	}
+	parent := path.Dir(addedDir)
+	return parent == genesisDir || parent == path.Dir(genesisDir)
+}
+
+// correctionAddedPathAdmissible reports whether one path a correction adds
+// beyond the frozen genesis scope may enter the reviewed candidate.
+func correctionAddedPathAdmissible(added string, genesis []string) bool {
+	if !correctionTestPath(added) {
+		return false
+	}
+	directory := path.Dir(added)
+	for _, reviewed := range genesis {
+		if correctionCompanionDirectory(directory, path.Dir(reviewed)) {
+			return true
+		}
+	}
+	return false
+}
+
+// admitCorrectionScope returns the canonical paths a correction adds beyond
+// the frozen genesis scope. It answers nil for a correction that stays inside
+// genesis — byte-for-byte the pathsAreSubset outcome that preceded it — and
+// refuses, naming the exact path, as soon as one addition is inadmissible.
+func admitCorrectionScope(paths, genesis []string) ([]string, error) {
+	canonicalCandidate, err := canonicalPaths(paths)
+	if err != nil || !equalStrings(canonicalCandidate, paths) {
+		// refusal:by-design world-action: a non-canonical snapshot path set is derived by native Git, so its repair belongs to code or storage, not to an operator command
+		return nil, errors.New("snapshot paths must be canonical")
+	}
+	canonicalGenesis, err := canonicalPaths(genesis)
+	if err != nil || !equalStrings(canonicalGenesis, genesis) {
+		// refusal:by-design world-action: the frozen genesis manifest is persisted authority, so a non-canonical one requires code or storage repair
+		return nil, errors.New("genesis snapshot paths must be canonical")
+	}
+	reviewed := make(map[string]struct{}, len(genesis))
+	for _, item := range genesis {
+		reviewed[item] = struct{}{}
+	}
+	var added []string
+	for _, item := range paths {
+		if _, ok := reviewed[item]; ok {
+			continue
+		}
+		if !correctionAddedPathAdmissible(item, genesis) {
+			// refusal:by-design operator-knowledge: only the human writing the correction can decide whether to keep it inside the reviewed manifest or take the recovery route, and no command can make that choice for them
+			return nil, fmt.Errorf("correction path %q is outside immutable genesis scope", item)
+		}
+		added = append(added, item)
+	}
+	return added, nil
+}
+
+// correctionScopeRefused is the boolean spelling of admitCorrectionScope, for
+// the composite conditions that only need to know whether the paths were
+// refused.
+func correctionScopeRefused(paths, genesis []string) bool {
+	_, err := admitCorrectionScope(paths, genesis)
+	return err != nil
+}
+
+// CorrectionScopePaths is the path set an approved candidate may actually
+// deliver: the frozen genesis manifest plus any companion test paths one
+// admitted bounded correction added. It is identical to GenesisPaths for
+// every authority that never added one, which is every authority written
+// before issue #3375 and every correction that stays inside the manifest.
+//
+// Genesis itself is never widened. GenesisPaths remains exactly what the
+// lenses inspected, because that is what finding causality is judged against.
+func (state CompactState) CorrectionScopePaths() []string {
+	if len(state.CorrectionAddedPaths) == 0 {
+		return state.GenesisPaths
+	}
+	scope, err := canonicalPaths(append(append([]string(nil), state.GenesisPaths...), state.CorrectionAddedPaths...))
+	if err != nil {
+		// Fail closed: an authority whose persisted scope cannot be
+		// canonicalized delivers under the narrower reviewed manifest.
+		return state.GenesisPaths
+	}
+	return scope
+}
+
+// validateCompactCorrectionAddedPaths keeps the widened scope from becoming a
+// forgery surface: the field is meaningful only alongside a real completed
+// correction, may never restate a genesis path, and every entry must still
+// satisfy the same admission the correction had to pass.
+func validateCompactCorrectionAddedPaths(state CompactState) error {
+	if len(state.CorrectionAddedPaths) == 0 {
+		return nil
+	}
+	canonical, err := canonicalPaths(state.CorrectionAddedPaths)
+	if err != nil || !equalStrings(canonical, state.CorrectionAddedPaths) {
+		// refusal:by-design world-action: persisted authority that cannot be canonicalized requires code or storage repair
+		return errors.New("compact correction added paths must be canonical")
+	}
+	if len(state.CorrectionAttempts) == 0 && state.ActualCorrectionLines == nil {
+		// refusal:by-design world-action: a widened scope with no correction behind it is contradictory persisted authority and cannot be repaired by an operator command
+		return errors.New("compact correction added paths require a completed correction")
+	}
+	for _, added := range state.CorrectionAddedPaths {
+		if stringIndex(state.GenesisPaths, added) >= 0 {
+			// refusal:by-design world-action: an added path restating the frozen manifest is contradictory persisted authority and requires code or storage repair
+			return fmt.Errorf("compact correction added path %q is already inside the frozen genesis scope", added)
+		}
+		if !correctionAddedPathAdmissible(added, state.GenesisPaths) {
+			// refusal:by-design world-action: persisted authority claiming a scope this contract never admits cannot be repaired by an operator command
+			return fmt.Errorf("compact correction added path %q is not an admissible companion test path", added)
+		}
+	}
+	return nil
+}

--- a/internal/reviewtransaction/correction_scope.go
+++ b/internal/reviewtransaction/correction_scope.go
@@ -247,6 +247,47 @@ func (state CompactState) CorrectionScopePaths() []string {
 	return scope
 }
 
+// compactCorrectionCandidateScope is the path set a persisted authority may
+// legitimately describe: the delivery scope, plus whatever an on-record
+// correction attempt actually added.
+//
+// The two differ for exactly one shape, and it is why this exists. A
+// correction that escalated — over budget, or with a failed targeted check —
+// consumed the single attempt and is recorded together with the snapshot it
+// produced, while its widened delivery scope was rolled back. The authority
+// still has to be a valid record of that attempt, so every addition an attempt
+// carries is re-checked here against the exact admission the correction itself
+// had to pass. Nothing enters this set that the correction could not have
+// added, and nothing in it widens what may be delivered.
+func compactCorrectionCandidateScope(state CompactState) ([]string, error) {
+	scope := state.CorrectionScopePaths()
+	if len(state.CorrectionAttempts) == 0 {
+		return scope, nil
+	}
+	known := make(map[string]struct{}, len(scope))
+	for _, item := range scope {
+		known[item] = struct{}{}
+	}
+	var additions []string
+	for _, attempt := range state.CorrectionAttempts {
+		added, err := admitCorrectionScope(attempt.Snapshot.Paths, state.GenesisPaths)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range added {
+			if _, ok := known[item]; ok {
+				continue
+			}
+			known[item] = struct{}{}
+			additions = append(additions, item)
+		}
+	}
+	if len(additions) == 0 {
+		return scope, nil
+	}
+	return canonicalPaths(append(append([]string(nil), scope...), additions...))
+}
+
 // validateCompactCorrectionAddedPaths keeps the widened scope from becoming a
 // forgery surface: the field is meaningful only alongside a real completed
 // correction, may never restate a genesis path, and every entry must still

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -295,7 +295,7 @@ func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string,
 	if refs.DeliveredCommitCount != 1 {
 		return BaseAdvanceCompatibility{}, errors.New("boundary reconciliation requires exactly one delivery commit")
 	}
-	if len(state.GenesisPaths) == 0 {
+	if len(state.CorrectionScopePaths()) == 0 {
 		return BaseAdvanceCompatibility{}, errors.New("an empty reviewed scope cannot authorize a publication")
 	}
 	frozenBaseTree := state.InitialSnapshot.BaseTree
@@ -315,7 +315,7 @@ func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string,
 	if err != nil {
 		return BaseAdvanceCompatibility{}, err
 	}
-	if len(deliveredPaths) == 0 || pathsAreSubset(deliveredPaths, state.GenesisPaths) != nil {
+	if len(deliveredPaths) == 0 || pathsAreSubset(deliveredPaths, state.CorrectionScopePaths()) != nil {
 		return BaseAdvanceCompatibility{}, errors.New("delivered paths do not stay inside the reviewed genesis scope")
 	}
 	patch, err := patchIdentity(ctx, repo, frozenBaseTree, snapshot.CandidateTree)
@@ -329,7 +329,7 @@ func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string,
 	if !disjointPaths(deliveredPaths, basePaths) {
 		return BaseAdvanceCompatibility{}, errors.New("boundary advance overlaps delivered paths")
 	}
-	if err := validateReviewedPublicationRange(ctx, repo, state.GenesisPaths, refs); err != nil {
+	if err := validateReviewedPublicationRange(ctx, repo, state.CorrectionScopePaths(), refs); err != nil {
 		return BaseAdvanceCompatibility{}, err
 	}
 	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -491,6 +491,17 @@ type cloneLocalRDDModeMirror struct {
 	readErr   error
 }
 
+// cloneLocalRDDModeMirrorSlotScan reads the mirror's published slot numbers.
+//
+// It is a variable for the same reason rarPrivateDirectoryMkdir is: the
+// failure it has to survive cannot be produced by a test on ext4 or tmpfs. A
+// directory that fails the owner-only no-follow walk never becomes a mirror at
+// all, so the only way to reach an unreadable head is a directory that
+// validates and then refuses readdir(2) -- a permission change racing the
+// walk, EIO, or ESTALE on a network mount. Production always uses the real
+// scan.
+var cloneLocalRDDModeMirrorSlotScan = cloneLocalRDDOverrideHeadGeneration
+
 func openCloneLocalRDDModeMirror(ctx context.Context, repo string) *cloneLocalRDDModeMirror {
 	mirror := &cloneLocalRDDModeMirror{}
 	// An unreachable location is not an error here. It is reported as reach,
@@ -509,9 +520,26 @@ func openCloneLocalRDDModeMirror(ctx context.Context, repo string) *cloneLocalRD
 	// The slot scan is kept separate from the record read: an unparseable head
 	// still occupies its slot, and the successor that supersedes it has to
 	// clear that slot rather than collide with it.
-	head, headErr := cloneLocalRDDOverrideHeadGeneration(dir)
+	head, headErr := cloneLocalRDDModeMirrorSlotScan(dir)
 	if headErr != nil {
-		mirror.readErr = headErr
+		// A location whose slots cannot be enumerated has an UNKNOWN head, not
+		// an empty one, and the difference is the whole switch. Leaving it
+		// available with head zero published this build's next slot number
+		// into it: below the record a pre-relocation gentle-ai actually reads,
+		// invisible to the only reader it was written for, and reported as
+		// machine-wide reach -- #3284 with a success message on it.
+		//
+		// So it joins the location that cannot be opened at all. Not reached
+		// is the honest answer, the write still applies here, the operator is
+		// told reach=this_build, and nothing is published into a layout this
+		// build could not read. The lock stays held and released for the rest
+		// of this write, because the location itself is real.
+		//
+		// The scan error is dropped rather than carried, exactly like the two
+		// opens above: readErr is the record's own problem, consulted only
+		// while this location is still writable, and an unavailable mirror is
+		// never written to or asked what it decides.
+		mirror.available = false
 		return mirror
 	}
 	mirror.head = head

--- a/internal/reviewtransaction/rdd_mode.go
+++ b/internal/reviewtransaction/rdd_mode.go
@@ -69,6 +69,12 @@ var (
 	// ErrRDDConsentCorrupt reports an unreadable one-shot consent latch.
 	ErrRDDConsentCorrupt = errors.New("clone-local review consent latch is corrupt")
 
+	// ErrRDDModePartiallyApplied reports a clone-scope decision this build
+	// recorded but could not publish at the readable location a coexisting
+	// gentle-ai reads. It is the opposite of a fallback: it exists so a
+	// half-applied kill switch can never be reported as a working one.
+	ErrRDDModePartiallyApplied = errors.New("clone-local review mode was not applied for every gentle-ai on this machine")
+
 	// rddConsentPayload is the exact latch content. It deliberately carries no
 	// timestamp: identical bytes keep the immutable no-replace publish idempotent,
 	// so recording the same answer twice can never raise a slot conflict.
@@ -147,6 +153,33 @@ type RDDGlobalMode struct {
 	RecordedAt time.Time
 }
 
+// RDDModeReach reports how far a clone-scope write actually reached.
+//
+// The kill switch is a decision about this machine, not about one build, and
+// #3284 is what happens when a write reports plain success for less than that:
+// a modern binary published the decision only under the relocated switch root,
+// every gentle-ai installed before that relocation kept reading its own
+// location, and those builds went on enforcing review while the operator had
+// been told the switch was off.
+type RDDModeReach string
+
+const (
+	// RDDModeReachUnreported is the read-only projection's answer. Resolving a
+	// mode never writes and never probes the other location, so it asserts
+	// nothing about reach instead of guessing.
+	RDDModeReachUnreported RDDModeReach = ""
+	// RDDModeReachMachine means every gentle-ai installed on this machine
+	// observes the decision.
+	RDDModeReachMachine RDDModeReach = "machine"
+	// RDDModeReachThisBuild means only builds that read the relocated switch
+	// root observe it, because the pre-relocation location could not be
+	// reached. A gentle-ai installed before the relocation keeps reading the
+	// value it already has there -- which is also the value it fails closed to
+	// when that location is unreadable, so nothing is relaxed and nothing is
+	// silently claimed.
+	RDDModeReachThisBuild RDDModeReach = "this_build"
+)
+
 // RDDModeStatus is the read-only projection of both sources. Revision is the
 // clone-local compare-and-set token. The projection carries no time cutoff: it
 // answers "may review start now", never "which bytes are approved".
@@ -157,6 +190,7 @@ type RDDModeStatus struct {
 	Effective  RDDMode       `json:"effective"`
 	Source     RDDModeSource `json:"source"`
 	Revision   string        `json:"revision,omitempty"`
+	Reach      RDDModeReach  `json:"reach,omitempty"`
 }
 
 // Enabled reports whether new receipt-driven development may start.
@@ -222,6 +256,41 @@ func reviewModeScopeForSource(source RDDModeSource) string {
 
 func (err *RDDDisabledError) Unwrap() error { return ErrRDDDisabled }
 
+// RDDModePartialApplyError reports a clone-scope write that applied for this
+// build and did not apply at the readable pre-relocation location, so two
+// gentle-ai installations on this machine now disagree about whether reviews
+// run. It is raised only when that location was reachable and its publish
+// failed: an unreachable one is reported as reach instead, because refusing
+// there would re-close the exit #2882 opened.
+//
+// It deliberately does not unwrap to its cause. A caller that classified this
+// by the cause would report the other location's local problem and lose the
+// one fact the operator has to act on. The sentinel is enough to recognise it.
+type RDDModePartialApplyError struct {
+	Mode  RDDMode
+	Cause error
+}
+
+func (err *RDDModePartialApplyError) Error() string {
+	decision, verb := "no longer disables", "enable"
+	if err.Mode == RDDModeOff {
+		decision, verb = "disables", "disable"
+	}
+	return fmt.Sprintf(
+		"%v: this clone %s receipt-driven development for this gentle-ai, but publishing the same decision under gentle-ai/%s/%s/%s/%s failed, so a gentle-ai installed before the switch moved still reads the value it already has there and keeps enforcing it: %v; rerun `gentle-ai review mode %s --scope clone` to publish it in both places",
+		ErrRDDModePartiallyApplied,
+		decision,
+		rddModeLegacySwitchDirectory,
+		rarAuthorityDirectory,
+		rarAuthorityVersion,
+		rddModeDirectory,
+		err.Cause,
+		verb,
+	)
+}
+
+func (err *RDDModePartialApplyError) Unwrap() error { return ErrRDDModePartiallyApplied }
+
 // ResolveRDDMode combines the global user mode with this clone's off-only
 // override. Any off wins, a repository can never force on, and every failure
 // projects a disabled status so a caller that drops the error still fails safe.
@@ -272,8 +341,16 @@ func SetCloneLocalRDDMode(
 		// global source remains off, so refuse without publishing a generation.
 		return currentStatus, &RDDDisabledError{Operation: RDDOperationStart, Source: RDDModeSourceGlobal}
 	}
-	if currentErr == nil && ((mode == RDDModeOff && currentStatus.CloneLocal == RDDModeOff) ||
-		(mode == RDDModeUnset && currentStatus.CloneLocal == RDDModeUnset)) {
+	// A request that matches the mode this clone already carries publishes no
+	// new generation of its own -- but it is not finished until every gentle-ai
+	// on this machine carries it too, so it goes on to the mirror below rather
+	// than returning here.
+	alreadyDecided := currentErr == nil && ((mode == RDDModeOff && currentStatus.CloneLocal == RDDModeOff) ||
+		(mode == RDDModeUnset && currentStatus.CloneLocal == RDDModeUnset))
+	if alreadyDecided && currentStatus.Revision == "" {
+		// This clone holds no override in either location and is not being asked
+		// for one. There is no decision to record and none to mirror, so this
+		// stays the one path that creates nothing at all.
 		return currentStatus, nil
 	}
 	if currentErr != nil && !errors.Is(currentErr, ErrRDDModeCorrupt) {
@@ -288,6 +365,14 @@ func SetCloneLocalRDDMode(
 		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
 	}
 	defer func() { _ = lock.release() }()
+
+	// Every clone-scope write also publishes into the pre-relocation location,
+	// because that is where the other gentle-ai installations on this machine
+	// read the switch. Writers from before the relocation lock that path;
+	// taking this build's root first and that one second serialises either
+	// version of gentle-ai without a lock-order cycle.
+	mirror := openCloneLocalRDDModeMirror(ctx, repo)
+	defer mirror.release()
 
 	head, present, err := readCloneLocalRDDOverrideHead(dir)
 	repairingCurrentHead := false
@@ -312,26 +397,15 @@ func SetCloneLocalRDDMode(
 		head, present = rddModeOverrideRecord{Generation: generation}, false
 		repairingCurrentHead = true
 	}
-	if !present && !repairingCurrentHead {
+	if !present && !repairingCurrentHead && mirror.available {
 		// Legacy records are immutable forensic evidence. A valid one may advance
 		// only by publishing its successor in the switch-owned authority root;
 		// a damaged legacy record must never be shadowed by a fresh root.
-		legacy, legacyErr := cloneLocalRDDModeLegacyRoot(ctx, repo)
-		if legacyErr == nil {
-			// Writers before the relocation lock this path. Taking current then
-			// legacy serializes either version without a lock-order cycle.
-			legacyLock, lockErr := acquireRARAuthorityLock(ctx, filepath.Join(legacy, rddModeLockName))
-			if lockErr != nil {
-				return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), lockErr
-			}
-			defer func() { _ = legacyLock.release() }()
-			legacyHead, legacyPresent, legacyHeadErr := readCloneLocalRDDOverrideHead(legacy)
-			if legacyHeadErr != nil {
-				return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), legacyHeadErr
-			}
-			if legacyPresent {
-				head, present = legacyHead, true
-			}
+		if mirror.readErr != nil {
+			return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), mirror.readErr
+		}
+		if mirror.present {
+			head, present = mirror.record, true
 		}
 	}
 	current := ""
@@ -342,13 +416,28 @@ func SetCloneLocalRDDMode(
 		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), fmt.Errorf(
 			"%w: expected %q but the clone-local head is %q", ErrRDDModeRevisionMismatch, expectedRevision, current)
 	}
-	if head.Generation >= rddModeMaxGeneration {
+	if alreadyDecided && (!mirror.available || mirror.decides(persisted)) {
+		// Both readable locations already carry this decision, or the other one
+		// cannot be reached at all and no write would change what it reports.
+		// Publishing another generation would move the compare-and-set token
+		// for nothing.
+		return rddModeWriteStatus(globalMode, head, present, mirror.reach()), nil
+	}
+	// The generation is a slot number in both locations, so it clears whichever
+	// of them has published further. A pre-relocation gentle-ai that wrote its
+	// own generations must not have one of them overwritten, and this build's
+	// own head must still advance.
+	generation := head.Generation + 1
+	if mirror.available && mirror.head >= generation {
+		generation = mirror.head + 1
+	}
+	if generation > rddModeMaxGeneration {
 		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), errors.New("clone-local review mode generation space is exhausted")
 	}
 
 	record := rddModeOverrideRecord{
 		Schema:           rddModeOverrideSchema,
-		Generation:       head.Generation + 1,
+		Generation:       generation,
 		PreviousRevision: current,
 		Mode:             persisted,
 		RecordedAt:       time.Now().UTC().Format(time.RFC3339Nano),
@@ -363,10 +452,98 @@ func SetCloneLocalRDDMode(
 	// The immutable no-replace publish is the fail-closed backstop: a writer
 	// that somehow bypassed the lock still cannot overwrite a published
 	// generation, so a lost race can never corrupt the head record.
+	//
+	// This build's own root is published first and never waits on the other
+	// location's health. #2882 is exactly what happens when the switch can be
+	// held hostage by the review authority tree, and ordering the mirror ahead
+	// of it would reintroduce that through the back door.
 	if err := publishPrivateRARImmutable(filepath.Join(dir, rddModeGenerationName(record.Generation)), payload); err != nil {
 		return failedClosedRDDModeStatus(RDDModeSourceCloneLocal), err
 	}
-	return rddModeStatus(globalMode, record, true), nil
+	if !mirror.available {
+		return rddModeWriteStatus(globalMode, record, true, RDDModeReachThisBuild), nil
+	}
+	// The same exact bytes at the same slot: a pre-relocation gentle-ai parses,
+	// digests, and canonicalises this record identically, so the two locations
+	// hold one decision rather than two that have to be reconciled.
+	if err := publishPrivateRARImmutable(filepath.Join(mirror.dir, rddModeGenerationName(record.Generation)), payload); err != nil {
+		return rddModeWriteStatus(globalMode, record, true, RDDModeReachThisBuild),
+			&RDDModePartialApplyError{Mode: mode, Cause: err}
+	}
+	return rddModeWriteStatus(globalMode, record, true, RDDModeReachMachine), nil
+}
+
+// cloneLocalRDDModeMirror is the pre-relocation copy of this clone's override,
+// held open under its own lock for the duration of one write.
+//
+// It is deliberately best-effort about reachability and strict about writing.
+// A location this build cannot open is also a location a pre-relocation
+// gentle-ai fails closed on, so refusing there would only re-close the exit
+// #2882 opened; a location that opens and then refuses the publish is a real
+// half-applied switch and is reported as one.
+type cloneLocalRDDModeMirror struct {
+	dir       string
+	lock      *storeLock
+	available bool
+	head      int
+	record    rddModeOverrideRecord
+	present   bool
+	readErr   error
+}
+
+func openCloneLocalRDDModeMirror(ctx context.Context, repo string) *cloneLocalRDDModeMirror {
+	mirror := &cloneLocalRDDModeMirror{}
+	// An unreachable location is not an error here. It is reported as reach,
+	// because a location this build cannot open is one a pre-relocation
+	// gentle-ai cannot read either, and refusing over it would re-close the
+	// clone-scoped exit #2882 opened.
+	dir, err := cloneLocalRDDModeLegacyRoot(ctx, repo, true)
+	if err != nil {
+		return mirror
+	}
+	lock, err := acquireRARAuthorityLock(ctx, filepath.Join(dir, rddModeLockName))
+	if err != nil {
+		return mirror
+	}
+	mirror.dir, mirror.lock, mirror.available = dir, lock, true
+	// The slot scan is kept separate from the record read: an unparseable head
+	// still occupies its slot, and the successor that supersedes it has to
+	// clear that slot rather than collide with it.
+	head, headErr := cloneLocalRDDOverrideHeadGeneration(dir)
+	if headErr != nil {
+		mirror.readErr = headErr
+		return mirror
+	}
+	mirror.head = head
+	mirror.record, mirror.present, mirror.readErr = readCloneLocalRDDOverrideHead(dir)
+	return mirror
+}
+
+// decides reports whether a pre-relocation gentle-ai reading this location
+// already reaches the same conclusion as the requested mode. An absent record
+// is that conclusion for inherit: those builds spell "this clone holds no
+// override" by finding nothing here.
+func (mirror *cloneLocalRDDModeMirror) decides(mode string) bool {
+	if !mirror.available || mirror.readErr != nil {
+		return false
+	}
+	if !mirror.present {
+		return mode == rddModeOverrideInherit
+	}
+	return mirror.record.Mode == mode
+}
+
+func (mirror *cloneLocalRDDModeMirror) reach() RDDModeReach {
+	if mirror.available {
+		return RDDModeReachMachine
+	}
+	return RDDModeReachThisBuild
+}
+
+func (mirror *cloneLocalRDDModeMirror) release() {
+	if mirror.lock != nil {
+		_ = mirror.lock.release()
+	}
 }
 
 // AuthorizeRDDOperation is the single kill-switch gate. Reads and the
@@ -515,6 +692,19 @@ func rddModeStatus(
 	return status
 }
 
+// rddModeWriteStatus is the projection a clone-scope write returns. It differs
+// from the read-only one by exactly one fact: how far the decision reached.
+func rddModeWriteStatus(
+	globalMode RDDMode,
+	override rddModeOverrideRecord,
+	present bool,
+	reach RDDModeReach,
+) RDDModeStatus {
+	status := rddModeStatus(globalMode, override, present)
+	status.Reach = reach
+	return status
+}
+
 func failedClosedRDDModeStatus(source RDDModeSource) RDDModeStatus {
 	return RDDModeStatus{
 		Schema:     RDDModeStatusSchema,
@@ -577,6 +767,13 @@ func cloneLocalRDDOverrideValue(mode RDDMode) (string, error) {
 // rule, and drops only the dependency that had no reason to exist.
 const rddModeSwitchDirectory = "review-mode"
 
+// rddModeLegacySwitchDirectory is where the switch lived before #2882 moved it,
+// and therefore where every gentle-ai released before that move still reads it.
+// It is not history: those builds coexist with this one on the same machine and
+// share the same Git common directory, so a decision absent from this location
+// is a decision they never see (#3284).
+const rddModeLegacySwitchDirectory = "review-transactions"
+
 // cloneLocalRDDModeRoot derives the override directory from the exact Git
 // common directory, under the switch's own root.
 func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (string, error) {
@@ -596,10 +793,14 @@ func cloneLocalRDDModeRoot(ctx context.Context, repo string, create bool) (strin
 }
 
 // cloneLocalRDDModeLegacyRoot is the pre-#2882 location inside the review
-// authority tree. It is read-only and best-effort: overrides written before
-// this change must keep deciding, and a clone that never disabled has nothing
-// here.
-func cloneLocalRDDModeLegacyRoot(ctx context.Context, repo string) (string, error) {
+// authority tree. Reads pass create=false and are best-effort: overrides
+// written before that change must keep deciding, and a clone that never
+// disabled has nothing here.
+//
+// Writes pass create=true. The location is not merely history: it is where
+// every gentle-ai installed before the relocation still looks, so a clone-scope
+// decision that is never published here is invisible to those builds (#3284).
+func cloneLocalRDDModeLegacyRoot(ctx context.Context, repo string, create bool) (string, error) {
 	identity, err := cloneLocalRDDModeIdentity(ctx, repo)
 	if err != nil {
 		return "", err
@@ -607,15 +808,15 @@ func cloneLocalRDDModeLegacyRoot(ctx context.Context, repo string) (string, erro
 	base := filepath.Join(
 		identity.GitCommonDir,
 		"gentle-ai",
-		"review-transactions",
+		rddModeLegacySwitchDirectory,
 		rarAuthorityDirectory,
 		rarAuthorityVersion,
 	)
-	if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, false); err != nil {
+	if err := ensureRARRepositoryRoot(identity.GitCommonDir, base, create); err != nil {
 		return "", err
 	}
 	dir := filepath.Join(base, rddModeDirectory)
-	if err := ensurePrivateRARDirectoryTree(base, dir, false); err != nil {
+	if err := ensurePrivateRARDirectoryTree(base, dir, create); err != nil {
 		return "", err
 	}
 	return dir, nil
@@ -661,7 +862,7 @@ func cloneLocalRDDModeReadRoot(ctx context.Context, repo string) (string, error)
 			return dir, nil
 		}
 	}
-	legacy, legacyErr := cloneLocalRDDModeLegacyRoot(ctx, repo)
+	legacy, legacyErr := cloneLocalRDDModeLegacyRoot(ctx, repo, false)
 	if legacyErr != nil {
 		return "", nil
 	}

--- a/internal/reviewtransaction/rdd_mode_cross_version_test.go
+++ b/internal/reviewtransaction/rdd_mode_cross_version_test.go
@@ -1,0 +1,377 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// preRelocationCloneMode reports the clone-local mode exactly as a gentle-ai
+// installed before the switch moved out of the review authority tree reads it.
+// Those builds look in one place only, so this deliberately never consults the
+// switch's own root: it is the other reader on the machine, not this one.
+func preRelocationCloneMode(t *testing.T, ctx context.Context, repo string) RDDModeStatus {
+	t.Helper()
+	dir, err := cloneLocalRDDModeLegacyRoot(ctx, repo, false)
+	if err != nil {
+		// An absent legacy tree is how those builds spell "this clone holds no
+		// override", which leaves the global source deciding.
+		return rddModeStatus(RDDModeOn, rddModeOverrideRecord{}, false)
+	}
+	record, present, err := readCloneLocalRDDOverrideHead(dir)
+	if err != nil {
+		t.Fatalf("pre-relocation clone-local read: %v", err)
+	}
+	return rddModeStatus(RDDModeOn, record, present)
+}
+
+// TestCloneScopeDisableAppliesToPreRelocationBuilds is the #3284 guard.
+//
+// The kill switch is machine state, not build state. A clone-scope disable that
+// only this build can see reports success while every older gentle-ai on the
+// same machine keeps enforcing review, which is the one thing a safety switch
+// may never do.
+func TestCloneScopeDisableAppliesToPreRelocationBuilds(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", RDDGlobalMode{Value: "on"}); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+
+	if status := preRelocationCloneMode(t, ctx, repo); status.Enabled() {
+		t.Fatalf("a pre-relocation gentle-ai still reports reviews on: %#v; the clone-scope disable reported success without applying", status)
+	}
+	assertCloneModeLocationsAgree(t, ctx, repo)
+}
+
+// TestCloneScopeEnableAlsoReachesPreRelocationBuilds keeps the switch
+// symmetric. A disable that reaches every build and an enable that does not
+// would strand the operator with reviews permanently off for half the machine.
+func TestCloneScopeEnableAlsoReachesPreRelocationBuilds(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	if _, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, disabled.Revision, global); err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(inherit) error = %v", err)
+	}
+
+	if status := preRelocationCloneMode(t, ctx, repo); !status.Enabled() {
+		t.Fatalf("a pre-relocation gentle-ai still reports reviews off: %#v; the clone-scope enable never reached it", status)
+	}
+	assertCloneModeLocationsAgree(t, ctx, repo)
+}
+
+// TestCloneScopeWriteReportsMachineWideReach pins the claim the write is
+// allowed to make. Reporting reach is the whole difference between a switch
+// that applied and a switch that merely says so.
+func TestCloneScopeWriteReportsMachineWideReach(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+
+	status, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", RDDGlobalMode{Value: "on"})
+	if err != nil || status.Reach != RDDModeReachMachine {
+		t.Fatalf("clone-scope disable reach = %q, %v; want %q", status.Reach, err, RDDModeReachMachine)
+	}
+	// Resolution never probes the other location, so it must claim nothing
+	// rather than repeat a reach it did not verify.
+	resolved, err := ResolveRDDMode(ctx, repo, RDDGlobalMode{Value: "on"})
+	if err != nil || resolved.Reach != RDDModeReachUnreported {
+		t.Fatalf("read-only projection reach = %q, %v; want no claim", resolved.Reach, err)
+	}
+}
+
+// TestCloneScopeRerunRepairsABuildLocalDisable is the upgrade path out of
+// #3284. Operators who already disabled with an affected build hold a decision
+// only that build can see; rerunning the documented command has to finish the
+// job rather than report the same half-applied state as success.
+func TestCloneScopeRerunRepairsABuildLocalDisable(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	// Strip the mirrored copy to reproduce exactly what an affected build left
+	// behind: this clone's own root decides off, the other location says nothing.
+	legacy := legacyCloneModeRootForTest(t, ctx, repo)
+	if err := os.Remove(filepath.Join(legacy, rddModeGenerationName(1))); err != nil {
+		t.Fatalf("stage the build-local disable: %v", err)
+	}
+	if status := preRelocationCloneMode(t, ctx, repo); !status.Enabled() {
+		t.Fatalf("staging failed: the pre-relocation location still decides %#v", status)
+	}
+
+	repaired, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, disabled.Revision, global)
+	if err != nil {
+		t.Fatalf("rerunning the disable failed: %v", err)
+	}
+	if repaired.Reach != RDDModeReachMachine || repaired.Revision == disabled.Revision {
+		t.Fatalf("rerun status = %#v; want a fresh revision published with machine-wide reach", repaired)
+	}
+	if status := preRelocationCloneMode(t, ctx, repo); status.Enabled() {
+		t.Fatalf("rerunning the disable left a pre-relocation gentle-ai enforcing review: %#v", status)
+	}
+	assertCloneModeLocationsAgree(t, ctx, repo)
+
+	// Once both locations agree the same command is inert again: reconciling
+	// must not turn every repeat into another generation.
+	settled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, repaired.Revision, global)
+	if err != nil || settled.Revision != repaired.Revision {
+		t.Fatalf("redundant disable = %#v, %v; want the same head", settled, err)
+	}
+}
+
+// TestCloneScopeWriteSupersedesHigherPreRelocationGenerations covers the slot
+// arithmetic across two locations. A gentle-ai from before the relocation
+// publishes generations of its own, so this build's next slot has to clear
+// whichever location has gone further: colliding would refuse the write, and
+// publishing underneath would leave that build reading its own older record.
+func TestCloneScopeWriteSupersedesHigherPreRelocationGenerations(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	legacy := legacyCloneModeRootForTest(t, ctx, repo)
+	foreign := publishCurrentModeRecordForTest(t, legacy, rddModeOverrideRecord{Generation: 4}, string(RDDModeOff))
+	foreignPath := filepath.Join(legacy, rddModeGenerationName(foreign.Generation))
+	foreignBytes, err := os.ReadFile(foreignPath)
+	if err != nil {
+		t.Fatalf("read the pre-relocation record: %v", err)
+	}
+
+	cleared, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, disabled.Revision, global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(inherit) error = %v", err)
+	}
+	if cleared.Revision == "" || cleared.Reach != RDDModeReachMachine {
+		t.Fatalf("clear across two locations = %#v", cleared)
+	}
+	if after, err := os.ReadFile(foreignPath); err != nil || !bytes.Equal(after, foreignBytes) {
+		t.Fatalf("the pre-relocation record was overwritten: err=%v", err)
+	}
+	if head, err := cloneLocalRDDOverrideHeadGeneration(legacy); err != nil || head != foreign.Generation+1 {
+		t.Fatalf("pre-relocation head = %d, %v; want %d", head, err, foreign.Generation+1)
+	}
+	if status := preRelocationCloneMode(t, ctx, repo); !status.Enabled() {
+		t.Fatalf("a pre-relocation gentle-ai kept its own older record: %#v", status)
+	}
+	assertCloneModeLocationsAgree(t, ctx, repo)
+}
+
+// TestCloneScopeWriteRefusesToClaimSuccessOnAPartialPublish is the partial
+// failure this dual write introduces: the other location opened, so a
+// pre-relocation gentle-ai can read it, and the publish there failed anyway.
+// The decision applied here and did not apply there, and saying so is the whole
+// point -- a switch reported as working while half the machine still enforces
+// review is the defect, not the recovery.
+func TestCloneScopeWriteRefusesToClaimSuccessOnAPartialPublish(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	// Occupy the next slot at the other location with something that is not a
+	// publishable record. The head scan ignores directories, so the write still
+	// targets this slot and the immutable publish there refuses it.
+	legacy := legacyCloneModeRootForTest(t, ctx, repo)
+	blocked := filepath.Join(legacy, rddModeGenerationName(2))
+	if err := os.Mkdir(blocked, 0o700); err != nil {
+		t.Fatalf("block the pre-relocation slot: %v", err)
+	}
+
+	partial, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, disabled.Revision, global)
+	var reported *RDDModePartialApplyError
+	if !errors.Is(err, ErrRDDModePartiallyApplied) || !errors.As(err, &reported) {
+		t.Fatalf("partial publish error = %v, want ErrRDDModePartiallyApplied", err)
+	}
+	if reported.Mode != RDDModeUnset || !strings.Contains(err.Error(), "gentle-ai review mode enable --scope clone") {
+		t.Fatalf("partial publish refusal names no rerun: %v", err)
+	}
+	// The decision is real for this build; reporting it as reached-nowhere
+	// would be its own lie, and it must not claim the machine either.
+	if partial.CloneLocal != RDDModeUnset || !partial.Enabled() || partial.Reach != RDDModeReachThisBuild {
+		t.Fatalf("partial publish status = %#v; want this build's decision with this_build reach", partial)
+	}
+	if head, err := cloneLocalRDDOverrideHeadGeneration(cloneModeRootForTest(t, ctx, repo)); err != nil || head != 2 {
+		t.Fatalf("this build's head = %d, %v; want the decision recorded here", head, err)
+	}
+	if status := preRelocationCloneMode(t, ctx, repo); status.Enabled() {
+		t.Fatalf("the refusal was unnecessary: the pre-relocation location already agrees: %#v", status)
+	}
+
+	// Clearing the obstruction and rerunning converges both locations, so the
+	// refusal names a continuation that actually finishes the job.
+	if err := os.Remove(blocked); err != nil {
+		t.Fatalf("unblock the pre-relocation slot: %v", err)
+	}
+	healed, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, partial.Revision, global)
+	if err != nil || healed.Reach != RDDModeReachMachine {
+		t.Fatalf("rerun after the partial publish = %#v, %v", healed, err)
+	}
+	if status := preRelocationCloneMode(t, ctx, repo); !status.Enabled() {
+		t.Fatalf("rerun did not converge the two locations: %#v", status)
+	}
+	assertCloneModeLocationsAgree(t, ctx, repo)
+}
+
+// TestCloneScopeWriteStaysReachableWhenTheOtherLocationIsNot keeps #2882's exit
+// open. `review mode disable --scope clone` is the continuation the stop-reason
+// table names for unrecoverable review states, so a damaged review authority
+// tree may not make it refuse. It may, and must, stop it claiming the machine.
+func TestCloneScopeWriteStaysReachableWhenTheOtherLocationIsNot(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+	damageCloneModeLegacyTreeForTest(t, repo)
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("clone-scope disable refused while the other location was damaged: %v", err)
+	}
+	if disabled.Effective != RDDModeOff || disabled.Source != RDDModeSourceCloneLocal {
+		t.Fatalf("damaged-tree disable = %#v; want the clone-local source deciding off", disabled)
+	}
+	if disabled.Reach != RDDModeReachThisBuild {
+		t.Fatalf("damaged-tree disable reach = %q; want %q, because a location nothing can open is a location nothing was published to",
+			disabled.Reach, RDDModeReachThisBuild)
+	}
+	current := cloneModeRootForTest(t, ctx, repo)
+	if head, err := cloneLocalRDDOverrideHeadGeneration(current); err != nil || head != 1 {
+		t.Fatalf("damaged-tree disable head = %d, %v; want the decision persisted here", head, err)
+	}
+
+	// Repeating it must not churn generations: an unreachable location cannot
+	// be reconciled, so there is nothing left for the second run to do.
+	repeated, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, disabled.Revision, global)
+	if err != nil || repeated.Revision != disabled.Revision || repeated.Reach != RDDModeReachThisBuild {
+		t.Fatalf("repeated damaged-tree disable = %#v, %v", repeated, err)
+	}
+	if head, err := cloneLocalRDDOverrideHeadGeneration(current); err != nil || head != 1 {
+		t.Fatalf("repeated damaged-tree disable published generation %d, %v", head, err)
+	}
+}
+
+// TestCloneScopeConcurrentWritesLeaveBothLocationsAgreeing pins the invariant
+// that makes the dual write safe to reason about: one winner, and the two
+// locations hold the same decision afterwards rather than one each.
+func TestCloneScopeConcurrentWritesLeaveBothLocationsAgreeing(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+
+	var (
+		group   sync.WaitGroup
+		mutex   sync.Mutex
+		winners int
+	)
+	for range 4 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+			mutex.Lock()
+			defer mutex.Unlock()
+			if err == nil {
+				winners++
+				return
+			}
+			if !errors.Is(err, ErrRDDModeRevisionMismatch) && !errors.Is(err, ErrRARAuthorityConflict) {
+				t.Errorf("losing writer error = %v, want a CAS rejection", err)
+			}
+		}()
+	}
+	group.Wait()
+	if winners != 1 {
+		t.Fatalf("concurrent clone-scope writers = %d winners, want 1", winners)
+	}
+	if status := preRelocationCloneMode(t, ctx, repo); status.Enabled() {
+		t.Fatalf("concurrent writers left a pre-relocation gentle-ai enforcing review: %#v", status)
+	}
+	assertCloneModeLocationsAgree(t, ctx, repo)
+}
+
+// assertCloneModeLocationsAgree checks the property the two locations exist to
+// hold jointly: the same head record, byte for byte. A pre-relocation gentle-ai
+// re-derives the digest and rejects anything that is not canonical, so equal
+// bytes is the only form of agreement that survives its parser.
+func assertCloneModeLocationsAgree(t *testing.T, ctx context.Context, repo string) {
+	t.Helper()
+	current := cloneModeRootForTest(t, ctx, repo)
+	legacy := legacyCloneModeRootForTest(t, ctx, repo)
+	head, err := cloneLocalRDDOverrideHeadGeneration(current)
+	if err != nil || head == 0 {
+		t.Fatalf("this build's head = %d, %v", head, err)
+	}
+	legacyHead, err := cloneLocalRDDOverrideHeadGeneration(legacy)
+	if err != nil || legacyHead != head {
+		t.Fatalf("pre-relocation head = %d, %v; want %d", legacyHead, err, head)
+	}
+	name := rddModeGenerationName(head)
+	mine, err := os.ReadFile(filepath.Join(current, name))
+	if err != nil {
+		t.Fatalf("read this build's head: %v", err)
+	}
+	theirs, err := os.ReadFile(filepath.Join(legacy, name))
+	if err != nil {
+		t.Fatalf("read the pre-relocation head: %v", err)
+	}
+	if !bytes.Equal(mine, theirs) {
+		t.Fatalf("the two locations hold different decisions:\n  this build: %s  pre-relocation: %s", mine, theirs)
+	}
+}
+
+func cloneModeRootForTest(t *testing.T, ctx context.Context, repo string) string {
+	t.Helper()
+	dir, err := cloneLocalRDDModeRoot(ctx, repo, false)
+	if err != nil {
+		t.Fatalf("this build's clone-local root: %v", err)
+	}
+	return dir
+}
+
+func legacyCloneModeRootForTest(t *testing.T, ctx context.Context, repo string) string {
+	t.Helper()
+	dir, err := cloneLocalRDDModeLegacyRoot(ctx, repo, false)
+	if err != nil {
+		t.Fatalf("pre-relocation clone-local root: %v", err)
+	}
+	return dir
+}
+
+// damageCloneModeLegacyTreeForTest makes the pre-relocation tree fail RAR path
+// safety the way #2882's reporter hit it, without needing symlink support: the
+// shared ancestor is a regular file, so every walk over it refuses.
+func damageCloneModeLegacyTreeForTest(t *testing.T, repo string) {
+	t.Helper()
+	gentle := filepath.Join(repo, ".git", "gentle-ai")
+	if err := os.MkdirAll(gentle, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	authority := filepath.Join(gentle, rddModeLegacySwitchDirectory)
+	if err := os.RemoveAll(authority); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(authority, []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/reviewtransaction/rdd_mode_cross_version_test.go
+++ b/internal/reviewtransaction/rdd_mode_cross_version_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,6 +269,80 @@ func TestCloneScopeWriteStaysReachableWhenTheOtherLocationIsNot(t *testing.T) {
 	}
 	if head, err := cloneLocalRDDOverrideHeadGeneration(current); err != nil || head != 1 {
 		t.Fatalf("repeated damaged-tree disable published generation %d, %v", head, err)
+	}
+}
+
+// TestCloneScopeWriteNeverClaimsTheMachineOverAnUnscannableMirror is the
+// reproduction for R4-mirror-head-zero.
+//
+// The pre-relocation location can open, lock, and validate and still refuse to
+// enumerate its published slots. Its head is then unknown, not zero, and the
+// difference decides everything: publishing this build's next slot number into
+// a location whose head is higher lands the decision UNDERNEATH the record a
+// pre-relocation gentle-ai actually reads. That build keeps enforcing the
+// mode the operator just changed while the write reports it reached the whole
+// machine, which is #3284 wearing a success message.
+func TestCloneScopeWriteNeverClaimsTheMachineOverAnUnscannableMirror(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	global := RDDGlobalMode{Value: "on"}
+
+	disabled, err := SetCloneLocalRDDMode(ctx, repo, RDDModeOff, "", global)
+	if err != nil {
+		t.Fatalf("SetCloneLocalRDDMode(off) error = %v", err)
+	}
+	// A pre-relocation gentle-ai then published generations of its own, so the
+	// other location has gone further than this build's root. Its slot 2 is
+	// free, which is exactly what makes the mis-publish silent instead of loud.
+	legacy := legacyCloneModeRootForTest(t, ctx, repo)
+	foreign := publishCurrentModeRecordForTest(t, legacy, rddModeOverrideRecord{Generation: 4}, string(RDDModeOff))
+	if status := preRelocationCloneMode(t, ctx, repo); status.Enabled() {
+		t.Fatalf("staging failed: the pre-relocation location must decide off, got %#v", status)
+	}
+	failCloneModeMirrorSlotScanForTest(t, legacy)
+
+	status, err := SetCloneLocalRDDMode(ctx, repo, RDDModeUnset, disabled.Revision, global)
+	if err != nil {
+		t.Fatalf("clone-scope enable refused while the other location could not be enumerated: %v", err)
+	}
+	// The #2882 exit stays open: this build's own decision is recorded.
+	if !status.Enabled() || status.CloneLocal != RDDModeUnset {
+		t.Fatalf("clone-scope enable status = %#v; want this build's override cleared", status)
+	}
+	if status.Reach == RDDModeReachMachine {
+		if pre := preRelocationCloneMode(t, ctx, repo); !pre.Enabled() {
+			t.Fatalf("the write claimed machine-wide reach while a pre-relocation gentle-ai still reads reviews off: %#v", pre)
+		}
+	}
+	if status.Reach != RDDModeReachThisBuild {
+		t.Fatalf("reach over a mirror whose slots cannot be read = %q, want %q", status.Reach, RDDModeReachThisBuild)
+	}
+	// Nothing may be published into a location whose layout this build could
+	// not read: a record under its head is invisible to the only reader it was
+	// written for.
+	stray := filepath.Join(legacy, rddModeGenerationName(2))
+	if _, err := os.Lstat(stray); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("a record was published at slot 2, underneath the pre-relocation head %d: %v", foreign.Generation, err)
+	}
+	if head, err := cloneLocalRDDOverrideHeadGeneration(legacy); err != nil || head != foreign.Generation {
+		t.Fatalf("pre-relocation head = %d, %v; want the untouched %d", head, err, foreign.Generation)
+	}
+}
+
+// failCloneModeMirrorSlotScanForTest reproduces a mirror directory that opens,
+// validates, and then refuses to enumerate. The scan is a variable for the
+// same reason the private-directory primitives are: no test on ext4 or tmpfs
+// can produce a directory that passes the no-follow owner-only walk and then
+// fails readdir(2).
+func failCloneModeMirrorSlotScanForTest(t *testing.T, dir string) {
+	t.Helper()
+	real := cloneLocalRDDModeMirrorSlotScan
+	t.Cleanup(func() { cloneLocalRDDModeMirrorSlotScan = real })
+	cloneLocalRDDModeMirrorSlotScan = func(scanned string) (int, error) {
+		if scanned == dir {
+			return 0, fmt.Errorf("enumerate %q: %w", scanned, os.ErrPermission)
+		}
+		return real(scanned)
 	}
 }
 

--- a/internal/reviewtransaction/rdd_mode_legacy_root_test.go
+++ b/internal/reviewtransaction/rdd_mode_legacy_root_test.go
@@ -30,7 +30,7 @@ func TestLegacyCloneOverrideStillDecides(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	legacy, err := cloneLocalRDDModeLegacyRoot(ctx, repo)
+	legacy, err := cloneLocalRDDModeLegacyRoot(ctx, repo, false)
 	if err != nil {
 		// The legacy tree is created lazily; build it with the same helpers.
 		identity, idErr := cloneLocalRDDModeIdentity(ctx, repo)
@@ -253,7 +253,7 @@ func legacyCloneOverrideForTest(t *testing.T, ctx context.Context, repo string, 
 	if err != nil {
 		t.Fatalf("current root: %v", err)
 	}
-	legacy, err := cloneLocalRDDModeLegacyRoot(ctx, repo)
+	legacy, err := cloneLocalRDDModeLegacyRoot(ctx, repo, false)
 	if err != nil {
 		identity, identityErr := cloneLocalRDDModeIdentity(ctx, repo)
 		if identityErr != nil {

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -351,7 +351,7 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 				continue
 			}
 		} else if proof := compactLocalBaseAdvanceCompatibility(ctx, repo, state, request.Target, live); proof != nil &&
-			classifyCompactTargetRelation(state.CurrentSnapshot, live, state.GenesisPaths,
+			classifyCompactTargetRelation(state.CurrentSnapshot, live, state.CorrectionScopePaths(),
 				compactTargetRelationEvidence{CompatibleAdvance: proof}).Kind == compactTargetCompatibleAdvance {
 			candidates = append(candidates, candidate)
 			continue

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -341,13 +341,13 @@ func projectCompactTerminalHistory(state CompactState, live Snapshot) compactTer
 		// The reviewed bytes and modes are now the immutable HEAD base. A clean
 		// target or a disjoint next slice is not an applicability claim on the
 		// historical receipt.
-		if len(live.Paths) == 0 || classifyCompactPathSetRelation(state.GenesisPaths, live.Paths) == compactPathsDisjoint {
+		if len(live.Paths) == 0 || classifyCompactPathSetRelation(state.CorrectionScopePaths(), live.Paths) == compactPathsDisjoint {
 			return compactTerminalHistoryUnrelated
 		}
 		return compactTerminalHistoryScopeChanged
 	}
 
-	relation := classifyCompactTargetRelation(state.CurrentSnapshot, live, state.GenesisPaths, compactTargetRelationEvidence{})
+	relation := classifyCompactTargetRelation(state.CurrentSnapshot, live, state.CorrectionScopePaths(), compactTargetRelationEvidence{})
 	if relation.Kind != compactTargetUnsafe {
 		return compactTerminalHistoryScopeChanged
 	}
@@ -368,7 +368,7 @@ func compactLiveTargetMatchesValidatedSnapshot(state CompactState, live Snapshot
 	return compactTargetProjectionsCompatible(initial.Kind, initial.Projection, live.Kind, live.Projection) &&
 		compactStartTargetKindsCompatible(initial.Kind, live.Kind) &&
 		initial.BaseTree == live.BaseTree && (!requireCurrentCandidate || state.CurrentSnapshot.CandidateTree == live.CandidateTree) &&
-		pathsAreSubset(live.Paths, state.GenesisPaths) == nil && sideBandMatches && len(live.LedgerIDs) == 0
+		pathsAreSubset(live.Paths, state.CorrectionScopePaths()) == nil && sideBandMatches && len(live.LedgerIDs) == 0
 }
 
 func legacyLiveTargetMatchesValidatedSnapshot(transaction Transaction, live Snapshot) bool {

--- a/internal/reviewtransaction/targeted_validation_request.go
+++ b/internal/reviewtransaction/targeted_validation_request.go
@@ -88,7 +88,7 @@ func buildTargetedValidationRequest(ctx context.Context, repo string, state Comp
 	if fix.CandidateTree == state.CurrentSnapshot.CandidateTree || fix.Identity == state.CurrentSnapshot.Identity {
 		return TargetedValidationRequest{}, errors.New("targeted validation request requires a changed correction candidate")
 	}
-	if err := pathsAreSubset(fix.Paths, state.GenesisPaths); err != nil {
+	if _, err := admitCorrectionScope(fix.Paths, state.GenesisPaths); err != nil {
 		return TargetedValidationRequest{}, err
 	}
 	return targetedValidationRequestForCorrection(state, revision, fix)
@@ -101,7 +101,7 @@ func buildTargetedValidationRequest(ctx context.Context, repo string, state Comp
 func targetedValidationRequestForCorrection(state CompactState, revision string, fix Snapshot) (TargetedValidationRequest, error) {
 	snapshotProjection, err := canonicalProjection(state.InitialSnapshot.Projection)
 	if err != nil || !validSHA256(revision) || fix.Kind != TargetFixDiff || fix.Projection != snapshotProjection ||
-		!equalStrings(fix.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(fix.Paths, state.GenesisPaths) != nil {
+		!equalStrings(fix.LedgerIDs, state.FixFindingIDs) || correctionScopeRefused(fix.Paths, state.GenesisPaths) {
 		return TargetedValidationRequest{}, errors.New("targeted validation request correction binding is invalid")
 	}
 	projection := snapshotProjection

--- a/scripts/cross-lane-battery.sh
+++ b/scripts/cross-lane-battery.sh
@@ -14,6 +14,9 @@
 #   claude    - one low-risk full lifecycle to gate allow, plus one medium
 #               candidate consent/v3 round-trip; --with-model additionally
 #               runs the real compiled claude-code reviewer runtime.
+#   advisory  - the middle path: a medium candidate reviewed into one WARNING
+#               and one SUGGESTION must reach an approved receipt that
+#               declares both non-blocking and offers no correction route.
 #   schema    - validates every envelope captured above against the published
 #               schemas in contracts/review-integration/.
 #

--- a/scripts/crosslane/advisory.go
+++ b/scripts/crosslane/advisory.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const advisoryLane = "advisory"
+
+// runAdvisoryLane drives the MIDDLE path the other lanes never reach.
+//
+// The opencode lane covers the blocker path (candidate-causal severe finding
+// -> correction -> approved) and the claude lane covers the clean path (no
+// findings at all -> approved). Neither covers a review that reaches an
+// approved receipt WHILE carrying findings that do not block. That gap is not
+// theoretical: in the field a host read a WARNING off an approved receipt,
+// inferred from the bare severity string that it had to act, "fixed" it, and
+// re-ran a whole review on an already-approved candidate.
+//
+// So this lane freezes exactly that shape -- a medium candidate reviewed into
+// one WARNING and one SUGGESTION -- and requires the approved payload to
+// declare both non-blocking out loud and to offer no way back into review.
+// It is fully deterministic: the reviewer result is supplied through
+// `review capture-result --input`, so the lane costs no model or host spend
+// and runs in the default battery tier.
+func (b *battery) runAdvisoryLane() {
+	repo, err := b.scratchRepo("advisory-lane")
+	if err != nil {
+		b.fail(advisoryLane, "scratch repository", err.Error())
+		return
+	}
+	base := "export function mul(a, b) {\n  return a * b;\n}\n"
+	if err = writeFile(repo, "src/mul.js", base); err == nil {
+		err = commitAll(repo, "feat: mul")
+	}
+	if err != nil {
+		b.fail(advisoryLane, "scratch repository", err.Error())
+		return
+	}
+	if err := writeFile(repo, "src/mul.js", base+"export function twice(a) {\n  return a + a;\n}\n"); err != nil {
+		b.fail(advisoryLane, "scratch repository", err.Error())
+		return
+	}
+
+	statusDoc, stderr, code := b.status(repo, "claude-code")
+	target := getString(statusDoc, "target_identity")
+	if target == "" {
+		b.fail(advisoryLane, "negotiated status", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+		return
+	}
+	consent, stderr, _ := b.runJSON("consent", repo,
+		"review", "start", "--contract", reviewContract, "--cwd", repo,
+		"--target", target, "--projection", "workspace", "--agent", "claude-code", "--consent", "relay")
+	granted := grantedInvocation(consent)
+	if granted == "" {
+		b.fail(advisoryLane, "consent granted round-trip", fmt.Sprintf("no granted invocation in envelope; %s", firstLine(stderr)))
+		return
+	}
+	startDoc, stderr, code := b.runCommandLine("start", repo, granted)
+	if code != 0 || getString(startDoc, "state") != "reviewing" || len(getSlice(startDoc, "selected_lenses")) != 1 {
+		b.fail(advisoryLane, "consent granted round-trip", fmt.Sprintf("exit=%d state=%q %s", code, getString(startDoc, "state"), firstLine(stderr)))
+		return
+	}
+
+	// Reviewer result: non-blocking only. No evidence_class and no
+	// causal_disposition, because a non-severe finding never enters causal
+	// classification in the first place.
+	statusDoc, stderr, _ = b.status(repo, "claude-code")
+	input := collectInput(statusDoc)
+	if input == nil || input["capture_operation"] != "review.capture-result" {
+		b.fail(advisoryLane, "reviewer collect slot", fmt.Sprintf("no capture-result collect input; %s", firstLine(stderr)))
+		return
+	}
+	args := argumentValues(input)
+	reviewer := map[string]any{
+		"subject_hash": args["subject-hash"],
+		"inspection":   map[string]any{"status": "completed", "paths": []string{"src/mul.js"}},
+		"evidence":     []string{"twice() is added by the candidate hunk and no test in the candidate tree covers it"},
+		"findings": []map[string]any{
+			{
+				"lens": args["lens"], "location": "src/mul.js:4", "severity": "WARNING",
+				"claim":      "twice() has no covering test in the candidate tree, so its behaviour is unproved.",
+				"proof_refs": []string{"src/mul.js:4-6 adds twice() and the candidate adds no test file"},
+			},
+			{
+				"lens": args["lens"], "location": "src/mul.js:5", "severity": "SUGGESTION",
+				"claim":      "twice() could reuse mul(a, 2) instead of duplicating the doubling arithmetic.",
+				"proof_refs": []string{"src/mul.js:2 already implements the multiplication twice() open-codes"},
+			},
+		},
+	}
+	reviewerPath := filepath.Join(b.workRoot, "advisory-reviewer.json")
+	payload, err := json.MarshalIndent(reviewer, "", " ")
+	if err == nil {
+		err = os.WriteFile(reviewerPath, payload, 0o644)
+	}
+	if err != nil {
+		b.fail(advisoryLane, "reviewer manifest", err.Error())
+		return
+	}
+	capture, stderr, code := b.runJSON("result-artifact", repo,
+		"review", "capture-result",
+		"--lineage", args["lineage"], "--expected-revision", args["expected-revision"],
+		"--target", args["target"], "--repository-context", args["repository-context"],
+		"--lens", args["lens"], "--order", args["order"], "--subject-hash", args["subject-hash"],
+		"--input", reviewerPath)
+	if code != 0 || getString(capture, "admission_decision") != "completed" {
+		b.fail(advisoryLane, "non-blocking reviewer result captured", fmt.Sprintf("exit=%d %s", code, firstLine(stderr)))
+		return
+	}
+
+	lineage := args["lineage"]
+	finalize := b.driveAdvisoryToApproval(repo, lineage)
+	if finalize == nil {
+		return
+	}
+
+	// The claim under test: the approved payload names the disposition instead
+	// of leaving the consumer to infer it from the severity string.
+	advisory := advisoryBlock(finalize)
+	if advisory == nil {
+		b.fail(advisoryLane, "approval declares non-blocking findings",
+			"approved payload carries no advisory_findings block: a consumer can only infer disposition from the severity string")
+		return
+	}
+	statement := strings.ToLower(getString(advisory, "statement"))
+	for _, phrase := range []string{"approved", "non-blocking", "no correction"} {
+		if !strings.Contains(statement, phrase) {
+			b.fail(advisoryLane, "approval declares non-blocking findings",
+				fmt.Sprintf("advisory statement does not state %q: %q", phrase, getString(advisory, "statement")))
+			return
+		}
+	}
+	severities := map[string]string{}
+	for _, raw := range getSlice(advisory, "findings") {
+		finding, _ := raw.(map[string]any)
+		if finding == nil {
+			continue
+		}
+		severity, _ := finding["severity"].(string)
+		disposition, _ := finding["disposition"].(string)
+		severities[severity] = disposition
+	}
+	for _, severity := range []string{"WARNING", "SUGGESTION"} {
+		if severities[severity] != "informational" {
+			b.fail(advisoryLane, "approval declares non-blocking findings",
+				fmt.Sprintf("%s finding disposition = %q, want informational: %v", severity, severities[severity], severities))
+			return
+		}
+	}
+	b.pass(advisoryLane, "approval declares non-blocking findings",
+		"approved receipt with WARNING + SUGGESTION declares both informational and states the approval stands")
+
+	// The negative half: nothing about a non-blocking finding may route back
+	// into review. Not in the terminal payload, and not in the transition a
+	// consumer queries next.
+	if finalize["validation_request"] != nil || getMap(finalize, "result", "validation_request") != nil {
+		b.fail(advisoryLane, "approval offers no correction route", "approved payload carries a validation request")
+		return
+	}
+	if err := runGit(repo, "add", "-A"); err != nil {
+		b.fail(advisoryLane, "approval offers no correction route", err.Error())
+		return
+	}
+	statusDoc, stderr, _ = b.status(repo, "claude-code", "--lineage", lineage, "--projection", "staged", "--gate", "pre-commit")
+	transition := getMap(statusDoc, "next_transition")
+	reason := getString(statusDoc, "next_transition", "reason_code")
+	operation := getString(statusDoc, "next_transition", "execute", "operation")
+	if transition == nil || transition["correction_request"] != nil || strings.Contains(reason, "correction") {
+		b.fail(advisoryLane, "approval offers no correction route",
+			fmt.Sprintf("transition after advisory approval routes to correction: reason=%q %s", reason, firstLine(stderr)))
+		return
+	}
+	if operation != "review.validate" {
+		b.fail(advisoryLane, "approval offers no correction route",
+			fmt.Sprintf("transition after advisory approval = %q/%q, want the review.validate delivery gate %s", reason, operation, firstLine(stderr)))
+		return
+	}
+	b.pass(advisoryLane, "approval offers no correction route",
+		"no validation request, no correction transition; the only route forward is the review.validate delivery gate")
+}
+
+// driveAdvisoryToApproval follows the native transitions from a captured
+// non-blocking reviewer result to the terminal approved payload, then replays
+// the terminal finalize under the negotiated contract so the schema lane sees
+// the published operation envelope carrying the new block.
+func (b *battery) driveAdvisoryToApproval(repo, lineage string) map[string]any {
+	evidencePath := filepath.Join(b.workRoot, "advisory-evidence.txt")
+	evidence := fmt.Sprintf("crosslane battery %s: node --check src/mul.js passed on the frozen candidate\n", timestamp())
+	if err := os.WriteFile(evidencePath, []byte(evidence), 0o644); err != nil {
+		b.fail(advisoryLane, "lifecycle to approved receipt", err.Error())
+		return nil
+	}
+	for step := 0; step < 8; step++ {
+		statusDoc, stderr, _ := b.status(repo, "claude-code")
+		switch getString(statusDoc, "next_transition", "kind") {
+		case "execute":
+			doc, execStderr, code := b.runCommandLine("operation", repo, getString(statusDoc, "next_transition", "execute", "command"))
+			if code != 0 {
+				b.fail(advisoryLane, "lifecycle to approved receipt",
+					fmt.Sprintf("%s exit=%d %s", getString(statusDoc, "next_transition", "execute", "operation"), code, firstLine(execStderr)))
+				return nil
+			}
+			switch operationState(doc) {
+			case "approved":
+				// Replay the terminal finalize under the negotiated contract:
+				// same approved bytes, published envelope, so the schema lane
+				// validates advisory_findings against contracts/.
+				negotiated, replayStderr, replayCode := b.runJSON("operation", repo,
+					"review", "finalize", "--cwd", repo, "--lineage", lineage, "--contract", reviewContract)
+				if replayCode != 0 || operationState(negotiated) != "approved" {
+					b.fail(advisoryLane, "lifecycle to approved receipt",
+						fmt.Sprintf("negotiated terminal replay exit=%d %s", replayCode, firstLine(replayStderr)))
+					return nil
+				}
+				b.pass(advisoryLane, "lifecycle to approved receipt",
+					"medium candidate with WARNING + SUGGESTION reached an approved receipt without a correction")
+				return negotiated
+			case "correction_required", "escalated":
+				b.fail(advisoryLane, "lifecycle to approved receipt",
+					fmt.Sprintf("non-blocking findings changed the outcome to %q; only candidate-caused severe findings may block", operationState(doc)))
+				return nil
+			}
+		case "collect":
+			input := collectInput(statusDoc)
+			if input == nil || input["capture_operation"] != "review.capture-evidence" {
+				b.fail(advisoryLane, "lifecycle to approved receipt",
+					fmt.Sprintf("unsupported collect input %v", input["capture_operation"]))
+				return nil
+			}
+			tokens := substituteTokens(getSlice(input, "submission", "argument_tokens"), map[string]string{"outcome": "passed", "input": evidencePath})
+			captureArgs := append([]string{"review", getString(input, "submission", "operation_token")}, tokens...)
+			if record, captureStderr, code := b.runJSON("verification-evidence", b.workRoot, captureArgs...); code != 0 || getString(record, "outcome") != "passed" {
+				b.fail(advisoryLane, "lifecycle to approved receipt",
+					fmt.Sprintf("evidence capture exit=%d %s", code, firstLine(captureStderr)))
+				return nil
+			}
+		default:
+			b.fail(advisoryLane, "lifecycle to approved receipt",
+				fmt.Sprintf("unexpected transition %s/%s %s", getString(statusDoc, "next_transition", "kind"),
+					getString(statusDoc, "next_transition", "reason_code"), firstLine(stderr)))
+			return nil
+		}
+	}
+	b.fail(advisoryLane, "lifecycle to approved receipt", "did not reach a terminal state within the step budget")
+	return nil
+}
+
+// advisoryBlock reads advisory_findings from either the negotiated operation
+// envelope (result.advisory_findings) or the legacy bare finalize result,
+// mirroring operationState's own tolerance of both surfaces.
+func advisoryBlock(doc map[string]any) map[string]any {
+	if block := getMap(doc, "result", "advisory_findings"); block != nil {
+		return block
+	}
+	return getMap(doc, "advisory_findings")
+}

--- a/scripts/crosslane/main.go
+++ b/scripts/crosslane/main.go
@@ -12,6 +12,10 @@
 //     gate allow) and one medium-candidate consent/v3 round-trip (granted).
 //     With --with-model it additionally runs the real compiled claude-code
 //     reviewer runtime, which is why this battery lives outside CI.
+//   - advisory lane: the middle path neither of the two lanes above reaches —
+//     a review that arrives at an approved receipt WHILE carrying findings
+//     that do not block. Fully deterministic (the reviewer result is supplied
+//     through capture-result --input), so it costs no model or host spend.
 //   - schema lane: every envelope captured along the way is validated
 //     against the published schemas in contracts/review-integration/.
 //     Any emitter/schema divergence fails the battery.
@@ -81,6 +85,7 @@ func run() int {
 	b.captureCapabilities()
 	b.runOpenCodeLane()
 	b.runClaudeLane()
+	b.runAdvisoryLane()
 	b.runHostLanes()
 	b.runSchemaLane()
 


### PR DESCRIPTION
Closes #3375.
Closes #3284.

Three independent fixes that never should have been separate candidates — they cherry-picked onto each other without a single conflict.

## A bounded correction can add its companion test (#3375)

A CRITICAL of the form "this behaviour has no test coverage" is among the most frequent a reviewer produces, and the bounded correction structurally could not apply it: adding a test file adds a path, and adding a path forced a recovery plus a full re-review. Observed on real work in this same wave, where that rule turned one finding into a second four-lens review that found three more.

A correction may now add a path only when it is a test file by that exact extension toolchain own default discovery rule, and a companion of an already-reviewed path. The predicate is extension-scoped and case-sensitive: in Go only the `_test` suffix excludes a file from the build, so `test_helper.go` is refused; a directory can never answer for a file, so a Go package under `tests/` is refused; and Java, Kotlin, C# and Rust are absent by design, because their test separation is build configuration rather than a name a path can be checked against. Anything unrecognised keeps today behaviour and still requires recovery.

The line budget still binds, the single-correction rule still holds, and additions are disclosed on the receipt as `CorrectionAddedPaths` so an auditor sees exactly which delivered paths no lens inspected.

## The clone kill switch applies to every gentle-ai on the machine (#3284)

A clone-scope disable published only into the relocated root, so a pre-relocation build kept enforcing review and the switch reported success without applying. It now dual-writes, verified byte-compatible by reading the older record shape directly. A partial apply is refused rather than claimed, and status carries an explicit reach so a build never asserts machine-wide when it reached one location.

## Non-blocking findings are declared (#3282-adjacent)

An approved receipt carrying WARNING or SUGGESTION findings now states their disposition explicitly and says the approval stands, that none opened a correction, and that no correction transition is offered. A field session had already corrected such a finding and relaunched a whole review over a candidate that was already approved.

## Review history

This candidate escalated once and was recovered. Across its rounds the reviewers caught: a test-path predicate that would have admitted compilable Go production source, a dual-write silently disabled whenever the mirror head scan failed, a widened scope persisted on the correction failure path, and — from a finding that simply said no test exercised a gate with a non-empty added-path set — a fifth call site that was never rewired, which made the entire #3375 feature fail at the delivery gate.

RDD receipt: review-group-b-successor-01 (approved, high, 4R, one bounded correction).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approved reviews can now include non-blocking advisory findings with severity, location, and disposition details.
  - Finalization responses distinguish informational findings from correction-required outcomes and continue to the delivery gate.
  - Approved corrections may include eligible companion test files, with expanded scope reflected in validation and delivery receipts.
  - Review-mode status now reports whether settings apply across installations or only to the current build.

- **Bug Fixes**
  - Improved synchronization of review-mode settings across current and older installations.
  - Added safeguards against invalid, unrelated, or partially applied correction paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->