### PR TITLE
fix(sdd): discover nested workspace projects

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -392,7 +392,10 @@ func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
 		"authoritative workspace root",
 		"Before classifying a stack or applying any no-runner fallback",
 		"Aggregate those project-to-tool associations in the one workspace-level result",
-		"every in-scope project has a usable test command",
+		"non-empty discovered project set",
+		"explicit workspace-level test command",
+		"covers every in-scope project",
+		"independent project commands",
 	} {
 		if !strings.Contains(skill, required) {
 			t.Fatalf("sdd-init skill missing workspace discovery contract %q", required)
@@ -406,7 +409,11 @@ func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
 		"`A/pyproject.toml` and `B/Cargo.toml`",
 		"nested-repository boundaries",
 		"`.git`, `node_modules`, `vendor`, `dist`, `build`, `out`, `target`, `.cache`, `__pycache__`, `.venv`, `venv`",
-		"a table or `projects:` list",
+		"`projects:` list",
+		"discovered project set is non-empty",
+		"explicit workspace-level test command",
+		"covers every in-scope project",
+		"Do not synthesize or concatenate independent project commands",
 	} {
 		if !strings.Contains(details, required) {
 			t.Fatalf("sdd-init details missing bounded discovery contract %q", required)
@@ -415,6 +422,9 @@ func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
 
 	if discovery, fallback := strings.Index(details, "## Workspace Project Discovery"), strings.Index(details, "only then apply the no-runner fallback"); discovery < 0 || fallback < discovery {
 		t.Fatal("sdd-init details must complete workspace discovery before the no-runner fallback")
+	}
+	if discovery, fallback := strings.Index(skill, "authoritative workspace root"), strings.Index(skill, "no-runner fallback"); discovery < 0 || fallback < discovery {
+		t.Fatal("sdd-init skill must complete workspace discovery before the no-runner fallback")
 	}
 }
 

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -386,6 +386,38 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 	}
 }
 
