### PR TITLE
refactor(sdd): delete orphaned review binding codec provider

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -208,14 +208,6 @@ internal/reviewtransaction/verification_contract.go	verificationSVGIsPassive
 internal/reviewtransaction/verification_convergence.go	ResnapshotVerificationSubject
 internal/reviewtransaction/verification_convergence.go	VerificationSubjectMutationError.Error
 internal/reviewtransaction/verification_convergence.go	VerificationSubjectMutationError.Unwrap
-internal/sddstatus/review_binding.go	bindingBytes
-internal/sddstatus/review_binding.go	bindingDigest
-internal/sddstatus/review_binding.go	bindingHash
-internal/sddstatus/review_binding.go	bindingPath
-internal/sddstatus/review_binding.go	parseBinding
-internal/sddstatus/review_binding.go	reviewBindingViolation
-internal/sddstatus/review_binding.go	validReviewBindingChange
-internal/sddstatus/review_binding.go	validReviewBindingLineage
 internal/sddstatus/review_door.go	resetReviewEntryHookCallCountForTest
 internal/sddstatus/review_door.go	reviewEntryHookCallCountForTest
 internal/sddstatus/status.go	RenderNativePhasePrompt

--- a/.refusal-ratchet-baseline.txt
+++ b/.refusal-ratchet-baseline.txt
@@ -1170,7 +1170,6 @@ internal/reviewtransaction/verification_contract.go	"verification subject requir
 internal/reviewtransaction/verification_convergence.go	"unsupported mutable verification subject kind %q"
 internal/reviewtransaction/verification_convergence.go	"verification resnapshot context is nil"
 internal/reviewtransaction/verification_convergence.go	"verification subject mutated during final verification"
-internal/sddstatus/review_binding.go	"multiple binding values"
 internal/sddstatus/review_binding.go	"planning workspace is outside selected repository"
 internal/sddstatus/review_binding.go	"selected OpenSpec change does not exist"
 internal/sddstatus/review_binding.go	"selected OpenSpec change is ambiguous within repository"

