### PR TITLE
fix(pi): clean legacy APPEND_SYSTEM.md sections across the Pi lifecycle

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -317,6 +317,62 @@ func ConfigPath(homeDir string) string { return filepath.Join(homeDir, ".pi") }
 // AgentConfigPath returns Pi's current agent-owned config directory path.
 func AgentConfigPath(homeDir string) string { return filepath.Join(ConfigPath(homeDir), "agent") }
 
+// LegacyPiAppendSections lists the allowlisted Gentle-managed sections that are cleaned from Pi's APPEND_SYSTEM.md.
+var LegacyPiAppendSections = []string{
+	"persona",
+	"engram-protocol",
+	"sdd-orchestrator",
+	"strict-tdd-mode",
+	"agent-routing",
+	"trigger-rules",
+	"codegraph-guidance",
+}
+
+// CleanLegacyAppendSystem removes the allowlisted Gentle-managed legacy sections
+// from Pi's APPEND_SYSTEM.md file while preserving user-authored content and file permissions.
+// If the file becomes empty (or contains only whitespace), it is deleted.
+// A second identical run is an idempotent no-op.
+func CleanLegacyAppendSystem(homeDir string) (bool, string, error) {
+	path := filepath.Join(AgentConfigPath(homeDir), piAppendSystemFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, "", nil
+		}
+		return false, "", fmt.Errorf("stat pi append system file %q: %w", path, err)
+	}
+
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return false, "", fmt.Errorf("read pi append system file %q: %w", path, err)
+	}
+
+	content := string(contentBytes)
+	original := content
+	for _, section := range LegacyPiAppendSections {
+		content = filemerge.InjectMarkdownSection(content, section, "")
+	}
+
+	if content == original {
+		return false, "", nil
+	}
+
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return false, "", fmt.Errorf("remove empty pi append system file %q: %w", path, err)
+		}
+		return true, path, nil
+	}
+
+	perm := info.Mode().Perm()
+	writeRes, err := filemerge.WriteFileAtomic(path, []byte(content), perm)
+	if err != nil {
+		return false, "", fmt.Errorf("rewrite pi append system file %q: %w", path, err)
+	}
+	return writeRes.Changed, path, nil
+}
+
 // ProvisionEngramMCP declares pi-mcp-adapter in Pi's settings.json and
 // package.json. It is invoked by ComponentEngram; keeping it here lets Pi
 // own the exact config shape without teaching the generic Engram injector

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -374,3 +374,97 @@ func TestMergePiSettingsFileRemovesLegacySubagentPackages(t *testing.T) {
 		t.Fatalf("packages = %#v", settings.Packages)
 	}
 }
