### PR TITLE
fix(review): allow base-equivalent correction status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
             completed_once("j89-staged-validation-is-informational-and-unmanaged") and
             completed_once("j104-repository-context-survives-fresh-process") and
             completed_once("j110-untracked-terminal-burn-and-unmanaged-staged-validation") and
-            completed_once("j111-approved-transaction-burns-and-shipped-gates-are-unmanaged")
+            completed_once("j111-approved-transaction-burns-and-shipped-gates-are-unmanaged") and
+            completed_once("j113-correction-removes-candidate-only-path")
           ' "$RUNNER_TEMP/bench-portable.json"
           "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j105-compiled-provider-capture-retries-same-binding --out "$RUNNER_TEMP/bench-provider-capture.json"
           jq -e '

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -711,6 +711,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, sddSharedScaffoldingJourneys()...)
 	journeys = append(journeys, sddPostReviewVerifyReportJourneys()...)
 	journeys = append(journeys, issue3564Journeys()...)
+	journeys = append(journeys, issue3321Journeys()...)
 	journeys = append(journeys, handoffJourneys()...)
 	journeys = removeRetiredAtomicJourneys(journeys)
 	return declareCoreJourneyReviewModes(journeys)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -61,6 +61,7 @@ func journeySources() []journeySource {
 		{"journeys_sdd_shared_scaffolding.go", sddSharedScaffoldingJourneys()},
 		{"journeys_sdd_post_review_verify_report.go", sddPostReviewVerifyReportJourneys()},
 		{"journeys_issue3564.go", issue3564Journeys()},
+		{"journeys_issue3321.go", issue3321Journeys()},
 	}
 	for index := range sources {
 		sources[index].Journeys = removeRetiredAtomicJourneys(sources[index].Journeys)

--- a/bench/journeys_issue3321.go
+++ b/bench/journeys_issue3321.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const issue3321Lineage = "issue-3321-base-equivalent-correction"
+
+// issue3321Journeys proves a valid correction may remove a candidate-only path.
+// The correction delta remains bound to the frozen genesis path even though the
+// restored base-to-current projection no longer lists that path.
+func issue3321Journeys() []Journey {
+	return []Journey{{
+		ID:     "j113-correction-removes-candidate-only-path",
+		Review: reviewOptedIn,
+		Title:  "A bounded correction may remove a candidate-only file and continue through STATUS",
+		Source: "issue #3321: correction paths are frozen-to-current deltas, not current projection paths",
+		Steps: []Step{
+			{Name: "fixture: repository", Fixture: baseRepo},
+			{Name: "fixture: candidate-only defect and unchanged reviewed companion", Fixture: stageIssue3321Candidate},
+			{Name: "start the exact review lineage", Requires: startNamedCapability,
+				Args: productArgs("review", "start", "--lineage", issue3321Lineage)},
+			{Name: "capture the blocking candidate-only finding and finish selected lenses", Requires: captureResultCapability,
+				Composite: func(r *journeyRun) error { return captureCorrectableFindingFor(r, "--lineage", issue3321Lineage) }},
+			{Name: "enter correction-required", Requires: finalizeResultsCapability,
+				Args: productArgs("review", "finalize", "--lineage", issue3321Lineage, "--captured-results=true")},
+			{Name: "forecast the three-line deletion", Requires: finalizeCorrectionCapability,
+				Args: productArgs("review", "finalize", "--lineage", issue3321Lineage, "--correction-lines", "3")},
+			{Name: "fixture: remove the candidate-only file exactly back to base", Fixture: removeIssue3321CandidateOnlyPath},
+			{Name: "STATUS v2 captures repository evidence for the base-equivalent correction", Requires: captureOutcomeEvidenceCapability,
+				Composite: func(r *journeyRun) error {
+					return capturePassedCorrectionEvidenceForContract(r, issue3321Lineage, reviewContractV2)
+				}},
+			{Name: "targeted validation approves and burns the corrected lineage", Requires: finalizeValidationCapability,
+				Composite: completeIssue3321Correction},
+		},
+	}}
+}
+
+func stageIssue3321Candidate(sandbox *Sandbox) error {
+	candidate := "package candidate\n\nfunc value() int { return 1 }\n"
+	companion := "package candidate\n\nfunc companion() int {\n\tvalue := 1\n\tvalue++\n\tvalue++\n\treturn value\n}\n"
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "candidate.go"), candidate); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "companion.go"), companion); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "candidate.go", "companion.go"); err != nil {
+		return err
+	}
+	paths, err := gitOut(sandbox, sandbox.Repo, "diff", "--cached", "--name-only")
+	if err != nil || paths != "candidate.go\ncompanion.go" {
+		return fmt.Errorf("issue #3321 staged candidate paths = %q, %v", paths, err)
+	}
+	return nil
+}
+
+func removeIssue3321CandidateOnlyPath(sandbox *Sandbox) error {
+	if err := os.Remove(filepath.Join(sandbox.Repo, "candidate.go")); err != nil {
+		return err
+	}
+	paths, err := gitOut(sandbox, sandbox.Repo, "diff", "HEAD", "--name-only")
+	if err != nil || paths != "companion.go" {
+		return fmt.Errorf("base-equivalent correction paths = %q, %v; candidate.go must disappear from the current projection", paths, err)
+	}
+	status, err := gitOut(sandbox, sandbox.Repo, "status", "--short", "--", "candidate.go")
+	if err != nil || status != "AD candidate.go" {
+		return fmt.Errorf("candidate-only correction index state = %q, %v", status, err)
+	}
+	return nil
+}
+
+func completeIssue3321Correction(r *journeyRun) error {
+	if err := completeCorrectedReviewForContract(r, issue3321Lineage, reviewContractV2); err != nil {
+		return err
+	}
+	return requireAtomicLineageBurned(r, issue3321Lineage)
+}

