### PR TITLE
fix(review): stop unrelated lineages from obstructing denials, abandons, and repair

### DIFF
--- a/contracts/review-integration/v1/schemas/repair.schema.json
+++ b/contracts/review-integration/v1/schemas/repair.schema.json
@@ -48,6 +48,10 @@
     },
     "execution": {
       "$ref": "#/$defs/execution"
+    },
+    "continuation": {
+      "type": "string",
+      "minLength": 1
     }
   },
   "allOf": [
@@ -152,6 +156,41 @@
               "provider_inputs"
             ]
           }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "mode": {
+            "const": "preflight"
+          },
+          "assessment": {
+            "properties": {
+              "status": {
+                "const": "truncated"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "mode",
+          "assessment"
+        ]
+      },
+      "then": {
+        "required": [
+          "continuation"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "continuation"
+          ]
         }
       }
     }

--- a/contracts/review-integration/v2/schemas/repair.schema.json
+++ b/contracts/review-integration/v2/schemas/repair.schema.json
@@ -13,10 +13,12 @@
     "assessment": {"$ref": "../../v1/schemas/repair.schema.json#/properties/assessment"},
     "provider_inputs": {"$ref": "../../v1/schemas/repair.schema.json#/properties/provider_inputs"},
     "required_inputs": {"$ref": "../../v1/schemas/repair.schema.json#/properties/required_inputs"},
-    "execution": {"$ref": "../../v1/schemas/repair.schema.json#/properties/execution"}
+    "execution": {"$ref": "../../v1/schemas/repair.schema.json#/properties/execution"},
+    "continuation": {"$ref": "../../v1/schemas/repair.schema.json#/properties/continuation"}
   },
   "allOf": [
     {"$ref": "../../v1/schemas/repair.schema.json#/allOf/0"},
-    {"$ref": "../../v1/schemas/repair.schema.json#/allOf/1"}
+    {"$ref": "../../v1/schemas/repair.schema.json#/allOf/1"},
+    {"$ref": "../../v1/schemas/repair.schema.json#/allOf/2"}
   ]
 }

--- a/internal/cli/review_abandon_disabled_test.go
+++ b/internal/cli/review_abandon_disabled_test.go
@@ -238,3 +238,94 @@ func TestReviewStartBooleanFlagHelpDoesNotSuggestSeparateValue(t *testing.T) {
 		t.Fatalf("space-separated boolean value error = %v", err)
 	}
 }
