### PR TITLE
fix(sdd): share Engram identity across worktrees

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -345,6 +345,7 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"skills/judgment-day/references/prompts-and-formats.md",
 		"skills/_shared/persistence-contract.md",
 		"skills/_shared/engram-convention.md",
+		"skills/_shared/engram-project-identity.md",
 		"skills/_shared/openspec-convention.md",
 		"skills/_shared/sdd-phase-common.md",
 		"skills/_shared/sdd-status-contract.md",

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1509,6 +1509,19 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 	}
 }
 
+func TestEngramConventionReusesResolvedProjectUnchanged(t *testing.T) {
+	content := MustRead("skills/_shared/engram-convention.md")
+	for _, want := range []string{
+		"`ENGRAM_PROJECT`, `--project`, and lowercase/trim normalization are resolver inputs or behavior only before `mem_current_project` returns.",
+		"every explicit Engram call and phase handoff MUST reuse the cached project unchanged.",
+		"Do not re-override, renormalize, rediscover, or substitute the workspace basename.",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("engram convention missing canonical-project reuse contract %q", want)
+		}
+	}
+}
+
 func TestClaudeManagedOutputStylesAnchorReplyLanguageToLatestUserRequest(t *testing.T) {
 	tests := []struct {
 		path              string

--- a/internal/assets/claude/commands/sdd-apply.md
+++ b/internal/assets/claude/commands/sdd-apply.md
@@ -9,7 +9,7 @@ The sdd-apply skill (v2.0) supports TDD workflow (RED-GREEN-REFACTOR cycle) when
 
 CONTEXT:
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Artifact store mode: engram
 
 TASK:

--- a/internal/assets/claude/commands/sdd-archive.md
+++ b/internal/assets/claude/commands/sdd-archive.md
@@ -7,7 +7,7 @@ Otherwise, read the skill file at `~/.claude/skills/sdd-archive/SKILL.md` FIRST,
 
 CONTEXT:
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Artifact store mode: engram
 
 TASK:

--- a/internal/assets/claude/commands/sdd-continue.md
+++ b/internal/assets/claude/commands/sdd-continue.md
@@ -18,7 +18,7 @@ WORKFLOW:
 CONTEXT:
 
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 - Execution mode: ask/cache per orchestrator
 - Artifact store mode: ask/cache per orchestrator

--- a/internal/assets/claude/commands/sdd-explore.md
+++ b/internal/assets/claude/commands/sdd-explore.md
@@ -7,7 +7,7 @@ Otherwise, read the skill file at `~/.claude/skills/sdd-explore/SKILL.md` FIRST,
 
 CONTEXT:
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Topic to explore: $ARGUMENTS
 - Artifact store mode: engram
 

--- a/internal/assets/claude/commands/sdd-ff.md
+++ b/internal/assets/claude/commands/sdd-ff.md
@@ -21,7 +21,7 @@ Planning phases:
 CONTEXT:
 
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 - Execution mode: ask/cache per orchestrator
 - Artifact store mode: ask/cache per orchestrator

--- a/internal/assets/claude/commands/sdd-init.md
+++ b/internal/assets/claude/commands/sdd-init.md
@@ -7,7 +7,7 @@ Otherwise, read the skill file at `~/.claude/skills/sdd-init/SKILL.md` FIRST, th
 
 CONTEXT:
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Artifact store mode: engram
 
 TASK:

--- a/internal/assets/claude/commands/sdd-new.md
+++ b/internal/assets/claude/commands/sdd-new.md
@@ -15,7 +15,7 @@ WORKFLOW:
 CONTEXT:
 
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 - Execution mode: ask/cache per orchestrator
 - Artifact store mode: ask/cache per orchestrator

--- a/internal/assets/claude/commands/sdd-onboard.md
+++ b/internal/assets/claude/commands/sdd-onboard.md
@@ -7,7 +7,7 @@ Otherwise, read the skill file at `~/.claude/skills/sdd-onboard/SKILL.md` FIRST,
 
 CONTEXT:
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Artifact store mode: engram
 
 TASK:

--- a/internal/assets/claude/commands/sdd-status.md
+++ b/internal/assets/claude/commands/sdd-status.md
@@ -11,7 +11,7 @@ SDD Session Preflight must already be complete for this session. It must include
 CONTEXT:
 
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 
 TASK:

--- a/internal/assets/claude/commands/sdd-verify.md
+++ b/internal/assets/claude/commands/sdd-verify.md
@@ -7,7 +7,7 @@ Otherwise, read the skill file at `~/.claude/skills/sdd-verify/SKILL.md` FIRST, 
 
 CONTEXT:
 - Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Artifact store mode: engram
 
 TASK:

--- a/internal/assets/opencode/commands/sdd-apply.md
+++ b/internal/assets/opencode/commands/sdd-apply.md
@@ -9,7 +9,7 @@ You are the `gentle-orchestrator`, not an SDD executor. This command is allowed 
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 
 HARD GATES:
 

--- a/internal/assets/opencode/commands/sdd-archive.md
+++ b/internal/assets/opencode/commands/sdd-archive.md
@@ -9,7 +9,7 @@ You are the `gentle-orchestrator`, not an SDD executor. This command may launch 
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 
 HARD GATES:
 

--- a/internal/assets/opencode/commands/sdd-continue.md
+++ b/internal/assets/opencode/commands/sdd-continue.md
@@ -21,7 +21,7 @@ WORKFLOW:
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 - Execution mode: ask/cache per orchestrator
 - Artifact store mode: ask/cache per orchestrator; do not hardcode Engram

--- a/internal/assets/opencode/commands/sdd-explore.md
+++ b/internal/assets/opencode/commands/sdd-explore.md
@@ -9,7 +9,7 @@ You are the `gentle-orchestrator`, not an SDD executor. This command may launch 
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Topic to explore: $ARGUMENTS
 
 HARD GATES:

--- a/internal/assets/opencode/commands/sdd-ff.md
+++ b/internal/assets/opencode/commands/sdd-ff.md
@@ -24,7 +24,7 @@ Planning phases:
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 - Execution mode: ask/cache per orchestrator
 - Artifact store mode: ask/cache per orchestrator; do not hardcode Engram

--- a/internal/assets/opencode/commands/sdd-init.md
+++ b/internal/assets/opencode/commands/sdd-init.md
@@ -9,7 +9,7 @@ You are the `gentle-orchestrator`, not an SDD executor. This command may launch 
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 
 HARD GATES:
 

--- a/internal/assets/opencode/commands/sdd-new.md
+++ b/internal/assets/opencode/commands/sdd-new.md
@@ -18,7 +18,7 @@ WORKFLOW:
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 - Execution mode: ask/cache per orchestrator
 - Artifact store mode: ask/cache per orchestrator; do not hardcode Engram

--- a/internal/assets/opencode/commands/sdd-onboard.md
+++ b/internal/assets/opencode/commands/sdd-onboard.md
@@ -9,7 +9,7 @@ You are the `gentle-orchestrator`, not an SDD executor. This command may launch 
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 
 HARD GATES:
 

--- a/internal/assets/opencode/commands/sdd-status.md
+++ b/internal/assets/opencode/commands/sdd-status.md
@@ -12,7 +12,7 @@ SDD Session Preflight must already be complete for this session. It must include
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 - Change name: $ARGUMENTS
 
 TASK:

--- a/internal/assets/opencode/commands/sdd-verify.md
+++ b/internal/assets/opencode/commands/sdd-verify.md
@@ -9,7 +9,7 @@ You are the `gentle-orchestrator`, not an SDD executor. This command may launch 
 CONTEXT:
 
 - Working directory: before doing anything else, run `git rev-parse --show-toplevel 2>/dev/null || pwd` with your bash tool and use the returned path as the authoritative workspace. In OpenCode Desktop (Electron) the parse-time interpolation resolves to the app data directory, not the project.
-- Current project: the `basename` of the detected workspace above.
+- Logical Engram identity: use the canonical project returned by `mem_current_project`, not the active workspace basename. The injected Engram Project Identity Contract defines caching and fallback behavior.
 
 HARD GATES:
 

--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -127,7 +127,9 @@ mem_search(query: "sdd/{change-name}/", project: "{project}")
 
 ## Project Name Resolution (engram v1.11.0+)
 
-Follow `engram-project-identity.md`: before explicit project-scoped Engram work, call `mem_current_project` once when it is callable and reuse its returned canonical `project`. Do not derive this value from the workspace basename. Engram auto-detects the project name from the Git remote at MCP startup; the `--project` flag and `ENGRAM_PROJECT` environment variable can override detection. All project names are normalized to lowercase and trimmed.
+Follow `engram-project-identity.md`: before explicit project-scoped Engram work, call `mem_current_project` once when it is callable and reuse its returned canonical `project`. Do not derive this value from the workspace basename. `ENGRAM_PROJECT`, `--project`, and lowercase/trim normalization are resolver inputs or behavior only before `mem_current_project` returns.
+
+After canonical resolution, every explicit Engram call and phase handoff MUST reuse the cached project unchanged. Do not re-override, renormalize, rediscover, or substitute the workspace basename.
 
 If the agent saves a memory under a project name that doesn't match existing observations, engram warns about potential name drift. Use `mem_merge_projects` (MCP tool) or `engram projects consolidate` (CLI) to merge variants.
 

--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -10,7 +10,7 @@ ALL SDD artifacts persisted to Engram MUST follow this deterministic naming:
 title:     sdd/{change-name}/{artifact-type}
 topic_key: sdd/{change-name}/{artifact-type}
 type:      architecture
-project:   {detected or current project name}
+project:   {canonical project returned by mem_current_project}
 scope:     project
 capture_prompt: false
 ```
@@ -127,7 +127,7 @@ mem_search(query: "sdd/{change-name}/", project: "{project}")
 
 ## Project Name Resolution (engram v1.11.0+)
 
-Engram auto-detects the project name from the git remote at MCP startup. The `--project` flag and `ENGRAM_PROJECT` env var can override detection. All project names are normalized to lowercase and trimmed.
+Follow `engram-project-identity.md`: before explicit project-scoped Engram work, call `mem_current_project` once when it is callable and reuse its returned canonical `project`. Do not derive this value from the workspace basename. Engram auto-detects the project name from the Git remote at MCP startup; the `--project` flag and `ENGRAM_PROJECT` environment variable can override detection. All project names are normalized to lowercase and trimmed.
 
 If the agent saves a memory under a project name that doesn't match existing observations, engram warns about potential name drift. Use `mem_merge_projects` (MCP tool) or `engram projects consolidate` (CLI) to merge variants.
 

--- a/internal/assets/skills/_shared/engram-project-identity.md
+++ b/internal/assets/skills/_shared/engram-project-identity.md
@@ -1,0 +1,9 @@
+# Engram Project Identity Contract
+
+The active workspace and the logical Engram project are separate identities.
+
+1. Resolve the **active workspace** agent-side with `git rev-parse --show-toplevel`; if it fails, use the existing workspace fallback. Use that returned path for every filesystem read, write, and native command `--cwd`. Never redirect file operations to another checkout because of an Engram project name.
+2. Before the first Engram read or write in a session, when `mem_current_project` is callable, call it once and cache its returned canonical `project`. Use that exact cached value for every explicit Engram `project` argument and every project-scoped topic, including `sdd-init/{project}`. Forward the cached value unchanged to phase agents.
+3. Never derive the logical Engram project from the active workspace basename. A phase agent consumes the cached canonical project supplied by its orchestrator; it does not rediscover or rename it.
+4. If `mem_current_project` is unavailable, reuse an already-supplied canonical project only. Do not invent an explicit project for Engram persistence. When explicit project-scoped persistence is required and no canonical project is available, fail closed and report the unavailable identity.
+5. Native status resolution keeps its established fallback order: `ENGRAM_PROJECT`, then the active workspace's Git remote (including the shared Git configuration for linked worktrees), then the basename only for a non-Git workspace. Agents must not reimplement or weaken that resolver.

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -6,6 +6,7 @@ Executor boundary: every SDD phase agent is an EXECUTOR, not an orchestrator. Do
 
 ## A. Skill Loading
 
+0. Read and follow `skills/_shared/engram-project-identity.md`. The orchestrator supplies its cached canonical Engram project to every phase; use it for all explicit Engram `project` arguments and project-scoped topics.
 1. Check if the orchestrator injected a `## Skills to load before work` block in your launch prompt. If yes, read those exact `SKILL.md` files before task-specific work.
 2. If no skills block was provided, check for `SKILL: Load` instructions. If present, load those exact skill files.
 3. If neither was provided, search for the skill registry as a fallback:

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -633,7 +633,11 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter) ([]string, error) {
 	paths := map[string]struct{}{}
 	for _, component := range selection.Components {
-		for _, path := range syncComponentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
+		componentSelection := selection
+		if component == model.ComponentSDD {
+			_, _, componentSelection.SDDMode = resolveSyncSDDProfileMode(homeDir, selection, adapters)
+		}
+		for _, path := range syncComponentPathsWithWorkspace(homeDir, workspaceDir, componentSelection, adapters, component) {
 			paths[path] = struct{}{}
 		}
 		if component == model.ComponentContext7 {
@@ -1056,39 +1060,7 @@ func (s componentSyncStep) Run() error {
 		return nil
 
 	case model.ComponentSDD:
-		profileStrategy := sdd.ResolveProfileStrategy(s.homeDir, s.selection.SDDProfileStrategy)
-
-		// Resolve profiles for injection:
-		// - When profiles are explicitly provided (TUI/CLI), use them directly.
-		// - On a regular sync (no explicit profiles), detect existing named profiles
-		//   from disk so their orchestrator prompts are refreshed from updated embedded
-		//   assets while model assignments are preserved.
-		profiles := s.selection.Profiles
-		if len(profiles) == 0 && profileStrategy != model.SDDProfileStrategyExternalSingleActive {
-			settingsPath := ""
-			for _, adapter := range adapters {
-				if adapter.Agent() == model.AgentOpenCode {
-					settingsPath = adapter.SettingsPath(s.homeDir)
-					break
-				}
-			}
-			if settingsPath != "" {
-				detected, detectErr := sdd.DetectProfiles(settingsPath)
-				if detectErr == nil {
-					profiles = detected
-				}
-				// If detect fails (e.g. file missing), silently skip — no profiles to refresh.
-			}
-		}
-
-		// If profiles exist (explicit or detected), SDDModeMulti is required:
-		// shared prompt files must be written and {file:...} refs must resolve.
-		sddMode := s.selection.SDDMode
-		if profileStrategy == model.SDDProfileStrategyExternalSingleActive {
-			sddMode = model.SDDModeMulti
-		} else if len(profiles) > 0 && sddMode == "" {
-			sddMode = model.SDDModeMulti
-		}
+		profiles, profileStrategy, sddMode := resolveSyncSDDProfileMode(s.homeDir, s.selection, adapters)
 
 		for _, adapter := range adapters {
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
@@ -1232,6 +1204,32 @@ func (s componentSyncStep) Run() error {
 	default:
 		return fmt.Errorf("component %q is not supported in sync runtime", s.component)
 	}
+}
+
+// resolveSyncSDDProfileMode preserves sync's profile detection and effective
+// SDD-mode rules so backup targets and injection agree on shared prompt writes.
+func resolveSyncSDDProfileMode(homeDir string, selection model.Selection, adapters []agents.Adapter) ([]model.Profile, model.SDDProfileStrategyID, model.SDDModeID) {
+	profileStrategy := sdd.ResolveProfileStrategy(homeDir, selection.SDDProfileStrategy)
+	profiles := selection.Profiles
+	if len(profiles) == 0 && profileStrategy != model.SDDProfileStrategyExternalSingleActive {
+		for _, adapter := range adapters {
+			if adapter.Agent() != model.AgentOpenCode {
+				continue
+			}
+			if settingsPath := adapter.SettingsPath(homeDir); settingsPath != "" {
+				if detected, err := sdd.DetectProfiles(settingsPath); err == nil {
+					profiles = detected
+				}
+			}
+			break
+		}
+	}
+
+	sddMode := selection.SDDMode
+	if profileStrategy == model.SDDProfileStrategyExternalSingleActive || (len(profiles) > 0 && sddMode == "") {
+		sddMode = model.SDDModeMulti
+	}
+	return profiles, profileStrategy, sddMode
 }
 
 // countChanged records candidate changed paths from an aggregate injector result.

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -3001,6 +3001,44 @@ func TestRunSyncExternalSingleActiveSkipsDetectAndPreservesOrchestratorPrompt(t 
 	}
 }
 
+func TestSyncRollbackRestoresSharedPromptsForEffectiveMultiMode(t *testing.T) {
+	home := t.TempDir()
+	original := []byte("custom shared prompt\n")
+	promptDir := filepath.Join(home, ".config", "opencode", "prompts", "sdd")
+	for _, phase := range sdd.SharedPromptPhases() {
+		mustWriteFile(t, filepath.Join(promptDir, phase+".md"), original)
+	}
+	selection := model.Selection{
+		Agents:             []model.AgentID{model.AgentOpenCode},
+		Components:         []model.ComponentID{model.ComponentSDD},
+		SDDMode:            model.SDDModeSingle,
+		SDDProfileStrategy: model.SDDProfileStrategyExternalSingleActive,
+	}
+
+	rt, err := newSyncRuntime(home, selection)
+	if err != nil {
+		t.Fatalf("newSyncRuntime() error = %v", err)
+	}
+	plan := rt.stagePlan()
+	for _, phase := range sdd.SharedPromptPhases() {
+		promptPath := filepath.Join(promptDir, phase+".md")
+		if !containsPath(rt.managedPaths, promptPath) {
+			t.Fatalf("sync backup targets missing effective multi-mode shared prompt %q", promptPath)
+		}
+	}
+	plan.Apply = append(plan.Apply, failingSyncStep{})
+	result := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(plan)
+	if result.Err == nil || !result.Rollback.Success {
+		t.Fatalf("sync execution = %#v, want a successful rollback after forced failure", result)
+	}
+	for _, phase := range sdd.SharedPromptPhases() {
+		promptPath := filepath.Join(promptDir, phase+".md")
+		if got := readTextFile(t, promptPath); got != string(original) {
+			t.Fatalf("restored shared prompt %q = %q, want %q", phase, got, original)
+		}
+	}
+}
+
 // containsAny returns true if s contains any of the given substrings (case-insensitive).
 func containsAny(s string, subs ...string) bool {
 	lower := strings.ToLower(s)

--- a/internal/components/sdd/boundedreview.go
+++ b/internal/components/sdd/boundedreview.go
@@ -75,7 +75,20 @@ func renderSDDOrchestratorAsset(agent model.AgentID, options ...OrchestratorRend
 // hand every runtime the same false identity and walk it straight through the
 // review transport admission check (issue #2440).
 func renderBoundedReviewAsset(agent model.AgentID, path string) string {
-	return bindRuntimeAgentIdentity(renderBoundedReviewAssetBody(agent, path), agent)
+	content := bindRuntimeAgentIdentity(renderBoundedReviewAssetBody(agent, path), agent)
+	if isSDDCommandAsset(path) {
+		return injectEngramProjectIdentityContract(content)
+	}
+	return content
+}
+
+func isSDDCommandAsset(path string) bool {
+	for _, commandDir := range []string{"claude/commands", "opencode/commands"} {
+		if strings.HasPrefix(path, commandDir+"/sdd-") && strings.HasSuffix(path, ".md") {
+			return true
+		}
+	}
+	return false
 }
 
 // bindRuntimeAgentIdentity is the single substitution point every rendered

--- a/internal/components/sdd/engram_project_identity.go
+++ b/internal/components/sdd/engram_project_identity.go
@@ -1,0 +1,21 @@
+package sdd
+
+import (
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+)
+
+const engramProjectIdentityContractAsset = "skills/_shared/engram-project-identity.md"
+
+func engramProjectIdentityContract() string {
+	return strings.TrimSpace(assets.MustRead(engramProjectIdentityContractAsset))
+}
+
+// injectEngramProjectIdentityContract gives every rendered SDD entry point the
+// same workspace-versus-Engram identity contract without duplicating it across
+// provider-specific assets.
+func injectEngramProjectIdentityContract(prompt string) string {
+	return filemerge.InjectMarkdownSection(prompt, "engram-project-identity", engramProjectIdentityContract())
+}

--- a/internal/components/sdd/engram_project_identity_test.go
+++ b/internal/components/sdd/engram_project_identity_test.go
@@ -1,0 +1,104 @@
+package sdd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func requireEngramProjectIdentityContract(t *testing.T, content, client string) {
+	t.Helper()
+	for _, want := range []string{
+		"Engram Project Identity Contract",
+		"mem_current_project",
+		"cache its returned canonical `project`",
+		"every filesystem read, write, and native command `--cwd`",
+		"Never derive the logical Engram project from the active workspace basename",
+		"When explicit project-scoped persistence is required and no canonical project is available, fail closed",
+		"`ENGRAM_PROJECT`, then the active workspace's Git remote",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("%s missing Engram project identity contract %q", client, want)
+		}
+	}
+}
+
+func TestRenderedSDDOrchestratorsUseCanonicalEngramProjectIdentity(t *testing.T) {
+	for _, agent := range catalog.AllAgents() {
+		t.Run(string(agent.ID), func(t *testing.T) {
+			requireEngramProjectIdentityContract(t, renderSDDOrchestratorAsset(agent.ID), string(agent.ID)+" orchestrator")
+		})
+	}
+}
+
+func TestRenderedSDDCommandsDoNotDeriveEngramProjectFromWorkspaceBasename(t *testing.T) {
+	clients := []struct {
+		name  string
+		agent model.AgentID
+		dir   string
+	}{
+		{name: "Claude", agent: model.AgentClaudeCode, dir: "claude/commands"},
+		{name: "OpenCode", agent: model.AgentOpenCode, dir: "opencode/commands"},
+	}
+
+	for _, client := range clients {
+		t.Run(client.name, func(t *testing.T) {
+			entries, err := assets.FS.ReadDir(client.dir)
+			if err != nil {
+				t.Fatalf("ReadDir(%s): %v", client.dir, err)
+			}
+			for _, entry := range entries {
+				if entry.IsDir() || !strings.HasPrefix(entry.Name(), "sdd-") || !strings.HasSuffix(entry.Name(), ".md") {
+					continue
+				}
+				path := client.dir + "/" + entry.Name()
+				source := assets.MustRead(path)
+				if strings.Contains(source, "Current project: Derive agent-side from the detected working directory basename") ||
+					strings.Contains(source, "Current project: the `basename` of the detected workspace above") {
+					t.Fatalf("%s retains the workspace-basename project derivation", path)
+				}
+				for _, want := range []string{"git rev-parse --show-toplevel", "Logical Engram identity:"} {
+					if !strings.Contains(source, want) {
+						t.Fatalf("%s missing workspace/identity separation %q", path, want)
+					}
+				}
+				requireEngramProjectIdentityContract(t, renderBoundedReviewAsset(client.agent, path), path)
+			}
+		})
+	}
+}
+
+func TestRenderedNonSDDCommandDoesNotReceiveEngramProjectIdentity(t *testing.T) {
+	content := renderBoundedReviewAsset(model.AgentOpenCode, "opencode/commands/skill-registry.md")
+	if strings.Contains(content, "Engram Project Identity Contract") {
+		t.Fatal("non-SDD OpenCode command received the Engram project identity contract")
+	}
+}
+
+func TestRenderedSDDPhaseAndClaudeWorkflowReceiveEngramProjectIdentity(t *testing.T) {
+	home := t.TempDir()
+	if _, err := WriteSharedPromptFiles(home, nil); err != nil {
+		t.Fatalf("WriteSharedPromptFiles(): %v", err)
+	}
+	for _, phase := range SharedPromptPhases() {
+		content, err := os.ReadFile(filepath.Join(SharedPromptDir(home), phase+".md"))
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", phase, err)
+		}
+		requireEngramProjectIdentityContract(t, string(content), phase+" shared prompt")
+	}
+
+	if _, err := Inject(home, claudeAdapter(), ""); err != nil {
+		t.Fatalf("Inject(Claude): %v", err)
+	}
+	workflow, err := os.ReadFile(filepath.Join(home, ".claude", "skills", "_shared", "sdd-orchestrator-workflow.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(Claude workflow): %v", err)
+	}
+	requireEngramProjectIdentityContract(t, string(workflow), "Claude lazy workflow")
+}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -702,6 +702,9 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				contentStr = injectCodeGraphToolGrantIntoPrompt(contentStr, adapter.Agent(), opts.CodeGraphGuidanceMarkdown)
 				contentStr = injectCodeGraphGuidanceIntoPrompt(contentStr, opts.CodeGraphGuidanceMarkdown)
 				contentStr = injectLanguageContractIntoPrompt(contentStr)
+				if strings.HasPrefix(entry.Name(), "sdd-") {
+					contentStr = injectEngramProjectIdentityContract(contentStr)
+				}
 			}
 			outPath := filepath.Join(agentsDir, entry.Name())
 			writeResult, err := filemerge.WriteFileAtomic(outPath, []byte(contentStr), 0o644)
@@ -2504,7 +2507,7 @@ func writeClaudeLazySDDWorkflow(homeDir string, adapter agents.Adapter, legacyAs
 		return InjectionResult{}, nil
 	}
 
-	content := assets.MustRead("claude/sdd-orchestrator-workflow.md")
+	content := injectEngramProjectIdentityContract(assets.MustRead("claude/sdd-orchestrator-workflow.md"))
 	if len(legacyAssignments) > 0 || len(phaseAssignments) > 0 {
 		var err error
 		content, err = injectClaudePhaseAssignments(content, legacyAssignments, phaseAssignments)

--- a/internal/components/sdd/orchestrator.go
+++ b/internal/components/sdd/orchestrator.go
@@ -35,7 +35,7 @@ func composeOrchestratorPrompt(agent model.AgentID, options ...OrchestratorRende
 	if policy := renderOpenCodeBackgroundPolicy(agent, renderOptions); policy != "" {
 		content = appendOpenCodeBackgroundPolicy(content, policy)
 	}
-	return bindRuntimeAgentIdentity(renderBoundedReviewAssetBodyFromContent(agent, path, content), agent)
+	return injectEngramProjectIdentityContract(bindRuntimeAgentIdentity(renderBoundedReviewAssetBodyFromContent(agent, path, content), agent))
 }
 
 func renderOpenCodeBackgroundPolicy(agent model.AgentID, options ...OrchestratorRenderOptions) string {

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -15,7 +15,7 @@ func TestCanonicalCompositionPreservesHistoricalOrchestratorBytes(t *testing.T) 
 	for _, agent := range catalog.AllAgents() {
 		t.Run(string(agent.ID), func(t *testing.T) {
 			path := sddOrchestratorAsset(agent.ID)
-			before := renderBoundedReviewAsset(agent.ID, path)
+			before := injectEngramProjectIdentityContract(renderBoundedReviewAsset(agent.ID, path))
 			after := composeOrchestratorPrompt(agent.ID)
 			if after != before {
 				t.Fatalf("canonical composition changed %s orchestrator bytes", agent.ID)

--- a/internal/components/sdd/prompts.go
+++ b/internal/components/sdd/prompts.go
@@ -102,6 +102,7 @@ func WriteSharedPromptFiles(homeDir string, phaseCapabilities map[string]string,
 		// indirection, which the in-settings injection deliberately skips —
 		// the contract must land here or those executors would miss it.
 		content = injectLanguageContractIntoPrompt(content)
+		content = injectEngramProjectIdentityContract(content)
 
 		path := filepath.Join(promptDir, phase+".md")
 		result, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
@@ -214,7 +215,7 @@ func injectCodeGraphGuidanceIntoOpenCodeSubagentPrompts(agentMap map[string]any,
 // Primary-mode agents keep the persona channel's own rules; {file:...}
 // indirections are resolved elsewhere and stay untouched.
 func injectLanguageContractIntoOpenCodeSubagentPrompts(agentMap map[string]any) {
-	for _, agentRaw := range agentMap {
+	for name, agentRaw := range agentMap {
 		agent, ok := agentRaw.(map[string]any)
 		if !ok {
 			continue
@@ -226,6 +227,10 @@ func injectLanguageContractIntoOpenCodeSubagentPrompts(agentMap map[string]any) 
 		if !ok || strings.HasPrefix(prompt, "{file:") {
 			continue
 		}
-		agent["prompt"] = injectLanguageContractIntoPrompt(prompt)
+		prompt = injectLanguageContractIntoPrompt(prompt)
+		if strings.HasPrefix(name, "sdd-") {
+			prompt = injectEngramProjectIdentityContract(prompt)
+		}
+		agent["prompt"] = prompt
 	}
 }

--- a/internal/components/sdd/review_ledger_contract_test.go
+++ b/internal/components/sdd/review_ledger_contract_test.go
@@ -457,7 +457,9 @@ func TestKilocodeReviewSettingsMatchCurrentMainBaseline(t *testing.T) {
 	// renders through the OpenCode orchestrator asset. The hash is rederived.
 	// #3417 also classifies OpenCode background launch acknowledgements as
 	// nonterminal, preventing false task-result failures and session latches.
-	const want = "8b4e161971530355248addfc62fb101d1ea71a5ba4e293b427e85c87a2c535c7"
+	// #702 injects the canonical Engram project identity contract into every
+	// rendered orchestrator, so the hash moved. Deliberate, not drift.
+	const want = "ce62dcf471a18258e50dc04b8d8d2452d879ea24efd68111e46bff14e8eb854a"
 	if got != want {
 		t.Fatalf("Kilocode settings SHA-256 = %s, want current-main baseline %s", got, want)
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #702

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Separates the active worktree filesystem root from the logical Engram project identity.
- Resolves and caches the canonical project through `mem_current_project` instead of using each worktree directory basename.
- Applies one shared identity contract across rendered SDD orchestrators, phases, and Claude/OpenCode SDD commands.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/_shared/engram-project-identity.md` | Defines the canonical workspace-versus-memory identity contract. |
| `internal/assets/{claude,opencode}/commands/sdd-*.md` | Replaces workspace-basename identity derivation with the cached Engram project. |
| `internal/components/sdd` | Injects the shared contract into SDD entry points and protects non-SDD commands from unrelated changes. |
| `internal/components/sdd/engram_project_identity_test.go` | Adds cross-client, orchestrator, phase, workflow, and scope regressions. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with `openai/gpt-5.6-sol` orchestration and `openai/gpt-5.6-terra` implementation/verification workers.

**Material scope:** Root-cause analysis, implementation, regression tests, and PR preparation.

**Verification performed:** Independently inspected the final diff; focused SDD, asset, and linked-worktree identity tests passed; `gofmtcheck` and `git diff --check` passed. The full `go test ./...` attempt exceeded the 120-second local worker limit and is left to CI.

---

## 🧪 Test Plan

**Passed locally**

```bash
go test ./internal/components/sdd -count=1
go test ./internal/assets -count=1
go test ./internal/sddstatus -run "^TestInferEngramProject" -count=1
go run ./internal/gofmtcheck
git diff --check
```

**Not completed locally**

- `go test ./...` exceeded the 120-second worker limit after starting successfully; CI should complete the full suite.
- Docker E2E was not run locally.
- Benchmark validation: N/A, this changes SDD prompt identity and rendering rather than review lifecycle, gates, recovery, delivery, or benchmark behavior.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually validated rendered SDD identity invariants through focused tests

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 217 changed lines, below the 400-line limit |
| Check Issue Reference | ⏳ | Links approved issue #702 |
| Check Issue Has `status:approved` | ⏳ | Issue is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` will be applied |
| Unit Tests | ⏳ | Full suite delegated to CI |
| Go Format | ✅ | Passed locally |
| E2E Tests | ⏳ | Delegated to CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation is not applicable, as explained above
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The key invariant is that filesystem operations remain anchored to the active worktree while every explicit Engram project argument uses one cached canonical identity. Please pay particular attention to the renderer coverage and the regression ensuring non-SDD OpenCode commands remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDD workflows now use a consistent canonical project identity across supported agents.
  * Workspace paths remain unchanged for filesystem and project-scoped operations.
  * Added safe fallback behavior when a canonical project identity is unavailable.

* **Bug Fixes**
  * Improved SDD synchronization backups and rollback when shared prompts use multi-mode assets.

* **Documentation**
  * Updated SDD commands and shared guidance with project identity and caching rules.

* **Tests**
  * Added coverage for canonical identity handling, prompt rendering, and synchronization rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->