### PR TITLE
refactor(sdd): remove remediation binding parser

### DIFF
--- a/internal/sddstatus/remediation_test.go
+++ b/internal/sddstatus/remediation_test.go
@@ -2,7 +2,6 @@ package sddstatus
 
 import (
 	"encoding/json"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -21,24 +20,29 @@ func TestParseRemediationResultRejectsBareAndStaleEvidence(t *testing.T) {
 	}
 }
 
-func TestParseRemediationResultRequiresExactTransactionBinding(t *testing.T) {
-	revision := "sha256:" + strings.Repeat("d", 64)
-	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 1}
-	evidence := remediationResultEvidenceWithBinding(revision, binding)
-	if got := parseRemediationResult(evidence, revision, binding); !got.Complete {
-		t.Fatal("exact transaction-bound remediation evidence did not pass")
-	}
-	stale := binding
-	stale.Generation++
-	if got := parseRemediationResult(evidence, revision, stale); got.Complete {
-		t.Fatal("remediation evidence passed for a different transaction generation")
+func TestResolveBoundedRemediationRejectsHistoricalTransactionFields(t *testing.T) {
+	failedRevision := "sha256:" + strings.Repeat("d", 64)
+	for _, test := range []struct {
+		name          string
+		applyProgress string
+	}{
+		{name: "result envelope", applyProgress: remediationResultEvidenceWithHistoricalEnvelopeFields(failedRevision)},
+		{name: "JSON evidence", applyProgress: remediationResultEvidenceWithHistoricalEvidenceFields(failedRevision)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			remediation := resolveBoundedRemediation(true, verifyResultEvaluation{
+				EvidenceRevision: failedRevision,
+				Reason:           "verification failed",
+			}, test.applyProgress)
+			if remediation.Complete || !remediation.Required || remediation.Reason == "" {
+				t.Fatalf("historical transaction fields completed authority-free remediation: %#v", remediation)
+			}
+		})
 	}
 }
 
 func TestParseRemediationResultCumulativeProgress(t *testing.T) {
 	revision := "sha256:" + strings.Repeat("d", 64)
-	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
-
 	otherRevision := "sha256:" + strings.Repeat("e", 64)
 	type parseCase struct {
 		name, text string
@@ -47,60 +51,49 @@ func TestParseRemediationResultCumulativeProgress(t *testing.T) {
 	cases := []parseCase{
 		{
 			name: "accepts earlier history with different revision",
-			text: remediationResultEvidenceWithBinding(otherRevision, binding) + "\n\n" + remediationResultEvidenceWithBinding(revision, binding),
+			text: remediationResultEvidence(otherRevision) + "\n\n" + remediationResultEvidence(revision),
 			want: true,
 		},
 		{
 			name: "rejects non-adjacent evidence",
-			text: strings.Replace(remediationResultEvidenceWithBinding(revision, binding), "\n```json\n", "\nprogress prose\n```json\n", 1),
+			text: strings.Replace(remediationResultEvidence(revision), "\n```json\n", "\nprogress prose\n```json\n", 1),
 		},
 		{
 			name: "rejects invalid trailing content",
-			text: remediationResultEvidenceWithBinding(revision, binding) + "\ntrailing prose",
+			text: remediationResultEvidence(revision) + "\ntrailing prose",
 		},
 		{
 			name: "rejects trailing prose with an inline fence marker",
 			text: strings.Join([]string{
-				remediationResultEvidenceWithBinding(revision, binding),
+				remediationResultEvidence(revision),
 				"trailing prose with a ```yaml marker",
 			}, "\n"),
 			want: false,
 		},
 		{
 			name: "allows a closed bare fence after the valid pair",
-			text: remediationResultEvidenceWithBinding(revision, binding) + "\n```\nunrelated content\n```",
+			text: remediationResultEvidence(revision) + "\n```\nunrelated content\n```",
 			want: true,
 		},
 		{
 			name: "rejects a pair inside an unclosed bare fence",
-			text: "```\n" + remediationResultEvidenceWithBinding(revision, binding),
+			text: "```\n" + remediationResultEvidence(revision),
 		},
-	}
-	for _, tc := range []struct {
-		name     string
-		revision string
-		binding  RemediationBinding
-	}{
-		{"different lineage", revision, RemediationBinding{LineageID: "lineage-2", Generation: binding.Generation, FixBatch: binding.FixBatch}},
-		{"different generation", revision, RemediationBinding{LineageID: binding.LineageID, Generation: binding.Generation + 1, FixBatch: binding.FixBatch}},
-		{"different fix batch", revision, RemediationBinding{LineageID: binding.LineageID, Generation: binding.Generation, FixBatch: binding.FixBatch + 1}},
-	} {
-		cases = append(cases, parseCase{"accepts earlier history with " + tc.name, remediationResultEvidenceWithBinding(tc.revision, tc.binding) + "\n\n" + remediationResultEvidenceWithBinding(revision, binding), true})
 	}
 	for _, tc := range []struct {
 		name, text string
 	}{
-		{"strict pair", remediationResultEvidenceWithBinding(revision, binding)},
-		{"legacy json result", legacyRemediationResult(revision, binding)},
-		{"blockquoted result", quoteRemediationEnvelope(remediationEnvelopeWithBinding(revision, binding), "> ")},
-		{"nested blockquoted result", quoteRemediationEnvelope(remediationEnvelopeWithBinding(revision, binding), "> > ")},
+		{"strict pair", remediationResultEvidence(revision)},
+		{"legacy json result", legacyRemediationResult(revision)},
+		{"blockquoted result", quoteRemediationEnvelope(remediationEnvelope(revision), "> ")},
+		{"nested blockquoted result", quoteRemediationEnvelope(remediationEnvelope(revision), "> > ")},
 	} {
-		cases = append(cases, parseCase{"rejects duplicate " + tc.name, tc.text + "\n\n" + remediationResultEvidenceWithBinding(revision, binding), false})
+		cases = append(cases, parseCase{"rejects duplicate " + tc.name, tc.text + "\n\n" + remediationResultEvidence(revision), false})
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseRemediationResult(tc.text, revision, binding).Complete
+			got := parseRemediationResult(tc.text, revision).Complete
 			if got != tc.want {
 				t.Fatalf("parseRemediationResult(...).Complete = %v, want %v", got, tc.want)
 			}
@@ -111,15 +104,6 @@ func TestParseRemediationResultCumulativeProgress(t *testing.T) {
 func TestParseRemediationResultRejectsManyUnclosedFences(t *testing.T) {
 	if got := parseRemediationResult(strings.Repeat("```yaml\n", 4096), "sha256:"+strings.Repeat("d", 64)); got.Complete {
 		t.Fatal("many unclosed fences passed remediation parsing")
-	}
-}
-
-func TestParseRemediationResultMultipleBindingsPreserveEvidenceRevision(t *testing.T) {
-	revision := "sha256:" + strings.Repeat("d", 64)
-	binding := RemediationBinding{LineageID: "lineage-1", Generation: 2, FixBatch: 2}
-	got := parseRemediationResult(remediationResultEvidenceWithBinding(revision, binding), revision, binding, binding)
-	if got.Complete || got.EvidenceRevision != revision {
-		t.Fatalf("multiple-binding result = %#v, want incomplete result retaining %q", got, revision)
 	}
 }
 
@@ -154,14 +138,17 @@ func remediationResultEvidence(revision string) string {
 	return remediationEnvelope(revision) + "\n```json\n" + string(raw) + "\n```"
 }
 
-func remediationResultEvidenceWithBinding(revision string, binding RemediationBinding) string {
-	envelope := remediationEnvelopeWithBinding(revision, binding)
+func remediationResultEvidenceWithHistoricalEnvelopeFields(revision string) string {
+	return strings.Replace(remediationResultEvidence(revision), "focused_tests: passed", "lineage_id: historical-lineage\ngeneration: 2\nfix_batch: 1\nfocused_tests: passed", 1)
+}
+
+func remediationResultEvidenceWithHistoricalEvidenceFields(revision string) string {
 	payload := map[string]any{
 		"schema":                   "gentle-ai.remediation-evidence/v1",
 		"failed_evidence_revision": revision,
-		"lineage_id":               binding.LineageID,
-		"generation":               binding.Generation,
-		"fix_batch":                binding.FixBatch,
+		"lineage_id":               "historical-lineage",
+		"generation":               2,
+		"fix_batch":                1,
 		"commands":                 []map[string]any{{"command": "go test ./internal/example", "exit_code": 0, "result": "1 test passed"}},
 		"runtime_harness": map[string]any{
 			"status": "not_applicable", "command": "", "result": "",
@@ -173,15 +160,11 @@ func remediationResultEvidenceWithBinding(revision string, binding RemediationBi
 		},
 	}
 	raw, _ := json.Marshal(payload)
-	return envelope + "\n```json\n" + string(raw) + "\n```"
+	return remediationEnvelope(revision) + "\n```json\n" + string(raw) + "\n```"
 }
 
-func remediationEnvelopeWithBinding(revision string, binding RemediationBinding) string {
-	return strings.Replace(remediationEnvelope(revision), "focused_tests: passed", "lineage_id: "+binding.LineageID+"\ngeneration: "+strconv.Itoa(binding.Generation)+"\nfix_batch: "+strconv.Itoa(binding.FixBatch)+"\nfocused_tests: passed", 1)
-}
-
-func legacyRemediationResult(revision string, binding RemediationBinding) string {
-	return "```json\n{\"schema\":\"gentle-ai.remediation-result/v1\",\"failedVerifyRevision\":\"" + revision + "\",\"lineageId\":\"" + binding.LineageID + "\",\"generation\":" + strconv.Itoa(binding.Generation) + ",\"fixBatch\":" + strconv.Itoa(binding.FixBatch) + "}\n```"
+func legacyRemediationResult(revision string) string {
+	return "```json\n{\"schema\":\"gentle-ai.remediation-result/v1\",\"failedVerifyRevision\":\"" + revision + "\"}\n```"
 }
 
 func quoteRemediationEnvelope(envelope, prefix string) string {

--- a/internal/sddstatus/remediation_test.go
+++ b/internal/sddstatus/remediation_test.go
@@ -26,8 +26,12 @@ func TestResolveBoundedRemediationRejectsHistoricalTransactionFields(t *testing.
 		name          string
 		applyProgress string
 	}{
-		{name: "result envelope", applyProgress: remediationResultEvidenceWithHistoricalEnvelopeFields(failedRevision)},
-		{name: "JSON evidence", applyProgress: remediationResultEvidenceWithHistoricalEvidenceFields(failedRevision)},
+		{name: "result envelope lineage_id", applyProgress: remediationResultEvidenceWithHistoricalEnvelopeField(failedRevision, "lineage_id", "historical-lineage")},
+		{name: "result envelope generation", applyProgress: remediationResultEvidenceWithHistoricalEnvelopeField(failedRevision, "generation", "2")},
+		{name: "result envelope fix_batch", applyProgress: remediationResultEvidenceWithHistoricalEnvelopeField(failedRevision, "fix_batch", "1")},
+		{name: "JSON evidence lineage_id", applyProgress: remediationResultEvidenceWithHistoricalEvidenceField(failedRevision, "lineage_id", "historical-lineage")},
+		{name: "JSON evidence generation", applyProgress: remediationResultEvidenceWithHistoricalEvidenceField(failedRevision, "generation", 2)},
+		{name: "JSON evidence fix_batch", applyProgress: remediationResultEvidenceWithHistoricalEvidenceField(failedRevision, "fix_batch", 1)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			remediation := resolveBoundedRemediation(true, verifyResultEvaluation{
@@ -35,7 +39,7 @@ func TestResolveBoundedRemediationRejectsHistoricalTransactionFields(t *testing.
 				Reason:           "verification failed",
 			}, test.applyProgress)
 			if remediation.Complete || !remediation.Required || remediation.Reason == "" {
-				t.Fatalf("historical transaction fields completed authority-free remediation: %#v", remediation)
+				t.Fatalf("historical transaction field completed authority-free remediation: %#v", remediation)
 			}
 		})
 	}
@@ -138,17 +142,14 @@ func remediationResultEvidence(revision string) string {
 	return remediationEnvelope(revision) + "\n```json\n" + string(raw) + "\n```"
 }
 
-func remediationResultEvidenceWithHistoricalEnvelopeFields(revision string) string {
-	return strings.Replace(remediationResultEvidence(revision), "focused_tests: passed", "lineage_id: historical-lineage\ngeneration: 2\nfix_batch: 1\nfocused_tests: passed", 1)
+func remediationResultEvidenceWithHistoricalEnvelopeField(revision, field, value string) string {
+	return strings.Replace(remediationResultEvidence(revision), "focused_tests: passed", field+": "+value+"\nfocused_tests: passed", 1)
 }
 
-func remediationResultEvidenceWithHistoricalEvidenceFields(revision string) string {
+func remediationResultEvidenceWithHistoricalEvidenceField(revision, field string, value any) string {
 	payload := map[string]any{
 		"schema":                   "gentle-ai.remediation-evidence/v1",
 		"failed_evidence_revision": revision,
-		"lineage_id":               "historical-lineage",
-		"generation":               2,
-		"fix_batch":                1,
 		"commands":                 []map[string]any{{"command": "go test ./internal/example", "exit_code": 0, "result": "1 test passed"}},
 		"runtime_harness": map[string]any{
 			"status": "not_applicable", "command": "", "result": "",
@@ -159,6 +160,7 @@ func remediationResultEvidenceWithHistoricalEvidenceFields(revision string) stri
 			"evidence": "Revert those files without changing unrelated status behavior.",
 		},
 	}
+	payload[field] = value
 	raw, _ := json.Marshal(payload)
 	return remediationEnvelope(revision) + "\n```json\n" + string(raw) + "\n```"
 }

--- a/internal/sddstatus/status_v2_clean_break_test.go
+++ b/internal/sddstatus/status_v2_clean_break_test.go
@@ -265,24 +265,12 @@ func TestResolveRuntimeAuthorityFailureBlocksFinalRoutingBeforeOfferingReview(t 
 
 func TestResolveBoundedRemediationCompletesAuthorityFreeEvidence(t *testing.T) {
 	failedEvidenceRevision := "sha256:" + strings.Repeat("d", 64)
-	historicalBinding := RemediationBinding{LineageID: "historical-lineage", Generation: 2, FixBatch: 1}
-
-	for _, test := range []struct {
-		name          string
-		applyProgress string
-	}{
-		{name: "ordinary unbound evidence", applyProgress: remediationResultEvidence(failedEvidenceRevision)},
-		{name: "historical bound evidence", applyProgress: remediationResultEvidenceWithBinding(failedEvidenceRevision, historicalBinding)},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			remediation := resolveBoundedRemediation(true, verifyResultEvaluation{
-				EvidenceRevision: failedEvidenceRevision,
-				Reason:           "verification failed",
-			}, test.applyProgress)
-			if !remediation.Complete || remediation.Required || remediation.Reason != "" {
-				t.Fatalf("authority-free remediation = %#v, want completed evidence", remediation)
-			}
-		})
+	remediation := resolveBoundedRemediation(true, verifyResultEvaluation{
+		EvidenceRevision: failedEvidenceRevision,
+		Reason:           "verification failed",
+	}, remediationResultEvidence(failedEvidenceRevision))
+	if !remediation.Complete || remediation.Required || remediation.Reason != "" {
+		t.Fatalf("authority-free remediation = %#v, want completed evidence", remediation)
 	}
 }
 

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -335,25 +335,13 @@ type remediationResultEvaluation struct {
 type remediationEvidence struct {
 	Schema                 string                       `json:"schema"`
 	FailedEvidenceRevision string                       `json:"failed_evidence_revision"`
-	LineageID              string                       `json:"lineage_id,omitempty"`
-	Generation             int                          `json:"generation,omitempty"`
-	FixBatch               int                          `json:"fix_batch,omitempty"`
 	Commands               []remediationCommandEvidence `json:"commands"`
 	RuntimeHarness         remediationRuntimeEvidence   `json:"runtime_harness"`
 	Rollback               remediationRollbackEvidence  `json:"rollback"`
 }
 
-type RemediationBinding struct {
-	LineageID  string
-	Generation int
-	FixBatch   int
-}
-
 type remediationIdentity struct {
-	Revision   string
-	LineageID  string
-	Generation int
-	FixBatch   int
+	Revision string
 }
 
 type remediationFenceBlock struct {
@@ -380,7 +368,7 @@ type remediationRollbackEvidence struct {
 	Evidence string `json:"evidence"`
 }
 
-func parseRemediationResult(text, expectedRevision string, bindings ...RemediationBinding) remediationResultEvaluation {
+func parseRemediationResult(text, expectedRevision string) remediationResultEvaluation {
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	lines := strings.Split(text, "\n")
 	blocks, invalid := scanRemediationFences(lines)
@@ -398,7 +386,7 @@ func parseRemediationResult(text, expectedRevision string, bindings ...Remediati
 			continue
 		}
 		if block.token == "json" {
-			if identity, ok := remediationJSONIdentity(lines[block.start+1 : block.end]); ok && remediationIdentityMatches(identity, expectedRevision, bindings) {
+			if identity, ok := remediationJSONIdentity(lines[block.start+1 : block.end]); ok && remediationIdentityMatches(identity, expectedRevision) {
 				claims++
 			}
 			continue
@@ -407,10 +395,10 @@ func parseRemediationResult(text, expectedRevision string, bindings ...Remediati
 			continue
 		}
 
-		if identity, ok := remediationYAMLIdentity(lines[block.start+1 : block.end]); ok && remediationIdentityMatches(identity, expectedRevision, bindings) {
+		if identity, ok := remediationYAMLIdentity(lines[block.start+1 : block.end]); ok && remediationIdentityMatches(identity, expectedRevision) {
 			claims++
 		}
-		envelope := parseRemediationResultEnvelope(strings.Join(lines[block.start:block.end+1], "\n"), expectedRevision, bindings...)
+		envelope := parseRemediationResultEnvelope(strings.Join(lines[block.start:block.end+1], "\n"), expectedRevision)
 		if fallback.EvidenceRevision == "" && envelope.EvidenceRevision != "" {
 			fallback = envelope
 		}
@@ -429,11 +417,11 @@ func parseRemediationResult(text, expectedRevision string, bindings ...Remediati
 		}
 
 		pair := strings.Join(lines[block.start:evidenceBlock.end+1], "\n")
-		evaluation := parseRemediationResultEnvelope(pair, expectedRevision, bindings...)
+		evaluation := parseRemediationResultEnvelope(pair, expectedRevision)
 		if fallback.EvidenceRevision == "" && evaluation.EvidenceRevision != "" {
 			fallback = evaluation
 		}
-		if evaluation.Complete && len(bindings) <= 1 {
+		if evaluation.Complete {
 			candidate = evaluation
 			candidateEnd = evidenceBlock.end
 		}
@@ -531,11 +519,8 @@ func remediationJSONIdentity(lines []string) (remediationIdentity, bool) {
 	}
 
 	identity := remediationIdentity{
-		Revision:  firstStringFieldAny(fields, "failed_evidence_revision", "failed_verify_revision", "failedEvidenceRevision", "failedVerifyRevision"),
-		LineageID: firstStringFieldAny(fields, "lineage_id", "lineageId", "lineageID"),
+		Revision: firstStringFieldAny(fields, "failed_evidence_revision", "failed_verify_revision", "failedEvidenceRevision", "failedVerifyRevision"),
 	}
-	identity.Generation, _ = firstIntField(fields, "generation")
-	identity.FixBatch, _ = firstIntField(fields, "fix_batch", "fixBatch")
 	return identity, identity.Revision != ""
 }
 
@@ -544,11 +529,8 @@ func remediationIdentityFromFields(fields map[string]string) (remediationIdentit
 		return remediationIdentity{}, false
 	}
 	identity := remediationIdentity{
-		Revision:  firstStringField(fields, "failed_evidence_revision", "failed_verify_revision", "failedEvidenceRevision", "failedVerifyRevision"),
-		LineageID: firstStringField(fields, "lineage_id", "lineageId", "lineageID"),
+		Revision: firstStringField(fields, "failed_evidence_revision", "failed_verify_revision", "failedEvidenceRevision", "failedVerifyRevision"),
 	}
-	identity.Generation, _ = parseFirstIntField(fields, "generation")
-	identity.FixBatch, _ = parseFirstIntField(fields, "fix_batch", "fixBatch")
 	return identity, identity.Revision != ""
 }
 
@@ -570,40 +552,8 @@ func firstStringFieldAny(fields map[string]any, keys ...string) string {
 	return ""
 }
 
-func firstIntField(fields map[string]any, keys ...string) (int, bool) {
-	for _, key := range keys {
-		switch value := fields[key].(type) {
-		case float64:
-			if value >= 0 && value == float64(int(value)) {
-				return int(value), true
-			}
-		case string:
-			if parsed, ok := parseNonnegativeInt(value); ok {
-				return parsed, true
-			}
-		}
-	}
-	return 0, false
-}
-
-func parseFirstIntField(fields map[string]string, keys ...string) (int, bool) {
-	for _, key := range keys {
-		if parsed, ok := parseNonnegativeInt(fields[key]); ok {
-			return parsed, true
-		}
-	}
-	return 0, false
-}
-
-func remediationIdentityMatches(identity remediationIdentity, expectedRevision string, bindings []RemediationBinding) bool {
-	if identity.Revision != expectedRevision || len(bindings) > 1 {
-		return false
-	}
-	if len(bindings) == 0 {
-		return true
-	}
-	binding := bindings[0]
-	return identity.LineageID == binding.LineageID && identity.Generation == binding.Generation && identity.FixBatch == binding.FixBatch
+func remediationIdentityMatches(identity remediationIdentity, expectedRevision string) bool {
+	return identity.Revision == expectedRevision
 }
 
 func remediationTrailingContentValid(lines []string, start int, blocksByStart map[int]remediationFenceBlock) bool {
@@ -657,7 +607,7 @@ func remediationFenceContents(lines []string) []string {
 	return contents
 }
 
-func parseRemediationResultEnvelope(text, expectedRevision string, bindings ...RemediationBinding) remediationResultEvaluation {
+func parseRemediationResultEnvelope(text, expectedRevision string) remediationResultEvaluation {
 	lines, end, reason := parseLeadingEnvelope(text)
 	if reason != "" {
 		return remediationResultEvaluation{}
@@ -665,7 +615,6 @@ func parseRemediationResultEnvelope(text, expectedRevision string, bindings ...R
 	allowed := map[string]bool{
 		"schema": true, "status": true, "failed_evidence_revision": true,
 		"focused_tests": true, "runtime_harness": true, "rollback_boundary": true,
-		"lineage_id": true, "generation": true, "fix_batch": true,
 	}
 	fields, reason := parseScalarFields(lines[1:end], allowed, "remediation result")
 	if reason != "" {
@@ -676,17 +625,6 @@ func parseRemediationResultEnvelope(text, expectedRevision string, bindings ...R
 	if fields["schema"] != RemediationResultSchema || fields["status"] != "complete" || revision != expectedRevision {
 		return evaluation
 	}
-	if len(bindings) > 1 {
-		return evaluation
-	}
-	if len(bindings) == 1 {
-		binding := bindings[0]
-		generation, generationOK := parseNonnegativeInt(fields["generation"])
-		fixBatch, fixBatchOK := parseNonnegativeInt(fields["fix_batch"])
-		if fields["lineage_id"] != binding.LineageID || !generationOK || generation != binding.Generation || !fixBatchOK || fixBatch != binding.FixBatch {
-			return evaluation
-		}
-	}
 	if fields["focused_tests"] != "passed" || fields["rollback_boundary"] != "recorded" {
 		return evaluation
 	}
@@ -696,12 +634,6 @@ func parseRemediationResultEnvelope(text, expectedRevision string, bindings ...R
 	evidence, ok := parseRemediationEvidence(lines[end+1:])
 	if !ok || evidence.FailedEvidenceRevision != expectedRevision || len(evidence.Commands) == 0 {
 		return evaluation
-	}
-	if len(bindings) == 1 {
-		binding := bindings[0]
-		if evidence.LineageID != binding.LineageID || evidence.Generation != binding.Generation || evidence.FixBatch != binding.FixBatch {
-			return evaluation
-		}
 	}
 	for _, command := range evidence.Commands {
 		if command.ExitCode != 0 || !isConcreteEvidence(command.Command) || !isConcreteEvidence(command.Result) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3699

Parent cleanup: #3564

## 🏷️ PR Type

- [x] `type:refactor` — Code refactoring

## 📝 Summary

- removes historical transaction-bound `RemediationBinding` parsing;
- rejects retired `lineage_id`, `generation`, and `fix_batch` fields at both strict parser boundaries;
- preserves authority-free remediation and live `sdd-attempt finish` behavior.

This is #3564 Slice 2A. Runtime binding/receipt codecs, tagged compatibility cleanup, and the universal D6 guard remain separate follow-up slices so each PR stays reviewable.

## 📂 Changes

| File / Area | What Changed |
|---|---|
| `internal/sddstatus/verification.go` | Removed the binding type, variadic parser API, and transaction identity validation. |
| `internal/sddstatus/remediation_test.go` | Replaced binding acceptance with strict YAML and JSON historical-field rejection coverage. |
| `internal/sddstatus/status_v2_clean_break_test.go` | Retained only the authority-free V2 remediation completion path. |

## 🧪 Test Plan

**Mechanical RED**

Candidate tests against base production failed because historical transaction fields completed remediation. Both `result_envelope` and `JSON_evidence` cases failed for the intended reason.

**Validation**

- [x] Focused remediation/V2 parser tests pass.
- [x] Failed, interrupted, passed-remediation, and objective-advance controls pass.
- [x] Public in-process `sdd-attempt finish` controls pass.
- [x] `go test ./internal/sddstatus ./internal/cli -count=1` passes.
- [x] `go test ./... -count=1` passes: 74 packages reported, 69 `ok`, 5 without test files.
- [x] `go vet ./...` passes.
- [x] `go run ./internal/gofmtcheck` passes.
- [x] Deadcode and refusal ratchets pass.
- [x] `git diff --check` passes.
- [x] Docker E2E is not applicable; no external runtime/operator flow changed, and the repository Go suite includes the retained runtime coverage.

Current `main@01ade68d` has a pre-existing red Windows Full Suite run (`32751543905`) and one failed-shard rerun in unrelated atomic-review tests. This PR does not touch those files or claim new native Windows evidence.

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #3699; parent #3564 remains open for later slices.
- [x] PR is within the 400-line budget: **217 lines** (`+59/-156`).
- [x] Exactly one `type:*` label will be applied.
- [x] Tests and formatting pass.
- [x] Documentation is not required for this internal compatibility deletion.
- [x] Commit follows Conventional Commits and has no attribution trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remediation verification now consistently uses the failed evidence revision when evaluating results.
  * Historical transaction details no longer incorrectly mark remediation as complete.
  * Improved validation rejects duplicate, malformed, or trailing result content while preserving support for valid legacy results.
  * Cumulative progress now reflects revision-based evidence more accurately across remediation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->