### PR TITLE
docs(engram): add Cloud Sync (Optional) section per #1021

### DIFF
--- a/docs/engram.md
+++ b/docs/engram.md
@@ -110,6 +110,56 @@ If you're working outside a git repo, engram falls back to the directory name.
 
 ---
 
+## Cloud Sync (Optional)
+
+> gentle-ai ships engram, which already supports an in-process cloud sync.
+> This page shows the one-time setup; the engine itself is maintained upstream.
+>
+> — Useful if you want your memories to follow you between machines you own.
+> — Not needed for team sharing via your repo (`engram sync --commit` does that).
+> — Skip if you only ever work on one machine — local memory is the default.
+
+### Pick your env-var carrier (persists across reboots)
+
+| OS / setup                            | Mechanism                                                 |
+|---------------------------------------|-----------------------------------------------------------|
+| macOS (LaunchAgents / GUI daemons)    | `launchctl setenv KEY VALUE`                              |
+| Linux (systemd user instance)         | `systemctl --user import-environment KEY=VALUE`           |
+| Anywhere (only this shell's children) | `export KEY=VALUE` in `~/.zshrc` / `~/.bashrc`             |
+
+### Three commands, one time
+
+```bash
+engram cloud config --server https://your-cloud-server.example
+engram cloud config --token <your-token>     # or paste at the interactive prompt
+launchctl setenv ENGRAM_CLOUD_AUTOSYNC 1     # or your carrier from the table above
+```
+
+### Verify
+
+```bash
+engram cloud status                          # "Sync readiness: ready"
+engram cloud enroll <project-name>           # one-time, per project
+engram sync --cloud --project <project-name> # first push (the loop handles the rest)
+```
+
+### Troubleshooting
+
+```bash
+engram cloud upgrade doctor --project <project-name>
+engram cloud upgrade repair --project <project-name> --apply
+```
+
+### Reference
+
+- Engram cloud docs: [github.com/Gentleman-Programming/engram/blob/main/docs/engram-cloud/README.md](https://github.com/Gentleman-Programming/engram/blob/main/docs/engram-cloud/README.md)
+- The in-process background loop: `internal/cloud/autosync/manager.go` (engram source)
+- Why this lives as a doc, not code, here: `docs/codebase/sync-and-cloud.md`
+
+> **Boundary note.** The token is passed via `engram cloud config --token`, not as an env var. Tokens in `ENGRAM_CLOUD_TOKEN` leak through `ps eww`, `log show`, `/proc/<pid>/environ` on Linux, and to any child process. The runtime resolves the token from `~/.engram/cloud.json` first; the env var is only a fallback.
+
+---
+
 ## Full Documentation
 
 For the complete source, configuration options, and contribution guide: [github.com/Gentleman-Programming/engram](https://github.com/Gentleman-Programming/engram)

--- a/docs/engram.md
+++ b/docs/engram.md
@@ -116,7 +116,7 @@ If you're working outside a git repo, engram falls back to the directory name.
 > This page shows the one-time setup; the engine itself is maintained upstream.
 >
 > — Useful if you want your memories to follow you between machines you own.
-> — Not needed for team sharing via your repo (`engram sync --commit` does that).
+> — Not needed for team sharing via your repo.
 > — Skip if you only ever work on one machine — local memory is the default.
 
 ### Pick your env-var carrier (persists across reboots)
@@ -127,12 +127,14 @@ If you're working outside a git repo, engram falls back to the directory name.
 | Linux (systemd user instance)         | `systemctl --user import-environment KEY=VALUE`           |
 | Anywhere (only this shell's children) | `export KEY=VALUE` in `~/.zshrc` / `~/.bashrc`             |
 
-### Three commands, one time
+### Three env vars, then start
+
+Set these through the carrier from the table above, then start (or restart) `engram serve` / `engram mcp` so they are present in the process environment:
 
 ```bash
-engram cloud config --server https://your-cloud-server.example
-engram cloud config --token <your-token>     # or paste at the interactive prompt
-launchctl setenv ENGRAM_CLOUD_AUTOSYNC 1     # or your carrier from the table above
+launchctl setenv ENGRAM_CLOUD_SERVER   https://your-cloud-server.example
+launchctl setenv ENGRAM_CLOUD_TOKEN    <your-token>
+launchctl setenv ENGRAM_CLOUD_AUTOSYNC 1
 ```
 
 ### Verify
@@ -147,6 +149,7 @@ engram sync --cloud --project <project-name> # first push (the loop handles the 
 
 ```bash
 engram cloud upgrade doctor --project <project-name>
+engram cloud upgrade repair --dry-run --project <project-name>
 engram cloud upgrade repair --project <project-name> --apply
 ```
 
@@ -156,7 +159,7 @@ engram cloud upgrade repair --project <project-name> --apply
 - The in-process background loop: `internal/cloud/autosync/manager.go` (engram source)
 - Why this lives as a doc, not code, here: `docs/codebase/sync-and-cloud.md`
 
-> **Boundary note.** The token is passed via `engram cloud config --token`, not as an env var. Tokens in `ENGRAM_CLOUD_TOKEN` leak through `ps eww`, `log show`, `/proc/<pid>/environ` on Linux, and to any child process. The runtime resolves the token from `~/.engram/cloud.json` first; the env var is only a fallback.
+> **Boundary note.** `ENGRAM_CLOUD_TOKEN` must be set before `engram serve` or `engram mcp` is started. Tokens in env vars leak through `ps eww`, `log show`, `/proc/<pid>/environ` on Linux, and to any child process, so use the carrier appropriate to your OS rather than a plain shell export.
 
 ---
 


### PR DESCRIPTION
Closes #1021

## Summary
- Adds the `## Cloud Sync (Optional)` section to `docs/engram.md` per the issue's proposed text, placed between "How Project Detection Works" and "Full Documentation" so it appears near the end as the issue requested.

## Changes
| File | Change |
|------|--------|
| `docs/engram.md` | New section: framing blockquote, env-var carrier table (macOS / Linux / anywhere), three-command setup, verify commands, troubleshooting commands, reference block, and a token-handling boundary note. |

## What was followed from the issue verbatim
- Section title, framing, carrier table, three-command setup, verify, troubleshooting, reference — all from the issue's proposed block.
- The token-handling boundary note appears as a closing blockquote rather than as inline prose, matching the issue's intent without inflating the section.

## What respects the boundary in `docs/codebase/sync-and-cloud.md`
- The section points at external Engram sources for the implementation (`internal/cloud/autosync/manager.go`) and never describes the cloud transport as Gentle-AI code.
- No `scripts/setup-cloud-sync.sh` is added (the issue explicitly forbids it; `docs/codebase/sync-and-cloud.md` reinforces that boundary).

## Test Plan
- [x] Markdown renders: section sits between the existing sections with the same `---` separator.
- [x] All internal links resolve to existing files: `docs/codebase/sync-and-cloud.md` and the README mention.
- [x] External links point at the Engram repo, not invented URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for setting up optional Cloud Sync.
  * Documented environment-variable persistence, project enrollment, and initial synchronization.
  * Added troubleshooting commands and reference material for diagnosing sync issues.
  * Included recommendations for protecting access tokens and avoiding accidental exposure during configuration and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->