### PR TITLE
fix(guidance): require change intent before implementation

### DIFF
--- a/internal/components/agentguidance/inject_test.go
+++ b/internal/components/agentguidance/inject_test.go
@@ -59,6 +59,9 @@ func TestInjectRoutingInstallsGuidanceForEverySupportedAgent(t *testing.T) {
 			if !strings.Contains(written, "<!-- /gentle-ai:"+RoutingSectionID+" -->") {
 				t.Fatalf("InjectRouting(%q) did not close the managed section:\n%s", agent.ID, written)
 			}
+			if !strings.Contains(written, "First establish whether the requested outcome explicitly authorizes a change.") {
+				t.Fatalf("InjectRouting(%q) did not deliver the outcome-authorization guard:\n%s", agent.ID, written)
+			}
 		})
 	}
 }

--- a/internal/components/agentguidance/routing.go
+++ b/internal/components/agentguidance/routing.go
@@ -38,8 +38,10 @@ func RenderRouting(agent model.AgentID) (string, error) {
 
 	var output strings.Builder
 	output.WriteString("## Implementation Routing\n\n")
-	output.WriteString("Route work for the requested outcome with the smallest useful topology. ")
-	output.WriteString("Every change takes exactly one implementation route: direct inline, delegated direct, or optional SDD.\n\n")
+	output.WriteString("First establish whether the requested outcome explicitly authorizes a change. Investigation, explanation, review, audit, comparison, and solution-proposal or planning-only requests are read-only unless the user explicitly requests implementation or another mutation.\n")
+	output.WriteString("- Read-only work may inspect, explain, compare, and recommend, but must not write or edit files, delegate a writer, invoke apply, or create implementation artifacts.\n")
+	output.WriteString("- If change intent is ambiguous or conditional, ask one clarification and remain read-only until answered.\n\n")
+	output.WriteString("After explicit change intent is established, route work for the requested outcome with the smallest useful topology. Every authorized change takes exactly one implementation route: direct inline, delegated direct, or optional SDD.\n\n")
 
 	_, _ = fmt.Fprintf(
 		&output,
@@ -55,6 +57,7 @@ func RenderRouting(agent model.AgentID) (string, error) {
 	)
 	output.WriteString("- **Optional SDD:** propose SDD only when durable proposal, spec, design, and tasks would materially reduce substantial ambiguity. SDD is selected only by an explicit request or an accepted proposal.\n")
 	output.WriteString("- File count, changed lines, size, or perceived risk alone never selects SDD and never forces a heavier route.\n")
+	output.WriteString("- Automatic SDD pace is not mutation authorization; once implementation is explicitly authorized, it continues under the selected route.\n")
 	output.WriteString("- These are implementation routes, not a ban on per-action delegation. Tests, builds, installs, and review actors may still use fresh workers without changing the selected route.\n")
 	output.WriteString("- Direct and delegated work never create SDD artifacts, prompts, phase attempts, or synthetic SDD runs.\n")
 

--- a/internal/components/agentguidance/routing_test.go
+++ b/internal/components/agentguidance/routing_test.go
@@ -114,6 +114,41 @@ func TestRenderRoutingKeepsSDDSelectionExplicit(t *testing.T) {
 	}
 }
 
+func TestRenderRoutingAuthorizesOutcomesBeforeSelectingTopology(t *testing.T) {
+	t.Parallel()
+
+	for _, agent := range catalog.AllAgents() {
+		t.Run(string(agent.ID), func(t *testing.T) {
+			t.Parallel()
+
+			rendered, err := RenderRouting(agent.ID)
+			if err != nil {
+				t.Fatalf("RenderRouting(%q) error = %v", agent.ID, err)
+			}
+
+			guard := "First establish whether the requested outcome explicitly authorizes a change."
+			guardOffset := strings.Index(rendered, guard)
+			topologyOffset := strings.Index(rendered, "**Direct inline:**")
+			if guardOffset < 0 || topologyOffset < 0 || guardOffset > topologyOffset {
+				t.Fatalf("RenderRouting(%q) must place outcome authorization before topology:\n%s", agent.ID, rendered)
+			}
+
+			for _, want := range []string{
+				"Investigation, explanation, review, audit, comparison, and solution-proposal or planning-only requests are read-only",
+				"must not write or edit files, delegate a writer, invoke apply, or create implementation artifacts",
+				"If change intent is ambiguous or conditional, ask one clarification and remain read-only until answered.",
+				"After explicit change intent is established",
+				"SDD is selected only by an explicit request or an accepted proposal.",
+				"Automatic SDD pace is not mutation authorization",
+			} {
+				if !strings.Contains(rendered, want) {
+					t.Fatalf("RenderRouting(%q) is missing outcome-authorization clause %q:\n%s", agent.ID, want, rendered)
+				}
+			}
+		})
+	}
+}
+
 // TestRenderRoutingMakesTheReviewKillSwitchDiscoverable guards the product
 // promise that configuring an agent tells it what it may do. The kill switch is
 // only real for the user if every configured agent can name it, so the exact

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
 	windsurfagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/windsurf"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	opencodemodel "github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	// agents/cursor, agents/gemini, agents/vscode used via agents.NewAdapter()
@@ -1167,6 +1168,34 @@ PRESERVE_THIS_UNRELATED_SECTION exactly as authored.
 		firstEnd := min(len(prompt), diffAt+160)
 		secondEnd := min(len(secondPrompt), diffAt+160)
 		t.Fatalf("preserved v1 Review Execution Contract migration is not idempotent at byte %d\nfirst:  %q\nsecond: %q", diffAt, prompt[start:firstEnd], secondPrompt[start:secondEnd])
+	}
+}
+
+func TestInjectOpenCodePreservesRoutingGuardAcrossMigratedPrompt(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	seed := `{"agent":{"gentle-orchestrator":{"prompt":"Bind this to the dedicated \u0060sdd-orchestrator\u0060 agent only."}}}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	if _, err := agentguidance.InjectRouting(home, model.AgentOpenCode); err != nil {
+		t.Fatalf("InjectRouting() error = %v", err)
+	}
+	if _, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{PreserveOpenCodeOrchestratorPrompt: true}); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	prompt := readGentleOrchestratorPrompt(t, settingsPath)
+	const guard = "First establish whether the requested outcome explicitly authorizes a change."
+	if got := strings.Count(prompt, guard); got != 1 {
+		t.Fatalf("migrated OpenCode prompt contains the routing guard %d times, want 1:\n%s", got, prompt)
+	}
+	if !strings.Contains(prompt, "Bind this to the dedicated `gentle-orchestrator` agent only.") {
+		t.Fatalf("migrated OpenCode prompt lost its orchestrator migration:\n%s", prompt)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #608

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Classifies whether the requested outcome authorizes mutation before selecting an implementation topology.
- Keeps investigation, explanation, review, audit, comparison, and planning-only requests read-only until implementation is explicitly requested.
- Preserves direct, delegated, and SDD implementation while preventing automatic SDD pace from acting as mutation consent.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/agentguidance/routing.go` | Adds the canonical outcome-authorization guard before implementation routing. |
| `internal/components/agentguidance/routing_test.go` | Verifies guard ordering and semantics for every supported adapter. |
| `internal/components/agentguidance/inject_test.go` | Verifies every adapter receives the canonical guard. |
| `internal/components/sdd/inject_test.go` | Verifies OpenCode preserved-prompt migration retains exactly one guard. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with OpenAI GPT-5.6 Sol, Luna, and Terra profiles.

**Material scope:** Root-cause analysis, implementation, regression tests, verification, and PR preparation.

**Verification performed:** Focused Go tests, formatting check, whitespace validation, diff inspection, and an attempted full repository test run.

---

## 🧪 Test Plan

- [x] `go test ./internal/components/agentguidance ./internal/components/sdd`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`
- [ ] `go test ./...` — attempted locally. `e2e/organicruntime` passed after adding the installed Git Bash shell to PATH, but unrelated packages hit existing 10-minute timeouts and environment-sensitive update/upgrade failures. CI remains authoritative.
- [ ] Docker E2E — N/A: this changes generated agent guidance and injection tests, not container/runtime behavior.
- [x] Benchmark validation — N/A: no review lifecycle, gate, recovery, delivery, benchmark corpus, or classifier behavior changed.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added exactly one `type:*` label
- [ ] Unit tests pass (`go test ./...`) — focused tests pass; full local limitations are documented above
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass — Docker E2E is not applicable to this change
- [x] Benchmark validation completed, or this change is not applicable
- [x] Documentation was updated where necessary; the changed product surface is the canonical guidance itself
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This fixes the root contract gap rather than copying an explanation-first sentence into each provider asset. The always-installed canonical routing block now establishes outcome authorization before topology, and tests prove cross-provider delivery plus OpenCode migration behavior.

This replaces the remaining intent-gating scope from the now-closed #1486 against current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent guidance to distinguish read-only requests from explicitly authorized changes.
  - Agents now request clarification when change authorization is ambiguous and avoid mutation or delegation until authorization is confirmed.
  - Automatic SDD pacing no longer implies permission to make changes.
  - Explicitly authorized implementations continue using the selected workflow.
  - Updated guidance remains consistent across supported agents and routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->