### PR TITLE
docs: add Hermes knowledge-layer section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -398,6 +398,29 @@ Resolves #42
 
 ---
 
+## Hermes — Knowledge-Layer Agent
+
+Hermes is a detect-only agent in the Gentle AI ecosystem. Unlike coding agents (Claude Code, OpenCode, Cursor), Hermes does not have skills directories, system prompt injection targets, or subagent support. It operates purely as a configuration layer.
+
+**Capabilities:**
+
+- SOUL.md system prompt via `StrategyMarkdownSections` — marker-based injection (`internal/agents/hermes/adapter.go`)
+- YAML MCP config via `StrategyMergeIntoYAML` — merges MCP server blocks into `~/.hermes/config.yaml`
+- Skills directory support (`~/.hermes/skills/`)
+
+**Why it matters:**
+
+Hermes's YAML MCP strategy is the reference implementation for non-coding agents that still need MCP configuration. If you are building a knowledge-layer integration (MCP servers for context, memory, or retrieval), Hermes's YAML merge strategy is the adapter pattern to follow.
+
+**Contributing to Hermes:**
+
+- Hermes cannot be auto-installed — `InstallCommand` returns `AgentNotInstallableError`. Users install Hermes manually before Gentle AI detects it.
+- Adapter lives at `internal/agents/hermes/adapter.go` and implements the full `agents.Adapter` interface.
+- `Tier()` returns `TierFull` for display purposes only (no auto-install follows).
+- No subagents, slash commands, or output styles — the corresponding `*Dir` methods all return empty strings.
+
+---
+
 ## Code of Conduct
 
 Be respectful. We're building something together.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Before you dive in, please read this guide fully. We have a structured workflow 
 - [Commit Convention](#commit-convention)
 - [Delivery Strategy for SDD Changes](#delivery-strategy-for-sdd-changes)
 - [Pull Request Rules](#pull-request-rules)
+- [Hermes — Knowledge-Layer Agent](#hermes--knowledge-layer-agent)
 - [Code of Conduct](#code-of-conduct)
 
 ---
@@ -400,7 +401,7 @@ Resolves #42
 
 ## Hermes — Knowledge-Layer Agent
 
-Hermes is a detect-only agent in the Gentle AI ecosystem. Unlike coding agents (Claude Code, OpenCode, Cursor), Hermes does not have skills directories, system prompt injection targets, or subagent support. It operates purely as a configuration layer.
+Hermes is a detect-only agent in the Gentle AI ecosystem. Unlike coding agents (Claude Code, OpenCode, Cursor), Hermes has no subagent support. It operates as a configuration layer with skills-directory loading and a markdown system prompt.
 
 **Capabilities:**
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Gentle-AI is NOT an AI agent installer. It adapts the agent runtime(s) already o
 | **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config  |
 | **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
 | **Pi**              | Full (package-managed subagents) | First-class `gentle-pi` harness with Pi-native persona/models, SDD, and Engram memory |
-| **Hermes**          |         Detect-only              | YAML MCP config, SOUL.md persona; install manually first        |
+| **Hermes**          |         Detect-only              | Knowledge-layer agent: YAML MCP config, SOUL.md persona; install manually first |
 
 > **Pi is package-managed, not just configured.** Selecting Pi installs the first-class [`gentle-pi`](docs/pi.md) harness, which owns Pi-native persona and model controls, SDD assets, chains, and memory wiring.
 


### PR DESCRIPTION
Closes #966

## Summary
- Adds a `## Hermes — Knowledge-Layer Agent` section in `CONTRIBUTING.md` explaining Hermes's role, capabilities, and contribution constraints per #966.
- Expands the Hermes row description in the README agent table by one phrase ("Knowledge-layer agent") so the table entry aligns with the new CONTRIBUTING.md section.

## Changes
| File | Change |
|------|--------|
| `CONTRIBUTING.md` | New section after "Pull Request Rules": Hermes overview, capabilities, why-it-matters, contributing notes. |
| `README.md` | One-word prefix on the Hermes row description: `Knowledge-layer agent:`. |

Every claim in the new section is verifiable from `internal/agents/hermes/adapter.go` (`Tier()`, `InstallCommand`, `MCPStrategy`, `SystemPromptStrategy`, `SkillsDir`, `*Dir` methods). One deviation from the issue's proposed text: the issue said "All SupportTier methods return TierFull" but the adapter only has one (`Tier()` at line 41), so the section reads "`Tier()` returns `TierFull`" — verifiable, no plural-method fiction.

## Test Plan
- [x] Markdown renders: no broken links added; the new section sits between the existing PR-rules block and Code of Conduct with the same `---` separators.
- [x] No code touched; no tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for the Hermes knowledge-layer agent, including capabilities, configuration, installation limitations, tier behavior, and unsupported features.
  - Updated the supported-agent documentation to clarify Hermes integration, YAML MCP configuration, and `SOUL.md` persona support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->