### PR TITLE
feat(pr-check): strict fork-safe Refs #N references and terminal stack closure

### DIFF
--- a/.github/scripts/parse-linked-issues.cjs
+++ b/.github/scripts/parse-linked-issues.cjs
@@ -1,10 +1,10 @@
 'use strict';
 
-// Shared parser for closing issue references in PR bodies.
+// Shared parser for issue references in PR bodies.
 // Single seam used by every pr-check.yml gate that reads linked issues:
 // both check-issue-reference and check-issue-approved consume this parse.
 
-const CLOSING_REFERENCE_PATTERN = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
+const ANY_REFERENCE_PATTERN = /\b(?:(closes|fixes|resolves)|(refs?|references))\s+#(\d+)\b/gi;
 
 // An HTML comment runs from `<!--` to the next `-->`, or to the end of the
 // body when unclosed. The unclosed case matches how GitHub renders Markdown
@@ -17,12 +17,54 @@ function stripHtmlComments(body) {
   return (body || '').replace(HTML_COMMENT_PATTERN, '');
 }
 
-// Returns the linked issue numbers referenced by closing keywords in the
-// visible (non-comment) PR body, in order of first appearance.
-function parseLinkedIssues(body) {
+// Parses visible (non-comment) PR body for closing and non-closing issue references.
+// Returns structured lists of issue numbers preserving order of first appearance.
+function parseIssueReferences(body) {
   const visible = stripHtmlComments(body);
-  const matches = [...visible.matchAll(CLOSING_REFERENCE_PATTERN)];
-  return matches.map((m) => parseInt(m[1], 10));
+  const closing = [];
+  const nonClosing = [];
+  const all = [];
+  const seenAll = new Set();
+  const seenClosing = new Set();
+  const seenNonClosing = new Set();
+
+  for (const match of visible.matchAll(ANY_REFERENCE_PATTERN)) {
+    const isClosing = Boolean(match[1]);
+    const num = parseInt(match[3], 10);
+    if (!Number.isSafeInteger(num) || num <= 0) {
+      continue;
+    }
+    if (isClosing) {
+      if (!seenClosing.has(num)) {
+        seenClosing.add(num);
+        closing.push(num);
+      }
+    } else {
+      if (!seenNonClosing.has(num)) {
+        seenNonClosing.add(num);
+        nonClosing.push(num);
+      }
+    }
+    if (!seenAll.has(num)) {
+      seenAll.add(num);
+      all.push(num);
+    }
+  }
+
+  return {
+    closing,
+    nonClosing,
+    all,
+  };
 }
 
-module.exports = { parseLinkedIssues, stripHtmlComments };
+// Backwards-compatible helper returning all referenced issue numbers (closing and non-closing).
+function parseLinkedIssues(body) {
+  return parseIssueReferences(body).all;
+}
+
+module.exports = {
+  parseIssueReferences,
+  parseLinkedIssues,
+  stripHtmlComments,
+};

--- a/.github/scripts/parse-linked-issues.test.cjs
+++ b/.github/scripts/parse-linked-issues.test.cjs
@@ -3,7 +3,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { parseLinkedIssues } = require('./parse-linked-issues.cjs');
+const { parseLinkedIssues, parseIssueReferences } = require('./parse-linked-issues.cjs');
 
 test('a closing reference that only appears inside an HTML comment is not a linked issue', () => {
   const body = [
@@ -18,6 +18,22 @@ test('a closing reference that only appears inside an HTML comment is not a link
   ].join('\n');
 
   assert.deepEqual(parseLinkedIssues(body), []);
+  assert.deepEqual(parseIssueReferences(body), { closing: [], nonClosing: [], all: [] });
+});
+
+test('a non-closing reference that only appears inside an HTML comment is ignored', () => {
+  const body = [
+    '## Summary',
+    '',
+    '<!--',
+    'Refs #3154',
+    '-->',
+    '',
+    'Some visible description without any reference.',
+  ].join('\n');
+
+  assert.deepEqual(parseLinkedIssues(body), []);
+  assert.deepEqual(parseIssueReferences(body), { closing: [], nonClosing: [], all: [] });
 });
 
 test('a real reference outside a comment plus the template example inside one finds exactly the real one', () => {
@@ -30,18 +46,82 @@ test('a real reference outside a comment plus the template example inside one fi
   ].join('\n');
 
   assert.deepEqual(parseLinkedIssues(body), [1770]);
+  assert.deepEqual(parseIssueReferences(body), { closing: [1770], nonClosing: [], all: [1770] });
 });
 
 test('a single-line HTML comment is also ignored', () => {
   const body = 'Fixes #7\n<!-- Closes #42 --> trailing visible text';
 
   assert.deepEqual(parseLinkedIssues(body), [7]);
+  assert.deepEqual(parseIssueReferences(body), { closing: [7], nonClosing: [], all: [7] });
 });
 
 test('multiple visible closing references are all preserved, in order', () => {
   const body = 'Closes #10\nFixes #11\nResolves #12';
 
   assert.deepEqual(parseLinkedIssues(body), [10, 11, 12]);
+  assert.deepEqual(parseIssueReferences(body), {
+    closing: [10, 11, 12],
+    nonClosing: [],
+    all: [10, 11, 12],
+  });
+});
+
+test('non-closing references (Refs #N, Ref #N, References #N) are distinguished from closing references', () => {
+  const body = [
+    '## Summary',
+    '',
+    'Closes #3352',
+    'Refs #3154',
+    'Ref #2000',
+    'References #2001',
+  ].join('\n');
+
+  assert.deepEqual(parseLinkedIssues(body), [3352, 3154, 2000, 2001]);
+  assert.deepEqual(parseIssueReferences(body), {
+    closing: [3352],
+    nonClosing: [3154, 2000, 2001],
+    all: [3352, 3154, 2000, 2001],
+  });
+});
+
+test('non-closing reference only satisfies parse and pr-check without closing keywords', () => {
+  const body = 'Intermediate epic PR. Refs #3154';
+
+  assert.deepEqual(parseLinkedIssues(body), [3154]);
+  assert.deepEqual(parseIssueReferences(body), {
+    closing: [],
+    nonClosing: [3154],
+    all: [3154],
+  });
+});
+
+test('duplicate references in the body are deduplicated while preserving first-appearance order', () => {
+  const body = [
+    'Closes #10',
+    'Refs #20',
+    'Closes #10',
+    'Refs #20',
+    'Fixes #30',
+  ].join('\n');
+
+  assert.deepEqual(parseLinkedIssues(body), [10, 20, 30]);
+  assert.deepEqual(parseIssueReferences(body), {
+    closing: [10, 30],
+    nonClosing: [20],
+    all: [10, 20, 30],
+  });
+});
+
+test('case insensitivity for keywords', () => {
+  const body = 'closes #10 fixes #11 RESOLVES #12 REFS #13 ref #14';
+
+  assert.deepEqual(parseLinkedIssues(body), [10, 11, 12, 13, 14]);
+  assert.deepEqual(parseIssueReferences(body), {
+    closing: [10, 11, 12],
+    nonClosing: [13, 14],
+    all: [10, 11, 12, 13, 14],
+  });
 });
 
 // Documented behavior: an unclosed `<!--` hides everything through the end of
@@ -49,13 +129,17 @@ test('multiple visible closing references are all preserved, in order', () => {
 // open comment at end of input), so a reference after an unclosed `<!--` is
 // invisible to reviewers and must not count as a linked issue.
 test('an unclosed HTML comment hides the rest of the body, matching rendered output', () => {
-  const body = 'Closes #1770\n<!-- forgot to close this comment\nCloses #42';
+  const body = 'Closes #1770\n<!-- forgot to close this comment\nCloses #42\nRefs #99';
 
   assert.deepEqual(parseLinkedIssues(body), [1770]);
+  assert.deepEqual(parseIssueReferences(body), { closing: [1770], nonClosing: [], all: [1770] });
 });
 
 test('an empty or missing body yields no linked issues', () => {
   assert.deepEqual(parseLinkedIssues(''), []);
   assert.deepEqual(parseLinkedIssues(null), []);
   assert.deepEqual(parseLinkedIssues(undefined), []);
+  assert.deepEqual(parseIssueReferences(''), { closing: [], nonClosing: [], all: [] });
+  assert.deepEqual(parseIssueReferences(null), { closing: [], nonClosing: [], all: [] });
+  assert.deepEqual(parseIssueReferences(undefined), { closing: [], nonClosing: [], all: [] });
 });

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       issue-numbers: ${{ steps.parse.outputs.issue-numbers }}
+      closing-issue-numbers: ${{ steps.parse.outputs.closing-issue-numbers }}
+      non-closing-issue-numbers: ${{ steps.parse.outputs.non-closing-issue-numbers }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
@@ -64,27 +66,35 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
-            const { parseLinkedIssues } = require(
+            const { parseIssueReferences } = require(
               `${process.env.GITHUB_WORKSPACE}/.github/scripts/parse-linked-issues.cjs`
             );
 
             // Parse the visible body once; HTML comments (like the PR
             // template's `Closes #42` example) are stripped by the shared
             // parser, and check-issue-approved reuses this exact result.
-            const issueNumbers = parseLinkedIssues(context.payload.pull_request.body);
-            core.setOutput('issue-numbers', JSON.stringify(issueNumbers));
+            const refs = parseIssueReferences(context.payload.pull_request.body);
+            core.setOutput('issue-numbers', JSON.stringify(refs.all));
+            core.setOutput('closing-issue-numbers', JSON.stringify(refs.closing));
+            core.setOutput('non-closing-issue-numbers', JSON.stringify(refs.nonClosing));
 
-            if (issueNumbers.length === 0) {
+            if (refs.all.length === 0) {
               core.setFailed(
                 '❌ PR body must reference a linked issue using one of:\n' +
                 '  - Closes #<number>\n' +
                 '  - Fixes #<number>\n' +
-                '  - Resolves #<number>\n\n' +
+                '  - Resolves #<number>\n' +
+                '  - Refs #<number>\n\n' +
                 'References inside HTML comments (<!-- ... -->) do not count.\n' +
                 'Every PR must be linked to an approved issue.'
               );
             } else {
-              console.log(`✅ Found issue reference(s): ${issueNumbers.map(n => `#${n}`).join(', ')}`);
+              if (refs.closing.length > 0) {
+                console.log(`✅ Found closing issue reference(s): ${refs.closing.map(n => `#${n}`).join(', ')}`);
+              }
+              if (refs.nonClosing.length > 0) {
+                console.log(`✅ Found non-closing issue reference(s) (Refs #N): ${refs.nonClosing.map(n => `#${n}`).join(', ')}`);
+              }
             }
 
   check-issue-approved:

--- a/skills/branch-pr/SKILL.md
+++ b/skills/branch-pr/SKILL.md
@@ -84,7 +84,7 @@ The PR body must follow the template at `.github/PULL_REQUEST_TEMPLATE.md`. All 
 ```markdown
 ## 🔗 Linked Issue
 
-Closes #<N>
+Closes #<N> (or `Refs #<N>` for intermediate stacked/chained PRs)
 
 ## 🏷️ PR Type
 
@@ -148,7 +148,7 @@ These checks run on every PR and **all must pass** before merge:
 | Check | What It Verifies | How to Fix |
 |-------|-----------------|------------|
 | **Check PR Cognitive Load** | PR stays within 400 changed lines (`additions + deletions`) or has `size:exception` | Split the PR, or request/obtain maintainer-applied `size:exception` and document the rationale |
-| **Check Issue Reference** | PR body contains `Closes/Fixes/Resolves #N` | Add `Closes #<N>` to the PR body |
+| **Check Issue Reference** | PR body contains `Closes/Fixes/Resolves #N` or `Refs #N` | Add `Closes #<N>` (or `Refs #<N>` for intermediate stacked PRs) to the PR body |
 | **Check Issue Has `status:approved`** | Linked issue has been approved by a maintainer | Wait for maintainer to add `status:approved` to the issue |
 | **Check PR Has `type:*` Label** | Exactly one `type:*` label is applied to the PR | Ask a maintainer to add the correct label; remove extras |
 | **Unit Tests** | `go test ./...` passes | Fix failing tests before pushing |

--- a/skills/chained-pr/SKILL.md
+++ b/skills/chained-pr/SKILL.md
@@ -17,6 +17,8 @@ Load this skill when a planned PR may exceed **400 changed lines**, SDD forecast
 - Keep each PR reviewable in about **≤60 minutes**.
 - Use one deliverable work unit per PR; keep tests/docs with the unit they verify.
 - State start, end, prior dependencies, follow-up work, and out-of-scope items in every chained PR.
+- Intermediate chained PRs reference the parent epic with `Refs #N`; only the terminal PR (or tracker PR) uses `Closes #N`.
+- Partial or abandoned stacks keep the parent issue open; reduced scope requires an explicit maintainer decision.
 - Every child PR must include a dependency diagram marking the current PR with `📍`.
 - In Feature Branch Chain, create a draft/no-merge tracker PR; child PR #1 targets the tracker branch, later children target the immediate parent branch.
 - Treat polluted diffs as base bugs: retarget or rebase until only the current work unit appears.

--- a/skills/chained-pr/references/chaining-details.md
+++ b/skills/chained-pr/references/chaining-details.md
@@ -44,6 +44,13 @@ main <- PR 1: foundation
 
 After a parent PR merges, rebase/retarget the next PR so GitHub shows only the current slice.
 
+## Issue References in Chained Stacks
+
+- **Intermediate PRs**: Link the parent epic/issue with `Refs #<N>` in `## 🔗 Linked Issue`. This satisfies `Check Issue Reference` and `Check Issue Has status:approved` without closing the issue when the slice merges.
+- **Terminal PR / Tracker PR**: Link with `Closes #<N>` so the issue closes only when the full chain or tracker lands.
+- **Partial or Abandoned Stacks**: If work is halted or abandoned, intermediate PRs already merged with `Refs #<N>` will have left the parent issue open.
+- **Reduced Scope**: If a stack is truncated and the remaining work is deemed complete or moved elsewhere, an explicit maintainer action/comment is required to close or update the parent issue.
+
 ## Chain Context Section
 
 Append this section to the repo PR template; do not replace required issue/checklist sections.

--- a/skills/gentle-ai-collab-perfect/SKILL.md
+++ b/skills/gentle-ai-collab-perfect/SKILL.md
@@ -51,7 +51,7 @@ These files evolve. Re-read them at the start of every contribution.
 ## Hard rules (do not negotiate)
 
 1. **Issue-first is mandatory.** No PR opens without an issue that already has `status:approved` from a maintainer. Enforced by `pr-check.yml` and CONTRIBUTING.md.
-2. **Use `Closes/Fixes/Resolves #N`** in the PR body. `Refs #N` does NOT satisfy `Check Issue Reference`. Verified empirically on this repo.
+2. **Use `Closes/Fixes/Resolves #N` for standalone/terminal PRs, or `Refs #N` for intermediate chained PRs.** Both satisfy `Check Issue Reference` and require `status:approved` on the referenced issue in the base repo.
 3. **Exactly one `type:*` label per PR.** Two `type:*` labels fail the check. No `type:*` label fails the check.
 4. **400-line budget per PR** (`additions + deletions`). Above that, request `size:exception` from a maintainer with rationale documented in the PR body.
 5. **No `Co-Authored-By` trailers** on commits. AI attribution is not acceptable in this repo.
@@ -113,7 +113,7 @@ End-to-end steps once the issue (or chain of sub-issues) is approved.
    - `go test ./internal/...` with pre-existing failures acknowledged via `git stash` baseline. The repo has known pre-existing failures in `internal/components/communitytool/pi_codegraph`, `internal/tui/sync`, and similar — confirm they exist with `git stash` AND `git stash pop`, then name them in the PR body's Test Plan.
 
 4. **Open the PR with `gh pr create`.** Body matches `.github/PULL_REQUEST_TEMPLATE.md`:
-   - `## 🔗 Linked Issue` → `Closes #N` (or `Fixes`/`Resolves`). Never `Refs`.
+   - `## 🔗 Linked Issue` → `Closes #N` (or `Fixes`/`Resolves`), or `Refs #N` for intermediate chained PRs that must not close the parent issue prematurely.
    - `## 🏷️ PR Type` → exactly one `[x] type:*` matching the actual type
    - `## 📝 Summary` → one paragraph: what + why
    - `## 📂 Changes` → file table with line counts from `gh pr view --json additions,deletions,changedFiles`
@@ -255,7 +255,7 @@ Run this in your head (or print and tick) before requesting review:
 | Anti-pattern | Symptom | Fix |
 |---|---|---|
 | "type:* added" checkbox while `labels: []` | CodeRabbit or maintainer catches the lie on first read | Move to `## Pending maintainer actions` with `pending Alan` |
-| `Refs #N` instead of `Closes #N` | `Check Issue Reference` fails; PR auto-rejected | Use `Closes`/`Fixes`/`Resolves` keyword |
+| Unapproved issue reference | `Check Issue Approved` fails; PR blocked | Ensure every referenced issue (closing or `Refs #N`) is approved by a maintainer |
 | `[x] PR stays within 400 changed lines` for a 3,200-line PR | `Check PR Cognitive Load` fails; `size:exception` not requested | Compute real totals, document `size:exception` rationale in Pending maintainer section |
 | `feat(tui,cli): wire...` title | Title fails the single-scope regex | Use one of `feat(tui): ...`, `feat(cli): ...`, `feat(tui-cli): ...` (dash, not comma) |
 | Slice branches all base on `main` with stale carry-over commits | Reviewers can't isolate slice-specific changes; `size:exception` needed | Accept Stacked to main (request exception) OR ask maintainer to push slice branches upstream and use Feature Branch Chain |


### PR DESCRIPTION
## Summary

Implements strict fork-safe `Refs #N` reference parsing and validation in PR check workflows and contributor guidelines. Distinguishes closing references (`Closes`, `Fixes`, `Resolves`) from non-closing references (`Refs`, `Ref`, `References`), requiring and validating approval status across all referenced issues in the base repository while preventing early stack closure.

Closes #3352

## Test Plan

- `node --test .github/scripts/parse-linked-issues.test.cjs`
- Verify schema and skill references
- `go run ./internal/gofmtcheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request checks now recognize and report both closing and non-closing issue references.
  * Supports `Refs `#N`` references for intermediate chained pull requests.
  * Issue references are deduplicated and categorized while retaining combined results.

* **Documentation**
  * Updated pull request and chained-workflow guidance to clarify when to use `Refs` versus closing references.

* **Tests**
  * Added coverage for reference types, duplicates, casing, comments, invalid values, and empty descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->