### PR TITLE
test(review): release generic coverage from legacy compact tag

### DIFF
--- a/internal/reviewtransaction/invalidated_status_test.go
+++ b/internal/reviewtransaction/invalidated_status_test.go
@@ -1,5 +1,3 @@
-//go:build legacy_compact_receipt
-
 package reviewtransaction
 
 import (
@@ -73,44 +71,5 @@ func TestInventoryAuthorityKeepsValidInvalidatedAuthoritiesCompleteAndAuthoritat
 		if entry.Status != AuthorityStatusInvalidated || entry.State != StateInvalidated || len(entry.Problems) != 0 {
 			t.Fatalf("invalidated entry = %#v", entry)
 		}
-	}
-}
-
-func TestInventoryAuthorityKeepsMalformedInvalidatedAuthorityFailClosed(t *testing.T) {
-	repo := initSnapshotRepo(t)
-	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
-	state := newCompactTestState(t, repo, "invalidated-with-receipt")
-	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	revision, err := store.Replace("", "review/start", state)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := state.Invalidate("candidate no longer applies"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := store.Replace(revision, "review/invalidate", state); err != nil {
-		t.Fatal(err)
-	}
-	terminal := newCompactTestState(t, repo, "invalidated-with-receipt-terminal")
-	terminal.State = StateEscalated
-	receipt, err := terminal.Receipt()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
-		t.Fatal(err)
-	}
-
-	report, err := InventoryAuthority(context.Background(), repo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Scoped: the malformed invalidated lineage is reported invalid on its
-	// own entry, and carries no verdict about the rest of the inventory.
-	if !hasAuthorityInventoryStatus(report.Entries, state.LineageID, AuthorityStatusInvalid) {
-		t.Fatalf("malformed invalidated report = %#v", report)
 	}
 }

--- a/internal/reviewtransaction/invalidation_test.go
+++ b/internal/reviewtransaction/invalidation_test.go
@@ -1,5 +1,3 @@
-//go:build legacy_compact_receipt
-
 package reviewtransaction
 
 import (
@@ -64,9 +62,6 @@ func TestInvalidatePristineFencesLegacyReadOnlyAndKeepsCompactTerminal(t *testin
 	}
 	if retry, err := compactStore.Replace(revision, "review/invalidate", compact); err != nil || retry != invalidated {
 		t.Fatalf("compact exact retry = %q, %v", retry, err)
-	}
-	if _, err := compact.Receipt(); err == nil {
-		t.Fatal("invalidated compact review produced a receipt")
 	}
 }
 

--- a/internal/reviewtransaction/reviewer_context_level_test.go
+++ b/internal/reviewtransaction/reviewer_context_level_test.go
@@ -1,14 +1,6 @@
-//go:build legacy_compact_receipt
-
 package reviewtransaction
 
-import (
-	"bytes"
-	"encoding/json"
-	"reflect"
-	"strings"
-	"testing"
-)
+import "testing"
 
 // TestReviewerContextLevelIsClosedOnInputAndOpenOnRead pins the asymmetry the
 // whole forward-compatibility design rests on.
@@ -40,95 +32,4 @@ func TestReviewerContextLevelIsClosedOnInputAndOpenOnRead(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestCompactReceiptOmitsUnrecordedReviewerContextLevel proves the field is
-// absent — not defaulted — when nothing recorded it. Absence is what every
-// receipt issued before this field existed carries, so a re-derived receipt for
-// such a lineage stays byte-identical and its immutable publication converges.
-func TestCompactReceiptOmitsUnrecordedReviewerContextLevel(t *testing.T) {
-	receipt := reviewerContextLevelReceipt(t, "")
-	payload, err := json.Marshal(receipt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Contains(payload, []byte("reviewer_context_level")) {
-		t.Fatalf("unrecorded level was serialized: %s", payload)
-	}
-	if receipt.ReviewerContextLevel != "" {
-		t.Fatalf("unrecorded level = %q", receipt.ReviewerContextLevel)
-	}
-}
-
-// TestCompactReceiptPreservesUnknownReviewerContextLevel is the forward
-// compatibility contract: a receipt written by a later release that records a
-// mechanism this binary has never heard of still parses, still validates, and
-// round-trips byte-identically. Every other closed vocabulary on this receipt
-// rejects its default case; this one must not, because a receipt is issued once
-// and read for the rest of its life.
-func TestCompactReceiptPreservesUnknownReviewerContextLevel(t *testing.T) {
-	for _, level := range []ReviewerContextLevel{
-		ReviewerContextLevelProviderCommand,
-		ReviewerContextLevelRuntimeInterception,
-		"a_mechanism_this_release_has_never_heard_of",
-	} {
-		t.Run(string(level), func(t *testing.T) {
-			payload, err := json.Marshal(reviewerContextLevelReceipt(t, level))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !strings.Contains(string(payload), `"reviewer_context_level":"`+string(level)+`"`) {
-				t.Fatalf("receipt did not record the level verbatim: %s", payload)
-			}
-			parsed, err := ParseCompactReceipt(payload)
-			if err != nil {
-				t.Fatalf("older-reader parse of level %q failed: %v", level, err)
-			}
-			if parsed.ReviewerContextLevel != level {
-				t.Fatalf("round-trip level = %q, want %q", parsed.ReviewerContextLevel, level)
-			}
-			again, err := json.Marshal(parsed)
-			if err != nil {
-				t.Fatal(err)
-			}
-			reparsed, err := ParseCompactReceipt(again)
-			if err != nil {
-				t.Fatalf("re-parse of level %q failed: %v", level, err)
-			}
-			if !reflect.DeepEqual(parsed, reparsed) {
-				t.Fatalf("round-trip is not stable:\n%+v\n%+v", parsed, reparsed)
-			}
-		})
-	}
-}
-
-// TestCompactReceiptRejectsMalformedReviewerContextLevel proves the open
-// vocabulary is still a bounded one: unknown is readable, malformed is not.
-func TestCompactReceiptRejectsMalformedReviewerContextLevel(t *testing.T) {
-	receipt := reviewerContextLevelReceipt(t, "")
-	receipt.ReviewerContextLevel = "not a level"
-	if err := receipt.Validate(); err == nil {
-		t.Fatal("malformed reviewer context level validated")
-	}
-}
-
-func reviewerContextLevelReceipt(t *testing.T, level ReviewerContextLevel) CompactReceipt {
-	t.Helper()
-	receipt := CompactReceipt{
-		Schema: CompactReceiptSchema, LineageID: "lens-context-receipt", Generation: 1,
-		BaseTree:           strings.Repeat("a", 40),
-		InitialReviewTree:  strings.Repeat("b", 40),
-		FinalCandidateTree: strings.Repeat("b", 40),
-		PathsDigest:        "sha256:" + strings.Repeat("1", 64),
-		FixDeltaHash:       EmptyFixDeltaHash,
-		PolicyHash:         "sha256:" + strings.Repeat("2", 64),
-		EvidenceHash:       "sha256:" + strings.Repeat("3", 64),
-		RiskLevel:          RiskLow, SelectedLenses: []string{}, ResolvedFindingIDs: []string{},
-		TerminalState:        TerminalApproved,
-		ReviewerContextLevel: level,
-	}
-	if err := receipt.Validate(); err != nil {
-		t.Fatalf("fixture receipt is invalid: %v", err)
-	}
-	return receipt
 }

--- a/internal/sddstatus/current_behavior_untagged_test.go
+++ b/internal/sddstatus/current_behavior_untagged_test.go
@@ -1,0 +1,33 @@
+package sddstatus
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCurrentBehaviorCoverageFilesAreUntagged(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+
+	for _, relativePath := range []string{
+		"internal/sddstatus/status_remediation_instructions_test.go",
+		"internal/sddstatus/status_test.go",
+		"internal/reviewtransaction/reviewer_context_level_test.go",
+		"internal/reviewtransaction/invalidated_status_test.go",
+		"internal/reviewtransaction/invalidation_test.go",
+	} {
+		contents, err := os.ReadFile(filepath.Join(repoRoot, relativePath))
+		if err != nil {
+			t.Fatalf("read current-behavior file %q: %v", relativePath, err)
+		}
+		if strings.Contains(string(contents), "legacy_compact_receipt") {
+			t.Fatalf("current-behavior file %q retains legacy_compact_receipt", relativePath)
+		}
+	}
+}

--- a/internal/sddstatus/status_remediation_instructions_test.go
+++ b/internal/sddstatus/status_remediation_instructions_test.go
@@ -1,5 +1,3 @@
-//go:build legacy_compact_receipt
-
 package sddstatus
 
 import (
@@ -23,7 +21,7 @@ func seedUnmanagedFailedVerification(t *testing.T, repo, change string, maxAttem
 	t.Helper()
 	changeRoot := seedReadyChange(t, repo, change, "- [x] 1.1 Work\n")
 	store, failedEvidence, failed := seedFailedVerificationLedger(t, repo, change, maxAttempts)
-	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(failedEvidence, "fail"))
+	write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("fail", 0, 0, "1/1", "1/1", 0, 0))
 	return store, failedEvidence, failed
 }
 
@@ -33,7 +31,7 @@ func resolveDisabledRemediationInstructions(t *testing.T, repo, change string) (
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !status.RemediationState.Required || status.RemediationState.LineageID != "" {
+	if !status.RemediationState.Required {
 		t.Fatalf("fixture did not require unmanaged remediation: %#v", status.RemediationState)
 	}
 	if status.PhaseInstructions == nil {
@@ -72,8 +70,8 @@ func TestStatusKeepsPrescribingChainBoundRemediationAfterReset(t *testing.T) {
 	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
 		t.Fatalf("post-reset status lost the chain-bound correction prescription:\n%s", joined)
 	}
-	if !strings.Contains(joined, "Disabled/unmanaged remediation has one bounded correction attempt") {
-		t.Fatalf("post-reset status lost the bounded correction framing:\n%s", joined)
+	if !strings.Contains(joined, "Remediation follows ordinary SDD failed-evidence accounting.") {
+		t.Fatalf("post-reset status lost the authority-free remediation framing:\n%s", joined)
 	}
 	if strings.Contains(joined, "cannot settle") {
 		t.Fatalf("post-reset status degraded a satisfiable correction to the decision route:\n%s", joined)
@@ -98,8 +96,8 @@ func TestStatusRendersResetRouteWhileRemediationNeedsADecision(t *testing.T) {
 	if strings.Contains(joined, "bounded correction attempt: run") {
 		t.Fatalf("decision-required status still prescribes the blocked correction acquire:\n%s", joined)
 	}
-	if !strings.Contains(joined, "sdd-attempt reset") || !strings.Contains(joined, failed.Revision) {
-		t.Fatalf("decision-required status does not render the audited reset route:\n%s", joined)
+	if !strings.Contains(joined, "Remediation follows ordinary SDD failed-evidence accounting.") || strings.Contains(joined, "sdd-attempt reset") {
+		t.Fatalf("decision-required status did not keep remediation authority-free:\n%s", joined)
 	}
 	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
 		t.Fatalf("decision-required status does not name the chain binding for the post-reset acquire:\n%s", joined)
@@ -119,8 +117,8 @@ func TestStatusStillPrescribesSatisfiableUnmanagedRemediation(t *testing.T) {
 	}
 
 	_, joined := resolveDisabledRemediationInstructions(t, repo, change)
-	if !strings.Contains(joined, "Disabled/unmanaged remediation has one bounded correction attempt") {
-		t.Fatalf("satisfiable status lost the bounded correction prescription:\n%s", joined)
+	if !strings.Contains(joined, "Remediation follows ordinary SDD failed-evidence accounting.") {
+		t.Fatalf("satisfiable status lost the authority-free remediation framing:\n%s", joined)
 	}
 	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
 		t.Fatalf("satisfiable status does not bind the settle to the failed evidence:\n%s", joined)
@@ -157,13 +155,13 @@ func TestStatusRendersFreshVerificationRouteWhenNothingRemediable(t *testing.T) 
 	}); err != nil {
 		t.Fatal(err)
 	}
-	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(failedEvidence, "fail"))
+	write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("fail", 0, 0, "1/1", "1/1", 0, 0))
 
 	_, joined := resolveDisabledRemediationInstructions(t, repo, change)
 	if strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
 		t.Fatalf("nothing-remediable status still prescribes an unsatisfiable binding:\n%s", joined)
 	}
-	if !strings.Contains(joined, "cannot settle") || !strings.Contains(joined, "fresh verification objective") {
-		t.Fatalf("nothing-remediable status does not render the fresh-verification route:\n%s", joined)
+	if !strings.Contains(joined, "A passing remediation requires fresh independent verification before archive.") {
+		t.Fatalf("nothing-remediable status does not preserve the independent-verification route:\n%s", joined)
 	}
 }

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -1,11 +1,8 @@
-//go:build legacy_compact_receipt
-
 package sddstatus
 
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -585,8 +582,7 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 			name: "archive ready only when verify report exists and tasks are complete",
 			seed: func(t *testing.T, root string) {
 				changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
-				write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("1"), "pass"))
-				writeApprovedReviewArtifacts(t, changeRoot)
+				write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("pass", 0, 0, "1/1", "1/1", 0, 0))
 			},
 			wantApply:   ApplyAllDone,
 			wantApplyD:  DependencyAllDone,
@@ -598,7 +594,7 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 			name: "archive ready for canonical passing verify report",
 			seed: func(t *testing.T, root string) {
 				changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
-				write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("1"), "pass")+"\n"+strings.Join([]string{
+				write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("pass", 0, 0, "1/1", "1/1", 0, 0)+"\n"+strings.Join([]string{
 					"## Verification Report",
 					"### Build & Tests Execution",
 					"**Tests**: ✅ 12 passed / ❌ 0 failed / ⚠️ 0 skipped",
@@ -610,7 +606,6 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 					"Verdict: PASS",
 					"",
 				}, "\n"))
-				writeApprovedReviewArtifacts(t, changeRoot)
 			},
 			wantApply:   ApplyAllDone,
 			wantApplyD:  DependencyAllDone,
@@ -622,7 +617,7 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 			name: "archive ready for canonical pass with warnings verdict",
 			seed: func(t *testing.T, root string) {
 				changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
-				write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("1"), "pass_with_warnings")+"\n"+strings.Join([]string{
+				write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("pass_with_warnings", 0, 0, "1/1", "1/1", 0, 0)+"\n"+strings.Join([]string{
 					"## Verification Report",
 					"**Tests**: ✅ 12 passed / ❌ 0 failed / ⚠️ 1 skipped",
 					"**CRITICAL**: None",
@@ -631,7 +626,6 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 					"PASS WITH WARNINGS",
 					"",
 				}, "\n"))
-				writeApprovedReviewArtifacts(t, changeRoot)
 			},
 			wantApply:   ApplyAllDone,
 			wantApplyD:  DependencyAllDone,
@@ -778,8 +772,7 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 			name: "archive ready when verify report has status pass",
 			seed: func(t *testing.T, root string) {
 				changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
-				write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("1"), "pass")+"\n# Verify\nStatus: PASS\n")
-				writeApprovedReviewArtifacts(t, changeRoot)
+				write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("pass", 0, 0, "1/1", "1/1", 0, 0)+"\n# Verify\nStatus: PASS\n")
 			},
 			wantApply:   ApplyAllDone,
 			wantApplyD:  DependencyAllDone,
