### PR TITLE
feat(ci): live 400-line gate with merge-queue coverage and durable grandfather authority

### DIFF
--- a/.github/grandfather-size-exceptions.json
+++ b/.github/grandfather-size-exceptions.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "description": "Frozen set of grandfathered PR numbers permitted to exceed the 400-line review budget with size:exception.",
+  "allowed_prs": []
+}

--- a/.github/scripts/check-pr-size.cjs
+++ b/.github/scripts/check-pr-size.cjs
@@ -1,0 +1,131 @@
+'use strict';
+
+const fs = require('fs');
+
+const REVIEW_BUDGET_LIMIT = 400;
+
+/**
+ * Loads and validates the grandfather size exceptions JSON file.
+ * Fails closed on any error (missing file, invalid JSON, unexpected schema).
+ *
+ * @param {string} filePath Path to grandfather exceptions JSON
+ * @returns {Set<number>} Set of allowed grandfathered PR numbers
+ */
+function loadGrandfatherExceptions(filePath) {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new Error('Grandfather exceptions file path must be a non-empty string');
+  }
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Grandfather exceptions file not found at: ${filePath}`);
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`Failed to read grandfather exceptions file: ${err.message}`);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Grandfather exceptions file is malformed JSON: ${err.message}`);
+  }
+
+  if (!data || typeof data !== 'object' || data.version !== 1 || !Array.isArray(data.allowed_prs)) {
+    throw new Error('Grandfather exceptions file has invalid schema (expected version: 1, allowed_prs: array)');
+  }
+
+  for (const pr of data.allowed_prs) {
+    if (typeof pr !== 'number' || !Number.isInteger(pr) || pr <= 0) {
+      throw new Error(`Invalid PR number in grandfather exceptions: ${JSON.stringify(pr)}`);
+    }
+  }
+
+  return new Set(data.allowed_prs);
+}
+
+/**
+ * Evaluates whether a pull request complies with the 400-line review budget.
+ *
+ * @param {Object} params
+ * @param {number} [params.additions=0]
+ * @param {number} [params.deletions=0]
+ * @param {Array<string|Object>} [params.labels=[]]
+ * @param {number|string} [params.prNumber]
+ * @param {Set<number>|Array<number>} [params.grandfatherSet=new Set()]
+ * @returns {{ pass: boolean, passed: boolean, warning: boolean, total: number, limit: number, message: string }}
+ */
+function evaluatePrSize({ additions = 0, deletions = 0, labels = [], prNumber, grandfatherSet = new Set() } = {}) {
+  const total = (Number(additions) || 0) + (Number(deletions) || 0);
+  const limit = REVIEW_BUDGET_LIMIT;
+
+  const labelList = Array.isArray(labels)
+    ? labels.map((l) => (typeof l === 'string' ? l : l?.name || ''))
+    : [];
+  const hasException = labelList.includes('size:exception');
+
+  const num = Number(prNumber);
+  const isGrandfathered = grandfatherSet instanceof Set
+    ? grandfatherSet.has(num)
+    : Array.isArray(grandfatherSet)
+      ? grandfatherSet.includes(num)
+      : false;
+
+  if (total <= limit) {
+    return {
+      pass: true,
+      passed: true,
+      warning: false,
+      total,
+      limit,
+      message: `PR is within the ${limit}-line cognitive review budget (+${additions}/-${deletions} = ${total}).`,
+    };
+  }
+
+  if (isGrandfathered && hasException) {
+    return {
+      pass: true,
+      passed: true,
+      warning: true,
+      total,
+      limit,
+      message:
+        `PR changes ${total} lines (+${additions}/-${deletions}), exceeding the ${limit}-line cognitive review budget.\n\n` +
+        `⚠️ Grandfathered PR #${num} with size:exception allowed with warning.`,
+    };
+  }
+
+  if (isGrandfathered && !hasException) {
+    return {
+      pass: false,
+      passed: false,
+      warning: false,
+      total,
+      limit,
+      message:
+        `PR changes ${total} lines (+${additions}/-${deletions}), exceeding the ${limit}-line cognitive review budget.\n\n` +
+        `PR #${num} is grandfathered but requires the 'size:exception' label to proceed.`,
+    };
+  }
+
+  return {
+    pass: false,
+    passed: false,
+    warning: false,
+    total,
+    limit,
+    message:
+      `PR changes ${total} lines (+${additions}/-${deletions}), exceeding the ${limit}-line cognitive review budget.\n\n` +
+      'Why this exists: reviews should stay small enough to complete in ~60 minutes without reviewer fatigue.\n' +
+      'New oversized PRs are not permitted even with size:exception. Please split this work into chained or stacked PRs.',
+  };
+}
+
+module.exports = {
+  evaluatePrSize,
+  loadGrandfatherExceptions,
+  REVIEW_BUDGET_LIMIT,
+};

