### PR TITLE
fix(tui): reject unusable interactive streams

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,10 @@ import (
 // Version is set from main via ldflags at build time.
 var Version = "dev"
 
+// ErrNoTTYForTUI is returned when the interactive route cannot use both
+// process streams as terminals.
+var ErrNoTTYForTUI = errors.New("gentle-ai: interactive mode requires terminal stdin and stdout; use --version, 'gentle-ai update', or --help instead")
+
 var (
 	updateCheckAll            = update.CheckAll
 	updateCheckFiltered       = update.CheckFiltered
@@ -56,6 +60,10 @@ var (
 		return err
 	}
 )
+
+func tuiStreamsAreTerminals() bool {
+	return isattyFn(os.Stdin.Fd()) && isattyFn(os.Stdout.Fd())
+}
 
 func Run() error {
 	return RunArgs(os.Args[1:], os.Stdout)
@@ -133,6 +141,13 @@ func RunArgs(args []string, stdout io.Writer) error {
 				return nil
 			}
 		}
+	}
+
+	// No arguments select the interactive TUI. Refuse before parsing, platform
+	// detection, persisted effects, or model construction when either process
+	// stream cannot support that route.
+	if len(args) == 0 && !tuiStreamsAreTerminals() {
+		return ErrNoTTYForTUI
 	}
 
 	// Issue #535: parse the upgrade command's arguments exactly once, before

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1389,6 +1389,96 @@ func TestHelpCommand(t *testing.T) {
 	}
 }
 
+func TestRunArgsNoTTYRefusesBeforeTUIEffects(t *testing.T) {
+	origIsatty := isattyFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		isattyFn = origIsatty
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	tests := []struct {
+		name           string
+		stdinTerminal  bool
+		stdoutTerminal bool
+	}{
+		{name: "non-terminal stdin", stdoutTerminal: true},
+		{name: "non-terminal stdout", stdinTerminal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var effects []string
+			isattyFn = func(fd uintptr) bool {
+				switch fd {
+				case os.Stdin.Fd():
+					return tt.stdinTerminal
+				case os.Stdout.Fd():
+					return tt.stdoutTerminal
+				default:
+					return false
+				}
+			}
+			ensureCurrentOSSupported = func() error {
+				effects = append(effects, "OS support")
+				return nil
+			}
+			detectSystem = func(context.Context) (system.DetectionResult, error) {
+				effects = append(effects, "system detection")
+				return system.DetectionResult{}, nil
+			}
+			runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+				effects = append(effects, "TUI launch")
+				return m, nil
+			}
+			deferredSyncFn = func() error {
+				effects = append(effects, "deferred sync")
+				return nil
+			}
+
+			err := RunArgs(nil, io.Discard)
+			if !errors.Is(err, ErrNoTTYForTUI) {
+				t.Fatalf("RunArgs(nil) error = %v, want ErrNoTTYForTUI", err)
+			}
+			if err != ErrNoTTYForTUI {
+				t.Fatalf("RunArgs(nil) error = %v, want exact ErrNoTTYForTUI sentinel", err)
+			}
+			for _, guidance := range []string{"--version", "gentle-ai update", "--help"} {
+				if !strings.Contains(err.Error(), guidance) {
+					t.Fatalf("RunArgs(nil) error = %q, want %q guidance", err, guidance)
+				}
+			}
+			if len(effects) != 0 {
+				t.Fatalf("RunArgs(nil) effects = %v, want none", effects)
+			}
+		})
+	}
+}
+
+func TestRunArgsInfoCommandsBypassTTYGuard(t *testing.T) {
+	origIsatty := isattyFn
+	t.Cleanup(func() { isattyFn = origIsatty })
+	isattyFn = func(uintptr) bool { return false }
+
+	for _, arg := range []string{"version", "--version", "-v", "help", "--help", "-h"} {
+		t.Run(arg, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunArgs([]string{arg}, &output); err != nil {
+				t.Fatalf("RunArgs(%q) error = %v", arg, err)
+			}
+			if output.Len() == 0 {
+				t.Fatalf("RunArgs(%q) produced no output", arg)
+			}
+		})
+	}
+}
+
 // TestUnknownCommandSuggestsHelp verifies that an unrecognised command returns
 // an error whose message suggests running 'gentle-ai help'.
 func TestUnknownCommandSuggestsHelp(t *testing.T) {
@@ -1532,8 +1622,16 @@ func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
 	}
 }
 
