### PR TITLE
docs: document Hermes as a knowledge-layer agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Before you dive in, please read this guide fully. We have a structured workflow 
 - [AI-Assisted Contributions](#ai-assisted-contributions)
 - [Label System](#label-system)
 - [Development Setup](#development-setup)
+- [Hermes — Knowledge-Layer Agent](#hermes--knowledge-layer-agent)
 - [Testing](#testing)
 - [Running the Cross-Lane Battery](#running-the-cross-lane-battery)
 - [Commit Convention](#commit-convention)
@@ -120,6 +121,24 @@ go build -o gentle-ai ./cmd/gentle-ai
 ```bash
 ./gentle-ai
 ```
+
+---
+
+## Hermes — Knowledge-Layer Agent
+
+Hermes is a detect-only knowledge-layer integration. Install Hermes separately
+before running Gentle AI; Gentle AI detects an existing installation and
+configures it, but does not install the agent.
+
+Hermes supports:
+
+- **Skills** in `~/.hermes/skills/`
+- **System prompt** in `~/.hermes/SOUL.md`, using marker-based Markdown sections
+- **MCP servers** in `~/.hermes/config.yaml`, using Hermes's YAML configuration format
+
+Hermes does not support subagents, slash commands, or output styles. When
+changing Hermes integration code, start with `internal/agents/hermes/adapter.go`
+and keep its global `~/.hermes` paths and manual-install boundary intact.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,11 +134,13 @@ Hermes supports:
 
 - **Skills** in `~/.hermes/skills/`
 - **System prompt** in `~/.hermes/SOUL.md`, using marker-based Markdown sections
-- **MCP servers** in `~/.hermes/config.yaml`, using Hermes's YAML configuration format
+- **MCP servers** in `~/.hermes/config.yaml`, using `StrategyMergeIntoYAML` to merge server blocks into the existing file, preserve unrelated YAML, and replace an existing block with the same server ID
 
-Hermes does not support subagents, slash commands, or output styles. When
-changing Hermes integration code, start with `internal/agents/hermes/adapter.go`
-and keep its global `~/.hermes` paths and manual-install boundary intact.
+Gentle AI does not install or manage persistent Hermes subagent files. Hermes
+supports native ephemeral delegation through `delegate_task`. It also has no
+slash commands or output styles. When changing Hermes integration code, start
+with `internal/agents/hermes/adapter.go` and keep its global `~/.hermes` paths
+and manual-install boundary intact.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Gentle-AI is NOT an AI agent installer. It adapts the agent runtime(s) already o
 | **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config  |
 | **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
 | **Pi**              | Full (package-managed subagents) | First-class `gentle-pi` harness with Pi-native persona/models, SDD, and Engram memory |
-| **Hermes**          |    Detect-only (manual install)    | Skills, `SOUL.md` system prompt, and MCP via YAML; no subagents, slash commands, or output styles |
+| **Hermes**          |    Detect-only (manual install)    | Skills, `SOUL.md` system prompt, MCP via YAML, and native ephemeral delegation through `delegate_task`; Gentle AI does not install or manage persistent Hermes subagent files |
 
 > **Pi is package-managed, not just configured.** Selecting Pi installs the first-class [`gentle-pi`](docs/pi.md) harness, which owns Pi-native persona and model controls, SDD assets, chains, and memory wiring.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Gentle-AI is NOT an AI agent installer. It adapts the agent runtime(s) already o
 | **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config  |
 | **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
 | **Pi**              | Full (package-managed subagents) | First-class `gentle-pi` harness with Pi-native persona/models, SDD, and Engram memory |
-| **Hermes**          |         Detect-only              | YAML MCP config, SOUL.md persona; install manually first        |
+| **Hermes**          |    Detect-only (manual install)    | Skills, `SOUL.md` system prompt, and MCP via YAML; no subagents, slash commands, or output styles |
 
 > **Pi is package-managed, not just configured.** Selecting Pi installs the first-class [`gentle-pi`](docs/pi.md) harness, which owns Pi-native persona and model controls, SDD assets, chains, and memory wiring.
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #966

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

---

## 📝 Summary

Documents Hermes as a knowledge-layer agent so users and contributors can understand its manual installation boundary, managed configuration surfaces, and current capability limits without reconstructing them from the adapter implementation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md` | Expanded the Hermes integration entry with its knowledge-layer capabilities and manual-install requirement. |
| `CONTRIBUTING.md` | Added a focused Hermes section covering managed paths, YAML MCP configuration, supported capabilities, and unsupported features. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** el Gentleman in Pi, using OpenAI Codex GPT-5.6 Luna

**Material scope:** Repository exploration, documentation drafting, capability cross-checking, and PR preparation.

**Verification performed:** I reviewed the complete diff, checked every Hermes capability claim against the adapter, capability manifest, and existing tests, and ran `git diff --check`.

---

## 🧪 Test Plan

- [x] `git diff --check`
- [x] Manually reviewed the Markdown structure and table-of-contents anchor.
- [x] Cross-checked Hermes claims against `internal/agents/hermes/adapter.go`, `internal/agents/capabilitymanifest/manifest.go`, and existing Hermes tests.
- [ ] Unit tests (`go test ./...`) — not run; documentation-only change.
- [ ] Go format (`go run ./internal/gofmtcheck`) — not applicable; no Go files changed.
- [ ] E2E tests (`cd e2e && ./docker-test.sh`) — not run; no runtime behavior changed.
- [x] Benchmark validation — N/A; this change does not touch review lifecycle, gates, recovery, delivery, or benchmark behavior.

---

## 🤖 Automated Checks

The repository checks will validate issue linkage, review workload, labels, and CI after publication.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (21 changed lines)
- [ ] Appropriate `type:*` label applied — pending maintainer action
- [ ] Unit tests pass (`go test ./...`) — not run for this documentation-only change
- [ ] Go format passes (`go run ./internal/gofmtcheck`) — not applicable
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run; no runtime behavior changed
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation is updated
- [x] Commit follows Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] Commit does not include `Co-Authored-By` trailers

## Pending maintainer actions

- [ ] Apply exactly one PR label: `type:docs`

---

## 💬 Notes for Reviewers

Please review the Hermes capability wording first. The statements are intentionally limited to behavior confirmed by the current adapter and capability manifest; no runtime behavior changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a dedicated Hermes knowledge-layer integration section with installation boundaries, supported integrations, configuration paths, and implementation guidance.
  - Clarified that Hermes is detection-only and must be installed manually.
  - Documented support for skills, `SOUL.md`, YAML-configured MCP, and native ephemeral delegation via `delegate_task`.
  - Noted unsupported features, including persistent subagent files, slash commands, and output styles.
  - Added the new section to the documentation table of contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->