### PR TITLE
fix(review): bind the correction transition to its frozen candidate

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -664,6 +664,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, stagedDeliveryJourneys()...)
 	journeys = append(journeys, frozenLineageResumeJourneys()...)
 	journeys = append(journeys, issue1800Journeys()...)
+	journeys = append(journeys, issue3194Journeys()...)
 	journeys = append(journeys, issue2879Journeys()...)
 	journeys = append(journeys, managedAssetJourneys()...)
 	journeys = append(journeys, issue2906Journeys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -49,6 +49,7 @@ func journeySources() []journeySource {
 		{"journeys_staged_delivery.go", stagedDeliveryJourneys()},
 		{"journeys_frozen_lineage_resume.go", frozenLineageResumeJourneys()},
 		{"journeys_issue1800.go", issue1800Journeys()},
+		{"journeys_issue3194.go", issue3194Journeys()},
 		{"journeys_issue2879.go", issue2879Journeys()},
 		{"journeys_managed_assets.go", managedAssetJourneys()},
 		{"journeys_issue2906.go", issue2906Journeys()},

--- a/bench/journeys_issue3194.go
+++ b/bench/journeys_issue3194.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -147,11 +146,11 @@ func proveIssue3194CorrectionContinues(r *journeyRun) error {
 }
 
 func issue3194ProposedCorrectionLines(r *journeyRun) (int, error) {
-	common, err := gitOut(r.sandbox, r.sandbox.Repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	statePath, err := storeStatePath(r.sandbox, issue3194Lineage)
 	if err != nil {
 		return 0, err
 	}
-	stateBytes, err := os.ReadFile(filepath.Join(strings.TrimSpace(common), "gentle-ai", "review-transactions", "v2", issue3194Lineage, "review-state.json"))
+	stateBytes, err := os.ReadFile(statePath)
 	if err != nil {
 		return 0, err
 	}

--- a/bench/journeys_issue3194.go
+++ b/bench/journeys_issue3194.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const issue3194Lineage = "issue-3194-preplan-correction-forecast"
+
+// issue3194Journeys proves the honest correction order: a consumer cannot know
+// a line count before writing the lines, so the bounded correction is already
+// in the working tree when the forecast is submitted. Every token of the
+// correction transition must name the frozen reviewed candidate the correction
+// request and the repository-context handle already commit to, and the
+// descriptor must execute exactly as issued.
+//
+// This is the within-budget sibling of j91 (issue #1800). D1800's audited
+// abandon stays the exit for a pre-plan edit that no longer fits the frozen
+// budget; it was never the exit for one that does, and issue #3194 collected
+// occurrences where a budget-compliant correction could not be submitted at
+// all because STATUS paired a live `--target` with a frozen handle.
+func issue3194Journeys() []Journey {
+	return []Journey{{
+		ID:     "j111-preplan-correction-forecast-executes-as-issued",
+		Review: reviewOptedIn,
+		Title:  "Within-budget correction written before its forecast submits as issued and keeps routing",
+		Source: "issue #3194: the correction transition binds the frozen candidate, not the moved live snapshot",
+		Steps: []Step{
+			{Name: "fixture: repository", Fixture: baseRepo},
+			{Name: "clear any clone-local review override (a clone may only ever assert off)", Requires: modeCapability, Args: productArgs("review", "mode", "enable", "--scope", "clone", "--json")},
+			{Name: "fixture: stage candidate", Fixture: stageWaveCandidate},
+			{Name: "start product-created compact review", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", issue3194Lineage)},
+			{Name: "capture candidate finding", Requires: captureResultCapability, Composite: captureIssue3194CorrectableFinding},
+			{Name: "finalize into correction-required", Requires: finalizeResultsCapability, Args: productArgs("review", "finalize", "--lineage", issue3194Lineage, "--captured-results=true"), After: requireReviewState("correction_required", issue3194Lineage)},
+			{Name: "freeze the pre-forecast candidate identity", Requires: statusCapability, Composite: recordIssue3194FrozenCandidate},
+			{Name: "fixture: write the within-budget correction before forecasting it", Fixture: writeCorrectedCandidate},
+			{Name: "STATUS binds the frozen candidate, not the moved live snapshot", Requires: statusCapability, Composite: proveIssue3194FrozenBinding},
+			{Name: "the issued forecast descriptor executes verbatim", Requires: finalizeCorrectionCapability, Composite: submitIssue3194CorrectionForecast},
+			{Name: "the corrected candidate keeps routing to repository verification", Requires: statusCapability, Composite: proveIssue3194CorrectionContinues},
+		},
+	}}
+}
+
+func captureIssue3194CorrectableFinding(r *journeyRun) error {
+	return captureCorrectableFindingFor(r, "--lineage", issue3194Lineage)
+}
+
+func recordIssue3194FrozenCandidate(r *journeyRun) error {
+	status, err := readCorrectionStatusForContract(r, issue3194Lineage, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	if status.Authority == nil || status.Authority.State != "correction_required" || status.NextTransition == nil ||
+		status.NextTransition.Kind != "collect" || status.NextTransition.ReasonCode != "correction_plan_required" ||
+		status.Projection.CurrentSnapshotIdentity == "" || status.TargetIdentity != status.Projection.CurrentSnapshotIdentity {
+		return fmt.Errorf("pre-forecast correction status = %+v", status)
+	}
+	r.sandbox.Scratch["issue3194-frozen-candidate"] = status.Projection.CurrentSnapshotIdentity
+	r.sandbox.Scratch["issue3194-revision"] = status.Authority.Revision
+	return nil
+}
+
+// proveIssue3194FrozenBinding is the defect's exact shape. The reported
+// occurrences all failed here: `--target` named the live snapshot the
+// correction edit had just produced, while the repository-context handle in the
+// same descriptor could only ever commit to the frozen candidate, so no value
+// substitution could satisfy both.
+func proveIssue3194FrozenBinding(r *journeyRun) error {
+	frozen := r.sandbox.Scratch["issue3194-frozen-candidate"]
+	status, err := readCorrectionStatusForContract(r, issue3194Lineage, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "correction_plan_required" || status.NextTransition.Collect == nil ||
+		len(status.NextTransition.Collect.Inputs) != 1 {
+		return fmt.Errorf("post-edit correction transition = %+v", status.NextTransition)
+	}
+	if status.TargetIdentity == frozen {
+		return fmt.Errorf("the correction edit never moved the live snapshot away from %s", frozen)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.Submission == nil {
+		return fmt.Errorf("correction transition carries no submission descriptor: %+v", input)
+	}
+	for _, argument := range input.Arguments {
+		if argument.Name == "target" && argument.Value != frozen {
+			return fmt.Errorf("collect target argument = %s, want the frozen candidate %s", argument.Value, frozen)
+		}
+	}
+	target, found := "", false
+	for _, token := range input.Submission.ArgumentTokens {
+		if value, ok := strings.CutPrefix(token, "--target="); ok {
+			target, found = value, true
+		}
+	}
+	if !found || target != frozen {
+		return fmt.Errorf("descriptor --target = %q (found %t), want the frozen candidate %s", target, found, frozen)
+	}
+	return nil
+}
+
+func submitIssue3194CorrectionForecast(r *journeyRun) error {
+	status, err := readCorrectionStatusForContract(r, issue3194Lineage, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	arguments, err := correctionSubmissionArguments(r, status, "correction_plan_required", "correction_lines", "1")
+	if err != nil {
+		return err
+	}
+	result, err := decodeWaveOperation(r.runAt(r.sandbox.Root, arguments, false), "pre-forecast correction submission")
+	if err != nil || result.State != "correction_required" || result.LineageID != issue3194Lineage {
+		return fmt.Errorf("pre-forecast correction submission result = %+v, %v", result, err)
+	}
+	return nil
+}
+
+// proveIssue3194CorrectionContinues proves the unblock, not just the accepted
+// forecast: the lineage routes on to repository verification for the corrected
+// candidate instead of dead-ending in correction_required.
+func proveIssue3194CorrectionContinues(r *journeyRun) error {
+	frozen := r.sandbox.Scratch["issue3194-frozen-candidate"]
+	status, err := readCorrectionStatusForContract(r, issue3194Lineage, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	if status.Authority == nil || status.Authority.State != "correction_required" || status.ValidationRequest == nil ||
+		status.NextTransition == nil || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "correction_repository_verification_required" {
+		return fmt.Errorf("post-forecast correction routing = %+v", status)
+	}
+	if status.ValidationRequest.CorrectionTargetIdentity == frozen {
+		return fmt.Errorf("correction target never advanced past the frozen candidate %s", frozen)
+	}
+	forecast, err := issue3194ProposedCorrectionLines(r)
+	if err != nil {
+		return err
+	}
+	if forecast != 1 {
+		return fmt.Errorf("recorded correction forecast = %d, want 1", forecast)
+	}
+	return nil
+}
+
+func issue3194ProposedCorrectionLines(r *journeyRun) (int, error) {
+	common, err := gitOut(r.sandbox, r.sandbox.Repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return 0, err
+	}
+	stateBytes, err := os.ReadFile(filepath.Join(strings.TrimSpace(common), "gentle-ai", "review-transactions", "v2", issue3194Lineage, "review-state.json"))
+	if err != nil {
+		return 0, err
+	}
+	var record struct {
+		State struct {
+			ProposedCorrectionLines *int `json:"proposed_correction_lines"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(stateBytes, &record); err != nil {
+		return 0, err
+	}
+	if record.State.ProposedCorrectionLines == nil {
+		return 0, fmt.Errorf("authority recorded no correction forecast")
+	}
+	return *record.State.ProposedCorrectionLines, nil
+}

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -20,6 +20,7 @@ j108-sdd-post-review-verify-report-is-natively-bound
 j109-sdd-legacy-post-review-report-requires-current-attestation
 j11-unborn-head
 j110-approved-unborn-intended-candidate-requires-staging
+j111-preplan-correction-forecast-executes-as-issued
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token

--- a/internal/cli/review_correction_forecast_binding_test.go
+++ b/internal/cli/review_correction_forecast_binding_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestCorrectionForecastDescriptorBindsFrozenCandidateAfterEdit covers issue
+// #3194. A consumer cannot forecast a line count before writing the lines, so
+// the bounded correction is normally already in the working tree by the time
+// the forecast is submitted. Every token of the correction transition must
+// therefore name the frozen reviewed candidate the correction request and the
+// repository-context handle already commit to, never the moved live snapshot,
+// and the descriptor STATUS issues must execute exactly as issued.
+func TestCorrectionForecastDescriptorBindsFrozenCandidateAfterEdit(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, started, store := submissionDescriptorCorrectionFixture(t)
+
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	frozen := record.State.CurrentSnapshot.Identity
+
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 2 }\n", 0o644)
+
+	status := submissionDescriptorStatus(t, repo, started.LineageID)
+	if status.TargetIdentity == frozen {
+		t.Fatal("fixture never moved the live workspace snapshot, so it cannot cover the reported defect")
+	}
+	input := submissionDescriptorInput(t, status)
+	if status.NextTransition.ReasonCode != "correction_plan_required" || status.NextTransition.CorrectionRequest == nil {
+		t.Fatalf("transition after the correction edit = %#v", status.NextTransition)
+	}
+	if request := status.NextTransition.CorrectionRequest; request.TargetIdentity != frozen {
+		t.Fatalf("correction request target = %s, want the frozen reviewed candidate %s", request.TargetIdentity, frozen)
+	}
+
+	if target := submissionDescriptorTokenValue(t, *input.Submission, "--target="); target != frozen {
+		t.Fatalf("descriptor --target = %s, want the frozen reviewed candidate %s", target, frozen)
+	}
+	handle := submissionDescriptorTokenValue(t, *input.Submission, "--repository-context=")
+	_, bound, err := reviewtransaction.ResolveReviewRepositoryContextBinding(context.Background(), handle)
+	if err != nil {
+		t.Fatalf("resolve descriptor repository context: %v", err)
+	}
+	if bound.TargetIdentity != frozen {
+		t.Fatalf("repository-context handle commits to %s, want the frozen reviewed candidate %s", bound.TargetIdentity, frozen)
+	}
+	arguments, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arguments["target"] != frozen {
+		t.Fatalf("collect argument target = %s, want the frozen reviewed candidate %s", arguments["target"], frozen)
+	}
+
+	if output, err := runSubmissionDescriptor(t, *input.Submission, "1"); err != nil {
+		t.Fatalf("provider-issued correction descriptor is not executable as issued: %v\n%s", err, output)
+	}
+	forecasted, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forecasted.State.ProposedCorrectionLines == nil || *forecasted.State.ProposedCorrectionLines != 1 ||
+		len(forecasted.State.CorrectionAttempts) != 0 || forecasted.State.CumulativeCorrectionLines != 0 {
+		t.Fatalf("forecast state = %#v", forecasted.State)
+	}
+	// The frozen candidate still governs: the forecast admitted no content and
+	// must not have advanced the reviewed snapshot to the edited tree.
+	if forecasted.State.CurrentSnapshot.Identity != frozen {
+		t.Fatalf("forecast moved the reviewed candidate to %s", forecasted.State.CurrentSnapshot.Identity)
+	}
+
+	// The lifecycle keeps routing on the already-corrected tree instead of
+	// dead-ending, which is what the reported occurrences could never reach.
+	next := submissionDescriptorStatus(t, repo, started.LineageID)
+	if next.NextTransition == nil || next.NextTransition.Kind != reviewNextTransitionCollect ||
+		next.NextTransition.ReasonCode != "correction_repository_verification_required" {
+		t.Fatalf("transition after the accepted forecast = %#v", next.NextTransition)
+	}
+}
+
+// TestCorrectionForecastRefusesTargetsOutsideTheFrozenCandidate keeps the
+// negative controls the #3194 fix must not weaken: the forecast still binds to
+// one exact candidate, so a substituted target is refused and nothing is
+// written.
+func TestCorrectionForecastRefusesTargetsOutsideTheFrozenCandidate(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, started, store := submissionDescriptorCorrectionFixture(t)
+
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 2 }\n", 0o644)
+	status := submissionDescriptorStatus(t, repo, started.LineageID)
+	input := submissionDescriptorInput(t, status)
+
+	for _, test := range []struct {
+		name   string
+		target string
+	}{
+		{name: "live workspace snapshot", target: status.TargetIdentity},
+		{name: "unrelated identity", target: "sha256:" + strings.Repeat("a", 64)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			before := readReviewOperationFile(t, store.StatePath())
+			tampered := replaceSubmissionToken(t, *input.Submission, "--target=", "--target="+test.target)
+			output, err := runSubmissionDescriptor(t, tampered, "1")
+			assertSubmissionNotStarted(t, err, output, store, before)
+		})
+	}
+}
+
+func submissionDescriptorTokenValue(t *testing.T, descriptor ReviewTransitionSubmission, prefix string) string {
+	t.Helper()
+	for _, token := range descriptor.ArgumentTokens {
+		if value, found := strings.CutPrefix(token, prefix); found {
+			return value
+		}
+	}
+	t.Fatalf("descriptor tokens lack %q: %v", prefix, descriptor.ArgumentTokens)
+	return ""
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -3071,7 +3071,8 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	}
 	// A zero-transition next-transition request is a read-only routing projection;
 	// correction routing may intentionally describe a live target not frozen yet.
-	if !terminalAtEntry && pendingAtEntry == nil && (len(plan.Transitions) > 0 || !*nextTransition) {
+	// A forecast-only plan is exempt for the reason documented on the field.
+	if !terminalAtEntry && pendingAtEntry == nil && !plan.CorrectionForecastOnly && (len(plan.Transitions) > 0 || !*nextTransition) {
 		if err := (reviewtransaction.SnapshotBuilder{Repo: root}).ValidateLiveSnapshot(ctx, plan.Candidate); err != nil {
 			return reviewPreflightRefusal(reviewPreflightStaleTargetReason,
 				fmt.Errorf("validate FINALIZE live target: %v", err))
@@ -3314,6 +3315,17 @@ type facadeFinalizePlan struct {
 	Candidate        reviewtransaction.Snapshot
 	Evidence         []byte
 	CapturedEvidence *reviewtransaction.CapturedVerificationEvidence
+	// CorrectionForecastOnly marks the one plan whose single transition admits
+	// no candidate content: BeginCorrection records a declared line count
+	// against the frozen budget and reads no repository state at all. Its
+	// candidate therefore does not have to still be the live workspace, which
+	// is what lets a consumer forecast a correction it has already written --
+	// the honest order, since a line count cannot be known before editing
+	// (issue #3194). The frozen candidate's own Git evidence is still proven
+	// by the unconditional ValidateEvidence above, and the real correction
+	// size is still measured against the fix diff when the correction is
+	// accepted, so the frozen budget stays enforced either way.
+	CorrectionForecastOnly bool
 }
 
 // prepareFacadeFinalizePlan performs every deterministic validation before the
@@ -3340,6 +3352,10 @@ func prepareFacadeFinalizePlan(ctx context.Context, repo, revision, storeDir str
 			return plan, err
 		}
 		appendState("review/begin-fix")
+		// Only when the forecast is the whole plan. A call that completed the
+		// review first admitted candidate content in the same breath, and that
+		// content must still describe the live workspace.
+		plan.CorrectionForecastOnly = len(plan.Transitions) == 1
 	}
 	if state.State == reviewtransaction.StateCorrectionRequired && entryState == reviewtransaction.StateCorrectionRequired && entryProposed &&
 		captured != nil && captured.Record.Outcome == reviewtransaction.VerificationOutcomeProceduralFailure {

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -308,9 +308,19 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 		if input.CorrectionRequest == nil {
 			return reviewStopTransition("corrupted_or_unverifiable_authority")
 		}
+		// The forecast is a declaration about the frozen reviewed candidate and
+		// its frozen budget, so every token names that candidate -- exactly
+		// like the validation branch above names its own corrected target. It
+		// must not name the live workspace snapshot `binding` carries: a
+		// consumer that already applied the bounded correction moved the live
+		// identity, while the repository-context handle and the correction
+		// request stay bound to the frozen one, and the resulting descriptor
+		// could never be satisfied by any substitution (issue #3194).
+		correctionBinding := binding
+		correctionBinding.TargetIdentity = input.CorrectionRequest.TargetIdentity
 		transition := reviewCollectTransition("correction_plan_required", ReviewTransitionInput{
 			Name: "correction_lines", Schema: "gentle-ai.review-correction-plan/v1", CaptureOperation: "external.plan_correction",
-			Arguments: reviewBindingArguments(binding), Submission: reviewCorrectionPlanSubmission(input.Contract, binding, *input.CorrectionRequest),
+			Arguments: reviewBindingArguments(correctionBinding), Submission: reviewCorrectionPlanSubmission(input.Contract, correctionBinding, *input.CorrectionRequest),
 		})
 		transition.CorrectionRequest = input.CorrectionRequest
 		return transition

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -737,9 +737,20 @@ func (result ReviewTargetStatusResult) validateSubmissionDescriptors() error {
 		if err != nil {
 			return err
 		}
+		// Every token names the correction request's own frozen target, never
+		// the live workspace identity in result.TargetIdentity. The two differ
+		// as soon as the consumer applies the bounded correction before
+		// forecasting it, and a descriptor that mixes them is unsatisfiable
+		// because its repository-context handle can only ever commit to the
+		// frozen candidate (issue #3194).
+		if arguments, err := reviewTransitionArgumentMap(input.Arguments); err != nil || len(arguments) != 3 ||
+			arguments["lineage"] != result.Authority.LineageID || arguments["expected-revision"] != result.Authority.Revision ||
+			arguments["target"] != transition.CorrectionRequest.TargetIdentity {
+			return errors.New("correction transition lacks the frozen candidate binding") // refusal:by-design world-action: only STATUS can issue a complete frozen-candidate binding
+		}
 		want := reviewCorrectionPlanSubmission(result.Contract, ReviewTransitionBinding{
 			LineageID: result.Authority.LineageID, Revision: result.Authority.Revision,
-			TargetIdentity: result.TargetIdentity, RepositoryContext: context,
+			TargetIdentity: transition.CorrectionRequest.TargetIdentity, RepositoryContext: context,
 		}, *transition.CorrectionRequest)
 		if want == nil || !reflect.DeepEqual(*input.Submission, *want) {
 			return errors.New("correction submission descriptor is not provider-bound") // refusal:by-design world-action: only a provider code fix can bind descriptor tokens to its request


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3194

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- A consumer cannot forecast a correction's line count before writing the lines, so the bounded correction is normally already in the working tree when `--correction-lines` is submitted. That moves the live workspace snapshot, and STATUS stamped the `correction_plan_required` transition's `--target` from it while the `--repository-context` handle and `BuildCorrectionPlanRequest` stayed bound to the frozen reviewed candidate — so the descriptor STATUS itself issued could never be satisfied.
- Every token of the correction transition now names the frozen candidate, exactly as the targeted-validation branch already names its own corrected target, and the forecast-only finalize plan is exempt from the live-snapshot freshness guard.
- The status contract now pins the collect arguments and the descriptor to the correction request's own target. That invariant existed only for `StateReviewing`, which is why a self-inconsistent envelope passed validation and shipped.

### The closed loop, as reported

The 20 occurrences on #3194 (2.3.0 → 2.4.0, Claude Code and OpenCode, Linux and macOS) all had no caller-side exit:

| Attempt | Result |
|---|---|
| descriptor verbatim | `invalid_request` / `repository_context_unavailable: ... review repository context binding is invalid` — the handle can only ever be published against the frozen candidate |
| substitute the handle's frozen target | `stale_target_identity`, whose documented remedy re-derives the same broken descriptor |
| drop the handle for `--cwd` | refused: "submission descriptors require the complete v2 revision, target, request hash, and repository context binding" |

`mutation_outcome: not_started` throughout, so the single correction attempt was never consumed and the lineage stayed stuck in `correction_required` with a green corrected candidate that could not be delivered.

### Why the suite was green

`TestSubmissionDescriptorsAreBoundAndExecuteOneValueOnly` submits `--correction-lines` **first** and only then writes the correction edit. No test in the corpus edited before forecasting, so only the clean-tree order — where live and frozen identities coincide by accident — was ever exercised.

### What is deliberately unchanged

An over-budget pre-forecast edit keeps D1800's audited abandon (`j91`) as its exit: `BeginCorrection` still validates the forecast against the frozen budget, and the real correction size is still measured against the fix diff at acceptance. This only unblocks a correction that fits the frozen budget — which is what every reporter had (report 2: 9 lines against a budget of 200).

The frozen candidate's Git evidence is still proven by the unconditional `ValidateEvidence` that runs before the exempted guard, so the authority stays bound to the reviewed candidate.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_next_transition.go` | The `correction_plan_required` transition binds `input.CorrectionRequest.TargetIdentity`, not the live `status.TargetIdentity`, for both the collect arguments and the submission descriptor |
| `internal/cli/review_status_contract.go` | Pins the collect arguments and the expected descriptor to the correction request's own target, so a self-inconsistent envelope is refused |
| `internal/cli/review_facade.go` | Adds `facadeFinalizePlan.CorrectionForecastOnly` and exempts that one plan from the `ValidateLiveSnapshot` guard |
| `internal/cli/review_correction_forecast_binding_test.go` | Unit coverage: frozen binding across request/handle/arguments/descriptor, verbatim execution, forecast recorded without moving the reviewed candidate, continued routing; plus negative controls for a live and an unrelated `--target` |
| `bench/journeys_issue3194.go` | New `j111`, the within-budget sibling of `j91` |
| `bench/journeys.go`, `bench/journeys_id_collision_test.go`, `bench/testdata/journeys.manifest` | Register `j111` |

---

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model (if known):** Claude Code (Opus 5)

**Material scope:** Root-cause analysis across the review transition/facade/locator path, the production fix, the unit test file, and the bench journey were drafted with AI assistance.

**Verification performed:** Every claim in this PR is backed by a command I ran locally, recorded below. The defect was reproduced on clean `main` before any fix existed, and `j111` was driven against a binary built from `35deba32` to confirm it fails there for the reported reason rather than passing vacuously. I reviewed each diff line and the surrounding contract invariants myself.

---

## 🧪 Test Plan

**Reproduction before the fix** — `main` @ `35deba32`, measured identities:

```
frozen reviewed candidate / handle bound target / correction request target : sha256:c626a4c4…
live status target AND the descriptor's own --target                        : sha256:3d4e4e1f…
verbatim submission      → invalid_request / repository_context_unavailable
frozen-target submission → stale_target_identity
authority state bytes    → unchanged (mutation_outcome: not_started)
```

**Focused unit tests**

```
$ go test ./internal/cli -run 'TestCorrectionForecast' -v
--- PASS: TestCorrectionForecastDescriptorBindsFrozenCandidateAfterEdit (5.54s)
--- PASS: TestCorrectionForecastRefusesTargetsOutsideTheFrozenCandidate (3.92s)
    --- PASS: .../live_workspace_snapshot (0.05s)
    --- PASS: .../unrelated_identity (0.05s)
ok  	github.com/gentleman-programming/gentle-ai/v2/internal/cli	10.006s
```

**Benchmark validation** — declarations, then driven mode against a locally built binary:

```
$ cd bench && go vet ./... && go test ./...
ok  	github.com/gentleman-programming/gentle-ai/bench	2.322s

$ gentle-ai-bench run --binary <built from this branch> --only j111-preplan-correction-forecast-executes-as-issued
j111-preplan-correction-forecast-executes-as-issued  completed  1 human_prompt  0 manual_tokens  11 commands  0 blocks  0 model_runs

$ gentle-ai-bench run --binary <built from 35deba32> --only j111-preplan-correction-forecast-executes-as-issued
j111-preplan-correction-forecast-executes-as-issued  failed
  failed: step "STATUS binds the frozen candidate, not the moved live snapshot":
  collect target argument = sha256:dedeb191…, want the frozen candidate sha256:8df6f4ee…
```

**Go format**

```
$ go run ./internal/gofmtcheck
(clean)
```

**Stale-pin sweep:** grepped the corpus for journeys pinning the old behavior. `j51-negotiated-status-correction-continuation` and `submitCorrectionPlan` (wave 1) submit the forecast on a clean tree and are unaffected; `j91`/`#1800` never submits a forecast after its pre-plan edit, so D1800's abandon exit stays pinned as written.

- [x] Unit tests pass — no new failures; the two `internal/cli` failures reproduce identically on `main` (evidence above)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — **not run locally** (no Docker in this environment); relying on CI
- [x] Manually tested locally
- [x] Benchmark validation completed

**Full `internal/cli` package**

```
$ go test ./internal/cli -timeout 60m
FAIL  internal/cli  2079.338s
--- FAIL: TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture
--- FAIL: TestEngramPathGuidanceDefault
```

Both are **pre-existing on `main` and unrelated to this change** — verified by running the same two tests in a detached worktree at `35deba32`, where they fail identically and in the same time:

```
$ git worktree add --detach <wt> 35deba32
$ cd <wt> && go test ./internal/cli -run 'TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture|TestEngramPathGuidanceDefault'
--- FAIL: TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture (1.64s)
--- FAIL: TestEngramPathGuidanceDefault (0.00s)
```

Both are environment-sensitive on this machine: `TestEngramPathGuidanceDefault` expects `go/bin` in the emitted PATH guidance while this host resolves it to a different directory, and the refuter deadline test exhausts its aggregate Git budget here. Neither touches the files in this change. **This change introduces no new failures.**

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — **#3194 is not yet labelled; it needs maintainer approval and I do not have triage rights on this repo**
- [x] PR stays within 400 changed lines (340: 337 additions + 3 deletions)
- [ ] I have added the appropriate `type:*` label to this PR — **`type:bug` applies; I cannot apply labels here, please add it**
- [x] Unit tests pass — no new failures introduced; see the Test Plan for the `main` baseline comparison
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — not run locally, no Docker available
- [x] Benchmark validation completed
- [x] I have updated documentation if necessary — no user-facing behavior is documented for this transition beyond the contract text already in the orchestrator instructions
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correction forecast handling when the working copy changes after review.
  * Kept correction forecasts tied to the frozen reviewed candidate.
  * Added validation to reject unrelated or substituted targets.
  * Preserved lifecycle routing and reviewed snapshot state after forecast submission.

* **Tests**
  * Added coverage for frozen-candidate binding, descriptor validation, and within-budget correction workflows.
  * Added a new journey covering correction forecast execution after pre-plan edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->