+func withTerminalStreams(t *testing.T) {
+	t.Helper()
+	origIsatty := isattyFn
+	isattyFn = func(uintptr) bool { return true }
+	t.Cleanup(func() { isattyFn = origIsatty })
+}
+
 func TestRunArgs_TUISkipsSelfUpdate(t *testing.T) {
 	// NOTE: modifies package-level vars; must not run in parallel.
+	withTerminalStreams(t)
 	origSelfUpdate := selfUpdateFn
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
@@ -2023,6 +2121,7 @@ func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 // reports a successful gentle-ai upgrade, RunArgs calls restartAfterGentleAIUpgrade
 // which (after task 4.6) prints the restart guidance message instead of re-execing.
 func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
+	withTerminalStreams(t)
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
 	origRunTUI := runTUI
@@ -2064,6 +2163,7 @@ func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
 // state.json has PendingSync=true, RunArgs (TUI path / no args) calls
 // the deferred sync runner and writes PendingSync=false on success.
 func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2127,6 +2227,7 @@ func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
 // TestRunArgs_PendingSync_LeavesSetOnFailure verifies that when the deferred
 // sync fails, PendingSync remains true so the next launch retries idempotently.
 func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2192,6 +2293,7 @@ func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
 // error is printed to stdout and RunArgs does not return an error.
 // This guards against silently swallowed write failures (Issue 2).
 func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2255,6 +2357,7 @@ func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
 // TestRunArgs_NoPendingSync_NoSyncCall verifies that when PendingSync=false,
 // the deferred sync runner is NOT called (no extra sync on a normal launch).
 func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2313,6 +2416,7 @@ func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
 // post-upgrade state. Per #1901, this reuses the existing PendingSync signal
 // rather than introducing a new persisted flag.
 func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2366,6 +2470,7 @@ func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
 // the doctor advisory is printed regardless of deferred sync outcome. The
 // advisory is informational and complements the sync outcome (not a replacement).
 func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2419,6 +2524,7 @@ func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T)
 // doctor advisory is NOT printed on a normal launch where PendingSync=false.
 // The advisory is gated strictly on the post-upgrade signal.
 func TestRunArgs_NoPendingSync_DoesNotPrintDoctorAdvisory(t *testing.T) {
+	withTerminalStreams(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -164,22 +165,26 @@ func TestGuardFlowLinuxDryRunPropagatesDecision(t *testing.T) {
 func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
 	withTerminalStreams(t)
 	origRunTUI := runTUI
-	t.Cleanup(func() { runTUI = origRunTUI })
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	t.Cleanup(func() {
+		runTUI = origRunTUI
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+	})
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
+	wantErr := errors.New("mock TUI reached")
 	runTUI = func(m tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {
-		return nil, errors.New("mock TUI error: no TTY")
+		return nil, wantErr
 	}
 
 	var buf bytes.Buffer
 	err := RunArgs(nil, &buf)
-	// With no args, RunArgs now launches the TUI via Bubbletea.
-	// In a headless/test environment without a TTY, this returns an error
-	// about opening /dev/tty. That's expected — the TUI requires a terminal.
-	if err == nil {
-		// If no error, we're somehow in a TTY — that's fine too.
-		return
-	}
-	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") && !strings.Contains(err.Error(), "mock TUI") {
-		t.Fatalf("RunArgs(nil) unexpected error = %v; want TTY-related error or nil", err)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RunArgs(nil) error = %v, want exact mocked TUI error", err)
 	}
 }
 

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -162,6 +162,7 @@ func TestGuardFlowLinuxDryRunPropagatesDecision(t *testing.T) {
 }
 
 func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
+	withTerminalStreams(t)
 	origRunTUI := runTUI
 	t.Cleanup(func() { runTUI = origRunTUI })
 	runTUI = func(m tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -32,8 +32,15 @@ const (
 	envYesUpdate      = "GENTLE_AI_YES"
 )
 
-// isattyFn is a package-level var for TTY detection, injectable for tests.
-var isattyFn = func(fd uintptr) bool { return isatty.IsTerminal(fd) }
+// isattyFn recognizes native and Cygwin/MSYS2 terminals and is injectable for
+// tests. Both the TUI boundary and self-update prompt share this predicate.
+var isattyFn = func(fd uintptr) bool {
+	return recognizedTerminal(fd, isatty.IsTerminal, isatty.IsCygwinTerminal)
+}
+
+func recognizedTerminal(fd uintptr, native, cygwin func(uintptr) bool) bool {
+	return native(fd) || cygwin(fd)
+}
 
 // selfUpdateYesFn returns true when the caller wants the upgrade to proceed
 // without an interactive prompt. Set GENTLE_AI_YES=1 for scripted upgrades.

--- a/internal/app/selfupdate_test.go
+++ b/internal/app/selfupdate_test.go
@@ -892,6 +892,29 @@ func TestDefaultPromptForUpdate_NonTTY_AutoDeclines(t *testing.T) {
 	}
 }
 
+func TestRecognizedTerminal(t *testing.T) {
+	tests := []struct {
+		name   string
+		native bool
+		cygwin bool
+		want   bool
+	}{
+		{name: "neither terminal"},
+		{name: "native terminal", native: true, want: true},
+		{name: "Cygwin or MSYS2 terminal", cygwin: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			native := func(uintptr) bool { return tt.native }
+			cygwin := func(uintptr) bool { return tt.cygwin }
+			if got := recognizedTerminal(0, native, cygwin); got != tt.want {
+				t.Fatalf("recognizedTerminal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestDefaultPromptForUpdate_EmptyInput_AcceptsDefault verifies that pressing Enter
 // (empty input) accepts the default Y. Task 5.6.
 func TestDefaultPromptForUpdate_EmptyInput_AcceptsDefault(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #95

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Refuses the no-argument interactive TUI before any startup effects when stdin or stdout is not a terminal.
- Reuses one terminal predicate with native and Cygwin/MSYS2 recognition.
- Keeps explicit commands available in headless environments and prevents Bubble Tea fallback hangs or redirected ANSI output.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/app/app.go` | Adds the stable no-TTY sentinel and the early two-stream interactive-boundary guard. |
| `internal/app/selfupdate.go` | Extends the existing shared terminal predicate to native and Cygwin/MSYS2 terminals. |
| `internal/app/app_test.go` | Covers missing input/output, zero startup effects, guidance, explicit-command bypass, and deterministic TUI tests. |
| `internal/app/parity_test.go` | Makes the existing interactive no-argument contract explicit. |
| `internal/app/selfupdate_test.go` | Covers native and Cygwin/MSYS2 terminal recognition. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenAI `gpt-5.6-sol` through OpenCode.

**Material scope:** Root-cause analysis, focused implementation, behavior-first test coverage, runtime harness verification, and independent read-only review.

**Verification performed:** Focused app suite, repository format check, diff check, built-binary closed-stdin behavior, explicit help/version controls, and one independent read-only review with no candidate-caused findings.

---

## 🧪 Test Plan

**Focused Unit Tests**

```bash
go test ./internal/app/... -count=1
```

Result: PASS.

**Go Format**

```bash
go run ./internal/gofmtcheck
```

Result: PASS.

**Built-binary boundary**

A freshly built binary was launched with closed redirected stdin and stdout. The no-argument route exited 1 in approximately 746 ms, wrote no stdout or ANSI, and returned actionable stderr. `--help` and `--version` exited 0 under the same redirected-stream harness.

**Full Unit and E2E Suites**

Pending repository CI on this exact commit.

**Benchmark Validation**

N/A. This change does not touch review lifecycle, gates, recovery, delivery, benchmark code, corpus, classifier, or benchmark claims.

- [ ] Full unit tests pass (`go test ./...`) — pending CI
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending CI
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 156 changed lines, below the 400-line budget |
| Check Issue Reference | ⏳ | `Closes #95` |
| Check Issue Has `status:approved` | ⏳ | Issue #95 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` will be the only type label |
| Unit Tests | ⏳ | Runs automatically |
| Go Format | ⏳ | Runs automatically |
| E2E Tests | ⏳ | Runs automatically |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Full unit tests pass (`go test ./...`) — pending CI
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending CI
- [x] Benchmark validation is not applicable to this change
- [x] Documentation changes are not necessary; the user-facing diagnostic and issue root-cause note are the complete documentation surface
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The production delta is 24 insertions and 2 deletions. The rest is deterministic coverage adapting existing no-argument TUI tests to explicit terminal conditions.

Please focus on the boundary ordering, the requirement for both stdin and stdout, and the reuse of one native/Cygwin terminal predicate. PR #905 was closed because its stale branch no longer represented current main; the updated root analysis is recorded in #95.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear error when interactive mode is launched without usable terminal input and output.
  * Informational commands such as version, help, and updates remain available in non-terminal environments.
  * Improved terminal recognition, including support for Cygwin and MSYS2 terminals.

* **Bug Fixes**
  * Prevented interactive mode from triggering unintended actions when terminal access is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->