+
+func TestPiLegacyAppendCleanupPreservesUserBytesModeAndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	agentDir := filepath.Join(home, ".pi", "agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+	appendFile := filepath.Join(agentDir, "APPEND_SYSTEM.md")
+
+	initial := "# User Preamble\n" +
+		"<!-- gentle-ai:persona -->Legacy persona<!-- /gentle-ai:persona -->\n" +
+		"<!-- gentle-ai:engram-protocol -->Legacy engram<!-- /gentle-ai:engram-protocol -->\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->Legacy SDD<!-- /gentle-ai:sdd-orchestrator -->\n" +
+		"<!-- gentle-ai:strict-tdd-mode -->Legacy TDD<!-- /gentle-ai:strict-tdd-mode -->\n" +
+		"<!-- gentle-ai:agent-routing -->Legacy routing<!-- /gentle-ai:agent-routing -->\n" +
+		"<!-- gentle-ai:trigger-rules -->Legacy trigger<!-- /gentle-ai:trigger-rules -->\n" +
+		"<!-- gentle-ai:codegraph-guidance -->Legacy codegraph<!-- /gentle-ai:codegraph-guidance -->\n" +
+		"<!-- gentle-ai:custom-user-marker -->\nPreserved custom marker\n<!-- /gentle-ai:custom-user-marker -->\n" +
+		"# User Epilogue\n"
+	origPerm := os.FileMode(0o640)
+	if err := os.WriteFile(appendFile, []byte(initial), origPerm); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	changed, path, err := CleanLegacyAppendSystem(home)
+	if err != nil {
+		t.Fatalf("CleanLegacyAppendSystem error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("CleanLegacyAppendSystem reported changed = false")
+	}
+	if path != appendFile {
+		t.Fatalf("CleanLegacyAppendSystem path = %q, want %q", path, appendFile)
+	}
+
+	info, err := os.Stat(appendFile)
+	if err != nil {
+		t.Fatalf("Stat error = %v", err)
+	}
+	if info.Mode().Perm() != origPerm {
+		t.Fatalf("File mode = %v, want %v", info.Mode().Perm(), origPerm)
+	}
+
+	contentBytes, err := os.ReadFile(appendFile)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	cleaned := string(contentBytes)
+
+	for _, sec := range LegacyPiAppendSections {
+		if strings.Contains(cleaned, "<!-- gentle-ai:"+sec) {
+			t.Errorf("cleaned file still contains legacy section %q", sec)
+		}
+	}
+	if !strings.Contains(cleaned, "# User Preamble") {
+		t.Errorf("cleaned file missing user preamble")
+	}
+	if !strings.Contains(cleaned, "<!-- gentle-ai:custom-user-marker -->\nPreserved custom marker\n<!-- /gentle-ai:custom-user-marker -->") {
+		t.Errorf("cleaned file missing non-allowlisted custom marker")
+	}
+	if !strings.Contains(cleaned, "# User Epilogue") {
+		t.Errorf("cleaned file missing user epilogue")
+	}
+
+	// Second run is idempotent no-op
+	secondChanged, secondPath, err := CleanLegacyAppendSystem(home)
+	if err != nil {
+		t.Fatalf("second CleanLegacyAppendSystem error = %v", err)
+	}
+	if secondChanged || secondPath != "" {
+		t.Fatalf("second run reported changed = %v, path = %q, want no-op", secondChanged, secondPath)
+	}
+
+	secondContent, err := os.ReadFile(appendFile)
+	if err != nil {
+		t.Fatalf("ReadFile after second run error = %v", err)
+	}
+	if string(secondContent) != cleaned {
+		t.Fatalf("content mutated on second run")
+	}
+
+	// Empty file test: only legacy sections should cause file deletion
+	onlyLegacy := "<!-- gentle-ai:persona -->Legacy persona<!-- /gentle-ai:persona -->\n<!-- gentle-ai:agent-routing -->Legacy routing<!-- /gentle-ai:agent-routing -->\n"
+	if err := os.WriteFile(appendFile, []byte(onlyLegacy), 0o644); err != nil {
+		t.Fatalf("WriteFile onlyLegacy error = %v", err)
+	}
+	delChanged, delPath, err := CleanLegacyAppendSystem(home)
+	if err != nil || !delChanged || delPath != appendFile {
+		t.Fatalf("CleanLegacyAppendSystem onlyLegacy error = %v, changed = %v, path = %q", err, delChanged, delPath)
+	}
+	if _, err := os.Stat(appendFile); !os.IsNotExist(err) {
+		t.Fatalf("expected empty file to be deleted, stat error = %v", err)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	codexagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
@@ -862,6 +863,18 @@ func (s agentRoutingGuidanceStep) Run() error {
 	if err != nil {
 		return fmt.Errorf("create adapter for %q: %w", s.agent, err)
 	}
+
+	if s.agent == model.AgentPi {
+		changed, path, err := pi.CleanLegacyAppendSystem(s.homeDir)
+		if err != nil {
+			return fmt.Errorf("clean legacy Pi append system: %w", err)
+		}
+		if changed && path != "" {
+			s.recordChanged(agentguidance.Result{Changed: true, Files: []string{path}})
+		}
+		return nil
+	}
+
 	targetDir := routingGuidanceDir(s.homeDir, s.workspaceDir, s.scope, adapter)
 
 	// Strip first: an installation upgraded from an older release still carries
@@ -2091,6 +2104,13 @@ func claudeMCPSettingsCleanupPaths(homeDir, workspaceDir string, scope InstallSc
 func routingGuidancePaths(homeDir, workspaceDir string, scope InstallScope, adapters []agents.Adapter) []string {
 	paths := []string{}
 	for _, adapter := range adapters {
+		if adapter.Agent() == model.AgentPi {
+			piAppend := filepath.Join(pi.AgentConfigPath(homeDir), "APPEND_SYSTEM.md")
+			if _, err := os.Stat(piAppend); err == nil {
+				paths = append(paths, piAppend)
+			}
+			continue
+		}
 		targetDir := routingGuidanceDir(homeDir, workspaceDir, scope, adapter)
 		routing, err := agentguidance.RoutingPaths(targetDir, adapter.Agent())
 		if err != nil {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1082,6 +1082,58 @@ func TestBackupTargetsContainNoDuplicatePaths(t *testing.T) {
 	assertNoDuplicatePaths(t, "backupTargets", targets)
 }
 
+func TestInstallPiCleansLegacyAppendSectionsWithoutRecreatingAgentRouting(t *testing.T) {
+	home := t.TempDir()
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "# User Custom Notes\n" +
+		"<!-- gentle-ai:persona -->Legacy persona<!-- /gentle-ai:persona -->\n" +
+		"<!-- gentle-ai:agent-routing -->Legacy routing<!-- /gentle-ai:agent-routing -->\n" +
+		"<!-- gentle-ai:engram-protocol -->Legacy engram<!-- /gentle-ai:engram-protocol -->\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->Legacy SDD<!-- /gentle-ai:sdd-orchestrator -->\n" +
+		"<!-- gentle-ai:strict-tdd-mode -->Legacy TDD<!-- /gentle-ai:strict-tdd-mode -->\n" +
+		"<!-- gentle-ai:trigger-rules -->Legacy trigger<!-- /gentle-ai:trigger-rules -->\n" +
+		"<!-- gentle-ai:codegraph-guidance -->Legacy codegraph<!-- /gentle-ai:codegraph-guidance -->\n" +
+		"# User Epilogue\n"
+	origPerm := os.FileMode(0o640)
+	if err := os.WriteFile(appendPath, []byte(content), origPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Persona:    model.PersonaGentleman,
+		Preset:     model.PresetFullGentleman,
+		Components: []model.ComponentID{model.ComponentEngram, model.ComponentSDD},
+	}
+	rt := newTestInstallRuntime(t, home, selection)
+	runInstallInjectionSteps(t, rt)
+
+	info, err := os.Stat(appendPath)
+	if err != nil {
+		t.Fatalf("Stat(APPEND_SYSTEM.md) error = %v", err)
+	}
+	if info.Mode().Perm() != origPerm {
+		t.Fatalf("File mode = %v, want %v", info.Mode().Perm(), origPerm)
+	}
+
+	gotBytes, err := os.ReadFile(appendPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+	for _, sec := range []string{"persona", "agent-routing", "engram-protocol", "sdd-orchestrator", "strict-tdd-mode", "trigger-rules", "codegraph-guidance"} {
+		if strings.Contains(got, "<!-- gentle-ai:"+sec) {
+			t.Errorf("APPEND_SYSTEM.md still contains legacy section %q: %s", sec, got)
+		}
+	}
+	if !strings.Contains(got, "# User Custom Notes") || !strings.Contains(got, "# User Epilogue") {
+		t.Errorf("user content lost: %s", got)
+	}
+}
+
 func assertNoDuplicatePaths(t *testing.T, label string, paths []string) {
 	t.Helper()
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -5374,4 +5375,76 @@ func TestSyncBackupTargetsContainNoDuplicatePaths(t *testing.T) {
 	}
 
 	assertNoDuplicatePaths(t, "syncBackupTargets", targets)
+}
+
+func testRunSyncPiAppendFixture(t *testing.T, args []string) {
+	t.Helper()
+	home := t.TempDir()
+	original := osUserHomeDir
+	osUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { osUserHomeDir = original })
+
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"pi", "claude-code"},
+		Components:      []model.ComponentID{model.ComponentEngram, model.ComponentSDD},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	appendPath := filepath.Join(piAgentDir, "APPEND_SYSTEM.md")
+	content := "# User Notes\n" +
+		"<!-- gentle-ai:persona -->p<!-- /gentle-ai:persona -->\n" +
+		"<!-- gentle-ai:agent-routing -->r<!-- /gentle-ai:agent-routing -->\n" +
+		"<!-- gentle-ai:engram-protocol -->e<!-- /gentle-ai:engram-protocol -->\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->s<!-- /gentle-ai:sdd-orchestrator -->\n" +
+		"<!-- gentle-ai:strict-tdd-mode -->t<!-- /gentle-ai:strict-tdd-mode -->\n" +
+		"<!-- gentle-ai:trigger-rules -->tr<!-- /gentle-ai:trigger-rules -->\n" +
+		"<!-- gentle-ai:codegraph-guidance -->c<!-- /gentle-ai:codegraph-guidance -->\n" +
+		"# User Notes End\n"
+	origPerm := os.FileMode(0o640)
+	if err := os.WriteFile(appendPath, []byte(content), origPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RunSync(args)
+	if err != nil {
+		t.Fatalf("RunSync(%v) error = %v", args, err)
+	}
+
+	info, err := os.Stat(appendPath)
+	if err != nil {
+		t.Fatalf("Stat(APPEND_SYSTEM.md) error = %v", err)
+	}
+	if info.Mode().Perm() != origPerm {
+		t.Fatalf("File mode = %v, want %v", info.Mode().Perm(), origPerm)
+	}
+
+	gotBytes, err := os.ReadFile(appendPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+	for _, sec := range []string{"persona", "agent-routing", "engram-protocol", "sdd-orchestrator", "strict-tdd-mode", "trigger-rules", "codegraph-guidance"} {
+		if strings.Contains(got, "<!-- gentle-ai:"+sec) {
+			t.Errorf("APPEND_SYSTEM.md still contains legacy section %q: %s", sec, got)
+		}
+	}
+	if !strings.Contains(got, "# User Notes") || !strings.Contains(got, "# User Notes End") {
+		t.Errorf("user content lost: %s", got)
+	}
+	if !slices.Contains(result.ChangedFiles, appendPath) {
+		t.Errorf("result.ChangedFiles = %v, want it to contain %q", result.ChangedFiles, appendPath)
+	}
+}
+
+func TestRunSyncCleansLegacyPiAppendSectionsWithoutRecreatingAgentRouting(t *testing.T) {
+	testRunSyncPiAppendFixture(t, nil)
+}
+
+func TestRunSyncExplicitPiCleansLegacyAppendSectionsWithoutRecreatingAgentRouting(t *testing.T) {
+	testRunSyncPiAppendFixture(t, []string{"--agent", "pi"})
 }

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
@@ -455,6 +456,20 @@ func (s *Service) executePlan(p plan, agentsToRemove []model.AgentID) (Result, e
 	// before other component cleanup (notably Engram) mutates that file, otherwise
 	// an unrelated mutation is indistinguishable from user drift.
 	if slices.Contains(agentsToRemove, model.AgentPi) {
+		if changed, path, err := pi.CleanLegacyAppendSystem(s.homeDir); err != nil {
+			failures = append(failures, operationFailure{
+				path:   filepath.Join(pi.AgentConfigPath(s.homeDir), "APPEND_SYSTEM.md"),
+				agents: []model.AgentID{model.AgentPi},
+				err:    fmt.Errorf("clean legacy Pi append system: %w", err),
+			})
+		} else if changed && path != "" {
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				result.RemovedFiles = append(result.RemovedFiles, path)
+			} else {
+				result.ChangedFiles = append(result.ChangedFiles, path)
+			}
+		}
+
 		piResult, piErr := communitytool.UninstallPiCodeGraph(s.homeDir)
 		if piErr != nil {
 			failures = append(failures, operationFailure{

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -246,6 +246,80 @@ func TestExecutePlanPiUninstallPreservesDriftedChildAndGentlePiSource(t *testing
 	}
 }
 
+func TestPiUninstallCleansLegacyAppendSectionsWithoutChangingPiOwnedAssets(t *testing.T) {
+	homeDir := t.TempDir()
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	agentDir := filepath.Join(homeDir, ".pi", "agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	appendPath := filepath.Join(agentDir, "APPEND_SYSTEM.md")
+	content := "# User Preamble\n" +
+		"<!-- gentle-ai:persona -->Legacy persona<!-- /gentle-ai:persona -->\n" +
+		"<!-- gentle-ai:agent-routing -->Legacy routing<!-- /gentle-ai:agent-routing -->\n" +
+		"<!-- gentle-ai:engram-protocol -->Legacy engram<!-- /gentle-ai:engram-protocol -->\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->Legacy SDD<!-- /gentle-ai:sdd-orchestrator -->\n" +
+		"<!-- gentle-ai:strict-tdd-mode -->Legacy TDD<!-- /gentle-ai:strict-tdd-mode -->\n" +
+		"<!-- gentle-ai:trigger-rules -->Legacy trigger<!-- /gentle-ai:trigger-rules -->\n" +
+		"<!-- gentle-ai:codegraph-guidance -->Legacy codegraph<!-- /gentle-ai:codegraph-guidance -->\n" +
+		"# User Epilogue\n"
+	origPerm := os.FileMode(0o640)
+	if err := os.WriteFile(appendPath, []byte(content), origPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.executePlan(plan{}, []model.AgentID{model.AgentPi})
+	if err != nil {
+		t.Fatalf("executePlan() error = %v", err)
+	}
+	if !slices.Contains(result.ChangedFiles, appendPath) {
+		t.Fatalf("result.ChangedFiles = %v, want %q", result.ChangedFiles, appendPath)
+	}
+
+	info, err := os.Stat(appendPath)
+	if err != nil {
+		t.Fatalf("Stat(APPEND_SYSTEM.md) error = %v", err)
+	}
+	if info.Mode().Perm() != origPerm {
+		t.Fatalf("File mode = %v, want %v", info.Mode().Perm(), origPerm)
+	}
+
+	gotBytes, err := os.ReadFile(appendPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+	for _, sec := range []string{"persona", "agent-routing", "engram-protocol", "sdd-orchestrator", "strict-tdd-mode", "trigger-rules", "codegraph-guidance"} {
+		if strings.Contains(got, "<!-- gentle-ai:"+sec) {
+			t.Errorf("APPEND_SYSTEM.md still contains legacy section %q: %s", sec, got)
+		}
+	}
+	if !strings.Contains(got, "# User Preamble") || !strings.Contains(got, "# User Epilogue") {
+		t.Errorf("user content lost: %s", got)
+	}
+
+	// When APPEND_SYSTEM.md contains only legacy sections, it should be deleted.
+	onlyLegacy := "<!-- gentle-ai:persona -->Legacy persona<!-- /gentle-ai:persona -->\n"
+	if err := os.WriteFile(appendPath, []byte(onlyLegacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result2, err := svc.executePlan(plan{}, []model.AgentID{model.AgentPi})
+	if err != nil {
+		t.Fatalf("executePlan() second run error = %v", err)
+	}
+	if !slices.Contains(result2.RemovedFiles, appendPath) {
+		t.Fatalf("result2.RemovedFiles = %v, want %q", result2.RemovedFiles, appendPath)
+	}
+	if _, err := os.Stat(appendPath); !os.IsNotExist(err) {
+		t.Fatalf("APPEND_SYSTEM.md was not deleted when empty")
+	}
+}
+
 func piCodeGraphProbeForServiceTest(string) (communitytool.PiCodeGraphMCPProbeResult, error) {
 	return communitytool.PiCodeGraphMCPProbeResult{
 		AdapterAvailable: true,


### PR DESCRIPTION
## Summary

Cleans known Gentle-managed legacy sections (`persona`, `engram-protocol`, `sdd-orchestrator`, `strict-tdd-mode`, `agent-routing`, `trigger-rules`, `codegraph-guidance`) from Pi's `APPEND_SYSTEM.md` across install, normal sync, explicit Pi sync, and uninstall without recreating `agent-routing` or modifying user-authored bytes/file mode. Preserves empty-file deletion on cleanup and maintains Pi runtime prompt ownership under `gentle-pi`.

Closes #3508
Refs #1194

## Test Plan

- `go test -v ./internal/agents/pi/... ./internal/components/uninstall/...`
- `go test -v -run "TestInstallPiCleansLegacyAppendSectionsWithoutRecreatingAgentRouting|TestRunSyncCleansLegacyPiAppendSectionsWithoutRecreatingAgentRouting|TestRunSyncExplicitPiCleansLegacyAppendSectionsWithoutRecreatingAgentRouting" ./internal/cli/...`
- `go run ./internal/gofmtcheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pi installations and syncs now remove outdated managed content from `APPEND_SYSTEM.md` without recreating legacy routing guidance.
  - User-authored content and existing file permissions are preserved.
  - Empty files are removed automatically, while missing files are handled safely.
  - Pi uninstall now cleans up legacy content and reports cleanup changes or errors.
  - Backup and rollback support includes existing Pi configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->