--- a/internal/reviewtransaction/legacy_readonly_guard_test.go
+++ b/internal/reviewtransaction/legacy_readonly_guard_test.go
@@ -31,17 +31,15 @@ import (
 
 // legacyRetainedReadSymbols is D5's closed retained-read list: file path
 // (relative to this package directory) -> identifier names that file must
-// still declare. sddstatus/legacy_binding_read.go, sddstatus/review_binding.go
-// and candidate_decline.go live outside this package's own directory, so
-// their paths are relative to this package's own directory.
+// still declare. candidate_decline.go lives outside this package's own
+// directory, so its path is relative to this package's own directory.
 // AuthoritativeStore/LoadChain/NewLegacyReadOnlyError are declared inside
 // THIS package (store.go, compact_store.go) — review_facade.go:1632-1635
 // (design.md) is only their call site, not their declaration.
 var legacyRetainedReadSymbols = map[string][]string{
-	"../sddstatus/review_binding.go": {"parseBinding", "bindingBytes", "bindingDigest", "bindingPath"},
-	"candidate_decline.go":           {"parseCandidateDeclineAuthorization"},
-	"store.go":                       {"AuthoritativeStore", "LoadChain"},
-	"compact_store.go":               {"NewLegacyReadOnlyError"},
+	"candidate_decline.go": {"parseCandidateDeclineAuthorization"},
+	"store.go":             {"AuthoritativeStore", "LoadChain"},
+	"compact_store.go":     {"NewLegacyReadOnlyError"},
 }
 
 // legacyRetiredMutationVerbs is the exact case-clause literal set this wave

--- a/internal/sddstatus/legacy_binding_read.go
+++ b/internal/sddstatus/legacy_binding_read.go
@@ -1,1 +1,0 @@
-package sddstatus

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -1,38 +1,15 @@
 package sddstatus
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pathidentity"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
-
-const reviewBindingSchema = "gentle-ai.sdd-review-binding/v1"
-
-var reviewBindingChange = regexp.MustCompile(`^[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*$`)
-var reviewBindingLineage = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
-var reviewBindingHash = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
-
-type ReviewBinding struct {
-	Schema            string                        `json:"schema"`
-	Revision          string                        `json:"revision"`
-	Change            string                        `json:"change"`
-	Lineage           string                        `json:"lineage"`
-	AuthorityRevision string                        `json:"authority_revision"`
-	ReceiptHash       string                        `json:"receipt_hash"`
-	GateContext       reviewtransaction.GateContext `json:"gate_context"`
-}
 
 func resolveBindingChangeRoot(ctx context.Context, root, workspace, change string) (string, error) {
 	// Both operands are canonicalized the same way before any containment or
@@ -178,83 +155,4 @@ func canonicalBindingPath(path string) (string, error) {
 // answers "is it inside", never "did it get there through a symlink".
 func pathWithinBindingRoot(root, path string) bool {
 	return pathidentity.Contains(root, path)
-}
-
-func bindingPath(store reviewtransaction.CompactStore, change string) string {
-	return filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(store.Dir)))), "gentle-ai", "sdd-review-bindings", "v1", change, "binding.json")
-}
-
-func bindingHash(payload []byte) string {
-	sum := sha256.Sum256(payload)
-	return "sha256:" + hex.EncodeToString(sum[:])
-}
-
-func bindingDigest(binding ReviewBinding) string {
-	binding.Revision = ""
-	payload, _ := json.Marshal(binding)
-	return bindingHash(payload)
-}
-
-func validReviewBindingChange(change string) bool {
-	return len(change) <= 96 && reviewBindingChange.MatchString(change)
-}
-
-func validReviewBindingLineage(lineage string) bool {
-	return len(lineage) <= 128 && reviewBindingLineage.MatchString(lineage)
-}
-
-func bindingBytes(binding ReviewBinding) ([]byte, error) {
-	payload, err := json.Marshal(binding)
-	if err != nil {
-		return nil, err
-	}
-	return append(payload, '\n'), nil
-}
-
-func parseBinding(payload []byte) (ReviewBinding, error) {
-	var binding ReviewBinding
-	decoder := json.NewDecoder(bytes.NewReader(payload))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&binding); err != nil {
-		return ReviewBinding{}, err
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		return ReviewBinding{}, errors.New("multiple binding values")
-	}
-	if violation := reviewBindingViolation(payload, binding); violation != "" {
-		return ReviewBinding{}, fmt.Errorf("invalid binding: %s", violation) // refusal:by-design world-action: this binding is written and digested by this package itself, so a violation is a mutated or corrupted record and the exit is restoring the Git-common-dir store, not a command
-	}
-	return binding, nil
-}
-
-func reviewBindingViolation(payload []byte, binding ReviewBinding) string {
-	canonical, err := bindingBytes(binding)
-	switch {
-	case err != nil:
-		return "binding could not be re-encoded for canonical comparison"
-	case !bytes.Equal(payload, canonical):
-		return "payload is not the canonical encoding of its own fields"
-	case binding.Schema != reviewBindingSchema:
-		return "schema is not " + reviewBindingSchema
-	case !validReviewBindingChange(binding.Change):
-		return "change name is not a valid change identifier"
-	case !validReviewBindingLineage(binding.Lineage):
-		return "lineage is not a valid lineage identifier"
-	case !reviewBindingHash.MatchString(binding.Revision):
-		return "revision is not a sha256 digest"
-	case !reviewBindingHash.MatchString(binding.AuthorityRevision):
-		return "authority_revision is not a sha256 digest"
-	case !reviewBindingHash.MatchString(binding.ReceiptHash):
-		return "receipt_hash is not a sha256 digest"
-	case binding.Revision != bindingDigest(binding):
-		return "revision does not match the digest of its own fields"
-	case binding.GateContext.Gate != reviewtransaction.GatePostApply:
-		return "gate_context.gate is not " + string(reviewtransaction.GatePostApply)
-	case binding.GateContext.LineageID != binding.Lineage:
-		return "gate_context.lineage_id does not match the binding lineage"
-	case binding.GateContext.StoreRevision != binding.AuthorityRevision:
-		return "gate_context.store_revision does not match authority_revision"
-	}
-	return ""
 }

