### PR TITLE
feat(review): add clone-scoped review store reset

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -143,7 +143,6 @@ internal/reviewtransaction/snapshot.go	sanitizedGitEnvironment
 internal/reviewtransaction/snapshot.go	snapshotIdentity
 internal/reviewtransaction/store.go	SnapshotsEqualExact
 internal/reviewtransaction/store.go	WriteReceiptAtomic
-internal/reviewtransaction/store_lock.go	AcquireReviewMaintenanceExclusive
 internal/reviewtransaction/target_status.go	AssessTargetStatus
 internal/reviewtransaction/target_status.go	compactLiveTargetMatchesSnapshot
 internal/reviewtransaction/target_status.go	legacyLiveTargetMatchesSnapshot

--- a/docs/trigger-rules.md
+++ b/docs/trigger-rules.md
@@ -83,6 +83,54 @@ defer to ordinary repository policy without fabricating approval.
 
 In stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0), prerelease [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), and unreleased `main`, disabled SDD status skips review authority and leaves `reviewGate` structurally absent. Pre-verify continues without routing to review, and archive proceeds under ordinary repository policy when `reviewGate` is absent. A present `reviewGate.result: allow` is required only when review activity was discovered for the candidate. Native delivery gates remain distinct: when no exact governing receipt applies, they report `disabled/unmanaged`. See the [SDD status contract](../internal/assets/skills/_shared/sdd-status-contract.md).
 
+## Review store reset
+
+Review authority accumulates without bound: every candidate leaves a lineage
+behind and nothing removes a delivered one, so a long-lived clone eventually
+holds hundreds of lineages and hundreds of megabytes of candidate checkouts.
+`review abandon` refuses terminal states and `review reclaim` refuses any entry
+holding authoritative artifacts, so until now a degraded store had no exit.
+
+| Command | Effect |
+|---|---|
+| `gentle-ai review store-reset --cwd <repo>` | Report, per category, what a reset would remove and what it would preserve. Removes nothing. |
+| `gentle-ai review store-reset --cwd <repo> --confirm` | Remove this clone's review lineage state. Irreversible. |
+| `gentle-ai review store-reset --cwd <repo> --confirm --include-in-flight` | Also remove reviews that have not reached a terminal state. |
+| `gentle-ai review store-reset --cwd <repo> --json` | The same report, machine-readable. |
+
+Every sub-action is user-initiated only; no adapter and no automation reaches
+it, because the verb carries no negotiated contract row. Preview is the default
+and `--confirm` is required to remove anything: the operation is irreversible
+and clone-wide, so the invocation typed from memory has to be the one that only
+looks. It is clone-scoped and never touches a global or machine-wide location.
+
+It **removes** `candidate-views/`, `reviews/`, and the `v1`, `v2`, `quarantine`,
+`effect-markers`, and `incidents` subtrees of `review-transactions/`. Candidate
+views are registered Git worktrees, so their administrative directories are
+removed too, but only when each one's own `gitdir` file proves it belongs to
+that exact view; no unrelated worktree is pruned.
+
+It **preserves** the receipt-driven-development kill switch in both the
+`review-mode/` location and the pre-#2882 mirror inside
+`review-transactions/rar-authority/`, along with `sdd-runtime/`,
+`defect-reports/`, `review-artifacts/`, `incidents/`, and
+`REVIEW-MAINTENANCE.lock`. Reviews that were off stay off. The list is an
+allowlist, so any path the command does not recognize -- including one a future
+release adds -- is reported and left in place rather than guessed at.
+
+Reviews that have not reached a terminal state (anything other than approved,
+escalated, or invalidated, plus any record that cannot be parsed) are refused by
+default and listed by name. The reset holds the same exclusive maintenance lease
+every other maintenance operation takes, and it runs while review mode is
+disabled -- gating cleanup on the kill switch would rebuild the dead end it
+exists to remove.
+
+The TUI exposes the same action as **Reset review store** in the main menu,
+between *Manage backups* and *Managed uninstall*, showing the same survey behind
+a confirmation. The TUI has no `--include-in-flight` equivalent: when open
+reviews exist it refuses and prints the CLI invocation instead, so destroying
+in-flight work is never one keystroke away.
+
 ## Installation and refresh
 
 `gentle-ai install` and `gentle-ai sync` project the same canonical rules into

--- a/docs/trigger-rules.md
+++ b/docs/trigger-rules.md
@@ -120,10 +120,15 @@ release adds -- is reported and left in place rather than guessed at.
 
 Reviews that have not reached a terminal state (anything other than approved,
 escalated, or invalidated, plus any record that cannot be parsed) are refused by
-default and listed by name. The reset holds the same exclusive maintenance lease
-every other maintenance operation takes, and it runs while review mode is
-disabled -- gating cleanup on the kill switch would rebuild the dead end it
-exists to remove.
+default and listed by name. The reset takes the same exclusive maintenance lease
+every other maintenance operation takes *before* it reads the store, so that
+classification and the removal it authorizes are one atomic step: a review that
+starts while the reset is waiting for the lease is seen and refused, never
+destroyed by a run that reported none open. Each category is removed all at once
+or not at all -- a category that cannot be moved aside is reported with its
+reason and left exactly as it was found, worktree registrations included. The
+reset runs while review mode is disabled: gating cleanup on the kill switch
+would rebuild the dead end it exists to remove.
 
 The TUI exposes the same action as **Reset review store** in the main menu,
 between *Manage backups* and *Managed uninstall*, showing the same survey behind

--- a/docs/trigger-rules.md
+++ b/docs/trigger-rules.md
@@ -96,6 +96,7 @@ holding authoritative artifacts, so until now a degraded store had no exit.
 | `gentle-ai review store-reset --cwd <repo>` | Report, per category, what a reset would remove and what it would preserve. Removes nothing. |
 | `gentle-ai review store-reset --cwd <repo> --confirm` | Remove this clone's review lineage state. Irreversible. |
 | `gentle-ai review store-reset --cwd <repo> --confirm --include-in-flight` | Also remove reviews that have not reached a terminal state. |
+| `gentle-ai review store-reset --cwd <repo> --confirm --include-adapter-reviews` | Also remove the adapter-written `reviews/` graph store, which the lease and the in-flight refusal do not cover. |
 | `gentle-ai review store-reset --cwd <repo> --json` | The same report, machine-readable. |
 
 Every sub-action is user-initiated only; no adapter and no automation reaches
@@ -104,11 +105,15 @@ and `--confirm` is required to remove anything: the operation is irreversible
 and clone-wide, so the invocation typed from memory has to be the one that only
 looks. It is clone-scoped and never touches a global or machine-wide location.
 
-It **removes** `candidate-views/`, `reviews/`, and the `v1`, `v2`, `quarantine`,
+It **removes** `candidate-views/` and the `v1`, `v2`, `quarantine`,
 `effect-markers`, and `incidents` subtrees of `review-transactions/`. Candidate
 views are registered Git worktrees, so their administrative directories are
 removed too, but only when each one's own `gitdir` file proves it belongs to
-that exact view; no unrelated worktree is pruned.
+that exact view; no unrelated worktree is pruned. A registration moved aside for
+a category that then could not be removed is put back; on the rare occasion the
+move back also fails, the directory is kept rather than deleted, and the report
+names it, names where it was left, and withdraws its usual claim that nothing
+marked SKIPPED was touched.
 
 It **preserves** the receipt-driven-development kill switch in both the
 `review-mode/` location and the pre-#2882 mirror inside
@@ -117,6 +122,17 @@ It **preserves** the receipt-driven-development kill switch in both the
 `REVIEW-MAINTENANCE.lock`. Reviews that were off stay off. The list is an
 allowlist, so any path the command does not recognize -- including one a future
 release adds -- is reported and left in place rather than guessed at.
+
+It **withholds** `reviews/`, the review graph store the gentle-pi adapter
+writes, and removes it only when `--include-adapter-reviews` is given. Both
+safeties described below stop at the edge of that directory:
+`REVIEW-MAINTENANCE.lock` does not cover any path under it, so the exclusive
+lease excludes no writer there, and the in-flight classification reads only
+`review-transactions/v2`, so a review living there can never be listed as open.
+A default run therefore cannot tell a dead graph from a live review, and a
+destructive command does not delete what it cannot vouch for. The category is
+still measured and still reported, under the preserved list, carrying that
+reason and the flag that overrides it.
 
 Reviews that have not reached a terminal state (anything other than approved,
 escalated, or invalidated, plus any record that cannot be parsed) are refused by
@@ -132,7 +148,8 @@ would rebuild the dead end it exists to remove.
 
 The TUI exposes the same action as **Reset review store** in the main menu,
 between *Manage backups* and *Managed uninstall*, showing the same survey behind
-a confirmation. The TUI has no `--include-in-flight` equivalent: when open
+a confirmation whose cursor starts on *Cancel*. The TUI has no
+`--include-in-flight` or `--include-adapter-reviews` equivalent: when open
 reviews exist it refuses and prints the CLI invocation instead, so destroying
 in-flight work is never one keystroke away.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1126,15 +1126,16 @@ func tuiReviewStoreSurvey() (reviewtransaction.StoreResetReport, error) {
 	if err != nil {
 		return reviewtransaction.StoreResetReport{}, err
 	}
-	return reviewtransaction.SurveyReviewStore(context.Background(), cwd)
+	return reviewtransaction.SurveyReviewStore(context.Background(), cwd, reviewtransaction.StoreResetRequest{})
 }
 
 // tuiReviewStoreReset applies the reset for that same clone.
 //
-// It never sets IncludeInFlight. The TUI has no keystroke that destroys a
-// review somebody is in the middle of: the confirmation screen refuses outright
-// and prints the CLI invocation that overrides it, so the override stays an act
-// the user has to type out.
+// It never sets IncludeInFlight, and never sets IncludeAdapterReviews either.
+// The TUI has no keystroke that destroys a review somebody is in the middle of,
+// nor one that destroys a store this command cannot classify: the confirmation
+// screen refuses outright and prints the CLI invocation that overrides it, so
+// every override stays an act the user has to type out.
 func tuiReviewStoreReset() (reviewtransaction.StoreResetReport, error) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/skillregistry"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
@@ -246,6 +247,13 @@ func RunArgs(args []string, stdout io.Writer) error {
 		// nil; assigning it explicitly here keeps the production wiring
 		// visible at the same seam as the other injected functions.
 		m.OpenCodePluginUninstallFn = opencodeplugin.Uninstall
+		// The review store is clone-scoped, so the TUI acts on the repository
+		// the user launched it from. Both closures resolve the working
+		// directory at call time rather than at wiring time, so a survey and
+		// the reset it authorized can never disagree about which clone they
+		// mean.
+		m.ReviewStoreResetSurveyFn = tuiReviewStoreSurvey
+		m.ReviewStoreResetFn = tuiReviewStoreReset
 		finalModel, err := runTUI(m, tea.WithAltScreen())
 		if err != nil {
 			return err
@@ -1109,4 +1117,28 @@ func codexOrchestratorFromState(a *state.CodexOrchestratorAssignmentState) *mode
 		return nil
 	}
 	return &model.CodexOrchestratorAssignment{Model: a.Model, Effort: model.CodexEffort(a.Effort)}
+}
+
+// tuiReviewStoreSurvey reports what a review store reset would remove for the
+// clone the TUI was launched from. It is read-only.
+func tuiReviewStoreSurvey() (reviewtransaction.StoreResetReport, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return reviewtransaction.StoreResetReport{}, err
+	}
+	return reviewtransaction.SurveyReviewStore(context.Background(), cwd)
+}
+
+// tuiReviewStoreReset applies the reset for that same clone.
+//
+// It never sets IncludeInFlight. The TUI has no keystroke that destroys a
+// review somebody is in the middle of: the confirmation screen refuses outright
+// and prints the CLI invocation that overrides it, so the override stays an act
+// the user has to type out.
+func tuiReviewStoreReset() (reviewtransaction.StoreResetReport, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return reviewtransaction.StoreResetReport{}, err
+	}
+	return reviewtransaction.ResetReviewStore(context.Background(), cwd, reviewtransaction.StoreResetRequest{})
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -453,7 +453,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capture-result|capture-refuter|capture-validation|lens-context|capture-evidence|preserve-result|capabilities|start|finalize|validate|status|repair|invalidate|abandon|recover|retry-final-verification|reclaim|inspect-authority|inspect-candidate|dispose-result|reopen-results|schema|opencode-transport|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capture-result|capture-refuter|capture-validation|lens-context|capture-evidence|preserve-result|capabilities|start|finalize|validate|status|repair|invalidate|abandon|recover|retry-final-verification|reclaim|store-reset|inspect-authority|inspect-candidate|dispose-result|reopen-results|schema|opencode-transport|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 	output.Reset()

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -680,7 +680,7 @@ func (err *reviewStartContextError) Unwrap() error { return err.Cause }
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capture-result|capture-refuter|capture-validation|lens-context|capture-evidence|preserve-result|capabilities|start|finalize|validate|status|repair|invalidate|abandon|recover|retry-final-verification|reclaim|inspect-authority|inspect-candidate|dispose-result|reopen-results|schema|opencode-transport|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go. Provider transports relay opaque bytes only; Go materializes, admits, captures, and decides delivery. Use review retry-final-verification only for a provider-proven completed failed final-verification tooling incident. Generic review recover remains unchanged. Use review repair --preflight for provider-owned classified authority repair.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capture-result|capture-refuter|capture-validation|lens-context|capture-evidence|preserve-result|capabilities|start|finalize|validate|status|repair|invalidate|abandon|recover|retry-final-verification|reclaim|store-reset|inspect-authority|inspect-candidate|dispose-result|reopen-results|schema|opencode-transport|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go. Provider transports relay opaque bytes only; Go materializes, admits, captures, and decides delivery. Use review retry-final-verification only for a provider-proven completed failed final-verification tooling incident. Generic review recover remains unchanged. Use review repair --preflight for provider-owned classified authority repair.")
 		return nil
 	}
 	operation, negotiated, preflightFailure := reviewIntegrationFailureRoute(args)
@@ -847,6 +847,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewRecover(args[1:], stdout)
 	case "reclaim":
 		return RunReviewReclaim(args[1:], stdout)
+	case "store-reset":
+		return RunReviewStoreReset(args[1:], stdout)
 	case "inspect-authority":
 		return RunReviewInspectAuthority(args[1:], stdout)
 	case "dispose-result":

