### PR TITLE
fix(sdd): support legacy Git object format lookup

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -711,6 +711,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, sddSharedScaffoldingJourneys()...)
 	journeys = append(journeys, sddPostReviewVerifyReportJourneys()...)
 	journeys = append(journeys, issue3564Journeys()...)
+	journeys = append(journeys, issue3541Journeys()...)
 	journeys = append(journeys, issue3321Journeys()...)
 	journeys = append(journeys, handoffJourneys()...)
 	journeys = removeRetiredAtomicJourneys(journeys)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -61,6 +61,7 @@ func journeySources() []journeySource {
 		{"journeys_sdd_shared_scaffolding.go", sddSharedScaffoldingJourneys()},
 		{"journeys_sdd_post_review_verify_report.go", sddPostReviewVerifyReportJourneys()},
 		{"journeys_issue3564.go", issue3564Journeys()},
+		{"journeys_issue3541.go", issue3541Journeys()},
 		{"journeys_issue3321.go", issue3321Journeys()},
 	}
 	for index := range sources {

--- a/bench/journeys_issue3541.go
+++ b/bench/journeys_issue3541.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// issue3541Journeys drives the compiled product through settlement while Git
+// reproduces the pre-2.38 successful echo of --show-object-format. The product
+// must use the repository-local object-format config instead of that probe.
+func issue3541Journeys() []Journey {
+	return []Journey{{
+		ID:     "j114-sdd-attempt-settle-uses-local-object-format-config",
+		Review: reviewUntouched,
+		Title:  "SDD attempt settlement ignores the legacy Git object-format probe",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/3541",
+		Steps: []Step{
+			{Name: "fixture: repository with a committed OpenSpec change", Fixture: sddRuntimeRepo},
+			{Name: "fixture: Git echoes the unsupported object-format probe", Fixture: issue3541LegacyGitFixture},
+			{Name: "acquire a bounded SDD attempt", Requires: sddAttemptRemediationCapability, Composite: issue3541Acquire},
+			{Name: "settle the attempt despite the legacy Git probe", Requires: sddAttemptRemediationCapability, Composite: issue3541Settle},
+		},
+	}}
+}
+
+func issue3541LegacyGitFixture(sandbox *Sandbox) error {
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		return err
+	}
+	bin := filepath.Join(sandbox.Root, "legacy-git-bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		return err
+	}
+	name := "git"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(bin, name)
+	source := "package main\nimport (\"os\"; \"os/exec\")\nconst realGit = " + strconv.Quote(realGit) + `
+func main() {
+	for _, arg := range os.Args[1:] {
+		if arg == "--show-object-format" {
+			_, _ = os.Stdout.WriteString("--show-object-format\n")
+			return
+		}
+	}
+	command := exec.Command(realGit, os.Args[1:]...)
+	command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := command.Run(); err != nil {
+		if exit, ok := err.(*exec.ExitError); ok {
+			os.Exit(exit.ExitCode())
+		}
+		panic(err)
+	}
+}
+`
+	sourcePath := filepath.Join(bin, "main.go")
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		return err
+	}
+	if output, err := exec.Command("go", "build", "-o", path, sourcePath).CombinedOutput(); err != nil {
+		return fmt.Errorf("build legacy Git shim: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	sandbox.PathOverride = bin
+	return nil
+}
+
+func issue3541Acquire(r *journeyRun) error {
+	observation := r.run(append([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", "issue3541-acquire",
+	}, sddChainVerifyObjective...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil ||
+		observation.ExitCode != 0 || result.State != "proceed" || result.Token == "" {
+		return fmt.Errorf("legacy-Git acquire = %#v exit=%d err=%v", result, observation.ExitCode, err)
+	}
+	r.sandbox.Scratch["issue3541-token"] = result.Token
+	return nil
+}
+
+func issue3541Settle(r *journeyRun) error {
+	token := r.sandbox.Scratch["issue3541-token"]
+	if token == "" {
+		return errors.New("legacy-Git journey has no attempt token")
+	}
+	observation := r.run(append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--token", token, "--request-id", "issue3541-settle", "--outcome", "passed",
+		"--evidence-revision", sddCorrectedEvidence,
+	}, sddTerminalEvidence...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil ||
+		observation.ExitCode != 0 || result.State != "complete" || result.Reason == "authority_failure" {
+		return fmt.Errorf("legacy-Git settle = %#v exit=%d err=%v", result, observation.ExitCode, err)
+	}
+	return nil
+}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -29,6 +29,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j111-approved-transaction-burns-and-shipped-gates-are-unmanaged":           reviewOptedIn,
 	"j112-sdd-attempt-settle-survives-review-mode-transition":                   reviewUntouched,
 	"j113-correction-removes-candidate-only-path":                               reviewOptedIn,
+	"j114-sdd-attempt-settle-uses-local-object-format-config":                   reviewUntouched,
 	"j12-rejected-capture-then-recapture":                                       reviewOptedIn,
 	"j13-next-transition-runs-verbatim":                                         reviewOptedIn,
 	"j14-abandon-needs-a-hand-built-token":                                      reviewOptedIn,

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -19,6 +19,7 @@ j110-untracked-terminal-burn-and-unmanaged-staged-validation
 j111-approved-transaction-burns-and-shipped-gates-are-unmanaged
 j112-sdd-attempt-settle-survives-review-mode-transition
 j113-correction-removes-candidate-only-path
+j114-sdd-attempt-settle-uses-local-object-format-config
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token

--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -306,13 +306,9 @@ func isolatedImmutableTreeGitWithAttributesFile(ctx context.Context, repo string
 	if err != nil {
 		return nil, "", func() error { return nil }, err
 	}
-	objectFormatOutput, err := runGit(ctx, identity.RepositoryRoot, nil, nil, "rev-parse", "--show-object-format")
+	objectFormat, err := repositoryObjectFormat(ctx, identity.RepositoryRoot)
 	if err != nil {
 		return nil, "", func() error { return nil }, err
-	}
-	objectFormat := strings.TrimSpace(string(objectFormatOutput))
-	if objectFormat != "sha1" && objectFormat != "sha256" {
-		return nil, "", func() error { return nil }, fmt.Errorf("unsupported Git object format %q", objectFormat)
 	}
 	// The repository Git directory is the reliable writable location when a
 	// sandboxed caller does not expose an accessible process temp directory.
@@ -366,6 +362,27 @@ func isolatedImmutableTreeGitWithAttributesFile(ctx context.Context, repo string
 		"GIT_ATTR_NOSYSTEM=1",
 		"LANG=C",
 	}, emptyFiles[2], cleanup, nil
+}
+
+func repositoryObjectFormat(ctx context.Context, repo string) (string, error) {
+	output, err := runGit(ctx, repo, nil, nil, "config", "--local", "--get", "extensions.objectFormat")
+	if err != nil {
+		var commandErr *GitCommandError
+		if errors.As(err, &commandErr) && commandErr.ExitCode == 1 {
+			return "sha1", nil
+		}
+		return "", err
+	}
+	return parseRepositoryObjectFormat(output)
+}
+
+func parseRepositoryObjectFormat(output []byte) (string, error) {
+	objectFormat := strings.TrimSuffix(string(output), "\n")
+	if strings.Contains(objectFormat, "\n") || objectFormat != strings.TrimSpace(objectFormat) ||
+		(objectFormat != "sha1" && objectFormat != "sha256") {
+		return "", fmt.Errorf("unsupported Git object format %q", objectFormat)
+	}
+	return objectFormat, nil
 }
 
 func validateChangedPathManifestEntry(entry ChangedPathManifestEntry) error {

--- a/internal/reviewtransaction/git_authority_path_test.go
+++ b/internal/reviewtransaction/git_authority_path_test.go
@@ -115,6 +115,79 @@ func TestReviewAuthorityRootRejectsLegacyOptionEchoWithoutMutation(t *testing.T)
 	}
 }
 
+func TestChangedLinesFallsBackToSHA1WhenLocalObjectFormatIsUnset(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "changed\n")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(t.Context(), Target{Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := gitCommandContext
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		switch {
+		case slicesContain(args, "config") && slicesContain(args, "--local") && slicesContain(args, "extensions.objectFormat"):
+			return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitObjectFormatMissingHelperProcess$")
+		case slicesContain(args, "--show-object-format"):
+			return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitObjectFormatEchoHelperProcess$")
+		default:
+			return original(ctx, name, args...)
+		}
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	lines, err := (SnapshotBuilder{Repo: repo}).ChangedLines(t.Context(), snapshot)
+	if err != nil || lines != 2 {
+		t.Fatalf("ChangedLines() = %d, %v; want 2, nil", lines, err)
+	}
+}
+
+func TestParseRepositoryObjectFormatAcceptsOnlySupportedValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    string
+		wantErr string
+	}{
+		{name: "explicit SHA-1", output: "sha1\n", want: "sha1"},
+		{name: "explicit SHA-256", output: "sha256\n", want: "sha256"},
+		{name: "empty output", output: "\n", wantErr: `unsupported Git object format ""`},
+		{name: "multiple values", output: "sha1\nsha256\n", wantErr: "unsupported Git object format"},
+		{name: "malformed value", output: " sha1\n", wantErr: "unsupported Git object format"},
+		{name: "unknown value", output: "sha512\n", wantErr: `unsupported Git object format "sha512"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRepositoryObjectFormat([]byte(tt.output))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseRepositoryObjectFormat() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Fatalf("parseRepositoryObjectFormat() = %q, %v; want %q, nil", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepositoryObjectFormatPreservesOtherGitCommandFailures(t *testing.T) {
+	original := gitCommandContext
+	t.Setenv("GENTLE_AI_TEST_GIT_PATH_FAIL", "1")
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$")
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	_, err := repositoryObjectFormat(t.Context(), t.TempDir())
+	var commandErr *GitCommandError
+	if !errors.As(err, &commandErr) || commandErr.ExitCode != 23 {
+		t.Fatalf("repositoryObjectFormat() error = %T %v, want GitCommandError exit 23", err, err)
+	}
+}
+
 func TestResolveRepositoryRootRejectsUnrelatedAbsoluteOutput(t *testing.T) {
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)
@@ -390,8 +463,12 @@ func TestGitAuthorityPathHelperProcess(t *testing.T) {
 		os.Exit(23)
 	}
 	encoded := os.Getenv("GENTLE_AI_TEST_GIT_PATH_OUTPUT")
-	if encoded == "" && len(os.Args) > 2 && os.Args[len(os.Args)-2] == "--" {
-		encoded = os.Args[len(os.Args)-1]
+	for index, arg := range os.Args {
+		if arg != "--" || index+1 >= len(os.Args) {
+			continue
+		}
+		encoded = os.Args[index+1]
+		break
 	}
 	if encoded == "" {
 		return
@@ -402,6 +479,30 @@ func TestGitAuthorityPathHelperProcess(t *testing.T) {
 	}
 	_, _ = os.Stdout.Write(payload)
 	os.Exit(0)
+}
+
+func TestGitObjectFormatMissingHelperProcess(t *testing.T) {
+	if !testHelperProcessRequested("TestGitObjectFormatMissingHelperProcess") {
+		return
+	}
+	os.Exit(1)
+}
+
+func TestGitObjectFormatEchoHelperProcess(t *testing.T) {
+	if !testHelperProcessRequested("TestGitObjectFormatEchoHelperProcess") {
+		return
+	}
+	_, _ = os.Stdout.WriteString("--show-object-format\n")
+	os.Exit(0)
+}
+
+func testHelperProcessRequested(name string) bool {
+	for _, arg := range os.Args {
+		if arg == "-test.run=^"+name+"$" {
+			return true
+		}
+	}
+	return false
 }
 
 func slicesContain(values []string, target string) bool {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3541

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- replace the Git 2.38-only object-format probe with repository-local `extensions.objectFormat` lookup
- default an absent object-format key to SHA-1 while preserving SHA-256 setup and typed Git failures
- add focused regressions and a compiled-product bench journey reproducing legacy Git behavior

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/frozen_candidate_context.go` | Resolves repository object format through local Git configuration with bounded validation and SHA-1 fallback. |
| `internal/reviewtransaction/git_authority_path_test.go` | Covers absent config, valid/invalid formats, preserved Git failures, and changed-line settlement behavior. |
| `bench/journeys_issue3541.go` | Drives the compiled product through SDD attempt acquire/settle behind a legacy-Git executable shim. |
| Bench registry and manifest | Registers `j114`, declares review mode, and updates collision/identity coverage. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, and `openai/gpt-5.6-luna`.

**Material scope:** Root-cause mapping, technical design, implementation, regression tests, benchmark journey, independent validation, and PR drafting.

**Verification performed:** Focused Go regressions, bench corpus checks, check-only formatting, diff checks, product/harness builds, and driven execution of journey `j114` against the compiled product.

---

## 🧪 Test Plan

**Focused regression tests**
```bash
go test ./internal/reviewtransaction -run '^(TestChangedLinesFallsBackToSHA1WhenLocalObjectFormatIsUnset|TestParseRepositoryObjectFormatAcceptsOnlySupportedValues|TestRepositoryObjectFormatPreservesOtherGitCommandFailures)$' -count=1
```
Passed.

**Benchmark validation**
```bash
# From bench/
go test ./...
go vet ./...
gentle-ai-bench run --binary <compiled-gentle-ai> --only j114-sdd-attempt-settle-uses-local-object-format-config
```
Passed. Driven summary: `journeys: 1 completed, 0 unsupported, 0 failed`.

**Formatting and diff integrity**
```bash
gofmt -l <changed-go-files>
git diff --check
```
Passed with no output.

The full root `go test ./...` did not complete locally on this Windows host: unchanged package paths waited on Git child processes, and `e2e/organicruntime` requires `sh`, which is unavailable in this environment. Focused package behavior and the compiled-product journey passed; CI remains authoritative for the full suite.

- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | Body contains `Closes #3541` |
| Check Issue Has `status:approved` | ⏳ | Issue #3541 was approved before implementation |
| Check PR Has `type:*` Label | ⏳ | `type:bug` is applied |
| Unit Tests | ⏳ | CI pending |
| Go Format | ⏳ | CI pending |
| E2E Tests | ⏳ | CI pending |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Approved design: https://github.com/Gentleman-Programming/gentle-ai/issues/3541#issuecomment-5383339293

The repository's Git 2.38+ full-product prerequisite remains unchanged. This fix only removes an avoidable 2.38-only probe from paths that need object-format discovery.

The object-format validation population was challenged against real Git configuration semantics: absent local key maps to SHA-1, explicit `sha1`/`sha256` pass, and malformed values or non-missing command failures fail closed. `.guard-population-baseline.txt` is unchanged because this helper decodes repository configuration rather than changing review authority or admission policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository review operations now reliably determine the configured Git object format from local settings.
  * Added a safe SHA-1 fallback when no local format is configured.
  * Unsupported, malformed, or ambiguous object-format values are rejected clearly while preserving other Git errors.

* **Tests**
  * Added end-to-end coverage for acquiring and settling review attempts with repository-local configuration.
  * Expanded validation for supported formats, fallback behavior, command failures, and response outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->