### PR TITLE
fix(sdd): settle truthful failed and interrupted remediations

### DIFF
--- a/internal/sddstatus/runtime_compact_post_reset_verification_test.go
+++ b/internal/sddstatus/runtime_compact_post_reset_verification_test.go
@@ -1,0 +1,110 @@
+package sddstatus
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCompactSettlePassesFinalVerificationAfterResetAndDischargedRemediation
+// is the #3547 shape end to end at the compact surface: a failed attempt, a
+// passed remediation that discharges it, an authorized reset opening a fresh
+// independent-verification objective, then one verification attempt settled
+// as passed WITHOUT a remediation binding. The final settlement must record
+// the passed outcome instead of blocking with invalid_continuation.
+func TestCompactSettlePassesFinalVerificationAfterResetAndDischargedRemediation(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "post-reset-verification")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	acquire := func(requestID, workUnit, goal, remediates string) CompactAttemptResult {
+		t.Helper()
+		result, err := store.Acquire(ctx, CompactAcquireRequest{
+			BeginAttemptRequest: BeginAttemptRequest{
+				RequestID: requestID, WorkUnit: workUnit, EvidenceGoal: goal,
+				MaxAttempts: 3, MaxChangedLines: 400,
+			},
+			RemediatesEvidenceRevision: remediates,
+		})
+		if err != nil {
+			t.Fatalf("acquire %s: %v", requestID, err)
+		}
+		if result.State != CompactStateProceed {
+			t.Fatalf("acquire %s = %#v, want proceed", requestID, result)
+		}
+		return result
+	}
+	settle := func(requestID, token string, outcome AttemptOutcome, evidence, remediates string) CompactAttemptResult {
+		t.Helper()
+		result, err := store.Settle(ctx, CompactSettleRequest{
+			RequestID: requestID, Token: token, Outcome: outcome,
+			EvidenceRevision: evidence, Diagnosis: "settlement for " + requestID,
+			HarnessDisposition: HarnessReused, CleanupEvidence: "workspace cleanup completed",
+			ProcessEvidence:            "process scan found no descendants",
+			RemediatesEvidenceRevision: remediates,
+		})
+		if err != nil {
+			t.Fatalf("settle %s: %v", requestID, err)
+		}
+		return result
+	}
+
+	// 1. Ordinary failed attempt records the chain's failed evidence.
+	first := acquire("post-reset-apply-acquire", "payments-apply", "implement payments", "")
+	appendRuntimeLedgerFile(t, repo, "implementation that failed verification\n")
+	failed := settle("post-reset-apply-settle", first.Token, AttemptFailed, runtimeTestHash('f'), "")
+	if failed.State != CompactStateProceed && failed.State != CompactStateBlocked {
+		t.Fatalf("failed settle = %#v", failed)
+	}
+
+	// 2. A passed remediation discharges that failure.
+	remediation := acquire("post-reset-remediation-acquire", "payments-apply", "implement payments", runtimeTestHash('f'))
+	appendRuntimeLedgerFile(t, repo, "correction that converged\n")
+	discharged := settle("post-reset-remediation-settle", remediation.Token, AttemptPassed, runtimeTestHash('b'), runtimeTestHash('f'))
+	if discharged.State != CompactStateComplete && discharged.State != CompactStateProceed {
+		t.Fatalf("remediation settle = %#v", discharged)
+	}
+
+	// 3. Authorized reset opens a fresh final independent-verification scope.
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reset, err := store.Reset(ctx, ResetObjectiveRequest{
+		ExpectedRevision: status.Revision, RequestID: "post-reset-authorization",
+		Reason: "maintainer authorized a fresh final independent verification", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("authorized reset: %v", err)
+	}
+	if reset.Objective != nil || reset.Complete {
+		t.Fatalf("reset state = %#v", reset)
+	}
+
+	// 4. One verification attempt without any remediation binding.
+	verification := acquire("post-reset-verify-acquire", "final-verification", "independently verify the change", "")
+	appendRuntimeLedgerFile(t, repo, "conventional verification report\n")
+
+	// 5. The truthful passed settlement of that verification must be admitted.
+	final := settle("post-reset-verify-settle", verification.Token, AttemptPassed, runtimeTestHash('c'), "")
+	if final.State == CompactStateBlocked {
+		t.Fatalf("final verification settle blocked: reason=%q exit=%q", final.Reason, final.Exit)
+	}
+	if final.State != CompactStateComplete && final.State != CompactStateProceed {
+		t.Fatalf("final verification settle = %#v", final)
+	}
+
+	verified, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	last := verified.Attempts[len(verified.Attempts)-1]
+	if last.Outcome != AttemptPassed || last.EvidenceRevision != runtimeTestHash('c') || last.RemediatesEvidenceRevision != "" {
+		t.Fatalf("final verification record = %#v", last)
+	}
+	if !verified.Complete {
+		t.Fatalf("final verification did not complete its objective: %#v", verified)
+	}
+}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -833,7 +833,13 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		if err != nil {
 			return runtimeRecord{}, fmt.Errorf("measure native SDD runtime line charge: %w", err)
 		}
