### PR TITLE
fix(review): make the pi transport and capture-result refusals actionable

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -297,15 +297,25 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		if _, err := reviewRuntimeWithImmutableTransport(string(providerRuntime)); err != nil {
 			return reviewPreflightError(err)
 		}
+		// Each refusal below names its own condition. They used to share one
+		// sentence, so a report could not say which of two opposite causes
+		// fired -- asking to materialize a runtime that never prints the task,
+		// or omitting --materialize for a runtime that has no in-process
+		// reviewer. Both state what the caller passed, what the runtime's
+		// compiled transport is, and the one form that would be accepted.
+		providerTransport := reviewImmutableRuntimeCapability(providerRuntime).Transport
 		if *materialize {
 			if reviewProviderCaptureRuntime(providerRuntime) {
 				return reviewPreflightError(fmt.Errorf("review capture-result --materialize is unavailable for %q: a compiled runtime materializes internally; run the capture operation without --materialize", providerRuntime)) // refusal:by-design operator-knowledge: compiled subprocess adapters already receive the Go-materialized request in-process
 			}
 			if !reviewProviderHostRelayMaterializeRuntime(providerRuntime) {
-				return reviewPreflightError(fmt.Errorf("review capture-result provider runtime %q is host-mediated; use its live transport collection", providerRuntime)) // refusal:by-design world-action: only the Pi host relay collects a printed provider task
+				return reviewPreflightError(fmt.Errorf("review capture-result --materialize is unavailable for %q: printing the Go-materialized provider task is the host-relay form, and this runtime's compiled transport is %q; collect its reviewer result through that live host transport instead", providerRuntime, providerTransport)) // refusal:by-design world-action: only the Pi host relay collects a printed provider task
 			}
 		} else if !reviewProviderCaptureRuntime(providerRuntime) {
-			return reviewPreflightError(fmt.Errorf("review capture-result provider runtime %q is host-mediated; use its live transport collection", providerRuntime)) // refusal:by-design world-action: only compiled subprocess adapters use this capture path
+			if reviewProviderHostRelayMaterializeRuntime(providerRuntime) {
+				return reviewPreflightError(fmt.Errorf("review capture-result --agent %q without --materialize has no in-process reviewer to run: its compiled transport is %q, whose host owns the reviewer subprocess; print the provider task with --materialize=true, run it in the host, then submit the raw result with --input and the same binding", providerRuntime, providerTransport)) // refusal:by-design world-action: the host relay owns the reviewer subprocess this process cannot launch
+			}
+			return reviewPreflightError(fmt.Errorf("review capture-result --agent %q has no compiled in-process reviewer adapter: its compiled transport is %q; collect its reviewer result through that live host transport instead", providerRuntime, providerTransport)) // refusal:by-design world-action: only compiled subprocess adapters use this capture path
 		}
 	}
 	ctx := context.Background()

