### PR TITLE
test(bench): reject duplicate journey number prefixes

### DIFF
--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -70,23 +70,88 @@ func journeySources() []journeySource {
 	return sources
 }
 
-// TestJourneyIDsAreUniqueAcrossSourceFiles is the focused duplicate-ID check.
+func TestJourneyIDCollisionsNameBothOffenders(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []journeySource
+		want    string
+	}{
+		{
+			name: "same full ID",
+			sources: []journeySource{
+				{File: "journeys_alpha.go", Journeys: []Journey{{ID: "j110-alpha"}}},
+				{File: "journeys_beta.go", Journeys: []Journey{{ID: "j110-alpha"}}},
+			},
+			want: `journey ID "j110-alpha" is defined in both journeys_alpha.go and journeys_beta.go; pick an ID no journeys_*.go file uses yet`,
+		},
+		{
+			name: "same numeric prefix",
+			sources: []journeySource{
+				{File: "journeys_alpha.go", Journeys: []Journey{{ID: "j110-alpha"}}},
+				{File: "journeys_beta.go", Journeys: []Journey{{ID: "j110-beta"}}},
+			},
+			want: `journey numeric prefix "j110" is shared by "j110-alpha" in journeys_alpha.go and "j110-beta" in journeys_beta.go; pick a number no journeys_*.go file uses yet`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collisions := journeyIDCollisions(tt.sources)
+			if len(collisions) != 1 {
+				t.Fatalf("journeyIDCollisions() returned %d collisions, want 1: %v", len(collisions), collisions)
+			}
+			if collisions[0] != tt.want {
+				t.Fatalf("journeyIDCollisions() = %q, want %q", collisions[0], tt.want)
+			}
+		})
+	}
+}
+
+type journeyIDOwner struct {
+	ID   string
+	File string
+}
+
+func journeyIDCollisions(sources []journeySource) []string {
+	fullOwners := map[string]string{}
+	prefixOwners := map[string]journeyIDOwner{}
+	collisions := []string{}
+
+	for _, source := range sources {
+		for _, journey := range source.Journeys {
+			if owner, taken := fullOwners[journey.ID]; taken {
+				collisions = append(collisions, fmt.Sprintf(
+					"journey ID %q is defined in both %s and %s; pick an ID no journeys_*.go file uses yet",
+					journey.ID, owner, source.File))
+				continue
+			}
+			fullOwners[journey.ID] = source.File
+
+			prefix := journey.ID
+			if separator := strings.IndexByte(journey.ID, '-'); separator >= 0 {
+				prefix = journey.ID[:separator]
+			}
+			if owner, taken := prefixOwners[prefix]; taken {
+				collisions = append(collisions, fmt.Sprintf(
+					"journey numeric prefix %q is shared by %q in %s and %q in %s; pick a number no journeys_*.go file uses yet",
+					prefix, owner.ID, owner.File, journey.ID, source.File))
+				continue
+			}
+			prefixOwners[prefix] = journeyIDOwner{ID: journey.ID, File: source.File}
+		}
+	}
+
+	return collisions
+}
+
+// TestJourneyIDsAreUniqueAcrossSourceFiles is the focused full-ID and numeric-prefix collision check.
 // Before it existed, a colliding ID was only caught downstream by the
 // registration test, whose seen[journey.ID] failure is generic and arrives
 // next to an unrelated count mismatch. This failure names both defining
 // files at the point of the mistake.
 func TestJourneyIDsAreUniqueAcrossSourceFiles(t *testing.T) {
-	owners := map[string]string{}
-	for _, source := range journeySources() {
-		for _, journey := range source.Journeys {
-			owner, taken := owners[journey.ID]
-			if !taken {
-				owners[journey.ID] = source.File
-				continue
-			}
-			t.Errorf("journey ID %q is defined in both %s and %s; pick an ID no journeys_*.go file uses yet",
-				journey.ID, owner, source.File)
-		}
+	for _, collision := range journeyIDCollisions(journeySources()) {
+		t.Error(collision)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3406

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Reject two active bench journeys that share either a full ID or a numeric prefix.
- Name both offending IDs and both source files at the point of failure.
- Keep the recovery scoped to the guard: the old journey rename was dropped because current `main` retires the original `j44` offender, while its proposed `j111` replacement is now occupied.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_id_collision_test.go` | Add synthetic full-ID and numeric-prefix collision cases, extract a shared detector, and apply it to the active journey corpus. |

No journey declaration, manifest entry, production behavior, or driven workflow changes.

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Codex (model not recorded)

**Material scope:** Repository and issue intake, collision analysis, implementation of the detector and regression tests, recovery of the PR onto current `main`, removal of the now-invalid rename, local verification orchestration, and preparation of this PR description.

**Verification performed:** The focused tests pass on the rebuilt candidate. The complete bench test result was compared with pristine `main`; both fail on the same eight Windows runner tests, so this work adds no failures. Formatting, vet, and diff checks pass. Driven execution is not applicable because this PR changes no journey or product semantic.

---

## 🧪 Test Plan

### Focused collision and corpus checks

```bash
cd bench
go test ./... -run '^TestJourney(IDCollisionsNameBothOffenders|IDsAreUniqueAcrossSourceFiles|SourcesCoverTheWholeCorpus)$' -count=1
```

Result on commit `bee53a17`: **PASS**

```text
ok  github.com/gentleman-programming/gentle-ai/bench  0.463s
```

The synthetic cases prove both diagnostic paths:

- duplicate full ID;
- distinct IDs sharing one numeric prefix.

Both diagnostics name the two IDs and their two source files.

### Complete bench tests

```bash
cd bench
go test ./... -count=1
```

Result on the candidate: **FAIL**, eight Windows runner tests.

The same command on pristine `main` at `26d7ceed` fails on the same eight test names. The failures depend on Unix-style fake executables and PATH shims that Windows cannot execute; the candidate adds zero failing tests.

### Static checks

```bash
cd bench
go vet ./...
gofmt -l .
git diff --check origin/main...HEAD
```

Results:

- `go vet ./...`: **PASS**
- `gofmt -l .`: **PASS**, no output
- `git diff --check origin/main...HEAD`: **PASS**

### Driven benchmark validation

**Not applicable.** This PR changes only the corpus collision unit guard. It adds or modifies no journey, manifest entry, product behavior, command, or transition for the harness to drive.

### E2E

**Not run.** The change is isolated to a bench unit-test guard and has no runtime boundary.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR — contributor account lacks triage permission
- [ ] Unit tests pass (`go test ./...`) — exact pre-existing Windows failures documented above
- [x] Go format passes
- [ ] E2E tests pass — not applicable and not run
- [x] Benchmark validation completed, or this change is not applicable to the benchmark — explained above
- [x] Documentation is updated if necessary — no documentation change required
- [x] My commits follow Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please review the diagnostic contract: duplicate full IDs preserve the existing failure meaning, while distinct IDs sharing a number now report the prefix, both full IDs, and both source files.

`journeySources()` already projects the active corpus through `removeRetiredAtomicJourneys`. This PR preserves that boundary: it detects collisions among active journeys and does not introduce a new allocation policy for retired IDs.

The earlier revision also renamed an SDD journey from `j44` to `j111`. That repair is obsolete on current `main`: the original `j44` offender is retired from the active corpus, and `j111` is now allocated. Keeping that rename would create the collision this guard is designed to reject, so the rebuilt PR deliberately contains only the guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for duplicate journey IDs and collisions involving shared numeric prefixes.
  * Improved validation reporting to identify all conflicting files and journey IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->