### PR TITLE
fix(review): name runnable disable exit on unadmitted damaged-store recovery edges

### DIFF
--- a/internal/reviewtransaction/compact_inspect.go
+++ b/internal/reviewtransaction/compact_inspect.go
@@ -247,7 +247,8 @@ func SanctionedCompactRecoveryExits(ctx context.Context, repo string, report Com
 		default:
 			exit.Blocked = "no advertised operation admits this edge: `review abandon` does not accept the successor, and no other operation applies to this anomaly class. " +
 				"Nothing quarantines this shape today, so no command clears it and the entry stays exactly as persisted. " +
-				"This report, with non_reconcilable_reason (or anomaly_classes, for a class reconciliation used to admit before it retired), is the artifact to escalate"
+				"This report, with non_reconcilable_reason (or anomaly_classes, for a class reconciliation used to admit before it retired), is the artifact to escalate. " +
+				"To bypass review authority and unblock delivery, run `gentle-ai review mode disable --scope clone --cwd <repo>` (omitting --scope disables it for every repository on the machine)"
 		}
 		exits = append(exits, exit)
 	}

--- a/internal/reviewtransaction/compact_inspect.go
+++ b/internal/reviewtransaction/compact_inspect.go
@@ -248,7 +248,7 @@ func SanctionedCompactRecoveryExits(ctx context.Context, repo string, report Com
 			exit.Blocked = "no advertised operation admits this edge: `review abandon` does not accept the successor, and no other operation applies to this anomaly class. " +
 				"Nothing quarantines this shape today, so no command clears it and the entry stays exactly as persisted. " +
 				"This report, with non_reconcilable_reason (or anomaly_classes, for a class reconciliation used to admit before it retired), is the artifact to escalate. " +
-				"To bypass review authority and unblock delivery, run `gentle-ai review mode disable --scope clone --cwd <repo>` (omitting --scope disables it for every repository on the machine)"
+				"To bypass review authority and unblock delivery, run `gentle-ai review mode disable --scope clone --cwd .` (omitting --scope disables it for every repository on the machine)"
 		}
 		exits = append(exits, exit)
 	}

--- a/internal/reviewtransaction/compact_inspect_test.go
+++ b/internal/reviewtransaction/compact_inspect_test.go
@@ -331,6 +331,36 @@ func TestSanctionedCompactRecoveryExitsDamagedStoreBlockedContainsDisableExit(t 
 	}
 }
 
+func TestSanctionedCompactRecoveryExitsUnchangedTargetOnlyBlockedContainsDisableExit(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	// Create unchanged_target edge with valid authorization: root -> child -> grandchild
+	_, _, child, _ := inspectRecoveryPair(t, repo, "child-unchanged", true, "")
+	_, _ = inspectRecoverySuccessor(t, repo, child, "grandchild-unchanged", "")
+
+	report, err := InspectCompactRecoveryEdges(ctx, repo)
+	inspectNoError(t, err)
+
+	exits, err := SanctionedCompactRecoveryExits(ctx, repo, report)
+	inspectNoError(t, err)
+
+	foundBlocked := false
+	for _, exit := range exits {
+		if exit.SuccessorLineageID == "child-unchanged-successor" {
+			if exit.Operation != "" {
+				t.Fatalf("child exit operation = %q, want empty (Blocked)", exit.Operation)
+			}
+			if !strings.Contains(exit.Blocked, "gentle-ai review mode disable --scope clone --cwd <repo>") {
+				t.Fatalf("exit.Blocked does not name runnable disable exit: %q", exit.Blocked)
+			}
+			foundBlocked = true
+		}
+	}
+	if !foundBlocked {
+		t.Fatalf("did not find child-unchanged-successor in exits: %#v", exits)
+	}
+}
+
 func inspectNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/internal/reviewtransaction/compact_inspect_test.go
+++ b/internal/reviewtransaction/compact_inspect_test.go
@@ -299,6 +299,38 @@ func inspectedEdge(t *testing.T, report CompactRecoveryInspectionReport, success
 	t.Fatalf("edge %q was omitted: %#v", successor, report.Edges)
 	return CompactRecoveryEdgeInspection{}
 }