--- a/internal/cli/review_capture_result_refusal_distinct_test.go
+++ b/internal/cli/review_capture_result_refusal_distinct_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// TestCaptureResultHostMediatedRefusalsAreDistinguishable is #3441.
+//
+// `review capture-result` has two opposite host-mediated refusals: one fires
+// inside `--materialize` when the runtime has no host-relay transport, the
+// other fires without `--materialize` when the runtime is not a compiled
+// capture runtime. They used to emit the byte-identical sentence
+//
+//	review capture-result provider runtime %q is host-mediated; use its live transport collection
+//
+// so a report that quoted it (Gentleman-Programming/gentle-pi#367, defect C)
+// could not be traced to either branch -- and the two branches send the
+// follow-up to different repositories. Each refusal now names the flag the
+// caller passed, the runtime's compiled transport, and the one accepted form.
+func TestCaptureResultHostMediatedRefusalsAreDistinguishable(t *testing.T) {
+	binding := []string{
+		"--repository-context", "rctx1_" + strings.Repeat("0", 64),
+		"--lineage", "distinct-host-mediated-refusals", "--target", "sha256:" + strings.Repeat("0", 64),
+		"--expected-revision", "sha256:" + strings.Repeat("1", 64), "--lens", "review-reliability", "--order", "0",
+	}
+
+	for _, test := range []struct {
+		name string
+		argv []string
+		// want is the complete refusal, asserted exactly: a substring match
+		// is what let two opposite causes share one sentence unnoticed.
+		want string
+	}{
+		{
+			// The materialize branch, reached by a runtime whose live host
+			// transport never prints the Go-materialized task.
+			name: "materialize requested for a non-host-relay transport",
+			argv: append(slices.Clone(binding), "--agent", string(model.AgentOpenCode), "--materialize=true"),
+			want: `review capture-result --materialize is unavailable for "opencode": ` +
+				`printing the Go-materialized provider task is the host-relay form, ` +
+				`and this runtime's compiled transport is "opencode_provider_injected"; ` +
+				`collect its reviewer result through that live host transport instead`,
+		},
+		{
+			// The opposite branch: --materialize did not take effect, and the
+			// host relay owns the reviewer subprocess this process cannot
+			// launch. Naming --materialize=true here is what turns the
+			// gentle-pi report into a checkable question.
+			name: "materialize omitted for the pi host relay",
+			argv: append(slices.Clone(binding), "--agent", string(model.AgentPi)),
+			want: `review capture-result --agent "pi" without --materialize has no in-process reviewer to run: ` +
+				`its compiled transport is "pi_host_relay", whose host owns the reviewer subprocess; ` +
+				`print the provider task with --materialize=true, run it in the host, ` +
+				`then submit the raw result with --input and the same binding`,
+		},
+		{
+			// Same branch as above, different runtime: OpenCode has no
+			// materialize form to point at, so it gets its own sentence
+			// rather than the pi one.
+			name: "materialize omitted for a runtime with no materialize form",
+			argv: append(slices.Clone(binding), "--agent", string(model.AgentOpenCode)),
+			want: `review capture-result --agent "opencode" has no compiled in-process reviewer adapter: ` +
+				`its compiled transport is "opencode_provider_injected"; ` +
+				`collect its reviewer result through that live host transport instead`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+			err := RunReviewCaptureResult(test.argv, io.Discard)
+			if err == nil {
+				t.Fatal("want a refusal")
+			}
+			if err.Error() != test.want {
+				t.Fatalf("refusal =\n\t%q\nwant\n\t%q", err.Error(), test.want)
+			}
+		})
+	}
+
+	// The property the shared sentence violated: no two of these refusals may
+	// read the same, whatever their wording becomes.
+	t.Run("no two refusals share their text", func(t *testing.T) {
+		seen := map[string]string{}
+		for _, argv := range [][]string{
+			append(slices.Clone(binding), "--agent", string(model.AgentOpenCode), "--materialize=true"),
+			append(slices.Clone(binding), "--agent", string(model.AgentPi)),
+			append(slices.Clone(binding), "--agent", string(model.AgentOpenCode)),
+			append(slices.Clone(binding), "--agent", string(model.AgentClaudeCode), "--materialize=true"),
+		} {
+			t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+			err := RunReviewCaptureResult(argv, io.Discard)
+			if err == nil {
+				t.Fatalf("%v: want a refusal", argv)
+			}
+			if first, duplicate := seen[err.Error()]; duplicate {
+				t.Fatalf("two refusals share one sentence:\n\t%v\n\t%v\n\t%q", first, argv, err.Error())
+			}
+			seen[err.Error()] = strings.Join(argv, " ")
+		}
+	})
+}