--- a/bench/journeys_wave1.go
+++ b/bench/journeys_wave1.go
@@ -577,7 +577,11 @@ func capturePassedCorrectionEvidence(r *journeyRun) error {
 }
 
 func capturePassedCorrectionEvidenceFor(r *journeyRun, lineage string) error {
-	status, err := readCorrectionStatusFor(r, lineage)
+	return capturePassedCorrectionEvidenceForContract(r, lineage, reviewContract)
+}
+
+func capturePassedCorrectionEvidenceForContract(r *journeyRun, lineage, contract string) error {
+	status, err := readCorrectionStatusForContract(r, lineage, contract)
 	if err != nil {
 		return err
 	}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -28,6 +28,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j110-untracked-terminal-burn-and-unmanaged-staged-validation":              reviewOptedIn,
 	"j111-approved-transaction-burns-and-shipped-gates-are-unmanaged":           reviewOptedIn,
 	"j112-sdd-attempt-settle-survives-review-mode-transition":                   reviewUntouched,
+	"j113-correction-removes-candidate-only-path":                               reviewOptedIn,
 	"j12-rejected-capture-then-recapture":                                       reviewOptedIn,
 	"j13-next-transition-runs-verbatim":                                         reviewOptedIn,
 	"j14-abandon-needs-a-hand-built-token":                                      reviewOptedIn,

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -18,6 +18,7 @@ j11-unborn-head
 j110-untracked-terminal-burn-and-unmanaged-staged-validation
 j111-approved-transaction-burns-and-shipped-gates-are-unmanaged
 j112-sdd-attempt-settle-survives-review-mode-transition
+j113-correction-removes-candidate-only-path
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token

--- a/internal/cli/review_repository_context_test.go
+++ b/internal/cli/review_repository_context_test.go
@@ -433,6 +433,24 @@ func TestNegotiatedStatusAcceptsCorrectionSubsetDigest(t *testing.T) {
 		!slices.Equal(status.Projection.Paths, []string{"corrected.go", "untouched.go"}) {
 		t.Fatalf("subset request/projection = %#v / %#v", status.ValidationRequest, status.Projection)
 	}
+
+	writeReviewStartCandidate(t, repo, "corrected.go", "package candidate\n\nfunc correctedSubset() int { return 0 }\n", 0o644)
+	if err := os.Chtimes(filepath.Join(repo, "corrected.go"), fixed.Add(time.Second), fixed.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	output.Reset()
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--lineage", started.LineageID, "--next-transition",
+	}, &output); err != nil {
+		t.Fatalf("status rejected a correction path restored exactly to base: %v\n%s", err, output.String())
+	}
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.ValidationRequest == nil ||
+		!slices.Equal(status.ValidationRequest.CorrectionPaths, []string{"corrected.go"}) ||
+		!slices.Equal(status.Projection.Paths, []string{"untouched.go"}) {
+		t.Fatalf("base-equivalent request/projection = %#v / %#v", status.ValidationRequest, status.Projection)
+	}
 }
 
 func TestNegotiatedStartPublishesStableOpaqueRepositoryContext(t *testing.T) {

--- a/internal/cli/review_repository_context_test.go
+++ b/internal/cli/review_repository_context_test.go
@@ -445,6 +445,7 @@ func TestNegotiatedStatusAcceptsCorrectionSubsetDigest(t *testing.T) {
 	}, &output); err != nil {
 		t.Fatalf("status rejected a correction path restored exactly to base: %v\n%s", err, output.String())
 	}