-		if evidenceRemediation {
+		// The changed-candidate and fresh-evidence demands exist to stop an
+		// unreviewed no-op from DISCHARGING a failure, so they bind only the
+		// passing outcome. A truthful failed or interrupted settlement (#3422)
+		// discharges nothing: it may leave the candidate unchanged (the blocker
+		// can be environmental) and its evidence is the correction's own new
+		// failure, not proof the named failure was repaired.
+		if evidenceRemediation && request.Outcome == AttemptPassed {
 			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, status.LastRescope, chainFailedAttempt, snapshot.CandidateTree)
 			// #3073: "changed" is judged against the failed evidence's candidate
 			// snapshot, not the attempt's begin snapshot. A correction applied
@@ -2006,10 +2012,15 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		// no implications while it is off), and this replay mirror has to agree
 		// with it or a legitimately committed record makes the whole chain
 		// unreplayable.
-		if event.Outcome != AttemptPassed ||
-			!chainHasFailedEvidence || chainFailedAttempt.EvidenceRevision != event.RemediatesEvidenceRevision ||
-			(unchangedCandidate && !evidenceOnly) ||
-			event.EvidenceRevision == event.RemediatesEvidenceRevision {
+		// The binding must hold for every outcome; the changed-candidate and
+		// fresh-evidence demands bind only the passing outcome, exactly as the
+		// write-time guard in Finish decides (#3422). A truthful failed or
+		// interrupted settlement discharges nothing, so it neither needs a
+		// changed candidate nor fresh corrected evidence.
+		bindingBroken := !chainHasFailedEvidence || chainFailedAttempt.EvidenceRevision != event.RemediatesEvidenceRevision
+		passedDemandsBroken := event.Outcome == AttemptPassed &&
+			((unchangedCandidate && !evidenceOnly) || event.EvidenceRevision == event.RemediatesEvidenceRevision)
+		if bindingBroken || passedDemandsBroken {
 			// refusal:by-design world-action: a replayed event that breaks immutable evidence/candidate binding can only be repaired by restoring the authority.
 			return errors.New("unmanaged remediation finish does not bind the final failed-evidence correction")
 		}
@@ -2160,7 +2171,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			!runtimeRevisionPattern.MatchString(event.FinishCandidateIdentity) || !runtimeGitTreePattern.MatchString(event.FinishCandidateTree) ||
 			validateRuntimeText(event.Diagnosis, 500) != nil || !validHarnessDisposition(event.HarnessDisposition) ||
 			validateRuntimeText(event.CleanupEvidence, 500) != nil || validateRuntimeText(event.ProcessEvidence, 500) != nil ||
-			(event.RemediatesEvidenceRevision != "" && (!runtimeRevisionPattern.MatchString(event.RemediatesEvidenceRevision) || event.Outcome != AttemptPassed)) ||
+			(event.RemediatesEvidenceRevision != "" && !runtimeRevisionPattern.MatchString(event.RemediatesEvidenceRevision)) ||
 			(event.AttestedVerifyReportDigest != "" && (!runtimeRevisionPattern.MatchString(event.AttestedVerifyReportDigest) || event.Outcome != AttemptPassed)) {
 			return errors.New("invalid SDD runtime finish event")
 		}
@@ -2440,10 +2451,11 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 		return FinishAttemptRequest{}, fmt.Errorf("invalid process_evidence: %w", err)
 	}
 	if request.RemediatesEvidenceRevision != "" {
-		if request.Outcome != AttemptPassed {
-			// refusal:by-design operator-knowledge: the caller alone knows whether its correction passed and must supply that outcome truthfully.
-			return FinishAttemptRequest{}, errors.New("failed-evidence remediation is valid only for a passed attempt")
-		}
+		// Every outcome is a truthful settlement of a declared correction
+		// (#3422): passed discharges the failure it names, failed records the
+		// correction's own new failure as the chain's bindable head, and
+		// interrupted discharges nothing. Only the binding shape is validated
+		// here; outcome-specific demands live in Finish and its replay twin.
 		if !runtimeRevisionPattern.MatchString(request.RemediatesEvidenceRevision) {
 			return FinishAttemptRequest{}, fmt.Errorf(
 				"remediates_evidence_revision must be sha256:<64-lowercase-hex> (%s); rerun `gentle-ai sdd-attempt finish` with --remediates-evidence-revision sha256:<64-lowercase-hex>",

--- a/internal/sddstatus/runtime_truthful_remediation_settle_test.go
+++ b/internal/sddstatus/runtime_truthful_remediation_settle_test.go
@@ -1,0 +1,212 @@
+package sddstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+const (
+	truthfulWorkUnit    = "payments-retry-implementation"
+	truthfulGoal        = "implement bounded payment retries"
+	truthfulMaxAttempts = 4
+	truthfulMaxLines    = 400
+)
+
+// newTruthfulRemediationChain settles one ordinary failed attempt so every
+// test starts from the exact state #3422 reproduces: an immutable chain whose
+// unremediated head is the failed evidence a bounded remediation binds.
+func newTruthfulRemediationChain(t *testing.T) (string, RuntimeStore, RuntimeStatus) {
+	t.Helper()
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "truthful-remediation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "truthful-apply-begin", WorkUnit: truthfulWorkUnit,
+		EvidenceGoal: truthfulGoal, MaxAttempts: truthfulMaxAttempts, MaxChangedLines: truthfulMaxLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRuntimeLedgerFile(t, repo, "first implementation slice\n")
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "truthful-apply-finish", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('f'), Diagnosis: "verification failed on retry backoff",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "workspace cleanup completed",
+		ProcessEvidence: "process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.Complete || failed.ActiveAttempt != nil {
+		t.Fatalf("failed predecessor settlement = %#v", failed)
+	}
+	return repo, store, failed
+}
+
+func beginTruthfulRemediation(t *testing.T, store RuntimeStore, previous RuntimeStatus, requestID string) RuntimeStatus {
+	t.Helper()
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: previous.Revision, RequestID: requestID, WorkUnit: truthfulWorkUnit,
+		EvidenceGoal: truthfulGoal, MaxAttempts: truthfulMaxAttempts, MaxChangedLines: truthfulMaxLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return started
+}
+
+// TestRuntimeFinishRecordsTruthfulFailedRemediation is #3422: a bounded
+// remediation whose verification genuinely still fails must settle with a
+// truthful failed outcome. Refusing it leaves the consumer with no terminal
+// transition at all — the attempt stays active while verification and archive
+// stay blocked.
+func TestRuntimeFinishRecordsTruthfulFailedRemediation(t *testing.T) {
+	repo, store, failed := newTruthfulRemediationChain(t)
+	started := beginTruthfulRemediation(t, store, failed, "truthful-remediation-begin")
+	appendRuntimeLedgerFile(t, repo, "attempted correction that did not converge\n")
+
+	settled, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "truthful-remediation-finish", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "runtime environment blocker persisted",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "workspace cleanup completed",
+		ProcessEvidence:            "process scan found no descendants",
+		RemediatesEvidenceRevision: runtimeTestHash('f'),
+	})
+	if err != nil {
+		t.Fatalf("truthful failed remediation settle refused: %v", err)
+	}
+	if settled.ActiveAttempt != nil {
+		t.Fatalf("failed remediation did not close the attempt: %#v", settled.ActiveAttempt)
+	}
+	if settled.Complete {
+		t.Fatalf("failed remediation marked the objective complete: %#v", settled)
+	}
+	last := settled.Attempts[len(settled.Attempts)-1]
+	if last.Outcome != AttemptFailed || last.EvidenceRevision != runtimeTestHash('b') ||
+		last.RemediatesEvidenceRevision != runtimeTestHash('f') {
+		t.Fatalf("failed remediation record = %#v", last)
+	}
+
+	// The chain's unremediated head is now the remediation's own failure, so
+	// the next correction binds the new evidence, not the discharged original.
+	if !failedEvidenceRemediationSettleable(settled, runtimeTestHash('b')) {
+		t.Fatalf("next remediation cannot bind the new failed evidence: %#v", settled.Attempts)
+	}
+	if failedEvidenceRemediationSettleable(settled, runtimeTestHash('f')) {
+		t.Fatal("original failed evidence stayed bindable past its failed correction")
+	}
+
+	// The persisted chain must replay: a committed truthful record that the
+	// replay twin rejects would make the whole ledger unreadable.
+	reopened, err := OpenRuntimeStore(context.Background(), repo, "truthful-remediation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := reopened.Status()
+	if err != nil {
+		t.Fatalf("chain with a truthful failed remediation does not replay: %v", err)
+	}
+	if len(replayed.Attempts) != len(settled.Attempts) {
+		t.Fatalf("replayed attempts = %d, want %d", len(replayed.Attempts), len(settled.Attempts))
+	}
+
+	// A later passed correction of the NEW failure still works: the truthful
+	// failed record is an ordinary predecessor, not a dead end.
+	restarted := beginTruthfulRemediation(t, store, settled, "truthful-second-remediation-begin")
+	appendRuntimeLedgerFile(t, repo, "second correction that converged\n")
+	passed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: restarted.Revision, RequestID: "truthful-second-remediation-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('c'), Diagnosis: "verification passed after correction",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "workspace cleanup completed",
+		ProcessEvidence:            "process scan found no descendants",
+		RemediatesEvidenceRevision: runtimeTestHash('b'),
+	})
+	if err != nil {
+		t.Fatalf("passed correction after a truthful failed remediation refused: %v", err)
+	}
+	if !passed.Complete {
+		t.Fatalf("passed correction did not complete the objective: %#v", passed)
+	}
+}
+
+// TestRuntimeFinishRecordsTruthfulInterruptedRemediation holds the same
+// principle for the third outcome: an interrupted remediation settles
+// truthfully, discharges nothing, and leaves the original failed evidence as
+// the chain's bindable head.
+func TestRuntimeFinishRecordsTruthfulInterruptedRemediation(t *testing.T) {
+	repo, store, failed := newTruthfulRemediationChain(t)
+	started := beginTruthfulRemediation(t, store, failed, "truthful-interrupted-begin")
+	appendRuntimeLedgerFile(t, repo, "partial correction before interruption\n")
+
+	settled, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "truthful-interrupted-finish", Outcome: AttemptInterrupted,
+		Diagnosis:          "operator interrupted the correction run",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "workspace cleanup completed",
+		ProcessEvidence:            "process scan found no descendants",
+		RemediatesEvidenceRevision: runtimeTestHash('f'),
+	})
+	if err != nil {
+		t.Fatalf("truthful interrupted remediation settle refused: %v", err)
+	}
+	if settled.ActiveAttempt != nil || settled.Complete {
+		t.Fatalf("interrupted remediation state = %#v", settled)
+	}
+	if !failedEvidenceRemediationSettleable(settled, runtimeTestHash('f')) {
+		t.Fatal("interrupted remediation discharged the failed evidence it never repaired")
+	}
+}
+
+// TestRuntimeFinishKeepsPassedRemediationGuards proves the fix loosens nothing
+// for passing corrections: the changed-candidate demand, the fresh-evidence
+// demand, and the exact chain binding all still refuse.
+func TestRuntimeFinishKeepsPassedRemediationGuards(t *testing.T) {
+	t.Run("unchanged candidate still refused", func(t *testing.T) {
+		_, store, failed := newTruthfulRemediationChain(t)
+		started := beginTruthfulRemediation(t, store, failed, "guard-unchanged-begin")
+		_, err := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: started.Revision, RequestID: "guard-unchanged-finish", Outcome: AttemptPassed,
+			EvidenceRevision: runtimeTestHash('b'), Diagnosis: "claims to pass without changes",
+			HarnessDisposition: HarnessReused, CleanupEvidence: "workspace cleanup completed",
+			ProcessEvidence:            "process scan found no descendants",
+			RemediatesEvidenceRevision: runtimeTestHash('f'),
+		})
+		if err == nil || !strings.Contains(err.Error(), "changed correction candidate") {
+			t.Fatalf("unchanged passing correction = %v, want changed-candidate refusal", err)
+		}
+	})
+
+	t.Run("stale evidence still refused", func(t *testing.T) {
+		repo, store, failed := newTruthfulRemediationChain(t)
+		started := beginTruthfulRemediation(t, store, failed, "guard-stale-begin")
+		appendRuntimeLedgerFile(t, repo, "changed candidate with stale evidence\n")
+		_, err := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: started.Revision, RequestID: "guard-stale-finish", Outcome: AttemptPassed,
+			EvidenceRevision: runtimeTestHash('f'), Diagnosis: "reuses the failed evidence",
+			HarnessDisposition: HarnessReused, CleanupEvidence: "workspace cleanup completed",
+			ProcessEvidence:            "process scan found no descendants",
+			RemediatesEvidenceRevision: runtimeTestHash('f'),
+		})
+		if err == nil || !strings.Contains(err.Error(), "fresh corrected evidence") {
+			t.Fatalf("stale passing evidence = %v, want fresh-evidence refusal", err)
+		}
+	})
+
+	t.Run("wrong binding still refused for a failed outcome", func(t *testing.T) {
+		repo, store, failed := newTruthfulRemediationChain(t)
+		started := beginTruthfulRemediation(t, store, failed, "guard-binding-begin")
+		appendRuntimeLedgerFile(t, repo, "correction bound to the wrong failure\n")
+		_, err := store.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: started.Revision, RequestID: "guard-binding-finish", Outcome: AttemptFailed,
+			EvidenceRevision: runtimeTestHash('b'), Diagnosis: "still failing",
+			HarnessDisposition: HarnessReused, CleanupEvidence: "workspace cleanup completed",
+			ProcessEvidence:            "process scan found no descendants",
+			RemediatesEvidenceRevision: runtimeTestHash('d'),
+		})
+		if err == nil || !strings.Contains(err.Error(), "unremediated failure") {
+			t.Fatalf("wrong failed-outcome binding = %v, want exact-binding refusal", err)
+		}
+	})
+}

