### PR TITLE
fix(review): emit structured reasons and menus for review stop transitions

### DIFF
--- a/contracts/review-integration/v1/schemas/status-v2.schema.json
+++ b/contracts/review-integration/v1/schemas/status-v2.schema.json
@@ -100,7 +100,8 @@
         "reason_code": { "type": "string", "pattern": "^[a-z0-9_]+$" },
         "execute": { "$ref": "#/$defs/transition_execution" },
         "collect": { "$ref": "#/$defs/transition_collection" },
-        "correction_request": { "$ref": "correction-plan-request.schema.json" }
+        "correction_request": { "$ref": "correction-plan-request.schema.json" },
+        "stop": { "$ref": "#/$defs/transition_stop" }
       },
       "allOf": [
         { "if": { "properties": { "kind": { "const": "execute" } }, "required": ["kind"] }, "then": { "required": ["execute"], "not": { "required": ["collect"] } } },
@@ -108,6 +109,27 @@
         { "if": { "properties": { "kind": { "const": "stop" } }, "required": ["kind"] }, "then": { "not": { "anyOf": [{ "required": ["execute"] }, { "required": ["collect"] }] } } },
         { "if": { "properties": { "reason_code": { "enum": ["correction_plan_required", "corrected_candidate_unavailable"] } }, "required": ["reason_code"] }, "then": { "required": ["correction_request"] }, "else": { "not": { "required": ["correction_request"] } } }
       ]
