### PR TITLE
fix(review): ignore semantic no-op index rewrites

### DIFF
--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1037,28 +1037,108 @@ func canonicalGitDirectory(repo string, output []byte) (string, error) {
 	return filepath.Clean(directory), nil
 }
 
-func readSnapshotIndex(path string) ([]byte, time.Time, error) {
-	file, err := os.Open(path)
+func readSnapshotIndex(ctx context.Context, repo, path string) ([]byte, time.Time, error) {
+	payload, modTime, stable, complete, err := readSnapshotIndexPhysical(path)
 	if err != nil {
 		return nil, time.Time{}, err
+	}
+	if stable {
+		return payload, modTime, nil
+	}
+	if !complete {
+		return nil, time.Time{}, errors.New("real index changed while being copied")
+	}
+	live, liveModTime, err := readStableSnapshotIndexPhysical(path)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	equal, err := snapshotIndexSemanticsEqual(ctx, repo, path, payload, live)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("compare changed real index semantics: %w", err)
+	}
+	if !equal {
+		return nil, time.Time{}, errors.New("real index changed while being copied")
+	}
+	return live, liveModTime, nil
+}
+
+func readStableSnapshotIndexPhysical(path string) ([]byte, time.Time, error) {
+	for range 3 {
+		payload, modTime, stable, _, err := readSnapshotIndexPhysical(path)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		if stable {
+			return payload, modTime, nil
+		}
+	}
+	return nil, time.Time{}, errors.New("real index changed while being copied")
+}
+
+func readSnapshotIndexPhysical(path string) ([]byte, time.Time, bool, bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, time.Time{}, false, false, err
 	}
 	defer file.Close()
 	before, err := file.Stat()
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, false, false, err
 	}
 	payload, err := io.ReadAll(file)
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, false, false, err
 	}
 	after, err := file.Stat()
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, false, false, err
 	}
-	if before.Size() != after.Size() || before.ModTime() != after.ModTime() || int64(len(payload)) != after.Size() {
-		return nil, time.Time{}, errors.New("real index changed while being copied")
+	complete := int64(len(payload)) == before.Size()
+	stable := before.Size() == after.Size() && before.ModTime() == after.ModTime() && int64(len(payload)) == after.Size()
+	return payload, after.ModTime(), stable, complete, nil
+}
+
+type snapshotIndexSemantics struct {
+	CandidateTree string
+	Entries       []byte
+}
+
+func snapshotIndexSemanticsEqual(ctx context.Context, repo, indexPath string, left, right []byte) (bool, error) {
+	leftSemantics, err := snapshotIndexSemanticsForContent(ctx, repo, indexPath, left)
+	if err != nil {
+		return false, err
 	}
-	return payload, after.ModTime(), nil
+	rightSemantics, err := snapshotIndexSemanticsForContent(ctx, repo, indexPath, right)
+	if err != nil {
+		return false, err
+	}
+	return leftSemantics.CandidateTree == rightSemantics.CandidateTree && bytes.Equal(leftSemantics.Entries, rightSemantics.Entries), nil
+}
+
+func snapshotIndexSemanticsForContent(ctx context.Context, repo, indexPath string, payload []byte) (snapshotIndexSemantics, error) {
+	temp, err := os.CreateTemp(filepath.Dir(indexPath), ".gentle-ai-review-index-compare-*")
+	if err != nil {
+		return snapshotIndexSemantics{}, err
+	}
+	tempIndex := temp.Name()
+	defer os.Remove(tempIndex)
+	if _, err := temp.Write(payload); err != nil {
+		_ = temp.Close()
+		return snapshotIndexSemantics{}, err
+	}
+	if err := temp.Close(); err != nil {
+		return snapshotIndexSemantics{}, err
+	}
+	env := []string{"GIT_INDEX_FILE=" + tempIndex}
+	candidateOutput, err := runGit(ctx, repo, env, nil, "write-tree")
+	if err != nil {
+		return snapshotIndexSemantics{}, err
+	}
+	entries, err := runGitInventoryWithEnv(ctx, repo, env, "ls-files", "--stage", "-z")
+	if err != nil {
+		return snapshotIndexSemantics{}, err
+	}
+	return snapshotIndexSemantics{CandidateTree: strings.TrimSpace(string(candidateOutput)), Entries: entries}, nil
 }
 
 func (builder *SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended []string, allowStagedIntended bool, projection Projection) (string, string, string, error) {
@@ -1075,7 +1155,7 @@ func (builder *SnapshotBuilder) buildCurrentChanges(ctx context.Context, intende
 	if !filepath.IsAbs(indexPath) {
 		indexPath = filepath.Join(builder.Repo, indexPath)
 	}
-	indexContent, indexModTime, err := readSnapshotIndex(indexPath)
+	indexContent, indexModTime, err := readSnapshotIndex(ctx, builder.Repo, indexPath)
 	missingIndex := errors.Is(err, os.ErrNotExist)
 	if err != nil && !missingIndex {
 		return "", "", "", fmt.Errorf("read real index: %w", err)

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -145,6 +145,75 @@ func TestSnapshotBuilderCurrentChangesIsCompleteAndPreservesRealIndex(t *testing
 	}
 }
 
+func TestSnapshotIndexSemanticsAllowWriteTreePhysicalRewrite(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "staged candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	indexPath := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "--git-path", "index"))
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(repo, indexPath)
+	}
+	before, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(index before): %v", err)
+	}
+	beforeTree := strings.TrimSpace(gitSnapshot(t, repo, "write-tree"))
+	after, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(index after): %v", err)
+	}
+	if bytes.Equal(before, after) {
+		t.Fatal("fixture did not make git write-tree rewrite the physical index")
+	}
+	afterTree := strings.TrimSpace(gitSnapshot(t, repo, "write-tree"))
+	if afterTree != beforeTree {
+		t.Fatalf("write-tree changed candidate tree: before=%s after=%s", beforeTree, afterTree)
+	}
+	equal, err := snapshotIndexSemanticsEqual(context.Background(), repo, indexPath, before, after)
+	if err != nil {
+		t.Fatalf("snapshotIndexSemanticsEqual(write-tree rewrite) error = %v", err)
+	}
+	if !equal {
+		t.Fatal("write-tree physical index rewrite changed semantic index fingerprint")
+	}
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatalf("Build(staged) after write-tree rewrite error = %v", err)
+	}
+	if err := (SnapshotBuilder{Repo: repo}).ValidateLiveSnapshot(context.Background(), snapshot); err != nil {
+		t.Fatalf("ValidateLiveSnapshot after write-tree physical rewrite error = %v", err)
+	}
+}
+
+func TestSnapshotIndexSemanticsDetectStagingMutation(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	indexPath := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "--git-path", "index"))
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(repo, indexPath)
+	}
+	before, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(index before): %v", err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "mutated candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	after, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(index after): %v", err)
+	}
+	equal, err := snapshotIndexSemanticsEqual(context.Background(), repo, indexPath, before, after)
+	if err != nil {
+		t.Fatalf("snapshotIndexSemanticsEqual(staging mutation) error = %v", err)
+	}
+	if equal {
+		t.Fatal("semantic staging mutation was treated as an unchanged index")
+	}
+}
+
 func TestSnapshotBuilderCurrentChangesPreservesRacyCleanDetection(t *testing.T) {
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)


