### PR TITLE
feat(doctor): detect mixed binary and managed-asset versions

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -644,7 +644,9 @@ func statusIcon(s CheckStatus) string {
 func checkInstalledAssetVersion(homeDir string) CheckResult {
 	catalog := managedbundle.DefaultCatalog(AppVersion, "")
 	res := managedbundle.Classify(context.Background(), homeDir, catalog)
-	if res.SyncEligibleReason != "no_manifest" && res.SyncEligibleReason != "manifest_unreadable" && res.SyncEligibleReason != "manifest_malformed" {
+	if res.SyncEligibleReason != managedbundle.SyncReasonNoManifest &&
+		res.SyncEligibleReason != managedbundle.SyncReasonManifestUnreadable &&
+		res.SyncEligibleReason != managedbundle.SyncReasonManifestMalformed {
 		switch res.BundleIdentity {
 		case managedbundle.BundleIdentityAligned:
 			return CheckResult{
@@ -663,11 +665,9 @@ func checkInstalledAssetVersion(homeDir string) CheckResult {
 				Detail: res.Detail,
 			}
 		default:
-			if res.UnsupportedSchema {
-				return CheckResult{
-					Status: CheckStatusWarn,
-					Detail: res.Detail,
-				}
+			return CheckResult{
+				Status: CheckStatusWarn,
+				Detail: res.Detail,
 			}
 		}
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/doctor"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/managedbundle"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/storage"
 )
@@ -641,6 +642,36 @@ func statusIcon(s CheckStatus) string {
 }
 
 func checkInstalledAssetVersion(homeDir string) CheckResult {
+	catalog := managedbundle.DefaultCatalog(AppVersion, "")
+	res := managedbundle.Classify(context.Background(), homeDir, catalog)
+	if res.SyncEligibleReason != "no_manifest" && res.SyncEligibleReason != "manifest_unreadable" && res.SyncEligibleReason != "manifest_malformed" {
+		switch res.BundleIdentity {
+		case managedbundle.BundleIdentityAligned:
+			return CheckResult{
+				Status: CheckStatusPass,
+				Detail: res.Detail,
+			}
+		case managedbundle.BundleIdentityStale:
+			return CheckResult{
+				Status: CheckStatusWarn,
+				Detail: res.Detail,
+				Remedy: doctor.NewRemedy(doctor.RemedySync, "Run 'gentle-ai sync' to update installed assets"),
+			}
+		case managedbundle.BundleIdentityUserModified, managedbundle.BundleIdentityMixed:
+			return CheckResult{
+				Status: CheckStatusWarn,
+				Detail: res.Detail,
+			}
+		default:
+			if res.UnsupportedSchema {
+				return CheckResult{
+					Status: CheckStatusWarn,
+					Detail: res.Detail,
+				}
+			}
+		}
+	}
+
 	s, err := state.Read(homeDir)
 	if err != nil {
 		return CheckResult{

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -628,6 +628,7 @@ func renderDoctorReport(w io.Writer, report DoctorReport) {
 	fmt.Fprintf(w, "Status:  %s\n", status)
 }
 
+// statusIcon maps a CheckStatus to its bracketed terminal representation.
 func statusIcon(s CheckStatus) string {
 	switch s {
 	case CheckStatusPass:
@@ -641,6 +642,9 @@ func statusIcon(s CheckStatus) string {
 	}
 }
 
+// checkInstalledAssetVersion verifies that managed bundle assets on disk match the running
+// binary version, inspecting the managed bundle manifest and active transactions before
+// falling back to state.json's installed binary version.
 func checkInstalledAssetVersion(homeDir string) CheckResult {
 	catalog := managedbundle.DefaultCatalog(AppVersion, "")
 	res := managedbundle.Classify(context.Background(), homeDir, catalog)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/doctor"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/managedbundle"
 )
 
 // --- checkOneTool ---
@@ -405,6 +406,103 @@ func TestCheckInstalledAssetVersion_SkewWarning(t *testing.T) {
 		t.Errorf("expected warn for version skew, got %s: %s", got.Status, got.Detail)
 	}
 	if !strings.Contains(got.Detail, "v0.9.0") || !strings.Contains(got.Detail, "gentle-ai sync") {
+		t.Errorf("unexpected detail: %s", got.Detail)
+	}
+}
+
+func TestCheckInstalledAssetVersion_ManagedBundle_AlignedPass(t *testing.T) {
+	homeDir := t.TempDir()
+	catalog := managedbundle.DefaultCatalog(AppVersion, "")
+	digest, err := catalog.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired, err := catalog.Resources[0].RenderDesired()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, filepath.FromSlash(managedbundle.DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, desired.Content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := managedbundle.ManagedBundleManifest{
+		Schema:        managedbundle.ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: managedbundle.ProducerInfo{
+			Version:       AppVersion,
+			CatalogDigest: digest,
+		},
+		Resources: []managedbundle.ResourceEntry{
+			{
+				ResourceID:     managedbundle.DefaultArchiveSkillResourceID,
+				TargetIdentity: managedbundle.TargetIdentityToken(managedbundle.DefaultArchiveSkillRelPath),
+				CanonicalPath:  managedbundle.DefaultArchiveSkillRelPath,
+				Ownership:      managedbundle.OwnershipDescriptor{Kind: managedbundle.OwnershipFullFile},
+				DesiredSHA256:  desired.SHA256,
+				ObservedSHA256: desired.SHA256,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := managedbundle.WriteManifest(homeDir, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkInstalledAssetVersion(homeDir)
+	if got.Status != CheckStatusPass {
+		t.Errorf("expected pass, got %s: %s", got.Status, got.Detail)
+	}
+}
+
+func TestCheckInstalledAssetVersion_ManagedBundle_StaleWarn(t *testing.T) {
+	homeDir := t.TempDir()
+	catalog := managedbundle.DefaultCatalog(AppVersion, "")
+	desired, err := catalog.Resources[0].RenderDesired()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, filepath.FromSlash(managedbundle.DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, desired.Content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := managedbundle.ManagedBundleManifest{
+		Schema:        managedbundle.ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: managedbundle.ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old-digest",
+		},
+		Resources: []managedbundle.ResourceEntry{
+			{
+				ResourceID:     managedbundle.DefaultArchiveSkillResourceID,
+				TargetIdentity: managedbundle.TargetIdentityToken(managedbundle.DefaultArchiveSkillRelPath),
+				CanonicalPath:  managedbundle.DefaultArchiveSkillRelPath,
+				Ownership:      managedbundle.OwnershipDescriptor{Kind: managedbundle.OwnershipFullFile},
+				DesiredSHA256:  desired.SHA256,
+				ObservedSHA256: desired.SHA256,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := managedbundle.WriteManifest(homeDir, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkInstalledAssetVersion(homeDir)
+	if got.Status != CheckStatusWarn {
+		t.Errorf("expected warn for stale bundle, got %s: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "2.1.10") || !strings.Contains(got.Detail, "gentle-ai sync") {
 		t.Errorf("unexpected detail: %s", got.Detail)
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -428,6 +428,9 @@ func TestCheckInstalledAssetVersion_ManagedBundle_AlignedPass(t *testing.T) {
 	if err := os.WriteFile(filePath, desired.Content, 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
 	manifest := managedbundle.ManagedBundleManifest{
 		Schema:        managedbundle.ManifestSchemaV1,
 		Generation:    1,
@@ -473,6 +476,9 @@ func TestCheckInstalledAssetVersion_ManagedBundle_StaleWarn(t *testing.T) {
 	if err := os.WriteFile(filePath, desired.Content, 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
 	manifest := managedbundle.ManagedBundleManifest{
 		Schema:        managedbundle.ManifestSchemaV1,
 		Generation:    1,
@@ -504,6 +510,75 @@ func TestCheckInstalledAssetVersion_ManagedBundle_StaleWarn(t *testing.T) {
 	}
 	if !strings.Contains(got.Detail, "2.1.10") || !strings.Contains(got.Detail, "gentle-ai sync") {
 		t.Errorf("unexpected detail: %s", got.Detail)
+	}
+}
+
+func TestCheckInstalledAssetVersion_ManagedBundle_UnresolvedTransactionWarn(t *testing.T) {
+	homeDir := t.TempDir()
+	catalog := managedbundle.DefaultCatalog(AppVersion, "")
+	desired, err := catalog.Resources[0].RenderDesired()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, filepath.FromSlash(managedbundle.DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, desired.Content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := managedbundle.ManagedBundleManifest{
+		Schema:        managedbundle.ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: managedbundle.ProducerInfo{
+			Version:       AppVersion,
+			CatalogDigest: "sha256:digest",
+		},
+		Resources: []managedbundle.ResourceEntry{
+			{
+				ResourceID:     managedbundle.DefaultArchiveSkillResourceID,
+				TargetIdentity: managedbundle.TargetIdentityToken(managedbundle.DefaultArchiveSkillRelPath),
+				CanonicalPath:  managedbundle.DefaultArchiveSkillRelPath,
+				Ownership:      managedbundle.OwnershipDescriptor{Kind: managedbundle.OwnershipFullFile},
+				DesiredSHA256:  desired.SHA256,
+				ObservedSHA256: desired.SHA256,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := managedbundle.WriteManifest(homeDir, manifest); err != nil {
+		t.Fatal(err)
+	}
+	journal := managedbundle.MigrationJournal{
+		Schema:             managedbundle.JournalSchemaV1,
+		TransactionID:      "tx-2",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          managedbundle.PhaseApplying,
+		Resources: []managedbundle.ResourceJournalEntry{
+			{
+				ResourceID:    managedbundle.DefaultArchiveSkillResourceID,
+				CanonicalPath: managedbundle.DefaultArchiveSkillRelPath,
+				Ownership:     managedbundle.OwnershipDescriptor{Kind: managedbundle.OwnershipFullFile},
+				BeforeSHA256:  "sha256:different",
+				BeforeMode:    0644,
+				DesiredSHA256: desired.SHA256,
+				DesiredMode:   0644,
+			},
+		},
+	}
+	if err := managedbundle.WriteJournal(homeDir, journal); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkInstalledAssetVersion(homeDir)
+	if got.Status != CheckStatusWarn {
+		t.Errorf("expected warn for unresolved transaction, got %s: %s", got.Status, got.Detail)
 	}
 }
 

--- a/internal/managedbundle/catalog.go
+++ b/internal/managedbundle/catalog.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -56,40 +58,66 @@ func WriteManifest(homeDir string, m ManagedBundleManifest) error {
 	}
 
 	manifestPath := filepath.Join(dir, ManifestFileName)
-	data, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal manifest: %w", err)
-	}
-
-	tmpPath := manifestPath + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return fmt.Errorf("write temp manifest: %w", err)
-	}
-	if err := os.Rename(tmpPath, manifestPath); err != nil {
-		return fmt.Errorf("commit manifest: %w", err)
-	}
-	return nil
+	return writeAtomicJSON(manifestPath, m)
 }
 
 // WriteJournal writes an active transaction journal under homeDir/.gentle-ai/managed/v1/transactions/<tx>/journal.json.
 func WriteJournal(homeDir string, j MigrationJournal) error {
-	dir := filepath.Join(homeDir, ManagedDirName, ManagedSubDir, JournalDirName, j.TransactionID)
+	txID := strings.TrimSpace(j.TransactionID)
+	if txID == "" || strings.Contains(txID, "/") || strings.Contains(txID, "\\") || txID == "." || txID == ".." {
+		return errors.New("invalid transaction ID: path traversal or unsafe characters detected")
+	}
+
+	dir := filepath.Join(homeDir, ManagedDirName, ManagedSubDir, JournalDirName, txID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create transaction dir: %w", err)
 	}
 
 	journalPath := filepath.Join(dir, JournalFileName)
-	data, err := json.MarshalIndent(j, "", "  ")
+	return writeAtomicJSON(journalPath, j)
+}
+
+func writeAtomicJSON(targetPath string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal journal: %w", err)
+		return fmt.Errorf("marshal json: %w", err)
 	}
 
-	tmpPath := journalPath + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return fmt.Errorf("write temp journal: %w", err)
+	dir := filepath.Dir(targetPath)
+	tmpFile, err := os.CreateTemp(dir, "atomic-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
 	}
-	if err := os.Rename(tmpPath, journalPath); err != nil {
-		return fmt.Errorf("commit journal: %w", err)
+	tmpName := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpName)
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write temp file: %w", err)
 	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := os.Chmod(tmpName, 0644); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, targetPath); err != nil {
+		return fmt.Errorf("atomic rename to target: %w", err)
+	}
+
+	// Sync parent directory
+	if parentDir, err := os.Open(dir); err == nil {
+		_ = parentDir.Sync()
+		_ = parentDir.Close()
+	}
+
 	return nil
 }

--- a/internal/managedbundle/catalog.go
+++ b/internal/managedbundle/catalog.go
@@ -1,0 +1,95 @@
+package managedbundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+const (
+	DefaultArchiveSkillResourceID = "opencode.skill/sdd-archive@1"
+	DefaultArchiveSkillRelPath    = ".config/opencode/skills/sdd-archive/SKILL.md"
+)
+
+// DefaultCatalog builds the default catalog for the active version of gentle-ai.
+// For Slice 1, it catalogs the full-file sdd-archive skill resource.
+func DefaultCatalog(version, vcsRevision string) ResourceCatalog {
+	return ResourceCatalog{
+		Version:     version,
+		VCSRevision: vcsRevision,
+		Resources: []ResourceDescriptor{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				SchemaVersion: 1,
+				ComponentID:   model.ComponentSkills,
+				AgentID:       model.AgentOpenCode,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				RenderDesired: func() (DesiredExtent, error) {
+					content, err := assets.FS.ReadFile("skills/sdd-archive/SKILL.md")
+					if err != nil {
+						return DesiredExtent{}, fmt.Errorf("read embedded sdd-archive skill: %w", err)
+					}
+					sum := sha256.Sum256(content)
+					return DesiredExtent{
+						Content: content,
+						SHA256:  "sha256:" + hex.EncodeToString(sum[:]),
+						Mode:    0644,
+					}, nil
+				},
+			},
+		},
+	}
+}
+
+// WriteManifest writes the manifest atomically under homeDir/.gentle-ai/managed/v1/manifest.json.
+func WriteManifest(homeDir string, m ManagedBundleManifest) error {
+	dir := filepath.Join(homeDir, ManagedDirName, ManagedSubDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create managed dir: %w", err)
+	}
+
+	manifestPath := filepath.Join(dir, ManifestFileName)
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	tmpPath := manifestPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("write temp manifest: %w", err)
+	}
+	if err := os.Rename(tmpPath, manifestPath); err != nil {
+		return fmt.Errorf("commit manifest: %w", err)
+	}
+	return nil
+}
+
+// WriteJournal writes an active transaction journal under homeDir/.gentle-ai/managed/v1/transactions/<tx>/journal.json.
+func WriteJournal(homeDir string, j MigrationJournal) error {
+	dir := filepath.Join(homeDir, ManagedDirName, ManagedSubDir, JournalDirName, j.TransactionID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create transaction dir: %w", err)
+	}
+
+	journalPath := filepath.Join(dir, JournalFileName)
+	data, err := json.MarshalIndent(j, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal journal: %w", err)
+	}
+
+	tmpPath := journalPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("write temp journal: %w", err)
+	}
+	if err := os.Rename(tmpPath, journalPath); err != nil {
+		return fmt.Errorf("commit journal: %w", err)
+	}
+	return nil
+}

--- a/internal/managedbundle/classify.go
+++ b/internal/managedbundle/classify.go
@@ -22,7 +22,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				ExtentIntegrity:    ExtentIntegrityMissing,
 				RecoveryState:      RecoveryStateNone,
 				SyncEligible:       false,
-				SyncEligibleReason: "no_manifest",
+				SyncEligibleReason: SyncReasonNoManifest,
 				Detail:             "no managed bundle manifest found — asset state unknown",
 			}
 		}
@@ -31,7 +31,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityMissing,
 			RecoveryState:      RecoveryStateNone,
 			SyncEligible:       false,
-			SyncEligibleReason: "manifest_unreadable",
+			SyncEligibleReason: SyncReasonManifestUnreadable,
 			Detail:             fmt.Sprintf("failed to read managed bundle manifest: %v", err),
 		}
 	}
@@ -43,7 +43,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityMissing,
 			RecoveryState:      RecoveryStateNone,
 			SyncEligible:       false,
-			SyncEligibleReason: "manifest_malformed",
+			SyncEligibleReason: SyncReasonManifestMalformed,
 			Detail:             "managed bundle manifest is malformed",
 		}
 	}
@@ -54,9 +54,9 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityMissing,
 			RecoveryState:      RecoveryStateNone,
 			SyncEligible:       false,
-			SyncEligibleReason: "unsupported_schema",
+			SyncEligibleReason: SyncReasonUnsupportedSchema,
 			UnsupportedSchema:  true,
-			Detail:             fmt.Sprintf("unsupported newer manifest schema %q — upgrade gentle-ai", manifest.Schema),
+			Detail:             fmt.Sprintf("unsupported manifest schema %q", manifest.Schema),
 		}
 	}
 
@@ -68,7 +68,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityUserModified,
 			RecoveryState:      recoveryState,
 			SyncEligible:       false,
-			SyncEligibleReason: "unresolved_transaction",
+			SyncEligibleReason: SyncReasonUnresolvedTransaction,
 			Detail:             journalDetail,
 		}
 	}
@@ -80,7 +80,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityMissing,
 			RecoveryState:      RecoveryStateNone,
 			SyncEligible:       false,
-			SyncEligibleReason: "empty_manifest",
+			SyncEligibleReason: SyncReasonEmptyManifest,
 			Detail:             "managed bundle manifest contains no resource entries",
 		}
 	}
@@ -90,10 +90,10 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 		if res.TransactionID != "" && manifest.TransactionID != "" && res.TransactionID != manifest.TransactionID {
 			return ClassificationResult{
 				BundleIdentity:     BundleIdentityMixed,
-				ExtentIntegrity:    ExtentIntegrityMatch,
+				ExtentIntegrity:    ExtentIntegrityUserModified,
 				RecoveryState:      RecoveryStateNone,
 				SyncEligible:       false,
-				SyncEligibleReason: "mixed_resource_transactions",
+				SyncEligibleReason: SyncReasonMixedResourceTransactions,
 				Detail:             "managed bundle contains mixed resource transactions",
 			}
 		}
@@ -110,7 +110,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 					ExtentIntegrity:    ExtentIntegrityMissing,
 					RecoveryState:      RecoveryStateNone,
 					SyncEligible:       false,
-					SyncEligibleReason: "resource_missing",
+					SyncEligibleReason: SyncReasonResourceMissing,
 					Detail:             fmt.Sprintf("managed resource %s is missing from disk: %s", res.ResourceID, res.CanonicalPath),
 				}
 			}
@@ -119,7 +119,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				ExtentIntegrity:    ExtentIntegrityUserModified,
 				RecoveryState:      RecoveryStateNone,
 				SyncEligible:       false,
-				SyncEligibleReason: "resource_unreadable",
+				SyncEligibleReason: SyncReasonResourceUnreadable,
 				Detail:             fmt.Sprintf("managed resource %s cannot be read: %v", res.ResourceID, err),
 			}
 		}
@@ -130,7 +130,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				ExtentIntegrity:    ExtentIntegrityTypeChanged,
 				RecoveryState:      RecoveryStateNone,
 				SyncEligible:       false,
-				SyncEligibleReason: "type_changed",
+				SyncEligibleReason: SyncReasonTypeChanged,
 				Detail:             fmt.Sprintf("managed resource %s type changed (not a regular file): %s", res.ResourceID, res.CanonicalPath),
 			}
 		}
@@ -142,7 +142,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				ExtentIntegrity:    ExtentIntegrityUserModified,
 				RecoveryState:      RecoveryStateNone,
 				SyncEligible:       false,
-				SyncEligibleReason: "resource_unreadable",
+				SyncEligibleReason: SyncReasonResourceUnreadable,
 				Detail:             fmt.Sprintf("managed resource %s cannot be read: %v", res.ResourceID, err),
 			}
 		}
@@ -155,7 +155,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				ExtentIntegrity:    ExtentIntegrityUserModified,
 				RecoveryState:      RecoveryStateNone,
 				SyncEligible:       false,
-				SyncEligibleReason: "content_mismatch",
+				SyncEligibleReason: SyncReasonContentMismatch,
 				Detail:             fmt.Sprintf("managed resource %s was modified on disk", res.ResourceID),
 			}
 		}
