### PR TITLE
feat(opencode): refine background subagent routing

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -538,6 +538,59 @@ func TestOpenCodeBackgroundPolicyMarkersAreBalanced(t *testing.T) {
 	}
 }
 
+// TestOpenCodeBackgroundPolicyDefinesDeterministicRouting pins the semantic
+// contract that lets the orchestrator choose background versus foreground work
+// without inventing runtime guarantees.
+func TestOpenCodeBackgroundPolicyDefinesDeterministicRouting(t *testing.T) {
+	content := MustRead("opencode/background-subagents.md")
+	for _, required := range []string{
+		"the parent MUST request `background: true`",
+		"eligible independent, non-mutating work",
+		"concrete non-overlapping work",
+		"does not need that result before its next action",
+		"repository exploration/mapping",
+		"external/web research",
+		"independent planning inputs",
+		"read-only audits/reviews outside formal RDD",
+		"independent long-running test/build/lint/check-only verification",
+		"does not mutate shared source, generated artifacts, repository state, or files needed by concurrent work",
+		"If that isolation cannot be established, run it in the foreground.",
+		"provider or network failure",
+		"no silent retries or duplicate launches",
+		"results are needed only at a later join",
+		"At the parent level, keep no more than 2 background tasks active concurrently.",
+		"join only through completion notifications",
+		"never poll, sleep, run status checks, or proactively read results",
+		"foreground for immediate next-step dependencies",
+		"user decisions or interaction",
+		"dependent SDD phases and gatekeepers",
+		"SDD apply or any writer",
+		"Any same-worktree or shared mutation is foreground.",
+		"archive or closure",
+		"lifecycle gates",
+		"formal RDD/4R reviewers, refuters, validators, or Judgment Day actors",
+		"A background failure still emits a completion/failure notification",
+		"Never silently retry",
+		"explicit reclassification",
+		"must not duplicate active work",
+		"Do not duplicate launches or overlap files or topics",
+		"Never run parallel writers in one worktree",
+		"Background work is process-local and non-durable",
+		"restarting the parent process loses all background jobs",
+		"Do not claim durable scheduling, recovery, isolation, or runtime activity",
+		"safe foreground fallback",
+		"If `background` is absent from the Task schema",
+		"capability is disabled or unknown",
+	} {
+		if !strings.Contains(content, required) {
+			t.Errorf("background policy missing routing contract %q", required)
+		}
+	}
+	if strings.Contains(content, "Use OpenCode's Task tool with `background: true` only for") {
+		t.Fatal("background policy retains an ambiguous allow-only routing rule")
+	}
+}
+
 // TestOpenCodeReviewTransportPluginContract pins the adapter-minimality
 // boundary: the plugin correlates one host Task with one Go process, while Go
 // owns all prompt, schema, admission, and capture semantics.

--- a/internal/assets/opencode/background-subagents.md
+++ b/internal/assets/opencode/background-subagents.md
@@ -1,13 +1,25 @@
 <!-- gentle-ai:opencode-background-subagents -->
 ### OpenCode Background Subagent Policy
 
-Use OpenCode's Task tool with `background: true` only for independent, read-only exploration, audit, or review work where the parent can continue non-overlapping work.
+Once this addendum is present and the Task capability is active, the parent MUST request `background: true` for eligible independent, non-mutating work when it has concrete non-overlapping work to continue and does not need that result before its next action.
 
-At the parent level, allow no more than 2 concurrent background tasks. Completion notifications only: do not poll, sleep, run status checks, or proactively read for completion.
+Eligible work includes:
 
-Use foreground tasks when the result is needed before the next action, for user decisions, SDD apply or other writers, dependent verify evidence, archive, formal RDD/4R lenses, refuters, fix validators, Judgment Day actors, or dependent phases.
+- repository exploration/mapping.
+- external/web research is eligible only when independent and non-blocking; provider or network failure means no silent retries or duplicate launches.
+- independent planning inputs.
+- read-only audits/reviews outside formal RDD.
+- independent long-running test/build/lint/check-only verification, but only when it does not mutate shared source, generated artifacts, repository state, or files needed by concurrent work. If that isolation cannot be established, run it in the foreground.
 