--- a/internal/cli/review_store_reset.go
+++ b/internal/cli/review_store_reset.go
@@ -36,10 +36,11 @@ type ReviewStoreResetResult struct {
 // the user a second invocation is a much smaller price than the first mistake.
 func RunReviewStoreReset(args []string, stdout io.Writer) error {
 	flags := newReviewFlagSet("review store-reset", stdout,
-		"Remove this clone's accumulated review lineage state so reviews start from nothing. Previews by default and reports what it would remove per category; --confirm applies it. Removal is irreversible: nothing is copied aside. The receipt-driven-development kill switch, SDD runtime state, defect reports, and any path this command does not recognize are always preserved and reported. Reviews that have not reached a terminal state are refused unless --include-in-flight is given.")
+		"Remove this clone's accumulated review lineage state so reviews start from nothing. Previews by default and reports what it would remove per category; --confirm applies it. Removal is irreversible: nothing is copied aside. The receipt-driven-development kill switch, SDD runtime state, defect reports, the adapter-written reviews/ graph store, and any path this command does not recognize are preserved and reported. Reviews that have not reached a terminal state are refused unless --include-in-flight is given.")
 	cwd := flags.String("cwd", ".", "repository path")
 	confirm := flags.Bool("confirm", false, "apply the removal instead of previewing it")
 	includeInFlight := flags.Bool("include-in-flight", false, "also remove reviews that have not reached a terminal state")
+	includeAdapterReviews := flags.Bool("include-adapter-reviews", false, "also remove the adapter-written reviews/ graph store, which this command's maintenance lease and in-flight refusal do not cover")
 	emitJSON := flags.Bool("json", false, "emit the machine-readable review store reset report")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
@@ -53,14 +54,17 @@ func RunReviewStoreReset(args []string, stdout io.Writer) error {
 	}
 
 	ctx := context.Background()
+	// The preview is the preview of the run these same flags would make, so
+	// the request is built once and both paths get it.
+	request := reviewtransaction.StoreResetRequest{
+		IncludeInFlight: *includeInFlight, IncludeAdapterReviews: *includeAdapterReviews,
+	}
 	var report reviewtransaction.StoreResetReport
 	var err error
 	if *confirm {
-		report, err = reviewtransaction.ResetReviewStore(ctx, *cwd, reviewtransaction.StoreResetRequest{
-			IncludeInFlight: *includeInFlight,
-		})
+		report, err = reviewtransaction.ResetReviewStore(ctx, *cwd, request)
 	} else {
-		report, err = reviewtransaction.SurveyReviewStore(ctx, *cwd)
+		report, err = reviewtransaction.SurveyReviewStore(ctx, *cwd, request)
 	}
 	// A refusal is not an attempt. It returns before touching anything, so the
 	// report has to be rendered in the same voice as a preview -- reporting it
@@ -148,9 +152,21 @@ func renderReviewStoreReset(stdout io.Writer, report reviewtransaction.StoreRese
 	case attempted:
 		fmt.Fprintf(&out, "freed %s across %d file(s).\n", reviewStoreResetBytes(report.RemovedBytes), report.RemovedFiles)
 		if report.Residue != "" {
-			fmt.Fprintf(&out, "staging directory %s could not be deleted; those bytes are not reclaimed.\n", report.Residue)
+			fmt.Fprintf(&out, "staging directory %s still exists; the bytes it holds are not reclaimed.\n", report.Residue)
 		}
-		if !report.Complete {
+		switch {
+		case len(report.UnrestoredAdminDirs) > 0:
+			// The usual line is withdrawn here, and it has to be. It promises
+			// that SKIPPED means untouched, and for these views that promise
+			// is already broken: the checkouts are where they were, but the
+			// worktree registrations that make them usable are not.
+			fmt.Fprintf(&out, "this reset was incomplete, and it did not leave everything it skipped untouched.\n")
+			fmt.Fprintf(&out, "these worktree administrative directories were moved aside for a SKIPPED category and could not be put back:\n")
+			for _, dir := range report.UnrestoredAdminDirs {
+				fmt.Fprintf(&out, "  %s\n    now at %s\n", dir.Original, dir.Staged)
+			}
+			fmt.Fprintf(&out, "move each one back to its original path before using those candidate views again.\n")
+		case !report.Complete:
 			fmt.Fprintf(&out, "this reset was incomplete; nothing above marked SKIPPED was removed.\n")
 		}
 	case confirmed:

--- a/internal/cli/review_store_reset.go
+++ b/internal/cli/review_store_reset.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// ReviewStoreResetSchema identifies the user-facing store reset projection.
+const ReviewStoreResetSchema = "gentle-ai.review-store-reset-result/v1"
+
+// ReviewStoreResetResult is the command's machine-readable output.
+type ReviewStoreResetResult struct {
+	Schema    string                             `json:"schema"`
+	Operation string                             `json:"operation"`
+	Report    reviewtransaction.StoreResetReport `json:"report"`
+}
+
+// RunReviewStoreReset removes this clone's accumulated review lineage state.
+//
+// It is user-initiated only, in the same sense `review mode disable` is: it
+// carries no negotiated contract row, so no adapter can reach it on the machine
+// route, and nothing in the product invokes it. A human types it or picks it in
+// the TUI, or it does not happen.
+//
+// Preview is the default and removal needs --confirm. That asymmetry is
+// deliberate. The operation is irreversible and clone-wide, so the bare
+// invocation -- the one that gets typed from memory, pasted out of a chat log,
+// or recalled from shell history -- has to be the one that only looks. Costing
+// the user a second invocation is a much smaller price than the first mistake.
+func RunReviewStoreReset(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review store-reset", stdout,
+		"Remove this clone's accumulated review lineage state so reviews start from nothing. Previews by default and reports what it would remove per category; --confirm applies it. Removal is irreversible: nothing is copied aside. The receipt-driven-development kill switch, SDD runtime state, defect reports, and any path this command does not recognize are always preserved and reported. Reviews that have not reached a terminal state are refused unless --include-in-flight is given.")
+	cwd := flags.String("cwd", ".", "repository path")
+	confirm := flags.Bool("confirm", false, "apply the removal instead of previewing it")
+	includeInFlight := flags.Bool("include-in-flight", false, "also remove reviews that have not reached a terminal state")
+	emitJSON := flags.Bool("json", false, "emit the machine-readable review store reset report")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		// refusal:by-design operator-knowledge: a stray positional argument is removed by whoever typed it; no command resolves a typo
+		return fmt.Errorf("unexpected review store-reset argument %q", flags.Arg(0))
+	}
+
+	ctx := context.Background()
+	var report reviewtransaction.StoreResetReport
+	var err error
+	if *confirm {
+		report, err = reviewtransaction.ResetReviewStore(ctx, *cwd, reviewtransaction.StoreResetRequest{
+			IncludeInFlight: *includeInFlight,
+		})
+	} else {
+		report, err = reviewtransaction.SurveyReviewStore(ctx, *cwd)
+	}
+	// A refusal is not an attempt. It returns before touching anything, so the
+	// report has to be rendered in the same voice as a preview -- reporting it
+	// as a removal that skipped everything would tell the user their store was
+	// half-processed when nothing was opened at all.
+	var refused *reviewtransaction.StoreResetInFlightError
+	attempted := *confirm && !errors.As(err, &refused)
+
+	// The report is emitted even on failure, and before the error is returned.
+	// A caller that cannot see which categories went away cannot reconcile a
+	// partially reset store, and a refusal is exactly when the list of open
+	// reviews matters most.
+	if report.Schema != "" {
+		if emitErr := emitReviewStoreReset(stdout, report, attempted, *confirm, *emitJSON); emitErr != nil && err == nil {
+			return emitErr
+		}
+	}
+	return err
+}
+
+func emitReviewStoreReset(stdout io.Writer, report reviewtransaction.StoreResetReport, attempted, confirmed, emitJSON bool) error {
+	if emitJSON {
+		payload, err := json.MarshalIndent(ReviewStoreResetResult{
+			Schema: ReviewStoreResetSchema, Operation: "review/store-reset", Report: report,
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(stdout, "%s\n", payload)
+		return err
+	}
+	return renderReviewStoreReset(stdout, report, attempted, confirmed)
+}
+
+func renderReviewStoreReset(stdout io.Writer, report reviewtransaction.StoreResetReport, attempted, confirmed bool) error {
+	var out strings.Builder
+	fmt.Fprintf(&out, "review store: %s\n", report.StoreRoot)
+
+	heading := "would remove"
+	if attempted {
+		heading = "removed"
+	}
+	present := reviewStoreResetPresent(report.Removable)
+	if len(present) == 0 {
+		fmt.Fprintf(&out, "\nnothing to remove: this clone holds no review lineage state.\n")
+	} else {
+		fmt.Fprintf(&out, "\n%s:\n", heading)
+		for _, entry := range present {
+			status := ""
+			switch {
+			case entry.Skipped != "":
+				status = "  SKIPPED: " + entry.Skipped
+			case attempted && !entry.Removed:
+				status = "  SKIPPED"
+			}
+			fmt.Fprintf(&out, "  %-34s %6d file(s)  %10s%s\n",
+				entry.Name, entry.Files, reviewStoreResetBytes(entry.Bytes), status)
+		}
+	}
+
+	if preserved := reviewStoreResetPresent(report.Preserved); len(preserved) > 0 {
+		fmt.Fprintf(&out, "\npreserved:\n")
+		for _, entry := range preserved {
+			fmt.Fprintf(&out, "  %-34s %10s  %s\n", entry.Name, reviewStoreResetBytes(entry.Bytes), entry.Reason)
+		}
+	}
+	if len(report.Unrecognized) > 0 {
+		fmt.Fprintf(&out, "\nleft in place, not recognized by this command:\n")
+		for _, entry := range report.Unrecognized {
+			fmt.Fprintf(&out, "  %-34s %10s\n", entry.Name, reviewStoreResetBytes(entry.Bytes))
+		}
+	}
+
+	fmt.Fprintf(&out, "\n%d settled review(s)", report.Settled)
+	if len(report.InFlight) > 0 {
+		verb := "still open"
+		if attempted {
+			verb = "removed while still open"
+		}
+		fmt.Fprintf(&out, ", %d %s: %s", len(report.InFlight), verb, reviewStoreResetLineages(report.InFlight))
+	}
+	out.WriteString("\n")
+
+	switch {
+	case attempted:
+		fmt.Fprintf(&out, "freed %s across %d file(s).\n", reviewStoreResetBytes(report.RemovedBytes), report.RemovedFiles)
+		if report.Residue != "" {
+			fmt.Fprintf(&out, "staging directory %s could not be deleted; those bytes are not reclaimed.\n", report.Residue)
+		}
+		if !report.Complete {
+			fmt.Fprintf(&out, "this reset was incomplete; nothing above marked SKIPPED was removed.\n")
+		}
+	case confirmed:
+		// A refused --confirm. The error that follows names the exact
+		// override, so repeating an instruction here would only compete
+		// with it.
+		fmt.Fprintf(&out, "nothing was removed.\n")
+	case len(present) > 0:
+		fmt.Fprintf(&out, "nothing was removed. Re-run with --confirm to apply this. Removal is irreversible: nothing is copied aside.\n")
+	}
+
+	_, err := io.WriteString(stdout, out.String())
+	return err
+}
+
+func reviewStoreResetPresent(entries []reviewtransaction.StoreResetEntry) []reviewtransaction.StoreResetEntry {
+	present := make([]reviewtransaction.StoreResetEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Present {
+			present = append(present, entry)
+		}
+	}
+	return present
+}
+
+func reviewStoreResetLineages(lineages []reviewtransaction.StoreResetLineage) string {
+	names := make([]string, 0, len(lineages))
+	for _, lineage := range lineages {
+		if lineage.Unreadable != "" {
+			names = append(names, lineage.LineageID+" (unreadable)")
+			continue
+		}
+		names = append(names, fmt.Sprintf("%s (%s)", lineage.LineageID, lineage.State))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// reviewStoreResetBytes renders a size the way a person reading a terminal
+// reads one. Exact byte counts stay available in the JSON projection.
+func reviewStoreResetBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	value, exponent := float64(bytes)/unit, 0
+	for value >= unit && exponent < 3 {
+		value /= unit
+		exponent++
+	}
+	return fmt.Sprintf("%.1f %sB", value, []string{"K", "M", "G", "T"}[exponent])
+}

--- a/internal/cli/review_store_reset_test.go
+++ b/internal/cli/review_store_reset_test.go
@@ -251,7 +251,7 @@ func TestReviewStoreResetReportsPartialFailureWithoutClaimingSuccess(t *testing.
 	t.Cleanup(func() { _ = os.Chmod(reviews, 0o755) })
 
 	var output bytes.Buffer
-	err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--json"}, &output)
+	err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--include-adapter-reviews", "--json"}, &output)
 	if err == nil {
 		t.Fatalf("a partial reset exited zero\n%s", output.String())
 	}
@@ -298,5 +298,114 @@ func TestReviewStoreResetIsNotOnTheNegotiatedRoute(t *testing.T) {
 		if operation.Command == "store-reset" || strings.Contains(string(operation.Operation), "store-reset") {
 			t.Fatalf("store-reset is reachable on the negotiated machine route: %#v", operation)
 		}
+	}
+}
+
+// TestReviewStoreResetWithdrawsTheUntouchedPromiseWhenARestoreFailed is the
+// line that must not survive a stranded worktree registration.
+//
+// "nothing above marked SKIPPED was removed" is the whole reassurance a partial
+// run offers. When the run moved a candidate view's worktree administrative
+// directory aside and could not put it back, that sentence is false: the
+// checkout is where it was, but the registration that makes it a worktree is
+// not, and printing the reassurance anyway leaves the user with no reason to go
+// looking.
+func TestReviewStoreResetWithdrawsTheUntouchedPromiseWhenARestoreFailed(t *testing.T) {
+	report := reviewtransaction.StoreResetReport{
+		Schema: reviewtransaction.StoreResetReportSchema, Operation: reviewtransaction.StoreResetApplied,
+		Repository: "/repo", StoreRoot: "/repo/.git/gentle-ai",
+		Removable: []reviewtransaction.StoreResetEntry{{
+			Name: "candidate-views", Present: true, Files: 4, Bytes: 2048,
+			Skipped: "simulated staging failure; and the worktree administrative directories moved aside for it could not be restored: simulated restore failure",
+		}},
+		Residue: "/repo/.git/gentle-ai/.store-reset-42",
+		UnrestoredAdminDirs: []reviewtransaction.StoreResetUnrestoredAdminDir{{
+			Original: "/repo/.git/worktrees/view-a",
+			Staged:   "/repo/.git/gentle-ai/.store-reset-42/worktrees-view-a",
+		}},
+		Complete: false,
+	}
+
+	var output bytes.Buffer
+	if err := renderReviewStoreReset(&output, report, true, true); err != nil {
+		t.Fatal(err)
+	}
+	rendered := output.String()
+	if strings.Contains(rendered, "nothing above marked SKIPPED was removed") {
+		t.Fatalf("a run that stranded a registration still promised nothing was removed:\n%s", rendered)
+	}
+	for _, want := range []string{
+		"/repo/.git/worktrees/view-a",
+		"/repo/.git/gentle-ai/.store-reset-42/worktrees-view-a",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("the output does not name %q:\n%s", want, rendered)
+		}
+	}
+}
+
+// TestReviewStoreResetKeepsTheUntouchedPromiseForAnOrdinaryPartialRun is the
+// other side: withdrawing the reassurance whenever anything failed would drop
+// it from the case it was written for.
+func TestReviewStoreResetKeepsTheUntouchedPromiseForAnOrdinaryPartialRun(t *testing.T) {
+	report := reviewtransaction.StoreResetReport{
+		Schema: reviewtransaction.StoreResetReportSchema, Operation: reviewtransaction.StoreResetApplied,
+		Repository: "/repo", StoreRoot: "/repo/.git/gentle-ai",
+		Removable: []reviewtransaction.StoreResetEntry{{
+			Name: "review-transactions/v2", Present: true, Files: 4, Bytes: 2048, Skipped: "permission denied",
+		}},
+		Complete: false,
+	}
+
+	var output bytes.Buffer
+	if err := renderReviewStoreReset(&output, report, true, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "nothing above marked SKIPPED was removed") {
+		t.Fatalf("an ordinary partial run lost its reassurance:\n%s", output.String())
+	}
+}
+
+// TestReviewStoreResetSparesTheAdapterReviewStoreByDefault is the coverage rule
+// at the surface the user types. reviews/ is written by the gentle-pi adapter,
+// which this command's maintenance lease does not exclude and whose reviews its
+// in-flight refusal cannot see, so a default run has to leave it alone and say
+// why.
+func TestReviewStoreResetSparesTheAdapterReviewStoreByDefault(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	root := storeResetStoreRoot(t, repo)
+	identity := filepath.Join(root, "reviews", "IDENTITY")
+	if err := os.MkdirAll(filepath.Dir(identity), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identity, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--json"}, &output); err != nil {
+		t.Fatalf("reset: %v\n%s", err, output.String())
+	}
+	var result ReviewStoreResetResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	for _, entry := range result.Report.Removable {
+		if entry.Name == "reviews" {
+			t.Fatalf("a default run offered to remove the adapter review store: %#v", entry)
+		}
+	}
+	if _, err := os.Stat(identity); err != nil {
+		t.Fatalf("a default run destroyed the adapter review store: %v", err)
+	}
+
+	// And the override actually removes it, so the withholding is a decision
+	// rather than a dead end.
+	output.Reset()
+	if err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--include-adapter-reviews"}, &output); err != nil {
+		t.Fatalf("opted-in reset: %v\n%s", err, output.String())
+	}
+	if _, err := os.Lstat(filepath.Join(root, "reviews")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("the override did not remove the adapter review store: %v", err)
 	}
 }

--- a/internal/cli/review_store_reset_test.go
+++ b/internal/cli/review_store_reset_test.go
@@ -1,0 +1,302 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// storeResetSeedLineage writes one compact-v2 lineage record straight to disk.
+// Going around the normal writers is the point: this command has to work on a
+// store the normal writers can no longer open.
+func storeResetSeedLineage(t *testing.T, repo, lineage string, state reviewtransaction.State) {
+	t.Helper()
+	dir := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", lineage)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"schema":"gentle-ai.review-state-record/v2","revision":"sha256:00","state":{"schema":"gentle-ai.review-state/v2","lineage_id":"` +
+		lineage + `","state":"` + string(state) + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "review-state.json"), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func storeResetStoreRoot(t *testing.T, repo string) string {
+	t.Helper()
+	return filepath.Dir(reviewCLIAuthorityRoot(t, repo))
+}
+
+// TestReviewStoreResetPreviewsByDefault is the safety default. The command is
+// irreversible and clone-wide, so the bare invocation reports and stops.
+func TestReviewStoreResetPreviewsByDefault(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"store-reset", "--cwd", repo}, &output); err != nil {
+		t.Fatalf("review store-reset preview: %v\n%s", err, output.String())
+	}
+	rendered := output.String()
+	if !strings.Contains(rendered, "--confirm") {
+		t.Fatalf("preview does not say how to apply it:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "review-transactions/v2") {
+		t.Fatalf("preview does not name the category it would remove:\n%s", rendered)
+	}
+	if _, err := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "review-approved", "review-state.json")); err != nil {
+		t.Fatalf("preview removed lineage state: %v", err)
+	}
+}
+
+// TestReviewStoreResetPreviewReportsBothLists proves the preview names what it
+// spares and why, not only what it takes.
+func TestReviewStoreResetPreviewReportsBothLists(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	disableReviewForClone(t, repo)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"store-reset", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("review store-reset preview: %v\n%s", err, output.String())
+	}
+	var result ReviewStoreResetResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Operation != "review/store-reset" {
+		t.Fatalf("operation = %q", result.Operation)
+	}
+	if result.Report.Operation != reviewtransaction.StoreResetPreview {
+		t.Fatalf("report operation = %q, want a preview", result.Report.Operation)
+	}
+	if len(result.Report.Preserved) == 0 || len(result.Report.Removable) == 0 {
+		t.Fatalf("preview report = %#v", result.Report)
+	}
+	for _, entry := range append(result.Report.Removable, result.Report.Preserved...) {
+		if strings.TrimSpace(entry.Reason) == "" {
+			t.Fatalf("category %q carries no reason", entry.Name)
+		}
+	}
+}
+
+// TestReviewStoreResetRefusesInFlightAndNamesTheOverride is the refusal the
+// maintainer asked for: it lists the open reviews and does not make the
+// dangerous path reachable by accident.
+func TestReviewStoreResetRefusesInFlightAndNamesTheOverride(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	storeResetSeedLineage(t, repo, "review-open", reviewtransaction.StateReviewing)
+
+	var output bytes.Buffer
+	err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm"}, &output)
+	if err == nil {
+		t.Fatalf("review store-reset destroyed an open review\n%s", output.String())
+	}
+	var inFlight *reviewtransaction.StoreResetInFlightError
+	if !errors.As(err, &inFlight) {
+		t.Fatalf("refusal is not typed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "review-open") || !strings.Contains(err.Error(), "--include-in-flight") {
+		t.Fatalf("refusal does not name the lineage and the override: %v", err)
+	}
+	// A refusal returns before opening the store, so it must not be rendered as
+	// a removal that skipped everything: that reads as a half-processed store.
+	rendered := output.String()
+	if strings.Contains(rendered, "SKIPPED") || strings.Contains(rendered, "removed while still open") {
+		t.Fatalf("the refusal is rendered as an attempted removal:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "would remove") || !strings.Contains(rendered, "still open") {
+		t.Fatalf("the refusal does not read as a preview:\n%s", rendered)
+	}
+	for _, lineage := range []string{"review-approved", "review-open"} {
+		if _, statErr := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", lineage, "review-state.json")); statErr != nil {
+			t.Fatalf("a refused reset removed %q: %v", lineage, statErr)
+		}
+	}
+}
+
+// TestReviewStoreResetConfirmRemovesSettledState is the ordinary success path.
+func TestReviewStoreResetConfirmRemovesSettledState(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	root := storeResetStoreRoot(t, repo)
+	views := filepath.Join(root, "candidate-views", "1a09d6f9")
+	if err := os.MkdirAll(views, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(views, "README.md"), []byte("checkout\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--json"}, &output); err != nil {
+		t.Fatalf("review store-reset --confirm: %v\n%s", err, output.String())
+	}
+	var result ReviewStoreResetResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if !result.Report.Complete || result.Report.RemovedFiles == 0 || result.Report.RemovedBytes == 0 {
+		t.Fatalf("confirmed reset report = %#v", result.Report)
+	}
+	for _, path := range []string{
+		filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2"),
+		filepath.Join(root, "candidate-views"),
+	} {
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s survived a confirmed reset: %v", path, err)
+		}
+	}
+}
+
+// TestReviewStoreResetOverrideRemovesInFlightState proves the escape hatch is
+// reachable once the user asks for it in as many words.
+func TestReviewStoreResetOverrideRemovesInFlightState(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-open", reviewtransaction.StateReviewing)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--include-in-flight"}, &output); err != nil {
+		t.Fatalf("override reset: %v\n%s", err, output.String())
+	}
+	if !strings.Contains(output.String(), "review-open") {
+		t.Fatalf("override output does not name what it destroyed:\n%s", output.String())
+	}
+	if _, err := os.Lstat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("override reset kept the open lineage: %v", err)
+	}
+}
+
+// TestReviewStoreResetKeepsTheKillSwitchOff is the regression guard for the
+// worst outcome this command could produce: silently turning reviews back on
+// for someone who turned them off.
+func TestReviewStoreResetKeepsTheKillSwitchOff(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	disableReviewForClone(t, repo)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm"}, &output); err != nil {
+		t.Fatalf("reset while reviews are off: %v\n%s", err, output.String())
+	}
+
+	var mode bytes.Buffer
+	if err := RunReviewMode([]string{"status", "--cwd", repo, "--json"}, &mode); err != nil {
+		t.Fatalf("review mode status: %v\n%s", err, mode.String())
+	}
+	if effective := decodeReviewModeResult(t, mode.Bytes()).Status.Effective; effective != reviewtransaction.RDDModeOff {
+		t.Fatalf("the reset re-enabled reviews: effective mode = %q", effective)
+	}
+}
+
+// TestReviewStoreResetRunsWhileReviewsAreDisabled states the deliberate gap in
+// the kill-switch gate. A user whose store degraded and who then turned reviews
+// off must still be able to clean up; refusing here would rebuild the dead end
+// this command exists to remove.
+func TestReviewStoreResetRunsWhileReviewsAreDisabled(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	disableReviewForClone(t, repo)
+
+	var output bytes.Buffer
+	err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm"}, &output)
+	if errors.Is(err, reviewtransaction.ErrRDDDisabled) {
+		t.Fatalf("store-reset refused because reviews are off: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("store-reset while reviews are off: %v\n%s", err, output.String())
+	}
+	if _, statErr := os.Lstat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("the reset did nothing while reviews were off: %v", statErr)
+	}
+}
+
+// TestReviewStoreResetReportsPartialFailureWithoutClaimingSuccess covers the
+// honesty requirement end to end: the CLI still prints the report, still exits
+// non-zero, and never shows a category it failed to remove as removed.
+func TestReviewStoreResetReportsPartialFailureWithoutClaimingSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the permission bit this test withholds is not enforced on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root ignores the permission bit this test withholds")
+	}
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	storeResetSeedLineage(t, repo, "review-approved", reviewtransaction.StateApproved)
+	root := storeResetStoreRoot(t, repo)
+	reviews := filepath.Join(root, "reviews")
+	if err := os.MkdirAll(reviews, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reviews, "IDENTITY"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Moving a directory to a new parent needs write permission on the
+	// directory itself, so clearing that bit makes this one category
+	// genuinely unmovable while every other category still works.
+	if err := os.Chmod(reviews, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(reviews, 0o755) })
+
+	var output bytes.Buffer
+	err := RunReview([]string{"store-reset", "--cwd", repo, "--confirm", "--json"}, &output)
+	if err == nil {
+		t.Fatalf("a partial reset exited zero\n%s", output.String())
+	}
+	// The report is still emitted, because a caller that cannot see what was
+	// removed cannot reconcile the store.
+	var result ReviewStoreResetResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Report.Complete {
+		t.Fatalf("a partial reset reported Complete: %#v", result.Report)
+	}
+	var failed reviewtransaction.StoreResetEntry
+	for _, entry := range result.Report.Removable {
+		if entry.Name == "reviews" {
+			failed = entry
+		}
+	}
+	if failed.Removed || failed.Skipped == "" {
+		t.Fatalf("the failed category = %#v", failed)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "reviews", "IDENTITY")); statErr != nil {
+		t.Fatalf("the failed category was destroyed anyway: %v", statErr)
+	}
+}
+
+// TestReviewStoreResetRejectsUnexpectedArguments keeps the verb aligned with
+// the parse-rejection shape the documented-invocation guard recognizes.
+func TestReviewStoreResetRejectsUnexpectedArguments(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	err := RunReview([]string{"store-reset", "--cwd", repo, "stray"}, &output)
+	if err == nil || !strings.Contains(err.Error(), "unexpected review store-reset argument") {
+		t.Fatalf("unexpected argument error = %v", err)
+	}
+}
+
+// TestReviewStoreResetIsNotOnTheNegotiatedRoute keeps the verb user-initiated.
+// The negotiated contract is the machine surface; a destructive clone-wide
+// reset has no business being reachable from it, exactly as abandon and reclaim
+// are not.
+func TestReviewStoreResetIsNotOnTheNegotiatedRoute(t *testing.T) {
+	for _, operation := range reviewIntegrationOperationRegistry {
+		if operation.Command == "store-reset" || strings.Contains(string(operation.Operation), "store-reset") {
+			t.Fatalf("store-reset is reachable on the negotiated machine route: %#v", operation)
+		}
+	}
+}

--- a/internal/reviewtransaction/store_reset.go
+++ b/internal/reviewtransaction/store_reset.go
@@ -69,6 +69,12 @@ const storeResetStagingPrefix = ".store-reset-"
 // compact_reclaim.go so partial-failure paths stay testable.
 var storeResetRename = os.Rename
 
+// storeResetAcquireLease is the lease seam. Production always takes the real
+// exclusive maintenance lease; a test substitutes a wrapper around it to prove,
+// from a barrier rather than from timing, that the store is classified only
+// after the lease is held.
+var storeResetAcquireLease = AcquireReviewMaintenanceExclusive
+
 // storeResetTarget names one path under <git-common-dir>/gentle-ai and why it
 // is in the list it is in. The reason is not decoration: this command destroys
 // data, and every entry it touches or spares has to be able to justify itself
@@ -78,8 +84,9 @@ type storeResetTarget struct {
 	parts  []string
 	reason string
 	// candidateViews marks the one category that is not merely files.
-	// Candidate views are registered Git worktrees written read-only, so they
-	// need their permissions relaxed and their admin directories removed.
+	// Candidate views are registered Git worktrees written read-only, so the
+	// administrative directories that register them go with the checkouts and
+	// the permissions have to be relaxed before anything can be unlinked.
 	candidateViews bool
 }
 
@@ -492,6 +499,31 @@ func storeResetLineages(root string) ([]StoreResetLineage, int, error) {
 // holding authoritative artifacts -- which is all of them. Reclaiming the space
 // is the point, so the space is reclaimed and the report says so plainly.
 func ResetReviewStore(ctx context.Context, repo string, request StoreResetRequest) (StoreResetReport, error) {
+	// The lease is taken before the store is read, and everything that decides
+	// what happens is decided under it.
+	//
+	// Surveying first and leasing afterwards would make the in-flight refusal
+	// advisory against exactly the population the lease exists to exclude. A
+	// review started, or transitioned out of a terminal state, in the window
+	// between the read and the lease is invisible to a decision already made,
+	// and what follows is not a per-lineage delete that would simply miss it:
+	// it renames whole categories, so the new lineage is destroyed by a run
+	// that reported zero reviews in flight. Every review writer takes the
+	// shared side of this same lease before touching a per-lineage store
+	// (acquireStoreLock), so holding it exclusively is what makes the
+	// classification and the removal one atomic step against other processes.
+	lockCtx, cancel := context.WithTimeout(ctx, storeResetLockTimeout)
+	defer cancel()
+	lock, err := storeResetAcquireLease(lockCtx, repo)
+	if err != nil {
+		// No report is returned with this. Nothing was read under the lease, so
+		// there is no classification this command is entitled to state, and a
+		// report rendered from an unleased read is the same stale picture the
+		// ordering above exists to refuse.
+		return StoreResetReport{}, fmt.Errorf("acquire review maintenance lease: %w", err)
+	}
+	defer func() { _ = lock.Release() }()
+
 	report, root, err := surveyReviewStore(ctx, repo)
 	if err != nil {
 		return report, err
@@ -501,17 +533,6 @@ func ResetReviewStore(ctx context.Context, repo string, request StoreResetReques
 		report.Complete = false
 		return report, &StoreResetInFlightError{Repository: report.Repository, Lineages: report.InFlight}
 	}
-
-	// Hold the same advisory lease every other maintenance operation takes, so
-	// a reset cannot race a review that is mid-transition.
-	lockCtx, cancel := context.WithTimeout(ctx, storeResetLockTimeout)
-	defer cancel()
-	lock, err := AcquireReviewMaintenanceExclusive(lockCtx, repo)
-	if err != nil {
-		report.Complete = false
-		return report, fmt.Errorf("acquire review maintenance lease: %w", err)
-	}
-	defer func() { _ = lock.Release() }()
 
 	return storeResetExecute(ctx, report, root)
 }
@@ -538,20 +559,31 @@ func storeResetExecute(ctx context.Context, report StoreResetReport, root string
 		}
 		target := targets[entry.Name]
 		source := filepath.Join(append([]string{root}, target.parts...)...)
+		var stagedAdmin []storeResetStagedAdminDir
+		restoreMode := func() {}
 		if target.candidateViews {
-			// Candidate views are registered worktrees written read-only.
-			// Relaxing the permissions and detaching the admin directories has
-			// to happen before the move, because after it the linkage that
-			// proves which admin directories are ours is gone.
-			if err := storeResetPrepareCandidateViews(root, source); err != nil {
-				report.Removable[index].Skipped = err.Error()
+			// Candidate views are registered worktrees, so which administrative
+			// directories belong to them has to be established before the move:
+			// the gitdir linkage that proves ownership names each view at its
+			// current path. They are moved aside rather than deleted, so this
+			// preparation is undoable right up until the rename below commits.
+			var err error
+			stagedAdmin, err = storeResetStageCandidateViewAdminDirs(root, source, staging)
+			if err != nil {
+				report.Removable[index].Skipped = storeResetSkipReason(err, storeResetRestoreAdminDirs(stagedAdmin))
 				report.Complete = false
 				continue
 			}
+			// Moving a directory to a new parent needs write permission on the
+			// directory itself, and the adapter writes candidate views
+			// read-only. Only this one directory is relaxed, and only until the
+			// rename either commits or is undone.
+			restoreMode = storeResetRelaxForRename(source)
 		}
 		destination := filepath.Join(staging, strings.ReplaceAll(entry.Path, "/", "-"))
 		if err := storeResetRename(source, destination); err != nil {
-			report.Removable[index].Skipped = err.Error()
+			restoreMode()
+			report.Removable[index].Skipped = storeResetSkipReason(err, storeResetRestoreAdminDirs(stagedAdmin))
 			report.Complete = false
 			continue
 		}
@@ -589,33 +621,94 @@ func storeResetSkipped(report StoreResetReport) []StoreResetEntry {
 	return skipped
 }
 
-// storeResetPrepareCandidateViews makes a candidate-views tree removable and
-// detaches the Git worktree administrative directories that point into it.
+// storeResetStagedAdminDir records one Git worktree administrative directory
+// moved out of the way, and where it came from.
+type storeResetStagedAdminDir struct{ original, staged string }
+
+// storeResetStageCandidateViewAdminDirs moves aside the Git worktree
+// administrative directories that point into a candidate-views tree.
 //
-// An admin directory is removed only when its own gitdir file proves it belongs
+// It moves rather than deletes because the category is not actually removed
+// until the rename that follows succeeds, and until then the store has to be
+// exactly as it was found. Deleting first is unrepairable: a rename that then
+// fails leaves the checkouts on disk with their registrations gone, so Git
+// commands inside them fail, the repository's worktree list no longer names
+// them, and a later review cannot register the same view again. A rename into
+// the same staging directory the categories go to costs nothing, is undone by
+// renaming back, and is deleted along with everything else once the category is
+// really gone.
+//
+// An admin directory is moved only when its own gitdir file proves it belongs
 // to this exact candidate view. That check is what keeps the operation from
 // touching a worktree the user created: a global `git worktree prune` would
 // also clear unrelated stale entries, and this command has no business
 // deciding that.
-func storeResetPrepareCandidateViews(root, views string) error {
+func storeResetStageCandidateViewAdminDirs(root, views, staging string) ([]storeResetStagedAdminDir, error) {
 	commonDir := filepath.Dir(root)
 	entries, err := os.ReadDir(views)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	staged := []storeResetStagedAdminDir{}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		view := filepath.Join(views, entry.Name())
 		admin := filepath.Join(commonDir, "worktrees", entry.Name())
-		if storeResetAdminDirBelongsTo(admin, view) {
-			if err := storeResetRemoveAll(admin); err != nil {
-				return fmt.Errorf("remove worktree administrative directory for candidate view %q: %w", entry.Name(), err)
-			}
+		if !storeResetAdminDirBelongsTo(admin, view) {
+			continue
+		}
+		destination := filepath.Join(staging, "worktrees-"+entry.Name())
+		if err := storeResetRename(admin, destination); err != nil {
+			return staged, fmt.Errorf("stage worktree administrative directory for candidate view %q: %w", entry.Name(), err)
+		}
+		staged = append(staged, storeResetStagedAdminDir{original: admin, staged: destination})
+	}
+	return staged, nil
+}
+
+// storeResetRestoreAdminDirs puts back every administrative directory staged
+// for a category that was then not removed.
+func storeResetRestoreAdminDirs(staged []storeResetStagedAdminDir) error {
+	failures := []error{}
+	for _, entry := range staged {
+		if err := storeResetRename(entry.staged, entry.original); err != nil {
+			failures = append(failures, err)
 		}
 	}
-	return storeResetMakeWritable(views)
+	return errors.Join(failures...)
+}
+
+// storeResetSkipReason names why a category was left alone, and says so louder
+// when undoing the preparation for it did not fully work: a restore that failed
+// is the one case where the store is not exactly as this run found it.
+func storeResetSkipReason(cause, restore error) string {
+	if restore == nil {
+		return cause.Error()
+	}
+	return fmt.Sprintf(
+		"%v; and the worktree administrative directories moved aside for it could not be restored: %v",
+		cause, restore,
+	)
+}
+
+// storeResetRelaxForRename grants write permission on one directory so it can
+// be moved to a new parent, and returns the undo. It changes nothing when the
+// directory is already writable, missing, or not a directory.
+func storeResetRelaxForRename(path string) func() {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() {
+		return func() {}
+	}
+	mode := info.Mode().Perm()
+	if mode&0o200 != 0 {
+		return func() {}
+	}
+	if err := os.Chmod(path, mode|0o700); err != nil {
+		return func() {}
+	}
+	return func() { _ = os.Chmod(path, mode) }
 }
 
 // storeResetAdminDirBelongsTo reports whether a worktree admin directory points

--- a/internal/reviewtransaction/store_reset.go
+++ b/internal/reviewtransaction/store_reset.go
@@ -42,6 +42,14 @@ import (
 // Honest accounting beats a clean-looking report. Bytes are counted as freed
 // only after they are actually gone. A category that could not be moved is
 // reported with its reason, is not counted, and makes the whole run incomplete.
+//
+// A fourth rule follows from the third. The safety this command advertises --
+// the exclusive maintenance lease and the in-flight refusal -- only covers the
+// state gentle-ai itself writes. A category outside that coverage cannot be
+// removed by a default run no matter how dead it looks, because "we could not
+// find a live writer" is not the same claim as "there is no live writer". Such
+// a category is spared, reported under Preserved with the coverage it lacks,
+// and removed only when the caller names it (storeResetTarget.optIn).
 
 // StoreResetReportSchema identifies the clone-scoped review store reset
 // projection.
@@ -54,10 +62,25 @@ const (
 	StoreResetApplied = "reset"
 )
 
-// storeResetLockTimeout bounds the exclusive maintenance lease. A reset that
-// cannot get the lease promptly is competing with a live review, and waiting
-// longer only makes the collision worse.
-const storeResetLockTimeout = 30 * time.Second
+// storeResetLockTimeout is the context deadline this command hands to
+// AcquireReviewMaintenanceExclusive. It is not an independent waiting budget,
+// and reading it as one is how the previous 30s literal came to describe
+// behavior that never happened: the acquisition applies maintenanceLockTimeout
+// internally, so that shorter bound is what a contended lease actually expires
+// on. The only reason this is larger is that the same context also covers the
+// Git identity resolution the acquisition performs first, and pinning it to the
+// lease bound would let a slow repository probe cancel an uncontended lease.
+//
+// A reset that cannot get the lease promptly is competing with a live review,
+// and waiting longer only makes the collision worse -- which is exactly what
+// the 2s bound already enforces, so this constant tracks it rather than
+// competing with it.
+const storeResetLockTimeout = maintenanceLockTimeout + storeResetIdentitySlack
+
+// storeResetIdentitySlack is the headroom storeResetLockTimeout adds for the
+// repository identity resolution that runs inside the same context, before the
+// lease bound applies.
+const storeResetIdentitySlack = 8 * time.Second
 
 // storeResetStagingPrefix names the directory a run moves categories into
 // before deleting them. Staging is what makes the store consistent at one
@@ -68,6 +91,15 @@ const storeResetStagingPrefix = ".store-reset-"
 // storeResetRename is the rename seam, mirroring reclaimQuarantineResidue in
 // compact_reclaim.go so partial-failure paths stay testable.
 var storeResetRename = os.Rename
+
+// storeResetRemoveTree is the deletion seam, and it exists for the same reason
+// the rename seam does. The interesting deletion failure is the one that leaves
+// the tree behind -- ENOSPC, EIO, a busy mount -- because that is when the byte
+// accounting has to subtract what survived, and no portable arrangement of
+// permissions reproduces it: every permission failure this package can stage on
+// a developer's disk is either retried into success or leaves a subtree the
+// accounting cannot read and therefore counts as zero.
+var storeResetRemoveTree = os.RemoveAll
 
 // storeResetAcquireLease is the lease seam. Production always takes the real
 // exclusive maintenance lease; a test substitutes a wrapper around it to prove,
@@ -88,6 +120,15 @@ type storeResetTarget struct {
 	// administrative directories that register them go with the checkouts and
 	// the permissions have to be relaxed before anything can be unlinked.
 	candidateViews bool
+	// optIn marks a category no default run removes. Such a category is
+	// reported under Preserved carrying withheldReason until the caller names
+	// it explicitly, and only then does it appear under Removable.
+	optIn bool
+	// withheldReason explains, to the person reading the preview, why the
+	// default run spares an optIn category. It is a different sentence from
+	// reason: reason says what the category is, withheldReason says what this
+	// command cannot promise about removing it.
+	withheldReason string
 }
 
 // storeResetRemovableTargets is the complete inclusion list. Every entry is
@@ -119,8 +160,10 @@ var storeResetRemovableTargets = []storeResetTarget{
 		reason: "per-lineage preserved raw reviewer results",
 	},
 	{
-		name: "reviews", parts: []string{"reviews"},
-		reason: "superseded review graph store written by the gentle-pi adapter; per-lineage authority in an earlier format",
+		name: "reviews", parts: []string{"reviews"}, optIn: true,
+		reason: "review graph store written by the gentle-pi adapter, outside this command's lease and in-flight coverage; removed only because --include-adapter-reviews was given",
+		withheldReason: "review graph store the gentle-pi adapter writes and this command cannot vouch for: " +
+			"REVIEW-MAINTENANCE.lock does not cover it and the in-flight refusal never reads it, so a default run cannot tell a dead graph from a live review; pass --include-adapter-reviews to remove it anyway",
 	},
 }
 
@@ -202,21 +245,44 @@ type StoreResetReport struct {
 	Settled      int                 `json:"settled_lineages"`
 	RemovedFiles int                 `json:"removed_files"`
 	RemovedBytes int64               `json:"removed_bytes"`
-	// Residue names a staging directory a failed run could not delete. Its
-	// contents are already out of the store, but the bytes are still on disk
-	// and are not counted as freed.
+	// Residue names a staging directory that outlived the run. Its contents
+	// are already out of the store, but the bytes are still on disk and are
+	// not counted as freed. It is set both when the deletion failed and when
+	// the run deliberately kept the directory to hold UnrestoredAdminDirs.
 	Residue string `json:"residue,omitempty"`
+	// UnrestoredAdminDirs names every Git worktree administrative directory
+	// this run moved aside for a category it then did not remove, and could
+	// not put back. They are the one case where a category reported SKIPPED is
+	// not in the state the run found it: the checkouts are still there, but
+	// their registrations are parked under Residue instead of at Original.
+	UnrestoredAdminDirs []StoreResetUnrestoredAdminDir `json:"unrestored_admin_dirs,omitempty"`
 	// Complete is false whenever any present removable category was not
 	// removed, for any reason. A partial run never reports success.
 	Complete bool `json:"complete"`
 }
 
-// StoreResetRequest carries the one decision the caller owns.
+// StoreResetUnrestoredAdminDir names one Git worktree administrative directory
+// a run moved aside and could not move back, and where it ended up.
+type StoreResetUnrestoredAdminDir struct {
+	// Original is where the directory belongs, and where it has to be put back
+	// before the candidate view it registers works again.
+	Original string `json:"original"`
+	// Staged is where the run left it.
+	Staged string `json:"staged"`
+}
+
+// StoreResetRequest carries the decisions the caller owns.
 type StoreResetRequest struct {
 	// IncludeInFlight permits removing lineages that have not reached a
 	// terminal state. It exists so the refusal has an exit, not so callers can
 	// set it by default.
 	IncludeInFlight bool
+	// IncludeAdapterReviews permits removing the adapter-written reviews/
+	// graph store. It is separate from IncludeInFlight because it overrides a
+	// different guarantee: IncludeInFlight discards reviews this command can
+	// see and named, while this one discards a category it cannot see into at
+	// all, and so cannot list, count as in flight, or lock out a writer from.
+	IncludeAdapterReviews bool
 }
 
 // StoreResetInFlightError refuses a reset that would destroy open reviews.
@@ -256,7 +322,11 @@ func (err *StoreResetIncompleteError) Error() string {
 	for _, entry := range err.Skipped {
 		names = append(names, fmt.Sprintf("%s (%s)", entry.Name, entry.Skipped))
 	}
-	return fmt.Sprintf("review store reset was incomplete: %s", strings.Join(names, "; "))
+	message := fmt.Sprintf("review store reset was incomplete: %s", strings.Join(names, "; "))
+	if err.Residue != "" {
+		message += fmt.Sprintf("; state this run moved aside is parked in %s", err.Residue)
+	}
+	return message
 }
 
 // storeResetRoot resolves <git-common-dir>/gentle-ai for one clone.
@@ -279,12 +349,17 @@ func storeResetRoot(ctx context.Context, repo string) (root, repository string, 
 // SurveyReviewStore reports what a reset would remove without touching
 // anything. It creates no directories, takes no lock, and is safe to run
 // against a store no other operation can open.
-func SurveyReviewStore(ctx context.Context, repo string) (StoreResetReport, error) {
-	report, _, err := surveyReviewStore(ctx, repo)
+//
+// It takes the same request the reset takes because the preview has to be the
+// preview of the run the caller is about to make: an opt-in category shown as
+// removable when the flag is absent would promise a removal that never comes,
+// and shown as preserved when the flag is present would hide one that does.
+func SurveyReviewStore(ctx context.Context, repo string, request StoreResetRequest) (StoreResetReport, error) {
+	report, _, err := surveyReviewStore(ctx, repo, request)
 	return report, err
 }
 
-func surveyReviewStore(ctx context.Context, repo string) (StoreResetReport, string, error) {
+func surveyReviewStore(ctx context.Context, repo string, request StoreResetRequest) (StoreResetReport, string, error) {
 	if err := ctx.Err(); err != nil {
 		return StoreResetReport{}, "", err
 	}
@@ -299,18 +374,43 @@ func surveyReviewStore(ctx context.Context, repo string) (StoreResetReport, stri
 		Unrecognized: []StoreResetEntry{}, InFlight: []StoreResetLineage{},
 		Complete: true,
 	}
+	withheld := []StoreResetEntry{}
 	for _, target := range storeResetRemovableTargets {
+		if target.optIn && !storeResetOptedIn(target, request) {
+			spared := target
+			spared.reason = target.withheldReason
+			withheld = append(withheld, storeResetMeasure(root, spared))
+			continue
+		}
 		report.Removable = append(report.Removable, storeResetMeasure(root, target))
 	}
 	for _, target := range storeResetPreservedTargets {
 		report.Preserved = append(report.Preserved, storeResetMeasure(root, target))
 	}
+	// Withheld categories go last so the standing exclusion list keeps its
+	// order and the conditional entries are visibly the conditional ones.
+	report.Preserved = append(report.Preserved, withheld...)
 	report.Unrecognized = storeResetUnrecognized(root)
 	report.InFlight, report.Settled, err = storeResetLineages(root)
 	if err != nil {
 		return report, root, err
 	}
 	return report, root, nil
+}
+
+// storeResetOptedIn reports whether the caller asked for one opt-in category by
+// name. It is a switch per category rather than a single "include everything"
+// flag on purpose: each opt-in category overrides a different guarantee, and a
+// blanket flag would let a caller who wanted one of them discard the others
+// without ever reading why they were withheld.
+func storeResetOptedIn(target storeResetTarget, request StoreResetRequest) bool {
+	if target.name == "reviews" {
+		return request.IncludeAdapterReviews
+	}
+	// An opt-in category nobody wired a switch for stays withheld. Failing
+	// closed here means adding a category to the list can spare data by
+	// accident, never destroy it by accident.
+	return false
 }
 
 // storeResetMeasure sizes one target without following symlinks into it.
@@ -443,6 +543,11 @@ type storeResetStateRecord struct {
 // Legacy v1 lineages are not classified. Their state lives in an append-only
 // event chain no current build can advance, so there is no open v1 review to
 // protect; the directory is removed as settled residue.
+//
+// Nothing outside review-transactions/v2 is classified at all, and that is the
+// whole reason the adapter-written reviews/ graph store is opt-in: a review
+// living there is invisible here, so "no lineages in flight" is a statement
+// about compact-v2 and must never be read as a statement about the store.
 func storeResetLineages(root string) ([]StoreResetLineage, int, error) {
 	inFlight := []StoreResetLineage{}
 	settled := 0
@@ -524,15 +629,21 @@ func ResetReviewStore(ctx context.Context, repo string, request StoreResetReques
 	}
 	defer func() { _ = lock.Release() }()
 
-	report, root, err := surveyReviewStore(ctx, repo)
+	report, root, err := surveyReviewStore(ctx, repo, request)
 	if err != nil {
 		return report, err
 	}
-	report.Operation = StoreResetApplied
 	if len(report.InFlight) > 0 && !request.IncludeInFlight {
+		// The operation stays the preview one. A refusal returns before the
+		// staging directory is created, so nothing was opened, nothing was
+		// moved, and nothing can be reconciled: labelling that run "reset"
+		// tells every machine reader that a removal was attempted and every
+		// category skipped, which is a different and much more alarming
+		// outcome than the one that occurred.
 		report.Complete = false
 		return report, &StoreResetInFlightError{Repository: report.Repository, Lineages: report.InFlight}
 	}
+	report.Operation = StoreResetApplied
 
 	return storeResetExecute(ctx, report, root)
 }
@@ -549,6 +660,13 @@ func storeResetExecute(ctx context.Context, report StoreResetReport, root string
 		targets[target.name] = target
 	}
 	staged := int64(0)
+	// stranded collects every administrative directory this run moved aside
+	// for a category it then did not remove, and could not move back. Those
+	// bytes are emphatically not this run's to delete: the category they
+	// belong to is reported SKIPPED, meaning untouched, and deleting the
+	// staging directory with them inside would make that report a lie that
+	// nothing on disk can contradict afterwards.
+	stranded := []storeResetStagedAdminDir{}
 	for index, entry := range report.Removable {
 		if err := ctx.Err(); err != nil {
 			report.Complete = false
@@ -570,7 +688,9 @@ func storeResetExecute(ctx context.Context, report StoreResetReport, root string
 			var err error
 			stagedAdmin, err = storeResetStageCandidateViewAdminDirs(root, source, staging)
 			if err != nil {
-				report.Removable[index].Skipped = storeResetSkipReason(err, storeResetRestoreAdminDirs(stagedAdmin))
+				unrestored, restoreErr := storeResetRestoreAdminDirs(stagedAdmin)
+				stranded = append(stranded, unrestored...)
+				report.Removable[index].Skipped = storeResetSkipReason(err, restoreErr)
 				report.Complete = false
 				continue
 			}
@@ -583,32 +703,147 @@ func storeResetExecute(ctx context.Context, report StoreResetReport, root string
 		destination := filepath.Join(staging, strings.ReplaceAll(entry.Path, "/", "-"))
 		if err := storeResetRename(source, destination); err != nil {
 			restoreMode()
-			report.Removable[index].Skipped = storeResetSkipReason(err, storeResetRestoreAdminDirs(stagedAdmin))
+			unrestored, restoreErr := storeResetRestoreAdminDirs(stagedAdmin)
+			stranded = append(stranded, unrestored...)
+			report.Removable[index].Skipped = storeResetSkipReason(err, restoreErr)
 			report.Complete = false
 			continue
 		}
 		report.Removable[index].Removed = true
 		report.RemovedFiles += entry.Files
-		staged += entry.Bytes
+		// The administrative directories went into staging alongside the
+		// category, so their bytes are freed with it. Leaving them out of the
+		// accumulator is what let the residual subtraction below outweigh it
+		// and print a negative size.
+		staged += entry.Bytes + storeResetStagedAdminBytes(stagedAdmin)
 	}
 	_ = SyncReviewDirectory(root)
+
+	report.UnrestoredAdminDirs = storeResetUnrestoredAdminDirs(stranded)
 
 	// Bytes count as freed only once they are actually gone. If the staging
 	// directory survives, the categories are out of the store but the disk is
 	// not back, and saying otherwise would be the exact dishonest report this
 	// command must not produce.
-	if err := storeResetRemoveAll(staging); err != nil {
-		_, residual := storeResetUsage(staging)
-		report.RemovedBytes = staged - residual
+	if err := storeResetRemoveStaging(staging, stranded); err != nil {
+		report.RemovedBytes = storeResetFreedBytes(staged, storeResetResidualBytes(staging, stranded))
 		report.Residue = staging
 		report.Complete = false
 		return report, &StoreResetIncompleteError{Skipped: storeResetSkipped(report), Residue: staging}
 	}
-	report.RemovedBytes = staged
+	report.RemovedBytes = storeResetFreedBytes(staged, 0)
+	if len(stranded) > 0 {
+		// The staging directory survived on purpose, holding registrations
+		// this run could not put back. Naming it as residue is the only thing
+		// that tells the user those bytes are still on disk and where the
+		// registrations went; without it the report says a category was
+		// skipped and shows nothing left over, which reads as "no harm done".
+		report.Residue = staging
+	}
 	if !report.Complete {
-		return report, &StoreResetIncompleteError{Skipped: storeResetSkipped(report)}
+		return report, &StoreResetIncompleteError{Skipped: storeResetSkipped(report), Residue: report.Residue}
 	}
 	return report, nil
+}
+
+// storeResetStagedAdminBytes sizes administrative directories already moved
+// into staging.
+func storeResetStagedAdminBytes(staged []storeResetStagedAdminDir) int64 {
+	total := int64(0)
+	for _, entry := range staged {
+		_, bytes := storeResetUsage(entry.staged)
+		total += bytes
+	}
+	return total
+}
+
+// storeResetUnrestoredAdminDirs projects the internal staging records into the
+// report.
+func storeResetUnrestoredAdminDirs(stranded []storeResetStagedAdminDir) []StoreResetUnrestoredAdminDir {
+	if len(stranded) == 0 {
+		return nil
+	}
+	entries := make([]StoreResetUnrestoredAdminDir, 0, len(stranded))
+	for _, entry := range stranded {
+		entries = append(entries, StoreResetUnrestoredAdminDir{Original: entry.original, Staged: entry.staged})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Original < entries[j].Original })
+	return entries
+}
+
+// storeResetRemoveStaging deletes the staging directory, except for anything
+// the run has to keep.
+//
+// With nothing to keep this is the whole directory, which is the ordinary case.
+// With something to keep the directory itself has to survive to hold it, so the
+// deletion becomes per-child: every category that really was removed still goes
+// away, and the administrative directories that could not be restored stay put
+// where the report can point at them. Deleting them here would destroy a
+// worktree registration for a checkout this same run reported as untouched, and
+// no later run could rebuild it.
+func storeResetRemoveStaging(staging string, keep []storeResetStagedAdminDir) error {
+	if len(keep) == 0 {
+		return storeResetRemoveAll(staging)
+	}
+	kept := storeResetKeptPaths(keep)
+	entries, err := os.ReadDir(staging)
+	if err != nil {
+		return err
+	}
+	failures := []error{}
+	for _, entry := range entries {
+		path := filepath.Join(staging, entry.Name())
+		if kept[filepath.Clean(path)] {
+			continue
+		}
+		if err := storeResetRemoveAll(path); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}
+
+func storeResetKeptPaths(keep []storeResetStagedAdminDir) map[string]bool {
+	kept := map[string]bool{}
+	for _, entry := range keep {
+		kept[filepath.Clean(entry.staged)] = true
+	}
+	return kept
+}
+
+// storeResetResidualBytes sizes what is left in staging that the run meant to
+// delete. Anything deliberately kept is excluded: it was never counted as
+// staged for removal, so subtracting it would charge the run for bytes it never
+// claimed to free.
+func storeResetResidualBytes(staging string, keep []storeResetStagedAdminDir) int64 {
+	kept := storeResetKeptPaths(keep)
+	entries, err := os.ReadDir(staging)
+	if err != nil {
+		_, bytes := storeResetUsage(staging)
+		return bytes
+	}
+	total := int64(0)
+	for _, entry := range entries {
+		path := filepath.Join(staging, entry.Name())
+		if kept[filepath.Clean(path)] {
+			continue
+		}
+		_, bytes := storeResetUsage(path)
+		total += bytes
+	}
+	return total
+}
+
+// storeResetFreedBytes reports what a run actually reclaimed, and never reports
+// less than nothing. The two counts are measured at different moments against a
+// tree other processes can touch, so their difference can invert; a negative
+// size printed to a user is a bug report about the accounting, not information
+// about their disk.
+func storeResetFreedBytes(staged, residual int64) int64 {
+	if freed := staged - residual; freed > 0 {
+		return freed
+	}
+	return 0
 }
 
 func storeResetSkipped(report StoreResetReport) []StoreResetEntry {
@@ -669,15 +904,28 @@ func storeResetStageCandidateViewAdminDirs(root, views, staging string) ([]store
 }
 
 // storeResetRestoreAdminDirs puts back every administrative directory staged
-// for a category that was then not removed.
-func storeResetRestoreAdminDirs(staged []storeResetStagedAdminDir) error {
+// for a category that was then not removed, and names the ones it could not.
+//
+// The names matter as much as the error. A directory left in staging is still a
+// worktree registration, and the run is about to delete staging; returning only
+// an error would fold that fact into a sentence in a skip reason and let the
+// deletion take it. Returning the entries lets the caller keep them.
+//
+// The second rename is not a formality that always works. It fails when
+// something recreated the path in the window, on a full or failing disk, and on
+// Windows whenever any process holds a handle inside the directory -- which is
+// also when the first rename is most likely to have failed, so the restore path
+// is at its least reliable exactly when it is reached.
+func storeResetRestoreAdminDirs(staged []storeResetStagedAdminDir) ([]storeResetStagedAdminDir, error) {
+	unrestored := []storeResetStagedAdminDir{}
 	failures := []error{}
 	for _, entry := range staged {
 		if err := storeResetRename(entry.staged, entry.original); err != nil {
+			unrestored = append(unrestored, entry)
 			failures = append(failures, err)
 		}
 	}
-	return errors.Join(failures...)
+	return unrestored, errors.Join(failures...)
 }
 
 // storeResetSkipReason names why a category was left alone, and says so louder
@@ -748,12 +996,12 @@ func storeResetMakeWritable(path string) error {
 // attempt is refused. Retrying exactly once keeps a genuine fault (a busy file,
 // a full disk, a vanished mount) from turning into a loop.
 func storeResetRemoveAll(path string) error {
-	err := os.RemoveAll(path)
+	err := storeResetRemoveTree(path)
 	if err == nil || !errors.Is(err, os.ErrPermission) {
 		return err
 	}
 	if writableErr := storeResetMakeWritable(path); writableErr != nil {
 		return err
 	}
-	return os.RemoveAll(path)
+	return storeResetRemoveTree(path)
 }

--- a/internal/reviewtransaction/store_reset.go
+++ b/internal/reviewtransaction/store_reset.go
@@ -1,0 +1,666 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Clone-scoped review store reset.
+//
+// Review authority accumulates without bound under <git-common-dir>/gentle-ai:
+// every candidate leaves a lineage behind, every lineage stays after delivery,
+// and nothing removes a delivered one. `review abandon` refuses terminal
+// states and `review reclaim` refuses any entry holding authoritative
+// artifacts, so a store that has degraded has no exit at all. This is that
+// exit, and it is deliberately the bluntest operation in the package: it does
+// not repair, migrate, or reconcile anything. It removes the lineage state for
+// one clone so the next review starts from nothing.
+//
+// Three rules shape the whole file.
+//
+// It is an allowlist, never a denylist. Only paths named in
+// storeResetRemovableTargets are ever removed. Anything else -- including a
+// directory a future release adds -- is reported and left exactly where it is.
+// The failure mode of a denylist here is destroying state nobody remembered to
+// exclude, and that failure is silent.
+//
+// The kill switch is not lineage state. It lives in two places, and one of them
+// (review-transactions/rar-authority/v1/rdd-mode) is *inside* the authority
+// tree, still written for gentle-ai builds installed before #2882 that read
+// only that location. A reset that removed review-transactions/ wholesale would
+// switch reviews back on for a user who had turned them off, which is the worst
+// thing this command could possibly do.
+//
+// Honest accounting beats a clean-looking report. Bytes are counted as freed
+// only after they are actually gone. A category that could not be moved is
+// reported with its reason, is not counted, and makes the whole run incomplete.
+
+// StoreResetReportSchema identifies the clone-scoped review store reset
+// projection.
+const StoreResetReportSchema = "gentle-ai.review-store-reset/v1"
+
+const (
+	// StoreResetPreview names a read-only survey that removes nothing.
+	StoreResetPreview = "preview"
+	// StoreResetApplied names a run that attempted removal.
+	StoreResetApplied = "reset"
+)
+
+// storeResetLockTimeout bounds the exclusive maintenance lease. A reset that
+// cannot get the lease promptly is competing with a live review, and waiting
+// longer only makes the collision worse.
+const storeResetLockTimeout = 30 * time.Second
+
+// storeResetStagingPrefix names the directory a run moves categories into
+// before deleting them. Staging is what makes the store consistent at one
+// instant instead of during a long recursive walk: a concurrent reader either
+// sees a category or does not, never half of one.
+const storeResetStagingPrefix = ".store-reset-"
+
+// storeResetRename is the rename seam, mirroring reclaimQuarantineResidue in
+// compact_reclaim.go so partial-failure paths stay testable.
+var storeResetRename = os.Rename
+
+// storeResetTarget names one path under <git-common-dir>/gentle-ai and why it
+// is in the list it is in. The reason is not decoration: this command destroys
+// data, and every entry it touches or spares has to be able to justify itself
+// to the person reading the preview.
+type storeResetTarget struct {
+	name   string
+	parts  []string
+	reason string
+	// candidateViews marks the one category that is not merely files.
+	// Candidate views are registered Git worktrees written read-only, so they
+	// need their permissions relaxed and their admin directories removed.
+	candidateViews bool
+}
+
+// storeResetRemovableTargets is the complete inclusion list. Every entry is
+// state derived from reviewing candidates; none of it is a user preference, and
+// none of it can be authored by hand.
+var storeResetRemovableTargets = []storeResetTarget{
+	{
+		name: "candidate-views", parts: []string{"candidate-views"}, candidateViews: true,
+		reason: "per-candidate repository checkouts materialized for reviewer inspection; regenerated on demand and the largest consumer of disk",
+	},
+	{
+		name: "review-transactions/v1", parts: []string{"review-transactions", "v1"},
+		reason: "legacy per-lineage authority event chains; read-only in current builds",
+	},
+	{
+		name: "review-transactions/v2", parts: []string{"review-transactions", "v2"},
+		reason: "compact per-lineage authority records, receipts, and captured reviewer results",
+	},
+	{
+		name: "review-transactions/quarantine", parts: []string{"review-transactions", "quarantine"},
+		reason: "audited residue of lineages already discarded by reclaim or abandon",
+	},
+	{
+		name: "review-transactions/effect-markers", parts: []string{"review-transactions", "effect-markers"},
+		reason: "per-lineage delivery idempotence markers; meaningless once their lineage is gone",
+	},
+	{
+		name: "review-transactions/incidents", parts: []string{"review-transactions", "incidents"},
+		reason: "per-lineage preserved raw reviewer results",
+	},
+	{
+		name: "reviews", parts: []string{"reviews"},
+		reason: "superseded review graph store written by the gentle-pi adapter; per-lineage authority in an earlier format",
+	},
+}
+
+// storeResetPreservedTargets is the complete exclusion list. Two of these are
+// the kill switch, two are state another component owns, and two are paths no
+// gentle-ai code has ever written -- which is itself the reason.
+var storeResetPreservedTargets = []storeResetTarget{
+	{
+		name: "review-mode", parts: []string{"review-mode"},
+		reason: "the receipt-driven-development kill switch and its consent latch: a user preference, not lineage state",
+	},
+	{
+		name: "review-transactions/rar-authority", parts: []string{"review-transactions", "rar-authority"},
+		reason: "holds the pre-#2882 mirror of that same kill switch, still written for installed builds that read only this location",
+	},
+	{
+		name: "sdd-runtime", parts: []string{"sdd-runtime"},
+		reason: "SDD attempt state keyed by change name rather than by review lineage; removing it would lose in-flight SDD work",
+	},
+	{
+		name: "defect-reports", parts: []string{"defect-reports"},
+		reason: "diagnostic reports that may not have been filed upstream yet; evidence this command cannot regenerate",
+	},
+	{
+		name: "review-artifacts", parts: []string{"review-artifacts"},
+		reason: "no gentle-ai code writes or reads this path, so its contents were placed by hand; a reset never removes what the product did not create",
+	},
+	{
+		name: "incidents", parts: []string{"incidents"},
+		reason: "same: nothing in this product writes this path, and per-lineage incidents live under review-transactions/incidents instead",
+	},
+	{
+		name: "REVIEW-MAINTENANCE.lock", parts: []string{"REVIEW-MAINTENANCE.lock"},
+		reason: "the advisory maintenance lease this operation itself holds; it carries no lineage state and is recreated on demand",
+	},
+}
+
+// StoreResetEntry is one category's line in the report.
+type StoreResetEntry struct {
+	Name    string `json:"name"`
+	Path    string `json:"path"`
+	Reason  string `json:"reason"`
+	Present bool   `json:"present"`
+	Files   int    `json:"files"`
+	Bytes   int64  `json:"bytes"`
+	Removed bool   `json:"removed"`
+	// Skipped carries why a present removable category was not removed. It is
+	// only ever set on a run that tried.
+	Skipped string `json:"skipped,omitempty"`
+}
+
+// StoreResetLineage names one review that is still open, or one whose record
+// this command could not read.
+type StoreResetLineage struct {
+	LineageID string `json:"lineage_id"`
+	State     State  `json:"state,omitempty"`
+	// Unreadable carries the parse failure for a record that could not be
+	// classified. Such a record is treated as in-flight, because guessing the
+	// other way destroys work.
+	Unreadable string `json:"unreadable,omitempty"`
+}
+
+// StoreResetReport is what both the preview and the reset return. The two carry
+// the same shape on purpose: the preview is not a different report, it is the
+// same report with nothing removed yet.
+type StoreResetReport struct {
+	Schema     string `json:"schema"`
+	Operation  string `json:"operation"`
+	Repository string `json:"repository"`
+	StoreRoot  string `json:"store_root"`
+	// Removable, Preserved, and Unrecognized together account for every entry
+	// found under the store root. Nothing is left out of the report because
+	// this command did not recognize it -- that is precisely what Unrecognized
+	// is for.
+	Removable    []StoreResetEntry   `json:"removable"`
+	Preserved    []StoreResetEntry   `json:"preserved"`
+	Unrecognized []StoreResetEntry   `json:"unrecognized"`
+	InFlight     []StoreResetLineage `json:"in_flight"`
+	Settled      int                 `json:"settled_lineages"`
+	RemovedFiles int                 `json:"removed_files"`
+	RemovedBytes int64               `json:"removed_bytes"`
+	// Residue names a staging directory a failed run could not delete. Its
+	// contents are already out of the store, but the bytes are still on disk
+	// and are not counted as freed.
+	Residue string `json:"residue,omitempty"`
+	// Complete is false whenever any present removable category was not
+	// removed, for any reason. A partial run never reports success.
+	Complete bool `json:"complete"`
+}
+
+// StoreResetRequest carries the one decision the caller owns.
+type StoreResetRequest struct {
+	// IncludeInFlight permits removing lineages that have not reached a
+	// terminal state. It exists so the refusal has an exit, not so callers can
+	// set it by default.
+	IncludeInFlight bool
+}
+
+// StoreResetInFlightError refuses a reset that would destroy open reviews.
+type StoreResetInFlightError struct {
+	Repository string
+	Lineages   []StoreResetLineage
+}
+
+func (err *StoreResetInFlightError) Error() string {
+	names := make([]string, 0, len(err.Lineages))
+	for _, lineage := range err.Lineages {
+		if lineage.Unreadable != "" {
+			names = append(names, fmt.Sprintf("%s (unreadable: %s)", lineage.LineageID, lineage.Unreadable))
+			continue
+		}
+		names = append(names, fmt.Sprintf("%s (%s)", lineage.LineageID, lineage.State))
+	}
+	return fmt.Sprintf(
+		"review store reset refused: %d review(s) have not reached a terminal state: %s; finish or abandon them, or run `gentle-ai review store-reset --cwd %s --confirm --include-in-flight` to remove them anyway",
+		len(err.Lineages), strings.Join(names, ", "), err.Repository,
+	)
+}
+
+// StoreResetIncompleteError reports a run that removed some categories and not
+// others. It carries no continuation of its own because the answer is always
+// the same one: read the report, fix what the skip reason names, run it again.
+type StoreResetIncompleteError struct {
+	Skipped []StoreResetEntry
+	Residue string
+}
+
+func (err *StoreResetIncompleteError) Error() string {
+	if len(err.Skipped) == 0 && err.Residue != "" {
+		return fmt.Sprintf("review store reset removed every category but could not delete its staging directory %s; the bytes are not reclaimed until it is removed", err.Residue)
+	}
+	names := make([]string, 0, len(err.Skipped))
+	for _, entry := range err.Skipped {
+		names = append(names, fmt.Sprintf("%s (%s)", entry.Name, entry.Skipped))
+	}
+	return fmt.Sprintf("review store reset was incomplete: %s", strings.Join(names, "; "))
+}
+
+// storeResetRoot resolves <git-common-dir>/gentle-ai for one clone.
+//
+// It deliberately does not apply the receipt-driven-development gate. The kill
+// switch decides whether reviews happen; it does not decide whether a user may
+// delete their own accumulated state. Gating cleanup on it would recreate
+// exactly the dead end this command exists to remove: a user whose store has
+// degraded turns reviews off, and then discovers the only tool that could clean
+// up refuses because reviews are off.
+func storeResetRoot(ctx context.Context, repo string) (root, repository string, err error) {
+	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	if err != nil {
+		return "", "", err
+	}
+	identity := lease.Identity()
+	return filepath.Join(identity.GitCommonDir, "gentle-ai"), identity.RepositoryRoot, nil
+}
+
+// SurveyReviewStore reports what a reset would remove without touching
+// anything. It creates no directories, takes no lock, and is safe to run
+// against a store no other operation can open.
+func SurveyReviewStore(ctx context.Context, repo string) (StoreResetReport, error) {
+	report, _, err := surveyReviewStore(ctx, repo)
+	return report, err
+}
+
+func surveyReviewStore(ctx context.Context, repo string) (StoreResetReport, string, error) {
+	if err := ctx.Err(); err != nil {
+		return StoreResetReport{}, "", err
+	}
+	root, repository, err := storeResetRoot(ctx, repo)
+	if err != nil {
+		return StoreResetReport{}, "", err
+	}
+	report := StoreResetReport{
+		Schema: StoreResetReportSchema, Operation: StoreResetPreview,
+		Repository: repository, StoreRoot: root,
+		Removable: []StoreResetEntry{}, Preserved: []StoreResetEntry{},
+		Unrecognized: []StoreResetEntry{}, InFlight: []StoreResetLineage{},
+		Complete: true,
+	}
+	for _, target := range storeResetRemovableTargets {
+		report.Removable = append(report.Removable, storeResetMeasure(root, target))
+	}
+	for _, target := range storeResetPreservedTargets {
+		report.Preserved = append(report.Preserved, storeResetMeasure(root, target))
+	}
+	report.Unrecognized = storeResetUnrecognized(root)
+	report.InFlight, report.Settled, err = storeResetLineages(root)
+	if err != nil {
+		return report, root, err
+	}
+	return report, root, nil
+}
+
+// storeResetMeasure sizes one target without following symlinks into it.
+func storeResetMeasure(root string, target storeResetTarget) StoreResetEntry {
+	path := filepath.Join(append([]string{root}, target.parts...)...)
+	entry := StoreResetEntry{
+		Name: target.name, Path: strings.Join(target.parts, "/"), Reason: target.reason,
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return entry
+	}
+	entry.Present = true
+	if !info.IsDir() {
+		entry.Files, entry.Bytes = 1, info.Size()
+		return entry
+	}
+	entry.Files, entry.Bytes = storeResetUsage(path)
+	return entry
+}
+
+// storeResetUsage sums one tree. Errors are absorbed rather than propagated:
+// this is a report about a store that may well be damaged, and refusing to
+// print a number because one subdirectory is unreadable would withhold the
+// whole survey over a detail.
+func storeResetUsage(path string) (files int, bytes int64) {
+	_ = filepath.WalkDir(path, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			// An unreadable subtree is skipped, not fatal. The count that
+			// results is a floor, which is the honest direction for a preview.
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil
+		}
+		files++
+		if info.Mode().IsRegular() {
+			bytes += info.Size()
+		}
+		return nil
+	})
+	return files, bytes
+}
+
+// storeResetUnrecognized reports every entry under the store root that neither
+// list covers. This is the allowlist made visible: a future directory shows up
+// here instead of quietly disappearing.
+func storeResetUnrecognized(root string) []StoreResetEntry {
+	known := map[string]bool{}
+	nested := map[string]bool{}
+	for _, target := range append(append([]storeResetTarget{}, storeResetRemovableTargets...), storeResetPreservedTargets...) {
+		if len(target.parts) == 1 {
+			known[target.parts[0]] = true
+			continue
+		}
+		// A target one level down means its parent is only partly claimed, so
+		// the parent itself is not "known" -- its other children still have to
+		// be reported.
+		nested[target.parts[0]] = true
+		known[strings.Join(target.parts, "/")] = true
+	}
+	unrecognized := []StoreResetEntry{}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return unrecognized
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, storeResetStagingPrefix) {
+			// Residue from an interrupted run of this same command. It is
+			// reported, never silently reused.
+			unrecognized = append(unrecognized, storeResetUnrecognizedEntry(root, name,
+				"staging residue from an interrupted review store reset"))
+			continue
+		}
+		if known[name] {
+			continue
+		}
+		if nested[name] {
+			children, err := os.ReadDir(filepath.Join(root, name))
+			if err != nil {
+				continue
+			}
+			for _, child := range children {
+				relative := name + "/" + child.Name()
+				if known[relative] {
+					continue
+				}
+				unrecognized = append(unrecognized, storeResetUnrecognizedEntry(root, relative,
+					"not covered by this command's inclusion or exclusion list"))
+			}
+			continue
+		}
+		unrecognized = append(unrecognized, storeResetUnrecognizedEntry(root, name,
+			"not covered by this command's inclusion or exclusion list"))
+	}
+	sort.Slice(unrecognized, func(i, j int) bool { return unrecognized[i].Name < unrecognized[j].Name })
+	return unrecognized
+}
+
+func storeResetUnrecognizedEntry(root, relative, reason string) StoreResetEntry {
+	entry := StoreResetEntry{Name: relative, Path: relative, Reason: reason, Present: true}
+	entry.Files, entry.Bytes = storeResetUsage(filepath.Join(root, filepath.FromSlash(relative)))
+	return entry
+}
+
+// storeResetStateRecord is the smallest shape that answers "is this lineage
+// still open". The full record parser is deliberately not used: it validates
+// far more than this question needs, and a record it rejects is exactly the
+// record this command has to be able to classify.
+type storeResetStateRecord struct {
+	State struct {
+		LineageID string `json:"lineage_id"`
+		State     State  `json:"state"`
+	} `json:"state"`
+}
+
+// storeResetLineages partitions compact-v2 lineages into settled and in-flight.
+//
+// Terminal is the same set the rest of the package uses -- approved, escalated,
+// invalidated (authorityStatusForState) -- and everything else is an open
+// review. A record that cannot be read counts as in-flight, because a damaged
+// store is precisely when that call gets made and the safe direction is to keep
+// the work and make the user say the word.
+//
+// Legacy v1 lineages are not classified. Their state lives in an append-only
+// event chain no current build can advance, so there is no open v1 review to
+// protect; the directory is removed as settled residue.
+func storeResetLineages(root string) ([]StoreResetLineage, int, error) {
+	inFlight := []StoreResetLineage{}
+	settled := 0
+	base := filepath.Join(root, "review-transactions", "v2")
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return inFlight, 0, nil
+		}
+		return inFlight, 0, fmt.Errorf("read compact review authority: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		record := filepath.Join(base, entry.Name(), compactStateFileName)
+		payload, err := os.ReadFile(record)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// No state record at all: crash residue, not a review.
+				settled++
+				continue
+			}
+			inFlight = append(inFlight, StoreResetLineage{LineageID: entry.Name(), Unreadable: err.Error()})
+			continue
+		}
+		var decoded storeResetStateRecord
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			inFlight = append(inFlight, StoreResetLineage{LineageID: entry.Name(), Unreadable: "state record does not parse"})
+			continue
+		}
+		state := decoded.State.State
+		if state == "" {
+			inFlight = append(inFlight, StoreResetLineage{LineageID: entry.Name(), Unreadable: "state record names no state"})
+			continue
+		}
+		switch authorityStatusForState(state) {
+		case AuthorityStatusApproved, AuthorityStatusEscalated, AuthorityStatusInvalidated:
+			settled++
+		default:
+			inFlight = append(inFlight, StoreResetLineage{LineageID: entry.Name(), State: state})
+		}
+	}
+	sort.Slice(inFlight, func(i, j int) bool { return inFlight[i].LineageID < inFlight[j].LineageID })
+	return inFlight, settled, nil
+}
+
+// ResetReviewStore removes the clone's review lineage state.
+//
+// This is irreversible. Nothing is copied aside for later recovery: the
+// package's existing quarantine (quarantineCompactStoreEntry) renames entries
+// into review-transactions/quarantine, which is inside the very store being
+// reset, so reusing it would free no disk and would refuse every lineage
+// holding authoritative artifacts -- which is all of them. Reclaiming the space
+// is the point, so the space is reclaimed and the report says so plainly.
+func ResetReviewStore(ctx context.Context, repo string, request StoreResetRequest) (StoreResetReport, error) {
+	report, root, err := surveyReviewStore(ctx, repo)
+	if err != nil {
+		return report, err
+	}
+	report.Operation = StoreResetApplied
+	if len(report.InFlight) > 0 && !request.IncludeInFlight {
+		report.Complete = false
+		return report, &StoreResetInFlightError{Repository: report.Repository, Lineages: report.InFlight}
+	}
+
+	// Hold the same advisory lease every other maintenance operation takes, so
+	// a reset cannot race a review that is mid-transition.
+	lockCtx, cancel := context.WithTimeout(ctx, storeResetLockTimeout)
+	defer cancel()
+	lock, err := AcquireReviewMaintenanceExclusive(lockCtx, repo)
+	if err != nil {
+		report.Complete = false
+		return report, fmt.Errorf("acquire review maintenance lease: %w", err)
+	}
+	defer func() { _ = lock.Release() }()
+
+	return storeResetExecute(ctx, report, root)
+}
+
+func storeResetExecute(ctx context.Context, report StoreResetReport, root string) (StoreResetReport, error) {
+	staging, err := os.MkdirTemp(root, storeResetStagingPrefix)
+	if err != nil {
+		report.Complete = false
+		return report, fmt.Errorf("create review store reset staging directory: %w", err)
+	}
+
+	targets := map[string]storeResetTarget{}
+	for _, target := range storeResetRemovableTargets {
+		targets[target.name] = target
+	}
+	staged := int64(0)
+	for index, entry := range report.Removable {
+		if err := ctx.Err(); err != nil {
+			report.Complete = false
+			return report, err
+		}
+		if !entry.Present {
+			continue
+		}
+		target := targets[entry.Name]
+		source := filepath.Join(append([]string{root}, target.parts...)...)
+		if target.candidateViews {
+			// Candidate views are registered worktrees written read-only.
+			// Relaxing the permissions and detaching the admin directories has
+			// to happen before the move, because after it the linkage that
+			// proves which admin directories are ours is gone.
+			if err := storeResetPrepareCandidateViews(root, source); err != nil {
+				report.Removable[index].Skipped = err.Error()
+				report.Complete = false
+				continue
+			}
+		}
+		destination := filepath.Join(staging, strings.ReplaceAll(entry.Path, "/", "-"))
+		if err := storeResetRename(source, destination); err != nil {
+			report.Removable[index].Skipped = err.Error()
+			report.Complete = false
+			continue
+		}
+		report.Removable[index].Removed = true
+		report.RemovedFiles += entry.Files
+		staged += entry.Bytes
+	}
+	_ = SyncReviewDirectory(root)
+
+	// Bytes count as freed only once they are actually gone. If the staging
+	// directory survives, the categories are out of the store but the disk is
+	// not back, and saying otherwise would be the exact dishonest report this
+	// command must not produce.
+	if err := storeResetRemoveAll(staging); err != nil {
+		_, residual := storeResetUsage(staging)
+		report.RemovedBytes = staged - residual
+		report.Residue = staging
+		report.Complete = false
+		return report, &StoreResetIncompleteError{Skipped: storeResetSkipped(report), Residue: staging}
+	}
+	report.RemovedBytes = staged
+	if !report.Complete {
+		return report, &StoreResetIncompleteError{Skipped: storeResetSkipped(report)}
+	}
+	return report, nil
+}
+
+func storeResetSkipped(report StoreResetReport) []StoreResetEntry {
+	skipped := []StoreResetEntry{}
+	for _, entry := range report.Removable {
+		if entry.Skipped != "" {
+			skipped = append(skipped, entry)
+		}
+	}
+	return skipped
+}
+
+// storeResetPrepareCandidateViews makes a candidate-views tree removable and
+// detaches the Git worktree administrative directories that point into it.
+//
+// An admin directory is removed only when its own gitdir file proves it belongs
+// to this exact candidate view. That check is what keeps the operation from
+// touching a worktree the user created: a global `git worktree prune` would
+// also clear unrelated stale entries, and this command has no business
+// deciding that.
+func storeResetPrepareCandidateViews(root, views string) error {
+	commonDir := filepath.Dir(root)
+	entries, err := os.ReadDir(views)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		view := filepath.Join(views, entry.Name())
+		admin := filepath.Join(commonDir, "worktrees", entry.Name())
+		if storeResetAdminDirBelongsTo(admin, view) {
+			if err := storeResetRemoveAll(admin); err != nil {
+				return fmt.Errorf("remove worktree administrative directory for candidate view %q: %w", entry.Name(), err)
+			}
+		}
+	}
+	return storeResetMakeWritable(views)
+}
+
+// storeResetAdminDirBelongsTo reports whether a worktree admin directory points
+// at exactly this candidate view.
+func storeResetAdminDirBelongsTo(admin, view string) bool {
+	payload, err := os.ReadFile(filepath.Join(admin, "gitdir"))
+	if err != nil {
+		return false
+	}
+	recorded := filepath.Clean(strings.TrimSpace(string(payload)))
+	return recorded == filepath.Clean(filepath.Join(view, ".git"))
+}
+
+// storeResetMakeWritable relaxes directory permissions across a tree so its
+// contents can be unlinked. The adapter writes candidate views at 0o555, which
+// forbids removing anything inside them.
+func storeResetMakeWritable(path string) error {
+	return filepath.WalkDir(path, func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode().Perm()&0o200 != 0 {
+			return nil
+		}
+		return os.Chmod(current, info.Mode().Perm()|0o700)
+	})
+}
+
+// storeResetRemoveAll deletes a tree, relaxing permissions once if the first
+// attempt is refused. Retrying exactly once keeps a genuine fault (a busy file,
+// a full disk, a vanished mount) from turning into a loop.
+func storeResetRemoveAll(path string) error {
+	err := os.RemoveAll(path)
+	if err == nil || !errors.Is(err, os.ErrPermission) {
+		return err
+	}
+	if writableErr := storeResetMakeWritable(path); writableErr != nil {
+		return err
+	}
+	return os.RemoveAll(path)
+}

--- a/internal/reviewtransaction/store_reset_test.go
+++ b/internal/reviewtransaction/store_reset_test.go
@@ -114,7 +114,7 @@ func TestSurveyReviewStoreReportsEveryCategoryWithoutMutating(t *testing.T) {
 	writeStoreResetFile(t, filepath.Join(root, "reviews", "IDENTITY"), "{}\n")
 	seedStoreResetKillSwitch(t, repo)
 
-	report, err := SurveyReviewStore(context.Background(), repo)
+	report, err := SurveyReviewStore(context.Background(), repo, StoreResetRequest{})
 	if err != nil {
 		t.Fatalf("survey: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestSurveyReviewStoreReportsEveryCategoryWithoutMutating(t *testing.T) {
 	if report.Schema != StoreResetReportSchema {
 		t.Fatalf("schema = %q", report.Schema)
 	}
-	for _, name := range []string{"candidate-views", "review-transactions/v2", "reviews"} {
+	for _, name := range []string{"candidate-views", "review-transactions/v2"} {
 		entry := storeResetEntryByName(t, report.Removable, name)
 		if !entry.Present || entry.Files == 0 || entry.Bytes == 0 {
 			t.Fatalf("removable %q = %#v, want a present non-empty category", name, entry)
@@ -155,7 +155,7 @@ func TestSurveyReviewStoreReportsEveryCategoryWithoutMutating(t *testing.T) {
 func TestSurveyReviewStoreCreatesNoStateOnACleanClone(t *testing.T) {
 	repo := initSnapshotRepo(t)
 
-	report, err := SurveyReviewStore(context.Background(), repo)
+	report, err := SurveyReviewStore(context.Background(), repo, StoreResetRequest{})
 	if err != nil {
 		t.Fatalf("survey: %v", err)
 	}
@@ -441,7 +441,7 @@ func TestResetReviewStoreReportsPartialFailureHonestly(t *testing.T) {
 		return os.Rename(oldpath, newpath)
 	})
 
-	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{IncludeAdapterReviews: true})
 	if err == nil {
 		t.Fatal("a partial reset reported success")
 	}
@@ -695,5 +695,384 @@ func TestResetReviewStoreRestoresWorktreeAdminDirsWhenStagingHalfSucceeds(t *tes
 		if got, want := strings.TrimSpace(string(payload)), filepath.Join(view, ".git"); got != want {
 			t.Fatalf("restored gitdir for %s = %q, want %q", view, got, want)
 		}
+	}
+}
+
+// stubStoreResetRemoveTree swaps the deletion seam for one test and restores it
+// afterwards, mirroring stubStoreResetRename.
+func stubStoreResetRemoveTree(t *testing.T, remove func(path string) error) {
+	t.Helper()
+	previous := storeResetRemoveTree
+	storeResetRemoveTree = remove
+	t.Cleanup(func() { storeResetRemoveTree = previous })
+}
+
+// TestResetReviewStoreKeepsWorktreeAdminDirsItCouldNotRestore is the failure
+// this command has no second chance at.
+//
+// The category is skipped, so the report calls it untouched. But the run had
+// already moved its worktree administrative directories into the staging
+// directory it is about to delete, and putting one back can fail on its own:
+// something recreated the path in the window, the disk is full, or -- on
+// Windows -- a process holds a handle inside the directory, which is also the
+// most likely reason the first move failed, so this path is at its least
+// reliable exactly when it is reached.
+//
+// Deleting staging then destroys a registration for a checkout that is still on
+// disk and still reported as spared. Git commands inside that view fail, the
+// repository's worktree list no longer names it, no later run can rebuild it,
+// and nothing in the report ever said so. The bytes have to survive, and the
+// report has to point at them.
+func TestResetReviewStoreKeepsWorktreeAdminDirsItCouldNotRestore(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	firstView, firstAdmin := seedStoreResetCandidateView(t, repo, "view-a")
+	_, secondAdmin := seedStoreResetCandidateView(t, repo, "view-b")
+
+	stubStoreResetRename(t, func(oldpath, newpath string) error {
+		if filepath.Base(newpath) == "worktrees-view-b" {
+			return errors.New("simulated staging failure")
+		}
+		if filepath.Base(oldpath) == "worktrees-view-a" {
+			return errors.New("simulated restore failure")
+		}
+		return os.Rename(oldpath, newpath)
+	})
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var incomplete *StoreResetIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("reset over an unrestorable registration = %v, want a typed incomplete run", err)
+	}
+	entry := storeResetEntryByName(t, report.Removable, "candidate-views")
+	if entry.Removed || !strings.Contains(entry.Skipped, "could not be restored") {
+		t.Fatalf("the skipped category does not admit the failed restore: %#v", entry)
+	}
+
+	// The report has to name the directory and where it went. A skip reason
+	// alone is prose; the user needs the path to put back.
+	if len(report.UnrestoredAdminDirs) != 1 {
+		t.Fatalf("unrestored registrations = %#v, want exactly the one that failed", report.UnrestoredAdminDirs)
+	}
+	stranded := report.UnrestoredAdminDirs[0]
+	if stranded.Original != firstAdmin {
+		t.Fatalf("unrestored registration names %q, want %q", stranded.Original, firstAdmin)
+	}
+	if report.Residue == "" || !strings.HasPrefix(stranded.Staged, report.Residue) {
+		t.Fatalf("staged registration %q is not reported under residue %q", stranded.Staged, report.Residue)
+	}
+
+	// The bytes are still there, and still usable: the gitdir file that proves
+	// which view it registers has to survive with them.
+	payload, err := os.ReadFile(filepath.Join(stranded.Staged, "gitdir"))
+	if err != nil {
+		t.Fatalf("the unrestored registration was destroyed with the staging directory: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(payload)), filepath.Join(firstView, ".git"); got != want {
+		t.Fatalf("stranded gitdir = %q, want %q", got, want)
+	}
+
+	// The one that did restore is back where it belongs, and is not reported
+	// as stranded.
+	if _, err := os.Stat(filepath.Join(secondAdmin, "gitdir")); err != nil {
+		t.Fatalf("the restorable registration was not put back: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(firstView, "README.md")); err != nil {
+		t.Fatalf("the skipped candidate view lost its contents: %v", err)
+	}
+	if report.Complete {
+		t.Fatalf("a run that stranded a registration reported Complete: %#v", report)
+	}
+	if !strings.HasPrefix(report.Residue, filepath.Join(root, storeResetStagingPrefix)) {
+		t.Fatalf("residue %q is not the staging directory under %q", report.Residue, root)
+	}
+}
+
+// TestResetReviewStoreStillClearsStagingAroundAnUnrestorableRegistration is the
+// other half of that rule: keeping what could not be restored must not turn
+// into keeping everything. A category that really was removed still goes.
+func TestResetReviewStoreStillClearsStagingAroundAnUnrestorableRegistration(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+	seedStoreResetCandidateView(t, repo, "view-a")
+	seedStoreResetCandidateView(t, repo, "view-b")
+
+	stubStoreResetRename(t, func(oldpath, newpath string) error {
+		if filepath.Base(newpath) == "worktrees-view-b" {
+			return errors.New("simulated staging failure")
+		}
+		if filepath.Base(oldpath) == "worktrees-view-a" {
+			return errors.New("simulated restore failure")
+		}
+		return os.Rename(oldpath, newpath)
+	})
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err == nil {
+		t.Fatal("a run that stranded a registration reported success")
+	}
+	if _, err := os.Lstat(filepath.Join(root, "review-transactions", "v2")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("the removable category survived: %v", err)
+	}
+	entries, err := os.ReadDir(report.Residue)
+	if err != nil {
+		t.Fatalf("read the kept staging directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "worktrees-view-a" {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("staging kept %v, want only the registration that could not be restored", names)
+	}
+}
+
+// TestResetReviewStoreNeverReportsNegativeFreedBytes covers the accounting on
+// the one path that subtracts.
+//
+// The administrative directories move into staging with their category, so
+// their bytes are freed with it; counting them only on the residual side of the
+// subtraction made a failed deletion print a size smaller than nothing. A
+// negative freed size is not a small inaccuracy -- it is the report saying the
+// command consumed disk, which is the opposite of what it does.
+func TestResetReviewStoreNeverReportsNegativeFreedBytes(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	seedStoreResetCandidateView(t, repo, "view-a")
+
+	// A deletion that fails without unlinking anything: the tree survives, so
+	// the residual is everything that was staged, administrative directories
+	// included.
+	stubStoreResetRemoveTree(t, func(string) error {
+		return errors.New("simulated device failure")
+	})
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var incomplete *StoreResetIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("reset whose staging survived = %v, want a typed incomplete run", err)
+	}
+	if report.RemovedBytes < 0 {
+		t.Fatalf("freed bytes = %d, want never less than nothing", report.RemovedBytes)
+	}
+	if report.RemovedBytes != 0 {
+		t.Fatalf("freed bytes = %d, want 0: nothing left the disk", report.RemovedBytes)
+	}
+	if report.Residue == "" || report.Complete {
+		t.Fatalf("a run whose staging survived = residue %q complete %v", report.Residue, report.Complete)
+	}
+}
+
+// TestResetReviewStoreCountsWorktreeAdminBytesAsFreed is the same accounting
+// from the successful side: the registrations really are deleted, so their
+// bytes really were reclaimed and belong in the total.
+func TestResetReviewStoreCountsWorktreeAdminBytesAsFreed(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	view, admin := seedStoreResetCandidateView(t, repo, "view-a")
+
+	_, viewBytes := storeResetUsage(view)
+	_, adminBytes := storeResetUsage(admin)
+	if adminBytes == 0 {
+		t.Fatal("the fixture registration is empty; the assertion below would prove nothing")
+	}
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if report.RemovedBytes != viewBytes+adminBytes {
+		t.Fatalf("freed bytes = %d, want %d (candidate view %d + its registration %d)",
+			report.RemovedBytes, viewBytes+adminBytes, viewBytes, adminBytes)
+	}
+}
+
+// TestSurveyReviewStoreWithholdsTheAdapterReviewStore is the coverage rule.
+//
+// reviews/ is written by the gentle-pi adapter, and neither guarantee this
+// command advertises reaches it: maintenanceLockPathForStoreLock returns no
+// lease path for anything under it, so the exclusive lease excludes no writer
+// there, and storeResetLineages reads only review-transactions/v2, so no review
+// living there can ever be listed as in flight. A default run removing it would
+// destroy a live review while reporting none open -- the exact failure the
+// lease ordering exists to prevent, arrived at from the other direction.
+func TestSurveyReviewStoreWithholdsTheAdapterReviewStore(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	writeStoreResetFile(t, filepath.Join(root, "reviews", "IDENTITY"), "{}\n")
+
+	report, err := SurveyReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err != nil {
+		t.Fatalf("survey: %v", err)
+	}
+	for _, entry := range report.Removable {
+		if entry.Name == "reviews" {
+			t.Fatalf("a default survey offers to remove the adapter review store: %#v", entry)
+		}
+	}
+	spared := storeResetEntryByName(t, report.Preserved, "reviews")
+	if !spared.Present || spared.Files == 0 {
+		t.Fatalf("the withheld category was not measured: %#v", spared)
+	}
+	// The reason has to name the way out, or the category is simply
+	// undeletable as far as the user can tell.
+	if !strings.Contains(spared.Reason, "--include-adapter-reviews") {
+		t.Fatalf("the withheld category does not name its override: %q", spared.Reason)
+	}
+
+	// The lease genuinely does not cover it. This is the claim the reason
+	// makes, checked rather than asserted in prose.
+	lease, err := maintenanceLockPathForStoreLock(filepath.Join(root, "reviews", "graph-v1", "objects", "aa"))
+	if err != nil {
+		t.Fatalf("resolve a lease path under the adapter review store: %v", err)
+	}
+	if lease != "" {
+		t.Fatalf("the maintenance lease covers %q after all; the withholding reason is stale", lease)
+	}
+}
+
+// TestResetReviewStoreSparesTheAdapterReviewStoreByDefault is the behavior that
+// rule buys: the bytes stay, and the run is still complete, because a spared
+// category is not a failed one.
+func TestResetReviewStoreSparesTheAdapterReviewStoreByDefault(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+	identity := filepath.Join(root, "reviews", "IDENTITY")
+	writeStoreResetFile(t, identity, "{}\n")
+	graph := filepath.Join(root, "reviews", "graph-v1", "objects", "aa", "record.json")
+	writeStoreResetFile(t, graph, "{}\n")
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if !report.Complete {
+		t.Fatalf("sparing an opt-in category made the run incomplete: %#v", report)
+	}
+	for _, path := range []string{identity, graph} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("a default reset destroyed the adapter review store at %s: %v", path, err)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(root, "review-transactions", "v2")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("sparing reviews/ also spared the categories this command does cover: %v", err)
+	}
+}
+
+// TestResetReviewStoreRemovesTheAdapterReviewStoreWhenAsked keeps the exit
+// real. Withholding a category is only defensible while there is a way to say
+// yes to it.
+func TestResetReviewStoreRemovesTheAdapterReviewStoreWhenAsked(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	writeStoreResetFile(t, filepath.Join(root, "reviews", "IDENTITY"), "{}\n")
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{IncludeAdapterReviews: true})
+	if err != nil {
+		t.Fatalf("opted-in reset: %v", err)
+	}
+	if entry := storeResetEntryByName(t, report.Removable, "reviews"); !entry.Removed {
+		t.Fatalf("the opted-in category was not removed: %#v", entry)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "reviews")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("the opted-in category survived: %v", err)
+	}
+}
+
+// TestResetReviewStoreRefusalIsNotReportedAsAnAttempt covers the one field a
+// machine reader routes on. The refusal returns before the staging directory
+// exists, so nothing was opened and nothing was skipped; labelling that run
+// "reset" describes a removal that tried every category and failed at all of
+// them, which is a far worse outcome than the one that happened.
+func TestResetReviewStoreRefusalIsNotReportedAsAnAttempt(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	seedStoreResetLineage(t, repo, "review-active", StateReviewing)
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var inFlight *StoreResetInFlightError
+	if !errors.As(err, &inFlight) {
+		t.Fatalf("reset with an in-flight lineage = %v, want a typed refusal", err)
+	}
+	if report.Operation != StoreResetPreview {
+		t.Fatalf("refused run reported operation %q, want %q", report.Operation, StoreResetPreview)
+	}
+	for _, entry := range report.Removable {
+		if entry.Skipped != "" || entry.Removed {
+			t.Fatalf("a refusal reported per-category outcomes: %#v", entry)
+		}
+	}
+}
+
+// TestResetReviewStoreLeaseDeadlineTracksTheRealBound keeps the constant honest
+// about what actually bounds the wait.
+//
+// storeResetLockTimeout is only the context deadline handed to the acquisition;
+// the acquisition applies maintenanceLockTimeout internally, and that shorter
+// bound is what a contended lease expires on. The previous 30s literal
+// documented a wait no run has ever performed, and a comment justifying
+// behavior that does not happen is worse than no comment: the next reader
+// reasons about contention from a number that is off by an order of magnitude.
+func TestResetReviewStoreLeaseDeadlineTracksTheRealBound(t *testing.T) {
+	if storeResetLockTimeout != maintenanceLockTimeout+storeResetIdentitySlack {
+		t.Fatalf("storeResetLockTimeout = %s, want the real lease bound %s plus its documented identity slack %s",
+			storeResetLockTimeout, maintenanceLockTimeout, storeResetIdentitySlack)
+	}
+	if storeResetLockTimeout <= maintenanceLockTimeout {
+		t.Fatalf("storeResetLockTimeout = %s must exceed the lease bound %s, or a slow identity probe cancels an uncontended lease",
+			storeResetLockTimeout, maintenanceLockTimeout)
+	}
+
+	// And the bound the constant claims to track is the one that fires.
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineageAt(t, root, "review-approved", StateApproved)
+
+	ctx, cancel := context.WithTimeout(context.Background(), storeResetLockTimeout)
+	defer cancel()
+	holder, err := acquireMaintenanceLock(ctx, filepath.Join(root, "REVIEW-MAINTENANCE.lock"), maintenanceExclusive)
+	if err != nil {
+		t.Fatalf("hold the exclusive maintenance lease: %v", err)
+	}
+	defer func() { _ = holder.Release() }()
+
+	start := time.Now()
+	if _, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{}); err == nil {
+		t.Fatal("a reset that never won the lease reported success")
+	}
+	elapsed := time.Since(start)
+	if elapsed >= storeResetLockTimeout {
+		t.Fatalf("contended reset waited %s, so the context deadline bounded it, not the lease bound %s",
+			elapsed, maintenanceLockTimeout)
+	}
+	if _, err := os.Stat(filepath.Join(root, "review-transactions", "v2", "review-approved", "review-state.json")); err != nil {
+		t.Fatalf("a reset that never won the lease still removed state: %v", err)
+	}
+}
+
+// TestReviewStoreResetFreedBytesNeverGoesNegative pins the clamp on its own.
+//
+// The two counts it subtracts are measured at different moments against a tree
+// other processes can touch, so their difference can invert for reasons no
+// accounting fix inside this command prevents. What the command controls is
+// what it prints, and a negative freed size tells the user this command
+// consumed disk -- the opposite of what it does, and a claim no reader can
+// check.
+func TestReviewStoreResetFreedBytesNeverGoesNegative(t *testing.T) {
+	for _, testCase := range []struct {
+		name             string
+		staged, residual int64
+		want             int64
+	}{
+		{name: "everything went away", staged: 4096, residual: 0, want: 4096},
+		{name: "some of it survived", staged: 4096, residual: 1024, want: 3072},
+		{name: "all of it survived", staged: 4096, residual: 4096, want: 0},
+		{name: "more survived than was staged", staged: 4096, residual: 8192, want: 0},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := storeResetFreedBytes(testCase.staged, testCase.residual); got != testCase.want {
+				t.Fatalf("storeResetFreedBytes(%d, %d) = %d, want %d",
+					testCase.staged, testCase.residual, got, testCase.want)
+			}
+		})
 	}
 }

--- a/internal/reviewtransaction/store_reset_test.go
+++ b/internal/reviewtransaction/store_reset_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // writeStoreResetFile creates one fixture file and every parent directory it
@@ -36,7 +37,14 @@ func storeResetGentleAIRoot(t *testing.T, repo string) string {
 // seedStoreResetLineage writes one compact-v2 lineage holding the given state.
 func seedStoreResetLineage(t *testing.T, repo, lineage string, state State) {
 	t.Helper()
-	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineageAt(t, storeResetGentleAIRoot(t, repo), lineage, state)
+}
+
+// seedStoreResetLineageAt writes the same lineage against an already-resolved
+// store root. Resolving the root shells out to Git, so a caller standing inside
+// a timed window uses this one and pays that cost before the window opens.
+func seedStoreResetLineageAt(t *testing.T, root, lineage string, state State) {
+	t.Helper()
 	writeStoreResetFile(t, filepath.Join(root, "review-transactions", "v2", lineage, "review-state.json"),
 		`{"schema":"gentle-ai.review-state-record/v2","revision":"sha256:00","state":{"schema":"gentle-ai.review-state/v2","lineage_id":"`+lineage+`","state":"`+string(state)+`"}}`+"\n")
 }
@@ -60,6 +68,28 @@ func stubStoreResetRename(t *testing.T, rename func(oldpath, newpath string) err
 	previous := storeResetRename
 	storeResetRename = rename
 	t.Cleanup(func() { storeResetRename = previous })
+}
+
+// stubStoreResetAcquireLease swaps the lease seam for one test and restores it
+// afterwards, mirroring stubStoreResetRename.
+func stubStoreResetAcquireLease(t *testing.T, acquire func(ctx context.Context, repo string) (*MaintenanceLock, error)) {
+	t.Helper()
+	previous := storeResetAcquireLease
+	storeResetAcquireLease = acquire
+	t.Cleanup(func() { storeResetAcquireLease = previous })
+}
+
+// seedStoreResetCandidateView writes one candidate view and the Git worktree
+// administrative directory that registers it, linked the way Git links them.
+func seedStoreResetCandidateView(t *testing.T, repo, name string) (view, admin string) {
+	t.Helper()
+	root := storeResetGentleAIRoot(t, repo)
+	view = filepath.Join(root, "candidate-views", name)
+	admin = filepath.Join(filepath.Dir(root), "worktrees", name)
+	writeStoreResetFile(t, filepath.Join(view, "README.md"), "checkout\n")
+	writeStoreResetFile(t, filepath.Join(view, ".git"), "gitdir: "+admin+"\n")
+	writeStoreResetFile(t, filepath.Join(admin, "gitdir"), filepath.Join(view, ".git")+"\n")
+	return view, admin
 }
 
 func storeResetEntryByName(t *testing.T, entries []StoreResetEntry, name string) StoreResetEntry {
@@ -454,6 +484,216 @@ func TestResetReviewStoreLeavesNoStagingResidue(t *testing.T) {
 	for _, entry := range entries {
 		if strings.HasPrefix(entry.Name(), storeResetStagingPrefix) {
 			t.Fatalf("reset left staging residue %q", entry.Name())
+		}
+	}
+}
+
+// TestResetReviewStoreClassifiesLineagesUnderTheMaintenanceLease is the
+// serialization contract, and it is a real race rather than an assertion about
+// where a line of code sits.
+//
+// The test holds the shared side of the maintenance lease, which is exactly
+// what a live review holds: every review writer takes it before it opens a
+// per-lineage store. A reset that decides what is in flight before it wins that
+// contention is deciding from a picture another process is still free to
+// change, and because removal renames whole categories rather than the
+// lineages the survey enumerated, a review that starts inside that window is
+// destroyed by a run that reported none open.
+//
+// The lease seam is used only as a barrier. It fires at the one point both a
+// correct and an incorrect ordering pass through, so the new lineage is created
+// strictly after anything the reset decided without mutual exclusion, and
+// strictly before the lease it is waiting for is free.
+func TestResetReviewStoreClassifiesLineagesUnderTheMaintenanceLease(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineageAt(t, root, "review-approved", StateApproved)
+
+	writer, err := acquireMaintenanceLock(context.Background(),
+		filepath.Join(root, "REVIEW-MAINTENANCE.lock"), maintenanceShared)
+	if err != nil {
+		t.Fatalf("hold the shared maintenance lease: %v", err)
+	}
+	held := true
+	defer func() {
+		if held {
+			_ = writer.Release()
+		}
+	}()
+
+	asked := make(chan struct{})
+	acquire := storeResetAcquireLease
+	stubStoreResetAcquireLease(t, func(ctx context.Context, repo string) (*MaintenanceLock, error) {
+		close(asked)
+		return acquire(ctx, repo)
+	})
+
+	type outcome struct {
+		report StoreResetReport
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+		done <- outcome{report: report, err: err}
+	}()
+
+	<-asked
+	// The window: a review starts while the reset is still waiting for the
+	// lease. Nothing about it is visible to a survey taken before this point.
+	seedStoreResetLineageAt(t, root, "review-active", StateReviewing)
+	held = false
+	if err := writer.Release(); err != nil {
+		t.Fatalf("release the shared maintenance lease: %v", err)
+	}
+
+	var result outcome
+	select {
+	case result = <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("reset never returned")
+	}
+
+	var inFlight *StoreResetInFlightError
+	if !errors.As(result.err, &inFlight) {
+		t.Fatalf("reset racing a review that started before the lease = %v, want a typed refusal", result.err)
+	}
+	if len(inFlight.Lineages) != 1 || inFlight.Lineages[0].LineageID != "review-active" {
+		t.Fatalf("refusal named %#v, want the lineage created inside the window", inFlight.Lineages)
+	}
+	if result.report.RemovedFiles != 0 || result.report.RemovedBytes != 0 {
+		t.Fatalf("the refused reset removed %d file(s)", result.report.RemovedFiles)
+	}
+	for _, lineage := range []string{"review-approved", "review-active"} {
+		path := filepath.Join(root, "review-transactions", "v2", lineage, "review-state.json")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("the reset destroyed %q: %v", lineage, err)
+		}
+	}
+}
+
+// TestResetReviewStoreReleasesTheLeaseAfterRefusing covers the cost of holding
+// the lease across the decision: the refusal now returns from inside the
+// critical section, so it has to hand the lease back or the next review is
+// blocked by a command that removed nothing.
+func TestResetReviewStoreReleasesTheLeaseAfterRefusing(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	seedStoreResetLineage(t, repo, "review-active", StateReviewing)
+
+	if _, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{}); err == nil {
+		t.Fatal("reset with an in-flight lineage reported success")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	lock, err := AcquireReviewMaintenanceExclusive(ctx, repo)
+	if err != nil {
+		t.Fatalf("the refusal kept the maintenance lease: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResetReviewStoreRestoresWorktreeAdminDirsWhenTheCategoryCannotMove is the
+// all-or-nothing contract for the one category that is not merely files.
+//
+// Detaching a candidate view's worktree registration is not reversible by
+// deletion, so it must not happen before the move that decides success. If it
+// did, a failed rename would leave a checkout on disk whose .git file points at
+// an administrative directory that no longer exists: Git commands inside it
+// fail, the repository's worktree list no longer names it, and a later review
+// that wants the same view finds a directory it can no longer register -- while
+// the report calls the category SKIPPED, meaning untouched.
+func TestResetReviewStoreRestoresWorktreeAdminDirsWhenTheCategoryCannotMove(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	view, admin := seedStoreResetCandidateView(t, repo, "1a09d6f9")
+
+	stubStoreResetRename(t, func(oldpath, newpath string) error {
+		if filepath.Base(oldpath) == "candidate-views" {
+			return errors.New("simulated rename failure")
+		}
+		return os.Rename(oldpath, newpath)
+	})
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var incomplete *StoreResetIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("reset over an unmovable category = %v, want a typed incomplete run", err)
+	}
+	entry := storeResetEntryByName(t, report.Removable, "candidate-views")
+	if entry.Removed {
+		t.Fatalf("the unmovable category counted as removed: %#v", entry)
+	}
+	if !strings.Contains(entry.Skipped, "simulated rename failure") {
+		t.Fatalf("the unmovable category does not carry its reason: %#v", entry)
+	}
+	if strings.Contains(entry.Skipped, "could not be restored") {
+		t.Fatalf("the restore itself failed: %#v", entry)
+	}
+
+	// SKIPPED has to mean untouched, and for a registered worktree that covers
+	// the registration as much as the checkout.
+	if _, err := os.Stat(filepath.Join(view, "README.md")); err != nil {
+		t.Fatalf("the skipped candidate view lost its contents: %v", err)
+	}
+	payload, err := os.ReadFile(filepath.Join(admin, "gitdir"))
+	if err != nil {
+		t.Fatalf("the skipped candidate view lost its worktree registration: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(payload)), filepath.Join(view, ".git"); got != want {
+		t.Fatalf("restored gitdir = %q, want %q", got, want)
+	}
+
+	// The restore puts registrations back where they were rather than leaving
+	// them parked in the store.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, staging := range entries {
+		if strings.HasPrefix(staging.Name(), storeResetStagingPrefix) {
+			t.Fatalf("the failed run left staging residue %q", staging.Name())
+		}
+	}
+}
+
+// TestResetReviewStoreRestoresWorktreeAdminDirsWhenStagingHalfSucceeds covers
+// the same rule one step earlier: the preparation itself can fail partway, and
+// the views it already detached have to go back too.
+func TestResetReviewStoreRestoresWorktreeAdminDirsWhenStagingHalfSucceeds(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	firstView, firstAdmin := seedStoreResetCandidateView(t, repo, "view-a")
+	secondView, secondAdmin := seedStoreResetCandidateView(t, repo, "view-b")
+
+	stubStoreResetRename(t, func(oldpath, newpath string) error {
+		if filepath.Base(newpath) == "worktrees-view-b" {
+			return errors.New("simulated staging failure")
+		}
+		return os.Rename(oldpath, newpath)
+	})
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var incomplete *StoreResetIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("reset over a half-staged category = %v, want a typed incomplete run", err)
+	}
+	entry := storeResetEntryByName(t, report.Removable, "candidate-views")
+	if entry.Removed || !strings.Contains(entry.Skipped, "simulated staging failure") {
+		t.Fatalf("the half-staged category = %#v", entry)
+	}
+
+	for view, admin := range map[string]string{firstView: firstAdmin, secondView: secondAdmin} {
+		if _, err := os.Stat(filepath.Join(view, "README.md")); err != nil {
+			t.Fatalf("candidate view %s lost its contents: %v", view, err)
+		}
+		payload, err := os.ReadFile(filepath.Join(admin, "gitdir"))
+		if err != nil {
+			t.Fatalf("candidate view %s lost its worktree registration: %v", view, err)
+		}
+		if got, want := strings.TrimSpace(string(payload)), filepath.Join(view, ".git"); got != want {
+			t.Fatalf("restored gitdir for %s = %q, want %q", view, got, want)
 		}
 	}
 }

--- a/internal/reviewtransaction/store_reset_test.go
+++ b/internal/reviewtransaction/store_reset_test.go
@@ -1,0 +1,459 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeStoreResetFile creates one fixture file and every parent directory it
+// needs. Fixtures are written straight to disk on purpose: this command has to
+// work against a store the normal writers can no longer open, so building the
+// fixture through those writers would only ever prove the healthy case.
+func writeStoreResetFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// storeResetGentleAIRoot returns <git-common-dir>/gentle-ai for a fixture repo.
+func storeResetGentleAIRoot(t *testing.T, repo string) string {
+	t.Helper()
+	authority, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Dir(authority)
+}
+
+// seedStoreResetLineage writes one compact-v2 lineage holding the given state.
+func seedStoreResetLineage(t *testing.T, repo, lineage string, state State) {
+	t.Helper()
+	root := storeResetGentleAIRoot(t, repo)
+	writeStoreResetFile(t, filepath.Join(root, "review-transactions", "v2", lineage, "review-state.json"),
+		`{"schema":"gentle-ai.review-state-record/v2","revision":"sha256:00","state":{"schema":"gentle-ai.review-state/v2","lineage_id":"`+lineage+`","state":"`+string(state)+`"}}`+"\n")
+}
+
+// seedStoreResetKillSwitch writes the clone-scoped kill switch into both the
+// current location and the pre-#2882 mirror that still-installed builds read.
+func seedStoreResetKillSwitch(t *testing.T, repo string) (current, legacy string) {
+	t.Helper()
+	root := storeResetGentleAIRoot(t, repo)
+	current = filepath.Join(root, "review-mode", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	legacy = filepath.Join(root, "review-transactions", "rar-authority", "v1", "rdd-mode", "gen-0000000001.json")
+	writeStoreResetFile(t, current, `{"schema":"gentle-ai.rdd-mode-override/v1","mode":"off"}`+"\n")
+	writeStoreResetFile(t, legacy, `{"schema":"gentle-ai.rdd-mode-override/v1","mode":"off"}`+"\n")
+	return current, legacy
+}
+
+// stubStoreResetRename swaps the rename seam for one test and restores it
+// afterwards, mirroring reclaimQuarantineResidue in compact_reclaim.go.
+func stubStoreResetRename(t *testing.T, rename func(oldpath, newpath string) error) {
+	t.Helper()
+	previous := storeResetRename
+	storeResetRename = rename
+	t.Cleanup(func() { storeResetRename = previous })
+}
+
+func storeResetEntryByName(t *testing.T, entries []StoreResetEntry, name string) StoreResetEntry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry
+		}
+	}
+	t.Fatalf("no entry named %q in %#v", name, entries)
+	return StoreResetEntry{}
+}
+
+// TestSurveyReviewStoreReportsEveryCategoryWithoutMutating is the preview
+// contract: it must name what it would remove, count it, and leave every byte
+// exactly where it found it.
+func TestSurveyReviewStoreReportsEveryCategoryWithoutMutating(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-settled", StateApproved)
+	writeStoreResetFile(t, filepath.Join(root, "candidate-views", "1a09d6f9", "README.md"), "checkout\n")
+	writeStoreResetFile(t, filepath.Join(root, "reviews", "IDENTITY"), "{}\n")
+	seedStoreResetKillSwitch(t, repo)
+
+	report, err := SurveyReviewStore(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("survey: %v", err)
+	}
+	if report.Operation != StoreResetPreview {
+		t.Fatalf("operation = %q, want %q", report.Operation, StoreResetPreview)
+	}
+	if report.Schema != StoreResetReportSchema {
+		t.Fatalf("schema = %q", report.Schema)
+	}
+	for _, name := range []string{"candidate-views", "review-transactions/v2", "reviews"} {
+		entry := storeResetEntryByName(t, report.Removable, name)
+		if !entry.Present || entry.Files == 0 || entry.Bytes == 0 {
+			t.Fatalf("removable %q = %#v, want a present non-empty category", name, entry)
+		}
+		if entry.Removed {
+			t.Fatalf("survey reported %q as removed", name)
+		}
+	}
+	if report.RemovedFiles != 0 || report.RemovedBytes != 0 {
+		t.Fatalf("survey reported removals: %d files / %d bytes", report.RemovedFiles, report.RemovedBytes)
+	}
+
+	// Nothing moved.
+	for _, path := range []string{
+		filepath.Join(root, "candidate-views", "1a09d6f9", "README.md"),
+		filepath.Join(root, "reviews", "IDENTITY"),
+		filepath.Join(root, "review-transactions", "v2", "review-settled", "review-state.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("survey mutated the store: %v", err)
+		}
+	}
+}
+
+// TestSurveyReviewStoreCreatesNoStateOnACleanClone proves the preview is safe
+// to run anywhere: a repository that never reviewed anything must not gain a
+// gentle-ai directory just because someone asked what a reset would do.
+func TestSurveyReviewStoreCreatesNoStateOnACleanClone(t *testing.T) {
+	repo := initSnapshotRepo(t)
+
+	report, err := SurveyReviewStore(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("survey: %v", err)
+	}
+	if report.RemovedFiles != 0 || len(report.InFlight) != 0 {
+		t.Fatalf("clean clone report = %#v", report)
+	}
+	for _, entry := range report.Removable {
+		if entry.Present {
+			t.Fatalf("clean clone reported %q present", entry.Name)
+		}
+	}
+	if _, err := os.Lstat(storeResetGentleAIRoot(t, repo)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("survey created review state: %v", err)
+	}
+}
+
+// TestResetReviewStoreRefusesWhileLineagesAreInFlight is the central safety
+// rule. A lineage that is not approved, escalated, or invalidated is a review
+// somebody is in the middle of, and the default answer is no.
+func TestResetReviewStoreRefusesWhileLineagesAreInFlight(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	seedStoreResetLineage(t, repo, "review-settled", StateApproved)
+	seedStoreResetLineage(t, repo, "review-active", StateReviewing)
+	seedStoreResetLineage(t, repo, "review-correcting", StateCorrectionRequired)
+	root := storeResetGentleAIRoot(t, repo)
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var inFlight *StoreResetInFlightError
+	if !errors.As(err, &inFlight) {
+		t.Fatalf("reset with in-flight lineages = %v, want a typed refusal", err)
+	}
+	if len(inFlight.Lineages) != 2 {
+		t.Fatalf("refusal listed %#v, want both in-flight lineages", inFlight.Lineages)
+	}
+	// The refusal has to name them; a count alone does not tell the user which
+	// review they are about to lose.
+	for _, lineage := range []string{"review-active", "review-correcting"} {
+		if !strings.Contains(inFlight.Error(), lineage) {
+			t.Fatalf("refusal does not name %q: %v", lineage, inFlight)
+		}
+	}
+	if strings.Contains(inFlight.Error(), "review-settled") {
+		t.Fatalf("refusal named a settled lineage: %v", inFlight)
+	}
+	if !strings.Contains(inFlight.Error(), "--include-in-flight") {
+		t.Fatalf("refusal does not name the override flag: %v", inFlight)
+	}
+	if report.RemovedFiles != 0 || report.RemovedBytes != 0 {
+		t.Fatalf("refused reset still removed %d files", report.RemovedFiles)
+	}
+	// A refusal removes nothing at all -- not even the settled lineages.
+	for _, lineage := range []string{"review-settled", "review-active", "review-correcting"} {
+		if _, err := os.Stat(filepath.Join(root, "review-transactions", "v2", lineage, "review-state.json")); err != nil {
+			t.Fatalf("refused reset removed %q: %v", lineage, err)
+		}
+	}
+}
+
+// TestResetReviewStoreUnreadableLineageCountsAsInFlight fails closed. A record
+// this command cannot parse might be an open review, and a degraded store is
+// exactly when that guess gets made, so it guesses in the direction that keeps
+// the work.
+func TestResetReviewStoreUnreadableLineageCountsAsInFlight(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	writeStoreResetFile(t, filepath.Join(root, "review-transactions", "v2", "review-damaged", "review-state.json"), "{not json\n")
+
+	_, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	var inFlight *StoreResetInFlightError
+	if !errors.As(err, &inFlight) {
+		t.Fatalf("reset over an unreadable record = %v, want a typed refusal", err)
+	}
+	if len(inFlight.Lineages) != 1 || inFlight.Lineages[0].Unreadable == "" {
+		t.Fatalf("unreadable lineage = %#v, want it reported as unreadable", inFlight.Lineages)
+	}
+}
+
+// TestResetReviewStoreRemovesSettledLineagesWithoutAnOverride is the ordinary
+// path: every lineage has reached a terminal state, so no explicit flag is
+// required and the store empties.
+func TestResetReviewStoreRemovesSettledLineagesWithoutAnOverride(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+	seedStoreResetLineage(t, repo, "review-escalated", StateEscalated)
+	seedStoreResetLineage(t, repo, "review-invalidated", StateInvalidated)
+	writeStoreResetFile(t, filepath.Join(root, "review-transactions", "quarantine", "review-old-1", "reclaim-record.json"), "{}\n")
+	writeStoreResetFile(t, filepath.Join(root, "review-transactions", "effect-markers", "v1", "marker.json"), "{}\n")
+	writeStoreResetFile(t, filepath.Join(root, "candidate-views", "abc", "file.txt"), "checkout\n")
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if !report.Complete {
+		t.Fatalf("reset reported incomplete: %#v", report)
+	}
+	if report.Operation != StoreResetApplied {
+		t.Fatalf("operation = %q", report.Operation)
+	}
+	if report.RemovedFiles == 0 || report.RemovedBytes == 0 {
+		t.Fatalf("reset removed nothing: %#v", report)
+	}
+	for _, name := range []string{"review-transactions/v2", "review-transactions/quarantine", "review-transactions/effect-markers", "candidate-views"} {
+		if entry := storeResetEntryByName(t, report.Removable, name); !entry.Removed {
+			t.Fatalf("category %q was not removed: %#v", name, entry)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(root, "review-transactions", "v2"),
+		filepath.Join(root, "review-transactions", "quarantine"),
+		filepath.Join(root, "candidate-views"),
+	} {
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s survived the reset: %v", path, err)
+		}
+	}
+}
+
+// TestResetReviewStoreOverrideRemovesInFlightLineages proves the escape hatch
+// works once the user asks for it explicitly.
+func TestResetReviewStoreOverrideRemovesInFlightLineages(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-active", StateReviewing)
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{IncludeInFlight: true})
+	if err != nil {
+		t.Fatalf("override reset: %v", err)
+	}
+	if len(report.InFlight) != 1 {
+		t.Fatalf("override report still has to name what it destroyed: %#v", report.InFlight)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "review-transactions", "v2")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("override reset kept the in-flight lineage: %v", err)
+	}
+}
+
+// TestResetReviewStorePreservesTheKillSwitchInBothLocations is the regression
+// this whole allowlist exists for. The pre-#2882 mirror lives *inside*
+// review-transactions/, so a reset that removed that directory wholesale would
+// silently switch reviews back on for a user who turned them off.
+func TestResetReviewStorePreservesTheKillSwitchInBothLocations(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	current, legacy := seedStoreResetKillSwitch(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+
+	if _, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{}); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	for _, path := range []string{current, legacy} {
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reset destroyed the kill switch at %s: %v", path, err)
+		}
+		if !strings.Contains(string(payload), `"mode":"off"`) {
+			t.Fatalf("kill switch at %s changed: %s", path, payload)
+		}
+	}
+}
+
+// TestResetReviewStorePreservesEverythingItDoesNotOwn covers the rest of the
+// exclusion list plus the allowlist rule: an unrecognized directory is reported
+// and left alone, never guessed at.
+func TestResetReviewStorePreservesEverythingItDoesNotOwn(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+	preserved := map[string]string{
+		"sdd-runtime":      filepath.Join(root, "sdd-runtime", "v1", "some-change", "HEAD"),
+		"defect-reports":   filepath.Join(root, "defect-reports", "operation-outcome-unknown-00ff.md"),
+		"review-artifacts": filepath.Join(root, "review-artifacts", "issue-1107", "notes.md"),
+		"incidents":        filepath.Join(root, "incidents", "1462", "notes.md"),
+	}
+	for _, path := range preserved {
+		writeStoreResetFile(t, path, "keep me\n")
+	}
+	future := filepath.Join(root, "some-future-feature", "state.json")
+	writeStoreResetFile(t, future, "{}\n")
+	nestedFuture := filepath.Join(root, "review-transactions", "v3", "state.json")
+	writeStoreResetFile(t, nestedFuture, "{}\n")
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	for name, path := range preserved {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("reset removed preserved category %q: %v", name, err)
+		}
+		if entry := storeResetEntryByName(t, report.Preserved, name); entry.Reason == "" {
+			t.Fatalf("preserved category %q carries no reason", name)
+		}
+	}
+	for _, path := range []string{future, nestedFuture} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("reset removed an unrecognized path %s: %v", path, err)
+		}
+	}
+	for _, name := range []string{"some-future-feature", "review-transactions/v3"} {
+		if entry := storeResetEntryByName(t, report.Unrecognized, name); !entry.Present {
+			t.Fatalf("unrecognized path %q was not reported", name)
+		}
+	}
+}
+
+// TestResetReviewStoreRemovesCandidateViewWorktreeAdminDirs covers the one
+// category that is not just files. Candidate views are registered Git
+// worktrees, so removing the checkout without its admin directory would leave
+// the repository's worktree list pointing at nothing.
+func TestResetReviewStoreRemovesCandidateViewWorktreeAdminDirs(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	commonDir := filepath.Dir(root)
+	view := filepath.Join(root, "candidate-views", "1a09d6f9")
+	admin := filepath.Join(commonDir, "worktrees", "1a09d6f9")
+	writeStoreResetFile(t, filepath.Join(view, "README.md"), "checkout\n")
+	writeStoreResetFile(t, filepath.Join(view, ".git"), "gitdir: "+admin+"\n")
+	writeStoreResetFile(t, filepath.Join(admin, "gitdir"), filepath.Join(view, ".git")+"\n")
+
+	// A worktree that is not a candidate view must survive untouched, even
+	// though it sits in the same admin directory.
+	foreign := filepath.Join(commonDir, "worktrees", "alans-branch")
+	writeStoreResetFile(t, filepath.Join(foreign, "gitdir"), filepath.Join(repo, "..", "alans-branch", ".git")+"\n")
+
+	if _, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{}); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if _, err := os.Lstat(view); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("candidate view survived: %v", err)
+	}
+	if _, err := os.Lstat(admin); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("candidate view admin directory survived: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(foreign, "gitdir")); err != nil {
+		t.Fatalf("reset pruned an unrelated worktree: %v", err)
+	}
+}
+
+// TestResetReviewStoreRemovesReadOnlyCandidateViews covers the shape the
+// adapter actually writes: the checkout is chmod'd read-only, which makes a
+// plain RemoveAll fail.
+func TestResetReviewStoreRemovesReadOnlyCandidateViews(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores the permission bits this test depends on")
+	}
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	view := filepath.Join(root, "candidate-views", "read-only-view")
+	writeStoreResetFile(t, filepath.Join(view, "nested", "file.txt"), "frozen\n")
+	for _, path := range []string{filepath.Join(view, "nested"), view} {
+		if err := os.Chmod(path, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(path, 0o755) })
+	}
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err != nil {
+		t.Fatalf("reset over a read-only candidate view: %v", err)
+	}
+	if !report.Complete {
+		t.Fatalf("reset reported incomplete: %#v", report.Removable)
+	}
+	if _, err := os.Lstat(view); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read-only candidate view survived: %v", err)
+	}
+}
+
+// TestResetReviewStoreReportsPartialFailureHonestly is the reporting contract.
+// When a category cannot be moved aside, the command must say so, must not
+// count it as removed, and must not claim it succeeded.
+func TestResetReviewStoreReportsPartialFailureHonestly(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+	writeStoreResetFile(t, filepath.Join(root, "reviews", "IDENTITY"), "{}\n")
+
+	stubStoreResetRename(t, func(oldpath, newpath string) error {
+		if filepath.Base(oldpath) == "reviews" {
+			return errors.New("simulated rename failure")
+		}
+		return os.Rename(oldpath, newpath)
+	})
+
+	report, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{})
+	if err == nil {
+		t.Fatal("a partial reset reported success")
+	}
+	if report.Complete {
+		t.Fatalf("a partial reset reported Complete: %#v", report)
+	}
+	failed := storeResetEntryByName(t, report.Removable, "reviews")
+	if failed.Removed {
+		t.Fatalf("the failed category counted as removed: %#v", failed)
+	}
+	if failed.Skipped == "" || !strings.Contains(failed.Skipped, "simulated rename failure") {
+		t.Fatalf("the failed category does not carry its reason: %#v", failed)
+	}
+	// The category that did work is still reported as removed, and the byte
+	// count covers only what actually went away.
+	removed := storeResetEntryByName(t, report.Removable, "review-transactions/v2")
+	if !removed.Removed || report.RemovedBytes != removed.Bytes {
+		t.Fatalf("partial reset byte accounting = %d, want %d", report.RemovedBytes, removed.Bytes)
+	}
+	if _, err := os.Stat(filepath.Join(root, "reviews", "IDENTITY")); err != nil {
+		t.Fatalf("the failed category was destroyed anyway: %v", err)
+	}
+}
+
+// TestResetReviewStoreLeavesNoStagingResidue proves the staged removal cleans
+// up after itself, so a reset never trades one accumulating directory for
+// another.
+func TestResetReviewStoreLeavesNoStagingResidue(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root := storeResetGentleAIRoot(t, repo)
+	seedStoreResetLineage(t, repo, "review-approved", StateApproved)
+
+	if _, err := ResetReviewStore(context.Background(), repo, StoreResetRequest{}); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), storeResetStagingPrefix) {
+			t.Fatalf("reset left staging residue %q", entry.Name())
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/tui/screens"
@@ -289,6 +290,22 @@ type OpenCodePluginUninstallDoneMsg struct {
 	Err    error
 }
 
+// ReviewStoreResetSurveyedMsg carries the read-only survey of the review
+// store. Err is non-nil when the store could not be read at all, which is
+// itself a reason to show the screen rather than fail silently.
+type ReviewStoreResetSurveyedMsg struct {
+	Report reviewtransaction.StoreResetReport
+	Err    error
+}
+
+// ReviewStoreResetDoneMsg carries the outcome of an applied reset. Report is
+// populated even when Err is non-nil, because a partial run has to be able to
+// say which categories went away.
+type ReviewStoreResetDoneMsg struct {
+	Report reviewtransaction.StoreResetReport
+	Err    error
+}
+
 type CommunityToolInstallationDoneMsg struct {
 	Results []communitytool.Result
 	Err     error
@@ -350,6 +367,11 @@ type ExecuteFunc func(
 type RestoreFunc func(manifest backup.Manifest) error
 
 // DeleteBackupFunc deletes the entire backup directory.
+// ReviewStoreResetFunc surveys or applies a clone-scoped review store reset.
+// Both directions share one signature because both answer the same question:
+// what is in the store, and what happened to it.
+type ReviewStoreResetFunc func() (reviewtransaction.StoreResetReport, error)
+
 type DeleteBackupFunc func(manifest backup.Manifest) error
 
 // RenameBackupFunc updates the backup's Description field in its manifest file.
@@ -427,6 +449,13 @@ const (
 	// ScreenOpenCodePluginUninstallResult reports the success/failure
 	// summary of the uninstall and returns to Welcome on Enter.
 	ScreenOpenCodePluginUninstallResult
+	// ScreenReviewStoreResetConfirm shows the read-only survey of this
+	// clone's review store and asks before removing any of it. It is the
+	// only place the TUI can start an irreversible review-store removal.
+	ScreenReviewStoreResetConfirm
+	// ScreenReviewStoreResetResult reports what was actually removed,
+	// including a partial run, and returns to Welcome on Enter.
+	ScreenReviewStoreResetResult
 )
 
 type Model struct {
@@ -632,6 +661,19 @@ type Model struct {
 	OpenCodePluginRegistrationResults []opencodeplugin.Result
 	OpenCodePluginRegistrationErr     error
 
+	// ReviewStoreResetSurveyFn reports what a review store reset would
+	// remove, without removing anything. Injected so the TUI never has to
+	// know how a repository is resolved.
+	ReviewStoreResetSurveyFn ReviewStoreResetFunc
+	// ReviewStoreResetFn applies the reset. It is only ever reached from an
+	// explicit confirmation on ScreenReviewStoreResetConfirm.
+	ReviewStoreResetFn ReviewStoreResetFunc
+	// ReviewStoreResetReport holds the most recent survey or result.
+	ReviewStoreResetReport reviewtransaction.StoreResetReport
+	// ReviewStoreResetSurveyErr records a survey that could not be read.
+	ReviewStoreResetSurveyErr error
+	// ReviewStoreResetErr records the outcome of an applied reset.
+	ReviewStoreResetErr error
 	// OpenCodePluginUninstallFn is the async uninstall runner. Returns a
 	// result and error from the 4-layer engine. Defaults to
 	// opencodeplugin.Uninstall if nil.
@@ -908,6 +950,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.OpenCodePluginUninstallResult = msg.Result
 		m.OpenCodePluginUninstallErr = msg.Err
 		m.setScreen(ScreenOpenCodePluginUninstallResult)
+		return m, nil
+	case ReviewStoreResetSurveyedMsg:
+		if m.Screen != ScreenReviewStoreResetConfirm {
+			return m, nil
+		}
+		m.OperationRunning = false
+		m.ReviewStoreResetReport = msg.Report
+		m.ReviewStoreResetSurveyErr = msg.Err
+		m.Cursor = 0
+		return m, nil
+	case ReviewStoreResetDoneMsg:
+		if m.Screen != ScreenReviewStoreResetConfirm {
+			return m, nil
+		}
+		m.OperationRunning = false
+		m.ReviewStoreResetReport = msg.Report
+		m.ReviewStoreResetErr = msg.Err
+		m.setScreen(ScreenReviewStoreResetResult)
 		return m, nil
 	case CommunityToolInstallationDoneMsg:
 		if m.Screen != ScreenCommunityToolInstalling {
@@ -1257,6 +1317,17 @@ func (m Model) View() string {
 		return screens.RenderRestoreConfirm(m.SelectedBackup, m.Cursor)
 	case ScreenRestoreResult:
 		return screens.RenderRestoreResult(m.SelectedBackup, m.RestoreErr)
+	case ScreenReviewStoreResetConfirm:
+		if m.OperationRunning {
+			detail := "Surveying the review store..."
+			if m.ReviewStoreResetReport.Schema != "" {
+				detail = "Removing review store state..."
+			}
+			return screens.RenderOperationRunning("Reset Review Store", detail, m.SpinnerFrame)
+		}
+		return screens.RenderReviewStoreResetConfirm(m.ReviewStoreResetReport, m.ReviewStoreResetSurveyErr, m.Cursor)
+	case ScreenReviewStoreResetResult:
+		return screens.RenderReviewStoreResetResult(m.ReviewStoreResetReport, m.ReviewStoreResetErr)
 	case ScreenDeleteConfirm:
 		return screens.RenderDeleteConfirm(m.SelectedBackup, m.Cursor)
 	case ScreenDeleteResult:
@@ -1778,6 +1849,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			if m.Cursor == next {
 				m.setScreen(ScreenBackups)
 				return m, nil
+			}
+			next++
+
+			if m.Cursor == next {
+				return m.startReviewStoreResetSurvey()
 			}
 			next++
 
@@ -2558,6 +2634,20 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Enter on the result screen returns to backup selection.
 		// Refresh the backup list to reflect any changes from the restore.
 		m = m.finishBackupResult(false)
+	case ScreenReviewStoreResetConfirm:
+		// Cursor 0 is "Delete permanently" only when the survey found
+		// something safe to delete; in every other state the sole option is
+		// "Back", so this cannot destroy an open review by cursor position.
+		options := screens.ReviewStoreResetConfirmOptions(m.ReviewStoreResetReport, m.ReviewStoreResetSurveyErr)
+		if m.Cursor == 0 && len(options) == 2 {
+			m.OperationRunning = true
+			return m, tea.Batch(m.startReviewStoreReset(), tickCmd())
+		}
+		m = m.withResetReviewStoreResetState()
+		m.setScreen(ScreenWelcome)
+	case ScreenReviewStoreResetResult:
+		m = m.withResetReviewStoreResetState()
+		m.setScreen(ScreenWelcome)
 	case ScreenDeleteConfirm:
 		// Cursor 0 = "Delete", Cursor 1 = "Cancel".
 		if m.Cursor == 0 {
@@ -2923,6 +3013,50 @@ func (m Model) startOpenCodePluginUninstall() tea.Cmd {
 		result, err := runner(home, id)
 		return OpenCodePluginUninstallDoneMsg{Result: result, Err: err}
 	}
+}
+
+// startReviewStoreResetSurvey moves to the confirmation screen and loads the
+// read-only survey behind a spinner. The screen is entered first on purpose: a
+// survey that fails has to be reportable, and a menu entry that silently does
+// nothing is worse than one that explains itself.
+func (m Model) startReviewStoreResetSurvey() (tea.Model, tea.Cmd) {
+	m = m.withResetReviewStoreResetState()
+	m.OperationRunning = true
+	m.setScreen(ScreenReviewStoreResetConfirm)
+	survey := m.ReviewStoreResetSurveyFn
+	return m, tea.Batch(func() tea.Msg {
+		if survey == nil {
+			return ReviewStoreResetSurveyedMsg{Err: errors.New("review store survey is not available in this build")}
+		}
+		report, err := survey()
+		return ReviewStoreResetSurveyedMsg{Report: report, Err: err}
+	}, tickCmd())
+}
+
+// startReviewStoreReset applies the reset. It is only reachable from an
+// explicit confirmation, and it never falls back to a default runner: a nil
+// injection means this build cannot perform the removal, and inventing one
+// here would be the wrong kind of helpful.
+func (m Model) startReviewStoreReset() tea.Cmd {
+	reset := m.ReviewStoreResetFn
+	return func() tea.Msg {
+		if reset == nil {
+			return ReviewStoreResetDoneMsg{Err: errors.New("review store reset is not available in this build")}
+		}
+		report, err := reset()
+		return ReviewStoreResetDoneMsg{Report: report, Err: err}
+	}
+}
+
+// withResetReviewStoreResetState clears every field the flow owns, so a second
+// visit never shows the previous run's numbers.
+func (m Model) withResetReviewStoreResetState() Model {
+	m.OperationRunning = false
+	m.ReviewStoreResetReport = reviewtransaction.StoreResetReport{}
+	m.ReviewStoreResetSurveyErr = nil
+	m.ReviewStoreResetErr = nil
+	m.Cursor = 0
+	return m
 }
 
 // confirmOpenCodePluginUninstallSelect handles Enter on the Select screen:
@@ -3762,6 +3896,10 @@ func (m Model) optionCount() int {
 	case ScreenDeleteConfirm:
 		return 2 // "Delete" + "Cancel"
 	case ScreenDeleteResult:
+		return 0
+	case ScreenReviewStoreResetConfirm:
+		return screens.ReviewStoreResetConfirmOptionCount(m.ReviewStoreResetReport, m.ReviewStoreResetSurveyErr)
+	case ScreenReviewStoreResetResult:
 		return 0
 	case ScreenRenameBackup:
 		return 0 // text input mode — no cursor navigation

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -958,12 +958,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.OperationRunning = false
 		m.ReviewStoreResetReport = msg.Report
 		m.ReviewStoreResetSurveyErr = msg.Err
-		m.Cursor = 0
+		// The cursor lands on the non-destructive option. Reaching this
+		// screen already costs one Enter from the main menu, so a cursor
+		// resting on "Delete permanently" would make an irreversible
+		// clone-wide removal the second keystroke of a two-keystroke
+		// sequence -- while the CLI equivalent requires typing --confirm.
+		m.Cursor = screens.ReviewStoreResetConfirmDefaultCursor(msg.Report, msg.Err)
 		return m, nil
 	case ReviewStoreResetDoneMsg:
-		if m.Screen != ScreenReviewStoreResetConfirm {
-			return m, nil
-		}
+		// Deliberately not guarded on the current screen. This message reports
+		// an irreversible removal that has already happened; dropping it
+		// because the model moved on would leave the user with a destroyed
+		// store and no statement that anything occurred, which is the one
+		// outcome this flow must never produce.
 		m.OperationRunning = false
 		m.ReviewStoreResetReport = msg.Report
 		m.ReviewStoreResetErr = msg.Err

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1813,13 +1813,13 @@ func TestWelcomeMenu_UninstallOpenCodePluginEmptyTUIJSON(t *testing.T) {
 func TestWelcomeMenu_UninstallNavigation_WithoutProfiles(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenWelcome
-	m.Cursor = 9
+	m.Cursor = 10
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
 	if state.Screen != ScreenUninstallMode {
-		t.Fatalf("cursor=9 (Managed uninstall): screen = %v, want %v", state.Screen, ScreenUninstallMode)
+		t.Fatalf("cursor=10 (Managed uninstall): screen = %v, want %v", state.Screen, ScreenUninstallMode)
 	}
 }
 
@@ -1828,30 +1828,31 @@ func TestWelcomeMenu_UninstallNavigation_WithProfiles(t *testing.T) {
 		Configs: []system.ConfigState{{Agent: string(model.AgentOpenCode), Exists: true}},
 	}, "dev")
 	m.Screen = ScreenWelcome
-	m.Cursor = 10
+	m.Cursor = 11
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
 	if state.Screen != ScreenUninstallMode {
-		t.Fatalf("cursor=10 (Managed uninstall with profiles): screen = %v, want %v", state.Screen, ScreenUninstallMode)
+		t.Fatalf("cursor=11 (Managed uninstall with profiles): screen = %v, want %v", state.Screen, ScreenUninstallMode)
 	}
 }
 
-// TestWelcomeMenu_OptionCount verifies the welcome menu has 12 items without OpenCode
-// and 13 items when OpenCode is detected (adds "OpenCode SDD Profiles" option).
+// TestWelcomeMenu_OptionCount verifies the welcome menu has 13 items without OpenCode
+// and 14 items when OpenCode is detected (adds "OpenCode SDD Profiles" option).
 func TestWelcomeMenu_OptionCount(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
-	// Without OpenCode detected: 12 options (includes dedicated OpenCode community plugins,
-	// the slice-3b "Uninstall OpenCode Plugin" shortcut, managed uninstall, and community tools).
+	// Without OpenCode detected: 13 options (includes dedicated OpenCode community plugins,
+	// the slice-3b "Uninstall OpenCode Plugin" shortcut, the review store reset,
+	// managed uninstall, and community tools).
 	opts := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, false, 0, true)
-	if len(opts) != 12 {
-		t.Fatalf("WelcomeOptions(showProfiles=false) len = %d, want 12; got %v", len(opts), opts)
+	if len(opts) != 13 {
+		t.Fatalf("WelcomeOptions(showProfiles=false) len = %d, want 13; got %v", len(opts), opts)
 	}
-	// With OpenCode detected: 13 options (adds "OpenCode SDD Profiles").
+	// With OpenCode detected: 14 options (adds "OpenCode SDD Profiles").
 	optsWithProfiles := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, true, 0, true)
-	if len(optsWithProfiles) != 13 {
-		t.Fatalf("WelcomeOptions(showProfiles=true) len = %d, want 13; got %v", len(optsWithProfiles), optsWithProfiles)
+	if len(optsWithProfiles) != 14 {
+		t.Fatalf("WelcomeOptions(showProfiles=true) len = %d, want 14; got %v", len(optsWithProfiles), optsWithProfiles)
 	}
 }
 

--- a/internal/tui/navigation_safety_test.go
+++ b/internal/tui/navigation_safety_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRunningScreensRejectInputAndExposeNoOptions(t *testing.T) {
-	for _, screen := range []Screen{ScreenRestoreConfirm, ScreenSync, ScreenUpgradeSync, ScreenOpenCodePlugins, ScreenUninstallConfirm} {
+	for _, screen := range []Screen{ScreenRestoreConfirm, ScreenSync, ScreenUpgradeSync, ScreenOpenCodePlugins, ScreenUninstallConfirm, ScreenReviewStoreResetConfirm} {
 		t.Run(screenName(screen), func(t *testing.T) {
 			m := NewModel(system.DetectionResult{}, "dev")
 			m.Screen = screen
@@ -34,7 +34,7 @@ func TestRunningScreensRejectInputAndExposeNoOptions(t *testing.T) {
 }
 
 func TestResultScreensDoNotExposePhantomCursorRows(t *testing.T) {
-	for _, screen := range []Screen{ScreenRestoreResult, ScreenDeleteResult, ScreenUninstallResult, ScreenOpenCodePluginResult, ScreenCommunityToolResult, ScreenComplete} {
+	for _, screen := range []Screen{ScreenRestoreResult, ScreenDeleteResult, ScreenUninstallResult, ScreenOpenCodePluginResult, ScreenCommunityToolResult, ScreenComplete, ScreenReviewStoreResetResult} {
 		m := NewModel(system.DetectionResult{}, "dev")
 		m.Screen = screen
 		if got := m.optionCount(); got != 0 {

--- a/internal/tui/review_store_reset_test.go
+++ b/internal/tui/review_store_reset_test.go
@@ -273,3 +273,109 @@ func TestReviewStoreResetConfirmNamesWhatItSpares(t *testing.T) {
 		t.Fatalf("the confirmation does not say the removal is irreversible:\n%s", rendered)
 	}
 }
+
+// TestReviewStoreResetResultIsNeverDropped covers the one message in this flow
+// that reports something already irreversible.
+//
+// The handler used to ignore it unless the model still sat on the confirmation
+// screen. Everything else in this flow can be re-derived by asking again; this
+// cannot. A dropped result leaves the user on some other screen with a store
+// that was just emptied and nothing anywhere saying so, which is strictly worse
+// than the failure it was guarding against.
+func TestReviewStoreResetResultIsNeverDropped(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.OperationRunning = true
+	report := settledStoreResetReport()
+	report.Operation = reviewtransaction.StoreResetApplied
+	report.RemovedFiles, report.RemovedBytes = 12, 4096
+	report.Removable[0].Removed = true
+
+	updated, _ := m.Update(ReviewStoreResetDoneMsg{Report: report})
+	state := updated.(Model)
+	if state.Screen != ScreenReviewStoreResetResult {
+		t.Fatalf("screen = %v, want the result screen: a completed removal was never reported", state.Screen)
+	}
+	if state.OperationRunning {
+		t.Fatal("the model still thinks the removal is running")
+	}
+	if state.ReviewStoreResetReport.RemovedBytes != 4096 {
+		t.Fatalf("the result carries %#v, want the applied report", state.ReviewStoreResetReport)
+	}
+	if !strings.Contains(state.View(), "4.0 KB") {
+		t.Fatalf("the result view does not report what was freed:\n%s", state.View())
+	}
+}
+
+// TestReviewStoreResetConfirmStartsOnCancel keeps the destructive row off the
+// path of least resistance.
+//
+// Reaching this screen already costs one Enter from the main menu. With the
+// cursor resting on "Delete permanently", the second Enter empties the store --
+// while the CLI equivalent makes the user type --confirm. Two keystrokes and a
+// typed flag are not the same bar.
+func TestReviewStoreResetConfirmStartsOnCancel(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.ReviewStoreResetSurveyFn = func() (reviewtransaction.StoreResetReport, error) {
+		return settledStoreResetReport(), nil
+	}
+	m.ReviewStoreResetFn = func() (reviewtransaction.StoreResetReport, error) {
+		t.Fatal("the second Enter after entering the screen destroyed the store")
+		return reviewtransaction.StoreResetReport{}, nil
+	}
+	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines())
+	for index, option := range options {
+		if option == "Reset review store" {
+			m.Cursor = index
+		}
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := drainReviewStoreResetCmd(t, updated.(Model), cmd)
+
+	confirmOptions := screens.ReviewStoreResetConfirmOptions(state.ReviewStoreResetReport, state.ReviewStoreResetSurveyErr)
+	if state.Cursor >= len(confirmOptions) || confirmOptions[state.Cursor] != "Cancel" {
+		t.Fatalf("cursor %d selects %#v, want Cancel", state.Cursor, confirmOptions)
+	}
+
+	// The second Enter has to be inert, which is the property the cursor
+	// position exists to produce.
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if after := updated.(Model); after.Screen != ScreenWelcome {
+		t.Fatalf("the second Enter went to %v, want back to the menu", after.Screen)
+	}
+}
+
+// TestReviewStoreResetResultNamesStrandedWorktreeRegistrations keeps the one
+// exception to "not removed means untouched" visible in the interface a user
+// actually reads. A run can free nothing and still have left a candidate view
+// unregistered, so it must not render as "Nothing was removed".
+func TestReviewStoreResetResultNamesStrandedWorktreeRegistrations(t *testing.T) {
+	report := settledStoreResetReport()
+	report.Operation = reviewtransaction.StoreResetApplied
+	report.Complete = false
+	report.RemovedFiles, report.RemovedBytes = 0, 0
+	report.Removable = []reviewtransaction.StoreResetEntry{{
+		Name: "candidate-views", Present: true, Files: 4, Bytes: 2048,
+		Skipped: "simulated staging failure; and the worktree administrative directories moved aside for it could not be restored: simulated restore failure",
+	}}
+	report.Residue = "/repo/.git/gentle-ai/.store-reset-42"
+	report.UnrestoredAdminDirs = []reviewtransaction.StoreResetUnrestoredAdminDir{{
+		Original: "/repo/.git/worktrees/view-a",
+		Staged:   "/repo/.git/gentle-ai/.store-reset-42/worktrees-view-a",
+	}}
+
+	rendered := screens.RenderReviewStoreResetResult(report, errors.New("review store reset was incomplete"))
+	if strings.Contains(rendered, "Nothing was removed") {
+		t.Fatalf("a run that stranded a registration claimed nothing was removed:\n%s", rendered)
+	}
+	for _, want := range []string{
+		"/repo/.git/worktrees/view-a",
+		"/repo/.git/gentle-ai/.store-reset-42/worktrees-view-a",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("the result screen does not name %q:\n%s", want, rendered)
+		}
+	}
+}

--- a/internal/tui/review_store_reset_test.go
+++ b/internal/tui/review_store_reset_test.go
@@ -1,0 +1,275 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/tui/screens"
+)
+
+func reviewStoreResetModel(t *testing.T) Model {
+	t.Helper()
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenReviewStoreResetConfirm
+	m.Cursor = 0
+	return m
+}
+
+func settledStoreResetReport() reviewtransaction.StoreResetReport {
+	return reviewtransaction.StoreResetReport{
+		Schema: reviewtransaction.StoreResetReportSchema, Operation: reviewtransaction.StoreResetPreview,
+		Repository: "/repo", StoreRoot: "/repo/.git/gentle-ai",
+		Removable: []reviewtransaction.StoreResetEntry{
+			{Name: "review-transactions/v2", Reason: "compact authority", Present: true, Files: 12, Bytes: 4096},
+		},
+		Preserved: []reviewtransaction.StoreResetEntry{
+			{Name: "review-mode", Reason: "the kill switch", Present: true, Files: 1, Bytes: 64},
+		},
+		Settled: 12, Complete: true,
+	}
+}
+
+// TestWelcomeMenuOffersTheReviewStoreReset proves the action is reachable from
+// the TUI at all, and that it sits in the maintenance cluster at the bottom
+// rather than among the everyday entries.
+func TestWelcomeMenuOffersTheReviewStoreReset(t *testing.T) {
+	options := screens.WelcomeOptions(nil, true, false, 0, true)
+	reset, backups, uninstall := -1, -1, -1
+	for index, option := range options {
+		switch option {
+		case "Reset review store":
+			reset = index
+		case "Manage backups":
+			backups = index
+		case "Managed uninstall":
+			uninstall = index
+		}
+	}
+	if reset < 0 {
+		t.Fatalf("the welcome menu does not offer the reset: %#v", options)
+	}
+	if reset != backups+1 || reset != uninstall-1 {
+		t.Fatalf("reset at %d is not between backups (%d) and uninstall (%d)", reset, backups, uninstall)
+	}
+}
+
+// TestWelcomeSelectionEntersTheSurvey proves the menu entry runs the read-only
+// survey and lands on the confirmation screen, never straight into a removal.
+func TestWelcomeSelectionEntersTheSurvey(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	surveyed := false
+	m.ReviewStoreResetSurveyFn = func() (reviewtransaction.StoreResetReport, error) {
+		surveyed = true
+		return settledStoreResetReport(), nil
+	}
+	m.ReviewStoreResetFn = func() (reviewtransaction.StoreResetReport, error) {
+		t.Fatal("selecting the menu entry applied a reset")
+		return reviewtransaction.StoreResetReport{}, nil
+	}
+	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines())
+	for index, option := range options {
+		if option == "Reset review store" {
+			m.Cursor = index
+		}
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.Screen != ScreenReviewStoreResetConfirm {
+		t.Fatalf("screen = %v, want the confirmation screen", state.Screen)
+	}
+	if !state.OperationRunning {
+		t.Fatal("the survey did not start")
+	}
+	if state.optionCount() != 0 {
+		t.Fatal("a running survey still exposes options")
+	}
+	if cmd == nil {
+		t.Fatal("no survey command was returned")
+	}
+	state = drainReviewStoreResetCmd(t, state, cmd)
+	if !surveyed {
+		t.Fatal("the survey function was never called")
+	}
+	if state.OperationRunning {
+		t.Fatal("the survey never finished")
+	}
+	if state.optionCount() != 2 {
+		t.Fatalf("settled survey exposes %d options, want Delete + Cancel", state.optionCount())
+	}
+}
+
+// drainReviewStoreResetCmd runs a returned command and feeds every message it
+// produces back into the model, so a tea.Batch of a worker plus a spinner tick
+// resolves the way the runtime would resolve it.
+func drainReviewStoreResetCmd(t *testing.T, m Model, cmd tea.Cmd) Model {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	switch typed := msg.(type) {
+	case tea.BatchMsg:
+		for _, batched := range typed {
+			m = drainReviewStoreResetCmd(t, m, batched)
+		}
+		return m
+	case nil:
+		return m
+	default:
+		updated, _ := m.Update(msg)
+		return updated.(Model)
+	}
+}
+
+// TestReviewStoreResetConfirmCancels proves the second option is inert.
+func TestReviewStoreResetConfirmCancels(t *testing.T) {
+	m := reviewStoreResetModel(t)
+	m.ReviewStoreResetReport = settledStoreResetReport()
+	m.ReviewStoreResetFn = func() (reviewtransaction.StoreResetReport, error) {
+		t.Fatal("cancel applied the reset")
+		return reviewtransaction.StoreResetReport{}, nil
+	}
+	m.Cursor = 1
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.Screen != ScreenWelcome {
+		t.Fatalf("cancel went to %v, want the welcome screen", state.Screen)
+	}
+	if state.ReviewStoreResetReport.Schema != "" {
+		t.Fatal("cancel kept the previous survey around")
+	}
+}
+
+// TestReviewStoreResetConfirmAppliesOnTheFirstOption is the one path in the TUI
+// that destroys anything, and it requires an explicit Enter on an explicitly
+// labelled option.
+func TestReviewStoreResetConfirmAppliesOnTheFirstOption(t *testing.T) {
+	m := reviewStoreResetModel(t)
+	m.ReviewStoreResetReport = settledStoreResetReport()
+	applied := false
+	m.ReviewStoreResetFn = func() (reviewtransaction.StoreResetReport, error) {
+		applied = true
+		report := settledStoreResetReport()
+		report.Operation = reviewtransaction.StoreResetApplied
+		report.RemovedFiles, report.RemovedBytes = 12, 4096
+		report.Removable[0].Removed = true
+		return report, nil
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if !state.OperationRunning {
+		t.Fatal("the reset did not start")
+	}
+	state = drainReviewStoreResetCmd(t, state, cmd)
+	if !applied {
+		t.Fatal("the reset function was never called")
+	}
+	if state.Screen != ScreenReviewStoreResetResult {
+		t.Fatalf("screen = %v, want the result screen", state.Screen)
+	}
+	if state.optionCount() != 0 {
+		t.Fatal("the result screen exposes phantom options")
+	}
+	rendered := state.View()
+	if !strings.Contains(rendered, "Review store reset") || !strings.Contains(rendered, "4.0 KB") {
+		t.Fatalf("result view does not report what was freed:\n%s", rendered)
+	}
+}
+
+// TestReviewStoreResetConfirmRefusesOpenReviews is the TUI half of the central
+// safety rule. There is no cursor position that destroys an open review, and
+// the screen names the CLI invocation that overrides it.
+func TestReviewStoreResetConfirmRefusesOpenReviews(t *testing.T) {
+	m := reviewStoreResetModel(t)
+	report := settledStoreResetReport()
+	report.InFlight = []reviewtransaction.StoreResetLineage{
+		{LineageID: "review-open", State: reviewtransaction.StateReviewing},
+	}
+	m.ReviewStoreResetReport = report
+	m.ReviewStoreResetFn = func() (reviewtransaction.StoreResetReport, error) {
+		t.Fatal("the TUI destroyed an open review")
+		return reviewtransaction.StoreResetReport{}, nil
+	}
+
+	if m.optionCount() != 1 {
+		t.Fatalf("blocked survey exposes %d options, want only Back", m.optionCount())
+	}
+	rendered := m.View()
+	if !strings.Contains(rendered, "review-open") {
+		t.Fatalf("the screen does not name the open review:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "--include-in-flight") {
+		t.Fatalf("the screen does not name the override:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "Delete permanently") {
+		t.Fatalf("the screen offered a destructive option:\n%s", rendered)
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if state := updated.(Model); state.Screen != ScreenWelcome {
+		t.Fatalf("Enter on the blocked screen went to %v", state.Screen)
+	}
+}
+
+// TestReviewStoreResetSurveyFailureIsReportable proves a store this command
+// cannot even read produces an explanation rather than a dead menu entry.
+func TestReviewStoreResetSurveyFailureIsReportable(t *testing.T) {
+	m := reviewStoreResetModel(t)
+	m.ReviewStoreResetSurveyErr = errors.New("not a git repository")
+
+	if m.optionCount() != 1 {
+		t.Fatalf("failed survey exposes %d options, want only Back", m.optionCount())
+	}
+	rendered := m.View()
+	if !strings.Contains(rendered, "not a git repository") {
+		t.Fatalf("the failure is not shown:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "Delete permanently") {
+		t.Fatalf("a failed survey still offered to delete:\n%s", rendered)
+	}
+}
+
+// TestReviewStoreResetResultReportsPartialFailure keeps the honesty rule
+// visible in the interface a user actually reads.
+func TestReviewStoreResetResultReportsPartialFailure(t *testing.T) {
+	report := settledStoreResetReport()
+	report.Operation = reviewtransaction.StoreResetApplied
+	report.Complete = false
+	report.RemovedFiles, report.RemovedBytes = 12, 4096
+	report.Removable[0].Removed = true
+	report.Removable = append(report.Removable, reviewtransaction.StoreResetEntry{
+		Name: "reviews", Present: true, Files: 3, Bytes: 900, Skipped: "permission denied",
+	})
+
+	rendered := screens.RenderReviewStoreResetResult(report, errors.New("review store reset was incomplete"))
+	if !strings.Contains(rendered, "Partially removed") {
+		t.Fatalf("a partial run was not reported as partial:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "✓") {
+		t.Fatalf("a partial run claimed success:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "reviews: permission denied") {
+		t.Fatalf("the skipped category and its reason are missing:\n%s", rendered)
+	}
+}
+
+// TestReviewStoreResetConfirmNamesWhatItSpares keeps the exclusion list in
+// front of the user, not only in the source.
+func TestReviewStoreResetConfirmNamesWhatItSpares(t *testing.T) {
+	rendered := screens.RenderReviewStoreResetConfirm(settledStoreResetReport(), nil, 0)
+	if !strings.Contains(rendered, "Preserved:") || !strings.Contains(rendered, "review-mode") {
+		t.Fatalf("the confirmation does not say what it spares:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "cannot be undone") {
+		t.Fatalf("the confirmation does not say the removal is irreversible:\n%s", rendered)
+	}
+}

--- a/internal/tui/router.go
+++ b/internal/tui/router.go
@@ -33,6 +33,8 @@ var linearRoutes = map[Screen]Route{
 	ScreenRestoreConfirm:                 {Backward: ScreenBackups},
 	ScreenRestoreResult:                  {Backward: ScreenBackups},
 	ScreenDeleteConfirm:                  {Backward: ScreenBackups},
+	ScreenReviewStoreResetConfirm:        {Backward: ScreenWelcome},
+	ScreenReviewStoreResetResult:         {Backward: ScreenWelcome},
 	ScreenDeleteResult:                   {Backward: ScreenBackups},
 	ScreenRenameBackup:                   {Backward: ScreenBackups},
 	ScreenUpgrade:                        {Backward: ScreenWelcome},

--- a/internal/tui/screens/review_store_reset.go
+++ b/internal/tui/screens/review_store_reset.go
@@ -1,0 +1,202 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/tui/styles"
+)
+
+// ReviewStoreResetConfirmOptionCount reports how many options the confirmation
+// screen exposes for a given survey.
+//
+// It is two in the ordinary case -- "Delete permanently" and "Cancel", the same
+// shape RenderDeleteConfirm uses -- and one when the survey found reviews that
+// have not reached a terminal state. In that case the only option is "Back":
+// there is deliberately no keystroke in this TUI that destroys an open review.
+// The override is a CLI flag the user has to type, and the screen prints the
+// exact command.
+func ReviewStoreResetConfirmOptionCount(report reviewtransaction.StoreResetReport, surveyErr error) int {
+	return len(ReviewStoreResetConfirmOptions(report, surveyErr))
+}
+
+// ReviewStoreResetConfirmOptions returns the options for the given survey. Any
+// state with nothing to destroy -- a failed survey, an empty store, or a store
+// holding open reviews -- offers only "Back", so cursor 0 is never a
+// destructive action except in the one case where destroying is what the user
+// came to do.
+func ReviewStoreResetConfirmOptions(report reviewtransaction.StoreResetReport, surveyErr error) []string {
+	if surveyErr != nil || len(report.InFlight) > 0 || len(reviewStoreResetPresent(report.Removable)) == 0 {
+		return []string{"Back"}
+	}
+	return []string{"Delete permanently", "Cancel"}
+}
+
+// RenderReviewStoreResetConfirm renders the survey and asks for confirmation.
+// Cursor 0 = "Delete permanently", Cursor 1 = "Cancel", unless the survey found
+// open reviews, in which case the only option is "Back".
+func RenderReviewStoreResetConfirm(report reviewtransaction.StoreResetReport, surveyErr error, cursor int) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Reset Review Store"))
+	b.WriteString("\n\n")
+
+	if surveyErr != nil {
+		b.WriteString(styles.ErrorStyle.Render("✗ Could not read the review store"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.ErrorStyle.Render("  " + surveyErr.Error()))
+		b.WriteString("\n\n")
+		b.WriteString(renderOptions(ReviewStoreResetConfirmOptions(report, surveyErr), cursor))
+		b.WriteString("\n")
+		b.WriteString(styles.HelpStyle.Render("enter: back • esc: back"))
+		return b.String()
+	}
+
+	b.WriteString(styles.HeadingStyle.Render("Store: "))
+	b.WriteString(styles.SelectedStyle.Render(report.StoreRoot))
+	b.WriteString("\n\n")
+
+	removable := reviewStoreResetPresent(report.Removable)
+	if len(removable) == 0 {
+		b.WriteString(styles.SuccessStyle.Render("This clone holds no review lineage state. Nothing to remove."))
+		b.WriteString("\n\n")
+		b.WriteString(renderOptions(ReviewStoreResetConfirmOptions(report, surveyErr), cursor))
+		b.WriteString("\n")
+		b.WriteString(styles.HelpStyle.Render("enter: back • esc: back"))
+		return b.String()
+	}
+
+	b.WriteString(styles.HeadingStyle.Render("Would remove:"))
+	b.WriteString("\n")
+	total := int64(0)
+	for _, entry := range removable {
+		total += entry.Bytes
+		b.WriteString(styles.UnselectedStyle.Render(fmt.Sprintf("  %-32s %6d files  %10s",
+			entry.Name, entry.Files, ReviewStoreResetBytes(entry.Bytes))))
+		b.WriteString("\n")
+	}
+	b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("  %-32s %19s", "total", ReviewStoreResetBytes(total))))
+	b.WriteString("\n\n")
+
+	if preserved := reviewStoreResetPresent(report.Preserved); len(preserved) > 0 {
+		b.WriteString(styles.HeadingStyle.Render("Preserved:"))
+		b.WriteString("\n")
+		for _, entry := range preserved {
+			b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("  %-32s %10s  %s",
+				entry.Name, ReviewStoreResetBytes(entry.Bytes), entry.Reason)))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if len(report.InFlight) > 0 {
+		b.WriteString(styles.WarningStyle.Render(fmt.Sprintf(
+			"%d review(s) have not reached a terminal state:", len(report.InFlight))))
+		b.WriteString("\n")
+		for _, lineage := range report.InFlight {
+			label := string(lineage.State)
+			if lineage.Unreadable != "" {
+				label = "unreadable: " + lineage.Unreadable
+			}
+			b.WriteString(styles.WarningStyle.Render("  " + lineage.LineageID + " (" + label + ")"))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(styles.UnselectedStyle.Render("Finish or abandon them first. To remove them anyway, run:"))
+		b.WriteString("\n")
+		b.WriteString(styles.SelectedStyle.Render("  gentle-ai review store-reset --cwd " + report.Repository + " --confirm --include-in-flight"))
+		b.WriteString("\n\n")
+		b.WriteString(renderOptions(ReviewStoreResetConfirmOptions(report, surveyErr), cursor))
+		b.WriteString("\n")
+		b.WriteString(styles.HelpStyle.Render("enter: back • esc: back"))
+		return b.String()
+	}
+
+	b.WriteString(styles.WarningStyle.Render(fmt.Sprintf(
+		"Permanently delete %s of review state for this clone?", ReviewStoreResetBytes(total))))
+	b.WriteString("\n")
+	b.WriteString(styles.WarningStyle.Render("This action cannot be undone. Nothing is copied aside."))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderOptions(ReviewStoreResetConfirmOptions(report, surveyErr), cursor))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • esc: back"))
+
+	return b.String()
+}
+
+// RenderReviewStoreResetResult reports what actually happened. A partial run is
+// never shown as a success: the categories that failed are listed with their
+// reasons, and the freed byte count covers only what really went away.
+func RenderReviewStoreResetResult(report reviewtransaction.StoreResetReport, err error) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Reset Review Store"))
+	b.WriteString("\n\n")
+
+	switch {
+	case err != nil && report.RemovedFiles == 0:
+		b.WriteString(styles.ErrorStyle.Render("✗ Nothing was removed"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.ErrorStyle.Render("  " + err.Error()))
+	case err != nil:
+		b.WriteString(styles.WarningStyle.Render("⚠ Partially removed"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.UnselectedStyle.Render(fmt.Sprintf("Freed %s across %d file(s).",
+			ReviewStoreResetBytes(report.RemovedBytes), report.RemovedFiles)))
+		b.WriteString("\n\n")
+		b.WriteString(styles.HeadingStyle.Render("Not removed:"))
+		b.WriteString("\n")
+		for _, entry := range report.Removable {
+			if entry.Skipped == "" {
+				continue
+			}
+			b.WriteString(styles.ErrorStyle.Render("  " + entry.Name + ": " + entry.Skipped))
+			b.WriteString("\n")
+		}
+		if report.Residue != "" {
+			b.WriteString("\n")
+			b.WriteString(styles.WarningStyle.Render("Staging directory left behind: " + report.Residue))
+			b.WriteString("\n")
+			b.WriteString(styles.SubtextStyle.Render("Those bytes are not reclaimed until it is deleted."))
+		}
+	default:
+		b.WriteString(styles.SuccessStyle.Render("✓ Review store reset"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.UnselectedStyle.Render(fmt.Sprintf("Freed %s across %d file(s).",
+			ReviewStoreResetBytes(report.RemovedBytes), report.RemovedFiles)))
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("The receipt-driven-development kill switch was not changed."))
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(styles.HelpStyle.Render("enter: back to menu • esc: back"))
+
+	return b.String()
+}
+
+func reviewStoreResetPresent(entries []reviewtransaction.StoreResetEntry) []reviewtransaction.StoreResetEntry {
+	present := make([]reviewtransaction.StoreResetEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Present {
+			present = append(present, entry)
+		}
+	}
+	return present
+}
+
+// ReviewStoreResetBytes renders a size the way a person reading a terminal
+// reads one.
+func ReviewStoreResetBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	value, exponent := float64(bytes)/unit, 0
+	for value >= unit && exponent < 3 {
+		value /= unit
+		exponent++
+	}
+	return fmt.Sprintf("%.1f %sB", value, []string{"K", "M", "G", "T"}[exponent])
+}

--- a/internal/tui/screens/review_store_reset.go
+++ b/internal/tui/screens/review_store_reset.go
@@ -33,6 +33,22 @@ func ReviewStoreResetConfirmOptions(report reviewtransaction.StoreResetReport, s
 	return []string{"Delete permanently", "Cancel"}
 }
 
+// ReviewStoreResetConfirmDefaultCursor reports where the cursor should rest
+// when this screen is first shown.
+//
+// It is the "Cancel" row whenever a destructive row exists. The option order is
+// kept the way every other confirmation in this TUI orders it, so the change is
+// only in what is preselected: an accidental Enter cancels, and destroying the
+// store takes a deliberate move onto a row labelled "Delete permanently". In
+// every other state the sole option is "Back", which is already inert.
+func ReviewStoreResetConfirmDefaultCursor(report reviewtransaction.StoreResetReport, surveyErr error) int {
+	options := ReviewStoreResetConfirmOptions(report, surveyErr)
+	if len(options) == 2 {
+		return 1
+	}
+	return 0
+}
+
 // RenderReviewStoreResetConfirm renders the survey and asks for confirmation.
 // Cursor 0 = "Delete permanently", Cursor 1 = "Cancel", unless the survey found
 // open reviews, in which case the only option is "Back".
@@ -136,7 +152,11 @@ func RenderReviewStoreResetResult(report reviewtransaction.StoreResetReport, err
 	b.WriteString("\n\n")
 
 	switch {
-	case err != nil && report.RemovedFiles == 0:
+	// "Nothing was removed" is only true when nothing left its place. A run
+	// that freed no bytes can still have moved a worktree registration it
+	// could not put back, and that is a change to the store the user has to be
+	// told about, so it routes to the partial branch instead.
+	case err != nil && report.RemovedFiles == 0 && len(report.UnrestoredAdminDirs) == 0:
 		b.WriteString(styles.ErrorStyle.Render("✗ Nothing was removed"))
 		b.WriteString("\n\n")
 		b.WriteString(styles.ErrorStyle.Render("  " + err.Error()))
@@ -160,6 +180,22 @@ func RenderReviewStoreResetResult(report reviewtransaction.StoreResetReport, err
 			b.WriteString(styles.WarningStyle.Render("Staging directory left behind: " + report.Residue))
 			b.WriteString("\n")
 			b.WriteString(styles.SubtextStyle.Render("Those bytes are not reclaimed until it is deleted."))
+			b.WriteString("\n")
+		}
+		if len(report.UnrestoredAdminDirs) > 0 {
+			// "Not removed" above means untouched everywhere else on this
+			// screen. For these views it does not, so the exception is
+			// spelled out rather than left to be inferred from a byte count.
+			b.WriteString("\n")
+			b.WriteString(styles.ErrorStyle.Render("Worktree registrations moved aside and not put back:"))
+			b.WriteString("\n")
+			for _, dir := range report.UnrestoredAdminDirs {
+				b.WriteString(styles.ErrorStyle.Render("  " + dir.Original))
+				b.WriteString("\n")
+				b.WriteString(styles.SubtextStyle.Render("    now at " + dir.Staged))
+				b.WriteString("\n")
+			}
+			b.WriteString(styles.SubtextStyle.Render("Move each one back before using those candidate views again."))
 		}
 	default:
 		b.WriteString(styles.SuccessStyle.Render("✓ Review store reset"))

--- a/internal/tui/screens/welcome.go
+++ b/internal/tui/screens/welcome.go
@@ -65,6 +65,7 @@ func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, s
 	}
 
 	opts = append(opts, "Manage backups")
+	opts = append(opts, "Reset review store")
 	opts = append(opts, "Managed uninstall")
 	opts = append(opts, "Community Tools/Plugins")
 	opts = append(opts, "Quit")

--- a/internal/tui/screens/welcome_test.go
+++ b/internal/tui/screens/welcome_test.go
@@ -69,7 +69,7 @@ func TestWelcomeOptions_WithProfiles_CountOne(t *testing.T) {
 	}
 }
 
-// TestWelcomeOptions_OptionCount_WithoutProfiles verifies 12 options when showProfiles=false
+// TestWelcomeOptions_OptionCount_WithoutProfiles verifies 13 options when showProfiles=false
 // and hasEngines=true (agent option visible). Slice 3b adds the
 // "Uninstall OpenCode Plugin" shortcut between "OpenCode Community Plugins"
 // and the OpenCode Profiles entry.
@@ -77,23 +77,23 @@ func TestWelcomeOptions_OptionCount_WithoutProfiles(t *testing.T) {
 	opts := screens.WelcomeOptions(nil, true, false, 0, true)
 	// Expected: Start installation, Upgrade tools, Sync configs, Upgrade + Sync,
 	// Configure models, Create your own Agent, OpenCode Community Plugins,
-	// Uninstall OpenCode Plugin, Manage backups, Managed uninstall,
-	// Community Tools/Plugins, Quit = 12
-	want := 12
+	// Uninstall OpenCode Plugin, Manage backups, Reset review store,
+	// Managed uninstall, Community Tools/Plugins, Quit = 13
+	want := 13
 	if len(opts) != want {
 		t.Errorf("WelcomeOptions(showProfiles=false, hasEngines=true) = %d options, want %d; opts: %v", len(opts), want, opts)
 	}
 }
 
-// TestWelcomeOptions_OptionCount_WithProfiles verifies 13 options when showProfiles=true
+// TestWelcomeOptions_OptionCount_WithProfiles verifies 14 options when showProfiles=true
 // and hasEngines=true.
 func TestWelcomeOptions_OptionCount_WithProfiles(t *testing.T) {
 	opts := screens.WelcomeOptions(nil, true, true, 2, true)
 	// Expected: Start installation, Upgrade tools, Sync configs, Upgrade + Sync,
 	// Configure models, Create your own Agent, OpenCode Community Plugins,
 	// Uninstall OpenCode Plugin, OpenCode SDD Profiles (2), Manage backups,
-	// Managed uninstall, Community Tools/Plugins, Quit = 13
-	want := 13
+	// Reset review store, Managed uninstall, Community Tools/Plugins, Quit = 14
+	want := 14
 	if len(opts) != want {
 		t.Errorf("WelcomeOptions(showProfiles=true, hasEngines=true) = %d options, want %d; opts: %v", len(opts), want, opts)
 	}


### PR DESCRIPTION
Closes #3414.

## What this adds

`gentle-ai review store-reset [--cwd <repo>] [--confirm] [--include-in-flight] [--include-adapter-reviews] [--json]`, plus a "Reset review store" entry in the TUI, both routing through one guarded code path in `internal/reviewtransaction/store_reset.go`.

Preview is the default. `--confirm` deletes. The command is deliberately **not** in `reviewIntegrationOperationRegistry`: it is a human maintenance action, not a negotiated lifecycle transition.

## Safety design

**Strict allowlist.** `storeResetExecute` iterates only `report.Removable`, built solely from `storeResetRemovableTargets`. `Preserved` and `Unrecognized` are report-only; nothing deletes from them. A path matching neither list is reported and left alone, so a directory added by a future feature is never destroyed by an older binary.

Preserved regardless of flags: `review-mode/`, `review-transactions/rar-authority/` (the pre-#2882 kill-switch mirror), `sdd-runtime/`, `defect-reports/`, `review-artifacts/`, `incidents/`, `REVIEW-MAINTENANCE.lock`.

**Decided under the lease it takes.** Survey, in-flight gate, and execution all run inside `AcquireReviewMaintenanceExclusive`. `acquireStoreLock` takes the shared side of the same file before opening any per-lineage store, so the classification cannot go stale under a concurrent writer.

**Worktree ownership is proven, not assumed.** `storeResetAdminDirBelongsTo` requires `<common>/worktrees/<name>/gitdir` to equal exactly `<store>/candidate-views/<name>/.git` after `filepath.Clean`. Only `candidate-views` children are enumerated, and only real directories, so symlinks are skipped.

**Preview mutates nothing.** The survey takes no lock, creates no directory, and uses only `Lstat` / `ReadDir` / `WalkDir` / `ReadFile`.

## Three rounds of review, and what each caught

**Bounded four-lens review — 4 CRITICAL.** Three were one defect: the in-flight guard ran *outside* the lease, so a lineage created between the check and the deletion was destroyed by a run reporting zero in flight. The fourth: candidate-view preparation deleted registrations before renaming, with no rollback.

**Adversarial audit — one proven defect and one the lenses missed.**

The rollback fix was incomplete. It moved the deletion from before the rename to after the rollback, but did not remove it: when staging failed partway *and* the restore then failed, `storeResetRemoveAll(staging)` deleted the staging directory including the admin directory that never got restored, while the CLI printed `nothing above marked SKIPPED was removed`. Reproduced with a test. Reachable on Windows in particular, where renaming a directory any process holds a handle in fails, which is also the most likely trigger for the rollback in the first place.

And `reviews/` was in the removable set with the reason "superseded", while having **none** of the three protections the safety story rests on: `maintenanceLockPathForStoreLock` returns `""` for that path so the lease does not cover it, `storeResetLineages` only scans `review-transactions/v2` so nothing there is ever classified in flight, and gentle-pi never takes `REVIEW-MAINTENANCE.lock` at all (zero occurrences in that repo). The audit could not determine whether the category was live. It is: `extensions/gentle-ai.ts` imports `ReviewTransactionStore` and calls `forRepository(...)` at five call sites in the live extension path, and `lib/review-repository.ts:261` builds that exact store root. `reviews/` now moves to `Preserved` unless `--include-adapter-reviews` is passed.

**Also fixed:** the `30s` lock timeout constant was dead (the real bound is `maintenanceLockTimeout = 2s`, measured at 2.0009s) and its comment justified behavior that did not happen; `RemovedBytes` could print negative because staged admin bytes were counted on one side of the subtraction only; the TUI could complete a deletion and drop the result message; the TUI confirm cursor defaulted to "Delete permanently" while the CLI requires typing `--confirm`; and an in-flight refusal reported `"operation": "reset"` for a run that opened nothing.

## Tests

Every fix carries a regression test proven by reverting its production hunk one at a time. A sample of the failures those reverts produce:

```
the unrestored registration was destroyed with the staging directory:
  open .../worktrees-view-a/gitdir: no such file or directory
a default reset destroyed the adapter review store at .../gentle-ai/reviews/IDENTITY
a run that stranded a registration still promised nothing was removed
storeResetLockTimeout = 30s, want the real lease bound 2s plus its documented identity slack 8s
freed bytes = -113, want never less than nothing
```

The concurrency test is real rather than a lease assertion: it holds the shared lease exactly as a live review does, contends for the exclusive side through real `flock`, and creates the in-flight lineage strictly inside the window, using the seam only as a barrier. It fails 5/5 against the pre-fix ordering and passes 20/20 under `-race`.

## Verification

| check | result |
| --- | --- |
| `go test ./...` | 67 packages ok, 0 FAIL, exit 0 |
| `go test ./internal/reviewtransaction/ -run ReviewStore -race -count=5` | ok, 13.011s |
| `go vet ./...` | exit 0 |
| `GOOS=windows go vet ./...` | exit 0 |
| `gofmt -l internal/` | clean |

## Known limitation

Preserved cross-references can outlive what they name: `sdd-review-bindings/` and `sdd-runtime/` survive while the `review-transactions/v2/<lineage>` they reference is deleted. Not destructive, and correct for a reset, but "SDD runtime state is preserved" is only half true when the lineage it points at is gone. Worth a follow-up rather than blocking this.
