### PR TITLE
fix(app): require terminal streams for tui

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -61,7 +61,13 @@ func Run() error {
 	return RunArgs(os.Args[1:], os.Stdout)
 }
 
+const nonInteractiveTUIError = "gentle-ai requires both stdin and stdout to be terminals (TTYs); use --version, gentle-ai update, or --help for non-interactive use"
+
 func RunArgs(args []string, stdout io.Writer) error {
+	if len(args) == 0 && (!isattyFn(os.Stdin.Fd()) || !isattyFn(os.Stdout.Fd())) {
+		return errors.New(nonInteractiveTUIError)
+	}
+
 	// Propagate the build-time version to the CLI and upgrade layers so backup
 	// manifests record which version of gentle-ai created them.
 	cli.AppVersion = Version

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1533,6 +1533,7 @@ func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
 }
 
 func TestRunArgs_TUISkipsSelfUpdate(t *testing.T) {
+	assumeInteractiveTTY(t)
 	// NOTE: modifies package-level vars; must not run in parallel.
 	origSelfUpdate := selfUpdateFn
 	origDetect := detectSystem
@@ -2023,6 +2024,7 @@ func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 // reports a successful gentle-ai upgrade, RunArgs calls restartAfterGentleAIUpgrade
 // which (after task 4.6) prints the restart guidance message instead of re-execing.
 func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
+	assumeInteractiveTTY(t)
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
 	origRunTUI := runTUI
@@ -2064,6 +2066,7 @@ func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
 // state.json has PendingSync=true, RunArgs (TUI path / no args) calls
 // the deferred sync runner and writes PendingSync=false on success.
 func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2127,6 +2130,7 @@ func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
 // TestRunArgs_PendingSync_LeavesSetOnFailure verifies that when the deferred
 // sync fails, PendingSync remains true so the next launch retries idempotently.
 func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2192,6 +2196,7 @@ func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
 // error is printed to stdout and RunArgs does not return an error.
 // This guards against silently swallowed write failures (Issue 2).
 func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2255,6 +2260,7 @@ func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
 // TestRunArgs_NoPendingSync_NoSyncCall verifies that when PendingSync=false,
 // the deferred sync runner is NOT called (no extra sync on a normal launch).
 func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2313,6 +2319,7 @@ func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
 // post-upgrade state. Per #1901, this reuses the existing PendingSync signal
 // rather than introducing a new persisted flag.
 func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2366,6 +2373,7 @@ func TestRunArgs_PendingSync_PrintsDoctorAdvisory(t *testing.T) {
 // the doctor advisory is printed regardless of deferred sync outcome. The
 // advisory is informational and complements the sync outcome (not a replacement).
 func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 
@@ -2419,6 +2427,7 @@ func TestRunArgs_PendingSync_PrintsDoctorAdvisoryEvenOnSyncFailure(t *testing.T)
 // doctor advisory is NOT printed on a normal launch where PendingSync=false.
 // The advisory is gated strictly on the post-upgrade signal.
 func TestRunArgs_NoPendingSync_DoesNotPrintDoctorAdvisory(t *testing.T) {
+	assumeInteractiveTTY(t)
 	home := t.TempDir()
 	setupMockHome(t, home)
 

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -32,8 +32,13 @@ const (
 	envYesUpdate      = "GENTLE_AI_YES"
 )
 
+// isTerminal reports whether fd belongs to a native or Cygwin/MSYS2 terminal.
+func isTerminal(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
 // isattyFn is a package-level var for TTY detection, injectable for tests.
-var isattyFn = func(fd uintptr) bool { return isatty.IsTerminal(fd) }
+var isattyFn = isTerminal
 
 // selfUpdateYesFn returns true when the caller wants the upgrade to proceed
 // without an interactive prompt. Set GENTLE_AI_YES=1 for scripted upgrades.

--- a/internal/app/tty_boundary_test.go
+++ b/internal/app/tty_boundary_test.go
@@ -1,0 +1,282 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+func assumeInteractiveTTY(t *testing.T) {
+	t.Helper()
+	origIsatty := isattyFn
+	isattyFn = func(uintptr) bool { return true }
+	t.Cleanup(func() { isattyFn = origIsatty })
+}
+
+func TestRunArgsNoArgumentRequiresInteractiveStdinAndStdout(t *testing.T) {
+	stdinFD, stdoutFD := os.Stdin.Fd(), os.Stdout.Fd()
+	tests := []struct {
+		name    string
+		isTTY   func(uintptr) bool
+		wantTTY string
+	}{
+		{
+			name:    "missing stdin",
+			isTTY:   func(fd uintptr) bool { return fd == stdoutFD },
+			wantTTY: "stdin",
+		},
+		{
+			name:    "missing stdout",
+			isTTY:   func(fd uintptr) bool { return fd == stdinFD },
+			wantTTY: "stdout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			setupMockHome(t, home)
+			if err := state.Write(home, state.InstallState{PendingSync: true}); err != nil {
+				t.Fatalf("write pending state: %v", err)
+			}
+
+			origIsatty := isattyFn
+			origEnsure := ensureCurrentOSSupported
+			origDetect := detectSystem
+			origSelfUpdate := selfUpdateFn
+			origDeferredSync := deferredSyncFn
+			origRunTUI := runTUI
+			t.Cleanup(func() {
+				isattyFn = origIsatty
+				ensureCurrentOSSupported = origEnsure
+				detectSystem = origDetect
+				selfUpdateFn = origSelfUpdate
+				deferredSyncFn = origDeferredSync
+				runTUI = origRunTUI
+			})
+
+			var calls []string
+			record := func(name string) {
+				calls = append(calls, name)
+			}
+			isattyFn = tt.isTTY
+			ensureCurrentOSSupported = func() error {
+				record("platform validation")
+				return nil
+			}
+			detectSystem = func(context.Context) (system.DetectionResult, error) {
+				record("system detection")
+				return system.DetectionResult{
+					System: system.SystemInfo{
+						Supported: true,
+						Profile:   system.PlatformProfile{OS: "linux", Supported: true},
+					},
+				}, nil
+			}
+			selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+				record("self-update")
+				return nil
+			}
+			deferredSyncFn = func() error {
+				record("deferred sync")
+				return nil
+			}
+			runTUI = func(tea.Model, ...tea.ProgramOption) (tea.Model, error) {
+				record("Bubble Tea")
+				return nil, nil
+			}
+
+			var output bytes.Buffer
+			err := RunArgs(nil, &output)
+			if err == nil {
+				t.Fatalf("RunArgs(nil) error = nil, want non-nil terminal guidance")
+			}
+			for _, want := range []string{"--version", "gentle-ai update", "--help"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("RunArgs(nil) error = %q, want actionable guidance containing %q", err, want)
+				}
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tt.wantTTY) {
+				t.Fatalf("RunArgs(nil) error = %q, want missing %s guidance", err, tt.wantTTY)
+			}
+			if len(calls) != 0 {
+				t.Fatalf("RunArgs(nil) reached downstream seams: %v", calls)
+			}
+		})
+	}
+}
+
+func TestRunArgsNoArgumentAllowsInteractiveStdinAndStdout(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	origIsatty := isattyFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origSelfUpdate := selfUpdateFn
+	origRunTUI := runTUI
+	t.Cleanup(func() {
+		isattyFn = origIsatty
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		selfUpdateFn = origSelfUpdate
+		runTUI = origRunTUI
+	})
+
+	var calls []string
+	isattyCalls := 0
+	isattyFn = func(uintptr) bool {
+		isattyCalls++
+		return true
+	}
+	ensureCurrentOSSupported = func() error {
+		calls = append(calls, "platform validation")
+		return nil
+	}
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		calls = append(calls, "system detection")
+		return system.DetectionResult{
+			System: system.SystemInfo{
+				Supported: true,
+				Profile:   system.PlatformProfile{OS: "linux", Supported: true},
+			},
+		}, nil
+	}
+	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+		calls = append(calls, "self-update")
+		return nil
+	}
+	runTUI = func(tea.Model, ...tea.ProgramOption) (tea.Model, error) {
+		calls = append(calls, "Bubble Tea")
+		return nil, nil
+	}
+
+	var output bytes.Buffer
+	if err := RunArgs(nil, &output); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v, want nil", err)
+	}
+	if isattyCalls != 2 {
+		t.Fatalf("terminal predicate called %d times, want once for stdin and once for stdout", isattyCalls)
+	}
+	for _, want := range []string{"platform validation", "system detection", "Bubble Tea"} {
+		if !slicesContains(calls, want) {
+			t.Fatalf("RunArgs(nil) did not reach %s; calls = %v", want, calls)
+		}
+	}
+}
+
+func TestRunArgsExplicitCommandsBypassTTYBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"--version"}},
+		{name: "help", args: []string{"--help"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origIsatty := isattyFn
+			origEnsure := ensureCurrentOSSupported
+			origDetect := detectSystem
+			t.Cleanup(func() {
+				isattyFn = origIsatty
+				ensureCurrentOSSupported = origEnsure
+				detectSystem = origDetect
+			})
+
+			isattyFn = func(uintptr) bool {
+				t.Fatal("explicit command evaluated the no-argument terminal boundary")
+				return false
+			}
+			ensureCurrentOSSupported = func() error {
+				t.Fatal("explicit command reached platform validation")
+				return errors.New("platform validation reached")
+			}
+			detectSystem = func(context.Context) (system.DetectionResult, error) {
+				t.Fatal("explicit command reached system detection")
+				return system.DetectionResult{}, errors.New("system detection reached")
+			}
+
+			var output bytes.Buffer
+			if err := RunArgs(tt.args, &output); err != nil {
+				t.Fatalf("RunArgs(%v) error = %v, want nil", tt.args, err)
+			}
+			if output.Len() == 0 {
+				t.Fatalf("RunArgs(%v) produced no output", tt.args)
+			}
+		})
+	}
+}
+
+func TestBuiltBinaryClosedStdinRefusesBeforeBubbleTea(t *testing.T) {
+	if testing.Short() {
+		t.Skip("built-binary process coverage is not run in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("closed-stdin process coverage is compile-only on Windows")
+	}
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(sourceFile), "..", "..")
+	binaryPath := filepath.Join(t.TempDir(), "gentle-ai")
+	build := exec.Command("go", "build", "-o", binaryPath, "./cmd/gentle-ai")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cmd/gentle-ai: %v\n%s", err, output)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, binaryPath)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	// A nil Cmd.Stdin is connected to the null device, proving the closed-stdin path.
+	command.Stdin = nil
+	err := command.Run()
+	if ctx.Err() != nil {
+		t.Fatalf("built binary did not terminate promptly: %v", ctx.Err())
+	}
+	if err == nil {
+		t.Fatalf("built binary exited successfully; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() == 0 {
+		t.Fatalf("built binary error = %v, want a non-zero process exit", err)
+	}
+
+	combined := stdout.String() + stderr.String()
+	for _, want := range []string{"--version", "gentle-ai update", "--help"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("built binary output = %q, want actionable guidance containing %q", combined, want)
+		}
+	}
+	if strings.Contains(strings.ToLower(combined), "/dev/tty") {
+		t.Fatalf("built binary reached Bubble Tea /dev/tty error: %q", combined)
+	}
+}
+
+func slicesContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #95

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Require both process stdin and stdout to be native or Cygwin/MSYS2 terminals before launching the no-argument TUI.
- Refuse non-interactive startup before platform detection, state reads, deferred sync, model construction, or Bubble Tea.
- Keep explicit commands available and return actionable guidance naming `--version`, `gentle-ai update`, and `--help`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/app.go` | Added the early no-argument terminal boundary. |
| `internal/app/selfupdate.go` | Shared native and Cygwin/MSYS2 terminal detection. |
| `internal/app/tty_boundary_test.go` | Added behavior-first unit and built-binary regression coverage. |
| `internal/app/app_test.go` | Made existing no-argument TUI tests declare interactive streams explicitly. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent with OpenAI Codex models

**Material scope:** Current-main investigation, strict-TDD implementation, regression-test design, and verification.

**Verification performed:** Human-directed diff inspection plus focused, race, cross-platform compile, and bounded process-level verification.

---

## 🧪 Test Plan

- [x] `go test ./internal/app -count=1`
- [x] `go test -race ./internal/app -count=1`
- [x] `GOOS=windows GOARCH=amd64 go test -c -o /tmp/gentle-ai-issue95-app.test.exe ./internal/app`
- [x] `go run ./internal/gofmtcheck`
- [x] Built-binary run with closed stdin exits promptly with actionable guidance and no Bubble Tea `/dev/tty` error.
- [x] PTY stdin with redirected stdout exits promptly, proving both streams are required.
- [ ] Full `go test ./... -count=1` completed. It reached the 150-second local limit after `internal/app` passed; no test failure was observed.
- [ ] Docker E2E completed. Docker is unavailable in the local environment, so hosted CI must provide this evidence.

Benchmark validation: **N/A**. This change does not affect review lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark claims.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`), pending hosted completion after the bounded local root-suite timeout
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`), pending hosted Docker CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained above)
- [x] I have updated documentation if necessary; no external documentation change is required for this startup-boundary fix
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please focus on the guard position and stream semantics: the no-argument route must reject either missing terminal before any platform/state/model/TUI work, while every explicit command continues to bypass the guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer guidance when launching the application without arguments in a non-interactive environment.
  * Improved terminal detection for Cygwin and MSYS2 environments, ensuring interactive update prompts appear correctly.
  * Preserved direct access to supported commands such as `--help` and `--version` without requiring an interactive terminal.

* **Tests**
  * Expanded coverage for interactive and non-interactive terminal behavior, including closed input streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->