-Do not duplicate launches or work, and do not overlap files or topics. Never run parallel writers in one worktree.
+### Joining background work
 
-Background jobs are process-local and non-durable. A restart loses them; make no recovery claim. If `background` is absent from the Task tool schema, or the capability is disabled or unknown, omit `background` and run the task in the foreground.
+Independent tasks whose results are needed only at a later join may launch concurrently. At the parent level, keep no more than 2 background tasks active concurrently. The parent must join only through completion notifications: never poll, sleep, run status checks, or proactively read results. A background failure still emits a completion/failure notification. Never silently retry; any retry requires explicit reclassification and must not duplicate active work. Do not duplicate launches or overlap files or topics.
+
+### Foreground invariants
+
+Keep foreground for immediate next-step dependencies, user decisions or interaction, dependent SDD phases and gatekeepers, SDD apply or any writer, archive or closure, lifecycle gates, and formal RDD/4R reviewers, refuters, validators, or Judgment Day actors whenever their governing contract requires foreground. Any same-worktree or shared mutation is foreground. Never run parallel writers in one worktree.
+
+### Capability limits
+
+Background work is process-local and non-durable; restarting the parent process loses all background jobs. Do not claim durable scheduling, recovery, isolation, or runtime activity. If `background` is absent from the Task schema, or the capability is disabled or unknown, omit it and use the safe foreground fallback.
 <!-- /gentle-ai:opencode-background-subagents -->

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -39,26 +39,25 @@ func TestOpenCodeBackgroundPolicyComposition(t *testing.T) {
 	if strings.Count(enabled, openCodeBackgroundPolicyMarker) != 1 || strings.Count(enabled, openCodeBackgroundPolicyEnd) != 1 {
 		t.Fatal("enabled OpenCode composition duplicated policy markers")
 	}
+	// The asset test owns the full policy vocabulary; composition only checks
+	// representative routing, safety, and fallback semantics survive injection.
 	for _, sentinel := range []string{
-		"background: true",
-		"independent, read-only exploration, audit, or review",
-		"foreground tasks when the result is needed before the next action",
-		"user decisions",
-		"SDD apply",
-		"dependent verify evidence",
-		"archive",
-		"formal RDD/4R lenses",
-		"refuters",
-		"fix validators",
-		"Judgment Day actors",
-		"no more than 2 concurrent background tasks",
-		"do not poll, sleep, run status checks, or proactively read",
-		"Do not duplicate launches or work, and do not overlap files or topics",
-		"Never run parallel writers in one worktree",
-		"process-local and non-durable",
-		"restart loses them",
-		"`background` is absent from the Task tool schema",
-		"capability is disabled or unknown",
+		"the parent MUST request `background: true`",
+		"eligible independent, non-mutating work",
+		"independent long-running test/build/lint/check-only verification",
+		"does not mutate shared source, generated artifacts, repository state, or files needed by concurrent work",
+		"If that isolation cannot be established, run it in the foreground.",
+		"At the parent level, keep no more than 2 background tasks active concurrently.",
+		"parent must join only through completion notifications",
+		"Any same-worktree or shared mutation is foreground.",
+		"formal RDD/4R reviewers, refuters, validators, or Judgment Day actors",
+		"A background failure still emits a completion/failure notification",
+		"Do not duplicate launches or overlap files or topics",
+		"Background work is process-local and non-durable",
+		"restarting the parent process loses all background jobs",
+		"Do not claim durable scheduling, recovery, isolation, or runtime activity",
+		"safe foreground fallback",
+		"If `background` is absent from the Task schema",
 	} {
 		if !strings.Contains(enabled, sentinel) {
 			t.Fatalf("enabled OpenCode composition missing policy sentinel %q", sentinel)


### PR DESCRIPTION
## 🔗 Linked Issue

Refs #3550

> This is the first independent delivery slice for #3550. Default activation and post-install CLI/TUI controls remain blocked by the active #3043 repair chain. If this PR merges before those follow-up slices, #3550 must remain the tracking authority for its unfinished acceptance criteria.

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Require background execution for eligible independent, non-mutating OpenCode tasks when the parent can continue useful non-overlapping work.
- Define explicit foreground boundaries for dependencies, user interaction, writers, lifecycle gates, and governed review actors.
- Pin concurrency, notification-only joins, failure/retry handling, capability fallback, and non-durable runtime limits with semantic contract tests.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/background-subagents.md` | Replaced the broad read-only rule with deterministic eligibility, isolation, join, foreground, and fallback contracts. |
| `internal/assets/assets_test.go` | Added the complete semantic policy contract. |
| `internal/components/sdd/orchestrator_composition_test.go` | Verified representative routing semantics survive OpenCode prompt composition. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi/el Gentleman with OpenAI Codex GPT-5.6 Luna and Sol profiles.

**Material scope:** Repository investigation, policy design, implementation of the managed prompt asset and tests, and verification planning.

**Verification performed:** Reviewed the complete three-file diff; exercised RED/GREEN contract tests; ran focused and package tests, OpenCode single/multi goldens, the full root Go suite, Go formatting checks, and Git integrity checks. Docker E2E was attempted but unavailable because the `docker` command is not installed in the local environment.

---

## 🧪 Test Plan

**Focused contract tests**
```bash
go test ./internal/assets -run '^(TestOpenCodeBackgroundPolicyMarkersAreBalanced|TestOpenCodeBackgroundPolicyDefinesDeterministicRouting)$'
go test ./internal/components/sdd -run '^TestOpenCodeBackgroundPolicyComposition$'
go test ./internal/components -run '^(TestGoldenSDD_OpenCode|TestGoldenSDD_OpenCode_Multi)$'
```

**Full unit suite and formatting**
```bash
go test ./...
go run ./internal/gofmtcheck
git diff --check
```

All commands above passed. The full Go suite completed in 558 seconds.

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

Not run locally: Docker is unavailable (`docker: command not found`). CI must provide the authoritative E2E result.

**Benchmark Validation:** N/A. This slice changes neither benchmark code/corpus nor review lifecycle, gates, recovery, delivery, or measured performance claims.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Docker unavailable locally; deferred to CI.
- [ ] Manually tested locally — no live native OpenCode Task run was claimed for this policy-only slice.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 112 changed lines; below the 400-line budget. |
| Check Issue Reference | ⏳ | PR body links #3550. |
| Check Issue Has `status:approved` | ⏳ | #3550 is approved. |
| Check PR Has `type:*` Label | ⏳ | `type:feature` will be applied. |
| Unit Tests | ⏳ | `go test ./...` passed locally. |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` passed locally. |
| E2E Tests | ⏳ | Deferred to CI because Docker is unavailable locally. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — awaiting CI.
- [x] Benchmark validation is not applicable to this policy-only slice.
- [x] Documentation is contained in the managed OpenCode policy asset; broader user-facing control docs belong to the blocked follow-up slices.
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review the policy asset first, then confirm the asset test owns the full vocabulary while the composition test samples only representative semantics.

Out of scope: default `auto` resolution, `ActivationPlan`, persisted controls, CLI/TUI surfaces, docs, and benchmark journeys. Those overlap #3043 repair PRs #3459–#3462 and are intentionally deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified when eligible, independent background tasks should run asynchronously.
  - Added guidance for isolation, shared mutations, concurrency limits, retries, failures, and completion notifications.
  - Documented foreground fallback when background execution is unavailable or unsupported.
  - Clarified that background work is non-durable and should not be treated as recoverable scheduling.

- **Tests**
  - Added coverage to verify deterministic background-task routing guidance and safety rules.
  - Updated composition checks to validate representative routing, isolation, lifecycle, and fallback requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->