### PR TITLE
fix(codex): wrap AGENTS.md persona in a managed marker section

### DIFF
--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -155,7 +155,7 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	case model.StrategyFileReplace:
 		promptPath := adapter.SystemPromptFile(homeDir)
 
-		if adapter.Agent() == model.AgentOpenCode {
+		if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentCodex {
 			existing, err := readFileOrEmpty(promptPath)
 			if err != nil {
 				return InjectionResult{}, err

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -3203,5 +3203,3 @@ func TestInjectCodexHealsUnmanagedLegacyPersonaAsset(t *testing.T) {
 		t.Fatalf("AGENTS.md has duplicated persona content: %d instances of 'Senior Architect'", strings.Count(text, "Senior Architect"))
 	}
 }
-
-

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
@@ -22,6 +23,7 @@ import (
 
 func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
 func claudeAdapter() agents.Adapter      { return claude.NewAdapter() }
+func codexAdapter() agents.Adapter       { return codex.NewAdapter() }
 func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
 func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
 func kilocodeAdapter() agents.Adapter    { return kilocode.NewAdapter() }
@@ -3001,3 +3003,205 @@ func TestHermesPersonaAssetsContainIdentitySection(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectCodexGentlemanWritesMarkedPersonaSection(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject() changed = false")
+	}
+
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing <!-- gentle-ai:persona --> open marker")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing <!-- /gentle-ai:persona --> close marker")
+	}
+	if !strings.Contains(text, "Senior Architect") {
+		t.Fatal("AGENTS.md missing Gentleman persona content")
+	}
+}
+
+func TestInjectCodexPreservesUserContentInsteadOfOverwriting(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	userContent := "# My Custom Codex Rules\n\nDo not overwrite this file.\n"
+	if err := os.WriteFile(path, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "Do not overwrite this file.") {
+		t.Fatal("AGENTS.md user content was overwritten")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing managed persona section after inject")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing managed persona close marker after inject")
+	}
+}
+
+func TestInjectCodexNeutralWritesMarkedPersonaSection(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, codexAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject() changed = false")
+	}
+
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing persona open marker")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing persona close marker")
+	}
+	if !strings.Contains(text, "without regional slang or dialect-specific grammar") {
+		t.Fatal("AGENTS.md missing neutral persona guidelines")
+	}
+}
+
+func TestInjectCustomCodexDoesNothing(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, codexAdapter(), model.PersonaCustom)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if result.Changed {
+		t.Fatal("Custom persona (Codex) should NOT change anything")
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("Custom persona (Codex) should return no files, got %v", result.Files)
+	}
+
+	// AGENTS.md should NOT be created.
+	agentsMD := filepath.Join(home, ".codex", "AGENTS.md")
+	if _, err := os.Stat(agentsMD); !os.IsNotExist(err) {
+		t.Fatal("Custom persona (Codex) should NOT create AGENTS.md")
+	}
+}
+
+func TestInjectCodexSwitchPersonaUpdatesSectionInPlace(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	userHeader := "# Custom User Section\n\nPreserve this.\n"
+	if err := os.WriteFile(path, []byte(userHeader), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// First inject Gentleman
+	_, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	// Then switch to Neutral
+	res, err := Inject(home, codexAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) error = %v", err)
+	}
+	if !res.Changed {
+		t.Fatal("Inject(neutral) changed = false, want true")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "# Custom User Section") || !strings.Contains(text, "Preserve this.") {
+		t.Fatal("user header was clobbered during persona switch")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") || !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("persona markers missing after persona switch")
+	}
+	if strings.Count(text, "<!-- gentle-ai:persona -->") != 1 {
+		t.Fatalf("duplicate persona sections found: %d", strings.Count(text, "<!-- gentle-ai:persona -->"))
+	}
+	if !strings.Contains(text, "without regional slang or dialect-specific grammar") {
+		t.Fatal("neutral persona content missing after switch")
+	}
+}
+
+func TestInjectCodexHealsUnmanagedLegacyPersonaAsset(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	legacyAsset := assets.MustRead("generic/persona-gentleman.md")
+	if err := os.WriteFile(path, []byte(legacyAsset), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	result, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing persona open marker after healing")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing persona close marker after healing")
+	}
+	if strings.Count(text, "<!-- gentle-ai:persona -->") != 1 {
+		t.Fatalf("AGENTS.md has %d persona markers, want 1", strings.Count(text, "<!-- gentle-ai:persona -->"))
+	}
+	if strings.Count(text, "Senior Architect") != 1 {
+		t.Fatalf("AGENTS.md has duplicated persona content: %d instances of 'Senior Architect'", strings.Count(text, "Senior Architect"))
+	}
+}
+
+

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1304,3 +1304,73 @@ func TestComponentOperationsSDD_CodexRemovesSkillRegistryHook(t *testing.T) {
 		t.Fatalf("unrelated hooks should be preserved:\n%s", text)
 	}
 }
+
+func TestUninstallPersonaCodexPreservesUserContentAndRemovesMarkerSection(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter, ok := svc.registry.Get(model.AgentCodex)
+	if !ok {
+		t.Fatal("Codex adapter not found in registry")
+	}
+
+	promptPath := adapter.SystemPromptFile(homeDir)
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := `# Custom Codex Instructions
+
+Always respond in concise markdown.
+
+<!-- gentle-ai:persona -->
+## Personality
+Senior Architect persona content.
+<!-- /gentle-ai:persona -->
+
+## Project Specific Rules
+Follow repository guidelines.
+`
+	if err := os.WriteFile(promptPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ops, targets, err := svc.componentOperations(adapter, model.ComponentPersona)
+	if err != nil {
+		t.Fatalf("componentOperations(persona) error = %v", err)
+	}
+	if !slices.Contains(targets, promptPath) {
+		t.Fatalf("targets missing %q: %v", promptPath, targets)
+	}
+
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		}
+	}
+
+	raw, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+
+	if strings.Contains(text, "<!-- gentle-ai:persona -->") || strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatalf("persona markers were not removed:\n%s", text)
+	}
+	if strings.Contains(text, "Senior Architect") {
+		t.Fatalf("persona body was not removed:\n%s", text)
+	}
+	if !strings.Contains(text, "# Custom Codex Instructions") || !strings.Contains(text, "Always respond in concise markdown.") {
+		t.Fatalf("user content before marker was lost:\n%s", text)
+	}
+	if !strings.Contains(text, "## Project Specific Rules") || !strings.Contains(text, "Follow repository guidelines.") {
+		t.Fatalf("user content after marker was lost:\n%s", text)
+	}
+}
+

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1373,4 +1373,3 @@ Follow repository guidelines.
 		t.Fatalf("user content after marker was lost:\n%s", text)
 	}
 }
-


### PR DESCRIPTION
Closes #981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persona injection for Codex, including preservation of existing managed and user-authored content.
  * Added support for switching personas without duplicating content.
  * Improved cleanup of legacy persona content.
  * Ensured Codex persona data is fully removed during uninstallation while preserving user content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->