+func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
+	skill := MustRead("skills/sdd-init/SKILL.md")
+	for _, required := range []string{
+		"authoritative workspace root",
+		"Before classifying a stack or applying any no-runner fallback",
+		"Aggregate those project-to-tool associations in the one workspace-level result",
+		"every in-scope project has a usable test command",
+	} {
+		if !strings.Contains(skill, required) {
+			t.Fatalf("sdd-init skill missing workspace discovery contract %q", required)
+		}
+	}
+
+	details := MustRead("skills/sdd-init/references/init-details.md")
+	for _, required := range []string{
+		"explicit workspace membership",
+		"at most two directory levels",
+		"`A/pyproject.toml` and `B/Cargo.toml`",
+		"nested-repository boundaries",
+		"`.git`, `node_modules`, `vendor`, `dist`, `build`, `out`, `target`, `.cache`, `__pycache__`, `.venv`, `venv`",
+		"a table or `projects:` list",
+	} {
+		if !strings.Contains(details, required) {
+			t.Fatalf("sdd-init details missing bounded discovery contract %q", required)
+		}
+	}
+
+	if discovery, fallback := strings.Index(details, "## Workspace Project Discovery"), strings.Index(details, "only then apply the no-runner fallback"); discovery < 0 || fallback < discovery {
+		t.Fatal("sdd-init details must complete workspace discovery before the no-runner fallback")
+	}
+}
+
 func TestSDDVerificationAndArchiveContractsIgnoreReviewContext(t *testing.T) {
 	statusContract := MustRead("skills/_shared/sdd-status-contract.md")
 	for _, want := range []string{

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -395,7 +395,8 @@ func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
 		"non-empty discovered project set",
 		"explicit workspace-level test command",
 		"covers every in-scope project",
-		"independent project commands",
+		"zero projects are discovered or no explicit workspace-level test command covers every in-scope project",
+		"including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project",
 	} {
 		if !strings.Contains(skill, required) {
 			t.Fatalf("sdd-init skill missing workspace discovery contract %q", required)
@@ -414,6 +415,8 @@ func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
 		"explicit workspace-level test command",
 		"covers every in-scope project",
 		"Do not synthesize or concatenate independent project commands",
+		"zero projects are discovered or no explicit workspace-level command covers every in-scope project",
+		"including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project",
 	} {
 		if !strings.Contains(details, required) {
 			t.Fatalf("sdd-init details missing bounded discovery contract %q", required)
@@ -423,8 +426,13 @@ func TestSDDInitRequiresBoundedWorkspaceProjectDiscovery(t *testing.T) {
 	if discovery, fallback := strings.Index(details, "## Workspace Project Discovery"), strings.Index(details, "only then apply the no-runner fallback"); discovery < 0 || fallback < discovery {
 		t.Fatal("sdd-init details must complete workspace discovery before the no-runner fallback")
 	}
-	if discovery, fallback := strings.Index(skill, "authoritative workspace root"), strings.Index(skill, "no-runner fallback"); discovery < 0 || fallback < discovery {
-		t.Fatal("sdd-init skill must complete workspace discovery before the no-runner fallback")
+	if workspaceDiscovery, strictTDDResolution := strings.Index(skill, "1. Identify the authoritative workspace root."), strings.Index(skill, "4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`"); workspaceDiscovery < 0 || strictTDDResolution < 0 || workspaceDiscovery >= strictTDDResolution {
+		t.Fatal("sdd-init skill must place workspace discovery step 1 before Strict TDD resolution step 4")
+	}
+	for _, content := range []string{skill, details} {
+		if strings.Contains(content, "a project has no test command") {
+			t.Fatal("sdd-init fallback must not treat a missing project-local command as an independent Strict TDD disablement reason")
+		}
 	}
 }
 

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -23,7 +23,7 @@ Resolve Strict TDD after the complete project list is evaluated; only then apply
 - Preserve explicit `strict_tdd: false`.
 - Use explicit `strict_tdd: true` only when an explicit workspace-level test command covers every in-scope project; otherwise fail closed to false and explain that downstream execution requires a workspace-wide command.
 - Without an explicit value, default to true only when the discovered project set is non-empty and one explicit workspace-level test command covers every in-scope project.
-- When no projects are discovered, a project has no test command, or projects have only independent project commands, use `strict_tdd: false`. Preserve and report every project command; explain the no-runner or workspace-wide-command fallback.
+- When zero projects are discovered or no explicit workspace-level command covers every in-scope project, use `strict_tdd: false`. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback.
 
 ## Skill Registry Scan Rules
 

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -7,6 +7,19 @@
 - Coverage: `vitest --coverage`, `jest --coverage`, `c8`, `pytest-cov`, `go test -cover`, `coverlet`.
 - Quality: linter, type checker, formatter commands.
 
+## Workspace Project Discovery
+
+Start at the authoritative workspace root. Complete this discovery before stack or test-runner classification and before applying the no-runner fallback.
+
+1. Read explicit workspace membership first when the workspace config declares it (for example package-manager workspaces or Cargo workspace members). Inspect each declared member that resolves inside the workspace root.
+2. If there is no explicit membership, inspect candidate project roots at the workspace root and at most two directory levels below it. This bounded fallback covers direct children such as `A/pyproject.toml` and `B/Cargo.toml`; do not recursively crawl beyond that depth.
+3. Never descend into VCS, dependency, generated/build, cache, virtual-environment, or nested-repository boundaries. At minimum exclude `.git`, `node_modules`, `vendor`, `dist`, `build`, `out`, `target`, `.cache`, `__pycache__`, `.venv`, `venv`, and directories that contain their own `.git` file or directory.
+4. Treat a directory with a supported project marker as one project root. For every discovered project, retain its workspace-relative path, stack, test command, test layers, coverage command, and quality-tool commands. Do not collapse multiple commands into a chosen workspace runner.
+
+Use one workspace-level project-context and testing-capabilities result. In the result and in `openspec/config.yaml` when it is written, represent projects as a table or `projects:` list with one entry per relative path; keep each project's commands in that entry. Existing consumers may only render the aggregate result, so do not imply that they can execute a single combined command.
+
+Resolve Strict TDD after the complete project list is evaluated: an explicit marker or config wins. Otherwise enable it only when every discovered in-scope project has a usable test command. If any in-scope project has none, disable it and name those paths; only then apply the no-runner fallback.
+
 ## Skill Registry Scan Rules
 
 - Scan user skills: `~/.pi/agent/skills/`, `~/.config/agents/skills/`, `~/.agents/skills/`, `~/.kimi/skills/`, `~/.config/opencode/skills/`, `~/.config/kilo/skills/`, `~/.claude/skills/`, `~/.gemini/skills/`, `~/.gemini/antigravity/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, `~/.codex/skills/`, `~/.codeium/windsurf/skills/`, `~/.qwen/skills/`, `~/.kiro/skills/`, and `~/.openclaw/skills/`.
@@ -66,31 +79,33 @@ openspec/
 **Strict TDD Mode**: {enabled/disabled}
 **Detected**: {date}
 
-### Test Runner
+### Projects
 
-- Command: `{command}`
-- Framework: {name}
+| Relative path | Stack | Test command | Framework |
+| ------------- | ----- | ------------ | --------- |
+| `{path}` | {stack} | `{command or —}` | {name or —} |
 
 ### Test Layers
 
-| Layer       | Available | Tool        |
-| ----------- | --------- | ----------- |
-| Unit        | ✅ / ❌   | {tool or —} |
-| Integration | ✅ / ❌   | {tool or —} |
-| E2E         | ✅ / ❌   | {tool or —} |
+| Relative path | Layer       | Available | Tool        |
+| ------------- | ----------- | --------- | ----------- |
+| `{path}` | Unit        | ✅ / ❌   | {tool or —} |
+| `{path}` | Integration | ✅ / ❌   | {tool or —} |
+| `{path}` | E2E         | ✅ / ❌   | {tool or —} |
 
 ### Coverage
 
-- Available: ✅ / ❌
-- Command: `{command or —}`
+| Relative path | Available | Command |
+| ------------- | --------- | ------- |
+| `{path}` | ✅ / ❌ | `{command or —}` |
 
 ### Quality Tools
 
-| Tool         | Available | Command        |
-| ------------ | --------- | -------------- |
-| Linter       | ✅ / ❌   | {command or —} |
-| Type checker | ✅ / ❌   | {command or —} |
-| Formatter    | ✅ / ❌   | {command or —} |
+| Relative path | Tool         | Available | Command        |
+| ------------- | ------------ | --------- | -------------- |
+| `{path}` | Linter       | ✅ / ❌   | {command or —} |
+| `{path}` | Type checker | ✅ / ❌   | {command or —} |
+| `{path}` | Formatter    | ✅ / ❌   | {command or —} |
 ```
 
 ## Output Templates

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -16,9 +16,14 @@ Start at the authoritative workspace root. Complete this discovery before stack 
 3. Never descend into VCS, dependency, generated/build, cache, virtual-environment, or nested-repository boundaries. At minimum exclude `.git`, `node_modules`, `vendor`, `dist`, `build`, `out`, `target`, `.cache`, `__pycache__`, `.venv`, `venv`, and directories that contain their own `.git` file or directory.
 4. Treat a directory with a supported project marker as one project root. For every discovered project, retain its workspace-relative path, stack, test command, test layers, coverage command, and quality-tool commands. Do not collapse multiple commands into a chosen workspace runner.
 
-Use one workspace-level project-context and testing-capabilities result. In the result and in `openspec/config.yaml` when it is written, represent projects as a table or `projects:` list with one entry per relative path; keep each project's commands in that entry. Existing consumers may only render the aggregate result, so do not imply that they can execute a single combined command.
+Use one workspace-level project-context and testing-capabilities result. In the result, represent projects as a table with one entry per relative path and keep each project's commands in that entry. In `openspec/config.yaml` when it is written, use a `projects:` list with the same entries and commands. Existing consumers may only render the aggregate result, so do not imply that they can execute a single combined command.
 
-Resolve Strict TDD after the complete project list is evaluated: an explicit marker or config wins. Otherwise enable it only when every discovered in-scope project has a usable test command. If any in-scope project has none, disable it and name those paths; only then apply the no-runner fallback.
+Resolve Strict TDD after the complete project list is evaluated; only then apply the no-runner fallback. An explicit workspace-level test command is an existing command or target defined by the workspace or explicit config that runs the complete in-scope set from the authoritative workspace root. Do not synthesize or concatenate independent project commands.
+
+- Preserve explicit `strict_tdd: false`.
+- Use explicit `strict_tdd: true` only when an explicit workspace-level test command covers every in-scope project; otherwise fail closed to false and explain that downstream execution requires a workspace-wide command.
+- Without an explicit value, default to true only when the discovered project set is non-empty and one explicit workspace-level test command covers every in-scope project.
+- When no projects are discovered, a project has no test command, or projects have only independent project commands, use `strict_tdd: false`. Preserve and report every project command; explain the no-runner or workspace-wide-command fallback.
 
 ## Skill Registry Scan Rules
 

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -48,16 +48,18 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=openspec` | Create/update openspec bootstrap files only. |
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
-| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
+| explicit `strict_tdd: false` marker/config | Preserve `strict_tdd: false`. |
+| explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
+| explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
+| no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
+| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -52,14 +52,14 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | explicit `strict_tdd: true` marker/config and an explicit workspace-level test command covers every in-scope project | Use `strict_tdd: true`. |
 | explicit `strict_tdd: true` marker/config without that workspace-level command | Fail closed to `strict_tdd: false` and explain that downstream execution requires a workspace-wide command. |
 | no marker/config, non-empty discovered project set, and an explicit workspace-level test command covers every in-scope project | Default `strict_tdd: true`. |
-| zero projects, missing project command, or only independent project commands | Set `strict_tdd: false`; preserve all discovered commands and explain the no-runner or workspace-wide-command fallback. |
+| zero projects are discovered or no explicit workspace-level test command covers every in-scope project | Set `strict_tdd: false`; preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Explain the no-runner or workspace-wide-command fallback. |
 
 ## Execution Steps
 
 1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
 2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
 3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
-4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Independent project commands do not satisfy that requirement; preserve them and use the false fallback unless an existing workspace command covers them all.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml` only after every discovered project has been evaluated. Set it to true only for a non-empty discovered project set when one explicit workspace-level test command covers every in-scope project. Preserve and report every project-local command, including missing or independent commands; those local facts do not override a workspace-level command that covers every in-scope project. Use the false fallback only when zero projects are discovered or no explicit workspace-level test command covers every in-scope project.
 5. Initialize persistence for the resolved mode.
 6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 7. Persist testing capabilities and project context.

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -49,18 +49,19 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 | `mode=hybrid` | Do both Engram and openspec persistence. |
 | `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
 | strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| no marker/config and every discovered in-scope project has a usable test command | Default `strict_tdd: true`. |
+| no marker/config and any discovered in-scope project lacks a usable test command | Set `strict_tdd: false` and explain the unavailable project(s). |
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
-6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+1. Identify the authoritative workspace root. Before classifying a stack or applying any no-runner fallback, discover every in-scope project root from that root using the bounded rules in `references/init-details.md`.
+2. Inspect each discovered project for `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, CI, and lint/test config; preserve its relative path and summarize its stack/conventions.
+3. Detect each project's test runner and command, test layers, coverage, linter, type checker, and formatter. Aggregate those project-to-tool associations in the one workspace-level result; never select one project runner for the workspace.
+4. Resolve Strict TDD from an agent marker or `openspec/config.yaml`. Without an explicit value, do so only after every discovered project has been evaluated: enable it only when every in-scope project has a usable test command; otherwise use the no-runner fallback and name the project(s).
+5. Initialize persistence for the resolved mode.
+6. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+7. Persist testing capabilities and project context.
+8. Return the structured initialization envelope.
 
 ## Output Contract
 


### PR DESCRIPTION
## Linked Issue

Closes #810

Supersedes #2725. This focused replacement preserves Denver2828 as the commit author for the original monorepo contract work and carries forward the investigation from #1565 and #2027.

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)

---

## Summary

`sdd-init` listed project marker files but never required discovery below the workspace root. In a monorepo with `A/pyproject.toml` and `B/Cargo.toml`, the executor could classify the workspace before inspecting either project, then persist an empty testing configuration with `strict_tdd: false`.

This replacement fixes that instruction-contract root without changing Go root placement, adding runtime scanners, or introducing per-subproject persistence states.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/sdd-init/SKILL.md` | Requires bounded workspace project discovery and aggregation before classification or fallback. |
| `internal/assets/skills/sdd-init/references/init-details.md` | Defines explicit-member discovery, two-level fallback scanning, exclusions, per-project capability output, and Strict TDD ordering. |
| `internal/assets/assets_test.go` | Adds a regression against the authoritative embedded skill contract. |
| `testdata/golden/sdd-*-skill-sdd-init.golden` | Regenerates all eight installed skill fixtures. |

---

## Test Plan

- [x] `go test ./internal/assets -run TestSDDInitRequiresBoundedWorkspaceProjectDiscovery -count=1`
- [x] `go test ./internal/components -run 'TestGoldenSDD_(OpenCode|Cursor|Gemini|VSCode|Codex|Windsurf|Kiro|Antigravity)$' -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `go build ./...`
- [x] `git diff --check`
- [ ] `go test ./...` was started once locally but the host terminated it at 120 seconds without reporting a failing package; CI is the full-suite authority.
- [ ] Docker E2E was not run locally; CI owns the environment-specific matrix.

---

## Contributor Checklist

- [x] PR is linked to approved issue #810.
- [x] PR stays within the 400-line review budget (+152/-96 = 248).
- [ ] Exactly one `type:*` label is required; the fork author cannot apply repository labels, so a maintainer must add `type:bug`.
- [x] Focused tests, format, build, and diff checks pass.
- [x] Generated goldens were updated with the repository generator.
- [x] Commit follows Conventional Commits format.
- [x] Commit has no `Co-Authored-By` trailer.

## Rollback

Revert the single commit to restore the previous `sdd-init` contract, regression test set, and generated goldens without affecting runtime root placement or unrelated SDD behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved project discovery during SDD initialization, including explicit workspace membership and bounded fallback scanning.
  - Added clearer handling for excluded directories and project-specific testing and quality tooling.
  - Strict TDD decisions now account for test-command coverage across all discovered projects.

- **Documentation**
  - Clarified workspace discovery, project metadata, testing layers, coverage, and quality-tool reporting.
  - Documented fallback behavior when no suitable test runner is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->