--- a/.github/scripts/check-pr-size.test.cjs
+++ b/.github/scripts/check-pr-size.test.cjs
@@ -1,0 +1,161 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  evaluatePrSize,
+  loadGrandfatherExceptions,
+  REVIEW_BUDGET_LIMIT,
+} = require('./check-pr-size.cjs');
+
+test('standard PR within 400-line budget passes', () => {
+  const result = evaluatePrSize({ additions: 150, deletions: 50, labels: [], prNumber: 100 });
+  assert.equal(result.pass, true);
+  assert.equal(result.passed, true);
+  assert.equal(result.warning, false);
+  assert.equal(result.total, 200);
+});
+
+test('PR exactly at 400 lines budget passes', () => {
+  const result = evaluatePrSize({ additions: 300, deletions: 100, labels: [], prNumber: 101 });
+  assert.equal(result.pass, true);
+  assert.equal(result.warning, false);
+  assert.equal(result.total, 400);
+});
+
+test('oversized PR (401 lines) without grandfathering fails even with size:exception label', () => {
+  const result = evaluatePrSize({
+    additions: 301,
+    deletions: 100,
+    labels: ['size:exception'],
+    prNumber: 999,
+    grandfatherSet: new Set([100, 200]),
+  });
+  assert.equal(result.pass, false);
+  assert.equal(result.passed, false);
+  assert.equal(result.warning, false);
+  assert.equal(result.total, 401);
+  assert.match(result.message, /New oversized PRs are not permitted even with size:exception/);
+});
+
+test('oversized PR without grandfathering and without label fails', () => {
+  const result = evaluatePrSize({ additions: 500, deletions: 200, labels: [], prNumber: 999 });
+  assert.equal(result.pass, false);
+  assert.equal(result.warning, false);
+  assert.equal(result.total, 700);
+});
+
+test('oversized PR with grandfathering AND size:exception passes with warning', () => {
+  const result = evaluatePrSize({
+    additions: 450,
+    deletions: 50,
+    labels: ['size:exception'],
+    prNumber: 100,
+    grandfatherSet: new Set([100]),
+  });
+  assert.equal(result.pass, true);
+  assert.equal(result.passed, true);
+  assert.equal(result.warning, true);
+  assert.equal(result.total, 500);
+  assert.match(result.message, /Grandfathered PR #100 with size:exception/);
+});
+
+test('oversized PR with grandfathering supports label objects', () => {
+  const result = evaluatePrSize({
+    additions: 450,
+    deletions: 50,
+    labels: [{ name: 'size:exception' }, { name: 'type:feature' }],
+    prNumber: 100,
+    grandfatherSet: new Set([100]),
+  });
+  assert.equal(result.pass, true);
+  assert.equal(result.warning, true);
+});
+
+test('oversized PR with grandfathering but WITHOUT size:exception fails', () => {
+  const result = evaluatePrSize({
+    additions: 450,
+    deletions: 50,
+    labels: ['type:feature'],
+    prNumber: 100,
+    grandfatherSet: new Set([100]),
+  });
+  assert.equal(result.pass, false);
+  assert.equal(result.passed, false);
+  assert.equal(result.warning, false);
+  assert.equal(result.total, 500);
+  assert.match(result.message, /requires the 'size:exception' label/);
+});
+
+test('loadGrandfatherExceptions parses valid grandfather json file', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-size-test-'));
+  const filePath = path.join(tmpDir, 'valid.json');
+  fs.writeFileSync(filePath, JSON.stringify({ version: 1, allowed_prs: [42, 100, 200] }));
+
+  const set = loadGrandfatherExceptions(filePath);
+  assert.equal(set instanceof Set, true);
+  assert.equal(set.size, 3);
+  assert.equal(set.has(42), true);
+  assert.equal(set.has(100), true);
+  assert.equal(set.has(200), true);
+  assert.equal(set.has(300), false);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('loadGrandfatherExceptions loads repository grandfather file', () => {
+  const repoFilePath = path.join(__dirname, '..', 'grandfather-size-exceptions.json');
+  const set = loadGrandfatherExceptions(repoFilePath);
+  assert.equal(set instanceof Set, true);
+});
+
+test('loadGrandfatherExceptions fails closed if file is missing', () => {
+  assert.throws(
+    () => loadGrandfatherExceptions('/non/existent/path/exceptions.json'),
+    /Grandfather exceptions file not found/
+  );
+});
+
+test('loadGrandfatherExceptions fails closed if path is invalid', () => {
+  assert.throws(() => loadGrandfatherExceptions(''), /non-empty string/);
+  assert.throws(() => loadGrandfatherExceptions(null), /non-empty string/);
+});
+
+test('loadGrandfatherExceptions fails closed if JSON is malformed', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-size-test-'));
+  const filePath = path.join(tmpDir, 'malformed.json');
+  fs.writeFileSync(filePath, '{ invalid json');
+
+  assert.throws(() => loadGrandfatherExceptions(filePath), /malformed JSON/);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('loadGrandfatherExceptions fails closed if schema/version is invalid', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-size-test-'));
+
+  const badVersion = path.join(tmpDir, 'bad-version.json');
+  fs.writeFileSync(badVersion, JSON.stringify({ version: 2, allowed_prs: [] }));
+  assert.throws(() => loadGrandfatherExceptions(badVersion), /invalid schema/);
+
+  const missingAllowed = path.join(tmpDir, 'missing-allowed.json');
+  fs.writeFileSync(missingAllowed, JSON.stringify({ version: 1 }));
+  assert.throws(() => loadGrandfatherExceptions(missingAllowed), /invalid schema/);
+
+  const badAllowedType = path.join(tmpDir, 'bad-allowed-type.json');
+  fs.writeFileSync(badAllowedType, JSON.stringify({ version: 1, allowed_prs: "42" }));
+  assert.throws(() => loadGrandfatherExceptions(badAllowedType), /invalid schema/);
+
+  const invalidPrElement = path.join(tmpDir, 'invalid-pr-element.json');
+  fs.writeFileSync(invalidPrElement, JSON.stringify({ version: 1, allowed_prs: [42, "100"] }));
+  assert.throws(() => loadGrandfatherExceptions(invalidPrElement), /Invalid PR number/);
+
+  const negativePrElement = path.join(tmpDir, 'negative-pr-element.json');
+  fs.writeFileSync(negativePrElement, JSON.stringify({ version: 1, allowed_prs: [-5] }));
+  assert.throws(() => loadGrandfatherExceptions(negativePrElement), /Invalid PR number/);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,45 +2,67 @@ name: PR Validation
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, labeled, unlabeled]
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   check-pr-size:
     name: Check PR Cognitive Load
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - name: Verify PR stays within review budget
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const limit = 400;
-            const pr = context.payload.pull_request;
-            const additions = pr.additions || 0;
-            const deletions = pr.deletions || 0;
-            const total = additions + deletions;
-            const labels = (pr.labels || []).map(label => label.name);
-            const hasException = labels.includes('size:exception');
+            const path = require('path');
+            const { evaluatePrSize, loadGrandfatherExceptions } = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/check-pr-size.cjs`
+            );
 
-            console.log(`PR size: +${additions} / -${deletions} = ${total} changed lines`);
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : context.issue.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const grandfatherFilePath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github',
+              'grandfather-size-exceptions.json'
+            );
+            const grandfatherSet = loadGrandfatherExceptions(grandfatherFilePath);
+
+            const labels = (pr.labels || []).map(label => label.name);
+            const result = evaluatePrSize({
+              additions: pr.additions,
+              deletions: pr.deletions,
+              labels,
+              prNumber: pr.number,
+              grandfatherSet,
+            });
+
+            console.log(`PR size: +${pr.additions} / -${pr.deletions} = ${result.total} changed lines`);
             console.log(`Labels: ${labels.join(', ') || '(none)'}`);
 
-            if (total <= limit) {
-              console.log(`✅ PR is within the ${limit}-line cognitive review budget.`);
+            if (result.pass) {
+              if (result.warning) {
+                core.warning(`⚠️ ${result.message}`);
+                console.log('✅ Grandfathered with size:exception; allowing oversized PR with warning.');
+              } else {
+                console.log(`✅ ${result.message}`);
+              }
               return;
             }
 
-            const message =
-              `PR changes ${total} lines (+${additions}/-${deletions}), exceeding the ${limit}-line cognitive review budget.\n\n` +
-              'Why this exists: reviews should stay small enough to complete in ~60 minutes without reviewer fatigue.\n' +
-              'Please split this work into chained or stacked PRs, or ask a maintainer for the size:exception label when the large diff is unavoidable.';
-
-            if (hasException) {
-              core.warning(`⚠️ ${message}`);
-              console.log('✅ size:exception label present; allowing oversized PR with warning.');
-              return;
-            }
-
-            core.setFailed(`❌ ${message}`);
+            core.setFailed(`❌ ${result.message}`);
 
   check-workflow-scripts:
     name: Check Workflow Scripts
@@ -49,7 +71,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - name: Run workflow script tests
-        run: node --test .github/scripts/parse-linked-issues.test.cjs
+        run: node --test .github/scripts/parse-linked-issues.test.cjs .github/scripts/check-pr-size.test.cjs
 
   check-issue-reference:
     name: Check Issue Reference


### PR DESCRIPTION
Closes #3353
Refs #3154

## Summary
Enforces `additions + deletions <= 400` from the live GitHub PR API, reevaluates on reopen, sync, base/head change, stack update, and merge queue admission, and temporarily permits only the trusted activation-time grandfather set to remain above the cap.

1. Expanded CI triggers in `.github/workflows/pr-check.yml` to include `reopened`, `ready_for_review`, `labeled`, `unlabeled`, and `merge_group: [checks_requested]`.
2. Created `.github/scripts/check-pr-size.cjs` to evaluate live additions and deletions with fail-closed grandfather store loading.
3. Created `.github/grandfather-size-exceptions.json` with frozen schema.
4. Added unit tests in `.github/scripts/check-pr-size.test.cjs` integrated with `check-workflow-scripts`.

## Verification
- `node --test .github/scripts/check-pr-size.test.cjs .github/scripts/parse-linked-issues.test.cjs`: 19/19 tests passing.
- Total diff: 342 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated pull request size checks with a 400-line review budget.
  - Added support for approved exceptions using the `size:exception` label.
  - Added validation for pull request sizes during additional review and merge-queue events.

- **Tests**
  - Added coverage for size limits, exceptions, labels, configuration loading, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->