### PR TITLE
feat(filecoord): back cooperative lock acquisition with the hardened authority lock

### DIFF
--- a/internal/filecoord/lock.go
+++ b/internal/filecoord/lock.go
@@ -122,11 +122,20 @@ func cleanTarget(path string) (string, error) {
 	return filepath.Clean(absolute), nil
 }
 
-// Acquire validates inputs, then fails closed in PR1 without filesystem work.
-// It is cooperative, provides no arbitrary-writer CAS, and defers platform primitives.
+// Acquire validates inputs, honors context cancellation before any
+// filesystem work, then takes the shared cooperative lock through the
+// hardened authority-lock primitive. Acquisition is one non-blocking attempt:
+// contention returns a typed BusyError and the caller owns retry pacing. The
+// lease is cooperative and provides no arbitrary-writer CAS. The secure
+// no-follow open walk rejects symlinked roots and lock paths, so lock roots
+// must be canonical paths.
 func Acquire(ctx context.Context, target, lockRoot string) (*Lease, error) {
-	if _, err := LockPath(lockRoot, target); err != nil {
+	path, err := LockPath(lockRoot, target)
+	if err != nil {
 		return nil, err
 	}
-	return nil, unsupportedBackend()
+	if err := ctx.Err(); err != nil {
+		return nil, &OperationalError{Cause: err}
+	}
+	return acquireCooperativeLock(path)
 }

--- a/internal/filecoord/lock_backend.go
+++ b/internal/filecoord/lock_backend.go
@@ -1,0 +1,28 @@
+package filecoord
+
+import (
+	"errors"
+	"os"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// acquireCooperativeLock backs the cooperative contract with the hardened
+// authority-lock primitive instead of a second platform implementation:
+// reviewtransaction.AcquireAuthorityFileLock owns the secure no-follow open
+// walk (O_NOFOLLOW per component on POSIX, reparse-safe NtCreateFile on
+// Windows) and kernel advisory locking (flock / LockFileEx), and never treats
+// lock-file residue as ownership. Symlinked roots and lock paths are rejected
+// by that walk, so callers must pass canonical lock roots. A later refactor
+// may move the primitive into this package and flip the dependency; reusing
+// it in place keeps one lock mechanism in the product (#3632).
+func acquireCooperativeLock(path string) (*Lease, error) {
+	authority, err := reviewtransaction.AcquireAuthorityFileLock(path)
+	if err != nil {
+		if errors.Is(err, reviewtransaction.ErrStoreLockContended) {
+			return nil, &BusyError{Cause: err}
+		}
+		return nil, &OperationalError{Cause: err}
+	}
+	return &Lease{unlock: func(*os.File) error { return authority.Release() }}, nil
+}

--- a/internal/filecoord/lock_backend_test.go
+++ b/internal/filecoord/lock_backend_test.go
@@ -1,0 +1,287 @@
+package filecoord
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// lockedBuffer collects subprocess output that may still be written while a
+// failure path reads it back for diagnostics.
+type lockedBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.String()
+}
+
+// canonicalBackendTempDir resolves the test temporary directory through
+// EvalSymlinks: the secure open walk rejects symlinked path components by
+// design (macOS /tmp and /var are symlinks), so lock roots used in tests must
+// be canonical, exactly as production callers must pass canonical roots.
+func canonicalBackendTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestAcquireGrantsExclusiveLeaseUntilRelease(t *testing.T) {
+	base := canonicalBackendTempDir(t)
+	root := filepath.Join(base, "locks")
+	target := filepath.Join(base, "target.txt")
+
+	lease, err := Acquire(context.Background(), target, root)
+	if err != nil || lease == nil {
+		t.Fatalf("Acquire() = %v, %v; want a live lease", lease, err)
+	}
+	lockPath := mustPath(t, root, target)
+	if _, statErr := os.Lstat(lockPath); statErr != nil {
+		t.Fatalf("acquired lease has no lock file at %s: %v", lockPath, statErr)
+	}
+
+	_, busyErr := Acquire(context.Background(), target, root)
+	if !errors.Is(busyErr, ErrBusy) || !errors.As(busyErr, new(*BusyError)) {
+		t.Fatalf("second Acquire() error = %v, want BusyError", busyErr)
+	}
+
+	if releaseErr := lease.Release(); releaseErr != nil {
+		t.Fatalf("Release() = %v, want nil", releaseErr)
+	}
+	if repeated := lease.Release(); repeated != nil {
+		t.Fatalf("repeated Release() = %v, want idempotent nil", repeated)
+	}
+
+	reacquired, err := Acquire(context.Background(), target, root)
+	if err != nil || reacquired == nil {
+		t.Fatalf("Acquire() after release = %v, %v; want a live lease", reacquired, err)
+	}
+	if err := reacquired.Release(); err != nil {
+		t.Fatalf("Release() of reacquired lease = %v", err)
+	}
+}
+
+func TestAcquireDistinguishesTargetsUnderOneRoot(t *testing.T) {
+	base := canonicalBackendTempDir(t)
+	root := filepath.Join(base, "locks")
+
+	first, err := Acquire(context.Background(), filepath.Join(base, "one.txt"), root)
+	if err != nil {
+		t.Fatalf("Acquire(one) = %v", err)
+	}
+	defer func() { _ = first.Release() }()
+
+	second, err := Acquire(context.Background(), filepath.Join(base, "two.txt"), root)
+	if err != nil {
+		t.Fatalf("Acquire(two) under the same root = %v, want independent lease", err)
+	}
+	if err := second.Release(); err != nil {
+		t.Fatalf("Release(two) = %v", err)
+	}
+}
+
+func TestAcquireHonorsCancelledContextWithoutFilesystemWork(t *testing.T) {
+	base := canonicalBackendTempDir(t)
+	root := filepath.Join(base, "never-created-locks")
+	target := filepath.Join(base, "target.txt")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lease, err := Acquire(ctx, target, root)
+	if lease != nil {
+		t.Fatal("cancelled Acquire returned a lease")
+	}
+	if !errors.Is(err, ErrOperational) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Acquire error = %v, want operational with context cause", err)
+	}
+	if _, statErr := os.Lstat(root); !os.IsNotExist(statErr) {
+		t.Fatalf("cancelled Acquire touched the lock root: %v", statErr)
+	}
+}
+
+func TestAcquireRejectsSymlinkedLockPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixtures are unavailable on Windows runners")
+	}
+	base := canonicalBackendTempDir(t)
+	root := filepath.Join(base, "locks")
+	target := filepath.Join(base, "target.txt")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(base, "victim.txt")
+	if err := os.WriteFile(victim, []byte("victim bytes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := mustPath(t, root, target)
+	if err := os.Symlink(victim, lockPath); err != nil {
+		t.Skipf("symlink fixture is unavailable: %v", err)
+	}
+
+	lease, err := Acquire(context.Background(), target, root)
+	if lease != nil || !errors.Is(err, ErrOperational) {
+		t.Fatalf("Acquire() through a symlinked lock path = %v, %v; want operational refusal", lease, err)
+	}
+	if info, statErr := os.Lstat(lockPath); statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlinked lock path was not preserved: %v, %v", info, statErr)
+	}
+	data, readErr := os.ReadFile(victim)
+	if readErr != nil || string(data) != "victim bytes\n" {
+		t.Fatalf("symlink target mutated: %q, %v", data, readErr)
+	}
+}
+
+func TestAcquireRejectsSymlinkedRootComponent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixtures are unavailable on Windows runners")
+	}
+	base := canonicalBackendTempDir(t)
+	realRoot := filepath.Join(base, "real-locks")
+	if err := os.MkdirAll(realRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkedRoot := filepath.Join(base, "linked-locks")
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Skipf("symlink fixture is unavailable: %v", err)
+	}
+
+	lease, err := Acquire(context.Background(), filepath.Join(base, "target.txt"), linkedRoot)
+	if lease != nil || !errors.Is(err, ErrOperational) {
+		t.Fatalf("Acquire() through a symlinked root = %v, %v; want operational refusal", lease, err)
+	}
+}
+
+const (
+	filecoordHolderEnv        = "GENTLE_AI_TEST_FILECOORD_HOLDER"
+	filecoordHolderTargetEnv  = "GENTLE_AI_TEST_FILECOORD_TARGET"
+	filecoordHolderRootEnv    = "GENTLE_AI_TEST_FILECOORD_ROOT"
+	filecoordHolderReadyEnv   = "GENTLE_AI_TEST_FILECOORD_READY"
+	filecoordHolderReleaseEnv = "GENTLE_AI_TEST_FILECOORD_RELEASE"
+)
+
+// TestFilecoordLockHolderHelperProcess is not a test: it is the subprocess
+// body for the cross-process contention proof below, gated by environment.
+func TestFilecoordLockHolderHelperProcess(t *testing.T) {
+	if os.Getenv(filecoordHolderEnv) != "1" {
+		return
+	}
+	lease, err := Acquire(context.Background(), os.Getenv(filecoordHolderTargetEnv), os.Getenv(filecoordHolderRootEnv))
+	if err != nil {
+		t.Fatalf("helper Acquire() = %v", err)
+	}
+	if err := os.WriteFile(os.Getenv(filecoordHolderReadyEnv), []byte("ready\n"), 0o600); err != nil {
+		t.Fatalf("helper ready signal: %v", err)
+	}
+	release := os.Getenv(filecoordHolderReleaseEnv)
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if _, err := os.Stat(release); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("helper timed out waiting for the release signal")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("helper Release() = %v", err)
+	}
+}
+
+func TestAcquireContendsAcrossRealProcesses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("cross-process contention is not run in short mode")
+	}
+	base := canonicalBackendTempDir(t)
+	root := filepath.Join(base, "locks")
+	target := filepath.Join(base, "target.txt")
+	ready := filepath.Join(base, "holder.ready")
+	release := filepath.Join(base, "holder.release")
+
+	holder := exec.Command(os.Args[0], "-test.run=^TestFilecoordLockHolderHelperProcess$", "-test.v")
+	holder.Env = append(os.Environ(),
+		filecoordHolderEnv+"=1",
+		filecoordHolderTargetEnv+"="+target,
+		filecoordHolderRootEnv+"="+root,
+		filecoordHolderReadyEnv+"="+ready,
+		filecoordHolderReleaseEnv+"="+release,
+	)
+	output := &lockedBuffer{}
+	holder.Stdout, holder.Stderr = output, output
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start holder process: %v", err)
+	}
+	holderDone := make(chan error, 1)
+	go func() { holderDone <- holder.Wait() }()
+	holderConsumed := false
+	defer func() {
+		_ = os.WriteFile(release, []byte("release\n"), 0o600)
+		if holderConsumed {
+			return
+		}
+		select {
+		case <-holderDone:
+		case <-time.After(20 * time.Second):
+			_ = holder.Process.Kill()
+		}
+	}()
+
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		select {
+		case err := <-holderDone:
+			holderConsumed = true
+			t.Fatalf("holder exited before signalling ready: %v\n%s", err, output.String())
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for the holder to acquire\n%s", output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_, err := Acquire(context.Background(), target, root)
+	if !errors.Is(err, ErrBusy) {
+		t.Fatalf("Acquire() against a live external holder = %v, want ErrBusy", err)
+	}
+
+	if err := os.WriteFile(release, []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	holderErr := <-holderDone
+	holderConsumed = true
+	if holderErr != nil {
+		t.Fatalf("holder process failed: %v\n%s", holderErr, output.String())
+	}
+
+	lease, err := Acquire(context.Background(), target, root)
+	if err != nil || lease == nil {
+		t.Fatalf("Acquire() after the holder exited = %v, %v; want a live lease", lease, err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("Release() = %v", err)
+	}
+}

--- a/internal/filecoord/lock_test.go
+++ b/internal/filecoord/lock_test.go
@@ -1,7 +1,6 @@
 package filecoord
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -67,22 +66,6 @@ func TestLockPathRejectsInvalidRootAndTarget(t *testing.T) {
 			_, err := LockPath(test.root, test.target)
 			assertError(t, err, test.want, test.typed)
 		})
-	}
-}
-
-func TestAcquireUnsupportedHasNoFilesystemSideEffects(t *testing.T) {
-	root := filepath.Join(t.TempDir(), "not-created-lock-root")
-	target := filepath.Join(t.TempDir(), "not-created-target")
-	lease, err := Acquire(context.Background(), target, root)
-	if lease != nil {
-		t.Fatal("unsupported Acquire returned a lease")
-	}
-	assertError(t, err, ErrUnsupported, new(*UnsupportedError))
-	if _, err := os.Stat(root); !os.IsNotExist(err) {
-		t.Fatalf("Acquire changed lock root: %v", err)
-	}
-	if _, err := os.Stat(target); !os.IsNotExist(err) {
-		t.Fatalf("Acquire changed target: %v", err)
 	}
 }
 

