### PR TITLE
fix(tui): cache agent builder availability to prevent navigation lag

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -862,6 +862,10 @@ type Model struct {
 	CommunityToolStatusErr     error
 	CommunityToolResults       []communitytool.Result
 	CommunityToolErr           error
+
+	// agentBuilderEngines is the immutable availability snapshot captured when
+	// the model is constructed. Welcome interactions must not scan PATH.
+	agentBuilderEngines []model.AgentID
 }
 
 // NewModel constructs the initial TUI model for the given detection result.
@@ -909,6 +913,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 			"Configure selected agents",
 			"Inject ecosystem components",
 		}),
+		agentBuilderEngines: detectAgentBuilderEnginesFn(),
 	}
 }
 
@@ -2069,7 +2074,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.AgentBuilder = AgentBuilderState{}
-			m.AgentBuilder.AvailableEngines = m.detectAgentBuilderEngines()
+			m.AgentBuilder.AvailableEngines = append([]model.AgentID(nil), m.agentBuilderEngines...)
 			ta := textarea.New()
 			ta.Placeholder = "Describe what you want your agent to do..."
 			ta.Focus()
@@ -5429,9 +5434,11 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 	}
 }
 
+var detectAgentBuilderEnginesFn = detectAgentBuilderEngines
+
 // detectAgentBuilderEngines scans for supported AI agent binaries on PATH and
 // returns the list of available AgentIDs.
-func (m Model) detectAgentBuilderEngines() []model.AgentID {
+func detectAgentBuilderEngines() []model.AgentID {
 	candidateIDs := []model.AgentID{
 		model.AgentClaudeCode,
 		model.AgentOpenCode,
@@ -5448,9 +5455,10 @@ func (m Model) detectAgentBuilderEngines() []model.AgentID {
 	return available
 }
 
-// hasAgentBuilderEngines reports whether any supported AI agent binary is installed.
+// hasAgentBuilderEngines reports whether the model's availability snapshot has
+// at least one supported AI agent binary.
 func (m Model) hasAgentBuilderEngines() bool {
-	return len(m.detectAgentBuilderEngines()) > 0
+	return len(m.agentBuilderEngines) > 0
 }
 
 // agentBuilderInstallTargets returns the list of install target paths for the preview screen.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2201,6 +2201,76 @@ func TestWelcomeMenu_UninstallNavigation_WithProfiles(t *testing.T) {
 	}
 }
 
+func TestWelcomeNavigationAndViewDoNotRescanAgentBuilderEngines(t *testing.T) {
+	original := detectAgentBuilderEnginesFn
+	checks := 0
+	detectAgentBuilderEnginesFn = func() []model.AgentID {
+		checks++
+		return []model.AgentID{model.AgentClaudeCode}
+	}
+	t.Cleanup(func() { detectAgentBuilderEnginesFn = original })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	if checks != 1 {
+		t.Fatalf("availability checks after construction = %d, want 1", checks)
+	}
+
+	for range 10 {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = updated.(Model)
+		_ = m.View()
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+		m = updated.(Model)
+		_ = m.View()
+	}
+
+	if checks != 1 {
+		t.Errorf("availability checks after Welcome navigation and rendering = %d, want 1", checks)
+	}
+}
+
+func TestWelcomeCreateAgentUsesCachedEngineSnapshot(t *testing.T) {
+	original := detectAgentBuilderEnginesFn
+	checks := 0
+	detectAgentBuilderEnginesFn = func() []model.AgentID {
+		checks++
+		return []model.AgentID{model.AgentClaudeCode}
+	}
+	t.Cleanup(func() { detectAgentBuilderEnginesFn = original })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Cursor = 5
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.Screen != ScreenAgentBuilderEngine {
+		t.Fatalf("screen = %v, want ScreenAgentBuilderEngine", m.Screen)
+	}
+	if !slices.Equal(m.AgentBuilder.AvailableEngines, []model.AgentID{model.AgentClaudeCode}) {
+		t.Errorf("available engines = %v, want [%s]", m.AgentBuilder.AvailableEngines, model.AgentClaudeCode)
+	}
+	if checks != 1 {
+		t.Errorf("availability checks after entering Create Agent = %d, want 1", checks)
+	}
+}
+
+func BenchmarkWelcomeKeyUpdateWithSlowEngineAvailability(b *testing.B) {
+	original := detectAgentBuilderEnginesFn
+	detectAgentBuilderEnginesFn = func() []model.AgentID {
+		time.Sleep(10 * time.Millisecond)
+		return []model.AgentID{model.AgentClaudeCode}
+	}
+	b.Cleanup(func() { detectAgentBuilderEnginesFn = original })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	keyDown := tea.KeyMsg{Type: tea.KeyDown}
+	b.ResetTimer()
+	for b.Loop() {
+		updated, _ := m.Update(keyDown)
+		m = updated.(Model)
+	}
+}
+
 // TestWelcomeMenu_OptionCount verifies the welcome menu has 14 items without OpenCode
 // and 15 items when OpenCode is detected (adds "OpenCode SDD Profiles" option).
 func TestWelcomeMenu_OptionCount(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #268

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Avoid repeated PATH lookups (`exec.LookPath`) during TUI welcome menu navigation and rendering.
- Cache agent builder engine availability once during model construction (`NewModel`) and reuse the immutable snapshot across welcome navigation and agent-builder entry.
- Add regression tests and benchmark verifying zero PATH scans on navigation and rendering hot paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Added `agentBuilderEngines` field to `Model`, initialized via `detectAgentBuilderEnginesFn()` in `NewModel`, and reused in `hasAgentBuilderEngines` and `confirmSelection`. |
| `internal/tui/model_test.go` | Added tests verifying single scan during construction and zero scans during welcome navigation/rendering, plus benchmark measuring key update latency with simulated slow detection. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Antigravity-pro/gemini-3.7-flash-high via OpenCode

**Material scope:** Implemented engine availability caching in `Model` and added regression tests/benchmark.

**Verification performed:** Unit tests (`go test -v ./internal/tui/...`), benchmark (`go test -bench=BenchmarkWelcomeKeyUpdateWithSlowEngineAvailability ./internal/tui`), formatting (`go run ./internal/gofmtcheck`).

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/tui/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally

```bash
go test -v -run "TestWelcomeNavigationAndViewDoNotRescanAgentBuilderEngines|TestWelcomeCreateAgentUsesCachedEngineSnapshot" ./internal/tui
go test -bench="BenchmarkWelcomeKeyUpdateWithSlowEngineAvailability" -benchmem ./internal/tui
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved TUI responsiveness by avoiding repeated agent-builder engine availability checks during navigation, rendering, and agent creation.
  * Engine availability is detected once when the interface starts and reused throughout the session.

* **Reliability**
  * Engine selection and availability reporting now remain consistent while navigating the welcome menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->