+    },
+    "transition_stop": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["statement"],
+      "properties": {
+        "statement": { "type": "string", "minLength": 1 },
+        "commands": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "off_path": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["note", "command"],
+          "properties": {
+            "note": { "type": "string", "minLength": 1 },
+            "command": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
     },
     "transition_argument": {
       "$comment": "One argument of a transition. \"token\", when present, is the exact argv token rendering this argument for a command this product runs, e.g. \"--lineage=review-abc\". It is required on an execute argument (see executable_transition_argument) and present on the arguments of a collect input whose capture_operation names an operation this product performs, because those arguments are literally that command's flags. It is absent on preconditions, on selector_arguments, and on the arguments of an \"external.*\" capture operation, which are assertions, a normalized echo, and values to hand elsewhere rather than argv.",

--- a/contracts/review-integration/v1/schemas/status.schema.json
+++ b/contracts/review-integration/v1/schemas/status.schema.json
@@ -83,7 +83,8 @@
         "reason_code": { "type": "string", "pattern": "^[a-z0-9_]+$" },
         "execute": { "$ref": "#/$defs/transition_execution" },
         "collect": { "$ref": "#/$defs/transition_collection" },
-        "correction_request": { "$ref": "correction-plan-request.schema.json" }
+        "correction_request": { "$ref": "correction-plan-request.schema.json" },
+        "stop": { "$ref": "#/$defs/transition_stop" }
       },
       "allOf": [
         { "if": { "properties": { "kind": { "const": "execute" } }, "required": ["kind"] }, "then": { "required": ["execute"], "not": { "required": ["collect"] } } },
@@ -91,6 +92,27 @@
         { "if": { "properties": { "kind": { "const": "stop" } }, "required": ["kind"] }, "then": { "not": { "anyOf": [{ "required": ["execute"] }, { "required": ["collect"] }] } } },
         { "if": { "properties": { "reason_code": { "enum": ["correction_plan_required", "corrected_candidate_unavailable"] } }, "required": ["reason_code"] }, "then": { "required": ["correction_request"] }, "else": { "not": { "required": ["correction_request"] } } }
       ]
+    },
+    "transition_stop": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["statement"],
+      "properties": {
+        "statement": { "type": "string", "minLength": 1 },
+        "commands": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "off_path": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["note", "command"],
+          "properties": {
+            "note": { "type": "string", "minLength": 1 },
+            "command": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
     },
     "transition_argument": {
       "$comment": "One argument of a transition. \"token\", when present, is the exact argv token rendering this argument for a command this product runs, e.g. \"--lineage=review-abc\". It is required on an execute argument (see executable_transition_argument) and present on the arguments of a collect input whose capture_operation names an operation this product performs, because those arguments are literally that command's flags. It is absent on preconditions, on selector_arguments, and on the arguments of an \"external.*\" capture operation, which are assertions, a normalized echo, and values to hand elsewhere rather than argv.",

--- a/contracts/review-integration/v2/fixtures/status-v5.fixture.json
+++ b/contracts/review-integration/v2/fixtures/status-v5.fixture.json
@@ -48,7 +48,14 @@
   "candidates": [],
   "next_transition": {
     "kind": "stop",
-    "reason_code": "manual_intervention_required"
+    "reason_code": "manual_intervention_required",
+    "stop": {
+      "statement": "This review reached an unrecoverable state. Ask a maintainer to inspect the review record directly, or run `gentle-ai review mode disable --scope clone --cwd <repo>` (omitting --scope disables it for every repository on the machine) to deliver under ordinary repository policy instead.",
+      "off_path": {
+        "note": "To deliver under ordinary repository policy instead, disable review for this repository.",
+        "command": "gentle-ai review mode disable --scope clone --cwd <repo>"
+      }
+    }
   },
   "forecast": {
     "horizon": "terminal",

--- a/contracts/review-integration/v2/schemas/status-v4.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v4.schema.json
@@ -49,7 +49,8 @@
         "reason_code": {"type": "string", "pattern": "^[a-z0-9_]+$"},
         "execute": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_execution"},
         "collect": {"$ref": "#/$defs/transition_collection"},
-        "correction_request": {"$ref": "../../v1/schemas/correction-plan-request.schema.json"}
+        "correction_request": {"$ref": "../../v1/schemas/correction-plan-request.schema.json"},
+        "stop": {"$ref": "#/$defs/transition_stop"}
       },
       "allOf": [
         {"if": {"properties": {"kind": {"const": "execute"}}, "required": ["kind"]}, "then": {"required": ["execute"], "not": {"required": ["collect"]}}},
@@ -60,6 +61,20 @@
         {"if": {"properties": {"reason_code": {"const": "targeted_validation_required"}}, "required": ["reason_code"]}, "then": {"properties": {"kind": {"const": "collect"}, "collect": {"properties": {"inputs": {"minItems": 1, "maxItems": 1, "items": {"properties": {"capture_operation": {"const": "external.run_targeted_validation"}}, "required": ["capture_operation", "submission"]}}}}}}},
         {"if": {"properties": {"reason_code": {"not": {"enum": ["correction_plan_required", "targeted_validation_required"]}}}, "required": ["reason_code"]}, "then": {"not": {"required": ["collect"], "properties": {"collect": {"required": ["inputs"], "properties": {"inputs": {"contains": {"required": ["submission"]}}}}}}}}
       ]
+    },
+    "transition_stop": {
+      "type": "object", "additionalProperties": false, "required": ["statement"],
+      "properties": {
+        "statement": {"type": "string", "minLength": 1},
+        "commands": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "off_path": {
+          "type": "object", "additionalProperties": false, "required": ["note", "command"],
+          "properties": {
+            "note": {"type": "string", "minLength": 1},
+            "command": {"type": "string", "minLength": 1}
+          }
+        }
+      }
     },
     "transition_collection": {
       "type": "object", "additionalProperties": false, "required": ["inputs"],

--- a/contracts/review-integration/v2/schemas/status-v5.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v5.schema.json
@@ -73,7 +73,8 @@
         "reason_code": {"type": "string", "pattern": "^[a-z0-9_]+$"},
         "execute": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_execution"},
         "collect": {"$ref": "#/$defs/transition_collection"},
-        "correction_request": {"$ref": "../../v1/schemas/correction-plan-request.schema.json"}
+        "correction_request": {"$ref": "../../v1/schemas/correction-plan-request.schema.json"},
+        "stop": {"$ref": "#/$defs/transition_stop"}
       },
       "allOf": [
         {"if": {"properties": {"kind": {"const": "execute"}}, "required": ["kind"]}, "then": {"required": ["execute"], "not": {"required": ["collect"]}}},
@@ -88,6 +89,20 @@
         ]}}}}}}},
         {"if": {"properties": {"reason_code": {"enum": ["verification_evidence_required", "correction_repository_verification_required"]}}, "required": ["reason_code"]}, "then": {"properties": {"kind": {"const": "collect"}, "collect": {"properties": {"inputs": {"minItems": 1, "maxItems": 1, "items": {"properties": {"capture_operation": {"const": "review.capture-evidence"}}, "required": ["capture_operation", "submission"]}}}}}}}
       ]