@@ -1116,7 +1109,7 @@ func TestParseCommandArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseCommandArgs() error = %v", err)
 	}
-	want := CommandArgs{ChangeName: "add-auth", CWD: "/tmp/repo", JSON: true, IncludeInstructions: true}
+	want := CommandArgs{ChangeName: "add-auth", CWD: "/tmp/repo", JSON: true, IncludeInstructions: true, Contract: "gentle-ai.sdd-status/v2"}
 	if got != want {
 		t.Fatalf("ParseCommandArgs() = %#v, want %#v", got, want)
 	}
@@ -1143,16 +1136,6 @@ func TestParseCommandArgsRejectsInvalidInput(t *testing.T) {
 	}
 }
 
-func seedReadyChange(t *testing.T, root string, name string, tasks string) string {
-	t.Helper()
-	changeRoot := filepath.Join(root, "openspec", "changes", name)
-	write(t, filepath.Join(changeRoot, "proposal.md"), "# Proposal\n")
-	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Expected behavior\n")
-	write(t, filepath.Join(changeRoot, "design.md"), "# Design\n")
-	write(t, filepath.Join(changeRoot, "tasks.md"), tasks)
-	return changeRoot
-}
-
 func seedPlanningRoute(t *testing.T, root string, name string, route string) {
 	t.Helper()
 	changeRoot := filepath.Join(root, "openspec", "changes", name)
@@ -1167,49 +1150,6 @@ func seedPlanningRoute(t *testing.T, root string, name string, route string) {
 	}
 	if route == "propose" {
 		write(t, filepath.Join(changeRoot, "tasks.md"), "- [ ] 1.1 Work\n")
-	}
-}
-
-func engramPlanningRoute(name string, route string) []engramObservation {
-	observations := []engramObservation{}
-	if route != "propose" {
-		observations = append(observations, engramObservation{Title: "sdd/" + name + "/proposal", Content: "# Proposal\n", Project: "gentle-ai", Scope: "project"})
-	}
-	if route == "design" || route == "tasks" {
-		observations = append(observations, engramObservation{Title: "sdd/" + name + "/spec", Content: "# Spec\n", Project: "gentle-ai", Scope: "project"})
-	}
-	if route == "tasks" {
-		observations = append(observations, engramObservation{Title: "sdd/" + name + "/design", Content: "# Design\n", Project: "gentle-ai", Scope: "project"})
-	}
-	if route == "propose" {
-		observations = append(observations, engramObservation{Title: "sdd/" + name + "/tasks", Content: "- [ ] 1.1 Work\n", Project: "gentle-ai", Scope: "project"})
-	}
-	return observations
-}
-
-func write(t *testing.T, path string, content string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-}
-
-func stubEngramExport(t *testing.T, observations []engramObservation) func() {
-	t.Helper()
-	original := engramExport
-	engramExport = func(_ string) ([]engramObservation, error) {
-		return observations, nil
-	}
-	return func() { engramExport = original }
-}
-
-func mkdir(t *testing.T, path string) {
-	t.Helper()
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
 	}
 }
 
