### PR TITLE
docs(agents): add OpenCode headless delegation recipe on Windows per #1017

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -73,13 +73,13 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 
 ### OpenCode headless delegation on Windows
 
-Windows users without WSL, tmux, or zellij can route headless OpenCode work into a persistent, identifiable terminal window using Windows Terminal (`wt.exe`, ships with Windows Terminal):
+Windows users without WSL, tmux, or zellij can run headless OpenCode work in a stable, named terminal window using Windows Terminal (`wt.exe`, ships with Windows Terminal):
 
 ```bash
-wt -w orquestador-gentleman new-tab --title "OpenCode" opencode run --agent gentle-orchestrator "<task>"
+wt --suppressApplicationTitle -w orquestador-gentleman new-tab --title "OpenCode" opencode run --agent gentle-orchestrator "<task>"
 ```
 
-`wt -w <name>` reuses an existing named window if one is already open, or creates it if not — the closest native Windows equivalent to targeting a persistent tmux pane by name. Combined with `opencode run --agent <name> "<task>"` headless mode (no TUI interaction required), this gives Windows users a scriptable delegation path with zero extra dependencies (no WSL, no tmux port).
+`wt -w <name>` reuses an existing named window if one is already open, or creates one if not; `new-tab` adds a fresh tab in it on each invocation. Each task lands in its own tab inside the named window — this is not a persistent pane or session like `tmux send-keys`. `--suppressApplicationTitle` keeps the `OpenCode` tab title stable across invocations. Combined with `opencode run --agent <name> "<task>"` headless mode (no TUI interaction required), this gives Windows users a scriptable delegation path with zero extra dependencies (no WSL, no tmux port).
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -71,6 +71,16 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - Phase-specific tools are preserved (`sdd-explore` and `sdd-verify` use read/shell/context7 as required)
 - Orchestrator remains in steering (`~/.kiro/steering/gentle-ai.md`) and delegates execution to native subagents
 
+### OpenCode headless delegation on Windows
+
+Windows users without WSL, tmux, or zellij can route headless OpenCode work into a persistent, identifiable terminal window using Windows Terminal (`wt.exe`, ships with Windows Terminal):
+
+```bash
+wt -w orquestador-gentleman new-tab --title "OpenCode" opencode run --agent gentle-orchestrator "<task>"
+```
+
+`wt -w <name>` reuses an existing named window if one is already open, or creates it if not — the closest native Windows equivalent to targeting a persistent tmux pane by name. Combined with `opencode run --agent <name> "<task>"` headless mode (no TUI interaction required), this gives Windows users a scriptable delegation path with zero extra dependencies (no WSL, no tmux port).
+
 ---
 
 ## SDD Mode Support


### PR DESCRIPTION
Closes #1017

## Summary
- Adds a new `### OpenCode headless delegation on Windows` subsection under `## Delegation Models` in `docs/agents.md` documenting the `wt.exe`-based recipe for Windows users who don't have WSL, tmux, or zellij installed.

## Changes
| File | Change |
|------|--------|
| `docs/agents.md` | New subsection after `### Kiro Native Subagents` (the last existing per-agent delegation subsection): one `wt -w orquestador-gentleman new-tab --title "OpenCode" opencode run --agent gentle-orchestrator "<task>"` command block plus a one-paragraph explanation of why `wt -w <name>` is the Windows-native equivalent of tmux pane naming. |

## What was followed from the issue verbatim
- The exact `wt` invocation from the issue's "Proposed Solution" block.
- The issue's framing of `wt -w <name>` as the closest Windows equivalent to targeting a persistent tmux pane by name.
- The zero-extra-dependencies note (no WSL, no tmux port).

## Test Plan
- [x] Markdown renders: subsection sits between the existing Kiro subsection and the existing `---` separator, matching the per-agent subsection convention.
- [x] The `opencode run --agent gentle-orchestrator "<task>"` shape is already referenced in the OpenCode note (line 103 of `docs/agents.md`), so the recipe's agent name and headless-mode contract trace to existing docs.
- [x] No code touched; no tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Windows guidance for delegating tasks to OpenCode in headless mode.
  * Instructions use a named Windows Terminal window and do not require WSL, tmux, or zellij.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->