+    },
+    "transition_stop": {
+      "type": "object", "additionalProperties": false, "required": ["statement"],
+      "properties": {
+        "statement": {"type": "string", "minLength": 1},
+        "commands": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "off_path": {
+          "type": "object", "additionalProperties": false, "required": ["note", "command"],
+          "properties": {
+            "note": {"type": "string", "minLength": 1},
+            "command": {"type": "string", "minLength": 1}
+          }
+        }
+      }
     },
     "transition_collection": {
       "type": "object", "additionalProperties": false, "required": ["inputs"],

--- a/contracts/review-integration/v2/schemas/status.schema.json
+++ b/contracts/review-integration/v2/schemas/status.schema.json
@@ -39,7 +39,8 @@
         "reason_code": {"type": "string", "pattern": "^[a-z0-9_]+$"},
         "execute": {"$ref": "../../v1/schemas/status-v2.schema.json#/$defs/transition_execution"},
         "collect": {"$ref": "#/$defs/transition_collection"},
-        "correction_request": {"$ref": "../../v1/schemas/correction-plan-request.schema.json"}
+        "correction_request": {"$ref": "../../v1/schemas/correction-plan-request.schema.json"},
+        "stop": {"$ref": "#/$defs/transition_stop"}
       },
       "allOf": [
         {"if": {"properties": {"kind": {"const": "execute"}}, "required": ["kind"]}, "then": {"required": ["execute"], "not": {"required": ["collect"]}}},
@@ -47,6 +48,20 @@
         {"if": {"properties": {"kind": {"const": "stop"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["execute"]}, {"required": ["collect"]}]}}},
         {"if": {"properties": {"reason_code": {"enum": ["correction_plan_required", "corrected_candidate_unavailable"]}}, "required": ["reason_code"]}, "then": {"required": ["correction_request"]}, "else": {"not": {"required": ["correction_request"]}}}
       ]