@@ -1229,11 +1169,4 @@ func equalStringPtr(left *string, right *string) bool {
 		return left == right
 	}
 	return *left == *right
-}
-
-func ptrValue(value *string) string {
-	if value == nil {
-		return "<nil>"
-	}
-	return *value
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3715

## 🏷️ PR Type

- [x] `type:chore` — Test and corpus maintenance

## 📝 Summary

Moves five current status/reviewtransaction suites out of the historical `legacy_compact_receipt` tag so their assertions run in the default test suite. It also removes six duplicate status helpers and obsolete `CompactReceipt`-only cases exposed by the migration.

The three mixed organic-runtime E2E suites remain tagged because they still contain retired FINALIZE-dependent cases. Their migration is a separate bounded slice. No compatibility API, provider type, alias, or placeholder is restored.

Material implementation was agent-assisted and independently verified against the complete diff and uncached test suite.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status*_test.go` | Untagged current status-v2/remediation coverage, adopted canonical fixture helpers, and aligned stale tagged assertions with current authority-free behavior |
| `internal/sddstatus/current_behavior_untagged_test.go` | Added a scoped guard requiring the five current suites to remain present and untagged |
| `internal/reviewtransaction/*test.go` | Untagged current authority/invalidation coverage and deleted only cases tied to removed CompactReceipt APIs |

## 🧪 Test Plan

**Root module**
```bash
go test ./internal/sddstatus -run '^TestCurrentBehaviorCoverageFilesAreUntagged$' -count=1
go test ./internal/sddstatus ./internal/reviewtransaction -count=1
go test ./... -count=1
go vet ./...
go run ./internal/gofmtcheck
./scripts/deadcode-ratchet.sh
go test ./internal/cli -run '^TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign$' -count=1
```

**Bench declarations only**
```bash
cd bench && go test ./... -count=1 && go vet ./...
```

No driven execution claim is made because this PR changes neither product semantics nor bench declarations.

**Deferred tagged diagnostic**
```bash
go test -tags legacy_compact_receipt ./internal/sddstatus -run '^$' -count=1
```

This remains intentionally red on separately deferred corpus: `aliasedRepository`, removed `ReviewBinding`, removed `SDDReceiptRef`, and removed `Status.ReviewGate`. It no longer reports the six duplicate status helpers removed here.

- [x] Root module tests pass uncached
- [x] Go vet and gofmtcheck pass
- [x] Deadcode and refusal ratchets pass
- [x] Bench declaration tests and vet pass
- [x] Protected Git-common-dir state remained byte-identical
- [ ] Platform E2E passes in CI

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within the 400-line budget: **281 lines** (`+50/-231`)
- [x] Exactly one `type:*` label is applied
- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] Platform E2E passes in CI
- [x] Documentation is not required for this test-corpus migration
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in review invalidation and SDD status handling.
  * Updated remediation flows to provide clearer authority-free failure guidance and preserve required chain verification.
  * Standardized verification behavior across supported build configurations.

* **Tests**
  * Expanded coverage to ensure legacy configuration markers are removed from current behavior tests.
  * Refined validation scenarios for malformed evidence, retries, remediation, and independent verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->