### PR TITLE
fix(opencode): grant Engram tools to SDD phase agents

### DIFF
--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -76,6 +76,7 @@ const (
 	organicProviderCaptureFakePayloadEnvironment    = "GENTLE_AI_ORGANIC_PROVIDER_CAPTURE_FAKE_PAYLOAD"
 	organicProviderCaptureFakeFailureEnvironment    = "GENTLE_AI_ORGANIC_PROVIDER_CAPTURE_FAKE_FAILURE"
 	organicProviderCaptureFakeInvocationEnvironment = "GENTLE_AI_ORGANIC_PROVIDER_CAPTURE_FAKE_INVOCATION"
+	organicMCPFixtureEnvironment                    = "GENTLE_AI_ORGANIC_MCP_FIXTURE"
 
 	organicActorRoleDirect    = "direct"
 	organicActorRoleDelegated = "delegated"
@@ -107,6 +108,9 @@ const (
 var organicBinary string
 
 func TestMain(m *testing.M) {
+	if os.Getenv(organicMCPFixtureEnvironment) == "1" {
+		os.Exit(runOrganicMCPFixture())
+	}
 	if agent := strings.TrimSpace(os.Getenv(organicProviderCaptureFakeAgentEnvironment)); agent != "" {
 		os.Exit(runOrganicProviderCaptureFake(agent))
 	}
@@ -137,6 +141,61 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	_ = os.RemoveAll(workspace)
 	os.Exit(code)
+}
+
+func runOrganicMCPFixture() int {
+	decoder := json.NewDecoder(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for {
+		var request struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Method  string          `json:"method"`
+			Params  struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			} `json:"params"`
+		}
+		if err := decoder.Decode(&request); err != nil {
+			if errors.Is(err, io.EOF) {
+				return 0
+			}
+			fmt.Fprintf(os.Stderr, "decode MCP request: %v\n", err)
+			return 1
+		}
+		if len(request.ID) == 0 {
+			continue
+		}
+
+		response := map[string]any{"jsonrpc": "2.0", "id": request.ID}
+		switch request.Method {
+		case "initialize":
+			protocolVersion := request.Params.ProtocolVersion
+			if protocolVersion == "" {
+				protocolVersion = "2024-11-05"
+			}
+			response["result"] = map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+				"serverInfo":      map[string]any{"name": "organic-engram-fixture", "version": "0"},
+			}
+		case "tools/list":
+			tools := make([]map[string]any, 0, 4)
+			for _, name := range []string{"mem_save", "mem_search", "mem_get_observation", "mem_update"} {
+				tools = append(tools, map[string]any{
+					"name":        name,
+					"description": "Organic runtime fixture tool",
+					"inputSchema": map[string]any{"type": "object", "additionalProperties": true},
+				})
+			}
+			response["result"] = map[string]any{"tools": tools}
+		default:
+			response["error"] = map[string]any{"code": -32601, "message": "method not found"}
+		}
+		if err := encoder.Encode(response); err != nil {
+			fmt.Fprintf(os.Stderr, "encode MCP response: %v\n", err)
+			return 1
+		}
+	}
 }
 
 // runOrganicActor is the implementation actor. It edits exactly one already