+
+// breakForeignCompactSnapshotIdentity rewrites one persisted compact record's
+// frozen snapshot identity so the record no longer loads. Validate() runs
+// before the checksum comparison in parseCompactRecord, so the load failure is
+// the same typed semantic "compact snapshot identity does not match its
+// metadata" a released binary reports for a record it can no longer read --
+// the exact shape issue #3124 and its occurrences describe.
+func breakForeignCompactSnapshotIdentity(t *testing.T, repo, lineage string) {
+	t.Helper()
+	statePath := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", lineage, "review-state.json")
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := record.Load()
+	if err != nil {
+		t.Fatalf("fixture lineage %q does not load before it is broken: %v", lineage, err)
+	}
+	retired := "sha256:" + strings.Repeat("c", 64)
+	broken := strings.ReplaceAll(string(payload), loaded.State.InitialSnapshot.Identity, retired)
+	if broken == string(payload) {
+		t.Fatalf("fixture lineage %q carries no snapshot identity to retire", lineage)
+	}
+	if err := os.WriteFile(statePath, []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, loadErr := record.Load(); loadErr == nil {
+		t.Fatalf("fixture lineage %q still loads after its snapshot identity was retired", lineage)
+	} else if !strings.Contains(loadErr.Error(), "identity does not match its metadata") {
+		t.Fatalf("fixture lineage %q load error = %v, want a snapshot identity mismatch", lineage, loadErr)
+	}
+}
+
+// TestReviewAbandonOfAPristineLineageIgnoresAnUnrelatedUnloadableApprovedLineage
+// is issue #3124 driven through the live `gentle-ai review abandon` command.
+//
+// The report, filed against 2.3.0, is that abandoning a pristine `reviewing`
+// lineage -- the documented sanctioned exit for a review that never captured a
+// lens result -- is refused because a DIFFERENT, unrelated compact entry in
+// the same repository-global store fails to load. At 2.3.0 that was exactly
+// true: AbandonPristineCompactStore walked every discovered store and returned
+// `review abandon refused: related compact authority %q does not load` on the
+// first failure, so one historical entry refused every abandonment in the
+// repository and each stranded lineage could strand the next.
+//
+// cff02464 ("finish scoping authority walks past outdated records", #2743/#2741,
+// merged after 2.3.0) routed both abandon walks through scanCompactAuthority,
+// where an entry nobody can read is ABSENT from the graph rather than a verdict
+// on it. This test is the CLI-level guard for that scoping, covering the
+// permutation the occurrence comments add: the unrelated blocking entry is
+// APPROVED, not reviewing, and it must still refuse nothing.
+//
+// The sibling proof at the transaction API is
+// TestPristineAbandonmentIgnoresUnreadableForeignLineage; this one drives the
+// same property through the command an operator actually runs, because a
+// scoped walk is only useful if the CLI path reaches it.
+func TestReviewAbandonOfAPristineLineageIgnoresAnUnrelatedUnloadableApprovedLineage(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "abandon-foreign-approved", "docs/foreign.md", "foreign\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "foreign approved candidate")
+	breakForeignCompactSnapshotIdentity(t, repo, "abandon-foreign-approved")
+
+	revision, snapshotIdentity := pristineReviewingCLIFixture(t, repo)
+	binding := staleReviewingAbandonBinding(t, repo, revision, snapshotIdentity)
+
+	var output bytes.Buffer
+	if err := RunReview(staleReviewingAbandonArgs(repo, revision, binding), &output); err != nil {
+		t.Fatalf("an unrelated unloadable approved lineage refused the sanctioned exit of a pristine one: %v\n%s", err, output.String())
+	}
+	var result ReviewAbandonResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Record.Status != reviewtransaction.CompactReclaimCommitted || result.Record.LineageID != "abandon-stale-reviewing" {
+		t.Fatalf("abandonment record = %#v", result.Record)
+	}
+
+	// Scoping never widens authority: the unrelated entry is untouched and
+	// still unreadable, so nothing was silently repaired to make this pass.
+	foreign, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "abandon-foreign-approved")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, loadErr := foreign.Load(); loadErr == nil {
+		t.Fatal("the unrelated lineage became readable, so this test proved nothing about scoping")
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -322,7 +322,15 @@ func (err *ReviewReceiptDiscoveryError) Error() string {
 	case ReviewReceiptMissing:
 		message = "no terminal review receipt exists for gate validation"
 	case ReviewReceiptUnrelated:
-		message = "terminal review receipts exist only for unrelated targets"
+		// issue #3408: the old wording ("terminal review receipts exist only
+		// for unrelated targets") reported OTHER lineages' existence as
+		// though one of them were the obstacle, so an operator went looking
+		// for what those receipts had to do with their work and found
+		// nothing, because there is nothing. Discovery has proven the exact
+		// opposite: every terminal receipt on file was assessed against this
+		// candidate and none of them governs it. That is the candidate's own
+		// situation, and it has one route, so the denial states both.
+		message = "no approved review receipt covers this candidate; review it with gentle-ai review start"
 	case ReviewReceiptScopeChanged:
 		message = "terminal review receipts do not exactly match the live gate target"
 	case ReviewReceiptAmbiguous:
@@ -3804,7 +3812,6 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	}
 	targetResolution := []targetResolutionFailure{}
 	terminalCount := 0
-	allLineages := []string{}
 	// organic-dx Phase 3d: as terminal lineages accumulate, most of them can
 	// never govern the live candidate again, yet every gate call re-assessed
 	// every one of them with AssessCompactGateTarget's several git
@@ -3857,7 +3864,6 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 		}
 		terminalCount++
-		allLineages = append(allLineages, record.State.LineageID)
 		if input.Gate == reviewtransaction.GatePreCommit {
 			if !preCommitBaselineTried {
 				preCommitBaselineTried = true
@@ -4042,8 +4048,16 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	if len(targetResolution) > 0 {
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 	}
-	sort.Strings(allLineages)
-	return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewReceiptUnrelated, Candidates: allLineages}
+	// issue #3408: reaching here means every terminal lineage the walk above
+	// examined assessed as UNRELATED to this candidate -- it contributed to
+	// no discovery bucket, so none of them can be recovered, selected, or
+	// acted on for THIS candidate. The denial used to carry all of them as
+	// Candidates, an enumeration that grows with the store (lineages
+	// accumulate and nothing reaps them, #1656) and is actionable for
+	// nothing. Candidates stays empty here on purpose; the kinds that DO
+	// carry it -- ambiguous, scope-changed -- carry only lineages a caller
+	// can genuinely select or recover.
+	return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewReceiptUnrelated}
 }
 
 // reviewAuthorityCorruptionConfinedToLegacyEntries reports whether every cause

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -1020,9 +1020,16 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 			// should not have to consult documentation to find it.
 			failure.NextAction = "review.start"
 		case ReviewReceiptUnrelated:
