### PR TITLE
docs(readme): trust the Homebrew tap instead of a single formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Run `gentle-ai doctor` at any time for a read-only health check of your ecosyste
 
 ```bash
 brew tap Gentleman-Programming/homebrew-tap
-brew trust --formula gentleman-programming/tap/gentle-ai  # one-time, for Homebrew tap trust
+brew trust --tap gentleman-programming/tap  # one-time, for Homebrew tap trust
 brew install gentle-ai
 ```
 


### PR DESCRIPTION
Closes #832

## Summary
- One-line fix in `README.md`: change `brew trust --formula gentleman-programming/tap/gentle-ai` to `brew trust --tap gentleman-programming/tap` so the entire tap is trusted at once and any future formula from the same tap (e.g. engram, gga, gentle-creation) installs without a second `brew trust` round-trip.

## Changes
| File | Change |
|------|--------|
| `README.md` | 1-line replacement of the brew-trust form per #832. |

## Test Plan
- [x] Markdown renders unchanged: the line is a single command substitution inside an existing fenced bash block.
- [x] Manually verified against the issue's reproduction: `HOMEBREW_REQUIRE_TAP_TRUST` no longer raises `Refusing to load formula from untrusted tap` after `brew trust --tap`.
- [x] No scripts touched; no `shellcheck` run needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew setup instructions to trust the entire tap rather than a single formula.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->