### PR TITLE
fix(install): avoid optional agent runtime failures

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -252,9 +252,6 @@ func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, er
 }
 
 func (a *Adapter) engramInitCommand() []string {
-	if _, err := a.lookPath("pnpm"); err == nil {
-		return []string{"pnpm", "dlx", "gentle-engram@latest", "pi-engram", "init"}
-	}
 	return []string{"npm", "exec", "--yes", "--package", "gentle-engram@latest", "--", "pi-engram", "init"}
 }
 

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -306,7 +306,7 @@ func TestAdapterInstallCommandSequenceUsesSameSubagentsPackageForWindows(t *test
 	}
 }
 
-func TestAdapterInstallCommandSequenceUsesPnpmForEngramInitWhenAvailable(t *testing.T) {
+func TestAdapterInstallCommandSequenceUsesNpmForEngramInitWhenPnpmIsAvailable(t *testing.T) {
 	a := &Adapter{
 		lookPath: func(file string) (string, error) {
 			if file == "pnpm" {
@@ -321,7 +321,7 @@ func TestAdapterInstallCommandSequenceUsesPnpmForEngramInitWhenAvailable(t *test
 		t.Fatalf("InstallCommand() error = %v", err)
 	}
 
-	want := []string{"pnpm", "dlx", "gentle-engram@latest", "pi-engram", "init"}
+	want := []string{"npm", "exec", "--yes", "--package", "gentle-engram@latest", "--", "pi-engram", "init"}
 	if !reflect.DeepEqual(commands[3], want) {
 		t.Fatalf("InstallCommand()[3] = %#v, want %#v", commands[3], want)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1237,33 +1237,25 @@ func (s agentInstallStep) ID() string {
 	return s.id
 }
 
-// Run adapts the runtime already on the machine; it never acquires or
-// executes anything to put one there on the user's behalf. If the agent's
-// runtime is not detected, this refuses and names the exact command the
-// user would need to run themselves, instead of running it for them.
+// Run executes Pi's package installation commands only. Other selected
+// agents remain config targets regardless of whether their runtime is present.
 //
-// Pi is the one exception, by design: the `pi` binary itself is never
-// installed by gentle-ai (validatePiInstallPreflight refuses if it is not
-// already on PATH), but once it is present, its own `pi install ...`
-// subcommands install gentle-ai's own Pi package stack through that
-// already-present tool — the same shape as running `npm install` inside a
-// project that already has npm, not an agent-runtime install.
+// The `pi` binary itself is never installed by gentle-ai
+// (validatePiInstallPreflight refuses if it is not already on PATH), but once
+// it is present, its own `pi install ...` subcommands install gentle-ai's Pi
+// package stack through that already-present tool.
 func (s agentInstallStep) Run() error {
+	if s.agent != model.AgentPi {
+		return nil
+	}
+
 	adapter, err := agents.NewAdapter(s.agent)
 	if err != nil {
 		return fmt.Errorf("create adapter for %q: %w", s.agent, err)
 	}
 
-	installed, _, _, _, err := adapter.Detect(context.Background(), s.homeDir)
-	if err != nil {
+	if _, _, _, _, err := adapter.Detect(context.Background(), s.homeDir); err != nil {
 		return fmt.Errorf("detect agent %q: %w", s.agent, err)
-	}
-	if installed && s.agent != model.AgentPi {
-		return nil
-	}
-
-	if s.agent != model.AgentPi {
-		return refuseMissingAgentRuntime(s.agent, s.profile, adapter)
 	}
 
 	if err := installcmd.ValidateAgentInstallPreflight(s.profile, s.agent); err != nil {
@@ -1279,39 +1271,6 @@ func (s agentInstallStep) Run() error {
 	}
 
 	return runCommandSequence(commands)
-}
-
-// refuseMissingAgentRuntime reports that an agent's runtime is not present
-// instead of installing it. When the adapter can resolve the exact command a
-// user would run themselves (an npm/uv install), that command is named
-// verbatim so the refusal is actionable. When the agent cannot be installed
-// this way at all (a desktop app, a vendor-managed tool), the adapter's own
-// explanation — e.g. "agent cursor is a desktop app and cannot be installed
-// via CLI" — is surfaced instead of a silent no-op.
-func refuseMissingAgentRuntime(agent model.AgentID, profile system.PlatformProfile, adapter agents.Adapter) error {
-	commands, err := adapter.InstallCommand(profile)
-	if err != nil {
-		return err
-	}
-	if len(commands) == 0 {
-		// refusal:by-design world-action: there is no install command to name for this platform; the exit is a manual install the user performs outside Gentle-AI, not a gentle-ai command.
-		return fmt.Errorf("agent %q is not installed and Gentle-AI has no install command to suggest for this platform", agent)
-	}
-	// refusal:by-design world-action: the exit is the printed external command the user runs themselves; Gentle-AI never runs it on their behalf, so no gentle-ai command can name the resolution.
-	return fmt.Errorf(
-		"agent %q is not installed. Gentle-AI does not install agent runtimes; run this yourself, then retry:\n%s",
-		agent, formatCommandSequenceForRefusal(commands),
-	)
-}
-
-// formatCommandSequenceForRefusal renders a resolved install command
-// sequence as the human-runnable lines shown in a refusal message.
-func formatCommandSequenceForRefusal(commands [][]string) string {
-	lines := make([]string, len(commands))
-	for i, command := range commands {
-		lines[i] = "  " + strings.Join(command, " ")
-	}
-	return strings.Join(lines, "\n")
 }
 
 type kimiSystemPromptHubStep struct {
@@ -2722,13 +2681,11 @@ func (s checkDependenciesStep) Run() error {
 	// failing with real error messages.
 	_ = system.DetectDependencies(context.Background(), s.profile)
 	for _, agent := range s.selection.Agents {
-		// Only Pi still executes anything on the user's behalf (its own
-		// already-present `pi` subcommands, which need npm/pnpm — see
-		// agentInstallStep). Every other agent's "not installed" outcome is
-		// now a printed refusal, which needs no local dependency at all, so
-		// failing this whole pipeline early over an unrelated agent's
-		// missing npm/uv would abort work agentInstallStep would otherwise
-		// complete correctly by just naming the command.
+		// Only Pi executes package commands (its already-present `pi`
+		// subcommands and npm-based Engram initialization — see
+		// agentInstallStep). Other selected agents receive configuration without
+		// runtime acquisition, so their missing package managers must not block
+		// this pipeline.
 		if agent != model.AgentPi {
 			continue
 		}

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -11,13 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
-	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/installcmd"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
-	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -49,12 +46,7 @@ func stringSliceContains(items []string, want string) bool {
 	return false
 }
 
-func engramInitCommandForTest() string {
-	if _, err := exec.LookPath("pnpm"); err == nil {
-		return "pnpm dlx gentle-engram@latest pi-engram init"
-	}
-	return "npm exec --yes --package gentle-engram@latest -- pi-engram init"
-}
+const engramInitCommandForTest = "npm exec --yes --package gentle-engram@latest -- pi-engram init"
 
 func TestRunInstallAppliesFilesystemChanges(t *testing.T) {
 	home := t.TempDir()
@@ -165,8 +157,7 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
 		// Simulate pi-engram init writing mcp.json with the new schema.
 		isNpmEngramInit := name == "npm" && len(args) >= 7 && args[5] == "pi-engram" && args[6] == "init"
-		isPnpmEngramInit := name == "pnpm" && len(args) >= 4 && args[2] == "pi-engram" && args[3] == "init"
-		if isNpmEngramInit || isPnpmEngramInit {
+		if isNpmEngramInit {
 			mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")
 			if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
 				return err
@@ -197,88 +188,30 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 	if !stringSliceContains(commands, "pi install npm:pi-mcp-adapter") {
 		t.Fatalf("commands missing %q; got %v", "pi install npm:pi-mcp-adapter", commands)
 	}
-	if !stringSliceContains(commands, "npm exec --yes --package gentle-engram@latest -- pi-engram init") &&
-		!stringSliceContains(commands, "pnpm dlx gentle-engram@latest pi-engram init") {
-		t.Fatalf("commands missing Engram init command; got %v", commands)
+	if !stringSliceContains(commands, engramInitCommandForTest) {
+		t.Fatalf("commands missing %q; got %v", engramInitCommandForTest, commands)
 	}
 }
 
-// TestAgentInstallStepRefusesMissingCodexInsteadOfInstalling proves that when
-// Codex is not detected, gentle-ai never runs an install command on the
-// user's behalf: it refuses and names the exact command the user would need
-// to run themselves. Before this behavior existed, this same scenario
-// (Codex undetected) executed `npm install -g --ignore-scripts
-// @openai/codex@0.144.0` via runCommand — see git history for the prior
-// version of this test, TestRunInstallInstallsMissingCodexBeforeRuntimeValidationAndProfileWrite.
-func TestAgentInstallStepRefusesMissingCodexInsteadOfInstalling(t *testing.T) {
-	home := t.TempDir()
-	codexInstallCalls := 0
-	validationCalls := 0
-
-	restoreCodexLookPath := codex.LookPathOverride
-	codex.LookPathOverride = func(string) (string, error) { return "", exec.ErrNotFound }
-	t.Cleanup(func() { codex.LookPathOverride = restoreCodexLookPath })
-
-	restoreVersionProbe := codex.SetRuntimeVersionProbeForTest(func() ([]byte, error) {
-		validationCalls++
-		return nil, exec.ErrNotFound
-	})
-	t.Cleanup(restoreVersionProbe)
-
-	restorePreflightLookPath := installcmd.OverrideLookPath(func(string) (string, error) { return "npm", nil })
-	t.Cleanup(restorePreflightLookPath)
-
-	restoreLookPath := cmdLookPath
-	cmdLookPath = func(name string) (string, error) {
-		if name == "engram" {
-			return filepath.Join(home, "bin", "engram"), nil
-		}
-		return "", exec.ErrNotFound
-	}
-	t.Cleanup(func() { cmdLookPath = restoreLookPath })
-
-	restoreDownload := engramDownloadFn
-	engramDownloadFn = func(system.PlatformProfile) (string, error) {
-		t.Fatal("engramDownloadFn must not use the network in this test")
-		return "", nil
-	}
-	t.Cleanup(func() { engramDownloadFn = restoreDownload })
-
+// TestAgentInstallStepSkipsMissingNonPiRuntime proves an explicitly selected
+// desktop agent does not block installation or trigger agent acquisition when
+// its runtime is absent.
+func TestAgentInstallStepSkipsMissingNonPiRuntime(t *testing.T) {
 	restoreCommand := runCommand
-	runCommand = func(name string, args ...string) error {
-		codexInstallCalls++
-		return fmt.Errorf("gentle-ai must never execute a command on the user's behalf, got: %s %s", name, strings.Join(args, " "))
-	}
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
 	t.Cleanup(func() { runCommand = restoreCommand })
 
-	runtime := installRuntime{
-		homeDir: home,
-		resolved: planner.ResolvedPlan{
-			Agents: []model.AgentID{model.AgentCodex}, OrderedComponents: []model.ComponentID{model.ComponentEngram},
-		},
-		profile: system.PlatformProfile{OS: "linux", NpmWritable: true},
+	step := agentInstallStep{
+		id:      "agent:vscode-copilot",
+		agent:   model.AgentVSCodeCopilot,
+		homeDir: t.TempDir(),
 	}
-
-	var refusal error
-	for _, step := range runtime.stagePlan().Apply {
-		if err := step.Run(); err != nil {
-			refusal = err
-			break
-		}
+	if err := step.Run(); err != nil {
+		t.Fatalf("agentInstallStep.Run() error = %v, want absent non-Pi runtime to be skipped", err)
 	}
-
-	if refusal == nil {
-		t.Fatal("agentInstallStep refusal error = nil, want a refusal because Codex is not installed")
-	}
-	const wantCommand = "npm install -g --ignore-scripts @openai/codex@latest"
-	if !strings.Contains(refusal.Error(), wantCommand) {
-		t.Fatalf("refusal error = %q, want it to name %q", refusal.Error(), wantCommand)
-	}
-	if codexInstallCalls != 0 {
-		t.Fatalf("Codex install calls = %d, want 0 — gentle-ai must never run an install command on the user's behalf", codexInstallCalls)
-	}
-	if validationCalls != 0 {
-		t.Fatalf("Codex runtime validation calls = %d, want 0 — the pipeline must stop at the refusal, never proceed past a missing runtime", validationCalls)
+	if got := recorder.get(); len(got) != 0 {
+		t.Fatalf("commands executed = %v, want none for non-Pi agent", got)
 	}
 }
 
@@ -331,7 +264,7 @@ func TestPiAgentInstallRunsPackageCommandsWhenPiAlreadyInstalled(t *testing.T) {
 		"pi install npm:gentle-pi",
 		"pi install npm:gentle-engram",
 		"pi install npm:pi-mcp-adapter",
-		engramInitCommandForTest(),
+		engramInitCommandForTest,
 		"pi install npm:pi-subagents-j0k3r",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",
 		"pi install npm:pi-web-access",
@@ -341,31 +274,6 @@ func TestPiAgentInstallRunsPackageCommandsWhenPiAlreadyInstalled(t *testing.T) {
 		if !stringSliceContains(commands, want) {
 			t.Fatalf("commands missing %q; got %v", want, commands)
 		}
-	}
-}
-
-// TestAgentInstallStepReportsUndetectedClassBAgentInsteadOfSilentNoop proves
-// that an agent with no AutoInstall claim (a desktop app or vendor-managed
-// tool gentle-ai has never been able to install) now reports when it is not
-// detected, instead of silently no-opping and letting the pipeline proceed
-// to write config for a tool that may not exist. Cursor's own
-// AgentNotInstallableError string is the refusal — it already existed and
-// was already unit-tested at the adapter level, but was unreachable from
-// this pipeline step before this behavior existed.
-func TestAgentInstallStepReportsUndetectedClassBAgentInsteadOfSilentNoop(t *testing.T) {
-	step := agentInstallStep{
-		id:      "agent:cursor",
-		agent:   model.AgentCursor,
-		homeDir: t.TempDir(),
-	}
-
-	err := step.Run()
-	if err == nil {
-		t.Fatal("agentInstallStep.Run() error = nil, want a report because Cursor is not installed")
-	}
-	const want = "agent cursor is a desktop app and cannot be installed via CLI"
-	if err.Error() != want {
-		t.Fatalf("agentInstallStep.Run() error = %q, want %q", err.Error(), want)
 	}
 }
 
@@ -786,70 +694,6 @@ func TestRunInstallFedoraQwenEngramSkipsUnsupportedSetupAndWritesSettings(t *tes
 		if strings.Contains(cmd, "engram setup qwen-code") {
 			t.Fatalf("unexpected unsupported setup command: %s", cmd)
 		}
-	}
-}
-
-// TestRunInstallRefusesMissingOpenCodeInsteadOfInstalling proves that when
-// OpenCode is not detected, gentle-ai never runs an install command on the
-// user's behalf: RunInstall fails with a refusal naming the exact command
-// the user would need to run themselves. Before this behavior existed, this
-// same scenario (OpenCode undetected on Ubuntu) executed `sudo npm install
-// -g --ignore-scripts opencode-ai@<pin>` via runCommand — see git history
-// for the prior version of this test,
-// TestRunInstallLinuxAgentInstallResolvesGoInstallCommand.
-func TestRunInstallRefusesMissingOpenCodeInsteadOfInstalling(t *testing.T) {
-	home := t.TempDir()
-	restoreHome := osUserHomeDir
-	restoreCommand := runCommand
-	restoreLookPath := cmdLookPath
-	t.Cleanup(func() {
-		osUserHomeDir = restoreHome
-		runCommand = restoreCommand
-		cmdLookPath = restoreLookPath
-	})
-
-	osUserHomeDir = func() (string, error) { return home, nil }
-	cmdLookPath = missingBinaryLookPath
-	recorder := &commandRecorder{}
-	runCommand = recorder.record
-
-	// The refusal makes the Apply stage fail, which triggers the pipeline's
-	// rollback of the pre-install snapshot. Rollback validates every restored
-	// path is under the real user home directory, so it must be told this
-	// test's fake home — otherwise the rollback itself fails first and its
-	// error masks the refusal this test is asserting on.
-	restoreBackupHome := backup.UserHomeDirFn
-	backup.UserHomeDirFn = func() (string, error) { return home, nil }
-	t.Cleanup(func() { backup.UserHomeDirFn = restoreBackupHome })
-
-	// Set the agent adapter's lookPath to simulate missing opencode
-	opencodeAdapterLookPath := opencode.LookPathOverride
-	opencode.LookPathOverride = missingBinaryLookPath
-	t.Cleanup(func() {
-		opencode.LookPathOverride = opencodeAdapterLookPath
-	})
-
-	detection := linuxDetectionResult(system.LinuxDistroUbuntu, "apt")
-	_, err := RunInstall(
-		[]string{"--agent", "opencode", "--component", "permissions"},
-		detection,
-	)
-	if err == nil {
-		t.Fatal("RunInstall() error = nil, want a refusal because opencode is not installed")
-	}
-
-	// OpenCode on Ubuntu resolves via npm install (official method from
-	// opencode.ai) — the refusal must name that exact command, never run it.
-	// This is deliberately "latest", not versions.OpenCode: that constant is
-	// the CI/E2E-owned pin for the binary actually installed in those tests,
-	// unrelated to this display-only advice string.
-	wantCommand := "sudo npm install -g --ignore-scripts opencode-ai@latest"
-	if !strings.Contains(err.Error(), wantCommand) {
-		t.Fatalf("RunInstall() error = %q, want it to name %q", err.Error(), wantCommand)
-	}
-
-	if commands := recorder.get(); len(commands) != 0 {
-		t.Fatalf("commands executed = %v, want none — gentle-ai must never run an install command on the user's behalf", commands)
 	}
 }
 
@@ -2381,76 +2225,6 @@ func TestRunInstallKimiBootstrapsHub(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "{% include \"persona.md\" ignore missing %}") {
 		t.Errorf("bootstrapped hub missing modular include: %s", string(content))
-	}
-}
-
-// TestRunInstallRefusesMissingKimiRegardlessOfUVPresence proves that when
-// Kimi is not detected, gentle-ai refuses and names the exact `uv` command
-// the user would run themselves — it no longer preflights uv presence for
-// Kimi at all (uv is not Pi's dependency, and gentle-ai never runs this
-// command itself), so the refusal fires the same way whether uv is on this
-// machine's PATH or not. Before this behavior existed, this same scenario
-// (Kimi undetected, uv missing) failed earlier and differently — at
-// checkDependenciesStep's preflight, with a "preflight for agent kimi: uv"
-// error — see git history for the prior version of this test,
-// TestRunInstallKimiMissingUVFailsBeforeExecutingInstallCommands.
-func TestRunInstallRefusesMissingKimiRegardlessOfUVPresence(t *testing.T) {
-	home := t.TempDir()
-	restoreHome := osUserHomeDir
-	restoreCommand := runCommand
-	restoreLookPath := cmdLookPath
-	t.Cleanup(func() {
-		osUserHomeDir = restoreHome
-		runCommand = restoreCommand
-		cmdLookPath = restoreLookPath
-	})
-
-	osUserHomeDir = func() (string, error) { return home, nil }
-	cmdLookPath = missingBinaryLookPath
-
-	recorder := &commandRecorder{}
-	runCommand = recorder.record
-
-	// Force Kimi absent explicitly rather than relying on it happening to be
-	// missing from the machine running go test — the whole point of this
-	// test is the refusal on genuine absence, so absence must be the tested
-	// condition, not an accident of the environment.
-	restoreKimiLookPath := kimi.LookPathOverride
-	kimi.LookPathOverride = func(string) (string, error) { return "", exec.ErrNotFound }
-	t.Cleanup(func() { kimi.LookPathOverride = restoreKimiLookPath })
-
-	restoreInstallcmdLookPath := installcmd.OverrideLookPath(func(name string) (string, error) {
-		if name == "uv" {
-			return "", exec.ErrNotFound
-		}
-		return "/usr/bin/" + name, nil
-	})
-	t.Cleanup(restoreInstallcmdLookPath)
-
-	// The refusal makes Apply fail, which triggers rollback of the
-	// pre-install snapshot; rollback validates restored paths are under the
-	// real user home directory, so it needs this test's fake home too (see
-	// TestRunInstallRefusesMissingOpenCodeInsteadOfInstalling for the same
-	// fix and its full explanation).
-	restoreBackupHome := backup.UserHomeDirFn
-	backup.UserHomeDirFn = func() (string, error) { return home, nil }
-	t.Cleanup(func() { backup.UserHomeDirFn = restoreBackupHome })
-
-	_, err := RunInstall(
-		[]string{"--agent", "kimi", "--component", "permissions"},
-		macOSDetectionResult(),
-	)
-	if err == nil {
-		t.Fatal("RunInstall() error = nil, want a refusal because Kimi is not installed")
-	}
-
-	const wantCommand = "uv tool install --python 3.13 kimi-cli"
-	if !strings.Contains(err.Error(), wantCommand) {
-		t.Fatalf("RunInstall() error = %q, want it to name %q", err.Error(), wantCommand)
-	}
-
-	if got := recorder.get(); len(got) != 0 {
-		t.Fatalf("commands executed = %v, want none — gentle-ai must never run an install command on the user's behalf", got)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Refs #3018
Closes #3279

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Prevent optional agent runtimes from turning an otherwise valid installation into a pipeline failure, and make Pi's Engram initialization independent of whether pnpm happens to be present on `PATH`.

Persisted agent selection remains unchanged. Non-Pi runtime acquisition is skipped because Gentle AI does not install those runtimes, while Pi continues through its existing npm-backed preflight and command sequence.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go` | Skip non-Pi runtime acquisition and remove the obsolete refusal path. |
| `internal/cli/run_integration_test.go` | Prove an absent VS Code Copilot runtime does not fail installation and remove refusal-specific scaffolding. |
| `internal/agents/pi/adapter.go` | Always generate the documented npm invocation for `pi-engram init`. |
| `internal/agents/pi/adapter_test.go` | Prove pnpm presence or absence cannot change the generated command. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi with OpenAI Codex GPT-5.6

**Material scope:** Root-cause analysis, regression-test design, implementation, verification orchestration, and PR preparation.

**Verification performed:** Focused Go tests, `go build ./...`, `go vet ./...`, `go run ./internal/gofmtcheck`, LSP diagnostics, and staged diff checks. The complete submission and generated diff were inspected before publication.

---

## 🧪 Test Plan

**Build and static analysis**

```bash
go build ./...
go vet ./...
go run ./internal/gofmtcheck
```

All passed.

**Focused unit tests**

```bash
TMPDIR=<physical-temp-root> go test ./internal/agents/pi ./internal/installcmd -count=1
TMPDIR=<physical-temp-root> go test ./internal/cli -run '^(TestAgentInstallStepSkipsMissingNonPiRuntime|TestPiAgentInstallRunsPackageCommandsWhenPiAlreadyInstalled|TestRunInstallSkipsProtocolProbeWhenSetupModeOff|TestRunInstallShellsOutEngramVersionOnlyOnce)$' -count=1
```

All passed. A physical macOS temp root was used because `/var` is a symlink to `/private/var`, while the existing hardened lock tests intentionally reject symlink traversal.

**Not run**

- `go test ./...`: the complete repository suite was not run; affected packages and control tests are covered above.
- `cd e2e && ./docker-test.sh`: no Docker journey represents this package-command selection and absent-runtime policy change.
- Real installer execution: intentionally excluded to avoid mutating the operator's installed Pi packages and configuration.

**Benchmark validation:** N/A. This change does not modify review lifecycle, gates, recovery, delivery, benchmark implementation, corpus, classifier, or benchmark claims.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR stays within 400 changed lines (`37 additions + 309 deletions = 346`) |
| Check Issue Reference | ⏳ | PR references #3018 and closes #3279 |
| Check Issue Has `status:approved` | ⏳ | Both linked issues are approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` is requested at PR creation |
| Unit Tests | ⏳ | CI will run the complete suite |
| Go Format | ⏳ | Local check passed; CI will re-run it |
| E2E Tests | ⏳ | CI applicability is authoritative |

---

## ✅ Contributor Checklist

- [x] PR is linked to issues with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan)
- [x] I have updated documentation if necessary (existing Pi docs already specify the npm command)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Suggested review order:

1. `internal/cli/run.go`: confirm that persisted non-Pi selections remain valid while runtime acquisition becomes a no-op.
2. `internal/agents/pi/adapter.go`: confirm that Pi retains its preflight and uses the documented npm invocation.
3. Regression tests: confirm both reported failure modes are covered without host-dependent package-manager behavior.

Guard population challenge: the removed refusal treated every absent non-Pi runtime as invalid, but persisted selections are a legitimate population even when a desktop or CLI runtime is temporarily unavailable. The Copilot regression exercises that real-world population directly. No `.guard-population-baseline.txt` change is needed because this removes refusal annotations rather than introducing or reclassifying a registered guard.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.
