### PR TITLE
revert(codex): remove dedicated sdd-spec profile

### DIFF
--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -166,19 +166,16 @@ const (
 var codexPresetMatrix = map[CodexPresetKey]map[string]CodexCarrilDefault{
 	CodexPresetLowCost: {
 		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortMedium},
-		"sdd-spec":   {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
 		"sdd-mid":    {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
 		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortHigh},
 	},
 	CodexPresetRecommended: {
 		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortMedium},
-		"sdd-spec":   {Model: "gpt-5.6-terra", Effort: CodexEffortHigh},
 		"sdd-mid":    {Model: "gpt-5.6-terra", Effort: CodexEffortHigh},
 		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortHigh},
 	},
 	CodexPresetPowerful: {
 		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortXHigh},
-		"sdd-spec":   {Model: "gpt-5.6-sol", Effort: CodexEffortHigh},
 		"sdd-mid":    {Model: "gpt-5.6-sol", Effort: CodexEffortHigh},
 		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortHigh},
 	},
@@ -291,11 +288,14 @@ func CodexModelPresetLowCost() map[string]CodexEffort {
 // extension), the canonical default model id for that carril, the default
 // reasoning_effort tier, and the SDD phases covered.
 //
-// Phase groupings:
-//   - sdd-strong (Razonamiento): propose, design, verify, judge-a, judge-b, default
-//   - sdd-spec   (Contratos):    spec
-//   - sdd-mid    (Código):       apply, tasks, fix-agent
-//   - sdd-cheap  (Liviano):      explore, archive, onboard
+// Phase groupings (Approach C — orthogonal carril axis). Sol reasons, Terra
+// writes, Luna transcribes:
+//   - sdd-strong (Razonamiento): explore, propose, design, verify, judge-a, judge-b, default
+//   - sdd-mid    (Código):       apply, fix-agent
+//   - sdd-cheap  (Liviano):      spec, tasks, archive, onboard
+//
+// codexTierGroups below is the single source of this grouping; the rendered
+// table derives its phase column from it via codexTierPhaseLabel.
 type CodexTierGroup struct {
 	Profile       string
 	Model         string
@@ -303,7 +303,7 @@ type CodexTierGroup struct {
 	Phases        []string
 }
 
-// codexTierGroups defines the CLI profile tiers and which phases they cover.
+// codexTierGroups defines the three CLI profile tiers and which phases they cover.
 //
 // Invariant: within each carril, ALL phases carry the same effort value in every
 // preset constructor (CodexModelPresetLowCost, CodexModelPresetRecommended,
@@ -319,7 +319,6 @@ type CodexTierGroup struct {
 //
 //	Carril      LowCost  Recommended  Powerful
 //	sdd-strong  medium   medium       xhigh
-//	sdd-spec    medium   high         high
 //	sdd-mid     medium   high         high
 //	sdd-cheap   high     high         high
 var codexTierGroups = []CodexTierGroup{
@@ -327,25 +326,19 @@ var codexTierGroups = []CodexTierGroup{
 		Profile:       "sdd-strong",
 		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-strong"].Model,
 		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-strong"].Effort,
-		Phases:        []string{"sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b", "default"},
-	},
-	{
-		Profile:       "sdd-spec",
-		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-spec"].Model,
-		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-spec"].Effort,
-		Phases:        []string{"sdd-spec"},
+		Phases:        []string{"sdd-explore", "sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b", "default"},
 	},
 	{
 		Profile:       "sdd-mid",
 		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-mid"].Model,
 		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-mid"].Effort,
-		Phases:        []string{"sdd-apply", "sdd-tasks", "jd-fix-agent"},
+		Phases:        []string{"sdd-apply", "jd-fix-agent"},
 	},
 	{
 		Profile:       "sdd-cheap",
 		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-cheap"].Model,
 		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-cheap"].Effort,
-		Phases:        []string{"sdd-explore", "sdd-archive", "sdd-onboard"},
+		Phases:        []string{"sdd-spec", "sdd-tasks", "sdd-archive", "sdd-onboard"},
 	},
 }
 

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -184,7 +184,6 @@ func TestCodexTierGroups_AllPhasesAssigned(t *testing.T) {
 	tiers := model.CodexTierGroups()
 	validCarrils := map[string]bool{
 		"sdd-strong": true,
-		"sdd-spec":   true,
 		"sdd-mid":    true,
 		"sdd-cheap":  true,
 	}
@@ -213,39 +212,6 @@ func TestCodexTierGroups_AllPhasesAssigned(t *testing.T) {
 	if len(seen) != 13 {
 		t.Errorf("expected 13 phases total, got %d", len(seen))
 	}
-
-	// Explicit assertions requested by CodeRabbit review:
-	// Verify sdd-spec belongs to sdd-spec carril and sdd-tasks belongs to sdd-mid
-	if got := seen["sdd-spec"]; got != "sdd-spec" {
-		t.Errorf("sdd-spec phase mapped to %q, want sdd-spec", got)
-	}
-	if got := seen["sdd-tasks"]; got != "sdd-mid" {
-		t.Errorf("sdd-tasks phase mapped to %q, want sdd-mid", got)
-	}
-
-	// Verify exact sdd-cheap phase set
-	var cheapPhases []string
-	for _, g := range tiers {
-		if g.Profile == "sdd-cheap" {
-			cheapPhases = g.Phases
-			break
-		}
-	}
-	wantCheap := []string{"sdd-explore", "sdd-archive", "sdd-onboard"}
-	if !reflect.DeepEqual(cheapPhases, wantCheap) {
-		t.Errorf("sdd-cheap phases = %v, want %v", cheapPhases, wantCheap)
-	}
-
-	// Verify sdd-spec effort across presets
-	if got := model.CodexModelPresetRecommended()["sdd-spec"]; got != model.CodexEffortHigh {
-		t.Errorf("Recommended preset sdd-spec effort = %q, want %q", got, model.CodexEffortHigh)
-	}
-	if got := model.CodexModelPresetLowCost()["sdd-spec"]; got != model.CodexEffortMedium {
-		t.Errorf("LowCost preset sdd-spec effort = %q, want %q", got, model.CodexEffortMedium)
-	}
-	if got := model.CodexModelPresetPowerful()["sdd-spec"]; got != model.CodexEffortHigh {
-		t.Errorf("Powerful preset sdd-spec effort = %q, want %q", got, model.CodexEffortHigh)
-	}
 }
 
 func TestDefaultCarrilModels(t *testing.T) {
@@ -253,17 +219,14 @@ func TestDefaultCarrilModels(t *testing.T) {
 	if m["sdd-strong"] != "gpt-5.6-sol" {
 		t.Errorf("sdd-strong = %q, want gpt-5.6-sol", m["sdd-strong"])
 	}
-	if m["sdd-spec"] != "gpt-5.6-terra" {
-		t.Errorf("sdd-spec = %q, want gpt-5.6-terra", m["sdd-spec"])
-	}
 	if m["sdd-mid"] != "gpt-5.6-terra" {
 		t.Errorf("sdd-mid = %q, want gpt-5.6-terra", m["sdd-mid"])
 	}
 	if m["sdd-cheap"] != "gpt-5.6-luna" {
 		t.Errorf("sdd-cheap = %q, want gpt-5.6-luna", m["sdd-cheap"])
 	}
-	if len(m) != 4 {
-		t.Errorf("DefaultCarrilModels() has %d entries, want 4", len(m))
+	if len(m) != 3 {
+		t.Errorf("DefaultCarrilModels() has %d entries, want 3", len(m))
 	}
 }
 
@@ -301,17 +264,18 @@ func TestPresetLowCost_ModelEffortPerCarril(t *testing.T) {
 	if m["sdd-propose"] != model.CodexEffortMedium {
 		t.Errorf("Low-cost preset sdd-propose = %q, want medium", m["sdd-propose"])
 	}
-	// explore is in sdd-cheap (Liviano) which is high effort in Low-cost preset
-	if m["sdd-explore"] != model.CodexEffortHigh {
-		t.Errorf("Low-cost preset sdd-explore = %q, want high", m["sdd-explore"])
+	// explore reasons over delivered context, so it rides Razonamiento/sdd-strong.
+	if m["sdd-explore"] != model.CodexEffortMedium {
+		t.Errorf("Low-cost preset sdd-explore = %q, want medium", m["sdd-explore"])
 	}
 	// apply (Código/sdd-mid) is medium
 	if m["sdd-apply"] != model.CodexEffortMedium {
 		t.Errorf("Low-cost preset sdd-apply = %q, want medium", m["sdd-apply"])
 	}
-	// spec is in sdd-spec carril (medium in Low-cost preset)
-	if m["sdd-spec"] != model.CodexEffortMedium {
-		t.Errorf("Low-cost preset sdd-spec = %q, want medium", m["sdd-spec"])
+	// spec (Liviano/sdd-cheap) is high: transcription is cheap per token, so
+	// effort buys accuracy without buying an expensive model.
+	if m["sdd-spec"] != model.CodexEffortHigh {
+		t.Errorf("Low-cost preset sdd-spec = %q, want high", m["sdd-spec"])
 	}
 
 	// Verify Low-cost preset carril models
@@ -619,7 +583,7 @@ func TestRenderCodexPhaseEffortsByPhase_UnassignedUsesProvidedCarrilModel(t *tes
 		"| `sdd-propose` | `gpt-5.4` | `medium` |",
 		"| `sdd-design` | `gpt-5.4-mini` | `medium` |",
 		"| `sdd-apply` | `gpt-5.5` | `high` |",
-		"| `sdd-explore` | `gpt-5.3-codex` | `high` |",
+		"| `sdd-explore` | `gpt-5.4-mini` | `medium` |",
 	}
 	for _, wantRow := range wantRows {
 		if !strings.Contains(out, wantRow) {

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -499,9 +499,8 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|-------|----------------------------------|------------|
-| `sdd-strong` | `gpt-5.6-sol` | `medium` | propose, design, verify, judge |
-| `sdd-spec` | `gpt-5.6-terra` | `medium` | spec |
-| `sdd-mid` | `gpt-5.6-terra` | `medium` | apply, tasks, fix-agent |
-| `sdd-cheap` | `gpt-5.6-luna` | `high` | explore, archive, onboard |
+| `sdd-strong` | `gpt-5.6-sol` | `medium` | explore, propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.6-terra` | `medium` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.6-luna` | `high` | spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -499,9 +499,8 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|-------|----------------------------------|------------|
-| `sdd-strong` | `gpt-5.6-sol` | `xhigh` | propose, design, verify, judge |
-| `sdd-spec` | `gpt-5.6-sol` | `high` | spec |
-| `sdd-mid` | `gpt-5.6-sol` | `high` | apply, tasks, fix-agent |
-| `sdd-cheap` | `gpt-5.6-luna` | `high` | explore, archive, onboard |
+| `sdd-strong` | `gpt-5.6-sol` | `xhigh` | explore, propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.6-sol` | `high` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.6-luna` | `high` | spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -499,9 +499,8 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|-------|----------------------------------|------------|
-| `sdd-strong` | `gpt-5.6-sol` | `medium` | propose, design, verify, judge |
-| `sdd-spec` | `gpt-5.6-terra` | `high` | spec |
-| `sdd-mid` | `gpt-5.6-terra` | `high` | apply, tasks, fix-agent |
-| `sdd-cheap` | `gpt-5.6-luna` | `high` | explore, archive, onboard |
+| `sdd-strong` | `gpt-5.6-sol` | `medium` | explore, propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.6-terra` | `high` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.6-luna` | `high` | spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1820

---

## 🏷️ PR Type

- [x] `type:feature` — Reverts the feature introduced by #1821 before release.

---

## 📝 Summary

Reverts merged PR #1821 while its model-policy rationale returns to discussion. The dedicated `sdd-spec` carril has the same default model and effort as `sdd-mid` in every preset, so it adds a phase-specific configuration surface without changing default execution.

This is a pure rollback. It restores the prior three-carril Codex mapping and does not introduce a replacement policy. Issue #1820 documents that its temporary `status:approved` scope applies only to this revert; after merge it will return to `status:needs-info` for design discussion.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/codex_model.go` | Removed the dedicated `sdd-spec` carril and restored the previous phase mappings. |
| `internal/model/codex_model_test.go` | Restored the pre-#1821 three-carril assertions. |
| `testdata/golden/sdd-codex-agentsmd*.golden` | Restored the three generated Codex model-profile tables. |

---

## 🤖 AI Assistance

- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent.

**Material scope:** Evidence audit, mechanical revert preparation, validation orchestration, and PR drafting.

**Verification performed:** The staged patch ID matched the exact reverse of #1821's first-parent patch. Full root and bench tests, focused model/golden tests, race tests, vet, formatting, and diff checks passed uncached.

---

## 🧪 Test Plan

```bash
go test ./... -count=1
(cd bench && go test ./... -count=1)
go test -race ./internal/model ./internal/components -count=1
go vet ./...
(cd bench && go vet ./...)
go run ./internal/gofmtcheck
git diff --check
```

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] Full Docker E2E is pending CI
- [x] Exact inverse patch ID verified locally

Benchmark validation: N/A. This rollback changes generated Codex model policy and profile goldens, not review lifecycle, gates, recovery, delivery, or benchmark behavior.

Runtime harness: N/A. No provider transport boundary changes; deterministic golden generation is the relevant artifact proof.

---

## 🤖 Automated Checks

The repository checks must pass before merge.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #1820 with rollback-only `status:approved`
- [x] PR stays within the 400-line review budget
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [x] Go format passes
- [ ] Full E2E matrix passes in CI
- [x] Benchmark validation is not applicable, as explained above
- [x] Generated documentation goldens are included
- [x] Commit follows Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance is declared above
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The final five-file patch has the same stable patch ID as the exact reverse of merge commit `e961d89f` against its first parent: `9e9c4febee8da54d07232ee0767dae9c7ae29097`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Codex model tiers and phase assignments.
  * Removed the dedicated `sdd-spec` tier; it is now grouped under the cost-efficient tier.
  * Adjusted model strengths and effort levels across Low-cost, Recommended, and Powerful presets.
  * Updated phase-specific model selection, including stronger support for exploration and revised task handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->