--- a/node_modules/.package-map.json
+++ b/node_modules/.package-map.json
@@ -1,0 +1,1 @@
+{"packages":{".":{"url":"..","dependencies":{"gentleman-ai-installer":"."}}}}

--- a/node_modules/.pnpm-workspace-state-v1.json
+++ b/node_modules/.pnpm-workspace-state-v1.json
@@ -1,0 +1,29 @@
+{
+  "lastValidatedTimestamp": 1787515777947,
+  "projects": {},
+  "pnpmfiles": [],
+  "settings": {
+    "autoInstallPeers": true,
+    "dedupeDirectDeps": false,
+    "dedupeInjectedDeps": true,
+    "dedupePeerDependents": true,
+    "dedupePeers": false,
+    "dev": true,
+    "excludeLinksFromLockfile": false,
+    "hoistPattern": [
+      "*"
+    ],
+    "hoistWorkspacePackages": true,
+    "injectWorkspacePackages": false,
+    "linkWorkspacePackages": false,
+    "minimumReleaseAge": 1440,
+    "minimumReleaseAgeIgnoreMissingTime": true,
+    "nodeLinker": "isolated",
+    "optional": true,
+    "peersSuffixMaxLength": 1000,
+    "preferWorkspacePackages": false,
+    "production": true,
+    "publicHoistPattern": []
+  },
+  "filteredInstall": false
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3422
Refs #3547

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- A bounded remediation whose verification genuinely still failed had no truthful terminal transition: three guards demanded a passed outcome for any settlement carrying a remediation binding, so the attempt stayed active forever while verification and archive stayed blocked (#3422).
- Separate the chain binding from the discharge demands: the binding (remediates must name the chain's unremediated failure) holds for every outcome; the changed-candidate and fresh-evidence demands bind only the passing outcome, because they exist to stop an unreviewed no-op from discharging a failure — and a truthful failed or interrupted settlement discharges nothing.
- A failed correction records its own new failure as the chain's bindable head; an interrupted one leaves the original failure bindable; a later passed correction of the new failure completes normally.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_ledger.go` | The passed-only refusal leaves `normalizeFinishAttemptRequest`; the changed-candidate and fresh-evidence demands in `Finish` and the replay twin (`applyRuntimeFinishEvent`) become passed-scoped with an identical predicate; the event-shape validator keeps revision-shape checks only. Committed truthful records replay. |
| `internal/sddstatus/runtime_truthful_remediation_settle_test.go` | Truthful failed and interrupted settlements succeed, the new failure becomes the bindable head, the chain replays after reopening, a subsequent passed correction completes, and every passed-outcome guard (changed candidate, fresh evidence, exact binding) still refuses. |
| `internal/sddstatus/runtime_compact_post_reset_verification_test.go` | End-to-end #3547 shape at the compact surface: failed attempt → passed remediation → authorized reset → final verification settled passed without a remediation binding. Proves the shape settles on current main (it passes with and without this fix), pinned as regression coverage. |

---

## 🧪 Test Plan

```bash
go test ./internal/sddstatus -count=1
go test ./internal/cli -count=1
go build ./...
go vet ./internal/sddstatus
GOOS=windows go vet ./internal/sddstatus
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
```

All passing (verified by a foreground delegated verification run). The new tests were written RED-first: both truthful-settlement tests failed on the pre-fix tree with `failed-evidence remediation is valid only for a passed attempt`.

Note: the `legacy_compact_receipt` build tag does not compile on clean main either — pre-existing, owned by the #2423 cleanup, untouched here.

---

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model:** Claude Code (Opus)

**Material scope:** Root-cause analysis across the three guards, TDD implementation, regression coverage for the #3547 shape, delegated verification run, and PR drafting under maintainer direction.

**Verification performed:** RED-first tests, full `internal/sddstatus` and `internal/cli` suites, build, vet (linux and GOOS=windows), format check, dead-code ratchet — all in the foreground.

https://claude.ai/code/session_019SpxE5JzfFPb3HeVp8iqQp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime status tracking now accurately records failed and interrupted remediation attempts without incorrectly marking issues as resolved.
  - Passed remediation continues to require valid, current evidence and appropriate verification.
  - Evidence history and follow-up correction workflows now remain consistent during replay and reset scenarios.

- **Tests**
  - Added end-to-end coverage for failed remediation, authorized resets, post-reset verification, and completion without continuation errors.
  - Added validation for truthful failed and interrupted outcomes and existing evidence safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->