### PR TITLE
fix(uninstall): default profile removal to no cleanup

### DIFF
--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -414,11 +414,12 @@ func (s *Service) SetProfileNamesToRemove(profileNames []string) {
 }
 
 func (s *Service) SetEngramUninstallScope(scope model.EngramUninstallScope) {
-	if scope == model.EngramUninstallScopeProject {
-		s.engramUninstallScope = model.EngramUninstallScopeProject
-		return
+	switch scope {
+	case model.EngramUninstallScopeProject, model.EngramUninstallScopeGlobal, model.EngramUninstallScopeNone:
+		s.engramUninstallScope = scope
+	default:
+		s.engramUninstallScope = model.EngramUninstallScopeNone
 	}
-	s.engramUninstallScope = model.EngramUninstallScopeGlobal
 }
 
 func (s *Service) CompleteUninstall() (Result, error) {
@@ -456,6 +457,9 @@ func (s *Service) buildPlan(agentIDs []model.AgentID, componentIDs []model.Compo
 		}
 
 		for _, componentID := range componentIDs {
+			if componentID == model.ComponentEngram && s.engramUninstallScope == model.EngramUninstallScopeNone {
+				continue
+			}
 			ops, targets, err := s.componentOperations(adapter, componentID)
 			if err != nil {
 				return plan{}, fmt.Errorf("plan uninstall for %q/%q: %w", agentID, componentID, err)
@@ -814,6 +818,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 		targets = append(targets, context7Targets(adapter, homeDir)...)
 		ops = append(ops, context7Operations(adapter, homeDir)...)
 	case model.ComponentEngram:
+		if s.engramUninstallScope == model.EngramUninstallScopeNone {
+			break
+		}
 		if s.engramUninstallScope == model.EngramUninstallScopeProject {
 			projectDataPath := filepath.Join(s.workspaceDir, ".engram")
 			if strings.TrimSpace(s.workspaceDir) != "" {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1527,6 +1527,81 @@ func TestComponentOperationsEngram_GlobalScopeKeepsWorkspaceProjectData(t *testi
 	}
 }
 
+func TestPartialUninstallWithProfilesEngramScope(t *testing.T) {
+	tests := []struct {
+		name               string
+		scope              model.EngramUninstallScope
+		wantProjectRemoved bool
+		wantEngramConfig   bool
+	}{
+		{name: "no cleanup preserves all Engram data", scope: model.EngramUninstallScopeNone, wantEngramConfig: true},
+		{name: "project cleanup removes only workspace data", scope: model.EngramUninstallScopeProject, wantProjectRemoved: true, wantEngramConfig: true},
+		{name: "global cleanup removes integration", scope: model.EngramUninstallScopeGlobal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			workspaceDir := t.TempDir()
+			svc, err := NewService(homeDir, workspaceDir, "dev")
+			if err != nil {
+				t.Fatalf("NewService() error = %v", err)
+			}
+			svc.snapshotter = stubSnapshotter{}
+			svc.now = func() time.Time { return time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC) }
+
+			adapter, ok := svc.registry.Get(model.AgentOpenCode)
+			if !ok {
+				t.Fatal("OpenCode adapter not found")
+			}
+			settingsPath := adapter.SettingsPath(homeDir)
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(`{"mcp":{"engram":{"command":["engram"]}},"agent":{"sdd-orchestrator-cheap":{},"sdd-apply-cheap":{},"sdd-orchestrator-keep":{}}}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			projectData := filepath.Join(workspaceDir, ".engram", "memory.db")
+			if err := os.MkdirAll(filepath.Dir(projectData), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(projectData, []byte("memory"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := svc.PartialUninstallWithProfiles(
+				[]model.AgentID{model.AgentOpenCode},
+				[]model.ComponentID{model.ComponentSDD, model.ComponentEngram},
+				[]string{"cheap"},
+				tt.scope,
+			); err != nil {
+				t.Fatalf("PartialUninstallWithProfiles() error = %v", err)
+			}
+
+			root := map[string]any{}
+			if err := json.Unmarshal(mustReadServiceFile(t, settingsPath), &root); err != nil {
+				t.Fatalf("json.Unmarshal(settings) error = %v", err)
+			}
+			agents := root["agent"].(map[string]any)
+			if _, exists := agents["sdd-orchestrator-cheap"]; exists {
+				t.Fatalf("selected profile assets remain: %#v", agents)
+			}
+			if _, exists := agents["sdd-orchestrator-keep"]; !exists {
+				t.Fatalf("unselected profile assets removed: %#v", agents)
+			}
+			mcp, _ := root["mcp"].(map[string]any)
+			_, hasEngramConfig := mcp["engram"]
+			if hasEngramConfig != tt.wantEngramConfig {
+				t.Fatalf("Engram config present = %t, want %t", hasEngramConfig, tt.wantEngramConfig)
+			}
+			_, projectErr := os.Stat(projectData)
+			if gotRemoved := os.IsNotExist(projectErr); gotRemoved != tt.wantProjectRemoved {
+				t.Fatalf("project data removed = %t, want %t (err = %v)", gotRemoved, tt.wantProjectRemoved, projectErr)
+			}
+		})
+	}
+}
+
 // TestComponentOperationsEngram_CodexRemovesConsolidatedProtocolAssetsWithNoOrphans
 // is the task 2.9 regression assertion: the canonical-asset consolidation
 // (design.md Decision 3) renamed/removed the SOURCE assets

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -111,6 +111,7 @@ const (
 type EngramUninstallScope string
 
 const (
+	EngramUninstallScopeNone    EngramUninstallScope = "none"
 	EngramUninstallScopeGlobal  EngramUninstallScope = "global"
 	EngramUninstallScopeProject EngramUninstallScope = "project"
 )

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -900,7 +900,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		PiBackgroundIntent:    s.PiBackgroundIntent,
 		UninstallAgents:       agents,
 		UninstallComponents:   defaultUninstallComponents(),
-		UninstallEngramScope:  model.EngramUninstallScopeGlobal,
+		UninstallEngramScope:  model.EngramUninstallScopeNone,
 		ReviewModeCwdFn:       os.Getwd,
 		ReviewModeStatusFn:    cli.ReviewModeStatus,
 		ReviewModeSetGlobalFn: cli.SetGlobalReviewMode,
@@ -1506,7 +1506,7 @@ func (m Model) View() string {
 	case ScreenUninstallComponents:
 		return screens.RenderUninstallComponents(m.UninstallComponents, m.Cursor)
 	case ScreenUninstallProfiles:
-		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.UninstallEngramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
+		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.shouldShowUninstallEngramScopeSelection(), m.shouldOfferNoCleanupEngramScope(), m.UninstallEngramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
 	case ScreenUninstallConfirm:
 		return screens.RenderUninstallConfirm(m.UninstallMode, m.UninstallAgents, m.UninstallComponents, m.UninstallProfilesToRemove, m.UninstallEngramScope, m.UninstallEngramProjectScopeAvailable, m.Cursor, m.OperationRunning, m.SpinnerFrame)
 	case ScreenUninstallResult:
@@ -2164,6 +2164,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		switch {
 		case m.Cursor < len(options):
 			m.UninstallMode = options[m.Cursor].Mode
+			m.UninstallEngramScope = defaultUninstallEngramScope(m.UninstallMode)
 			switch m.UninstallMode {
 			case model.UninstallModePartial:
 				m.setScreen(ScreenUninstall)
@@ -2226,7 +2227,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		profileCount := len(m.UninstallProfilesAvailable)
 		engramScopeOptionCount := 0
 		if m.shouldShowUninstallEngramScopeSelection() {
-			engramScopeOptionCount = 2
+			engramScopeOptionCount = len(m.uninstallEngramScopeOptions())
 		}
 		continueIdx := profileCount + engramScopeOptionCount
 		switch {
@@ -3175,7 +3176,7 @@ func (m Model) withResetUninstallState() Model {
 	m.UninstallProfilesToRemove = nil
 	m.UninstallProfileSelection = false
 	m.UninstallEngramProjectScopeAvailable = false
-	m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+	m.UninstallEngramScope = model.EngramUninstallScopeNone
 	m.UninstallResult = componentuninstall.Result{}
 	m.UninstallErr = nil
 	m.SyncCleanInstallFiles = nil
@@ -3639,7 +3640,7 @@ func (m Model) startUninstall() tea.Cmd {
 
 func (m *Model) refreshUninstallProfiles() {
 	m.UninstallEngramProjectScopeAvailable = m.detectProjectEngramData()
-	m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+	m.UninstallEngramScope = defaultUninstallEngramScope(m.UninstallMode)
 
 	if !m.hasDetectedOpenCode() {
 		m.UninstallProfilesAvailable = nil
@@ -3656,6 +3657,9 @@ func (m *Model) refreshUninstallProfiles() {
 		return
 	}
 	m.UninstallProfilesAvailable = profileNames(profiles)
+	if m.shouldOfferNoCleanupEngramScope() {
+		m.UninstallEngramScope = model.EngramUninstallScopeNone
+	}
 }
 
 func (m Model) detectProjectEngramData() bool {
@@ -4191,10 +4195,10 @@ func (m *Model) setScreen(next Screen) {
 		}
 	}
 	if next == ScreenUninstallMode {
+		m.UninstallEngramScope = defaultUninstallEngramScope(m.UninstallMode)
 		m.refreshUninstallProfiles()
 		m.UninstallProfilesToRemove = nil
 		m.UninstallProfileSelection = false
-		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
 	}
 }
 
@@ -4281,7 +4285,7 @@ func (m Model) optionCount() int {
 	case ScreenUninstallProfiles:
 		count := len(m.UninstallProfilesAvailable) + 2
 		if m.shouldShowUninstallEngramScopeSelection() {
-			count += 2
+			count += len(m.uninstallEngramScopeOptions())
 		}
 		return count
 	case ScreenUninstallConfirm:
@@ -4518,13 +4522,14 @@ func (m *Model) toggleCurrentUninstallEngramScope() {
 		return
 	}
 	idx := m.Cursor - profileCount
-	if idx == 0 {
-		m.UninstallEngramScope = model.EngramUninstallScopeProject
-		return
+	options := m.uninstallEngramScopeOptions()
+	if idx >= 0 && idx < len(options) {
+		m.UninstallEngramScope = options[idx].Scope
 	}
-	if idx == 1 {
-		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
-	}
+}
+
+func defaultUninstallEngramScope(mode model.UninstallMode) model.EngramUninstallScope {
+	return model.EngramUninstallScopeGlobal
 }
 
 func (m *Model) toggleCurrentSkill() {
@@ -5234,10 +5239,16 @@ func (m Model) shouldShowUninstallProfilesSelection() bool {
 }
 
 func (m Model) shouldShowUninstallEngramScopeSelection() bool {
-	if !hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
-		return false
-	}
-	return m.UninstallEngramProjectScopeAvailable
+	return hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) &&
+		(m.shouldShowUninstallProfilesSelection() || m.UninstallEngramProjectScopeAvailable)
+}
+
+func (m Model) shouldOfferNoCleanupEngramScope() bool {
+	return m.UninstallMode == model.UninstallModePartial && m.shouldShowUninstallProfilesSelection()
+}
+
+func (m Model) uninstallEngramScopeOptions() []screens.UninstallEngramScopeOption {
+	return screens.UninstallEngramScopeOptions(m.UninstallEngramProjectScopeAvailable, m.shouldOfferNoCleanupEngramScope())
 }
 
 func (m Model) shouldShowUninstallSubSelection() bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2601,6 +2601,9 @@ func TestUninstallModeScreen_FullWithProfilesNavigatesToProfileSelection(t *test
 	if !reflect.DeepEqual(state.UninstallProfilesToRemove, []string{"cheap", "fast"}) {
 		t.Fatalf("UninstallProfilesToRemove = %v, want [cheap fast]", state.UninstallProfilesToRemove)
 	}
+	if state.UninstallEngramScope != model.EngramUninstallScopeGlobal {
+		t.Fatalf("UninstallEngramScope = %q, want %q", state.UninstallEngramScope, model.EngramUninstallScopeGlobal)
+	}
 }
 
 func TestUninstallScreen_ContinueNavigatesToComponents(t *testing.T) {
@@ -2663,7 +2666,7 @@ func TestUninstallProfiles_ContinueNavigatesToConfirm(t *testing.T) {
 	m.Screen = ScreenUninstallProfiles
 	m.UninstallProfilesAvailable = []string{"cheap"}
 	m.UninstallProfilesToRemove = []string{"cheap"}
-	m.Cursor = len(m.UninstallProfilesAvailable)
+	m.Cursor = len(m.UninstallProfilesAvailable) + len(m.uninstallEngramScopeOptions())
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
@@ -2894,6 +2897,58 @@ func TestStartUninstall_UsesProfileAwareUninstallWhenConfigured(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("UninstallWithProfilesFn was not called")
+	}
+}
+
+func TestUninstallProfileEngramScopeDefaultsAndRefreshes(t *testing.T) {
+	original := readProfilesFn
+	readProfilesFn = func(string) ([]model.Profile, error) { return []model.Profile{{Name: "cheap"}}, nil }
+	t.Cleanup(func() { readProfilesFn = original })
+
+	tests := []struct {
+		name string
+		mode model.UninstallMode
+		want model.EngramUninstallScope
+	}{
+		{name: "profile-only defaults to no cleanup", mode: model.UninstallModePartial, want: model.EngramUninstallScopeNone},
+		{name: "full uninstall keeps global cleanup", mode: model.UninstallModeFull, want: model.EngramUninstallScopeGlobal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{Configs: []system.ConfigState{{Agent: string(model.AgentOpenCode), Exists: true}}}, "dev")
+			m.UninstallMode = tt.mode
+			m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+			m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+			m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+			m.refreshUninstallProfiles()
+			if m.UninstallEngramScope != tt.want {
+				t.Fatalf("scope after refresh = %q, want %q", m.UninstallEngramScope, tt.want)
+			}
+			m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+			m.setScreen(ScreenUninstallMode)
+			if m.UninstallEngramScope != tt.want {
+				t.Fatalf("scope after re-entering uninstall = %q, want %q", m.UninstallEngramScope, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartUninstall_PassesNoCleanupProfileScope(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+	m.UninstallProfilesToRemove = []string{"cheap"}
+	m.UninstallEngramScope = model.EngramUninstallScopeNone
+	m.UninstallWithProfilesFn = func(_ []model.AgentID, _ []model.ComponentID, _ []string, scope model.EngramUninstallScope) (componentuninstall.Result, error) {
+		if scope != model.EngramUninstallScopeNone {
+			t.Fatalf("scope = %q, want %q", scope, model.EngramUninstallScopeNone)
+		}
+		return componentuninstall.Result{}, nil
+	}
+
+	if msg := m.startUninstall()().(UninstallDoneMsg); msg.Err != nil {
+		t.Fatalf("startUninstall() error = %v", msg.Err)
 	}
 }
 

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -171,8 +171,15 @@ func RenderUninstallComponents(selected []model.ComponentID, cursor int) string 
 	return b.String()
 }
 
-func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramScopeOption {
-	options := make([]UninstallEngramScopeOption, 0, 2)
+func UninstallEngramScopeOptions(projectScopeAvailable, includeNoCleanup bool) []UninstallEngramScopeOption {
+	options := make([]UninstallEngramScopeOption, 0, 3)
+	if includeNoCleanup {
+		options = append(options, UninstallEngramScopeOption{
+			Scope:       model.EngramUninstallScopeNone,
+			Label:       "No cleanup",
+			Description: "Keep all Engram data and configuration",
+		})
+	}
 	if projectScopeAvailable {
 		options = append(options, UninstallEngramScopeOption{
 			Scope:       model.EngramUninstallScopeProject,
@@ -188,7 +195,7 @@ func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramSc
 	return options
 }
 
-func RenderUninstallProfiles(available []string, selected []string, engramProjectScopeAvailable bool, selectedEngramScope model.EngramUninstallScope, cursor int) string {
+func RenderUninstallProfiles(available []string, selected []string, showEngramScope bool, includeNoCleanup bool, engramProjectScopeAvailable bool, selectedEngramScope model.EngramUninstallScope, cursor int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Uninstall Scope Selection"))
@@ -212,9 +219,9 @@ func RenderUninstallProfiles(available []string, selected []string, engramProjec
 		b.WriteString(renderCheckbox(profileName, checked, focused))
 	}
 
-	engramScopeOptions := uninstallEngramScopeOptions(engramProjectScopeAvailable)
+	engramScopeOptions := UninstallEngramScopeOptions(engramProjectScopeAvailable, includeNoCleanup)
 	engramScopeDisplayed := 0
-	if len(engramScopeOptions) > 1 {
+	if showEngramScope {
 		engramScopeDisplayed = len(engramScopeOptions)
 		if len(available) > 0 {
 			b.WriteString("\n")
@@ -315,11 +322,14 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 		b.WriteString("\n")
 		b.WriteString(styles.SubtextStyle.Render("Engram cleanup scope:"))
 		b.WriteString("\n")
-		scopeLabel := "Global"
-		detail := "  • Removes global Engram MCP/system prompt configuration"
+		scopeLabel := "No cleanup"
+		detail := "  • Keeps all Engram data and configuration"
 		if engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable {
 			scopeLabel = "Project-only"
 			detail = "  • Deletes .engram/ in the current project only"
+		} else if engramScope == model.EngramUninstallScopeGlobal {
+			scopeLabel = "Global"
+			detail = "  • Removes global Engram MCP/system prompt configuration"
 		}
 		b.WriteString(styles.UnselectedStyle.Render("  • " + scopeLabel))
 		b.WriteString("\n")

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -340,26 +340,28 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 	b.WriteString("\n")
 
 	// Workspace-scoped assets warning
-	hasWorkspaceAssets := false
-	for _, comp := range components {
-		if comp == model.ComponentSDD || comp == model.ComponentSkills {
-			hasWorkspaceAssets = true
-			break
-		}
-	}
-	if (mode == model.UninstallModeFull || mode == model.UninstallModeFullRemove) || hasWorkspaceAssets {
+	hasEngramProjectAsset := engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable && hasSelectedComponent(components, model.ComponentEngram)
+	hasSDD := (mode == model.UninstallModeFull || mode == model.UninstallModeFullRemove) || hasSelectedComponent(components, model.ComponentSDD)
+	hasSkills := (mode == model.UninstallModeFull || mode == model.UninstallModeFullRemove) || hasSelectedComponent(components, model.ComponentSkills)
+
+	if hasSDD || hasSkills || hasEngramProjectAsset {
 		b.WriteString(styles.WarningStyle.Render("⚠ Workspace Assets Warning:"))
 		b.WriteString("\n")
-		b.WriteString(styles.SubtextStyle.Render("  Removing SDD or Skills will delete workspace-scoped files like:"))
+		b.WriteString(styles.SubtextStyle.Render("  Removing managed components will delete workspace-scoped files like:"))
 		b.WriteString("\n")
-		b.WriteString(styles.SubtextStyle.Render("  • .windsurf/workflows/ (SDD workflows)"))
-		b.WriteString("\n")
-		if engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable {
+		if hasSDD {
+			b.WriteString(styles.SubtextStyle.Render("  • .windsurf/workflows/ (SDD workflows)"))
+			b.WriteString("\n")
+		}
+		if hasEngramProjectAsset {
 			b.WriteString(styles.SubtextStyle.Render("  • .engram/ (persistent memory context)"))
 			b.WriteString("\n")
 		}
-		b.WriteString(styles.SubtextStyle.Render("  • Skills directories"))
-		b.WriteString("\n\n")
+		if hasSkills {
+			b.WriteString(styles.SubtextStyle.Render("  • Skills directories"))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
 		b.WriteString(styles.ErrorStyle.Render("  If you commit these deletions, ALL collaborators will lose this context!"))
 		b.WriteString("\n\n")
 	}

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -354,8 +354,10 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 		b.WriteString("\n")
 		b.WriteString(styles.SubtextStyle.Render("  • .windsurf/workflows/ (SDD workflows)"))
 		b.WriteString("\n")
-		b.WriteString(styles.SubtextStyle.Render("  • .engram/ (persistent memory context)"))
-		b.WriteString("\n")
+		if engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable {
+			b.WriteString(styles.SubtextStyle.Render("  • .engram/ (persistent memory context)"))
+			b.WriteString("\n")
+		}
 		b.WriteString(styles.SubtextStyle.Render("  • Skills directories"))
 		b.WriteString("\n\n")
 		b.WriteString(styles.ErrorStyle.Render("  If you commit these deletions, ALL collaborators will lose this context!"))

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -340,7 +340,7 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 	b.WriteString("\n")
 
 	// Workspace-scoped assets warning
-	hasEngramProjectAsset := engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable && hasSelectedComponent(components, model.ComponentEngram)
+	hasEngramProjectAsset := engramScope == model.EngramUninstallScopeProject && engramProjectScopeAvailable
 	hasSDD := (mode == model.UninstallModeFull || mode == model.UninstallModeFullRemove) || hasSelectedComponent(components, model.ComponentSDD)
 	hasSkills := (mode == model.UninstallModeFull || mode == model.UninstallModeFullRemove) || hasSelectedComponent(components, model.ComponentSkills)
 

--- a/internal/tui/screens/uninstall_result_test.go
+++ b/internal/tui/screens/uninstall_result_test.go
@@ -89,3 +89,27 @@ func TestRenderUninstallResultIncludesEngramScopeSummary(t *testing.T) {
 		t.Fatalf("RenderUninstallResult() should include Engram project scope summary; got:\n%s", out)
 	}
 }
+
+func TestRenderUninstallConfirmWorkspaceWarningOmitsEngramWhenScopeIsNone(t *testing.T) {
+	out := RenderUninstallConfirm(
+		model.UninstallModePartial,
+		[]model.AgentID{model.AgentOpenCode},
+		[]model.ComponentID{model.ComponentSDD, model.ComponentEngram},
+		[]string{"cheap"},
+		model.EngramUninstallScopeNone,
+		true,
+		0,
+		false,
+		0,
+	)
+
+	if !strings.Contains(out, "⚠ Workspace Assets Warning:") {
+		t.Fatalf("RenderUninstallConfirm() should include Workspace Assets Warning; got:\n%s", out)
+	}
+	if !strings.Contains(out, ".windsurf/workflows/") {
+		t.Fatalf("RenderUninstallConfirm() should mention .windsurf/workflows/ for SDD; got:\n%s", out)
+	}
+	if strings.Contains(out, "• .engram/") {
+		t.Fatalf("RenderUninstallConfirm() should NOT mention .engram/ deletion when scope is none; got:\n%s", out)
+	}
+}

--- a/internal/tui/screens/uninstall_result_test.go
+++ b/internal/tui/screens/uninstall_result_test.go
@@ -113,3 +113,27 @@ func TestRenderUninstallConfirmWorkspaceWarningOmitsEngramWhenScopeIsNone(t *tes
 		t.Fatalf("RenderUninstallConfirm() should NOT mention .engram/ deletion when scope is none; got:\n%s", out)
 	}
 }
+
+func TestRenderUninstallConfirmWorkspaceWarningIncludesEngramWhenProjectScopeSelected(t *testing.T) {
+	out := RenderUninstallConfirm(
+		model.UninstallModePartial,
+		[]model.AgentID{model.AgentOpenCode},
+		[]model.ComponentID{model.ComponentEngram},
+		nil,
+		model.EngramUninstallScopeProject,
+		true,
+		0,
+		false,
+		0,
+	)
+
+	if !strings.Contains(out, "⚠ Workspace Assets Warning:") {
+		t.Fatalf("RenderUninstallConfirm() should include Workspace Assets Warning; got:\n%s", out)
+	}
+	if !strings.Contains(out, "• .engram/ (persistent memory context)") {
+		t.Fatalf("RenderUninstallConfirm() should mention .engram/ deletion when scope is project; got:\n%s", out)
+	}
+	if strings.Contains(out, ".windsurf/workflows/") {
+		t.Fatalf("RenderUninstallConfirm() should NOT mention SDD workflows when only Engram is selected; got:\n%s", out)
+	}
+}

--- a/internal/tui/screens/uninstall_result_test.go
+++ b/internal/tui/screens/uninstall_result_test.go
@@ -90,50 +90,40 @@ func TestRenderUninstallResultIncludesEngramScopeSummary(t *testing.T) {
 	}
 }
 
-func TestRenderUninstallConfirmWorkspaceWarningOmitsEngramWhenScopeIsNone(t *testing.T) {
-	out := RenderUninstallConfirm(
-		model.UninstallModePartial,
-		[]model.AgentID{model.AgentOpenCode},
-		[]model.ComponentID{model.ComponentSDD, model.ComponentEngram},
-		[]string{"cheap"},
-		model.EngramUninstallScopeNone,
-		true,
-		0,
-		false,
-		0,
-	)
+func TestRenderUninstallConfirmEngramWorkspaceWarningMatchesCleanupEffect(t *testing.T) {
+	tests := []struct {
+		name             string
+		components       []model.ComponentID
+		profiles         []string
+		scope            model.EngramUninstallScope
+		projectAvailable bool
+		wantWarning      bool
+	}{
+		{name: "Engram-only project cleanup", components: []model.ComponentID{model.ComponentEngram}, scope: model.EngramUninstallScopeProject, projectAvailable: true, wantWarning: true},
+		{name: "no cleanup", components: []model.ComponentID{model.ComponentEngram}, scope: model.EngramUninstallScopeNone, projectAvailable: true},
+		{name: "project cleanup with unrelated selection", components: []model.ComponentID{model.ComponentPersona}, scope: model.EngramUninstallScopeProject, projectAvailable: true, wantWarning: true},
+		{name: "global cleanup", components: []model.ComponentID{model.ComponentEngram}, scope: model.EngramUninstallScopeGlobal, projectAvailable: true},
+		{name: "profile-only removal", components: []model.ComponentID{model.ComponentSDD, model.ComponentEngram}, profiles: []string{"cheap"}, scope: model.EngramUninstallScopeNone, projectAvailable: true},
+	}
 
-	if !strings.Contains(out, "⚠ Workspace Assets Warning:") {
-		t.Fatalf("RenderUninstallConfirm() should include Workspace Assets Warning; got:\n%s", out)
-	}
-	if !strings.Contains(out, ".windsurf/workflows/") {
-		t.Fatalf("RenderUninstallConfirm() should mention .windsurf/workflows/ for SDD; got:\n%s", out)
-	}
-	if strings.Contains(out, "• .engram/") {
-		t.Fatalf("RenderUninstallConfirm() should NOT mention .engram/ deletion when scope is none; got:\n%s", out)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := RenderUninstallConfirm(
+				model.UninstallModePartial,
+				[]model.AgentID{model.AgentOpenCode},
+				tt.components,
+				tt.profiles,
+				tt.scope,
+				tt.projectAvailable,
+				0,
+				false,
+				0,
+			)
 
-func TestRenderUninstallConfirmWorkspaceWarningIncludesEngramWhenProjectScopeSelected(t *testing.T) {
-	out := RenderUninstallConfirm(
-		model.UninstallModePartial,
-		[]model.AgentID{model.AgentOpenCode},
-		[]model.ComponentID{model.ComponentEngram},
-		nil,
-		model.EngramUninstallScopeProject,
-		true,
-		0,
-		false,
-		0,
-	)
-
-	if !strings.Contains(out, "⚠ Workspace Assets Warning:") {
-		t.Fatalf("RenderUninstallConfirm() should include Workspace Assets Warning; got:\n%s", out)
-	}
-	if !strings.Contains(out, "• .engram/ (persistent memory context)") {
-		t.Fatalf("RenderUninstallConfirm() should mention .engram/ deletion when scope is project; got:\n%s", out)
-	}
-	if strings.Contains(out, ".windsurf/workflows/") {
-		t.Fatalf("RenderUninstallConfirm() should NOT mention SDD workflows when only Engram is selected; got:\n%s", out)
+			gotWarning := strings.Contains(out, "• .engram/ (persistent memory context)")
+			if gotWarning != tt.wantWarning {
+				t.Fatalf(".engram warning present = %t, want %t; got:\n%s", gotWarning, tt.wantWarning, out)
+			}
+		})
 	}
 }

--- a/internal/tui/screens/uninstall_test.go
+++ b/internal/tui/screens/uninstall_test.go
@@ -1,0 +1,17 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func TestRenderUninstallProfilesShowsExplicitEngramChoices(t *testing.T) {
+	output := RenderUninstallProfiles([]string{"cheap"}, []string{"cheap"}, true, true, true, model.EngramUninstallScopeNone, 1)
+	for _, want := range []string{"No cleanup", "Keep all Engram data and configuration", "Project-only cleanup", "Global cleanup"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("RenderUninstallProfiles() missing %q:\n%s", want, output)
+		}
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #445

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add `EngramUninstallScopeNone` (`"none"`) scope to avoid deleting Engram memory when removing profiles.
- In partial uninstall with profile selection, default Engram scope to `none` ("No cleanup"), keeping global cleanup for full uninstall modes.
- Present explicit Engram cleanup choices ("No cleanup", "Project-only cleanup", "Global cleanup") in the TUI uninstall scope selection and confirmation screens.
- Add comprehensive unit and TUI tests verifying scope defaulting, rendering, and execution behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/types.go` | Added `EngramUninstallScopeNone` constant. |
| `internal/components/uninstall/service.go` | Supported `none` scope in `SetEngramUninstallScope`, skipping Engram operations/cleanup when scope is `none`. |
| `internal/components/uninstall/service_test.go` | Added `TestPartialUninstallWithProfilesEngramScope` testing all three scope behaviors. |
| `internal/tui/model.go` | Updated scope initialization, default calculations, option counting, and toggle logic to support `none` scope for partial profile removal. |
| `internal/tui/model_test.go` | Added test coverage for profile-only scope defaulting, screen transitions, and execution parameters. |
| `internal/tui/screens/uninstall.go` | Updated rendering for profile selection and confirmation screens to support "No cleanup" scope. |
| `internal/tui/screens/uninstall_test.go` | Added test verifying explicit Engram cleanup options are rendered. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Antigravity-pro/gemini-3.7-flash-high via OpenCode

**Material scope:** Implemented `EngramUninstallScopeNone` scope across service, TUI, and tests.

**Verification performed:** Unit tests (`go test ./internal/components/uninstall/...`, `go test ./internal/tui/...`), formatting (`go run ./internal/gofmtcheck`).

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/components/uninstall/... ./internal/tui/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally

```bash
go test -v ./internal/components/uninstall/... ./internal/tui/...
go run ./internal/gofmtcheck
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “No cleanup” option for selected-profile uninstallations, preserving Engram data and configuration.
  * Added project-only and global Engram cleanup choices.
  * Uninstall screens now display cleanup options based on available data.
  * Confirmation messages identify workspace data that will be removed.

* **Bug Fixes**
  * Partial and profile-based uninstallations no longer remove Engram data by default.
  * Full uninstallations continue to remove global Engram configuration.
  * Invalid cleanup selections now default to “No cleanup.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->