@@ -3180,7 +3239,7 @@ func TestRealAgentOrganicJourneys(t *testing.T) {
 				"XDG_CACHE_HOME="+sharedCache,
 				"OPENCODE_CONFIG_DIR="+filepath.Join(sharedConfig, "opencode"),
 				"OPENCODE_TEST_HOME="+filepath.Join(home, "opencode"),
-				"OPENCODE_CONFIG_CONTENT="+organicOpenCodeConfig(t, model.URL),
+				"OPENCODE_CONFIG_CONTENT="+organicOpenCodeConfig(t, model.URL, nil),
 				"OPENCODE_AUTH_CONTENT={}",
 				"OPENCODE_DISABLE_PROJECT_CONFIG=1",
 				"OPENCODE_DISABLE_AUTOUPDATE=1",
@@ -3270,7 +3329,7 @@ func TestRealAgentInstalledSDDApplyExecutorDoesNotDelegate(t *testing.T) {
 	fixture.actorCommand = "echo " + executorNonce
 
 	settingsPath := filepath.Join(configRoot, "opencode", "opencode.json")
-	if err := os.WriteFile(settingsPath, []byte(organicOpenCodeConfig(t, fixture.URL)), 0o600); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(organicOpenCodeConfig(t, fixture.URL, []string{os.Args[0]})), 0o600); err != nil {
 		t.Fatalf("write OpenCode fixture config: %v", err)
 	}
 	if _, err := sdd.Inject(home, opencode.NewAdapter(), model.SDDModeMulti); err != nil {
@@ -3593,6 +3652,12 @@ func (fixture *openCodeFixtureServer) acceptInstalledSDDApplyExecutor(writer htt
 			return false
 		}
 	}
+	requiredTools := map[string]bool{
+		"engram_mem_save":            false,
+		"engram_mem_search":          false,
+		"engram_mem_get_observation": false,
+		"engram_mem_update":          false,
+	}
 	for _, rawTool := range input.Tools {
 		var tool struct {
 			Function struct {
@@ -3605,6 +3670,15 @@ func (fixture *openCodeFixtureServer) acceptInstalledSDDApplyExecutor(writer htt
 		}
 		if tool.Function.Name == "task" {
 			fixture.fail(writer, "installed sdd-apply executor was offered the task delegation tool")
+			return false
+		}
+		if _, required := requiredTools[tool.Function.Name]; required {
+			requiredTools[tool.Function.Name] = true
+		}
+	}
+	for tool, exposed := range requiredTools {
+		if !exposed {
+			fixture.fail(writer, "installed sdd-apply executor was not offered required tool %q", tool)
 			return false
 		}
 	}
@@ -3793,7 +3867,7 @@ func (fixture *openCodeFixtureServer) assertComplete(t *testing.T, wantSubagent 
 	}
 }
 
-func organicOpenCodeConfig(t *testing.T, serverURL string) string {
+func organicOpenCodeConfig(t *testing.T, serverURL string, mcpCommand []string) string {
 	t.Helper()
 	config := map[string]any{
 		"provider": map[string]any{
@@ -3814,6 +3888,16 @@ func organicOpenCodeConfig(t *testing.T, serverURL string) string {
 		},
 		"plugin":     []any{},
 		"compaction": map[string]any{"auto": false},
+	}
+	if len(mcpCommand) > 0 {
+		config["mcp"] = map[string]any{
+			"engram": map[string]any{
+				"type":        "local",
+				"command":     mcpCommand,
+				"enabled":     true,
+				"environment": map[string]string{organicMCPFixtureEnvironment: "1"},
+			},
+		}
 	}
 	encoded, err := json.Marshal(config)
 	if err != nil {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -471,6 +471,10 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			// NOT contain model fields — otherwise the deep merge overwrites
 			// whatever the user already has in opencode.json.
 			overlayBytes := []byte(overlayContent)
+			overlayBytes, err = projectOpenCodeSDDPhaseTools(overlayBytes, "", adapter.Agent() == model.AgentOpenCode)
+			if err != nil {
+				return InjectionResult{}, err
+			}
 			if adapter.Agent() == model.AgentKilocode {
 				overlayBytes, err = stripOpenCodeNativeFallbackAgents(overlayBytes)
 				if err != nil {
@@ -566,6 +570,12 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				profileOverlay, profileErr := GenerateProfileOverlay(profile, homeDir, settingsPath, opts.OpenCodeModelAssignments, opts.CodeGraphGuidanceMarkdown, opts.orchestratorPolicyRenderOptions())
 				if profileErr != nil {
 					return InjectionResult{}, fmt.Errorf("generate profile overlay %q: %w", profile.Name, profileErr)
+				}
+				if adapter.Agent() == model.AgentKilocode {
+					profileOverlay, profileErr = projectOpenCodeSDDPhaseTools(profileOverlay, "-"+profile.Name, false)
+					if profileErr != nil {
+						return InjectionResult{}, fmt.Errorf("strip OpenCode-only profile tools %q: %w", profile.Name, profileErr)
+					}
 				}
 				profileResult, profileErr := mergeJSONFile(settingsPath, profileOverlay)
 				if profileErr != nil {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -621,6 +621,79 @@ func TestInjectOpenCodeUsesOpenCodeSpecificOrchestratorPrompt(t *testing.T) {
 	}
 }
 
+func TestInjectOpenCodeGrantsSDDPhaseEngramTools(t *testing.T) {
+	required := []string{
+		"engram_mem_save",
+		"engram_mem_search",
+		"engram_mem_get_observation",
+		"engram_mem_update",
+	}
+	forbidden := []string{
+		"engram_mem_session_summary",
+		"engram_mem_current_project",
+		"engram_mem_suggest_topic_key",
+	}
+
+	for _, mode := range []model.SDDModeID{model.SDDModeSingle, model.SDDModeMulti} {
+		t.Run(string(mode), func(t *testing.T) {
+			home := t.TempDir()
+			mockNoPackageManager(t)
+			profile := makeHaikuProfile()
+			profile.PhaseAssignments["jd-judge-a"] = model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-haiku-3-5"}
+
+			if _, err := Inject(home, opencodeAdapter(), mode, InjectOptions{
+				Profiles: []model.Profile{profile},
+			}); err != nil {
+				t.Fatalf("Inject(%s) error = %v", mode, err)
+			}
+
+			agents := readOpenCodeAgents(t, opencodeAdapter().SettingsPath(home))
+			for _, phase := range profilePhaseOrder {
+				for _, key := range []string{phase, phase + "-cheap"} {
+					agent, ok := agents[key].(map[string]any)
+					if !ok {
+						t.Fatalf("installed config missing SDD phase agent %q", key)
+					}
+					tools, ok := agent["tools"].(map[string]any)
+					if !ok {
+						t.Fatalf("SDD phase agent %q tools = %#v, want object", key, agent["tools"])
+					}
+					for _, tool := range required {
+						if enabled, _ := tools[tool].(bool); !enabled {
+							t.Errorf("SDD phase agent %q tool %q = %#v, want true", key, tool, tools[tool])
+						}
+					}
+					for _, existing := range []string{"read", "write", "edit", "bash"} {
+						if enabled, _ := tools[existing].(bool); !enabled {
+							t.Errorf("SDD phase agent %q lost existing tool %q", key, existing)
+						}
+					}
+					for _, tool := range forbidden {
+						if enabled, _ := tools[tool].(bool); enabled {
+							t.Errorf("SDD phase agent %q gained unnecessary tool %q", key, tool)
+						}
+					}
+					if enabled, _ := tools["task"].(bool); enabled {
+						t.Errorf("SDD phase agent %q gained task delegation: %#v", key, tools)
+					}
+				}
+			}
+
+			nonSDDAgents := append(opencodemodel.JDPhases(), opencodemodel.ReviewPhases()...)
+			nonSDDAgents = append(nonSDDAgents, "jd-judge-a-cheap")
+			for _, key := range nonSDDAgents {
+				agent := agents[key].(map[string]any)
+				tools := agent["tools"].(map[string]any)
+				for _, tool := range required {
+					if enabled, _ := tools[tool].(bool); enabled {
+						t.Errorf("non-SDD agent %q gained phase tool %q", key, tool)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestInjectOpenCodePreservesExistingOrchestratorPromptWhenRequested(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)

--- a/internal/components/sdd/opencode_phase_tools.go
+++ b/internal/components/sdd/opencode_phase_tools.go
@@ -1,0 +1,53 @@
+package sdd
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var openCodeSDDPhaseEngramTools = []string{
+	"engram_mem_save",
+	"engram_mem_search",
+	"engram_mem_get_observation",
+	"engram_mem_update",
+}
+
+func grantOpenCodeSDDPhaseEngramTools(tools map[string]any) {
+	for _, tool := range openCodeSDDPhaseEngramTools {
+		tools[tool] = true
+	}
+}
+
+func projectOpenCodeSDDPhaseTools(overlay []byte, suffix string, enabled bool) ([]byte, error) {
+	var root map[string]any
+	if err := json.Unmarshal(overlay, &root); err != nil {
+		return nil, fmt.Errorf("decode OpenCode SDD overlay: %w", err)
+	}
+	agents, ok := root["agent"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("decode OpenCode SDD overlay: agent is not an object")
+	}
+	for _, phase := range profilePhaseOrder {
+		key := phase + suffix
+		agent, ok := agents[key].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("decode OpenCode SDD overlay: agent %q is not an object", key)
+		}
+		tools, ok := agent["tools"].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("decode OpenCode SDD overlay: agent %q tools is not an object", key)
+		}
+		if enabled {
+			grantOpenCodeSDDPhaseEngramTools(tools)
+		} else {
+			for _, tool := range openCodeSDDPhaseEngramTools {
+				delete(tools, tool)
+			}
+		}
+	}
+	result, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode OpenCode SDD overlay: %w", err)
+	}
+	return append(result, '\n'), nil
+}

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -352,17 +352,19 @@ func GenerateProfileOverlay(profile model.Profile, homeDir, settingsPath string,
 		if err != nil {
 			return nil, fmt.Errorf("build shared prompt file reference for %q: %w", phase, err)
 		}
+		tools := map[string]any{
+			"read":  true,
+			"write": true,
+			"edit":  true,
+			"bash":  true,
+		}
+		grantOpenCodeSDDPhaseEngramTools(tools)
 		entry := map[string]any{
 			"mode":        "subagent",
 			"hidden":      true,
 			"description": phaseDescriptions[phase],
 			"prompt":      prompt,
-			"tools": map[string]any{
-				"read":  true,
-				"write": true,
-				"edit":  true,
-				"bash":  true,
-			},
+			"tools":       tools,
 		}
 		// Issue #557: consult fallback when the profile did not set the phase,
 		// so generated *-{name} agents stay consistent with what the user sees


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2710

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Project one canonical Engram MCP capability contract into every OpenCode SDD phase executor.
- Cover default single/multi installs and named profiles without duplicating grants in raw overlay assets.
- Prove effective runtime exposure through a real pinned OpenCode provider request while preserving the no-delegation boundary.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/opencode_phase_tools.go` | Defines and projects the four required Engram MCP tool IDs. |
| `internal/components/sdd/inject.go` | Applies the shared contract to default OpenCode agents and strips it from Kilocode. |
| `internal/components/sdd/profiles.go` | Applies the same contract to named-profile SDD phase agents. |
| `internal/components/sdd/inject_test.go` | Verifies merged single/multi and named-profile configurations, retained baseline tools, and negative boundaries. |
| `e2e/organicruntime/organic_runtime_test.go` | Adds an isolated Engram MCP fixture and validates effective tool schemas in the delegated executor provider request. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with `openai/gpt-5.6-sol`

**Material scope:** Repository mapping, implementation, tests, runtime fixture, validation, and PR preparation.

**Verification performed:** Behavior-first RED/GREEN testing, complete SDD package tests, one real pinned OpenCode runtime execution, and independent read-only candidate validation.

---

## 🧪 Test Plan

**Unit and integration tests**

- [x] `go test ./internal/components/sdd -count=1`
- [x] `go test ./internal/components/sdd -run '^(TestInjectOpenCodeGrantsSDDPhaseEngramTools|TestKilocodeReviewSettingsMatchCurrentMainBaseline)$' -count=1`
- [x] `go test ./e2e/organicruntime -run '^(TestRealAgentInstalledSDDApplyExecutorDoesNotDelegate|TestInstalledSDDApplyExecutorProofRejectsOrchestratorSpoof)$' -count=1`

**Real OpenCode runtime proof**

- [x] Ran `TestRealAgentInstalledSDDApplyExecutorDoesNotDelegate` once with isolated OpenCode `1.18.10` and `GENTLE_AI_REAL_AGENT_E2E=1`.
- [x] Confirmed the delegated executor request exposed `engram_mem_save`, `engram_mem_search`, `engram_mem_get_observation`, and `engram_mem_update`.
- [x] Confirmed the same request excluded `task`.

**Go format**

- [x] `go run ./internal/gofmtcheck`

**Repository-wide / Docker checks**

- [ ] Unit tests pass (`go test ./...`) — delegated to CI; focused and complete affected-package tests pass locally.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to CI; the affected organic runtime test passes locally.
- [x] Manually tested locally through the real pinned OpenCode provider boundary.

**Benchmark validation:** N/A. This change does not alter review lifecycle, gates, recovery, delivery, benchmark implementation, corpus, or classifier behavior. The applicable runtime boundary is covered by the organic OpenCode E2E test.

---

## 🤖 Automated Checks

The repository's PR validation and CI checks remain authoritative for the full suite.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (240 additions + deletions)
- [ ] `type:bug` label requires a maintainer because the contributor account cannot apply repository labels
- [ ] Unit tests pass (`go test ./...`) — pending CI
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending CI
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation updates are not necessary for this internal capability projection
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is a narrow current-`main` carrier for #2710. It does not copy the unrelated recovery or dead-validator scope from #2724, and it avoids the duplicated raw-overlay grants and incomplete named-profile coverage in #2712.

The runtime evidence proves managed tool exposure for the pinned OpenCode path. It intentionally does not claim that missing grants caused every historical `sdd_task_result_empty` occurrence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDD workflow agents now have access to the required Engram tools across supported OpenCode and Kilocode configurations.
  * Tool permissions are applied consistently across standard and lower-cost SDD agent modes.
  * SDD configuration validation now checks for all required Engram capabilities and prevents unsupported task delegation.

* **Bug Fixes**
  * Improved handling and error reporting when processing SDD tool configuration overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->