### PR TITLE
fix(review): validate result storage readiness

### DIFF
--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -243,6 +243,9 @@ func (store CompactStore) CaptureAdmittedReviewerResult(
 					return err
 				}
 			}
+			if err := store.CheckRoleResultStorageReadiness(ctx); err != nil {
+				return err
+			}
 			published, err = publishCompactAdmittedReviewerResult(
 				store.Dir,
 				expected,

--- a/internal/reviewtransaction/compact_reviewer_capture_test.go
+++ b/internal/reviewtransaction/compact_reviewer_capture_test.go
@@ -24,6 +24,75 @@ type compactReviewerCaptureFixture struct {
 	path    string
 }
 
+func TestReviewResultStoragePublication(t *testing.T) {
+	for _, role := range []string{"lens", "refuter"} {
+		t.Run(role+" revalidates after admission without publication", func(t *testing.T) {
+			fixture := newCompactReviewerCaptureFixture(t, "storage-change-"+role)
+			before, err := os.ReadFile(fixture.store.StatePath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			original := reviewResultStorageReadinessHook
+			t.Cleanup(func() { reviewResultStorageReadinessHook = original })
+			changeStorage := func() {
+				reviewResultStorageReadinessHook = func(stage string) error {
+					if stage == "directory-created" {
+						return errors.New("storage changed after admission")
+					}
+					return nil
+				}
+			}
+			var captureErr error
+			var slotPath string
+			if role == "lens" {
+				request := fixture.request
+				request.PreparePublication = func(CompactState) error { changeStorage(); return nil }
+				_, captureErr = fixture.store.CaptureAdmittedReviewerResult(t.Context(), request)
+				slotPath = fixture.path
+			} else {
+				slotPath = filepath.Join(fixture.store.Dir, compactRefuterResultsDir, compactRefuterResultFile)
+				captureErr = fixture.store.CaptureAdmittedRefuterResult(t.Context(), CompactAdmittedRefuterResultRequest{
+					ExpectedRevision:   fixture.request.ExpectedRevision,
+					TargetIdentity:     fixture.request.TargetIdentity,
+					Payload:            []byte("{}\n"),
+					PreparePublication: func(CompactState) error { changeStorage(); return nil },
+				})
+			}
+			if !errors.Is(captureErr, ErrReviewResultStorageNotReady) {
+				t.Fatalf("capture error = %v", captureErr)
+			}
+			after, err := os.ReadFile(fixture.store.StatePath())
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("capture changed authority: %v", err)
+			}
+			for _, path := range []string{slotPath, slotPath + ".sha256", fixture.store.ReceiptPath()} {
+				if _, err := os.Lstat(path); !errors.Is(err, fs.ErrNotExist) {
+					t.Fatalf("capture published %q: %v", path, err)
+				}
+			}
+		})
+	}
+
+	t.Run("stale binding wins before readiness", func(t *testing.T) {
+		fixture := newCompactReviewerCaptureFixture(t, "storage-stale-precedence")
+		checks := 0
+		original := reviewResultStorageReadinessHook
+		reviewResultStorageReadinessHook = func(string) error { checks++; return errors.New("must not run") }
+		t.Cleanup(func() { reviewResultStorageReadinessHook = original })
+		err := fixture.store.CaptureAdmittedRefuterResult(t.Context(), CompactAdmittedRefuterResultRequest{
+			ExpectedRevision: hash("stale-storage-binding"),
+			TargetIdentity:   fixture.request.TargetIdentity,
+			Payload:          []byte("{}\n"),
+			PreparePublication: func(CompactState) error {
+				return errors.New("stale authority invoked preparation")
+			},
+		})
+		if err == nil || checks != 0 {
+			t.Fatalf("stale capture error = %v, readiness checks = %d", err, checks)
+		}
+	})
+}
+
 func newCompactReviewerCaptureFixture(
 	t *testing.T,
 	lineage string,

--- a/internal/reviewtransaction/compact_role_result_slot.go
+++ b/internal/reviewtransaction/compact_role_result_slot.go
@@ -3,9 +3,12 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -19,7 +22,124 @@ const (
 	compactRefuterResultFile           = "batch.json"
 	compactTargetedValidatorResultsDir = "targeted-validator-results"
 	compactTargetedValidatorResultFile = "result.json"
+	reviewResultReadinessAttempts      = 8
 )
+
+// ErrReviewResultStorageNotReady classifies compact role-result storage that
+// cannot currently uphold the private immutable publication contract.
+var ErrReviewResultStorageNotReady = errors.New("review result storage is not ready")
+
+// ReviewResultStorageNotReadyError preserves the concrete readiness failure.
+type ReviewResultStorageNotReadyError struct{ Cause error }
+
+func (err *ReviewResultStorageNotReadyError) Error() string {
+	return fmt.Sprintf("%v: %v", ErrReviewResultStorageNotReady, err.Cause)
+}
+
+func (err *ReviewResultStorageNotReadyError) Unwrap() []error {
+	return []error{ErrReviewResultStorageNotReady, err.Cause}
+}
+
+var (
+	createReviewResultReadinessDirectory = createPrivateRARDirectory
+	reviewResultStorageReadinessHook     = func(string) error { return nil }
+)
+
+// CheckRoleResultStorageReadiness proves the compact store can safely publish
+// and read private immutable role-result pairs without addressing a real slot.
+func (store CompactStore) CheckRoleResultStorageReadiness(ctx context.Context) (result error) {
+	if ctx == nil {
+		return reviewResultStorageNotReady(errors.New("readiness context is nil"))
+	}
+	if err := ctx.Err(); err != nil {
+		return reviewResultStorageNotReady(err)
+	}
+	var scratch string
+	defer func() {
+		if scratch == "" {
+			return
+		}
+		if err := cleanupReviewResultReadiness(scratch); err != nil {
+			result = errors.Join(result, reviewResultStorageNotReady(err))
+		}
+	}()
+	for range reviewResultReadinessAttempts {
+		name := make([]byte, 8)
+		if _, err := rand.Read(name); err != nil {
+			return reviewResultStorageNotReady(err)
+		}
+		candidate := filepath.Join(store.Dir, ".review-result-readiness-"+hex.EncodeToString(name))
+		created, err := createReviewResultReadinessDirectory(candidate)
+		if errors.Is(err, fs.ErrExist) || err == nil && !created {
+			continue
+		}
+		scratch = candidate
+		if err != nil {
+			return reviewResultStorageNotReady(err)
+		}
+		break
+	}
+	if scratch == "" {
+		return reviewResultStorageNotReady(errors.New("readiness scratch allocation exhausted"))
+	}
+	if err := reviewResultStorageReadinessHook("directory-created"); err != nil {
+		return reviewResultStorageNotReady(err)
+	}
+	payload := []byte("review-result-readiness\n")
+	digest := []byte(compactPreservedPayloadDigest(payload) + "\n")
+	payloadPath, digestPath := filepath.Join(scratch, "payload"), filepath.Join(scratch, "payload.sha256")
+	if err := publishPrivateRARImmutable(payloadPath, payload); err != nil {
+		return reviewResultStorageNotReady(err)
+	}
+	if err := reviewResultStorageReadinessHook("payload-published"); err != nil {
+		return reviewResultStorageNotReady(err)
+	}
+	if err := publishPrivateRARImmutable(digestPath, digest); err != nil {
+		return reviewResultStorageNotReady(err)
+	}
+	if err := reviewResultStorageReadinessHook("digest-published"); err != nil {
+		return reviewResultStorageNotReady(err)
+	}
+	var conflict *RARAuthorityConflictError
+	if err := publishPrivateRARImmutable(payloadPath, []byte("conflict\n")); !errors.As(err, &conflict) {
+		return reviewResultStorageNotReady(errors.Join(errors.New("immutable conflicting publication was not refused safely"), err))
+	}
+	readPayload, err := readPrivateCompactReviewerFile(payloadPath, int64(len(payload)))
+	if err != nil || !bytes.Equal(readPayload, payload) {
+		return reviewResultStorageNotReady(errors.Join(errors.New("readiness payload readback mismatch"), err))
+	}
+	readDigest, err := readPrivateCompactReviewerFile(digestPath, int64(len(digest)))
+	if err != nil || !bytes.Equal(readDigest, digest) {
+		return reviewResultStorageNotReady(errors.Join(errors.New("readiness digest readback mismatch"), err))
+	}
+	return nil
+}
+
+func reviewResultStorageNotReady(cause error) error {
+	return &ReviewResultStorageNotReadyError{Cause: cause}
+}
+
+func cleanupReviewResultReadiness(scratch string) error {
+	var cleanup error
+	cleanup = errors.Join(cleanup, reviewResultStorageReadinessHook("cleanup-started"))
+	for _, path := range []string{filepath.Join(scratch, "payload.sha256"), filepath.Join(scratch, "payload")} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			cleanup = errors.Join(cleanup, err)
+		}
+	}
+	if err := os.Remove(scratch); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		cleanup = errors.Join(cleanup, err)
+	}
+	if err := SyncReviewDirectory(filepath.Dir(scratch)); err != nil {
+		cleanup = errors.Join(cleanup, err)
+	}
+	if _, err := os.Lstat(scratch); err == nil {
+		cleanup = errors.Join(cleanup, errors.New("readiness scratch remains"))
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		cleanup = errors.Join(cleanup, fmt.Errorf("verify readiness scratch removal: %w", err))
+	}
+	return cleanup
+}
 
 type compactRoleResultSlotKind string
 
