### PR TITLE
fix(review): fsync newly created Unix authority directories before state publication

### DIFF
--- a/internal/reviewtransaction/bundle.go
+++ b/internal/reviewtransaction/bundle.go
@@ -249,7 +249,7 @@ func (store Store) installBundle(chain ValidatedChain, events []ChainBundleEvent
 		}
 		defer maintenance.Release()
 	}
-	if err := os.MkdirAll(filepath.Join(store.Dir, "events"), 0o755); err != nil {
+	if err := mkdirAllSync(filepath.Join(store.Dir, "events"), 0o755); err != nil {
 		return ValidatedChain{}, err
 	}
 	lock, err := acquireLocalStoreLock(filepath.Join(store.Dir, "LOCK"))
@@ -276,6 +276,9 @@ func (store Store) installBundle(chain ValidatedChain, events []ChainBundleEvent
 		if err := installContentAddressedFile(path, event.Payload); err != nil {
 			return ValidatedChain{}, err
 		}
+	}
+	if err := SyncReviewDirectory(filepath.Join(store.Dir, "events")); err != nil {
+		return ValidatedChain{}, &directorySyncError{path: filepath.Join(store.Dir, "events"), cause: err}
 	}
 	if err := writeAtomic(filepath.Join(store.Dir, "HEAD"), []byte(chain.HeadRevision+"\n"), 0o644); err != nil {
 		return ValidatedChain{}, err

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -2717,7 +2717,7 @@ func recordCompactTrace(path string, entry CompactTraceEntry) {
 }
 
 func appendCompactTrace(path string, entry CompactTraceEntry) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := mkdirAllSync(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 )
 
@@ -35,6 +36,8 @@ var syncReviewDirectory = func(path string) error {
 	}
 	return directory.Close()
 }
+var mkdirAllSyncMu sync.Mutex
+var mkdirAllSyncAfterMkdir = func(path string) {}
 
 type directorySyncError struct {
 	path  string
@@ -1018,6 +1021,8 @@ func mkdirAllSync(dir string, mode os.FileMode) error {
 	if dir == "." || dir == "" || dir == string(filepath.Separator) || dir == filepath.VolumeName(dir)+string(filepath.Separator) {
 		return nil
 	}
+	mkdirAllSyncMu.Lock()
+	defer mkdirAllSyncMu.Unlock()
 	var stack []string
 	for p := dir; ; p = filepath.Dir(p) {
 		stack = append(stack, p)
@@ -1039,6 +1044,7 @@ func mkdirAllSync(dir string, mode os.FileMode) error {
 			return err
 		}
 		if mkdirErr := os.Mkdir(p, mode); mkdirErr == nil {
+			mkdirAllSyncAfterMkdir(p)
 			if syncErr := SyncReviewDirectory(filepath.Dir(p)); syncErr != nil {
 				return &directorySyncError{path: p, cause: syncErr}
 			}

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -1018,14 +1018,6 @@ func mkdirAllSync(dir string, mode os.FileMode) error {
 	if dir == "." || dir == "" || dir == string(filepath.Separator) || dir == filepath.VolumeName(dir)+string(filepath.Separator) {
 		return nil
 	}
-	if info, err := os.Stat(dir); err == nil {
-		if !info.IsDir() {
-			return fmt.Errorf("%w: %q is not a directory", syscall.ENOTDIR, dir)
-		}
-		return nil
-	} else if !os.IsNotExist(err) {
-		return err
-	}
 	var stack []string
 	for p := dir; ; p = filepath.Dir(p) {
 		stack = append(stack, p)
@@ -1036,21 +1028,30 @@ func mkdirAllSync(dir string, mode os.FileMode) error {
 	}
 	for i := len(stack) - 1; i >= 0; i-- {
 		p := stack[i]
-		err := os.Mkdir(p, mode)
+		info, err := os.Lstat(p)
 		if err == nil {
-			if syncErr := SyncReviewDirectory(filepath.Dir(p)); syncErr != nil {
-				return &directorySyncError{path: p, cause: syncErr}
-			}
-		} else if os.IsExist(err) {
-			info, statErr := os.Lstat(p)
-			if statErr != nil {
-				return statErr
-			}
 			if !info.IsDir() {
 				return fmt.Errorf("%w: %q is not a directory", syscall.ENOTDIR, p)
 			}
-		} else {
+			continue
+		}
+		if !os.IsNotExist(err) {
 			return err
+		}
+		if mkdirErr := os.Mkdir(p, mode); mkdirErr == nil {
+			if syncErr := SyncReviewDirectory(filepath.Dir(p)); syncErr != nil {
+				return &directorySyncError{path: p, cause: syncErr}
+			}
+		} else if os.IsExist(mkdirErr) {
+			info2, statErr := os.Lstat(p)
+			if statErr != nil {
+				return statErr
+			}
+			if !info2.IsDir() {
+				return fmt.Errorf("%w: %q is not a directory", syscall.ENOTDIR, p)
+			}
+		} else {
+			return mkdirErr
 		}
 	}
 	return nil

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -200,7 +200,7 @@ func (store Store) append(expectedRevision string, record Record) (string, error
 		}
 		defer maintenance.Release()
 	}
-	if err := os.MkdirAll(filepath.Join(store.Dir, "events"), 0o755); err != nil {
+	if err := mkdirAllSync(filepath.Join(store.Dir, "events"), 0o755); err != nil {
 		return "", err
 	}
 	lockPath := filepath.Join(store.Dir, "LOCK")
@@ -310,6 +310,9 @@ func (store Store) append(expectedRevision string, record Record) (string, error
 		} else {
 			return "", err
 		}
+	}
+	if err := SyncReviewDirectory(filepath.Join(store.Dir, "events")); err != nil {
+		return "", &directorySyncError{path: filepath.Join(store.Dir, "events"), cause: err}
 	}
 	if err := writeAtomic(filepath.Join(store.Dir, "HEAD"), []byte(revision+"\n"), 0o644); err != nil {
 		return "", err
@@ -919,7 +922,7 @@ func readRevision(path string) (string, error) {
 }
 
 func writeAtomic(path string, payload []byte, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := mkdirAllSync(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 	temp, err := os.CreateTemp(filepath.Dir(path), ".atomic-*")
@@ -954,7 +957,7 @@ func writeAtomic(path string, payload []byte, mode os.FileMode) error {
 
 func publishImmutable(path string, payload []byte, mode os.FileMode) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := mkdirAllSync(dir, 0o755); err != nil {
 		return err
 	}
 	temp, err := os.CreateTemp(dir, ".publish-*")
@@ -1003,6 +1006,44 @@ func publishImmutable(path string, payload []byte, mode os.FileMode) error {
 	}
 	if err := SyncReviewDirectory(dir); err != nil {
 		return &directorySyncError{path: path, cause: err}
+	}
+	return nil
+}
+
+// mkdirAllSync creates missing directory components from root down to dir and
+// synchronizes each newly created entry's parent directory bottom-up before
+// returning, guaranteeing durability of the directory entries on Unix platforms.
+func mkdirAllSync(dir string, mode os.FileMode) error {
+	dir = filepath.Clean(dir)
+	if dir == "." || dir == "" || dir == string(filepath.Separator) || dir == filepath.VolumeName(dir)+string(filepath.Separator) {
+		return nil
+	}
+	var stack []string
+	for p := dir; ; p = filepath.Dir(p) {
+		stack = append(stack, p)
+		parent := filepath.Dir(p)
+		if parent == p || p == filepath.VolumeName(p)+string(filepath.Separator) || p == string(filepath.Separator) || p == "." {
+			break
+		}
+	}
+	for i := len(stack) - 1; i >= 0; i-- {
+		p := stack[i]
+		err := os.Mkdir(p, mode)
+		if err == nil {
+			if syncErr := SyncReviewDirectory(filepath.Dir(p)); syncErr != nil {
+				return &directorySyncError{path: p, cause: syncErr}
+			}
+		} else if os.IsExist(err) {
+			info, statErr := os.Lstat(p)
+			if statErr != nil {
+				return statErr
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("%w: %q is not a directory", syscall.ENOTDIR, p)
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -1018,6 +1018,14 @@ func mkdirAllSync(dir string, mode os.FileMode) error {
 	if dir == "." || dir == "" || dir == string(filepath.Separator) || dir == filepath.VolumeName(dir)+string(filepath.Separator) {
 		return nil
 	}
+	if info, err := os.Stat(dir); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("%w: %q is not a directory", syscall.ENOTDIR, dir)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	var stack []string
 	for p := dir; ; p = filepath.Dir(p) {
 		stack = append(stack, p)

--- a/internal/reviewtransaction/store_authority_fsync_test.go
+++ b/internal/reviewtransaction/store_authority_fsync_test.go
@@ -1,0 +1,276 @@
+package reviewtransaction
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newFsyncTestRecord(t *testing.T) Record {
+	t.Helper()
+	tx, err := NewTransaction(boundedStart(t, []string{LensReliability}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StartReview(); err != nil {
+		t.Fatal(err)
+	}
+	return Record{Operation: "review/start", Transaction: *tx}
+}
+
+func TestLegacyPublicationSyncsEventsBeforeHead(t *testing.T) {
+	store := Store{Dir: filepath.Join(t.TempDir(), "legacy-store"), lineageID: "bounded-lineage"}
+	var mu sync.Mutex
+	var syncLog []string
+	var eventsSyncedBeforeHead bool
+
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		syncLog = append(syncLog, path)
+		if strings.HasSuffix(filepath.Clean(path), "events") {
+			if _, err := os.Stat(filepath.Join(store.Dir, "HEAD")); os.IsNotExist(err) {
+				eventsSyncedBeforeHead = true
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if _, err := store.Append("", newFsyncTestRecord(t)); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !eventsSyncedBeforeHead {
+		t.Fatalf("events directory not synced before HEAD; log = %v", syncLog)
+	}
+}
+
+func TestLegacyPublicationFailsBeforeHeadWhenEventsSyncFails(t *testing.T) {
+	store := Store{Dir: filepath.Join(t.TempDir(), "legacy-store-fail"), lineageID: "bounded-lineage"}
+	injectedErr := errors.New("injected events fsync failure")
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		if strings.HasSuffix(filepath.Clean(path), "events") {
+			return injectedErr
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if _, err := store.Append("", newFsyncTestRecord(t)); err == nil || !errors.Is(err, injectedErr) {
+		t.Fatalf("Append() error = %v, want %v", err, injectedErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(store.Dir, "HEAD")); !os.IsNotExist(statErr) {
+		t.Fatal("HEAD exists despite events sync failure")
+	}
+}
+
+func setupBundleFsyncFixture(t *testing.T, dir string) (Store, ValidatedChain, []ChainBundleEvent) {
+	t.Helper()
+	store := Store{Dir: dir, lineageID: "bounded-lineage"}
+	record := newFsyncTestRecord(t)
+	record.Schema = RecordSchema
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(payload)
+	rev := "sha256:" + hex.EncodeToString(sum[:])
+	chain := ValidatedChain{
+		Records: []Record{record}, Revisions: []string{rev},
+		GenesisRevision: rev, HeadRevision: rev, Identity: chainIdentity([]string{rev}),
+	}
+	return store, chain, []ChainBundleEvent{{Revision: rev, Payload: payload}}
+}
+
+func TestBundleInstallationSyncsEventsBeforeHead(t *testing.T) {
+	store, chain, events := setupBundleFsyncFixture(t, filepath.Join(t.TempDir(), "bundle-store"))
+	var mu sync.Mutex
+	var syncLog []string
+	var eventsSyncedBeforeHead bool
+
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		syncLog = append(syncLog, path)
+		if strings.HasSuffix(filepath.Clean(path), "events") {
+			if _, err := os.Stat(filepath.Join(store.Dir, "HEAD")); os.IsNotExist(err) {
+				eventsSyncedBeforeHead = true
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if _, err := store.installBundle(chain, events); err != nil {
+		t.Fatalf("installBundle() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !eventsSyncedBeforeHead {
+		t.Fatalf("bundle events not synced before HEAD; log = %v", syncLog)
+	}
+}
+
+func TestBundleInstallationFailsBeforeHeadWhenEventsSyncFails(t *testing.T) {
+	store, chain, events := setupBundleFsyncFixture(t, filepath.Join(t.TempDir(), "bundle-fail"))
+	injectedErr := errors.New("injected bundle events sync error")
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		if strings.HasSuffix(filepath.Clean(path), "events") {
+			return injectedErr
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if _, err := store.installBundle(chain, events); err == nil || !errors.Is(err, injectedErr) {
+		t.Fatalf("installBundle() error = %v, want %v", err, injectedErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(store.Dir, "HEAD")); !os.IsNotExist(statErr) {
+		t.Fatal("HEAD exists despite bundle events sync failure")
+	}
+}
+
+func TestFirstCompactPublicationSyncsParentsBottomUp(t *testing.T) {
+	authorityRoot := filepath.Join(t.TempDir(), "authority-root")
+	lineageID := "lineage-compact-fsync-test"
+	v2Dir := filepath.Join(authorityRoot, "v2")
+	lineageDir := filepath.Join(v2Dir, lineageID)
+
+	var mu sync.Mutex
+	var syncLog []string
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		syncLog = append(syncLog, filepath.Clean(path))
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := CompactStore{Dir: lineageDir, lineageID: lineageID, lockPath: filepath.Join(v2Dir, "LOCK")}
+	state, err := NewCompactState(Start{
+		LineageID: lineageID, Mode: ModeOrdinaryBounded, Generation: 1,
+		Snapshot: snapshot, PolicyHash: hash("a"), RiskLevel: risk,
+		SelectedLenses: []string{LensReliability}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatalf("NewCompactState: %v", err)
+	}
+
+	if _, err := store.ReplaceContext(context.Background(), "", "review/start", state); err != nil {
+		t.Fatalf("ReplaceContext() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	v2Clean := filepath.Clean(v2Dir)
+	lineageClean := filepath.Clean(lineageDir)
+	v2Idx, lineageIdx := -1, -1
+	for i, p := range syncLog {
+		if p == v2Clean && v2Idx == -1 {
+			v2Idx = i
+		}
+		if p == lineageClean && lineageIdx == -1 {
+			lineageIdx = i
+		}
+	}
+	if v2Idx == -1 || lineageIdx == -1 || v2Idx > lineageIdx {
+		t.Fatalf("invalid sync order: v2Idx=%d, lineageIdx=%d, log=%v", v2Idx, lineageIdx, syncLog)
+	}
+}
+
+func TestMkdirAllSyncBottomUpOrderingAndDurability(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "base")
+	if err := os.Mkdir(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(base, "a", "b", "c", "d")
+
+	var mu sync.Mutex
+	var syncLog []string
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		syncLog = append(syncLog, filepath.Clean(path))
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if err := mkdirAllSync(target, 0o755); err != nil {
+		t.Fatalf("mkdirAllSync() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	expectedOrder := []string{
+		filepath.Clean(base),
+		filepath.Clean(filepath.Join(base, "a")),
+		filepath.Clean(filepath.Join(base, "a", "b")),
+		filepath.Clean(filepath.Join(base, "a", "b", "c")),
+	}
+	if !reflect.DeepEqual(syncLog, expectedOrder) {
+		t.Fatalf("mkdirAllSync sync log = %v, want %v", syncLog, expectedOrder)
+	}
+}
+
+func TestMkdirAllSyncPrePublicationSyncFailurePreventsFileCreation(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "base-fail")
+	if err := os.Mkdir(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetFile := filepath.Join(base, "parent", "child", "test.json")
+
+	injectedErr := errors.New("parent directory sync failed")
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		if strings.HasSuffix(filepath.Clean(path), "parent") {
+			return injectedErr
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if err := writeAtomic(targetFile, []byte("data\n"), 0o644); err == nil || !errors.Is(err, injectedErr) {
+		t.Fatalf("writeAtomic() error = %v, want %v", err, injectedErr)
+	}
+	if _, statErr := os.Stat(targetFile); !os.IsNotExist(statErr) {
+		t.Fatal("target file was created despite parent directory sync failure")
+	}
+}
+
+func TestMkdirAllSyncRejectsExistingNonDirectory(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(filePath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := mkdirAllSync(filepath.Join(filePath, "child"), 0o755); err == nil {
+		t.Fatal("mkdirAllSync() succeeded on regular file parent, want error")
+	}
+}

--- a/internal/reviewtransaction/store_authority_fsync_test.go
+++ b/internal/reviewtransaction/store_authority_fsync_test.go
@@ -299,3 +299,43 @@ func TestMkdirAllSyncFastPathWhenDirectoryExists(t *testing.T) {
 		t.Fatalf("mkdirAllSync() called syncReviewDirectory %d times on existing directory; want 0", syncCount)
 	}
 }
+
+func TestMkdirAllSyncRejectsSymlinkedTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	outsideDir := filepath.Join(tempDir, "outside")
+	if err := os.Mkdir(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := filepath.Join(tempDir, "store")
+	if err := os.Mkdir(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkedEvents := filepath.Join(storeDir, "events")
+	if err := os.Symlink(outsideDir, symlinkedEvents); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mkdirAllSync(symlinkedEvents, 0o755); err == nil {
+		t.Fatal("mkdirAllSync() succeeded on symlinked target directory, want error")
+	}
+}
+
+func TestMkdirAllSyncRejectsSymlinkedAncestor(t *testing.T) {
+	tempDir := t.TempDir()
+	outsideDir := filepath.Join(tempDir, "outside")
+	if err := os.Mkdir(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkedParent := filepath.Join(tempDir, "symlinked-parent")
+	if err := os.Symlink(outsideDir, symlinkedParent); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(symlinkedParent, "nested", "events")
+	if err := mkdirAllSync(target, 0o755); err == nil {
+		t.Fatal("mkdirAllSync() succeeded with symlinked ancestor component, want error")
+	}
+}

--- a/internal/reviewtransaction/store_authority_fsync_test.go
+++ b/internal/reviewtransaction/store_authority_fsync_test.go
@@ -273,4 +273,29 @@ func TestMkdirAllSyncRejectsExistingNonDirectory(t *testing.T) {
 	if err := mkdirAllSync(filepath.Join(filePath, "child"), 0o755); err == nil {
 		t.Fatal("mkdirAllSync() succeeded on regular file parent, want error")
 	}
+	if err := mkdirAllSync(filePath, 0o755); err == nil {
+		t.Fatal("mkdirAllSync() succeeded on regular file target, want error")
+	}
+}
+
+func TestMkdirAllSyncFastPathWhenDirectoryExists(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "existing", "dir")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var syncCount int
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		syncCount++
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	if err := mkdirAllSync(dir, 0o755); err != nil {
+		t.Fatalf("mkdirAllSync() error = %v", err)
+	}
+	if syncCount != 0 {
+		t.Fatalf("mkdirAllSync() called syncReviewDirectory %d times on existing directory; want 0", syncCount)
+	}
 }

--- a/internal/reviewtransaction/store_authority_fsync_test.go
+++ b/internal/reviewtransaction/store_authority_fsync_test.go
@@ -11,7 +11,9 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func newFsyncTestRecord(t *testing.T) Record {
@@ -337,5 +339,65 @@ func TestMkdirAllSyncRejectsSymlinkedAncestor(t *testing.T) {
 	target := filepath.Join(symlinkedParent, "nested", "events")
 	if err := mkdirAllSync(target, 0o755); err == nil {
 		t.Fatal("mkdirAllSync() succeeded with symlinked ancestor component, want error")
+	}
+}
+
+func TestMkdirAllSyncConcurrentWritersCoordinateParentSync(t *testing.T) {
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "a", "b")
+
+	var writer1SyncDone atomic.Bool
+	var writer2ObservedBeforeSync atomic.Bool
+
+	mkdirHookCalled := make(chan struct{})
+	unblockWriter1 := make(chan struct{})
+
+	originalHook := mkdirAllSyncAfterMkdir
+	mkdirAllSyncAfterMkdir = func(path string) {
+		if path == target {
+			close(mkdirHookCalled)
+			<-unblockWriter1
+		}
+	}
+	t.Cleanup(func() { mkdirAllSyncAfterMkdir = originalHook })
+
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		if strings.HasSuffix(filepath.Clean(path), "a") {
+			writer1SyncDone.Store(true)
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		if err := mkdirAllSync(target, 0o755); err != nil {
+			t.Errorf("writer 1 mkdirAllSync error = %v", err)
+		}
+	}()
+
+	<-mkdirHookCalled
+
+	go func() {
+		defer wg.Done()
+		if err := mkdirAllSync(target, 0o755); err != nil {
+			t.Errorf("writer 2 mkdirAllSync error = %v", err)
+		}
+		if !writer1SyncDone.Load() {
+			writer2ObservedBeforeSync.Store(true)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(unblockWriter1)
+
+	wg.Wait()
+
+	if writer2ObservedBeforeSync.Load() {
+		t.Fatal("writer 2 returned from mkdirAllSync before writer 1 finished parent directory sync")
 	}
 }

--- a/internal/reviewtransaction/store_lock.go
+++ b/internal/reviewtransaction/store_lock.go
@@ -179,7 +179,7 @@ func acquireStoreLock(path string) (*storeLock, error) {
 }
 
 func acquireLocalStoreLock(path string) (*storeLock, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := mkdirAllSync(filepath.Dir(path), 0o755); err != nil {
 		return nil, &StoreLockPreAcquisitionError{Err: err}
 	}
 	file, err := secureOpenLocalStoreLock(path)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1721

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

On Unix/Linux systems, review authority publication previously lacked guaranteed bottom-up fsync ordering for newly created parent directory entries before writing dependent state pointer/state records (`HEAD` or `review-state.json`).

This PR:
1. Implements `mkdirAllSync(dir, mode)` in `internal/reviewtransaction/store.go` which creates missing directory ancestry and immediately synchronizes each newly created directory's parent bottom-up on Unix, preventing TOCTOU issues.
2. Synchronizes the `events/` directory before atomically publishing `HEAD` in both legacy append and bundle install flows.
3. Propagates directory sync failures before dependent state is published.
4. Adds thorough regression tests asserting callback presence, bottom-up synchronization order, error propagation, and failure short-circuiting.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/store.go` | Added `mkdirAllSync`, synchronized `events/` before writing `HEAD` in legacy store append |
| `internal/reviewtransaction/bundle.go` | Used `mkdirAllSync` and synchronized `events/` before writing `HEAD` in bundle install |
| `internal/reviewtransaction/store_lock.go` | Used `mkdirAllSync` for store lock directory creation |
| `internal/reviewtransaction/compact_store.go` | Used `mkdirAllSync` for compact trace directory creation |
| `internal/reviewtransaction/store_authority_fsync_test.go` | Comprehensive unit tests for bottom-up sync ordering and error short-circuiting |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):**
Antigravity-pro5/gemini-3.7-flash-high via OpenCode

**Material scope:**
Drafting bottom-up directory sync helper `mkdirAllSync` and regression test suite.

**Verification performed:**
100% verified locally with Go test suites (`go test ./internal/reviewtransaction/...`), `go run ./internal/gofmtcheck`, `go vet ./...`, and `go build ./...`.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/reviewtransaction/...
go test -v -run 'TestLegacyPublication|TestBundleInstallation|TestFirstCompactPublication|TestMkdirAllSync' ./internal/reviewtransaction
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data durability when installing bundles, publishing events, and writing compact traces.
  * Ensured directories are synchronized before related updates are finalized.
  * Prevented incomplete publications when synchronization fails.
  * Added validation to reject invalid paths, including symlinked paths and paths that are not directories.
  * Improved reliability when creating directories and acquiring local storage locks.
* **Tests**
  * Added coverage for synchronization ordering, failure handling, directory creation, path validation, and atomic file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->