### PR TITLE
test(review): opt the lineage-scoping tests into review mode

### DIFF
--- a/internal/cli/review_abandon_disabled_test.go
+++ b/internal/cli/review_abandon_disabled_test.go
@@ -299,7 +299,7 @@ func breakForeignCompactSnapshotIdentity(t *testing.T, repo, lineage string) {
 // same property through the command an operator actually runs, because a
 // scoped walk is only useful if the CLI path reaches it.
 func TestReviewAbandonOfAPristineLineageIgnoresAnUnrelatedUnloadableApprovedLineage(t *testing.T) {
-	reviewModeHome(t)
+	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)
 	approveDiscoveryMarkdown(t, repo, "abandon-foreign-approved", "docs/foreign.md", "foreign\n")
 	runReviewCLIGit(t, repo, "add", "-A")

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -177,7 +177,7 @@ func TestPreCommitGateDiscoveryStillSelectsExactReceiptAmongDisjointNoiseLineage
 // in the refusal. The refusal must state the candidate's own situation and
 // the one route out of it.
 func TestUnrelatedReceiptDenialNamesTheCandidateSituationNotOtherLineages(t *testing.T) {
-	reviewModeHome(t)
+	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)
 	const n = 6
 	lineages := make([]string, 0, n)


### PR DESCRIPTION
Closes #3420.

`main` is red on `0a33077d`. Two tests from #3410 call `reviewModeHome(t)`, which only points `HOME`/`USERPROFILE` at a temp directory; that sufficed while review resolved on by default. #3413 flipped the default, so both now exercise a review that never starts.

Neither PR was wrong on its own branch: #3410 merged first and never saw the new default, and #3413's sweep could not reach tests that were not yet in `main`.

Both get `reviewEnabledHome(t)`, the same opt-in the rest of the suite already carries.

## Verification

Reproduced and fixed against a clean HOME, which is the only environment where this appears:

```
HOME=$(mktemp -d) USERPROFILE=$same go test ./internal/cli/ \
  -run 'TestReviewAbandonOfAPristineLineageIgnoresAnUnrelatedUnloadableApprovedLineage|TestUnrelatedReceiptDenialNamesTheCandidateSituationNotOtherLineages' -count=1
ok  github.com/gentleman-programming/gentle-ai/v2/internal/cli  1.231s
```

Full suite on the branch: **67 packages ok, 0 FAIL, exit 0**.

## Note on the Windows Full Suite run

Three of its four failing shards failed for an unrelated reason: GitHub returned 503 and 429 while downloading `actions/setup-go`. Only `cli-review-a-m` carried a real failure, and it is one of the two tests fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated review-related test setup to use the current review-enabled configuration.
  * Improved coverage for abandonment and denial scenarios involving review receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->