+	status = ReviewTargetStatusResult{}
 	decodeStrictReviewJSON(t, output.Bytes(), &status)
 	if status.ValidationRequest == nil ||
 		!slices.Equal(status.ValidationRequest.CorrectionPaths, []string{"corrected.go"}) ||

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -606,7 +606,6 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 			result.ValidationRequest.TargetIdentity != result.Projection.InitialSnapshotIdentity ||
 			result.ValidationRequest.Projection != result.Projection.Projection ||
 			result.ValidationRequest.CorrectionCandidateTree != result.Projection.CurrentCandidateTree ||
-			!reviewStatusPathsContain(result.Projection.Paths, result.ValidationRequest.CorrectionPaths) ||
 			reviewtransaction.ValidateTargetedValidationRequest(*result.ValidationRequest) != nil {
 			return errors.New("negotiated status validation request is invalid")
 		}
@@ -1250,19 +1249,6 @@ func manifestPathsForStatus(entries []reviewtransaction.ChangedPathManifestEntry
 		paths[index] = entry.Path
 	}
 	return paths
-}
-
-func reviewStatusPathsContain(candidate, correction []string) bool {
-	available := make(map[string]struct{}, len(candidate))
-	for _, value := range candidate {
-		available[value] = struct{}{}
-	}
-	for _, value := range correction {
-		if _, exists := available[value]; !exists {
-			return false
-		}
-	}
-	return len(correction) > 0
 }
 
 func reviewTransitionValidationRequest(transition *ReviewNextTransition) *reviewtransaction.TargetedValidationRequest {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3321

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Allow negotiated STATUS to represent corrections that restore a frozen path exactly to base.
- Keep correction scope authority in the native `GenesisPaths` admission boundary instead of reconstructing it from the current base-to-candidate projection.
- Add unit and driven black-box coverage for deleting a candidate-only file through evidence capture, targeted validation, approval, and atomic burn.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_status_contract.go` | Removes the invalid `correction_paths ⊆ projection.paths` output check and its dead helper. |
| `internal/cli/review_repository_context_test.go` | Reproduces STATUS after a corrected file returns byte-identically to base. |
| `bench/journeys_issue3321.go` | Adds driven journey `j113` for a candidate-only file deletion. |
| Benchmark registration and CI | Registers, manifests, and requires `j113` in portable benchmark evidence. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** el Gentleman in Pi; `openai-codex/gpt-5.6-sol`

**Material scope:** Root-cause diagnosis, implementation, unit and benchmark test authoring, verification orchestration, and PR drafting.

**Verification performed:** Genuine RED on the clean `main` fixture; focused and full uncached Go tests; Go vet and format checks; deadcode, review capability, and contract-package checks; Windows compilation; driven `j113`; full 77-journey portable corpus; native high-risk 4R review with terminal approval and burn.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/cli ./internal/reviewtransaction -count=1
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests**

Docker E2E was not run locally. The PR CI remains authoritative for that environment.

**Benchmark Validation**
```bash
cd bench
go vet ./...
go test ./... -count=1
go build -o "$RUNNER_TEMP/gentle-ai-bench" .
cd ..
go build -trimpath -o "$RUNNER_TEMP/gentle-ai" ./cmd/gentle-ai
"$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j113-correction-removes-candidate-only-path
"$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai"
```

Driven result: `77 completed, 0 unsupported, 0 failed`.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass locally (`cd e2e && ./docker-test.sh`) — delegated to CI
- [x] Manually tested locally through the real driven review lifecycle

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines: 126 total
- [x] I have added exactly one `type:*` label: `type:bug`
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass locally — CI will execute the repository workflow
- [x] Benchmark validation completed
- [x] No documentation update is required; behavior is internal and covered by contract plus journey evidence
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- [x] The removed check was a duplicate governance guard with the wrong population: valid frozen-to-current correction paths may disappear from the current base-to-candidate projection.
- [x] The authoritative scope guard remains in `BuildTargetedValidationRequest`: `admitCorrectionScope(fix.Paths, state.GenesisPaths)` runs before STATUS receives the request.
- [x] The legitimate population is proven by issue #3321, the live blocked correction lineage, the clean-main RED, and driven journey `j113`.
- [x] No `guard:population` claim or `.guard-population-baseline.txt` entry existed for the removed helper, so the baseline remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected validation for reviewed files restored to their base content.
  - Candidate-only paths can now be removed while remaining included in targeted correction validation.
  - Improved handling of correction status and lineage completion.

- **Tests**
  - Added regression coverage for corrections that remove candidate-only paths.
  - Expanded benchmark and evidence checks to verify the new review scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->