+
+func TestSanctionedCompactRecoveryExitsDamagedStoreBlockedContainsDisableExit(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+	// Create a graph with root -> child -> grandchild where child and grandchild are invalid edges.
+	// Removing grandchild is fine, but removing child would orphan grandchild, so child's exit is Blocked!
+	_, _, child, _ := inspectRecoveryPair(t, repo, "child", true, "legacy malformed authorization")
+	_, _ = inspectRecoverySuccessor(t, repo, child, "grandchild", "legacy malformed authorization")
+
+	report, err := InspectCompactRecoveryEdges(ctx, repo)
+	inspectNoError(t, err)
+
+	exits, err := SanctionedCompactRecoveryExits(ctx, repo, report)
+	inspectNoError(t, err)
+
+	foundBlocked := false
+	for _, exit := range exits {
+		if exit.SuccessorLineageID == "child-successor" {
+			if exit.Operation != "" {
+				t.Fatalf("child exit operation = %q, want empty (Blocked)", exit.Operation)
+			}
+			if !strings.Contains(exit.Blocked, "gentle-ai review mode disable --scope clone --cwd <repo>") {
+				t.Fatalf("exit.Blocked does not name runnable disable exit: %q", exit.Blocked)
+			}
+			foundBlocked = true
+		}
+	}
+	if !foundBlocked {
+		t.Fatalf("did not find child-successor in exits: %#v", exits)
+	}
+}
+
 func inspectNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/internal/reviewtransaction/compact_inspect_test.go
+++ b/internal/reviewtransaction/compact_inspect_test.go
@@ -320,7 +320,7 @@ func TestSanctionedCompactRecoveryExitsDamagedStoreBlockedContainsDisableExit(t 
 			if exit.Operation != "" {
 				t.Fatalf("child exit operation = %q, want empty (Blocked)", exit.Operation)
 			}
-			if !strings.Contains(exit.Blocked, "gentle-ai review mode disable --scope clone --cwd <repo>") {
+			if !strings.Contains(exit.Blocked, "gentle-ai review mode disable --scope clone --cwd .") {
 				t.Fatalf("exit.Blocked does not name runnable disable exit: %q", exit.Blocked)
 			}
 			foundBlocked = true
@@ -350,7 +350,7 @@ func TestSanctionedCompactRecoveryExitsUnchangedTargetOnlyBlockedContainsDisable
 			if exit.Operation != "" {
 				t.Fatalf("child exit operation = %q, want empty (Blocked)", exit.Operation)
 			}
-			if !strings.Contains(exit.Blocked, "gentle-ai review mode disable --scope clone --cwd <repo>") {
+			if !strings.Contains(exit.Blocked, "gentle-ai review mode disable --scope clone --cwd .") {
 				t.Fatalf("exit.Blocked does not name runnable disable exit: %q", exit.Blocked)
 			}
 			foundBlocked = true


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2422

## 🏷️ PR Type

- [x] `type:bug`

## 📝 Summary

- Names the runnable scoped disable exit (`gentle-ai review mode disable --scope clone --cwd <repo>`) on `SanctionedCompactRecoveryExits` default `Blocked` fallthrough for invalid recovery edges that cannot be repaired or abandoned.
- Prevents dead-end terminal states in accordance with the repository's blocking-budget and exit-naming policies.
- Adds regression unit test verifying `SanctionedCompactRecoveryExits` returns the runnable exit in its `Blocked` diagnosis.

## 📋 Changes Table

| File | Change |
|------|--------|
| `internal/reviewtransaction/compact_inspect.go` | Appended scoped disable exit guidance to `SanctionedCompactRecoveryExits` default blocked text |
| `internal/reviewtransaction/compact_inspect_test.go` | Added `TestSanctionedCompactRecoveryExitsDamagedStoreBlockedContainsDisableExit` regression test |

## 🧪 Test Plan

- [x] `go test -v ./internal/reviewtransaction -run "^TestSanctionedCompact" -count=1` passes
- [x] `go test -v ./internal/cli -run "^TestEvery" -count=1` passes (refusal resolution ratchet & structural continuation checks)
- [x] `go test -v ./internal/cli -run "^TestReviewInspectAuthority" -count=1` passes

## 📋 Contributor Checklist

- [x] Linked an approved issue (`Closes #2422`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocked-exit diagnostics with clear escalation guidance.
  * Added the runnable command for disabling review mode, including its scope behavior.
  * Corrected compact recovery diagnostics for damaged and unchanged recovery states by identifying blocked intermediate exits and omitting unsupported operations.

* **Tests**
  * Added regression coverage for blocked exits and clone-scope review mode disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->