### PR TITLE
ci(windows): rebalance internal/cli shards by measured cost

### DIFF
--- a/.github/workflows/windows-full-suite.yml
+++ b/.github/workflows/windows-full-suite.yml
@@ -43,9 +43,23 @@ jobs:
   #
   # Split by measured cost: internal/cli and internal/reviewtransaction are
   # ~44% and ~33% of total test time. internal/cli alone exceeded the 30m
-  # go-test timeout, so it takes five shards; TestR* dominates the package and
-  # is split again by its next letter. `rest` is derived from `go list` rather
-  # than listed, so a new package is covered the day it is added.
+  # go-test timeout, so it takes six shards. `rest` is derived from `go list`
+  # rather than listed, so a new package is covered the day it is added.
+  #
+  # The first cut of this split tiled A-Z by first letter, which is cost-blind:
+  # cli-d-q reached 1818s and cli-r-a-m 1692s against a 1800s go-test timeout
+  # while cli-r-n-z finished in 143s. Test names cluster by prefix, and cost
+  # clusters with them, so a first-letter tile cannot be balanced -- 423 of the
+  # 649 TestR* tests are TestReview*, a single indivisible letter. The shards
+  # below are sized from measured per-selector cost instead (Linux seconds,
+  # which Windows tracks at a steady ~20x across every shard in the matrix):
+  #
+  #   cli-a-m         33.5s   cli-review-a-m  41.1s
+  #   cli-n-o         46.1s   cli-review-n-z  34.9s
+  #   cli-p-q-s-z     48.6s   cli-r-other     14.3s
+  #
+  # That puts the worst shard near 1000s on Windows, roughly half the go-test
+  # timeout, instead of 1% over it.
   #
   # Intra-package t.Parallel() would be the deeper fix, but internal/cli has 89
   # os.Setenv/t.Setenv sites and t.Setenv panics in a parallel test, so that is
@@ -57,26 +71,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Top-level ranges are contiguous and disjoint over A-Z. R is further
-        # partitioned by its next letter; internal/assets requires that exact
-        # pair and treats it as the R tile. A shard therefore cannot leave a
-        # letter uncovered and silently skip tests while the lane reports green.
+        # Selectors are free-form -run regexes, not a letter tiling, so they can
+        # be sized by cost. internal/assets checks them against the real
+        # `go test -list` inventory of each package and fails unless every test
+        # is claimed by exactly one shard, so a shard cannot leave tests unrun
+        # and silently report the lane green.
         shard:
-          - name: cli-a-c
+          - name: cli-a-m
             packages: ./internal/cli
-            run: ^Test[A-C]
-          - name: cli-d-q
+            run: ^Test[A-M]
+          - name: cli-n-o
             packages: ./internal/cli
-            run: ^Test[D-Q]
-          - name: cli-r-a-m
+            run: ^Test[N-O]
+          - name: cli-p-q-s-z
             packages: ./internal/cli
-            run: ^TestR[A-Ma-m]
-          - name: cli-r-n-z
+            run: ^Test[P-Q]|^Test[S-Z]
+          - name: cli-review-a-m
             packages: ./internal/cli
-            run: ^TestR[N-Zn-z]
-          - name: cli-s-z
+            run: ^TestReview[A-Ma-m]
+          - name: cli-review-n-z
             packages: ./internal/cli
-            run: ^Test[S-Z]
+            run: ^TestReview[N-Zn-z]
+          # Every TestR* that the two cli-review shards do not claim: the
+          # non-Review TestRe* tests, TestRevision* (TestRevi + s, where
+          # TestReview is TestRevi + e), and TestRo*/TestRu*. The empty
+          # ^TestR[A-Da-d] arm keeps the R space fully tiled for names nobody
+          # has written yet.
+          - name: cli-r-other
+            packages: ./internal/cli
+            run: ^TestR[A-Da-d]|^TestRe[A-Ua-u]|^TestRevi[N-Zn-z]|^TestR[F-Zf-z]
           - name: reviewtransaction-a-c
             packages: ./internal/reviewtransaction
             run: ^Test[A-C]