--- a/internal/cli/review_pi_handshake_refusal_test.go
+++ b/internal/cli/review_pi_handshake_refusal_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// piRelayHandshakeRefusalCause is the exact cause a handshake-less `pi`
+// invocation must read (#3440). It names the one missing condition and
+// nothing else.
+//
+// The old cause offered `gentle-ai review mode disable --scope clone` and
+// then listed `claude-code, opencode, codex` as the supported runtimes. That
+// list is built by reviewTransportSupportedRuntimeIDs, which calls
+// reviewImmutableRuntimeCapability for every agent IN THIS PROCESS -- under
+// the exact condition that is failing -- so `pi` can never appear in the
+// message that would explain how to enable `pi`. A community report read that
+// message and concluded v2.4.0 had dropped Pi support, when the fix was one
+// exported variable.
+const piRelayHandshakeRefusalCause = "the active runtime is not eligible for immutable receipt review; " +
+	"pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT declares the exact relay contract this binary admits, " +
+	"which the gentle-pi host exports on every invocation it relays; export it in this shell and re-run"
+
+// TestPiTransportRefusalNamesTheHandshakeNotTheKillSwitch runs the exact
+// documented shell entry point both ways round: the identical command must
+// refuse actionably without the handshake and succeed with it. Asserting only
+// the refusal would leave the message free to name a condition that is not
+// actually the deciding one.
+func TestPiTransportRefusalNamesTheHandshakeNotTheKillSwitch(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\ncandidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	statusArgs := []string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentPi), "--next-transition",
+	}
+
+	t.Run("handshake absent names the handshake", func(t *testing.T) {
+		t.Setenv(reviewPiHostRelayContractEnvironment, "")
+		var output bytes.Buffer
+		if err := RunReview(statusArgs, &output); err == nil {
+			t.Fatalf("handshake-less pi STATUS succeeded: %s", output.String())
+		}
+		failure := decodeReviewIntegrationFailure(t, output.Bytes())
+		if failure.Code != reviewImmutableTransportUnsupportedCode {
+			t.Fatalf("handshake-less pi failure code = %q, want %q", failure.Code, reviewImmutableTransportUnsupportedCode)
+		}
+		if failure.Cause != piRelayHandshakeRefusalCause {
+			t.Fatalf("handshake-less pi cause =\n\t%q\nwant\n\t%q", failure.Cause, piRelayHandshakeRefusalCause)
+		}
+		// The two halves of the old cause, named explicitly: disabling
+		// receipt-driven review is a legitimate exit from the practice, but it
+		// is not the remedy here, and a supported list that structurally
+		// cannot contain `pi` reads as "pi was dropped".
+		if strings.Contains(failure.Cause, "review mode disable") {
+			t.Fatalf("handshake-less pi cause still offers the kill switch as the remedy: %q", failure.Cause)
+		}
+		if strings.Contains(failure.Cause, "supported immutable review runtimes") {
+			t.Fatalf("handshake-less pi cause still lists a supported set that cannot contain pi: %q", failure.Cause)
+		}
+	})
+
+	t.Run("handshake present admits the identical command", func(t *testing.T) {
+		t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+		var output bytes.Buffer
+		if err := RunReview(statusArgs, &output); err != nil {
+			t.Fatalf("pi STATUS with the declared handshake refused: %v\n%s", err, output.String())
+		}
+		if strings.Contains(output.String(), reviewImmutableTransportUnsupportedCode) {
+			t.Fatalf("pi STATUS with the declared handshake still reported the transport refusal: %s", output.String())
+		}
+	})
+}
+
+// TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate is the guard
+// the first draft of this fix needed, and the reason the cause names the
+// variable without its value.
+//
+// This prose reaches the operator only as the negotiated envelope's `cause`,
+// and every refusal crosses reviewScrubDefectReportField to get there. That
+// gate rewrites any `KEY=VALUE` token to `<redacted>` in full, and any
+// `/`-rooted run to `<redacted>` from the slash onward. A cause that spells
+// the handshake out therefore arrives as advice to export `<redacted>`:
+// strictly worse than the misleading message it replaced.
+func TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate(t *testing.T) {
+	guidance := reviewPiRelayHandshakeGuidance()
+	if scrubbed := reviewScrubDefectReportField(guidance); scrubbed != guidance {
+		t.Fatalf("the privacy gate rewrites the pi guidance before the operator reads it:\n\tguidance %q\n\tscrubbed %q", guidance, scrubbed)
+	}
+	if !strings.Contains(guidance, reviewPiHostRelayContractEnvironment) {
+		t.Fatalf("the pi guidance no longer names the missing condition: %q", guidance)
+	}
+
+	// The tripwire for the half of #3440 this change cannot deliver. While
+	// the gate still destroys the spelled-out handshake, the omission is a
+	// constraint. The day it stops, this fails and the cause owes the
+	// operator the exact value.
+	spelled := reviewPiHostRelayContractEnvironment + "=" + reviewPiHostRelayContract
+	if scrubbed := reviewScrubDefectReportField("export " + spelled + " and re-run"); scrubbed != "export "+reviewDefectReportRedactionMarker+" and re-run" {
+		t.Fatalf("the privacy gate no longer destroys %q (it now renders %q); the pi cause can carry the exact handshake and should", spelled, scrubbed)
+	}
+	if scrubbed := reviewScrubDefectReportField("the value " + reviewPiHostRelayContract); scrubbed != "the value gentle-pi.review-relay"+reviewDefectReportRedactionMarker {
+		t.Fatalf("the privacy gate no longer truncates the bare contract value (it now renders %q); the pi cause can carry it and should", scrubbed)
+	}
+}
+
+// TestPiHandshakeGuidanceStaysScopedToPi proves the new cause does not leak.
+// Two directions: a runtime the handshake cannot help keeps the generic exit
+// guidance, and `pi` never advertises itself as supported while it is refused.
+func TestPiHandshakeGuidanceStaysScopedToPi(t *testing.T) {
+	t.Setenv(reviewPiHostRelayContractEnvironment, "")
+
+	for _, runtime := range []string{string(model.AgentKilocode), "unknown-runtime"} {
+		t.Run(runtime, func(t *testing.T) {
+			_, err := reviewRuntimeWithImmutableTransport(runtime)
+			if err == nil {
+				t.Fatal("want a refusal")
+			}
+			if strings.Contains(err.Error(), reviewPiHostRelayContractEnvironment) {
+				t.Fatalf("refusal for %q leaks the pi relay handshake: %v", runtime, err)
+			}
+			if !strings.Contains(err.Error(), "gentle-ai review mode disable --scope clone --cwd <repo>") {
+				t.Fatalf("refusal for %q lost the generic exit guidance: %v", runtime, err)
+			}
+		})
+	}
+
+	t.Run("pi is never offered as its own substitute", func(t *testing.T) {
+		_, err := reviewRuntimeWithImmutableTransport(string(model.AgentPi))
+		if err == nil {
+			t.Fatal("want a refusal")
+		}
+		if strings.Contains(err.Error(), "supported immutable review runtimes") {
+			t.Fatalf("pi refusal reintroduced the substitute list: %v", err)
+		}
+	})
+}
+
+// TestPiRelayHandshakeIsSoleMissingConditionStaysDiagnostic pins the predicate
+// that selects the cause. It must never be read as an admission decision:
+// reviewImmutableRuntimeCapability stays the only authority, and the predicate
+// is false the moment the handshake is declared, whatever the capability says.
+func TestPiRelayHandshakeIsSoleMissingConditionStaysDiagnostic(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		declared string
+		agent    model.AgentID
+		want     bool
+	}{
+		{name: "pi without the handshake", declared: "", agent: model.AgentPi, want: true},
+		{name: "pi with a stale contract", declared: "gentle-pi.review-relay/v0", agent: model.AgentPi, want: true},
+		{name: "pi with the exact handshake", declared: reviewPiHostRelayContract, agent: model.AgentPi, want: false},
+		{name: "kilocode without the handshake", declared: "", agent: model.AgentKilocode, want: false},
+		{name: "opencode without the handshake", declared: "", agent: model.AgentOpenCode, want: false},
+		{name: "unknown runtime", declared: "", agent: model.AgentID("unknown-runtime"), want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(reviewPiHostRelayContractEnvironment, test.declared)
+			if got := reviewPiRelayHandshakeIsSoleMissingCondition(test.agent); got != test.want {
+				t.Fatalf("reviewPiRelayHandshakeIsSoleMissingCondition(%q) = %t, want %t", test.agent, got, test.want)
+			}
+			// Eligibility is unchanged by the diagnostic in every case.
+			capability := reviewImmutableRuntimeCapability(test.agent)
+			if test.agent == model.AgentPi && test.declared != reviewPiHostRelayContract && capability.supportsImmutableReceiptReview() {
+				t.Fatalf("the diagnostic widened pi eligibility: %#v", capability)
+			}
+		})
+	}
+}

