### PR TITLE
fix(tui): detect missing tty on startup and exit cleanly

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/opencodeplugin"
@@ -42,6 +43,16 @@ var (
 	runTUI                    = func(m tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {
 		p := tea.NewProgram(m, opts...)
 		return p.Run()
+	}
+	isTerminalStream = func(f *os.File) bool {
+		if f == nil {
+			return false
+		}
+		fd := f.Fd()
+		return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+	}
+	isInteractiveTerminalFn = func() bool {
+		return isTerminalStream(os.Stdin) && isTerminalStream(os.Stdout)
 	}
 	// deferredSyncFn is the function called when PendingSync=true is found on
 	// launch. Swappable for tests; production value calls cli.RunSync directly.
@@ -148,6 +159,13 @@ func RunArgs(args []string, stdout io.Writer) error {
 			return err
 		}
 		parsedUpgrade = &parsed
+	}
+
+	// Issue #95: The no-argument route launches the interactive TUI.
+	// Verify that both stdin and stdout are interactive terminals before
+	// performing OS validation, system detection, probes, or launching Bubbletea.
+	if len(args) == 0 && !isInteractiveTerminalFn() {
+		return errors.New("gentle-ai interactive TUI requires an interactive terminal (TTY)\nFor non-interactive usage, run 'gentle-ai --help' or 'gentle-ai --version'")
 	}
 
 	if err := ensureCurrentOSSupported(); err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -44,6 +44,8 @@ var (
 		p := tea.NewProgram(m, opts...)
 		return p.Run()
 	}
+	// isTerminalStream checks if a file descriptor is an interactive terminal
+	// (native or Cygwin/MSYS2 terminal); injectable for tests.
 	isTerminalStream = func(f *os.File) bool {
 		if f == nil {
 			return false
@@ -51,6 +53,8 @@ var (
 		fd := f.Fd()
 		return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 	}
+	// isInteractiveTerminalFn verifies both stdin and stdout are interactive terminals;
+	// injectable for tests.
 	isInteractiveTerminalFn = func() bool {
 		return isTerminalStream(os.Stdin) && isTerminalStream(os.Stdout)
 	}
@@ -165,7 +169,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 	// Verify that both stdin and stdout are interactive terminals before
 	// performing OS validation, system detection, probes, or launching Bubbletea.
 	if len(args) == 0 && !isInteractiveTerminalFn() {
-		return errors.New("gentle-ai interactive TUI requires an interactive terminal (TTY)\nFor non-interactive usage, run 'gentle-ai --help' or 'gentle-ai --version'")
+		return errors.New("gentle-ai interactive TUI requires an interactive terminal (TTY)\nFor non-interactive usage, run 'gentle-ai --help', 'gentle-ai --version', or 'gentle-ai update'")
 	}
 
 	if err := ensureCurrentOSSupported(); err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1534,6 +1534,7 @@ func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
 
 func TestRunArgs_TUISkipsSelfUpdate(t *testing.T) {
 	// NOTE: modifies package-level vars; must not run in parallel.
+	setupMockInteractiveTerminal(t, true)
 	origSelfUpdate := selfUpdateFn
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
@@ -1611,6 +1612,17 @@ func setupMockHome(t *testing.T, home string) {
 	})
 	os.Setenv("HOME", home)
 	os.Setenv("USERPROFILE", home)
+}
+
+func setupMockInteractiveTerminal(t *testing.T, interactive bool) {
+	t.Helper()
+	orig := isInteractiveTerminalFn
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = orig
+	})
+	isInteractiveTerminalFn = func() bool {
+		return interactive
+	}
 }
 
 // TestTUIExecuteReturnsStatePersistenceFailure verifies that the TUI applies
@@ -2023,6 +2035,7 @@ func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 // reports a successful gentle-ai upgrade, RunArgs calls restartAfterGentleAIUpgrade
 // which (after task 4.6) prints the restart guidance message instead of re-execing.
 func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
 	origRunTUI := runTUI