+    },
+    "transition_stop": {
+      "type": "object", "additionalProperties": false, "required": ["statement"],
+      "properties": {
+        "statement": {"type": "string", "minLength": 1},
+        "commands": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "off_path": {
+          "type": "object", "additionalProperties": false, "required": ["note", "command"],
+          "properties": {
+            "note": {"type": "string", "minLength": 1},
+            "command": {"type": "string", "minLength": 1}
+          }
+        }
+      }
     },
     "transition_collection": {
       "type": "object", "additionalProperties": false, "required": ["inputs"],

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -20,13 +21,30 @@ const (
 
 // ReviewNextTransition is the sole negotiated routing decision. Its execute
 // form is complete, its collect form identifies one externally supplied input,
-// and its stop form intentionally contains no command-shaped data.
+// and its stop form carries structured continuations and exit guidance.
 type ReviewNextTransition struct {
 	Kind              string                                   `json:"kind"`
 	ReasonCode        string                                   `json:"reason_code"`
 	Execute           *ReviewTransitionExecution               `json:"execute,omitempty"`
 	Collect           *ReviewTransitionCollection              `json:"collect,omitempty"`
 	CorrectionRequest *reviewtransaction.CorrectionPlanRequest `json:"correction_request,omitempty"`
+	Stop              *ReviewTransitionStop                    `json:"stop,omitempty"`
+}
+
+// ReviewTransitionStop carries structured machine-readable continuations for a
+// stop transition: the narrative statement explaining why execution stopped,
+// any runnable follow-up commands, and the documented off-path exit.
+type ReviewTransitionStop struct {
+	Statement string                       `json:"statement"`
+	Commands  []string                     `json:"commands,omitempty"`
+	OffPath   *ReviewTransitionStopOffPath `json:"off_path,omitempty"`
+}
+
+// ReviewTransitionStopOffPath names the documented deliberate exit outside the
+// review lifecycle.
+type ReviewTransitionStopOffPath struct {
+	Note    string `json:"note"`
+	Command string `json:"command"`
 }
 
 type ReviewTransitionExecution struct {
@@ -1242,8 +1260,42 @@ func reviewCollectTransition(reason string, inputs ...ReviewTransitionInput) Rev
 	return ReviewNextTransition{Kind: reviewNextTransitionCollect, ReasonCode: reason, Collect: &ReviewTransitionCollection{Inputs: collected}}
 }
 
+var reviewCommandInStatementRegexp = regexp.MustCompile("`([^`]+)`")
+
+func newReviewTransitionStop(reason string) ReviewTransitionStop {
+	statement, ok := reviewStopReasonNarration[reason]
+	if !ok {
+		statement = reviewReasonDescription(reason)
+	}
+	stop := ReviewTransitionStop{
+		Statement: statement,
+	}
+	if strings.Contains(statement, reviewConsentOffPathCommand) || strings.Contains(statement, reviewModeDisableCloneCommand) {
+		stop.OffPath = &ReviewTransitionStopOffPath{
+			Note:    "To deliver under ordinary repository policy instead, disable review for this repository.",
+			Command: reviewModeDisableCloneCommand,
+		}
+	}
+	matches := reviewCommandInStatementRegexp.FindAllStringSubmatch(statement, -1)
+	seen := make(map[string]bool)
+	for _, m := range matches {
+		cmd := m[1]
+		if strings.HasPrefix(cmd, "gentle-ai ") {
+			if strings.HasPrefix(cmd, "gentle-ai review mode disable") {
+				continue
+			}
+			if !seen[cmd] {
+				seen[cmd] = true
+				stop.Commands = append(stop.Commands, cmd)
+			}
+		}
+	}
+	return stop
+}
+
 func reviewStopTransition(reason string) ReviewNextTransition {
-	return ReviewNextTransition{Kind: reviewNextTransitionStop, ReasonCode: reason}
+	stop := newReviewTransitionStop(reason)
+	return ReviewNextTransition{Kind: reviewNextTransitionStop, ReasonCode: reason, Stop: &stop}
 }
 
 func reviewReasonDescription(reason string) string {

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -1104,3 +1104,62 @@ func reviewSchemaRegexpEngine(pattern string) (jsonschema.Regexp, error) {
 	}
 	return reviewSchemaRegexp{pattern: pattern, re: re}, nil
 }
+
+// TestReviewStopTransitionEmitsStructuredContinuations verifies that every stop
+// transition emitted by reviewStopTransition carries structured continuations
+// (statement, runnable commands, and/or off-path exit) so consuming adapters
+// and runtime agents do not invent their own menus (#3384).
+func TestReviewStopTransitionEmitsStructuredContinuations(t *testing.T) {
+	source, err := os.ReadFile("review_next_transition.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := reviewStopTransitionCallRegexp.FindAllStringSubmatch(string(source), -1)
+	if len(matches) == 0 {
+		t.Fatal("found no reviewStopTransition calls")
+	}
+	for _, match := range matches {
+		code := match[1]
+		transition := reviewStopTransition(code)
+		if transition.Kind != reviewNextTransitionStop {
+			t.Errorf("stop reason %q: kind = %q, want stop", code, transition.Kind)
+		}
+		if transition.ReasonCode != code {
+			t.Errorf("stop reason %q: reason_code = %q, want %q", code, transition.ReasonCode, code)
+		}
+		if transition.Stop == nil {
+			t.Errorf("stop reason %q: Stop is nil, want structured continuation", code)
+			continue
+		}
+		if strings.TrimSpace(transition.Stop.Statement) == "" {
+			t.Errorf("stop reason %q: Stop.Statement is empty", code)
+		}
+		hasContinuation := (transition.Stop.OffPath != nil && transition.Stop.OffPath.Command != "") || len(transition.Stop.Commands) > 0
+		if !hasContinuation {
+			t.Errorf("stop reason %q: Stop has neither OffPath nor Commands", code)
+		}
+		if transition.Stop.OffPath != nil {
+			if transition.Stop.OffPath.Command != reviewModeDisableCloneCommand {
+				t.Errorf("stop reason %q: OffPath.Command = %q, want %q", code, transition.Stop.OffPath.Command, reviewModeDisableCloneCommand)
+			}
+			if strings.TrimSpace(transition.Stop.OffPath.Note) == "" {
+				t.Errorf("stop reason %q: OffPath.Note is empty", code)
+			}
+		}
+
+		// Ensure clean JSON serialization and deserialization
+		payload, err := json.Marshal(transition)
+		if err != nil {
+			t.Errorf("stop reason %q: json.Marshal failed: %v", code, err)
+			continue
+		}
+		var decoded ReviewNextTransition
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Errorf("stop reason %q: json.Unmarshal failed: %v", code, err)
+			continue
+		}
+		if decoded.Stop == nil || decoded.Stop.Statement != transition.Stop.Statement {
+			t.Errorf("stop reason %q: roundtrip mismatch: got %#v, want %#v", code, decoded.Stop, transition.Stop)
+		}
+	}
+}

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -33,8 +33,8 @@ func TestReviewProviderArtifactV1ContractsArePinned(t *testing.T) {
 		"schemas/result-artifact.schema.json":    "91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6",
 		"schemas/start.schema.json":              "4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229",
 		"schemas/start-v2.schema.json":           "ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c",
-		"schemas/status.schema.json":             "250d2c646b8822b38eaefafd2bfdefa1134cc23a00e553a7201f33257573149a",
-		"schemas/status-v2.schema.json":          "dd9914b647a1d9edc4ecdcbed4f0c800b39ec290912d5c2a4cc6ba3098d5f21e",
+		"schemas/status.schema.json":             "634e81390389648842ba2fa2572c9ce0d8e920ab406ce6c8b35a828b488963d4",
+		"schemas/status-v2.schema.json":          "bbb8655bad2e33ad65c3f953c704ea6804c103140a8acb49ee311251fe1c5c12",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -56,7 +56,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 		"fixtures/status.fixture.json":       "4cd77906bacdca35d8f99773de147211d2b05fe34dd1b999011ead09e84be7a5",
 		"schemas/capabilities.schema.json":   "7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248",
 		"schemas/consent.schema.json":        "b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858",
-		"schemas/status.schema.json":         "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+		"schemas/status.schema.json":         "74a6ce72aef46ea03ab510a365742fcf4aa503888c7d7e56ea7e0c6afbdcce46",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -89,7 +89,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		// the emitter legitimately publishes once the relay handshake is
 		// declared. Deliberate, not drift.
 		"schemas/consent-v3.schema.json": "f56b1809c1bff21713795ef37a095c6ecfdbbb3cf928bcf604b8d5f33be3dea5",
-		"schemas/status.schema.json":     "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+		"schemas/status.schema.json":     "74a6ce72aef46ea03ab510a365742fcf4aa503888c7d7e56ea7e0c6afbdcce46",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -106,7 +106,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
-		"fixtures/status-v5.fixture.json": "1a6d002c9691c87e50687f8d5f3e59013e9229d93004028f746bfcda7947d5fc",
+		"fixtures/status-v5.fixture.json": "8f3ca8967b85dd2972d0de834bfa86de552b540ed3f35d665c308b1595f1de5b",
 		// Cross-lane battery conformance fix: live negotiated STATUS publishes
 		// the top-level repository_context reference (review_status_contract.go's
 		// ReviewTargetStatusResult, populated since the recovered-units merges),
@@ -120,7 +120,7 @@ func TestReviewProviderArtifactV25StatusContractsArePinned(t *testing.T) {
 		// input with a capture-result submission descriptor, which the
 		// submission oneOf and the no-submission allOf rule both rejected.
 		// Deliberate, not drift.
-		"schemas/status-v5.schema.json": "4dd17e863725edb20e9cbb85d9614dfdc07ef6c9257aa789f4c9e8835400483e",
+		"schemas/status-v5.schema.json": "c43a3905f4b349417b711a5d6562f1bf819af27d7b06250b9eade859462e1b6b",
 	}
 	for name, expected := range want {
 		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))

--- a/internal/cli/review_transition_command_test.go
+++ b/internal/cli/review_transition_command_test.go
@@ -337,12 +337,8 @@ func TestReviewNextTransitionCollectAndStopCarryNoCommand(t *testing.T) {
 	if stop.Execute != nil {
 		t.Fatalf("stop transition = %#v, want no execute payload", stop)
 	}
-	payload, err := json.Marshal(stop)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(payload), "\"command\"") {
-		t.Fatalf("stop transition payload = %s, want no command field", payload)
+	if stop.Stop == nil || stop.Stop.Statement == "" {
+		t.Fatalf("stop transition = %#v, want structured stop continuation", stop)
 	}
 	binding := ReviewTransitionBinding{
 		LineageID:      "review-collect-no-command",
@@ -356,7 +352,7 @@ func TestReviewNextTransitionCollectAndStopCarryNoCommand(t *testing.T) {
 	if collect.Collect.Inputs[0].Arguments[0].Token == "" {
 		t.Fatal("native collect input carries no token, so this test would pass vacuously")
 	}
-	payload, err = json.Marshal(collect)
+	payload, err := json.Marshal(collect)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Stop transitions previously emitted a bare `reason_code` and required external consumers to invent their own menus and explanations. This adds structured stop reasons and next action continuations to `ReviewTransitionStop` in the review status schema and transition generator, with backwards-compatible schema fixtures and test coverage.

Closes #3384

## Test Plan

- `go test -v ./internal/cli/...`
- `go test -v ./internal/reviewtransaction/...`
- `go run ./internal/gofmtcheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured stop transitions with a required explanation, optional runnable commands, and optional off-path exit details.
  * Stop messages can now identify deliberate review exits, including the relevant note and command.
  * Recognized commands are automatically included as machine-readable continuation data.

* **Improvements**
  * Updated supported status contracts to validate and exchange stop transition information consistently across versions.

* **Tests**
  * Added coverage ensuring stop transitions contain valid statements and structured continuation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->