--- a/internal/cli/review_provider_materialize_test.go
+++ b/internal/cli/review_provider_materialize_test.go
@@ -131,9 +131,14 @@ func TestReviewCaptureResultMaterializeRefusals(t *testing.T) {
 			want: "materializes internally",
 		},
 		{
+			// #3441: this refusal used to be byte-identical to the opposite
+			// one (--materialize omitted for a non-capture runtime), so the
+			// assertion could not tell them apart either. The exact texts of
+			// both live in
+			// TestCaptureResultHostMediatedRefusalsAreDistinguishable.
 			name: "opencode keeps its host-mediated refusal", env: reviewPiHostRelayContract,
 			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentOpenCode), "--materialize=true"),
-			want: "is host-mediated; use its live transport collection",
+			want: "--materialize is unavailable for \"opencode\": printing the Go-materialized provider task is the host-relay form",
 		},
 		{
 			name: "combined with input", env: reviewPiHostRelayContract,

--- a/internal/cli/review_transport_capability.go
+++ b/internal/cli/review_transport_capability.go
@@ -122,6 +122,61 @@ func reviewTransportRefusalExitGuidance() string {
 		strings.Join(reviewTransportSupportedRuntimeIDs(), ", ")
 }
 
+// reviewPiRelayHandshakeIsSoleMissingCondition reports whether Pi's refusal is
+// caused by nothing but the absent relay handshake: every other compiled
+// conjunct already holds, so declaring the exact contract is the single
+// remaining step. It decides which cause the operator reads and nothing else;
+// reviewImmutableRuntimeCapability stays the only admission authority, and no
+// runtime becomes eligible because of what this reports.
+func reviewPiRelayHandshakeIsSoleMissingCondition(agent model.AgentID) bool {
+	if agent != model.AgentPi {
+		return false
+	}
+	if os.Getenv(reviewPiHostRelayContractEnvironment) == reviewPiHostRelayContract {
+		return false
+	}
+	manifest, err := capabilitymanifest.ForAgent(agent)
+	return err == nil && manifest.Advertises(capabilitymanifest.ContractImmutableReviewExecutorV1)
+}
+
+// reviewPiRelayHandshakeGuidance names the one missing condition instead of
+// the kill switch. reviewTransportSupportedRuntimeIDs can never name `pi`
+// here, because it is computed by calling reviewImmutableRuntimeCapability in
+// this same process, under the exact condition that is failing. Offering
+// `review mode disable` is worse than unhelpful: leaving receipt-driven
+// review is a legitimate choice, but it is not the remedy for a runtime one
+// declared contract away from eligible, and a reader who follows it concludes
+// the runtime was dropped.
+//
+// The guidance names the variable but NOT its value, and that is deliberate
+// rather than an oversight. This prose reaches the operator only as the
+// negotiated envelope's `cause`, which every refusal crosses
+// reviewScrubDefectReportField to reach: that gate rewrites any `KEY=VALUE`
+// token to `<redacted>` in full, and any `/`-rooted run to `<redacted>` from
+// the slash onward. The exact handshake collides with both rules, so
+// `GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1` renders as
+// `<redacted>` and `gentle-pi.review-relay/v1` renders as
+// `gentle-pi.review-relay<redacted>`. Naming the variable alone survives the
+// gate byte for byte (pinned by
+// TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate), so it is
+// the most actionable cause that can actually reach the operator without
+// relaxing a privacy boundary from a diagnostics change.
+func reviewPiRelayHandshakeGuidance() string {
+	return "; pi is eligible only while " + reviewPiHostRelayContractEnvironment +
+		" declares the exact relay contract this binary admits, which the gentle-pi host exports on every invocation it relays; export it in this shell and re-run"
+}
+
+// reviewTransportRefusalGuidanceFor selects the guidance the refused runtime
+// can actually act on. Every runtime other than a handshake-less Pi keeps the
+// generic exit guidance unchanged, so the env-var remedy never leaks to a
+// runtime it cannot help.
+func reviewTransportRefusalGuidanceFor(agent model.AgentID) string {
+	if reviewPiRelayHandshakeIsSoleMissingCondition(agent) {
+		return reviewPiRelayHandshakeGuidance()
+	}
+	return reviewTransportRefusalExitGuidance()
+}
+
 // reviewRuntimeWithImmutableTransport accepts only the exact compiled runtime
 // identities. It never selects a substitute transport for an unsupported one.
 func reviewRuntimeWithImmutableTransport(agent string) (model.AgentID, error) {
@@ -133,11 +188,11 @@ func reviewRuntimeWithImmutableTransport(agent string) (model.AgentID, error) {
 	capability := reviewImmutableRuntimeCapability(identity)
 	if !capability.Eligible {
 		// refusal:by-design world-action: runtimes outside the fixed RDD policy cannot receive immutable review authority
-		return "", fmt.Errorf("the active runtime is not eligible for immutable receipt review%s", reviewTransportRefusalExitGuidance())
+		return "", fmt.Errorf("the active runtime is not eligible for immutable receipt review%s", reviewTransportRefusalGuidanceFor(identity))
 	}
 	if !capability.supportsImmutableReceiptReview() {
 		// refusal:by-design world-action: unsupported transport cannot bind immutable evidence or capture an admissible result
-		return "", fmt.Errorf("the active runtime lacks immutable receipt-review transport%s", reviewTransportRefusalExitGuidance())
+		return "", fmt.Errorf("the active runtime lacks immutable receipt-review transport%s", reviewTransportRefusalGuidanceFor(identity))
 	}
 	return identity, nil
 }


### PR DESCRIPTION
Two refusal messages in the review CLI could not be acted on. Both changes are diagnostics: eligibility, transport resolution, and which forms are admitted are all unchanged.

Closes #3441.
Refs #3440.
Refs #3443.

## #3441 — two opposite capture-result refusals shared identical text

`review capture-result` refused with the same sentence from two opposite branches: `--materialize` requested for a runtime with no host-relay transport, and `--materialize` absent for a runtime that is not a compiled capture runtime. A report quoting it could not be traced to either branch, and the two branches send the follow-up to different repositories.

Before, from both sites:

```
review capture-result provider runtime "opencode" is host-mediated; use its live transport collection
review capture-result provider runtime "pi" is host-mediated; use its live transport collection
```

After:

```
review capture-result --materialize is unavailable for "opencode": printing the Go-materialized provider task is the host-relay form, and this runtime's compiled transport is "opencode_provider_injected"; collect its reviewer result through that live host transport instead

review capture-result --agent "pi" without --materialize has no in-process reviewer to run: its compiled transport is "pi_host_relay", whose host owns the reviewer subprocess; print the provider task with --materialize=true, run it in the host, then submit the raw result with --input and the same binding

review capture-result --agent "opencode" has no compiled in-process reviewer adapter: its compiled transport is "opencode_provider_injected"; collect its reviewer result through that live host transport instead
```

Each names the flag the caller passed, the runtime's compiled transport, and the one accepted form. The no-materialize branch splits by runtime so the pi case names `--materialize=true` plus `--input`, which is what turns the gentle-pi report into a checkable question: that message firing means `--materialize` never took effect, and the follow-up belongs in gentle-pi rather than here.

The `refusal:by-design world-action` annotations are unchanged; this changes text, not classification.

## #3440 — the pi transport refusal named the kill switch, not the handshake

Before:

```
the active runtime is not eligible for immutable receipt review; exit receipt-driven review with `gentle-ai review mode disable --scope clone --cwd <repo>`; supported immutable review runtimes: claude-code, opencode, codex
```

`reviewTransportSupportedRuntimeIDs` builds that list by calling `reviewImmutableRuntimeCapability` for every agent **in the current process**, under the exact condition that is failing, so `pi` can never appear in the message that would explain how to enable `pi`. A community report read this and concluded Pi support had been dropped.

After, only when the absent relay handshake is the sole missing condition:

```
the active runtime is not eligible for immutable receipt review; pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT declares the exact relay contract this binary admits, which the gentle-pi host exports on every invocation it relays; export it in this shell and re-run
```

Leaving receipt-driven review is a legitimate choice, but it is not the remedy for a runtime one declared contract away from eligible. Every other runtime keeps the generic exit guidance verbatim, and the env var never leaks to a runtime it cannot help.

The eligibility rule itself is untouched: the relay's declared contract is still a required conjunct, and `reviewPiRelayHandshakeIsSoleMissingCondition` only selects which cause the operator reads.

### Why this is `Refs #3440` and not `Closes #3440`

#3440 asks the cause to name `GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1`. The variable is delivered; **its value is withheld by #3443** and this PR does not close that gap.

Every refusal crosses `reviewScrubDefectReportField` on its way into the negotiated envelope's `cause` field. Measured on the live binary:

| Input | Rendered `cause` |
| --- | --- |
| `GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1` | `<redacted>` |
| `gentle-pi.review-relay/v1` (bare or backticked) | `gentle-pi.review-relay<redacted>` |

The first is the `KEY=VALUE` rule; the second is the path rule, which matches at *any* embedded slash rather than at a path root. The first draft of this change shipped the exact text from the issue and the live envelope read "export `<redacted>`" — strictly worse than the message it replaced. `cause` is the only surface: stderr prints just the constant `message`, and every `--agent pi` route requires the negotiated `--contract`, so there is no raw-error escape hatch.

Making the value reachable means relaxing a privacy boundary, which is #3443's call, not a diagnostics PR's. `TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate` asserts the guidance survives the gate byte for byte today, and **fails the day the gate stops destroying the spelled-out handshake**, so the omission stays tracked rather than forgotten. When #3443 lands, that test is the prompt to put the value back and close #3440.

## Tests

Both regressions were proven by reverting each production hunk independently.

Reverting the two `reviewTransportRefusalGuidanceFor` call sites:

```
--- FAIL: TestPiTransportRefusalNamesTheHandshakeNotTheKillSwitch/handshake_absent_names_the_handshake
    cause = "...; exit receipt-driven review with `gentle-ai review mode disable --scope clone --cwd <repo>`; supported immutable review runtimes: claude-code, opencode, codex"
    want  = "...; pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT declares the exact relay contract this binary admits, ..."
```

Reverting `review_artifact.go` to `main`: all four subtests red, including the property test, which reproduces the reported defect directly:

```
--- FAIL: TestCaptureResultHostMediatedRefusalsAreDistinguishable/no_two_refusals_share_their_text
    two refusals share one sentence: "review capture-result provider runtime \"opencode\" is host-mediated; use its live transport collection"
```

#3440 is covered both ways round: handshake absent asserts the exact cause, handshake present runs the identical live CLI command through `RunReview` and requires it to succeed, so the message cannot name a condition that is not the deciding one.

## Notes for the reviewer

- **The `!reviewProviderHostRelayMaterializeRuntime` guard inside `if *materialize` is load-bearing.** While drafting this I collapsed it into an unconditional return, which would have refused the valid pi materialize path — the one form the host relay actually uses. Caught before running anything, and the fall-through is deliberate.
- **The refusal ratchet needed nothing.** `.refusal-ratchet-baseline.txt` is unchanged: both edited sites carry `refusal:by-design` markers, so they count as annotated and never enter the baseline. Worth knowing for the next message edit — the ratchet treats a `refusal:by-design` marker plus a `gentle-ai <cmd>` in the same string literal as a hard contradictory-claims error, so guidance has to stay behind a helper call rather than being inlined into the format string.

## Verification

All foreground, with a clean `HOME` (several tests resolve review mode from the real home directory).

```
go test ./...                  EXIT=0    internal/cli ok 272.472s, no FAIL/panic lines
go vet ./...                   EXIT=0
GOOS=windows go vet ./...      EXIT=0
gofmt -l internal/             EXIT=0    (no output)
./scripts/deadcode-ratchet.sh  EXIT=0    "no new unreachable functions"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review result validation for compiled and host-relay runtimes.
  - Added clearer guidance when materialization is unsupported or when host-side review results must be materialized and resubmitted.
  - Improved Pi runtime diagnostics by identifying missing relay-handshake configuration.
  - Prevented misleading or duplicate refusal messages across supported runtimes.

- **Tests**
  - Added regression coverage for materialization refusals, relay-handshake failures, privacy-scrubbed guidance, and runtime-specific error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->