### PR TITLE
test(review): make relative-root fixture platform-aware

### DIFF
--- a/internal/reviewtransaction/compact_role_result_slot_test.go
+++ b/internal/reviewtransaction/compact_role_result_slot_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -62,17 +62,14 @@ func TestCompactRoleResultSlotsPreserveImmutablePublicationSemantics(t *testing.
 }
 
 func TestCompactRoleResultSlotAcceptsCompatibleRelativeStoreRoot(t *testing.T) {
-	workingDirectory, err := os.Getwd()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows NT path validation requires absolute authority roots")
+	}
+	storeDir, err := os.MkdirTemp(".", "relative-role-result-store-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A same-volume relative path is the test's input contract; Windows
-	// runners keep temp on another volume, where the OS cannot express it
-	// at all — skip rather than reshape the capability under test (#3231).
-	storeDir, err := filepath.Rel(workingDirectory, t.TempDir())
-	if err != nil {
-		t.Skipf("no same-volume relative store root available: %v", err)
-	}
+	t.Cleanup(func() { _ = os.RemoveAll(storeDir) })
 	payload := []byte(`{"results":[]}` + "\n")
 	key := compactRefuterRoleResultSlotKey()
 	if _, err := publishCompactRoleResultSlot(storeDir, key, payload); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3233

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Keep relative authority-root coverage on platforms where the production path contract supports it.
- Skip that incompatible fixture on Windows, where NT authority validation requires an absolute root.
- Build the Unix relative fixture under the package directory without changing the process cwd or depending on the runner temp volume.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_role_result_slot_test.go` | Makes the relative-root fixture platform-aware and removes cross-volume/global-cwd assumptions. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi with OpenAI Codex models.

**Material scope:** Issue analysis, fixture correction, test execution, and platform-contract verification.

**Verification performed:** Focused issue tests, Windows amd64 cross-compilation, full reviewtransaction package suite with canonical macOS TMPDIR, gofmt, diff check, and LSP diagnostics.

---

## 🧪 Test Plan

- [x] Focused issue tests:
  `go test ./internal/reviewtransaction -run 'TestCompactRoleResultSlotAcceptsCompatibleRelativeStoreRoot|TestCompactStartReturnsCommittedRecordWhenRepositoryContextReconciliationFails' -count=1`
- [x] Windows amd64 package cross-compilation:
  `GOOS=windows GOARCH=amd64 go test -c ./internal/reviewtransaction`
- [x] Package suite:
  `TMPDIR=/private/tmp go test ./internal/reviewtransaction -count=1 -timeout 20m`
- [x] `git diff --check`
- [ ] Real Windows runtime remains CI-owned.
- Benchmark validation: N/A. This is a test-fixture correction and changes no review lifecycle behavior or benchmark contract.

The package suite fails under macOS's default `/var/...` temp alias because authority-path tests intentionally reject the symlinked `/var` path. It passes with canonical `/private/tmp`; this is pre-existing and unrelated to the candidate.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 15 authored lines
- [ ] Maintainer must apply exactly one `type:bug` label
- [x] Affected tests pass
- [x] Go format passes
- [ ] Windows runtime is delegated to CI
- [x] Benchmark validation is not applicable
- [x] Documentation is not required for a test-only fixture correction
- [x] Commit follows Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance is declared above
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Current `main` already sets both `HOME` and `USERPROFILE` in `TestCompactStartReturnsCommittedRecordWhenRepositoryContextReconciliationFails`, covering the later fixture class added to #3233. This PR addresses the remaining relative-root fixture only.

The skip does not hide a supported Windows product behavior: Windows NT authority validation requires absolute roots. Unix continues to exercise a genuinely relative root.

RDD delivery is `disabled/unmanaged`; no review receipt or approval is claimed. This test-only change adds no qualifying security, integrity, admission, repair, or governance guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test reliability by skipping an unsupported relative-path scenario on Windows.
  * Updated temporary-directory handling to ensure test files are cleaned up after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->