@@ -177,6 +297,9 @@ func (store CompactStore) captureAdmittedRoleResult(
 			return err
 		}
 		if err := prepare(state); err != nil {
+			return err
+		}
+		if err := store.CheckRoleResultStorageReadiness(ctx); err != nil {
 			return err
 		}
 		_, err = publishCompactRoleResultSlot(store.Dir, key, payload)

--- a/internal/reviewtransaction/compact_role_result_slot_test.go
+++ b/internal/reviewtransaction/compact_role_result_slot_test.go
@@ -4,10 +4,103 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
+
+func TestReviewResultStorageReadiness(t *testing.T) {
+	t.Run("safe lifecycle leaves no artifacts", func(t *testing.T) {
+		store := CompactStore{Dir: t.TempDir()}
+		if err := store.CheckRoleResultStorageReadiness(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		assertEmptyReadinessStore(t, store.Dir)
+	})
+
+	t.Run("unsupported owner mode is typed and cleaned", func(t *testing.T) {
+		store := CompactStore{Dir: t.TempDir()}
+		original := createReviewResultReadinessDirectory
+		createReviewResultReadinessDirectory = func(path string) (bool, error) {
+			if err := os.Mkdir(path, 0o700); err != nil {
+				return false, err
+			}
+			return false, errUnsafeRARAuthorityPath
+		}
+		t.Cleanup(func() { createReviewResultReadinessDirectory = original })
+		err := store.CheckRoleResultStorageReadiness(t.Context())
+		var cause *ReviewResultStorageNotReadyError
+		if !errors.Is(err, ErrReviewResultStorageNotReady) || !errors.As(err, &cause) ||
+			!errors.Is(cause.Cause, errUnsafeRARAuthorityPath) {
+			t.Fatalf("readiness error = %T %v", err, err)
+		}
+		assertEmptyReadinessStore(t, store.Dir)
+	})
+
+	for _, stage := range []string{"payload-published", "digest-published", "cleanup-started"} {
+		t.Run("injected "+stage+" failure cleans scratch", func(t *testing.T) {
+			store := CompactStore{Dir: t.TempDir()}
+			injected := errors.New("injected " + stage)
+			original := reviewResultStorageReadinessHook
+			reviewResultStorageReadinessHook = func(got string) error {
+				if got == stage {
+					return injected
+				}
+				return nil
+			}
+			t.Cleanup(func() { reviewResultStorageReadinessHook = original })
+			err := store.CheckRoleResultStorageReadiness(t.Context())
+			if !errors.Is(err, ErrReviewResultStorageNotReady) || !errors.Is(err, injected) {
+				t.Fatalf("readiness error = %v", err)
+			}
+			assertEmptyReadinessStore(t, store.Dir)
+		})
+	}
+
+	t.Run("concurrent probes use independent scratch", func(t *testing.T) {
+		store := CompactStore{Dir: t.TempDir()}
+		const probes = 8
+		errs := make(chan error, probes)
+		var group sync.WaitGroup
+		for range probes {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				errs <- store.CheckRoleResultStorageReadiness(t.Context())
+			}()
+		}
+		group.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		assertEmptyReadinessStore(t, store.Dir)
+	})
+}
+
+func assertEmptyReadinessStore(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("readiness left artifacts: %v", entries)
+	}
+	for _, path := range []string{
+		filepath.Join(dir, CompactReviewerResultsDir, "00-"+LensReliability+".json"),
+		filepath.Join(dir, compactRefuterResultsDir, compactRefuterResultFile),
+		filepath.Join(dir, "receipt.json"),
+	} {
+		if _, err := os.Lstat(path); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("readiness created authority artifact %q: %v", path, err)
+		}
+	}
+}
 
 func TestCompactRoleResultSlotsPreserveImmutablePublicationSemantics(t *testing.T) {
 	revision := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2411

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add a typed, bounded readiness probe for secure reviewer-result storage.
- Revalidate readiness inside the existing authority lock before lens and role-result publication.
- Preserve stale-binding precedence, immutable publication, replay/conflict, owner-only, and EXDEV behavior.

This is chain slice 1 of 3. It establishes the storage/publication foundation; later slices wire STATUS, compiled/Pi, and OpenCode transport boundaries.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_role_result_slot.go` | Added typed bounded readiness probing, private immutable publication/readback checks, and cleanup. |
| `internal/reviewtransaction/compact_role_result_slot_test.go` | Added lifecycle, unsupported owner-mode, cleanup-stage, and concurrency coverage. |
| `internal/reviewtransaction/compact_reviewer_capture.go` | Revalidated readiness under the existing capture lock before publication. |
| `internal/reviewtransaction/compact_reviewer_capture_test.go` | Proved zero publication, unchanged authority, and stale-binding precedence for lens/refuter paths. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with `openai/gpt-5.6-sol`

**Material scope:** SDD exploration, proposal/spec/design/tasks, strict-TDD implementation, focused tests, review preparation, and PR drafting.

**Verification performed:** Focused race tests, full `internal/reviewtransaction` package tests, compatibility allowlist, `go vet`, `gofmtcheck`, driven benchmark journey j105, independent SDD verification, and native receipt review.

---

## 🧪 Test Plan

**Focused race tests**
```bash
go test -race ./internal/reviewtransaction -run "^TestReviewResultStorage(Readiness|Publication)$" -count=1 -v
```

**Package tests and static analysis**
```bash
go test ./internal/reviewtransaction -count=1
go vet ./internal/reviewtransaction
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Driven benchmark validation**
```bash
/tmp/opencode/gentle-ai-bench run --binary /tmp/opencode/gentle-ai --only j105-compiled-provider-capture-retries-same-binding
```
Result: `journeys: 1 completed, 0 unsupported, 0 failed`.

The broad root suite and Docker E2E were not run locally because the requested scope explicitly forbids using or indirectly consuming the setup-infisical snapshot. CI remains authoritative for those broad checks.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 288 changed lines, within the 400-line budget |
| Check Issue Reference | ⏳ | Links approved issue #2411 |
| Check Issue Has `status:approved` | ⏳ | Issue was approved before work began |
| Check PR Has `type:*` Label | ⚠️ | `type:bug` requested; contributor token cannot apply repository labels |
| Unit Tests | ⏳ | CI runs `go test ./...` |
| Go Format | ✅ | Local `gofmtcheck` passed |
| E2E Tests | ⏳ | CI runs Docker E2E |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — maintainer action required: add `type:bug`
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- Maintainer action required: add the `type:bug` label; the contributor token lacks label permission.

- Native review lineage: `review-75349e05b335d4ab`; receipt: `sha256:819315d15826bb8c91c4f901e394c852cb7595077eac120847c67f0acf8fb8dc`.
- The readiness boundary was challenged against the issue’s DrvFS/9p evidence: unsupported owner-only semantics fail closed, cleanup is mandatory, and no authoritative slot is consumed.
- This probe is not one of the ten registered v2.2.1 guard-population families, so no new `guard:population` declaration or `.guard-population-baseline.txt` change is required. Existing registered guards are untouched.
- The setup-infisical snapshot and fixtures were neither used nor modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review results are now published only after storage readiness is verified.
  * Prevented publication and authority changes when storage becomes unavailable or inconsistent.
  * Added safeguards to reject stale storage bindings before publishing results.
  * Readiness checks now clean up temporary artifacts, including after failures and concurrent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->