@@ -169,7 +169,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 					ExtentIntegrity:    ExtentIntegrityUserModified,
 					RecoveryState:      RecoveryStateNone,
 					SyncEligible:       false,
-					SyncEligibleReason: "mode_mismatch",
+					SyncEligibleReason: SyncReasonModeMismatch,
 					Detail:             fmt.Sprintf("managed resource %s file mode was modified on disk", res.ResourceID),
 				}
 			}
@@ -184,7 +184,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityMatch,
 			RecoveryState:      RecoveryStateNone,
 			SyncEligible:       false,
-			SyncEligibleReason: "catalog_digest_error",
+			SyncEligibleReason: SyncReasonCatalogDigestError,
 			Detail:             fmt.Sprintf("failed to compute catalog digest: %v", err),
 		}
 	}
@@ -196,7 +196,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			ExtentIntegrity:    ExtentIntegrityMatch,
 			RecoveryState:      RecoveryStateNone,
 			SyncEligible:       true,
-			SyncEligibleReason: "aligned_with_current_binary",
+			SyncEligibleReason: SyncReasonAlignedWithCurrentBinary,
 			Detail:             fmt.Sprintf("installed managed assets match running binary (%s)", catalog.Version),
 		}
 	}
@@ -207,7 +207,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 		ExtentIntegrity:    ExtentIntegrityMatch,
 		RecoveryState:      RecoveryStateNone,
 		SyncEligible:       true,
-		SyncEligibleReason: "exact_committed_older_bundle",
+		SyncEligibleReason: SyncReasonExactCommittedOlderBundle,
 		Detail: fmt.Sprintf("installed assets were configured by gentle-ai %s, but running binary is %s — run 'gentle-ai sync' to update installed assets",
 			manifest.Producer.Version, catalog.Version),
 	}
@@ -216,7 +216,13 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (RecoveryState, string) {
 	txDir := filepath.Join(homeDir, ManagedDirName, ManagedSubDir, JournalDirName)
 	entries, err := os.ReadDir(txDir)
-	if err != nil || len(entries) == 0 {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return RecoveryStateNone, ""
+		}
+		return RecoveryStateBlockedConflict, fmt.Sprintf("cannot read transactions directory: %v", err)
+	}
+	if len(entries) == 0 {
 		return RecoveryStateNone, ""
 	}
 