--- a/internal/filecoord/lock_unsupported.go
+++ b/internal/filecoord/lock_unsupported.go
@@ -1,4 +1,0 @@
-package filecoord
-
-// Temporary all-platform PR1 backend: it makes no platform capability claim or filesystem change; POSIX and Windows backends are later PRs.
-func unsupportedBackend() error { return &UnsupportedError{} }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3632
Refs #3570 (work units 2 and 3)

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Back `filecoord.Acquire` with the exported hardened authority-lock primitive instead of a second platform lock implementation.
- Map kernel contention to the typed `BusyError`, pre-acquisition and release failures to `OperationalError`, and refuse a cancelled context before any filesystem work.
- Prove real cross-process contention with a helper-process test and keep symlinked roots and lock paths rejected through the secure no-follow open walk.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/filecoord/lock_backend.go` | Delegates acquisition to `reviewtransaction.AcquireAuthorityFileLock` (secure no-follow walk, `flock` / `LockFileEx`), with typed error mapping. |
| `internal/filecoord/lock.go` | `Acquire` now honors context cancellation and returns a live lease; the API documents the non-blocking, cooperative, non-CAS boundary. |
| `internal/filecoord/lock_unsupported.go` | Removed: the all-platform fail-closed placeholder is replaced by the real backend. |
| `internal/filecoord/lock_backend_test.go` | Exclusive lease, per-target independence, cancelled context, symlinked root and lock-path refusal, and real subprocess contention coverage. |
| `internal/filecoord/lock_test.go` | Retires the PR1 unsupported-behavior test; the typed taxonomy tests stay. |

Deliberate design decision: `internal/reviewtransaction` already exports `AcquireAuthorityFileLock` for adjacent consumers, including the reparse-safe Windows `NtCreateFile` path. Duplicating that in `filecoord` would put two lock mechanisms in the product; reusing it keeps one. A later refactor can move the primitive down into `filecoord` and flip the dependency.

Work units 4-6 of #3570 (no-follow snapshot authority, cooperative optimistic rewrite, #3460 integration) remain open on that issue.

---

## 🧪 Test Plan

```bash
go test ./internal/filecoord -count=1
go build ./...
go vet ./internal/filecoord
GOOS=windows go vet ./internal/filecoord
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
```

All passing locally; the cross-process contention test spawns a real second process that holds the lock while the parent observes `BusyError`, then acquires after release.

---

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model:** Claude Code (Opus)

**Material scope:** Root-cause analysis of the unsupported backend, design decision to reuse the hardened primitive, TDD implementation, and PR drafting under maintainer direction.

**Verification performed:** RED-first failing tests, full package tests, build, vet (linux and GOOS=windows), format check, dead-code ratchet.

https://claude.ai/code/session_019SpxE5JzfFPb3HeVp8iqQp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File-based coordination locks are now supported for exclusive access across processes.
  * Lock acquisition respects cancellation and safely isolates separate targets.
* **Bug Fixes**
  * Rejects unsafe lock paths involving symbolic links.
  * Correctly reports lock contention and operational failures.
  * Releasing a lock multiple times is handled safely.
* **Tests**
  * Added coverage for cross-process contention, cancellation, target isolation, exclusive leases, and symlink protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->