-			// Every terminal receipt on file targets something else. STATUS
-			// re-derives the same discovery and can name the candidate
-			// lineages (or confirm none apply) without guessing.
+			// issue #3408: discovery assessed every terminal receipt on file
+			// against this candidate and none of them governs it, so the
+			// message leads with the candidate's own situation and its route
+			// instead of the generic "no unique exact receipt applies", which
+			// read as though one of those other receipts were the obstacle.
+			// NextAction stays review.status: STATUS is the negotiated entry
+			// that re-derives this discovery and returns the exact
+			// transition, which for a candidate nothing governs is the
+			// review.start the message names.
+			failure.Message = "No approved review receipt covers this candidate; review it with gentle-ai review start."
 			failure.NextAction = "review.status"
 		case ReviewReceiptScopeChanged:
 			if discovery.Context != nil {

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -104,7 +104,11 @@ func TestPreCommitGateDiscoverySkipsAssessmentForGenesisDisjointTerminalLeaves(t
 
 	_, _, discoveryErr := discoverCompactFacadeGateReview(context.Background(), repo, "", reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
 	var discovery *ReviewReceiptDiscoveryError
-	if !errors.As(discoveryErr, &discovery) || discovery.Kind != ReviewReceiptUnrelated || len(discovery.Candidates) != n {
+	// issue #3408: the unrelated denial no longer enumerates the terminal
+	// leaves it walked -- none of them is actionable for this candidate -- so
+	// the surviving observable is the kind, and the skip count below is what
+	// this test actually proves.
+	if !errors.As(discoveryErr, &discovery) || discovery.Kind != ReviewReceiptUnrelated || len(discovery.Candidates) != 0 {
 		t.Fatalf("pre-commit discovery over %d disjoint terminal leaves = %#v, err=%v", n, discovery, discoveryErr)
 	}
 	if assessed >= n {
@@ -152,6 +156,78 @@ func TestPreCommitGateDiscoveryStillSelectsExactReceiptAmongDisjointNoiseLineage
 		t.Fatalf("expensive assessment ran %d times for %d noise lineages plus the governing one, want at most %d", assessed, n, n+1)
 	}
 	t.Logf("expensive per-leaf assessment ran %d times for %d disjoint noise lineages plus the governing one", assessed, n)
+}
+
+// TestUnrelatedReceiptDenialNamesTheCandidateSituationNotOtherLineages is
+// issue #3408 at the live gate boundary. The denial itself is correct and
+// stays a denial: a candidate with no approved receipt must be refused.
+// What was wrong is what the refusal REPORTED. It carried every terminal
+// lineage the discovery walk had examined -- an enumeration that grows with
+// the store, because lineages accumulate and nothing reaps them (#1656) --
+// and worded itself as "terminal review receipts exist only for unrelated
+// targets", so an operator read it as "some old lineage is blocking me",
+// went looking for the connection, and found none, because there is none.
+//
+// Every lineage in that set assessed as UNRELATED to this candidate. None of
+// them can be selected, recovered, or acted on here, so none of them belongs
+// in the refusal. The refusal must state the candidate's own situation and
+// the one route out of it.
+func TestUnrelatedReceiptDenialNamesTheCandidateSituationNotOtherLineages(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	const n = 6
+	lineages := make([]string, 0, n)
+	for index := 0; index < n; index++ {
+		lineage := fmt.Sprintf("unrelated-denial-noise-%02d", index)
+		approveDiscoveryMarkdown(t, repo, lineage, fmt.Sprintf("docs/unrelated-denial-%02d.md", index), fmt.Sprintf("noise %d\n", index))
+		runReviewCLIGit(t, repo, "add", "-A")
+		runReviewCLIGit(t, repo, "commit", "-qm", lineage)
+		lineages = append(lineages, lineage)
+	}
+	// The live candidate touches a path none of those lineages reviewed, so
+	// discovery classifies every one of them unrelated and denies.
+	if err := os.WriteFile(filepath.Join(repo, "live-candidate.txt"), []byte("live staged change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "-A")
+
+	var output bytes.Buffer
+	gateErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &output)
+	var denied ReviewGateDeniedError
+	if !errors.As(gateErr, &denied) {
+		t.Fatalf("candidate with no approved receipt was not denied: %T %v\n%s", gateErr, gateErr, output.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Allowed || result.Context.Denial == nil || result.Context.Denial.Code != string(ReviewReceiptUnrelated) {
+		t.Fatalf("denial = %#v, want a fail-closed %q\n%s", result.Context.Denial, ReviewReceiptUnrelated, output.String())
+	}
+	if !strings.Contains(result.Reason, "no approved review receipt covers this candidate") ||
+		!strings.Contains(result.Reason, "gentle-ai review start") {
+		t.Fatalf("denial reason = %q, want it to lead with this candidate's own situation and name its route", result.Reason)
+	}
+	payload := output.String()
+	for _, lineage := range lineages {
+		if strings.Contains(payload, lineage) {
+			t.Fatalf("denial reported unrelated lineage %q as though it were the obstacle:\n%s", lineage, payload)
+		}
+	}
+
+	// The typed discovery error carries no enumeration either, so no other
+	// renderer can grow one back.
+	_, _, discoveryErr := discoverCompactFacadeGateReview(context.Background(), repo, "", reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePreCommit})
+	var discovery *ReviewReceiptDiscoveryError
+	if !errors.As(discoveryErr, &discovery) || discovery.Kind != ReviewReceiptUnrelated || len(discovery.Candidates) != 0 {
+		t.Fatalf("unrelated discovery over %d terminal lineages = %#v, err=%v", n, discovery, discoveryErr)
+	}
+
+	// The negotiated failure envelope leads with the same statement.
+	failure := newReviewIntegrationFailure("review.validate", nil, discoveryErr)
+	if failure.Code != string(ReviewReceiptUnrelated) ||
+		!strings.Contains(failure.Message, "No approved review receipt covers this candidate") ||
+		!strings.Contains(failure.Message, "gentle-ai review start") {
+		t.Fatalf("negotiated unrelated failure = %#v", failure)
+	}
 }
 
 func TestReceiptlessTerminalLegacyChainIsInventoryReadableButNeverGateAuthority(t *testing.T) {

--- a/internal/cli/review_repair.go
+++ b/internal/cli/review_repair.go
@@ -68,12 +68,39 @@ type ReviewRepairDispositionExecution struct {
 	AuthorizationSHA256        string `json:"authorization_sha256"`
 }
 
+// reviewRepairTruncatedContinuation is issue #3409's whole fix: what a
+// `truncated` preflight leaves the maintainer holding.
+//
+// The bound itself is honest and stays. It produces a typed `truncated`
+// status rather than a silently partial classification, which is the right
+// failure direction: a partial answer presented as complete is worse than a
+// refusal. What was wrong is that the refusal terminated. A store crosses the
+// assessment's bound by ordinary use, because lineages accumulate and nothing
+// reaps them (retention is #1656, deliberately out of scope here), and from
+// that point `review repair --preflight` classified nothing and named nothing
+// -- the documented repair route simply closed, precisely on the stores most
+// likely to need it.
+//
+// `review inspect-authority` is the way forward that already exists and is
+// already the command this codebase names for every shape of authority damage
+// (see compactBlockedLineageError and reviewAuthorityCorruptionDetail). It
+// reads through scanCompactAuthority, carries no assessment bound at all, and
+// reports a per-entry diagnosis plus each entry's own sanctioned exits -- so
+// it classifies exactly the large store this assessment refused to walk.
+// Naming it converts a dead end into a route without weakening the bound,
+// widening any authority, or presenting one byte of partial classification as
+// though it were complete.
+const reviewRepairTruncatedContinuation = "this authority store exceeds the bounded repair assessment, so nothing was classified here; classify every entry with `gentle-ai review inspect-authority`"
+
 type ReviewRepairResult struct {
-	Schema                    string                                                `json:"schema"`
-	Contract                  string                                                `json:"contract"`
-	Operation                 string                                                `json:"operation"`
-	Mode                      ReviewRepairMode                                      `json:"mode"`
-	Assessment                reviewtransaction.AuthorityRepairAssessment           `json:"assessment"`
+	Schema     string                                      `json:"schema"`
+	Contract   string                                      `json:"contract"`
+	Operation  string                                      `json:"operation"`
+	Mode       ReviewRepairMode                            `json:"mode"`
+	Assessment reviewtransaction.AuthorityRepairAssessment `json:"assessment"`
+	// Continuation is populated only for a truncated preflight, and is then
+	// exactly reviewRepairTruncatedContinuation.
+	Continuation              string                                                `json:"continuation,omitempty"`
 	ProviderInputs            *ReviewRepairProviderInputs                           `json:"provider_inputs,omitempty"`
 	RequiredInputs            []string                                              `json:"required_inputs"`
 	Execution                 *reviewtransaction.ClassifiedAuthorityRepairExecution `json:"execution,omitempty"`
@@ -91,6 +118,18 @@ func (result ReviewRepairResult) Validate() error {
 	}
 	if err := result.Assessment.Validate(); err != nil {
 		return fmt.Errorf("review repair assessment: %w", err)
+	}
+	// issue #3409: a truncated preflight carries the continuation and every
+	// other result carries none, so no surface can quietly lose the way
+	// forward again, and none can attach it to a classification that
+	// actually completed.
+	wantContinuation := ""
+	if result.Mode == ReviewRepairModePreflight && result.Assessment.Status == reviewtransaction.AuthorityRepairTruncated {
+		wantContinuation = reviewRepairTruncatedContinuation
+	}
+	if result.Continuation != wantContinuation {
+		// refusal:by-design world-action: the continuation is attached by newReviewRepairPreflightResult from the assessment status this same result carries; a mismatch is a product defect to fix in code, not a value any operator supplies
+		return errors.New("review repair result continuation does not match its assessment status")
 	}
 	switch result.Mode {
 	case ReviewRepairModePreflight:
@@ -443,6 +482,15 @@ func newReviewRepairPreflightResult(assessment reviewtransaction.AuthorityRepair
 	}
 	if len(contracts) > 0 && contracts[0] == ReviewIntegrationContractV2 {
 		result.Schema, result.Contract = ReviewIntegrationRepairSchemaV2, ReviewIntegrationContractV2
+	}
+	// issue #3409: a truncated assessment classified nothing, so it must not
+	// be the end of the road. It names the unbounded per-entry diagnosis
+	// instead. No candidate, no provider inputs and no required inputs are
+	// derived here: the bound still fails closed and still publishes no
+	// partial classification.
+	if assessment.Status == reviewtransaction.AuthorityRepairTruncated {
+		result.Continuation = reviewRepairTruncatedContinuation
+		return result
 	}
 	if assessment.Status != reviewtransaction.AuthorityRepairEligible || assessment.Candidate == nil {
 		return result

--- a/internal/cli/review_repair_test.go
+++ b/internal/cli/review_repair_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -879,6 +880,26 @@ func TestReviewRepairSchemasRejectShortContractArrays(t *testing.T) {
 	if err := repairSchema.Validate(document); err != nil {
 		t.Fatalf("valid repair fixture rejected: %v", err)
 	}
+	// issue #3409: the truncated preflight's way forward travels on the wire,
+	// under a schema whose additionalProperties is false, and it is required
+	// exactly where nothing else is offered.
+	truncatedAssessment := reviewtransaction.UnsupportedAuthorityRepairAssessment()
+	truncatedAssessment.Status = reviewtransaction.AuthorityRepairTruncated
+	truncatedPayload, err := json.Marshal(newReviewRepairPreflightResult(truncatedAssessment))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var truncatedDocument map[string]any
+	if err := json.Unmarshal(truncatedPayload, &truncatedDocument); err != nil {
+		t.Fatal(err)
+	}
+	if err := repairSchema.Validate(truncatedDocument); err != nil {
+		t.Fatalf("truncated preflight naming its way forward rejected: %v", err)
+	}
+	delete(truncatedDocument, "continuation")
+	if err := repairSchema.Validate(truncatedDocument); err == nil {
+		t.Fatal("repair schema accepted a truncated preflight that names no way forward")
+	}
 	shortInputs := cloneReviewJSONDocument(t, document)
 	shortInputs["required_inputs"] = []any{"actor", "reason"}
 	if err := repairSchema.Validate(shortInputs); err == nil {
@@ -949,5 +970,99 @@ func TestWindowsRuntimeIncludesRepairAndMaintenanceLockRegressions(t *testing.T)
 		if !bytes.Contains(payload, []byte(name)) {
 			t.Fatalf("Windows PR runtime allowlist is missing %s", name)
 		}
+	}
+}
+
+// TestReviewRepairPreflightNamesAWayForwardWhenTheStoreExceedsTheBound is
+// issue #3409. `gentle-ai review repair --preflight` exists so a maintainer
+// can classify a damaged authority store and act on it. Its assessment is
+// bounded, and the bound is honest: exceeding it yields a typed `truncated`
+// status rather than a partial classification presented as complete, which is
+// the right failure direction and is not what this test changes.
+//
+// What this test pins is what a `truncated` preflight LEAVES the maintainer
+// holding. A store crosses that bound by ordinary use, because lineages
+// accumulate and nothing reaps them (retention is #1656, out of scope here);
+// from that point preflight classified nothing, named nothing, and the
+// documented repair route simply closed -- on exactly the stores most likely
+// to need it. So the truncated result must name a way forward, and that way
+// forward must actually work on the same oversized store, which is why this
+// test runs it rather than only asserting a string.
+//
+// The store here is real: authority entries are planted on disk past the
+// bound and the assessment is driven through the CLI, never constructed.
+func TestReviewRepairPreflightNamesAWayForwardWhenTheStoreExceedsTheBound(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	compactRoot := filepath.Join(repo, ".git", "gentle-ai", "review-transactions", "v2")
+	// Comfortably past the bounded assessment's ceiling, and past the
+	// 271-lineage store the report measured, without this test naming an
+	// internal constant it does not own.
+	const oversizedLineages = 512
+	for index := 0; index < oversizedLineages; index++ {
+		entry := filepath.Join(compactRoot, fmt.Sprintf("oversized-store-lineage-%04d", index))
+		if err := os.MkdirAll(entry, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"repair", "--preflight", "--cwd", repo}, &output); err != nil {
+		t.Fatalf("repair preflight over an oversized store: %v\n%s", err, output.String())
+	}
+	var preflight ReviewRepairResult
+	decoder := json.NewDecoder(bytes.NewReader(output.Bytes()))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&preflight); err != nil {
+		t.Fatal(err)
+	}
+	if err := preflight.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	// Still fails closed: no candidate, no provider inputs, no required
+	// inputs, and no partial classification dressed up as a complete one.
+	if preflight.Assessment.Status != reviewtransaction.AuthorityRepairTruncated ||
+		preflight.Assessment.Candidate != nil || preflight.ProviderInputs != nil || len(preflight.RequiredInputs) != 0 {
+		t.Fatalf("oversized-store preflight = %#v", preflight)
+	}
+	if preflight.Continuation != reviewRepairTruncatedContinuation {
+		t.Fatalf("truncated preflight continuation = %q, want the named way forward %q", preflight.Continuation, reviewRepairTruncatedContinuation)
+	}
+	if !strings.Contains(output.String(), "gentle-ai review inspect-authority") {
+		t.Fatalf("truncated preflight named no runnable continuation:\n%s", output.String())
+	}
+
+	// The named continuation is not a string: it classifies this exact store
+	// the bounded assessment refused to walk.
+	var inspection bytes.Buffer
+	if err := RunReviewInspectAuthority([]string{"--cwd", repo}, &inspection); err != nil {
+		t.Fatalf("the continuation named by a truncated preflight does not run on the store that truncated: %v\n%s", err, inspection.String())
+	}
+	var inspected ReviewInspectAuthorityResult
+	decodeStrictReviewJSON(t, inspection.Bytes(), &inspected)
+	if inspected.Totals.CompactEntries != oversizedLineages || inspected.Totals.EntryDiagnostics != oversizedLineages {
+		t.Fatalf("the continuation classified %d of %d entries: %#v", inspected.Totals.EntryDiagnostics, oversizedLineages, inspected.Totals)
+	}
+}
+
+// TestReviewRepairResultRejectsAMisplacedContinuation keeps the way forward
+// bound to the one status that has no other exit: a completed classification
+// must never carry it, and a truncated one must never lose it.
+func TestReviewRepairResultRejectsAMisplacedContinuation(t *testing.T) {
+	truncated := reviewtransaction.UnsupportedAuthorityRepairAssessment()
+	truncated.Status = reviewtransaction.AuthorityRepairTruncated
+
+	missing := newReviewRepairPreflightResult(truncated)
+	missing.Continuation = ""
+	if err := missing.Validate(); err == nil {
+		t.Fatal("a truncated preflight validated with no way forward at all")
+	}
+
+	unsupported := newReviewRepairPreflightResult(reviewtransaction.UnsupportedAuthorityRepairAssessment())
+	if unsupported.Continuation != "" {
+		t.Fatalf("a completed classification carried a truncation continuation: %q", unsupported.Continuation)
+	}
+	unsupported.Continuation = reviewRepairTruncatedContinuation
+	if err := unsupported.Validate(); err == nil {
+		t.Fatal("a completed classification validated while claiming it was truncated")
 	}
 }


### PR DESCRIPTION
Three defects that share one root cause: the review authority store is repository-global, lineages accumulate, and nothing reaps them. The root retention question is #1656 and is deliberately **out of scope** here. Each defect gets its own bounded fix.

Closes #3408.
Closes #3124.
Closes #3409.

## #3408 — the receipt denial enumerated every unrelated lineage

The denial itself is correct and stays a denial. What was wrong is what it **reported**: `discoverCompactFacadeGateReview` carried every terminal lineage it had walked as `ReviewReceiptUnrelated` `Candidates`, and worded itself *"terminal review receipts exist only for unrelated targets"* — so an operator read it as "some old lineage is blocking me", went looking for the connection, and found none, because there is none.

Every lineage in that set had already assessed as **unrelated** to the candidate: it contributed to no discovery bucket and can be neither selected nor recovered there. The set also grows without bound as the store does.

- The enumeration is dropped where nothing in it is actionable.
- Both renderers (`ReviewReceiptDiscoveryError.Error`, the negotiated failure envelope) now lead with what is true for **this** candidate and its one route: *no approved review receipt covers this candidate; review it with `gentle-ai review start`*.
- `ReviewReceiptAmbiguous` and `ReviewReceiptScopeChanged` are untouched — they carry lineages a caller can genuinely select or recover.
- `NextAction` stays `review.status`: STATUS is the negotiated entry that re-derives this discovery and returns the exact transition.

The **refusal-wording ratchet was not touched**. These two strings are message assignments, not `errors.New`/`fmt.Errorf` origin sites, so they are not ratchet sites and `.refusal-ratchet-baseline.txt` is byte-identical. All three ratchet guards pass.

## #3124 — verified, does not reproduce on `main`; no production change

The report is filed against `2.3.0`, and it was real there: `AbandonPristineCompactStore` walked every discovered store and returned ``review abandon refused: related compact authority %q does not load`` on the first failure, so one historical entry refused every abandonment in the repository.

`cff02464` ("finish scoping authority walks past outdated records", #2743/#2741) landed **after** `2.3.0` and routed both abandon walks through `scanCompactAuthority`, where an entry nobody can read is *absent* from the graph rather than a verdict on it. Confirmed by reintroducing the `2.3.0` walk shape locally: the new test then fails with the issue's message verbatim, naming an `approved` foreign lineage — matching the occurrence comments.

No production change. What was missing is coverage at the boundary an operator actually uses: the existing proof (`TestPristineAbandonmentIgnoresUnreadableForeignLineage`) calls the transaction API directly, so the CLI path could regress silently. This PR adds that CLI-level guard and covers the permutation the occurrences contribute — the unrelated blocking entry is **approved**, not `reviewing`.

## #3409 — authority repair refused any store over 256 lineages

The bound is honest and **stays**: crossing it yields a typed `truncated` status rather than a partial classification presented as complete. What was wrong is that the refusal **terminated** — preflight classified nothing and named nothing, and the documented repair route closed on exactly the stores most likely to need it.

Raising `authorityRepairMaxLineages` is not the fix; it moves the ceiling and leaves the same cliff, and with retention out of scope any ceiling is crossed eventually. `authorityRepairMaxProofReads` derives from that constant and is likewise unchanged, as is `authorityRepairMaxQuarantineRecords`.

Instead, a `truncated` preflight now names the way forward that already exists: `gentle-ai review inspect-authority` reads through `scanCompactAuthority`, carries no assessment bound at all, and reports a per-entry diagnosis plus each entry's sanctioned exits. It is already the command this codebase names for every other shape of authority damage (`compactBlockedLineageError`, `reviewAuthorityCorruptionDetail`).

Still fail-closed: no candidate, no provider inputs, no required inputs, no partial classification published. `ReviewRepairResult.Validate()` and both repair JSON schemas pin the continuation to that one status, so it can neither be lost there nor attached to a classification that completed.

## Tests — revert-proofs

Each production hunk was reverted independently and the corresponding tests re-run.

**#3408**, reverting `review_facade.go` + `review_operation_contract.go`:

```
--- FAIL: TestUnrelatedReceiptDenialNamesTheCandidateSituationNotOtherLineages (0.76s)
    review_receipt_discovery_test.go:207: denial reason = "terminal review receipts exist only for unrelated targets", want it to lead with this candidate's own situation and name its route
```

```
--- FAIL: TestPreCommitGateDiscoverySkipsAssessmentForGenesisDisjointTerminalLeaves (1.58s)
    review_receipt_discovery_test.go:112: pre-commit discovery over 12 disjoint terminal leaves = &cli.ReviewReceiptDiscoveryError{Kind:"receipt_unrelated", Category:"", Candidates:[]string{"pre-commit-discovery-leaf-00", ... "pre-commit-discovery-leaf-11"}, ...}
```

**#3409**, reverting only the continuation-population hunk:

```
--- FAIL: TestReviewRepairSchemasRejectShortContractArrays (0.00s)
    review_repair_test.go:897: truncated preflight naming its way forward rejected: jsonschema validation failed
        - at '': missing property 'continuation'
--- FAIL: TestReviewRepairPreflightNamesAWayForwardWhenTheStoreExceedsTheBound (0.05s)
    review_repair_test.go:1010: repair preflight over an oversized store: validate review repair preflight: review repair result continuation does not match its assessment status
```

reverting only the two schema hunks:

```
--- FAIL: TestReviewRepairSchemasRejectShortContractArrays (0.00s)
    review_repair_test.go:897: truncated preflight naming its way forward rejected: jsonschema validation failed
        - at '': additional properties 'continuation' not allowed
```

The #3409 test plants **512 authority entries on disk**, past the ceiling, and drives the real CLI — never a constructed assessment object. It then **runs** the named continuation against that same oversized store and requires it to classify all 512 entries, so the way forward is proven rather than asserted.

**#3124** has no production change, so there is no revert-proof. Its negative proof is the inverse: reintroducing the `2.3.0` unscoped walk makes both the new CLI guard and the existing transaction-level sibling fail with the issue's message verbatim.

```
--- FAIL: TestReviewAbandonOfAPristineLineageIgnoresAnUnrelatedUnloadableApprovedLineage (0.17s)
    review_abandon_disabled_test.go:314: an unrelated unloadable approved lineage refused the sanctioned exit of a pristine one: review abandon refused: related compact authority "abandon-foreign-approved" does not load: compact lineage "abandon-foreign-approved" semantic state "approved" is invalid: initial snapshot: compact snapshot identity does not match its metadata
```

## Verification

All foreground, from the worktree root.

| Command | Exit |
| --- | --- |
| `go test ./...` | `0`, no failures |
| `go vet ./...` | `0` |
| `GOOS=windows go vet ./...` | `0` |
| `gofmt -l internal/` | `0`, no output |
| `./scripts/deadcode-ratchet.sh` | `0`, `no new unreachable functions` |

## Conflict awareness

PR #3268 touches `internal/cli/review_facade.go` and `internal/reviewtransaction/status.go` for `review status --lineage` scoping (#1997). Nothing from it is adopted or duplicated here. This PR's `review_facade.go` diff is 3 small hunks (a message string, one dropped accumulator, one return), `internal/reviewtransaction/` is untouched.