@@ -227,11 +233,11 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 		journalPath := filepath.Join(txDir, entry.Name(), JournalFileName)
 		data, err := os.ReadFile(journalPath)
 		if err != nil {
-			continue
+			return RecoveryStateBlockedConflict, fmt.Sprintf("cannot read transaction journal %s: %v", entry.Name(), err)
 		}
 		var journal MigrationJournal
 		if err := json.Unmarshal(data, &journal); err != nil {
-			continue
+			return RecoveryStateBlockedConflict, fmt.Sprintf("malformed transaction journal %s: %v", entry.Name(), err)
 		}
 
 		if journal.LastPhase == PhaseCompleted || journal.LastPhase == PhaseRolledBack {
@@ -241,6 +247,16 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 		// If the manifest already names this transaction, it was committed
 		if manifest.TransactionID == journal.TransactionID && manifest.Generation == journal.ProposedGeneration {
 			continue
+		}
+
+		// Non-terminal journals whose ExpectedGeneration is lower than current manifest generation are superseded
+		if manifest.Generation > 0 && journal.ExpectedGeneration < manifest.Generation {
+			continue
+		}
+
+		// If the journal declares no resources, it cannot provide recovery evidence
+		if len(journal.Resources) == 0 {
+			return RecoveryStateBlockedConflict, fmt.Sprintf("transaction %s contains no resource entries", journal.TransactionID)
 		}
 
 		// Evaluate on-disk files against journal Before / Desired states

--- a/internal/managedbundle/classify.go
+++ b/internal/managedbundle/classify.go
@@ -266,7 +266,13 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				}
 			}
 			expectedTarget := TargetIdentityToken(desc.CanonicalPath)
-			if res.TargetIdentity != expectedTarget || res.CanonicalPath != desc.CanonicalPath || res.Ownership.Kind != desc.Ownership.Kind || res.DesiredSHA256 != desired.SHA256 || res.ObservedSHA256 != desired.SHA256 || (desired.Mode != 0 && res.Mode != desired.Mode) {
+			desiredSHA := desired.SHA256
+			if desiredSHA == "" && len(desired.Content) > 0 {
+				sum := sha256.Sum256(desired.Content)
+				desiredSHA = "sha256:" + hex.EncodeToString(sum[:])
+			}
+
+			if res.TargetIdentity != expectedTarget || res.CanonicalPath != desc.CanonicalPath || res.Ownership.Kind != desc.Ownership.Kind || res.DesiredSHA256 != desiredSHA || res.ObservedSHA256 != desiredSHA || (desired.Mode != 0 && res.Mode != desired.Mode) {
 				return ClassificationResult{
 					BundleIdentity:     BundleIdentityUserModified,
 					ExtentIntegrity:    ExtentIntegrityUserModified,
@@ -285,6 +291,31 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			SyncEligible:       true,
 			SyncEligibleReason: SyncReasonAlignedWithCurrentBinary,
 			Detail:             fmt.Sprintf("installed managed assets match running binary (%s)", catalog.Version),
+		}
+	}
+
+	// Validate that a stale producer has non-empty metadata and internally consistent committed resources
+	if manifest.Producer.Version == "" || manifest.Producer.CatalogDigest == "" {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityMatch,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       false,
+			SyncEligibleReason: SyncReasonCatalogDigestError,
+			Detail:             "manifest producer metadata is incomplete",
+		}
+	}
+
+	for _, res := range manifest.Resources {
+		if res.ObservedSHA256 != res.DesiredSHA256 {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUserModified,
+				ExtentIntegrity:    ExtentIntegrityUserModified,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: SyncReasonContentMismatch,
+				Detail:             fmt.Sprintf("manifest resource %s was not cleanly committed in older bundle", res.ResourceID),
+			}
 		}
 	}
 
@@ -312,6 +343,10 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 	if len(entries) == 0 {
 		return RecoveryStateNone, ""
 	}
+
+	var finalState RecoveryState = RecoveryStateNone
+	var finalDetail string
+	unresolvedCount := 0
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -400,17 +435,34 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 			}
 		}
 
+		var jState RecoveryState
+		var jDetail string
 		if hasForeign {
-			return RecoveryStateBlockedConflict, fmt.Sprintf("transaction %s interrupted with conflicting modifications", journal.TransactionID)
+			jState = RecoveryStateBlockedConflict
+			jDetail = fmt.Sprintf("transaction %s interrupted with conflicting modifications", journal.TransactionID)
+		} else if allDesired {
+			jState = RecoveryStateResumableDesired
+			jDetail = fmt.Sprintf("transaction %s interrupted with desired state on disk — resumable commit", journal.TransactionID)
+		} else if allBefore {
+			jState = RecoveryStateResumableBefore
+			jDetail = fmt.Sprintf("transaction %s interrupted with before state preserved — recoverable", journal.TransactionID)
+		} else {
+			jState = RecoveryStateBlockedConflict
+			jDetail = fmt.Sprintf("transaction %s in partial state", journal.TransactionID)
 		}
-		if allDesired {
-			return RecoveryStateResumableDesired, fmt.Sprintf("transaction %s interrupted with desired state on disk — resumable commit", journal.TransactionID)
+
+		if jState == RecoveryStateBlockedConflict {
+			return jState, jDetail
 		}
-		if allBefore {
-			return RecoveryStateResumableBefore, fmt.Sprintf("transaction %s interrupted with before state preserved — recoverable", journal.TransactionID)
-		}
-		return RecoveryStateBlockedConflict, fmt.Sprintf("transaction %s in partial state", journal.TransactionID)
+
+		unresolvedCount++
+		finalState = jState
+		finalDetail = jDetail
 	}
 
-	return RecoveryStateNone, ""
+	if unresolvedCount > 1 {
+		return RecoveryStateBlockedConflict, "multiple unresolved transactions detected"
+	}
+
+	return finalState, finalDetail
 }

--- a/internal/managedbundle/classify.go
+++ b/internal/managedbundle/classify.go
@@ -124,7 +124,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			}
 		}
 