### PR DESCRIPTION
## 🔗 Linked Issue

Related to #2872

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Fixes a false stale-target path where `git write-tree` can rewrite physical `.git/index` metadata without changing the semantic candidate.
- Distinguishes semantic no-op index rewrites from real staged mutations by comparing candidate tree and staged entries from isolated index copies.
- Preserves RDD protection: candidate tree, staged entries/blobs/modes, and repository context still define the real candidate identity.

Root cause: `git write-tree` may rewrite physical `.git/index` bytes/metadata while leaving candidate tree, staged paths, blobs, and modes unchanged. The previous snapshot copy guard treated that physical rewrite as candidate drift, which could surface as a false `stale_target_identity`. This patch keeps the physical index hash/shape useful as diagnostics but does not let physical-only index churn invalidate an unchanged semantic candidate.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | Falls back to semantic index comparison when the real index changes physically during a complete copy. |
| `internal/reviewtransaction/snapshot_test.go` | Adds regression coverage for physical `write-tree` index rewrites and real staged mutations. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode / GPT-5.5

**Material scope:** Code navigation, patch implementation, regression tests, and validation command orchestration under maintainer direction.

**Verification performed:** Focused Go tests plus a minimal positive/negative lab E2E with the patched binary.

---

## 🧪 Test Plan

**Focused unit/regression tests**
```bash
go test ./internal/reviewtransaction -count=1 -run 'TestSnapshot(IndexSemantics|BuilderCurrentChanges|BuilderCurrentChangesPreservesRacyCleanDetection|BuilderStaged|ValidateLiveSnapshot)'
```
Result: PASS

**E2E positive**
- Lab staged candidate tree: `7203cf33026f76dc8d505b7cdf317066b6ab4b76`.
- `git write-tree` changed physical `.git/index` size `190 → 209` and SHA while preserving the semantic candidate.
- Patched RDD negotiated status returned `action=start`, `transition=execute`, `reason=fresh_target_ready` for the unchanged target.
Result: PASS

**E2E negative**
- Staged a real blob mutation for `a.txt` and ran `review start` against the previous target.
- RDD rejected it with `code=stale_target_identity`, `mutation_outcome=not_started`, cause `review start target does not match the freshly built snapshot`.
Result: PASS

- [ ] Unit tests pass (`go test ./...`) — not run; focused tests only for this narrow bugfix.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — not run; files were formatted with `gofmt`.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run; minimal lab E2E run instead.
- [x] Manually tested locally

Benchmark validation: N/A for this PR body; no benchmark corpus or journey changed. Runtime validation is covered by the minimal RDD lab E2E above.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — focused package tests pass; full suite intentionally not run.
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — gofmt applied; full checker not run.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — minimal lab E2E pass; Docker E2E not run.
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained above).
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is intentionally narrow: it does not relax RDD candidate identity. A physical-only `.git/index` rewrite is accepted only after semantic evidence from isolated index copies matches. Real staged blob/path/mode changes still produce a different semantic candidate and remain blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when capturing current changes while Git index files are being rewritten concurrently.
  * Prevented unnecessary failures when the index’s physical contents change without changing its staged content.
  * Continued detecting and rejecting genuine staging-content changes.

* **Tests**
  * Added coverage for stable snapshots, harmless index rewrites, and real staging mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->