### PR TITLE
fix(app): surface corrupt state read errors in persistAssignments

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -912,9 +912,11 @@ func persistAssignments(homeDir string, selection model.Selection) error {
 	current, err := state.Read(homeDir)
 	if err != nil {
 		// State file may not exist yet (e.g. pre-state users). Other read
-		// failures, such as invalid JSON, must not overwrite existing state.
+		// failures, such as invalid JSON, must not overwrite existing
+		// state — and must not be swallowed either, otherwise the caller's
+		// new assignments would be silently lost. Surface the error.
 		if !errors.Is(err, os.ErrNotExist) {
-			return nil
+			return fmt.Errorf("read existing state: %w", err)
 		}
 		current = state.InstallState{}
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1220,9 +1220,12 @@ func TestPersistAssignmentsSkipsCorruptState(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	persistAssignments(home, model.Selection{
+	err := persistAssignments(home, model.Selection{
 		CodexPhaseModelAssignments: map[string]string{},
 	})
+	if err == nil {
+		t.Fatal("persistAssignments() returned nil for corrupt state.json; want an error so assignments are not silently lost")
+	}
 
 	got, err := os.ReadFile(statePath)
 	if err != nil {


### PR DESCRIPTION
## Summary

`persistAssignments` silently swallowed read errors from `state.Read` when `state.json` existed but was unreadable (e.g. invalid JSON): it returned `nil`, so the caller's new model assignments were dropped without any warning to the user.

## Fix

- The fail-safe invariant is **preserved**: corrupt state is never overwritten.
- Read failures other than `os.ErrNotExist` are now wrapped (`read existing state: %w`) and returned, so the sync flow fails with a clear `persist model assignments: ...` message instead of losing assignments silently.
- `TestPersistAssignmentsSkipsCorruptState` now also asserts that the error is propagated (it previously ignored the return value).

## Verification

- `go build ./internal/app/` ✅
- `go test ./internal/app/ -count=1` — full package suite passes ✅
- `gofmt -l` clean on both touched files ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * State persistence errors are now reported instead of being silently ignored.
  * Corrupted or unreadable existing state is protected from accidental overwriting.
  * New installations continue to initialize correctly when no state file exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->