-		if fi.Mode()&os.ModeSymlink != 0 || fi.IsDir() {
+		if !fi.Mode().IsRegular() {
 			return ClassificationResult{
 				BundleIdentity:     BundleIdentityUserModified,
 				ExtentIntegrity:    ExtentIntegrityTypeChanged,
@@ -191,6 +191,59 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 
 	// Check if manifest producer matches the running binary catalog
 	if manifest.Producer.CatalogDigest == currentCatalogDigest {
+		// Validate that manifest.Resources exactly matches current catalog descriptors
+		if len(manifest.Resources) != len(catalog.Resources) {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityMixed,
+				ExtentIntegrity:    ExtentIntegrityUserModified,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: SyncReasonMixedResourceTransactions,
+				Detail:             "manifest resources count does not match current catalog",
+			}
+		}
+
+		manifestMap := make(map[string]ResourceEntry, len(manifest.Resources))
+		for _, r := range manifest.Resources {
+			manifestMap[r.ResourceID] = r
+		}
+
+		for _, desc := range catalog.Resources {
+			res, ok := manifestMap[desc.ResourceID]
+			if !ok {
+				return ClassificationResult{
+					BundleIdentity:     BundleIdentityMixed,
+					ExtentIntegrity:    ExtentIntegrityUserModified,
+					RecoveryState:      RecoveryStateNone,
+					SyncEligible:       false,
+					SyncEligibleReason: SyncReasonMixedResourceTransactions,
+					Detail:             fmt.Sprintf("manifest missing resource descriptor %s", desc.ResourceID),
+				}
+			}
+			desired, err := desc.RenderDesired()
+			if err != nil {
+				return ClassificationResult{
+					BundleIdentity:     BundleIdentityUnknown,
+					ExtentIntegrity:    ExtentIntegrityMatch,
+					RecoveryState:      RecoveryStateNone,
+					SyncEligible:       false,
+					SyncEligibleReason: SyncReasonCatalogDigestError,
+					Detail:             fmt.Sprintf("failed to render desired extent: %v", err),
+				}
+			}
+			expectedTarget := TargetIdentityToken(desc.CanonicalPath)
+			if res.TargetIdentity != expectedTarget || res.CanonicalPath != desc.CanonicalPath || res.Ownership.Kind != desc.Ownership.Kind || res.DesiredSHA256 != desired.SHA256 || (desired.Mode != 0 && res.Mode != desired.Mode) {
+				return ClassificationResult{
+					BundleIdentity:     BundleIdentityUserModified,
+					ExtentIntegrity:    ExtentIntegrityUserModified,
+					RecoveryState:      RecoveryStateNone,
+					SyncEligible:       false,
+					SyncEligibleReason: SyncReasonContentMismatch,
+					Detail:             fmt.Sprintf("manifest resource %s descriptor mismatch with running catalog", desc.ResourceID),
+				}
+			}
+		}
+
 		return ClassificationResult{
 			BundleIdentity:     BundleIdentityAligned,
 			ExtentIntegrity:    ExtentIntegrityMatch,
@@ -240,6 +293,10 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 			return RecoveryStateBlockedConflict, fmt.Sprintf("malformed transaction journal %s: %v", entry.Name(), err)
 		}
 
+		if journal.Schema != JournalSchemaV1 {
+			return RecoveryStateBlockedConflict, fmt.Sprintf("unsupported transaction journal schema %q in %s", journal.Schema, entry.Name())
+		}
+
 		if journal.LastPhase == PhaseCompleted || journal.LastPhase == PhaseRolledBack {
 			continue
 		}
@@ -266,7 +323,7 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 
 		for _, res := range journal.Resources {
 			targetPath := filepath.Join(homeDir, filepath.FromSlash(res.CanonicalPath))
-			content, err := os.ReadFile(targetPath)
+			fi, err := os.Lstat(targetPath)
 			if err != nil {
 				if os.IsNotExist(err) && res.BeforeSHA256 == "" {
 					// file didn't exist before
@@ -276,13 +333,29 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 				hasForeign = true
 				break
 			}
+			if !fi.Mode().IsRegular() {
+				hasForeign = true
+				break
+			}
+			fileMode := uint32(fi.Mode().Perm())
+
+			content, err := os.ReadFile(targetPath)
+			if err != nil {
+				hasForeign = true
+				break
+			}
 			sum := sha256.Sum256(content)
 			fileSHA := "sha256:" + hex.EncodeToString(sum[:])
 
-			if fileSHA == res.DesiredSHA256 {
+			matchesDesired := (fileSHA == res.DesiredSHA256) && (res.DesiredMode == 0 || fileMode == res.DesiredMode)
+			matchesBefore := (fileSHA == res.BeforeSHA256) && (res.BeforeMode == 0 || fileMode == res.BeforeMode)
+
+			if matchesDesired && !matchesBefore {
 				allBefore = false
-			} else if fileSHA == res.BeforeSHA256 {
+			} else if matchesBefore && !matchesDesired {
 				allDesired = false
+			} else if matchesDesired && matchesBefore {
+				// identical before and desired
 			} else {
 				hasForeign = true
 				break

--- a/internal/managedbundle/classify.go
+++ b/internal/managedbundle/classify.go
@@ -1,0 +1,289 @@
+package managedbundle
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Classify reads the durable managed bundle manifest and journals under homeDir,
+// comparing them against the running catalog and actual files on disk.
+func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) ClassificationResult {
+	manifestPath := filepath.Join(homeDir, ManagedDirName, ManagedSubDir, ManifestFileName)
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUnknown,
+				ExtentIntegrity:    ExtentIntegrityMissing,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: "no_manifest",
+				Detail:             "no managed bundle manifest found — asset state unknown",
+			}
+		}
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityMissing,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       false,
+			SyncEligibleReason: "manifest_unreadable",
+			Detail:             fmt.Sprintf("failed to read managed bundle manifest: %v", err),
+		}
+	}
+
+	var manifest ManagedBundleManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityMissing,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       false,
+			SyncEligibleReason: "manifest_malformed",
+			Detail:             "managed bundle manifest is malformed",
+		}
+	}
+
+	if manifest.Schema != ManifestSchemaV1 {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityMissing,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       false,
+			SyncEligibleReason: "unsupported_schema",
+			UnsupportedSchema:  true,
+			Detail:             fmt.Sprintf("unsupported newer manifest schema %q — upgrade gentle-ai", manifest.Schema),
+		}
+	}
+
+	// Check if there are active / uncommitted transactions
+	recoveryState, journalDetail := checkActiveTransactions(homeDir, manifest)
+	if recoveryState != RecoveryStateNone {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityUserModified,
+			RecoveryState:      recoveryState,
+			SyncEligible:       false,
+			SyncEligibleReason: "unresolved_transaction",
+			Detail:             journalDetail,
+		}
+	}
+
+	// Validate resources in the manifest
+	if len(manifest.Resources) == 0 {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityMissing,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       false,
+			SyncEligibleReason: "empty_manifest",
+			Detail:             "managed bundle manifest contains no resource entries",
+		}
+	}
+
+	// Check for producer consistency
+	for _, res := range manifest.Resources {
+		if res.TransactionID != "" && manifest.TransactionID != "" && res.TransactionID != manifest.TransactionID {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityMixed,
+				ExtentIntegrity:    ExtentIntegrityMatch,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: "mixed_resource_transactions",
+				Detail:             "managed bundle contains mixed resource transactions",
+			}
+		}
+	}
+
+	// Check on-disk extents for all committed resources
+	for _, res := range manifest.Resources {
+		targetPath := filepath.Join(homeDir, filepath.FromSlash(res.CanonicalPath))
+		fi, err := os.Lstat(targetPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return ClassificationResult{
+					BundleIdentity:     BundleIdentityUserModified,
+					ExtentIntegrity:    ExtentIntegrityMissing,
+					RecoveryState:      RecoveryStateNone,
+					SyncEligible:       false,
+					SyncEligibleReason: "resource_missing",
+					Detail:             fmt.Sprintf("managed resource %s is missing from disk: %s", res.ResourceID, res.CanonicalPath),
+				}
+			}
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUnknown,
+				ExtentIntegrity:    ExtentIntegrityUserModified,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: "resource_unreadable",
+				Detail:             fmt.Sprintf("managed resource %s cannot be read: %v", res.ResourceID, err),
+			}
+		}
+
+		if fi.Mode()&os.ModeSymlink != 0 || fi.IsDir() {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUserModified,
+				ExtentIntegrity:    ExtentIntegrityTypeChanged,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: "type_changed",
+				Detail:             fmt.Sprintf("managed resource %s type changed (not a regular file): %s", res.ResourceID, res.CanonicalPath),
+			}
+		}
+
+		content, err := os.ReadFile(targetPath)
+		if err != nil {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUnknown,
+				ExtentIntegrity:    ExtentIntegrityUserModified,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: "resource_unreadable",
+				Detail:             fmt.Sprintf("managed resource %s cannot be read: %v", res.ResourceID, err),
+			}
+		}
+
+		sum := sha256.Sum256(content)
+		observedSHA := "sha256:" + hex.EncodeToString(sum[:])
+		if observedSHA != res.ObservedSHA256 {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUserModified,
+				ExtentIntegrity:    ExtentIntegrityUserModified,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: "content_mismatch",
+				Detail:             fmt.Sprintf("managed resource %s was modified on disk", res.ResourceID),
+			}
+		}
+
+		// Optional check: compare mode if res.Mode is specified
+		if res.Mode != 0 {
+			fileMode := uint32(fi.Mode().Perm())
+			if fileMode != res.Mode {
+				return ClassificationResult{
+					BundleIdentity:     BundleIdentityUserModified,
+					ExtentIntegrity:    ExtentIntegrityUserModified,
+					RecoveryState:      RecoveryStateNone,
+					SyncEligible:       false,
+					SyncEligibleReason: "mode_mismatch",
+					Detail:             fmt.Sprintf("managed resource %s file mode was modified on disk", res.ResourceID),
+				}
+			}
+		}
+	}
+
+	// Compute current catalog digest
+	currentCatalogDigest, err := catalog.ComputeCatalogDigest()
+	if err != nil {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityUnknown,
+			ExtentIntegrity:    ExtentIntegrityMatch,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       false,
+			SyncEligibleReason: "catalog_digest_error",
+			Detail:             fmt.Sprintf("failed to compute catalog digest: %v", err),
+		}
+	}
+
+	// Check if manifest producer matches the running binary catalog
+	if manifest.Producer.CatalogDigest == currentCatalogDigest {
+		return ClassificationResult{
+			BundleIdentity:     BundleIdentityAligned,
+			ExtentIntegrity:    ExtentIntegrityMatch,
+			RecoveryState:      RecoveryStateNone,
+			SyncEligible:       true,
+			SyncEligibleReason: "aligned_with_current_binary",
+			Detail:             fmt.Sprintf("installed managed assets match running binary (%s)", catalog.Version),
+		}
+	}
+
+	// Trusted older producer with exact committed extents
+	return ClassificationResult{
+		BundleIdentity:     BundleIdentityStale,
+		ExtentIntegrity:    ExtentIntegrityMatch,
+		RecoveryState:      RecoveryStateNone,
+		SyncEligible:       true,
+		SyncEligibleReason: "exact_committed_older_bundle",
+		Detail: fmt.Sprintf("installed assets were configured by gentle-ai %s, but running binary is %s — run 'gentle-ai sync' to update installed assets",
+			manifest.Producer.Version, catalog.Version),
+	}
+}
+
+func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (RecoveryState, string) {
+	txDir := filepath.Join(homeDir, ManagedDirName, ManagedSubDir, JournalDirName)
+	entries, err := os.ReadDir(txDir)
+	if err != nil || len(entries) == 0 {
+		return RecoveryStateNone, ""
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		journalPath := filepath.Join(txDir, entry.Name(), JournalFileName)
+		data, err := os.ReadFile(journalPath)
+		if err != nil {
+			continue
+		}
+		var journal MigrationJournal
+		if err := json.Unmarshal(data, &journal); err != nil {
+			continue
+		}
+
+		if journal.LastPhase == PhaseCompleted || journal.LastPhase == PhaseRolledBack {
+			continue
+		}
+
+		// If the manifest already names this transaction, it was committed
+		if manifest.TransactionID == journal.TransactionID && manifest.Generation == journal.ProposedGeneration {
+			continue
+		}
+
+		// Evaluate on-disk files against journal Before / Desired states
+		hasForeign := false
+		allDesired := true
+		allBefore := true
+
+		for _, res := range journal.Resources {
+			targetPath := filepath.Join(homeDir, filepath.FromSlash(res.CanonicalPath))
+			content, err := os.ReadFile(targetPath)
+			if err != nil {
+				if os.IsNotExist(err) && res.BeforeSHA256 == "" {
+					// file didn't exist before
+					allDesired = false
+					continue
+				}
+				hasForeign = true
+				break
+			}
+			sum := sha256.Sum256(content)
+			fileSHA := "sha256:" + hex.EncodeToString(sum[:])
+
+			if fileSHA == res.DesiredSHA256 {
+				allBefore = false
+			} else if fileSHA == res.BeforeSHA256 {
+				allDesired = false
+			} else {
+				hasForeign = true
+				break
+			}
+		}
+
+		if hasForeign {
+			return RecoveryStateBlockedConflict, fmt.Sprintf("transaction %s interrupted with conflicting modifications", journal.TransactionID)
+		}
+		if allDesired {
+			return RecoveryStateResumableDesired, fmt.Sprintf("transaction %s interrupted with desired state on disk — resumable commit", journal.TransactionID)
+		}
+		if allBefore {
+			return RecoveryStateResumableBefore, fmt.Sprintf("transaction %s interrupted with before state preserved — recoverable", journal.TransactionID)
+		}
+		return RecoveryStateBlockedConflict, fmt.Sprintf("transaction %s in partial state", journal.TransactionID)
+	}
+
+	return RecoveryStateNone, ""
+}

--- a/internal/managedbundle/classify.go
+++ b/internal/managedbundle/classify.go
@@ -5,10 +5,29 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+func resolveSafeCanonicalPath(homeDir, relPath string) (string, error) {
+	relPath = strings.TrimSpace(relPath)
+	if relPath == "" {
+		return "", errors.New("canonical path is empty")
+	}
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("canonical path %q must not be absolute", relPath)
+	}
+	joined := filepath.Join(homeDir, filepath.FromSlash(relPath))
+	cleanHome := filepath.Clean(homeDir)
+	rel, err := filepath.Rel(cleanHome, joined)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("canonical path %q escapes home directory", relPath)
+	}
+	return joined, nil
+}
 
 // Classify reads the durable managed bundle manifest and journals under homeDir,
 // comparing them against the running catalog and actual files on disk.
@@ -101,7 +120,18 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 
 	// Check on-disk extents for all committed resources
 	for _, res := range manifest.Resources {
-		targetPath := filepath.Join(homeDir, filepath.FromSlash(res.CanonicalPath))
+		targetPath, pathErr := resolveSafeCanonicalPath(homeDir, res.CanonicalPath)
+		if pathErr != nil {
+			return ClassificationResult{
+				BundleIdentity:     BundleIdentityUserModified,
+				ExtentIntegrity:    ExtentIntegrityTypeChanged,
+				RecoveryState:      RecoveryStateNone,
+				SyncEligible:       false,
+				SyncEligibleReason: SyncReasonTypeChanged,
+				Detail:             fmt.Sprintf("managed resource %s has invalid path: %v", res.ResourceID, pathErr),
+			}
+		}
+
 		fi, err := os.Lstat(targetPath)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -190,7 +220,11 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 	}
 
 	// Check if manifest producer matches the running binary catalog
