### PR TITLE
docs(homebrew): clarify tap trust options

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,12 @@ Run `gentle-ai doctor` at any time for a read-only health check of your ecosyste
 **Homebrew (macOS / Linux)**
 
 ```bash
-brew tap Gentleman-Programming/homebrew-tap
-brew trust --formula gentleman-programming/tap/gentle-ai  # one-time, for Homebrew tap trust
+brew tap gentleman-programming/tap
+brew trust --formula gentleman-programming/tap/gentle-ai  # one-time, if Homebrew requires trust
 brew install gentle-ai
 ```
+
+To install several tools from this tap, you can instead run `brew trust gentleman-programming/tap`. This broader option trusts all current and future formulas, casks, and external commands published in the tap.
 
 **Go install: stable channel (any platform with Go 1.25.10+)**
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,8 @@
 
 - Homebrew installed and available in PATH.
 - `git` available.
-- If Homebrew requires tap trust, run `brew trust --formula gentleman-programming/tap/gentle-ai` once.
+- If Homebrew requires trust, run `brew trust --formula gentleman-programming/tap/gentle-ai` once for Gentle AI only.
+  - To install several tools from this tap, use `brew trust gentleman-programming/tap` instead. It trusts all current and future formulas, casks, and external commands published in the tap.
 
 ### Ubuntu/Debian (and derivatives like Linux Mint, Pop!\_OS)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,6 +175,8 @@ brew trust --cask gentleman-programming/tap/engram
 brew upgrade engram
 ```
 
+If you choose to install several tools from this tap, run `brew trust gentleman-programming/tap` instead. This broader option trusts all current and future formulas, casks, and external commands published in the tap.
+
 **Self-update prompt behavior** (changed in v1.x slice 5 — `GENTLE_AI_CONFIRM_UPDATE` removed):
 
 | Situation | Behavior |
@@ -302,8 +304,9 @@ gentle-ai install --agent windsurf --preset full-gentleman
 
 Homebrew 6 can require explicit trust for non-official taps and, on Linux, can
 sandbox builds with Bubblewrap. `gentle-ai upgrade` and `scripts/install.sh`
-auto-trust only the Gentle AI formula, but manual upgrades may still need this
-one-time command:
+auto-trust only the Gentle AI formula. For the broader tap-wide trust option,
+see the [update and upgrade guidance](#update--upgrade). Manual upgrades may
+still need this one-time command:
 
 ```bash
 brew trust --formula gentleman-programming/tap/gentle-ai


### PR DESCRIPTION
## Linked Issue

Closes #832

---

## PR Type

- [ ] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [x] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Keep formula/cask-scoped trust as the least-privilege default for single-tool installs.
- Document canonical whole-tap trust as an explicit option for users installing several tools.
- Align README, quickstart, usage, and troubleshooting guidance without changing installer or updater behavior.

---

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `README.md` | Clarifies the default formula trust command and adds the optional whole-tap command. |
| `docs/quickstart.md` | Distinguishes single-tool trust from the broader multi-tool option. |
| `docs/usage.md` | Adds canonical tap-wide guidance and links troubleshooting back to it. |

---

## AI Assistance

- [ ] **None** - No material AI assistance was used.
- [x] **Material assistance used** - Declaration completed below.

**Tool/model (if known):** OpenCode, OpenAI GPT-5.6 Sol

**Material scope:** Repository and issue analysis, documentation drafting, consistency review, and PR preparation.

**Verification performed:** Structural readback of every edited section, repository-wide `brew trust` search, official Homebrew 6.0.0 source/documentation validation, and `git diff --check`.

---

## Test Plan

- [x] `git diff --check`
- [x] Structural readback of all edited documentation
- [x] Repository-wide audit confirms runtime and installer remain formula/cask scoped
- [x] Unit tests: N/A, documentation-only change
- [x] Go format: N/A, no Go files changed
- [x] E2E tests: N/A, no runtime behavior changed
- [x] Benchmark validation: N/A, no benchmark or lifecycle behavior changed

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit tests are not applicable to this documentation-only change
- [x] Go format is not applicable because no Go files changed
- [x] E2E tests are not applicable because runtime behavior is unchanged
- [x] Benchmark validation is not applicable
- [x] Documentation is updated
- [x] The commit follows Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Exactly one AI-assistance option is selected and declared
- [x] The commit has no `Co-Authored-By` trailer

---

## Notes for Reviewers

This supersedes #1251, which is currently conflicting and has had no author maintenance since July 13. Thank you to @pichu2707 for surfacing the cross-tool trust problem and iterating on the initial guidance.

The policy choice is intentional: automation keeps least-privilege formula/cask trust. Users who accept every current and future formula, cask, and external command from the tap can explicitly run `brew trust gentleman-programming/tap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated macOS Homebrew installation instructions with the correct tap identifier.
  - Clarified options for trusting a single formula or the entire tap.
  - Added guidance for installing multiple tools and troubleshooting upgrades.
  - Linked to update and upgrade instructions for additional help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->