@@ -2064,6 +2077,7 @@ func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
 // state.json has PendingSync=true, RunArgs (TUI path / no args) calls
 // the deferred sync runner and writes PendingSync=false on success.
 func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2127,6 +2141,7 @@ func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
 // TestRunArgs_PendingSync_LeavesSetOnFailure verifies that when the deferred
 // sync fails, PendingSync remains true so the next launch retries idempotently.
 func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2192,6 +2207,7 @@ func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
 // error is printed to stdout and RunArgs does not return an error.
 // This guards against silently swallowed write failures (Issue 2).
 func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2255,6 +2271,7 @@ func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
 // TestRunArgs_NoPendingSync_NoSyncCall verifies that when PendingSync=false,
 // the deferred sync runner is NOT called (no extra sync on a normal launch).
 func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2313,6 +2330,7 @@ func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
 // post-upgrade state. Per #1901, this reuses the existing PendingSync signal
 // rather than introducing a new persisted flag.
 func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2366,6 +2384,7 @@ func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
 // the doctor advisory is printed regardless of deferred sync outcome. The
 // advisory is informational and complements the sync outcome (not a replacement).
 func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2419,6 +2438,7 @@ func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T)
 // doctor advisory is NOT printed on a normal launch where PendingSync=false.
 // The advisory is gated strictly on the post-upgrade signal.
 func TestRunArgs_NoPendingSync_DoesNotPrintDoctorAdvisory(t *testing.T) {
+	setupMockInteractiveTerminal(t, true)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2609,4 +2629,74 @@ func writeFakeOpenCodeRuntime(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return binDir
+}
+
+// ─── Issue #95: TTY detection before TUI launch ──────────────────────────────
+
+// TestRunArgs_NoArgs_RequiresInteractiveTerminal verifies that launching the TUI
+// without an interactive terminal returns a clear, actionable error before
+// performing OS validation, system detection, probes, or launching Bubbletea.
+func TestRunArgs_NoArgs_RequiresInteractiveTerminal(t *testing.T) {
+	setupMockInteractiveTerminal(t, false)
+
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
+	origRunTUI := runTUI
+	detectCalled := 0
+	ensureCalled := 0
+	tuiCalled := 0
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		detectCalled++
+		return system.DetectionResult{}, nil
+	}
+	ensureCurrentOSSupported = func() error {
+		ensureCalled++
+		return nil
+	}
+	runTUI = func(tea.Model, ...tea.ProgramOption) (tea.Model, error) {
+		tuiCalled++
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
+		runTUI = origRunTUI
+	})
+
+	var buf bytes.Buffer
+	err := RunArgs(nil, &buf)
+	if err == nil {
+		t.Fatalf("RunArgs(nil) with non-interactive terminal expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "interactive TUI requires an interactive terminal (TTY)") {
+		t.Errorf("error = %q, want TTY required notice", err.Error())
+	}
+	if !strings.Contains(err.Error(), "--help") || !strings.Contains(err.Error(), "--version") {
+		t.Errorf("error = %q, want guidance with --help and --version", err.Error())
+	}
+	if detectCalled != 0 || ensureCalled != 0 || tuiCalled != 0 {
+		t.Errorf("expected zero downstream calls, got detect=%d ensure=%d tui=%d", detectCalled, ensureCalled, tuiCalled)
+	}
+}
+
+// TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal verifies that
+// non-interactive commands (--version, --help) succeed without requiring a TTY.
+func TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal(t *testing.T) {
+	setupMockInteractiveTerminal(t, false)
+
+	var buf bytes.Buffer
+	if err := RunArgs([]string{"--version"}, &buf); err != nil {
+		t.Fatalf("RunArgs(--version) error = %v, want success in non-interactive environment", err)
+	}
+	if !strings.Contains(buf.String(), "gentle-ai") {
+		t.Fatalf("RunArgs(--version) output = %q, want version output", buf.String())
+	}
+
+	buf.Reset()
+	if err := RunArgs([]string{"--help"}, &buf); err != nil {
+		t.Fatalf("RunArgs(--help) error = %v, want success in non-interactive environment", err)
+	}
+	if !strings.Contains(buf.String(), "gentle-ai") {
+		t.Fatalf("RunArgs(--help) output = %q, want help output", buf.String())
+	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2680,7 +2680,7 @@ func TestRunArgs_NoArgs_RequiresInteractiveTerminal(t *testing.T) {
 }
 
 // TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal verifies that
-// non-interactive commands (--version, --help) succeed without requiring a TTY.
+// non-interactive commands (--version, --help, update) succeed without requiring a TTY.
 func TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal(t *testing.T) {
 	setupMockInteractiveTerminal(t, false)
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2684,6 +2684,30 @@ func TestRunArgs_NoArgs_RequiresInteractiveTerminal(t *testing.T) {
 func TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal(t *testing.T) {
 	setupMockInteractiveTerminal(t, false)
 
+	origCheckAll := updateCheckAll
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
+	t.Cleanup(func() {
+		updateCheckAll = origCheckAll
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
+	})
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
+	updateCheckAll = func(context.Context, string, system.PlatformProfile) []update.UpdateResult {
+		return []update.UpdateResult{
+			{
+				Tool:             update.ToolInfo{Name: "gentle-ai"},
+				InstalledVersion: "1.0.0",
+				LatestVersion:    "1.0.0",
+				Status:           update.UpToDate,
+			},
+		}
+	}
+
 	var buf bytes.Buffer
 	if err := RunArgs([]string{"--version"}, &buf); err != nil {
 		t.Fatalf("RunArgs(--version) error = %v, want success in non-interactive environment", err)
@@ -2698,5 +2722,10 @@ func TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal(t *testing.T) 
 	}
 	if !strings.Contains(buf.String(), "gentle-ai") {
 		t.Fatalf("RunArgs(--help) output = %q, want help output", buf.String())
+	}
+
+	buf.Reset()
+	if err := RunArgs([]string{"update"}, &buf); err != nil {
+		t.Fatalf("RunArgs(update) error = %v, want success in non-interactive environment", err)
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2728,4 +2728,7 @@ func TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal(t *testing.T) 
 	if err := RunArgs([]string{"update"}, &buf); err != nil {
 		t.Fatalf("RunArgs(update) error = %v, want success in non-interactive environment", err)
 	}
+	if !strings.Contains(buf.String(), "gentle-ai") {
+		t.Fatalf("RunArgs(update) output = %q, want update output", buf.String())
+	}
 }


### PR DESCRIPTION
## Summary
Resolves #95 by checking for an interactive terminal (`isatty`) on `stdin` and `stdout` before entering the interactive TUI route (`len(args) == 0`).

## Problem & Root Cause
When `gentle-ai` is executed without arguments in a non-interactive environment (e.g. CI/CD pipelines, non-interactive SSH, or scripts with redirected input), the startup path proceeds to initialize Bubble Tea directly. Bubble Tea attempts to open `/dev/tty` or `CONIN$`, which either hangs waiting for interactive input or crashes with an opaque error (`Error: could not open a new TTY: open /dev/tty: device not configured`).

## Solution
- **Pre-flight TTY check**: In `internal/app/app.go`, verify that both `os.Stdin` and `os.Stdout` are interactive terminals (`isatty.IsTerminal` / `isatty.IsCygwinTerminal`) before performing system detection, probes, state reading, or Bubble Tea initialization.
- **Actionable error output**: When no TTY is available, immediately return a clear diagnostic pointing to non-interactive commands (`--help`, `--version`) and exit with non-zero status.
- **Explicit commands unaffected**: Commands like `gentle-ai --version`, `gentle-ai --help`, `gentle-ai update`, etc., continue working without requiring a TTY.
- **Zero overengineering**: Reuses existing `github.com/mattn/go-isatty` without adding new flags, environment toggles, or unnecessary state.

## Verification
- **Unit & Regression Tests**: Added `TestRunArgs_NoArgs_RequiresInteractiveTerminal` and `TestRunArgs_ExplicitCommands_DoNotRequireInteractiveTerminal` to `internal/app/app_test.go`. Full package test suite passes:
  ```bash
  go test -v ./internal/app/...
  ```
- **Manual Verification**:
  - Closed/redirected stdin (`gentle-ai < /dev/null`): Exits immediately with code `1` and outputs:
    ```text
    Error: gentle-ai interactive TUI requires an interactive terminal (TTY)
    For non-interactive usage, run 'gentle-ai --help' or 'gentle-ai --version'
    ```
  - Non-interactive `--version` and `--help`: Execute cleanly with exit code `0`.

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The app now detects whether it is running in an interactive terminal before launching the terminal interface.
  - Starting the app without arguments in a non-interactive environment now provides clear guidance to use help, version, or update commands.
  - `--help`, `--version`, and `update` continue to work in non-interactive environments.
  - Non-interactive launches are rejected before system checks or interface startup, preventing confusing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->