-	if manifest.Producer.CatalogDigest == currentCatalogDigest {
+	producerMatches := (manifest.Producer.CatalogDigest == currentCatalogDigest) &&
+		(manifest.Producer.Version == catalog.Version) &&
+		(catalog.VCSRevision == "" || manifest.Producer.VCSRevision == catalog.VCSRevision)
+
+	if producerMatches {
 		// Validate that manifest.Resources exactly matches current catalog descriptors
 		if len(manifest.Resources) != len(catalog.Resources) {
 			return ClassificationResult{
@@ -232,7 +266,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 				}
 			}
 			expectedTarget := TargetIdentityToken(desc.CanonicalPath)
-			if res.TargetIdentity != expectedTarget || res.CanonicalPath != desc.CanonicalPath || res.Ownership.Kind != desc.Ownership.Kind || res.DesiredSHA256 != desired.SHA256 || (desired.Mode != 0 && res.Mode != desired.Mode) {
+			if res.TargetIdentity != expectedTarget || res.CanonicalPath != desc.CanonicalPath || res.Ownership.Kind != desc.Ownership.Kind || res.DesiredSHA256 != desired.SHA256 || res.ObservedSHA256 != desired.SHA256 || (desired.Mode != 0 && res.Mode != desired.Mode) {
 				return ClassificationResult{
 					BundleIdentity:     BundleIdentityUserModified,
 					ExtentIntegrity:    ExtentIntegrityUserModified,
@@ -322,7 +356,11 @@ func checkActiveTransactions(homeDir string, manifest ManagedBundleManifest) (Re
 		allBefore := true
 
 		for _, res := range journal.Resources {
-			targetPath := filepath.Join(homeDir, filepath.FromSlash(res.CanonicalPath))
+			targetPath, pathErr := resolveSafeCanonicalPath(homeDir, res.CanonicalPath)
+			if pathErr != nil {
+				hasForeign = true
+				break
+			}
 			fi, err := os.Lstat(targetPath)
 			if err != nil {
 				if os.IsNotExist(err) && res.BeforeSHA256 == "" {

--- a/internal/managedbundle/classify.go
+++ b/internal/managedbundle/classify.go
@@ -267,7 +267,7 @@ func Classify(ctx context.Context, homeDir string, catalog ResourceCatalog) Clas
 			}
 			expectedTarget := TargetIdentityToken(desc.CanonicalPath)
 			desiredSHA := desired.SHA256
-			if desiredSHA == "" && len(desired.Content) > 0 {
+			if desiredSHA == "" {
 				sum := sha256.Sum256(desired.Content)
 				desiredSHA = "sha256:" + hex.EncodeToString(sum[:])
 			}

--- a/internal/managedbundle/classify_test.go
+++ b/internal/managedbundle/classify_test.go
@@ -59,6 +59,9 @@ func TestFixture1_B2Manifest_ExactB2Bytes_Aligned(t *testing.T) {
 	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	sum := sha256.Sum256(b2Bytes)
 	sha := "sha256:" + hex.EncodeToString(sum[:])
@@ -111,7 +114,10 @@ func TestFixture2_B1Manifest_ExactB1Bytes_Stale(t *testing.T) {
 	b1Bytes := []byte("# sdd-archive skill v1\n")
 	b1Mode := uint32(0644)
 	catalogB1 := makeTestCatalog("2.1.10", b1Bytes, b1Mode)
-	b1Digest, _ := catalogB1.ComputeCatalogDigest()
+	b1Digest, err := catalogB1.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatalf("compute b1 digest: %v", err)
+	}
 
 	b2Bytes := []byte("# sdd-archive skill v2\n")
 	b2Mode := uint32(0644)
@@ -123,6 +129,9 @@ func TestFixture2_B1Manifest_ExactB1Bytes_Stale(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, b1Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -162,8 +171,8 @@ func TestFixture2_B1Manifest_ExactB1Bytes_Stale(t *testing.T) {
 	if res.ExtentIntegrity != ExtentIntegrityMatch {
 		t.Errorf("got extent integrity %s, want %s", res.ExtentIntegrity, ExtentIntegrityMatch)
 	}
-	if !res.SyncEligible || res.SyncEligibleReason != "exact_committed_older_bundle" {
-		t.Errorf("got sync eligible %v (%s), want true (exact_committed_older_bundle)", res.SyncEligible, res.SyncEligibleReason)
+	if !res.SyncEligible || res.SyncEligibleReason != SyncReasonExactCommittedOlderBundle {
+		t.Errorf("got sync eligible %v (%s), want true (%s)", res.SyncEligible, res.SyncEligibleReason, SyncReasonExactCommittedOlderBundle)
 	}
 }
 
@@ -174,7 +183,10 @@ func TestFixture3_B1Manifest_ChangedByte_UserModified(t *testing.T) {
 	b1Bytes := []byte("# sdd-archive skill v1\n")
 	b1Mode := uint32(0644)
 	catalogB1 := makeTestCatalog("2.1.10", b1Bytes, b1Mode)
-	b1Digest, _ := catalogB1.ComputeCatalogDigest()
+	b1Digest, err := catalogB1.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatalf("compute b1 digest: %v", err)
+	}
 
 	catalogB2 := makeTestCatalog("2.2.0", []byte("# sdd-archive skill v2\n"), 0644)
 
@@ -184,6 +196,9 @@ func TestFixture3_B1Manifest_ChangedByte_UserModified(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, []byte("# user edited content\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -243,6 +258,9 @@ func TestFixture4_NoManifest_Unknown(t *testing.T) {
 	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	res := Classify(context.Background(), home, catalogB2)
 	if res.BundleIdentity != BundleIdentityUnknown {
@@ -266,6 +284,9 @@ func TestFixture5_PreparedTransaction_ObservedBefore_Recoverable(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, b1Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -344,6 +365,9 @@ func TestFixture6_PreparedTransaction_ObservedDesired_ResumableCommit(t *testing
 	}
 	// Desired bytes already written to disk before crash
 	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -425,6 +449,9 @@ func TestFixture7_PreparedTransaction_ForeignBytes_BlockedConflict(t *testing.T)
 	if err := os.WriteFile(filePath, []byte("# conflict bytes\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	sum1 := sha256.Sum256(b1Bytes)
 	sha1 := "sha256:" + hex.EncodeToString(sum1[:])
@@ -487,9 +514,9 @@ func TestFixture7_PreparedTransaction_ForeignBytes_BlockedConflict(t *testing.T)
 	}
 }
 
-// TestFixture8_ManifestProducerMismatch_Mixed verifies:
-// 8. Manifest producer/catalog mismatch -> mixed, not eligible.
-func TestFixture8_ManifestProducerMismatch_Mixed(t *testing.T) {
+// TestFixture8_MixedResourceTransactions_Mixed verifies:
+// 8. Manifest with mixed resource transaction IDs -> mixed, not eligible.
+func TestFixture8_MixedResourceTransactions_Mixed(t *testing.T) {
 	home := t.TempDir()
 	b1Bytes := []byte("# sdd-archive skill v1\n")
 	catalogB2 := makeTestCatalog("2.2.0", []byte("# sdd-archive skill v2\n"), 0644)
@@ -499,6 +526,9 @@ func TestFixture8_ManifestProducerMismatch_Mixed(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, b1Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -579,13 +609,19 @@ func TestFixture10_SecondDoctorRun_ByteIdentical_ZeroWrites(t *testing.T) {
 	b2Bytes := []byte("# sdd-archive skill v2\n")
 	b2Mode := uint32(0644)
 	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, b2Mode)
-	b2Digest, _ := catalogB2.ComputeCatalogDigest()
+	b2Digest, err := catalogB2.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatalf("compute b2 digest: %v", err)
+	}
 
 	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
 	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -646,5 +682,110 @@ func TestFixture10_SecondDoctorRun_ByteIdentical_ZeroWrites(t *testing.T) {
 	}
 	if fileStat1.ModTime() != fileStat2.ModTime() {
 		t.Errorf("target file was mutated during read-only doctor classification")
+	}
+}
+
+// TestJournal_InvalidTransactionID_Rejected verifies that path traversal transaction IDs are rejected.
+func TestJournal_InvalidTransactionID_Rejected(t *testing.T) {
+	home := t.TempDir()
+	badJournals := []string{"../escape", "foo/bar", "foo\\bar", "..", ".", ""}
+	for _, id := range badJournals {
+		j := MigrationJournal{
+			Schema:        JournalSchemaV1,
+			TransactionID: id,
+		}
+		if err := WriteJournal(home, j); err == nil {
+			t.Errorf("expected error for transaction ID %q, got nil", id)
+		}
+	}
+}
+
+// TestJournal_EmptyResources_BlockedConflict verifies empty journal resources cannot pass as resumable.
+func TestJournal_EmptyResources_BlockedConflict(t *testing.T) {
+	home := t.TempDir()
+	catalog := makeTestCatalog("2.2.0", []byte("content"), 0644)
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			CatalogDigest: "sha256:digest",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  "sha256:1",
+				ObservedSHA256: "sha256:1",
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-2",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseApplying,
+		Resources:          []ResourceJournalEntry{},
+	}
+	if err := WriteJournal(home, journal); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.RecoveryState != RecoveryStateBlockedConflict {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateBlockedConflict)
+	}
+}
+
+// TestJournal_MalformedJournal_BlockedConflict verifies malformed journal is surfaced as a conflict.
+func TestJournal_MalformedJournal_BlockedConflict(t *testing.T) {
+	home := t.TempDir()
+	catalog := makeTestCatalog("2.2.0", []byte("content"), 0644)
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			CatalogDigest: "sha256:digest",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  "sha256:1",
+				ObservedSHA256: "sha256:1",
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, ManagedDirName, ManagedSubDir, JournalDirName, "tx-broken")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, JournalFileName), []byte("{ invalid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.RecoveryState != RecoveryStateBlockedConflict {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateBlockedConflict)
 	}
 }

--- a/internal/managedbundle/classify_test.go
+++ b/internal/managedbundle/classify_test.go
@@ -1,0 +1,650 @@
+package managedbundle
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func makeTestCatalog(version string, content []byte, mode uint32) ResourceCatalog {
+	sum := sha256.Sum256(content)
+	contentSHA := "sha256:" + hex.EncodeToString(sum[:])
+
+	return ResourceCatalog{
+		Version:     version,
+		VCSRevision: "commit-" + version,
+		Resources: []ResourceDescriptor{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				SchemaVersion: 1,
+				ComponentID:   model.ComponentSkills,
+				AgentID:       model.AgentOpenCode,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				RenderDesired: func() (DesiredExtent, error) {
+					return DesiredExtent{
+						Content: content,
+						SHA256:  contentSHA,
+						Mode:    mode,
+					}, nil
+				},
+			},
+		},
+	}
+}
+
+// TestFixture1_B2Manifest_ExactB2Bytes_Aligned verifies:
+// 1. B2 manifest + exact B2 bytes/mode -> aligned, eligible no-op.
+func TestFixture1_B2Manifest_ExactB2Bytes_Aligned(t *testing.T) {
+	home := t.TempDir()
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	b2Mode := uint32(0644)
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, b2Mode)
+	b2Digest, err := catalogB2.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatalf("compute digest: %v", err)
+	}
+
+	// Seed file on disk
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(b2Bytes)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    2,
+		TransactionID: "tx-2",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			VCSRevision:   "commit-2.2.0",
+			CatalogDigest: b2Digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           b2Mode,
+				TransactionID:  "tx-2",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.BundleIdentity != BundleIdentityAligned {
+		t.Errorf("got bundle identity %s, want %s", res.BundleIdentity, BundleIdentityAligned)
+	}
+	if res.ExtentIntegrity != ExtentIntegrityMatch {
+		t.Errorf("got extent integrity %s, want %s", res.ExtentIntegrity, ExtentIntegrityMatch)
+	}
+	if res.RecoveryState != RecoveryStateNone {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateNone)
+	}
+	if !res.SyncEligible {
+		t.Errorf("expected sync eligible")
+	}
+}
+
+// TestFixture2_B1Manifest_ExactB1Bytes_Stale verifies:
+// 2. B1 manifest + exact B1 bytes/mode under B2 -> stale, sync eligible.
+func TestFixture2_B1Manifest_ExactB1Bytes_Stale(t *testing.T) {
+	home := t.TempDir()
+	b1Bytes := []byte("# sdd-archive skill v1\n")
+	b1Mode := uint32(0644)
+	catalogB1 := makeTestCatalog("2.1.10", b1Bytes, b1Mode)
+	b1Digest, _ := catalogB1.ComputeCatalogDigest()
+
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	b2Mode := uint32(0644)
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, b2Mode)
+
+	// File on disk is B1
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, b1Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(b1Bytes)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			VCSRevision:   "commit-2.1.10",
+			CatalogDigest: b1Digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           b1Mode,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.BundleIdentity != BundleIdentityStale {
+		t.Errorf("got bundle identity %s, want %s", res.BundleIdentity, BundleIdentityStale)
+	}
+	if res.ExtentIntegrity != ExtentIntegrityMatch {
+		t.Errorf("got extent integrity %s, want %s", res.ExtentIntegrity, ExtentIntegrityMatch)
+	}
+	if !res.SyncEligible || res.SyncEligibleReason != "exact_committed_older_bundle" {
+		t.Errorf("got sync eligible %v (%s), want true (exact_committed_older_bundle)", res.SyncEligible, res.SyncEligibleReason)
+	}
+}
+
+// TestFixture3_B1Manifest_ChangedByte_UserModified verifies:
+// 3. B1 manifest + one changed byte or mode -> user_modified, not eligible.
+func TestFixture3_B1Manifest_ChangedByte_UserModified(t *testing.T) {
+	home := t.TempDir()
+	b1Bytes := []byte("# sdd-archive skill v1\n")
+	b1Mode := uint32(0644)
+	catalogB1 := makeTestCatalog("2.1.10", b1Bytes, b1Mode)
+	b1Digest, _ := catalogB1.ComputeCatalogDigest()
+
+	catalogB2 := makeTestCatalog("2.2.0", []byte("# sdd-archive skill v2\n"), 0644)
+
+	// User modified the file on disk
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte("# user edited content\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(b1Bytes)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			VCSRevision:   "commit-2.1.10",
+			CatalogDigest: b1Digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           b1Mode,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.BundleIdentity != BundleIdentityUserModified {
+		t.Errorf("got bundle identity %s, want %s", res.BundleIdentity, BundleIdentityUserModified)
+	}
+	if res.ExtentIntegrity != ExtentIntegrityUserModified {
+		t.Errorf("got extent integrity %s, want %s", res.ExtentIntegrity, ExtentIntegrityUserModified)
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture4_NoManifest_Unknown verifies:
+// 4. No manifest + bytes equal B1 or B2 -> unknown, not eligible.
+func TestFixture4_NoManifest_Unknown(t *testing.T) {
+	home := t.TempDir()
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, 0644)
+
+	// File exists on disk matching B2, but no manifest exists
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.BundleIdentity != BundleIdentityUnknown {
+		t.Errorf("got bundle identity %s, want %s", res.BundleIdentity, BundleIdentityUnknown)
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture5_PreparedTransaction_ObservedBefore_Recoverable verifies:
+// 5. Prepared transaction + observed before -> recoverable (resumable_before), not yet aligned.
+func TestFixture5_PreparedTransaction_ObservedBefore_Recoverable(t *testing.T) {
+	home := t.TempDir()
+	b1Bytes := []byte("# sdd-archive skill v1\n")
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, 0644)
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, b1Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum1 := sha256.Sum256(b1Bytes)
+	sha1 := "sha256:" + hex.EncodeToString(sum1[:])
+	sum2 := sha256.Sum256(b2Bytes)
+	sha2 := "sha256:" + hex.EncodeToString(sum2[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha1,
+				ObservedSHA256: sha1,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-2",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhasePrepared,
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				BeforeSHA256:  sha1,
+				BeforeMode:    0644,
+				DesiredSHA256: sha2,
+				DesiredMode:   0644,
+			},
+		},
+	}
+	if err := WriteJournal(home, journal); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.RecoveryState != RecoveryStateResumableBefore {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateResumableBefore)
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture6_PreparedTransaction_ObservedDesired_ResumableCommit verifies:
+// 6. Prepared transaction + observed desired -> resumable commit (resumable_desired), not a second mutation.
+func TestFixture6_PreparedTransaction_ObservedDesired_ResumableCommit(t *testing.T) {
+	home := t.TempDir()
+	b1Bytes := []byte("# sdd-archive skill v1\n")
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, 0644)
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Desired bytes already written to disk before crash
+	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum1 := sha256.Sum256(b1Bytes)
+	sha1 := "sha256:" + hex.EncodeToString(sum1[:])
+	sum2 := sha256.Sum256(b2Bytes)
+	sha2 := "sha256:" + hex.EncodeToString(sum2[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha1,
+				ObservedSHA256: sha1,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-2",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseApplying,
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				BeforeSHA256:  sha1,
+				BeforeMode:    0644,
+				DesiredSHA256: sha2,
+				DesiredMode:   0644,
+				Applied:       true,
+			},
+		},
+	}
+	if err := WriteJournal(home, journal); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.RecoveryState != RecoveryStateResumableDesired {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateResumableDesired)
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture7_PreparedTransaction_ForeignBytes_BlockedConflict verifies:
+// 7. Prepared transaction + foreign bytes -> blocked_conflict.
+func TestFixture7_PreparedTransaction_ForeignBytes_BlockedConflict(t *testing.T) {
+	home := t.TempDir()
+	b1Bytes := []byte("# sdd-archive skill v1\n")
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, 0644)
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// External modification during interrupted transaction
+	if err := os.WriteFile(filePath, []byte("# conflict bytes\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum1 := sha256.Sum256(b1Bytes)
+	sha1 := "sha256:" + hex.EncodeToString(sum1[:])
+	sum2 := sha256.Sum256(b2Bytes)
+	sha2 := "sha256:" + hex.EncodeToString(sum2[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha1,
+				ObservedSHA256: sha1,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-2",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseApplying,
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				BeforeSHA256:  sha1,
+				BeforeMode:    0644,
+				DesiredSHA256: sha2,
+				DesiredMode:   0644,
+			},
+		},
+	}
+	if err := WriteJournal(home, journal); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.RecoveryState != RecoveryStateBlockedConflict {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateBlockedConflict)
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture8_ManifestProducerMismatch_Mixed verifies:
+// 8. Manifest producer/catalog mismatch -> mixed, not eligible.
+func TestFixture8_ManifestProducerMismatch_Mixed(t *testing.T) {
+	home := t.TempDir()
+	b1Bytes := []byte("# sdd-archive skill v1\n")
+	catalogB2 := makeTestCatalog("2.2.0", []byte("# sdd-archive skill v2\n"), 0644)
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, b1Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum1 := sha256.Sum256(b1Bytes)
+	sha1 := "sha256:" + hex.EncodeToString(sum1[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha1,
+				ObservedSHA256: sha1,
+				Mode:           0644,
+				TransactionID:  "tx-foreign", // Mismatch with manifest.TransactionID
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.BundleIdentity != BundleIdentityMixed {
+		t.Errorf("got bundle identity %s, want %s", res.BundleIdentity, BundleIdentityMixed)
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture9_NewerManifestSchema_UnsupportedNewerSchema verifies:
+// 9. Newer manifest schema under older reader -> typed read-only refusal.
+func TestFixture9_NewerManifestSchema_UnsupportedNewerSchema(t *testing.T) {
+	home := t.TempDir()
+	catalogB2 := makeTestCatalog("2.2.0", []byte("# sdd-archive skill v2\n"), 0644)
+
+	manifestData := []byte(`{
+  "schema": "gentle-ai.managed-bundle/v99",
+  "generation": 1,
+  "transaction_id": "tx-1",
+  "producer": {
+    "version": "99.0.0",
+    "catalog_digest": "sha256:future"
+  },
+  "resources": []
+}`)
+	dir := filepath.Join(home, ManagedDirName, ManagedSubDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ManifestFileName), manifestData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if !res.UnsupportedSchema {
+		t.Errorf("expected unsupported schema flag to be true")
+	}
+	if res.SyncEligible {
+		t.Errorf("expected not sync eligible")
+	}
+}
+
+// TestFixture10_SecondDoctorRun_ByteIdentical_ZeroWrites verifies:
+// 10. Second doctor run is byte-identical and performs zero writes.
+func TestFixture10_SecondDoctorRun_ByteIdentical_ZeroWrites(t *testing.T) {
+	home := t.TempDir()
+	b2Bytes := []byte("# sdd-archive skill v2\n")
+	b2Mode := uint32(0644)
+	catalogB2 := makeTestCatalog("2.2.0", b2Bytes, b2Mode)
+	b2Digest, _ := catalogB2.ComputeCatalogDigest()
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, b2Bytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(b2Bytes)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    2,
+		TransactionID: "tx-2",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			VCSRevision:   "commit-2.2.0",
+			CatalogDigest: b2Digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           b2Mode,
+				TransactionID:  "tx-2",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	manifestPath := filepath.Join(home, ManagedDirName, ManagedSubDir, ManifestFileName)
+	manifestStat1, err := os.Stat(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileStat1, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res1 := Classify(context.Background(), home, catalogB2)
+	res2 := Classify(context.Background(), home, catalogB2)
+
+	res1JSON, _ := json.Marshal(res1)
+	res2JSON, _ := json.Marshal(res2)
+
+	if string(res1JSON) != string(res2JSON) {
+		t.Errorf("second run output differs: run1=%s, run2=%s", string(res1JSON), string(res2JSON))
+	}
+
+	manifestStat2, _ := os.Stat(manifestPath)
+	fileStat2, _ := os.Stat(filePath)
+
+	if manifestStat1.ModTime() != manifestStat2.ModTime() {
+		t.Errorf("manifest was mutated during read-only doctor classification")
+	}
+	if fileStat1.ModTime() != fileStat2.ModTime() {
+		t.Errorf("target file was mutated during read-only doctor classification")
+	}
+}

--- a/internal/managedbundle/classify_test.go
+++ b/internal/managedbundle/classify_test.go
@@ -836,7 +836,10 @@ func TestJournal_UnsupportedJournalSchema_BlockedConflict(t *testing.T) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	data, _ := json.Marshal(journal)
+	data, err := json.Marshal(journal)
+	if err != nil {
+		t.Fatalf("marshal journal: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, JournalFileName), data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -1013,5 +1016,94 @@ func TestClassify_ResourceDescriptorMismatch_NotAligned(t *testing.T) {
 	res := Classify(context.Background(), home, catalog)
 	if res.BundleIdentity == BundleIdentityAligned {
 		t.Errorf("expected mismatch to prevent aligned bundle identity, got %s", res.BundleIdentity)
+	}
+}
+
+// TestClassify_PathTraversal_Rejected verifies that path traversal canonical paths are rejected.
+func TestClassify_PathTraversal_Rejected(t *testing.T) {
+	home := t.TempDir()
+	catalog := makeTestCatalog("2.2.0", []byte("content"), 0644)
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			CatalogDigest: "sha256:digest",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken("escape"),
+				CanonicalPath:  "../../etc/passwd",
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  "sha256:1",
+				ObservedSHA256: "sha256:1",
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.ExtentIntegrity != ExtentIntegrityTypeChanged || res.SyncEligibleReason != SyncReasonTypeChanged {
+		t.Errorf("expected path traversal to be rejected as type_changed, got %s (%s)", res.ExtentIntegrity, res.SyncEligibleReason)
+	}
+}
+
+// TestClassify_ProducerVersionMismatch_Stale verifies that version difference prevents aligned state.
+func TestClassify_ProducerVersionMismatch_Stale(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("# content\n")
+	catalogB2 := makeTestCatalog("2.2.0", content, 0644)
+	digest, _ := catalogB2.ComputeCatalogDigest()
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(content)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	// Same digest but older version in producer info
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalogB2)
+	if res.BundleIdentity != BundleIdentityStale {
+		t.Errorf("expected stale due to version mismatch, got %s", res.BundleIdentity)
 	}
 }

--- a/internal/managedbundle/classify_test.go
+++ b/internal/managedbundle/classify_test.go
@@ -1278,3 +1278,79 @@ func TestClassify_EmptyDesiredExtentSHA_FallbackCalculated(t *testing.T) {
 		t.Errorf("expected aligned bundle identity with fallback sha calculation, got %s (%s)", res.BundleIdentity, res.Detail)
 	}
 }
+
+// TestClassify_EmptyFileContent_FallbackCalculated verifies empty content produces empty-file SHA256 digest.
+func TestClassify_EmptyFileContent_FallbackCalculated(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("")
+	sum := sha256.Sum256(content)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	catalog := ResourceCatalog{
+		Version:     "2.2.0",
+		VCSRevision: "commit-2.2.0",
+		Resources: []ResourceDescriptor{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				SchemaVersion: 1,
+				ComponentID:   model.ComponentSkills,
+				AgentID:       model.AgentOpenCode,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				RenderDesired: func() (DesiredExtent, error) {
+					return DesiredExtent{
+						Content: content,
+						SHA256:  "", // Empty Desired SHA256 with empty content
+						Mode:    0644,
+					}, nil
+				},
+			},
+		},
+	}
+	digest, err := catalog.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			VCSRevision:   "commit-2.2.0",
+			CatalogDigest: digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.BundleIdentity != BundleIdentityAligned {
+		t.Errorf("expected aligned bundle identity for empty file, got %s (%s)", res.BundleIdentity, res.Detail)
+	}
+}

--- a/internal/managedbundle/classify_test.go
+++ b/internal/managedbundle/classify_test.go
@@ -1076,13 +1076,14 @@ func TestClassify_ProducerVersionMismatch_Stale(t *testing.T) {
 	sum := sha256.Sum256(content)
 	sha := "sha256:" + hex.EncodeToString(sum[:])
 
-	// Same digest but older version in producer info
+	// Same digest and same VCSRevision but older version in producer info to isolate version mismatch
 	manifest := ManagedBundleManifest{
 		Schema:        ManifestSchemaV1,
 		Generation:    1,
 		TransactionID: "tx-1",
 		Producer: ProducerInfo{
 			Version:       "2.1.10",
+			VCSRevision:   catalogB2.VCSRevision,
 			CatalogDigest: digest,
 		},
 		Resources: []ResourceEntry{
@@ -1105,5 +1106,175 @@ func TestClassify_ProducerVersionMismatch_Stale(t *testing.T) {
 	res := Classify(context.Background(), home, catalogB2)
 	if res.BundleIdentity != BundleIdentityStale {
 		t.Errorf("expected stale due to version mismatch, got %s", res.BundleIdentity)
+	}
+}
+
+// TestJournal_MultipleJournals_ConflictPrecedence verifies that conflict takes precedence when multiple journals exist.
+func TestJournal_MultipleJournals_ConflictPrecedence(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("# content\n")
+	catalog := makeTestCatalog("2.2.0", content, 0644)
+	sum := sha256.Sum256(content)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Journal 1: resumable
+	journal1 := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-resumable",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseApplying,
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				BeforeSHA256:  "sha256:old",
+				DesiredSHA256: sha,
+				DesiredMode:   0644,
+			},
+		},
+	}
+	if err := WriteJournal(home, journal1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Journal 2: conflict
+	journal2 := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-conflict",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseApplying,
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				BeforeSHA256:  "sha256:foreign",
+				DesiredSHA256: "sha256:foreign2",
+				DesiredMode:   0644,
+			},
+		},
+	}
+	if err := WriteJournal(home, journal2); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.RecoveryState != RecoveryStateBlockedConflict {
+		t.Errorf("expected RecoveryStateBlockedConflict when a conflicting journal exists, got %s", res.RecoveryState)
+	}
+}
+
+// TestClassify_EmptyDesiredExtentSHA_FallbackCalculated verifies that empty DesiredExtent.SHA256 falls back to calculated content hash.
+func TestClassify_EmptyDesiredExtentSHA_FallbackCalculated(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("# content\n")
+	sum := sha256.Sum256(content)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	catalog := ResourceCatalog{
+		Version:     "2.2.0",
+		VCSRevision: "commit-2.2.0",
+		Resources: []ResourceDescriptor{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				SchemaVersion: 1,
+				ComponentID:   model.ComponentSkills,
+				AgentID:       model.AgentOpenCode,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				RenderDesired: func() (DesiredExtent, error) {
+					return DesiredExtent{
+						Content: content,
+						SHA256:  "", // Empty Desired SHA256!
+						Mode:    0644,
+					}, nil
+				},
+			},
+		},
+	}
+	digest, err := catalog.ComputeCatalogDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			VCSRevision:   "commit-2.2.0",
+			CatalogDigest: digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.BundleIdentity != BundleIdentityAligned {
+		t.Errorf("expected aligned bundle identity with fallback sha calculation, got %s (%s)", res.BundleIdentity, res.Detail)
 	}
 }

--- a/internal/managedbundle/classify_test.go
+++ b/internal/managedbundle/classify_test.go
@@ -789,3 +789,229 @@ func TestJournal_MalformedJournal_BlockedConflict(t *testing.T) {
 		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateBlockedConflict)
 	}
 }
+
+// TestJournal_UnsupportedJournalSchema_BlockedConflict verifies unsupported journal schema is rejected as conflict.
+func TestJournal_UnsupportedJournalSchema_BlockedConflict(t *testing.T) {
+	home := t.TempDir()
+	catalog := makeTestCatalog("2.2.0", []byte("content"), 0644)
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			CatalogDigest: "sha256:digest",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  "sha256:1",
+				ObservedSHA256: "sha256:1",
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := MigrationJournal{
+		Schema:             "gentle-ai.managed-journal/v999",
+		TransactionID:      "tx-future",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseCompleted, // Looks completed, but schema is unsupported
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+			},
+		},
+	}
+	dir := filepath.Join(home, ManagedDirName, ManagedSubDir, JournalDirName, "tx-future")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(journal)
+	if err := os.WriteFile(filepath.Join(dir, JournalFileName), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.RecoveryState != RecoveryStateBlockedConflict {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateBlockedConflict)
+	}
+}
+
+// TestJournal_DesiredModeMismatch_BlockedConflict verifies mode mismatch prevents false resumable_desired.
+func TestJournal_DesiredModeMismatch_BlockedConflict(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("# content\n")
+	catalog := makeTestCatalog("2.2.0", content, 0644)
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, content, 0600); err != nil { // mode is 0600, desired is 0644
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(content)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.1.10",
+			CatalogDigest: "sha256:old",
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := MigrationJournal{
+		Schema:             JournalSchemaV1,
+		TransactionID:      "tx-2",
+		ExpectedGeneration: 1,
+		ProposedGeneration: 2,
+		LastPhase:          PhaseApplying,
+		Resources: []ResourceJournalEntry{
+			{
+				ResourceID:    DefaultArchiveSkillResourceID,
+				CanonicalPath: DefaultArchiveSkillRelPath,
+				Ownership:     OwnershipDescriptor{Kind: OwnershipFullFile},
+				BeforeSHA256:  "sha256:before",
+				BeforeMode:    0644,
+				DesiredSHA256: sha,
+				DesiredMode:   0644, // Desired mode is 0644, file on disk is 0600
+			},
+		},
+	}
+	if err := WriteJournal(home, journal); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.RecoveryState != RecoveryStateBlockedConflict {
+		t.Errorf("got recovery state %s, want %s", res.RecoveryState, RecoveryStateBlockedConflict)
+	}
+}
+
+// TestClassify_NonRegularTarget_TypeChanged verifies symlink/directory target is classified as type_changed.
+func TestClassify_NonRegularTarget_TypeChanged(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("# content\n")
+	catalog := makeTestCatalog("2.2.0", content, 0644)
+	digest, _ := catalog.ComputeCatalogDigest()
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filePath, 0755); err != nil { // Directory instead of regular file!
+		t.Fatal(err)
+	}
+
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			CatalogDigest: digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken(DefaultArchiveSkillRelPath),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  "sha256:1",
+				ObservedSHA256: "sha256:1",
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.ExtentIntegrity != ExtentIntegrityTypeChanged {
+		t.Errorf("got extent integrity %s, want %s", res.ExtentIntegrity, ExtentIntegrityTypeChanged)
+	}
+}
+
+// TestClassify_ResourceDescriptorMismatch_NotAligned verifies that manifest with incorrect descriptor details is not reported as aligned.
+func TestClassify_ResourceDescriptorMismatch_NotAligned(t *testing.T) {
+	home := t.TempDir()
+	content := []byte("# content\n")
+	catalog := makeTestCatalog("2.2.0", content, 0644)
+	digest, _ := catalog.ComputeCatalogDigest()
+
+	filePath := filepath.Join(home, filepath.FromSlash(DefaultArchiveSkillRelPath))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(content)
+	sha := "sha256:" + hex.EncodeToString(sum[:])
+
+	// Manifest records matching Producer.CatalogDigest but has a decoy resource path
+	manifest := ManagedBundleManifest{
+		Schema:        ManifestSchemaV1,
+		Generation:    1,
+		TransactionID: "tx-1",
+		Producer: ProducerInfo{
+			Version:       "2.2.0",
+			CatalogDigest: digest,
+		},
+		Resources: []ResourceEntry{
+			{
+				ResourceID:     DefaultArchiveSkillResourceID,
+				TargetIdentity: TargetIdentityToken("other/decoy/path.md"),
+				CanonicalPath:  DefaultArchiveSkillRelPath,
+				Ownership:      OwnershipDescriptor{Kind: OwnershipFullFile},
+				DesiredSHA256:  sha,
+				ObservedSHA256: sha,
+				Mode:           0644,
+				TransactionID:  "tx-1",
+			},
+		},
+	}
+	if err := WriteManifest(home, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Classify(context.Background(), home, catalog)
+	if res.BundleIdentity == BundleIdentityAligned {
+		t.Errorf("expected mismatch to prevent aligned bundle identity, got %s", res.BundleIdentity)
+	}
+}

--- a/internal/managedbundle/types.go
+++ b/internal/managedbundle/types.go
@@ -213,7 +213,7 @@ func (c ResourceCatalog) ComputeCatalogDigest() (string, error) {
 			return "", fmt.Errorf("render desired extent for %s: %w", r.ResourceID, err)
 		}
 		digest := desired.SHA256
-		if digest == "" && len(desired.Content) > 0 {
+		if digest == "" {
 			sum := sha256.Sum256(desired.Content)
 			digest = "sha256:" + hex.EncodeToString(sum[:])
 		}

--- a/internal/managedbundle/types.go
+++ b/internal/managedbundle/types.go
@@ -1,0 +1,217 @@
+package managedbundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+const (
+	ManifestSchemaV1 = "gentle-ai.managed-bundle/v1"
+	JournalSchemaV1  = "gentle-ai.managed-journal/v1"
+
+	ManagedDirName   = ".gentle-ai"
+	ManagedSubDir    = "managed/v1"
+	ManifestFileName = "manifest.json"
+	JournalDirName   = "transactions"
+	JournalFileName  = "journal.json"
+)
+
+// OwnershipKind identifies the extent of managed ownership over a target file.
+type OwnershipKind string
+
+const (
+	OwnershipFullFile OwnershipKind = "full_file"
+)
+
+// BundleIdentity is the top-level bundle coherence classification for doctor.
+type BundleIdentity string
+
+const (
+	BundleIdentityAligned      BundleIdentity = "aligned"
+	BundleIdentityStale        BundleIdentity = "stale"
+	BundleIdentityMixed        BundleIdentity = "mixed"
+	BundleIdentityUserModified BundleIdentity = "user_modified"
+	BundleIdentityUnknown      BundleIdentity = "unknown"
+)
+
+// ExtentIntegrity represents the physical state of the managed files on disk.
+type ExtentIntegrity string
+
+const (
+	ExtentIntegrityMatch        ExtentIntegrity = "match"
+	ExtentIntegrityUserModified ExtentIntegrity = "user_modified"
+	ExtentIntegrityMissing      ExtentIntegrity = "missing"
+	ExtentIntegrityTypeChanged  ExtentIntegrity = "type_changed"
+)
+
+// RecoveryState represents the transaction recovery state overlay.
+type RecoveryState string
+
+const (
+	RecoveryStateNone             RecoveryState = "none"
+	RecoveryStateResumableBefore  RecoveryState = "resumable_before"
+	RecoveryStateResumableDesired RecoveryState = "resumable_desired"
+	RecoveryStateBlockedConflict  RecoveryState = "blocked_conflict"
+	RecoveryStateRollbackRequired RecoveryState = "rollback_required"
+	RecoveryStateRolledBack       RecoveryState = "rolled_back"
+)
+
+// JournalPhase represents the recorded phase of an active transaction.
+type JournalPhase string
+
+const (
+	PhasePlanned           JournalPhase = "planned"
+	PhaseDiscovered        JournalPhase = "discovered"
+	PhaseClassified        JournalPhase = "classified"
+	PhaseSnapshotted       JournalPhase = "snapshotted"
+	PhasePrepared          JournalPhase = "prepared"
+	PhaseApplying          JournalPhase = "applying"
+	PhaseVerified          JournalPhase = "verified"
+	PhaseManifestCommitted JournalPhase = "manifest_committed"
+	PhaseCompleted         JournalPhase = "completed"
+	PhaseRolledBack        JournalPhase = "rolled_back"
+)
+
+// ProducerInfo identifies the binary that created or owns the manifest.
+type ProducerInfo struct {
+	Version       string `json:"version"`
+	VCSRevision   string `json:"vcs_revision,omitempty"`
+	CatalogDigest string `json:"catalog_digest"`
+}
+
+// OwnershipDescriptor describes how a resource is owned.
+type OwnershipDescriptor struct {
+	Kind OwnershipKind `json:"kind"`
+}
+
+// ResourceEntry records one managed resource in the committed manifest.
+type ResourceEntry struct {
+	ResourceID     string              `json:"resource_id"`
+	TargetIdentity string              `json:"target_identity"`
+	CanonicalPath  string              `json:"canonical_path,omitempty"`
+	Ownership      OwnershipDescriptor `json:"ownership"`
+	DesiredSHA256  string              `json:"desired_sha256"`
+	ObservedSHA256 string              `json:"observed_sha256"`
+	Mode           uint32              `json:"mode"`
+	BackupRef      string              `json:"backup_ref,omitempty"`
+	TransactionID  string              `json:"transaction_id,omitempty"`
+}
+
+// ManagedBundleManifest records the durable committed state of all managed assets.
+type ManagedBundleManifest struct {
+	Schema        string          `json:"schema"`
+	Generation    uint64          `json:"generation"`
+	TransactionID string          `json:"transaction_id"`
+	Producer      ProducerInfo    `json:"producer"`
+	Resources     []ResourceEntry `json:"resources"`
+}
+
+// ResourceJournalEntry records the transition intent and observation for one resource.
+type ResourceJournalEntry struct {
+	ResourceID     string              `json:"resource_id"`
+	CanonicalPath  string              `json:"canonical_path"`
+	Ownership      OwnershipDescriptor `json:"ownership"`
+	BeforeSHA256   string              `json:"before_sha256"`
+	BeforeMode     uint32              `json:"before_mode"`
+	DesiredSHA256  string              `json:"desired_sha256"`
+	DesiredMode    uint32              `json:"desired_mode"`
+	ObservedSHA256 string              `json:"observed_sha256,omitempty"`
+	ObservedMode   uint32              `json:"observed_mode,omitempty"`
+	Applied        bool                `json:"applied,omitempty"`
+}
+
+// MigrationJournal records a transaction write-ahead log for crash recovery.
+type MigrationJournal struct {
+	Schema             string                 `json:"schema"`
+	TransactionID      string                 `json:"transaction_id"`
+	ExpectedGeneration uint64                 `json:"expected_generation"`
+	ProposedGeneration uint64                 `json:"proposed_generation"`
+	ExpectedDigest     string                 `json:"expected_digest,omitempty"`
+	ProposedDigest     string                 `json:"proposed_digest,omitempty"`
+	BackupRef          string                 `json:"backup_ref,omitempty"`
+	LastPhase          JournalPhase           `json:"last_phase"`
+	Resources          []ResourceJournalEntry `json:"resources"`
+}
+
+// ClassificationResult represents the evaluated doctor diagnostic outcome.
+type ClassificationResult struct {
+	BundleIdentity     BundleIdentity  `json:"bundle_identity"`
+	ExtentIntegrity    ExtentIntegrity `json:"extent_integrity"`
+	RecoveryState      RecoveryState   `json:"recovery_state"`
+	SyncEligible       bool            `json:"sync_eligible"`
+	SyncEligibleReason string          `json:"sync_eligible_reason"`
+	Detail             string          `json:"detail"`
+	UnsupportedSchema  bool            `json:"unsupported_schema,omitempty"`
+}
+
+// DesiredExtent represents the rendered content and desired metadata of a managed resource.
+type DesiredExtent struct {
+	Content []byte
+	SHA256  string
+	Mode    uint32
+}
+
+// ResourceDescriptor describes a compile-time managed resource definition.
+type ResourceDescriptor struct {
+	ResourceID    string
+	SchemaVersion uint32
+	ComponentID   model.ComponentID
+	AgentID       model.AgentID
+	CanonicalPath string // Relative to user home dir, forward-slash normalized
+	Ownership     OwnershipDescriptor
+	RenderDesired func() (DesiredExtent, error)
+}
+
+// ResourceCatalog is the compile-time collection of desired managed resources.
+type ResourceCatalog struct {
+	Version     string
+	VCSRevision string
+	Resources   []ResourceDescriptor
+}
+
+// ComputeCatalogDigest calculates a deterministic sha256 hash over descriptor metadata and desired extents.
+func (c ResourceCatalog) ComputeCatalogDigest() (string, error) {
+	sortedResources := make([]ResourceDescriptor, len(c.Resources))
+	copy(sortedResources, c.Resources)
+	sort.Slice(sortedResources, func(i, j int) bool {
+		return sortedResources[i].ResourceID < sortedResources[j].ResourceID
+	})
+
+	h := sha256.New()
+	for _, r := range sortedResources {
+		desired, err := r.RenderDesired()
+		if err != nil {
+			return "", fmt.Errorf("render desired extent for %s: %w", r.ResourceID, err)
+		}
+		digest := desired.SHA256
+		if digest == "" && len(desired.Content) > 0 {
+			sum := sha256.Sum256(desired.Content)
+			digest = "sha256:" + hex.EncodeToString(sum[:])
+		}
+		// Write canonical metadata
+		entryLine := fmt.Sprintf("%s|%d|%s|%s|%s|%s|%s|%d\n",
+			r.ResourceID,
+			r.SchemaVersion,
+			r.ComponentID,
+			r.AgentID,
+			filepath.ToSlash(r.CanonicalPath),
+			r.Ownership.Kind,
+			digest,
+			desired.Mode,
+		)
+		h.Write([]byte(entryLine))
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// TargetIdentityToken computes the canonical target identity token for a relative path.
+func TargetIdentityToken(relPath string) string {
+	normalized := filepath.ToSlash(relPath)
+	sum := sha256.Sum256([]byte(normalized))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/managedbundle/types.go
+++ b/internal/managedbundle/types.go
@@ -138,13 +138,34 @@ type MigrationJournal struct {
 	Resources          []ResourceJournalEntry `json:"resources"`
 }
 
+// SyncReason represents the typed reason code for a sync eligibility determination.
+type SyncReason string
+
+const (
+	SyncReasonNoManifest                  SyncReason = "no_manifest"
+	SyncReasonManifestUnreadable          SyncReason = "manifest_unreadable"
+	SyncReasonManifestMalformed           SyncReason = "manifest_malformed"
+	SyncReasonUnsupportedSchema           SyncReason = "unsupported_schema"
+	SyncReasonUnresolvedTransaction       SyncReason = "unresolved_transaction"
+	SyncReasonEmptyManifest               SyncReason = "empty_manifest"
+	SyncReasonMixedResourceTransactions   SyncReason = "mixed_resource_transactions"
+	SyncReasonResourceMissing             SyncReason = "resource_missing"
+	SyncReasonResourceUnreadable          SyncReason = "resource_unreadable"
+	SyncReasonTypeChanged                 SyncReason = "type_changed"
+	SyncReasonContentMismatch             SyncReason = "content_mismatch"
+	SyncReasonModeMismatch                SyncReason = "mode_mismatch"
+	SyncReasonCatalogDigestError          SyncReason = "catalog_digest_error"
+	SyncReasonAlignedWithCurrentBinary    SyncReason = "aligned_with_current_binary"
+	SyncReasonExactCommittedOlderBundle   SyncReason = "exact_committed_older_bundle"
+)
+
 // ClassificationResult represents the evaluated doctor diagnostic outcome.
 type ClassificationResult struct {
 	BundleIdentity     BundleIdentity  `json:"bundle_identity"`
 	ExtentIntegrity    ExtentIntegrity `json:"extent_integrity"`
 	RecoveryState      RecoveryState   `json:"recovery_state"`
 	SyncEligible       bool            `json:"sync_eligible"`
-	SyncEligibleReason string          `json:"sync_eligible_reason"`
+	SyncEligibleReason SyncReason      `json:"sync_eligible_reason"`
 	Detail             string          `json:"detail"`
 	UnsupportedSchema  bool            `json:"unsupported_schema,omitempty"`
 }
@@ -175,6 +196,9 @@ type ResourceCatalog struct {
 }
 
 // ComputeCatalogDigest calculates a deterministic sha256 hash over descriptor metadata and desired extents.
+// Note: c.Version and c.VCSRevision are intentionally excluded from the digest calculation so that
+// the digest reflects resource metadata and rendered content only, allowing two binaries built
+// with identical assets to produce the exact same catalog digest regardless of VCS stamp or build metadata.
 func (c ResourceCatalog) ComputeCatalogDigest() (string, error) {
 	sortedResources := make([]ResourceDescriptor, len(c.Resources))
 	copy(sortedResources, c.Resources)


### PR DESCRIPTION
## Problem Statement

Gentle AI can run with a new binary and older managed skills/prompts/config projections without detecting that the control plane is mixed-version.

## Proposed Solution (Slice 1)

1. Introduce `internal/managedbundle` with `ManagedBundleManifest`, `ResourceCatalog`, `ProducerInfo`, and deterministic catalog digests.
2. Implement read-only classification logic (`aligned`, `stale`, `user_modified`, `mixed`, `unknown`) and active transaction recovery classification.
3. Integrate bundle-level checking into `gentle-ai doctor` (`checkInstalledAssetVersion`) while preserving fallback compatibility with `state.json`.
4. Include 10 approved fixtures verifying zero disk writes, hermetic test isolation, stale-bundle warnings, and schema compatibility.

Closes #1884

## Test Plan

- `go test ./internal/managedbundle/...` (10 fixtures pass)
- `go test ./internal/doctor/...`
- `go test ./internal/cli/... -run TestCheckInstalledAssetVersion`
- `go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed-bundle validation for installed assets, including manifests, resources, integrity, and transaction status.
  * Added detection of aligned, outdated, modified, mixed, unsupported, and interrupted bundle states.
  * Added safe persistence for bundle metadata and recovery information.
* **Bug Fixes**
  * Diagnostics now provide clearer warnings and synchronization guidance for outdated or modified bundles.
  * Missing or invalid manifests continue to use the existing fallback validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->