--- a/internal/sddstatus/review_binding_absence_test.go
+++ b/internal/sddstatus/review_binding_absence_test.go
@@ -1,0 +1,51 @@
+package sddstatus
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestReviewBindingCodecDeclarationsRemoved(t *testing.T) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "review_binding.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse review_binding.go: %v", err)
+	}
+
+	declared := map[string]bool{}
+	for _, declaration := range file.Decls {
+		switch declaration := declaration.(type) {
+		case *ast.FuncDecl:
+			declared[declaration.Name.Name] = true
+		case *ast.GenDecl:
+			for _, spec := range declaration.Specs {
+				switch spec := spec.(type) {
+				case *ast.TypeSpec:
+					declared[spec.Name.Name] = true
+				case *ast.ValueSpec:
+					for _, name := range spec.Names {
+						declared[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+
+	for _, name := range []string{
+		"ReviewBinding", "parseBinding", "bindingBytes", "bindingDigest", "bindingHash", "bindingPath", "reviewBindingViolation",
+		"reviewBindingSchema", "reviewBindingChange", "reviewBindingLineage", "reviewBindingHash",
+		"validReviewBindingChange", "validReviewBindingLineage",
+	} {
+		if declared[name] {
+			t.Errorf("review_binding.go still declares removed provider codec symbol %q", name)
+		}
+	}
+
+	for _, name := range []string{"resolveBindingChangeRoot", "bindingChangeRoots", "canonicalBindingPath", "pathWithinBindingRoot"} {
+		if !declared[name] {
+			t.Errorf("review_binding.go no longer declares retained authority-free path helper %q", name)
+		}
+	}
+}

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -1,1 +1,0 @@
-package sddstatus

--- a/internal/sddstatus/runtime_ledger_binding_test.go
+++ b/internal/sddstatus/runtime_ledger_binding_test.go
@@ -1,1 +1,0 @@
-package sddstatus

--- a/internal/sddstatus/runtime_receipt.go
+++ b/internal/sddstatus/runtime_receipt.go
@@ -1,1 +1,0 @@
-package sddstatus


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3709

## 🏷️ PR Type

- [x] `type:refactor` — Code refactoring (no functional changes)

## 📝 Summary

Deletes the orphaned SDD review-binding codec provider after #3713 removed its final active runtime consumers. This completes the consumer-first/provider-second cleanup without restoring aliases, placeholders, receipts, or binding persistence.

The authority-free path helpers used by final verify-report anchoring remain in place. Tagged `legacy_compact_receipt` corpus cleanup is intentionally deferred to the next approved #3564 slice.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/review_binding.go` | Removed the `ReviewBinding` schema, parser, serializer, digest, hash, path, and validation provider while preserving four final-anchor path helpers |
| `internal/sddstatus/review_binding_absence_test.go` | Added a scoped AST guard for codec absence and helper preservation |
| `internal/sddstatus/*binding*.go`, `runtime_receipt.go` | Deleted four empty codec-era stubs/tests |
| `internal/reviewtransaction/legacy_readonly_guard_test.go` | Removed only the obsolete SDD binding row from the retained-read guard |
| Deadcode/refusal baselines | Removed eight codec deadcode entries and the deleted parser refusal |

## 🧪 Test Plan

**Root module**
```bash
go test ./internal/sddstatus -run '^(TestReviewBindingCodecDeclarationsRemoved|TestSDDStatusV2CleanBreak)$' -count=1
go test ./internal/reviewtransaction -run '^TestLegacyReadOnlyGuard' -count=1
go test ./internal/sddstatus ./internal/reviewtransaction ./internal/cli -count=1
go test ./... -count=1
go vet ./...
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
go test ./internal/cli -run '^TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign$' -count=1
```

**Bench declarations only**
```bash
cd bench && go test ./... -count=1 && go vet ./...
```

No driven execution claim is made because this PR does not change bench declarations and the bench corpus contains no stale binding-codec route strings.

**Deferred tagged diagnostic**
```bash
go test -tags legacy_compact_receipt ./internal/sddstatus -run '^$' -count=1
```

This remains intentionally red in the deferred Slice 2C corpus: the base already has duplicate tagged helpers, and deleting the provider now exposes tagged `ReviewBinding` consumers. Restoring provider types is explicitly out of scope.

- [x] Root module tests pass uncached
- [x] Go vet and gofmtcheck pass
- [x] Deadcode and refusal ratchets pass
- [x] Bench declaration tests and vet pass
- [x] Protected Git-common-dir state remained byte-identical
- [ ] Platform E2E passes in CI

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within the 400-line budget: **178 lines** (`+56/-122`)
- [x] Exactly one `type:*` label is applied
- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] Platform E2E passes in CI
- [x] Documentation is not required for this internal provider deletion
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete review-binding storage, serialization, validation, and related runtime code.
  * Retained path-resolution and repository-containment functionality.
  * Removed legacy binding-read support and unused review-binding tests.

* **Tests**
  * Added coverage confirming that removed review-binding functionality remains absent.
  * Updated internal checks to reflect the streamlined review transaction behavior.

* **Chores**
  * Cleaned up dead-code and obsolete error-message baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->