--- a/internal/assets/formatter_ordering_test.go
+++ b/internal/assets/formatter_ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -226,12 +227,18 @@ func TestFormatterOrderingBehaviorContract(t *testing.T) {
 
 // TestWindowsFullSuiteShardsCoverEveryTestName proves the sharded Windows lane
 // still runs every test. Sharding trades one long job for several short ones,
-// and its failure mode is silent: a range edited to leave a letter uncovered
-// skips those tests while every shard, and the lane, still reports green.
+// and its failure mode is silent: a selector edited to stop matching some tests
+// skips them while every shard, and the lane, still reports green.
 //
-// Go test names are "Test" plus an uppercase letter, so the space the ranges
-// must tile is exactly A-Z. Per package, the ranges have to be contiguous and
-// disjoint from A through Z -- no gap, no overlap.
+// The shards used to be letter ranges tiling A-Z, checked by range algebra.
+// That was cheap to verify but impossible to balance: Go test names cluster by
+// prefix and so does their cost, so one letter (TestReview*, 423 of the 649
+// TestR* tests in internal/cli) can own more work than a whole shard's budget.
+// Selectors are therefore arbitrary -run regexes now, and coverage is proved
+// against the package's real `go test -list` inventory instead: every test that
+// exists must be claimed by exactly one shard. That is strictly stronger than
+// the range check -- it catches an uncovered name even when the ranges look
+// contiguous -- and it leaves the split free to follow measured cost.
 func TestWindowsFullSuiteShardsCoverEveryTestName(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "windows-full-suite.yml"))
 	if err != nil {
@@ -248,15 +255,15 @@ func TestWindowsFullSuiteShardsCoverEveryTestName(t *testing.T) {
 		section = section[:end]
 	}
 
-	// Ranges are read straight out of the matrix, so this cannot drift from
+	// Selectors are read straight out of the matrix, so this cannot drift from
 	// what actually runs the way a copy of the list would.
-	type shard struct{ name, pkg, selector, lo, hi string }
-	const (
-		cliRAM = "^TestR[A-Ma-m]"
-		cliRNZ = "^TestR[N-Zn-z]"
-	)
+	type shard struct {
+		name     string
+		pkg      string
+		selector string
+		matcher  *regexp.Regexp
+	}
 	var shards []shard
-	var cliRSelectors []string
 	var name string
 	var pkg string
 	for _, line := range strings.Split(section, "\n") {
@@ -273,114 +280,71 @@ func TestWindowsFullSuiteShardsCoverEveryTestName(t *testing.T) {
 		}
 		value = strings.Trim(value, `"`)
 		if value == "" {
+			// The `rest` shard selects by package, not by name.
 			continue
 		}
-		if len(value) == len(`^Test[A-Z]`) && strings.HasPrefix(value, "^Test[") && strings.HasSuffix(value, "]") {
-			shards = append(shards, shard{name: name, pkg: pkg, selector: value, lo: value[6:7], hi: value[8:9]})
-			continue
+		matcher, err := regexp.Compile(value)
+		if err != nil {
+			t.Fatalf("shard %q selector %q does not compile as a -run regex: %v", name, value, err)
 		}
-		if pkg != "./internal/cli" || (value != cliRAM && value != cliRNZ) {
-			t.Fatalf("shard selector %q is neither a ^Test[A-Z] range nor a required cli TestR partition", value)
-		}
-		cliRSelectors = append(cliRSelectors, value)
+		shards = append(shards, shard{name: name, pkg: pkg, selector: value, matcher: matcher})
 	}
 	if len(shards) == 0 {
-		t.Fatal("no range shards found; the guard would pass vacuously")
+		t.Fatal("no name-selecting shards found; the guard would pass vacuously")
 	}
-	if len(cliRSelectors) != 2 {
-		t.Fatalf("cli TestR partitions = %v, want exactly %q and %q", cliRSelectors, cliRAM, cliRNZ)
-	}
-	seenRSelector := map[string]bool{}
-	for _, selector := range cliRSelectors {
-		seenRSelector[selector] = true
-	}
-	for _, selector := range []string{cliRAM, cliRNZ} {
-		if !seenRSelector[selector] {
-			t.Fatalf("cli TestR partition %q is required", selector)
-		}
-	}
-	// The two required selectors split TestR's next letter across uppercase and
-	// lowercase A-Z, so together they are the cli range shard for R.
-	shards = append(shards, shard{pkg: "./internal/cli", lo: "R", hi: "R"})
 
 	if strings.Contains(string(data), "reviewtransaction-a-k") {
 		t.Fatal("former reviewtransaction-a-k aggregate is still present")
 	}
-	wantReviewtransaction := map[string]string{
-		"reviewtransaction-a-c": "^Test[A-C]",
-		"reviewtransaction-d-k": "^Test[D-K]",
-		"reviewtransaction-l-z": "^Test[L-Z]",
-	}
-	gotReviewtransaction := map[string]shard{}
-	for _, s := range shards {
-		if s.pkg != "./internal/reviewtransaction" {
-			continue
-		}
-		if _, duplicate := gotReviewtransaction[s.name]; duplicate {
-			t.Fatalf("reviewtransaction shard %q is declared more than once", s.name)
-		}
-		gotReviewtransaction[s.name] = s
-	}
-	if len(gotReviewtransaction) != len(wantReviewtransaction) {
-		t.Fatalf("reviewtransaction shards = %v, want exactly %v", gotReviewtransaction, wantReviewtransaction)
-	}
-	for name, selector := range wantReviewtransaction {
-		got, ok := gotReviewtransaction[name]
-		if !ok || got.selector != selector {
-			t.Fatalf("reviewtransaction shard %q selector = %q, want %q", name, got.selector, selector)
-		}
-	}
 
 	byPackage := map[string][]shard{}
 	for _, s := range shards {
+		if s.pkg == "" {
+			t.Fatalf("shard %q selects tests by name but names no package", s.name)
+		}
 		byPackage[s.pkg] = append(byPackage[s.pkg], s)
 	}
-	for pkg, ranges := range byPackage {
-		covered := map[rune]string{}
-		for _, r := range ranges {
-			if r.lo > r.hi {
-				t.Fatalf("%s: range %s-%s is inverted", pkg, r.lo, r.hi)
-			}
-			for letter := rune(r.lo[0]); letter <= rune(r.hi[0]); letter++ {
-				if owner, taken := covered[letter]; taken {
-					t.Fatalf("%s: letter %c is covered by both %s and %s-%s", pkg, letter, owner, r.lo, r.hi)
-				}
-				covered[letter] = r.lo + "-" + r.hi
-			}
-		}
-		for letter := 'A'; letter <= 'Z'; letter++ {
-			if _, ok := covered[letter]; !ok {
-				t.Fatalf("%s: no shard runs tests starting with Test%c", pkg, letter)
-			}
-		}
-	}
 
-	// Ask go test for the current top-level inventory instead of maintaining a
-	// second list. Every A-Z reviewtransaction test must match one exact shard.
-	command := exec.Command("go", "test", "./internal/reviewtransaction", "-list", "^Test[A-Z]")
-	command.Dir = filepath.Join("..", "..")
-	output, err := command.CombinedOutput()
-	if err != nil {
-		t.Fatalf("list reviewtransaction tests: %v\n%s", err, output)
-	}
-	matchedTests := 0
-	for _, testName := range strings.Split(string(output), "\n") {
-		if !strings.HasPrefix(testName, "Test") {
-			continue
+	for pkg, packageShards := range byPackage {
+		// Ask go test for the current top-level inventory instead of
+		// maintaining a second list that would rot.
+		command := exec.Command("go", "test", pkg, "-list", "^Test")
+		command.Dir = filepath.Join("..", "..")
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("list %s tests: %v\n%s", pkg, err, output)
 		}
-		matchedTests++
-		letter := testName[4:5]
-		owners := 0
-		for _, s := range gotReviewtransaction {
-			if s.lo <= letter && letter <= s.hi {
-				owners++
+		inventory := 0
+		claimed := map[string]int{}
+		for _, testName := range strings.Split(string(output), "\n") {
+			testName = strings.TrimSpace(testName)
+			if !strings.HasPrefix(testName, "Test") {
+				continue
+			}
+			inventory++
+			var owners []string
+			for _, s := range packageShards {
+				// -run splits on "/" for subtests; these selectors address
+				// top-level names only, so a plain match is the same rule.
+				if s.matcher.MatchString(testName) {
+					owners = append(owners, s.name)
+				}
+			}
+			if len(owners) != 1 {
+				t.Fatalf("%s test %q is claimed by %d shards (%v), want exactly one", pkg, testName, len(owners), owners)
+			}
+			claimed[owners[0]]++
+		}
+		if inventory == 0 {
+			t.Fatalf("%s test inventory is empty; coverage guard would pass vacuously", pkg)
+		}
+		// A shard that matches nothing is the same silent hole seen from the
+		// other side, and the lane's own runtime guard throws on it. Catch it
+		// here instead of one push later.
+		for _, s := range packageShards {
+			if claimed[s.name] == 0 {
+				t.Fatalf("%s shard %q selector %q matches no test", pkg, s.name, s.selector)
 			}
 		}
-		if owners != 1 {
-			t.Fatalf("reviewtransaction test %q belongs to %d shards, want exactly one", testName, owners)
-		}
-	}
-	if matchedTests == 0 {
-		t.Fatal("reviewtransaction test inventory is empty; coverage guard would pass vacuously")
 	}
 }

--- a/internal/cli/gga_install_fix_test.go
+++ b/internal/cli/gga_install_fix_test.go
@@ -44,8 +44,14 @@ func TestGGAFixInstallErrorWhenAlreadyAvailable(t *testing.T) {
 	runCommandCalled := false
 	runCommand = func(name string, args ...string) error {
 		runCommandCalled = true
-		// Simulate install.sh failing due to TTY issue
-		return errors.New("exit status 1: read: open /dev/tty: no such device or address")
+		// Simulate install.sh failing due to TTY issue. The production path
+		// prints this error to os.Stderr, and `go test` without -v attributes
+		// it to no test at all, so a shard log shows a bare "gga install
+		// command reported an error" warning quoting a real-looking git clone.
+		// That has already been misread once as a live network clone hanging
+		// the Windows lane; the "simulated" marker makes the fixture
+		// unmistakable in a log where nothing else names this test.
+		return errors.New("simulated install failure: exit status 1: read: open /dev/tty: no such device or address")
 	}
 
 	// Make ggaAvailable return false initially (simulating install needed),


### PR DESCRIPTION
Closes #3404.

## What changed

Shard selectors for `internal/cli` are now sized from measured cost instead of test-name first letter. Six shards replace five.

The `cli-d-q` shard was hitting the 1800s `go test` timeout and panicking. It was not slow because of any single test: the A-Z tiling is cost-blind, and `TestReview*` alone is 423 of the 649 `TestR*` tests in the package, one indivisible letter worth more than a shard's budget. Two shards carried 77% of the package while two idled.

## Coverage ratchet is now stronger

Free-form selectors cannot be checked by range algebra, so `TestWindowsFullSuiteShardsCoverEveryTestName` (`internal/assets/formatter_ordering_test.go`) now validates the matrix against each package's real `go test -list` inventory: every test claimed by exactly one shard, and no shard matching zero. That is strictly stronger than the range check it replaces, and it drops the hardcoded `TestR` partition pair the old check had to special-case.

Negative-tested: a dropped arm, an overlapping pair, and an empty shard each fail with a named test.

## Measurements

Linux seconds, back-to-back on one machine against the same test binary:

| before | s | after | s |
|---|---|---|---|
| cli-a-c | 13.9 | cli-a-m | 37.0 |
| **cli-d-q** | **91.0** | cli-n-o | **51.0** |
| cli-r-a-m | 83.1 | cli-p-q-s-z | 43.0 |
| cli-r-n-z | 10.6 | cli-review-a-m | 40.1 |
| cli-s-z | 29.9 | cli-review-n-z | 31.8 |
| | | cli-r-other | 15.4 |
| **total** | **228.5** | **total** | **218.3** |

All 1493 tests still run: 193+505+472+177+146 before, 378+228+238+235+187+227 after.

Windows tracks Linux at a steady ~20x across every shard in the matrix, and that model predicts the observed 1818s for `cli-d-q` from its 91.0s almost exactly. Projected worst shard after this change is ~1020s, or ~1220s at a pessimistic 24x: 57-68% of the 1800s timeout instead of 101%.

`reviewtransaction-a-c` (1087s) and `rest` (991s) are both comfortable and are left alone.

## Also

`internal/cli/gga_install_fix_test.go` now labels its stubbed failure `simulated install failure: …`. The old fixture text rendered a `git clone … gentleman-guardian-angel` line to stderr immediately before the panic, which reads exactly like a live network clone in CI. It is not one, and it never was: instrumenting `executeCommand` to panic on that argv and running the whole `^Test[D-Q]` shard produces zero hits. Only the log wording changed.

## Verification

| check | result |
|---|---|
| `gofmt -l internal/` | clean |
| `go vet ./...` | pass |
| `GOOS=windows go vet ./...` | pass |
| `go test ./internal/cli/ -count=1` | ok, 235.8s |
| `go test ./internal/assets/ -count=1` | ok, 5.4s |
| ratchet negative cases (gap / overlap / empty) | all three fail as designed |
| `./scripts/deadcode-ratchet.sh` | no new unreachable functions |

Windows Full Suite does not run on pull requests, so it is dispatched against this branch separately; that run is the real proof and is linked in a comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Windows CLI test sharding to use six cost-based partitions for more balanced execution times.
  * Added validation to ensure all tests are assigned to exactly one shard.
  * Improved install failure test diagnostics with clearer simulated-error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->