### PR TITLE
fix(sdd): reject rescope that inherits an exhausted attempt allowance

### DIFF
--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -99,6 +99,16 @@ var (
 	// laundering; an unguarded widen here would be the same defect wearing a
 	// new operation name.
 	ErrRuntimeRescopeWidened = errors.New("SDD runtime objective rescope may only narrow or hold max_attempts and max_changed_lines, never widen them; " + runtimeLedgerStatusPointer)
+	// ErrRuntimeRescopeExhausted is rescope's second own sentinel (#2804):
+	// rescope carries cumulative_attempts and cumulative_changed_lines
+	// forward unchanged, so a successor whose ceiling the carried charge
+	// already meets has no runnable ordinal. Committing it published a
+	// wedge: status advertised begin while acquire refused
+	// budget-exhausted, reset was refused for zero drift, and a second
+	// rescope could not widen. The successor must stay runnable, which the
+	// predecessor ceiling always still admits (an exhausted predecessor is
+	// decision-required, where rescope is structurally refused).
+	ErrRuntimeRescopeExhausted = errors.New("SDD runtime objective rescope must leave the successor runnable: max_attempts and max_changed_lines must exceed the carried cumulative charges; " + runtimeLedgerStatusPointer)
 	// ErrRuntimeWorktreeMismatch never travels alone either. Every return site
 	// wraps it with runtimeWorktreeMismatchRefusal, which names the exact
 	// --cwd that reproduces the binding Begin actually recorded (#2296 part
@@ -1025,6 +1035,20 @@ func (store RuntimeStore) runtimeRescopeWidenedRefusal(status RuntimeStatus, fla
 		ErrRuntimeRescopeWidened, flag, requested, allowed, remaining, store.Workspace, store.Change)
 }
 
+// runtimeRescopeExhaustedRefusal (#2804) rejects a successor scope whose
+// ceiling the carried cumulative charge already meets, BEFORE mutation.
+// Committed, that successor is a published wedge: status answers begin, the
+// first acquire is refused budget-exhausted, reset is refused for zero
+// drift, and another rescope cannot widen from the newly accepted maximum.
+// The refusal names the exact runnable range instead, which is never empty:
+// rescope is only structurally reachable while the predecessor still has
+// budget left, so `carried < allowed` always holds here.
+func (store RuntimeStore) runtimeRescopeExhaustedRefusal(flag string, requested, carried, allowed int) error {
+	return fmt.Errorf(
+		"%w: received %s %d, and rescope carries the cumulative charges forward unchanged, so this successor would open already exhausted -- its status would advertise begin while every acquire is refused budget-exhausted, and no later rescope could widen it. A runnable successor needs %s greater than the carried %d and at most %d, the current objective's ceiling",
+		ErrRuntimeRescopeExhausted, flag, requested, flag, carried, allowed)
+}
+
 // runtimeObjectiveCompleteRefusal names what a completed objective's begin can
 // actually do. The sentinel said only that the objective is complete and
 // pointed at status, whose next_action is `complete` — true, and useless to a
@@ -1327,6 +1351,16 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 				status, "--max-attempts", request.MaxAttempts, objective.MaxAttempts,
 			)
 		}
+		// #2804: the carried charges bind at admission. A ceiling they
+		// already meet would commit a successor with no runnable ordinal.
+		if request.MaxAttempts <= status.CumulativeAttempts {
+			return runtimeRecord{}, store.runtimeRescopeExhaustedRefusal(
+				"--max-attempts", request.MaxAttempts, status.CumulativeAttempts, objective.MaxAttempts)
+		}
+		if request.MaxChangedLines <= status.CumulativeChangedLines {
+			return runtimeRecord{}, store.runtimeRescopeExhaustedRefusal(
+				"--max-changed-lines", request.MaxChangedLines, status.CumulativeChangedLines, objective.MaxChangedLines)
+		}
 		// The zero-drift `drift` snapshot above was captured with
 		// TargetBaseWorkspaceOverlay (same Kind/BaseRef Finish itself used),
 		// so its Identity is only comparable against another
@@ -1557,9 +1591,50 @@ func (store RuntimeStore) load() (runtimeReplay, error) {
 		return runtimeReplay{}, err
 	}
 	if !exists {
-		return store.loadRevision("")
+		head = ""
 	}
-	return store.loadRevision(head)
+	replay, err := store.loadRevision(head)
+	if err != nil {
+		return runtimeReplay{}, err
+	}
+	projectLegacyExhaustedSuccessor(&replay.Status)
+	return replay, nil
+}
+
+// projectLegacyExhaustedSuccessor tells the truth about a successor a
+// pre-#2804 writer published already exhausted: a rescope whose ceilings the
+// carried cumulative charges meet, so no begin can ever be admitted under
+// it. Left as replayed, that state advertised next_action: begin while
+// acquire refused budget-exhausted, reset was refused for zero drift, and a
+// second rescope could not widen -- the published wedge #2804's fresh
+// occurrence reports. The immutable chain is never rewritten (this runs only
+// on the terminal load() projection, never inside per-record replay, so the
+// consecutive-rescope repair keeps validating against the exact historical
+// writer state via loadRevision). It projects what
+// applyRuntimeConsecutiveRescopeRepairEvent already projects for the same
+// shape: an objective with no runnable ordinal is a maintainer decision, and
+// reset -- admitted at decision-required -- opens the fresh budget.
+//
+// The scope is PINNED to that publication wedge rather than asserted in
+// prose: the last transition must be the rescope that opened THIS objective,
+// and the successor must have no attempt of its own yet -- exactly the only
+// state the pre-guard writer could publish exhausted, because a begin under
+// it was always refused. Any other exhausted shape keeps its replayed
+// projection untouched, so an objective legitimately holding unused
+// allowance can never be silently converted into a demanded reset.
+func projectLegacyExhaustedSuccessor(status *RuntimeStatus) {
+	if status.ActiveAttempt != nil || status.Objective == nil || status.Complete || status.DecisionRequired {
+		return
+	}
+	if status.LastRescope == nil || status.LastRescope.ObjectiveID != status.Objective.ID ||
+		runtimeObjectiveHasRecordedAttempt(*status) {
+		return
+	}
+	if status.CumulativeAttempts >= status.Objective.MaxAttempts ||
+		status.CumulativeChangedLines >= status.Objective.MaxChangedLines {
+		status.DecisionRequired = true
+		status.NextAction = RuntimeActionReset
+	}
 }
 
 func (store RuntimeStore) loadRevision(head string) (runtimeReplay, error) {

--- a/internal/sddstatus/runtime_ledger_repair_test.go
+++ b/internal/sddstatus/runtime_ledger_repair_test.go
@@ -18,7 +18,26 @@ func TestRuntimeLedgerRepairsPublishedConsecutiveRescope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := store.Rescope(context.Background(), RescopeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "rescope-a-b", WorkUnit: "objective-b", EvidenceGoal: "prove B", MaxAttempts: 1, MaxChangedLines: 10, Reason: "narrow A to B", Actor: "maintainer"})
+	// The historical v2.4.0-rc.1 writer published successor B already
+	// exhausted (max_attempts equal to the carried cumulative_attempts).
+	// Today's writer refuses that shape before mutation (#2804), so the
+	// historical chain is reproduced the way it actually exists in the
+	// wild: as an already-published record.
+	lastA := failed.Attempts[0]
+	generationB := failed.ObjectiveGeneration + 1
+	requestB := RescopeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "rescope-a-b", WorkUnit: "objective-b", EvidenceGoal: "prove B", MaxAttempts: 1, MaxChangedLines: 10, Reason: "narrow A to B", Actor: "maintainer"}
+	recordB := runtimeRecord{Schema: runtimeRecordSchema, Change: store.Change, PreviousRevision: failed.Revision, Operation: runtimeOperationRescope, RequestID: requestB.RequestID, RequestDigest: runtimeValueHash("gentle-ai.sdd-runtime-rescope-request/v1", requestB), Rescope: &runtimeRescopeEvent{PreviousObjectiveID: failed.Objective.ID, PreviousGeneration: failed.Objective.Generation, PreviousMaxAttempts: failed.Objective.MaxAttempts, PreviousMaxChangedLines: failed.Objective.MaxChangedLines, RescopeCandidateIdentity: lastA.FinishCandidateIdentity, RescopeCandidateTree: lastA.FinishCandidateTree, ObjectiveID: runtimeObjectiveID(store.Change, requestB.WorkUnit, requestB.EvidenceGoal, lastA.FinishCandidateIdentity, generationB), ObjectiveGeneration: generationB, WorkUnit: requestB.WorkUnit, EvidenceGoal: requestB.EvidenceGoal, MaxAttempts: requestB.MaxAttempts, MaxChangedLines: requestB.MaxChangedLines, Reason: requestB.Reason, Actor: requestB.Actor}}
+	revisionB, payloadB, err := runtimeRecordRevision(recordB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishRecord(revisionB, payloadB); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishHead(revisionB); err != nil {
+		t.Fatal(err)
+	}
+	b, err := store.Status()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sddstatus/runtime_ledger_rescope_test.go
+++ b/internal/sddstatus/runtime_ledger_rescope_test.go
@@ -454,11 +454,16 @@ func TestRuntimeLedgerRescopeReplayRefusesForgedWidenedRecord(t *testing.T) {
 	}
 }
 
-// TestRuntimeLedgerRescopeCarriedBudgetBindsTheNextBegin is mutation proof
-// (d): carry-forward is not cosmetic. Rescoping to a ceiling already at or
-// below the carried-forward CumulativeChangedLines must bind -- the very
-// next begin is refused budget-exhausted.
-func TestRuntimeLedgerRescopeCarriedBudgetBindsTheNextBegin(t *testing.T) {
+// TestRuntimeLedgerRescopeCarriedBudgetBindsAtAdmission is mutation proof
+// (d), moved to its truthful boundary by #2804: carry-forward is not
+// cosmetic, and the place it binds is rescope ADMISSION. Narrowing to a
+// ceiling the carried CumulativeChangedLines already meets would publish a
+// successor whose status advertises begin while its first acquire is refused
+// budget-exhausted, whose reset is refused for zero drift, and whose own
+// rescope cannot widen -- a wedge with no admitted continuation. That
+// rescope is refused before mutation, and the runnable ceiling the refusal
+// names is executed, not asserted as prose.
+func TestRuntimeLedgerRescopeCarriedBudgetBindsAtAdmission(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	store, err := OpenRuntimeStore(context.Background(), repo, "rescope-budget-binds")
 	if err != nil {
@@ -486,27 +491,301 @@ func TestRuntimeLedgerRescopeCarriedBudgetBindsTheNextBegin(t *testing.T) {
 	}
 	consumed := interrupted.CumulativeChangedLines
 
-	// The candidate has not drifted further since Finish: rescope is
-	// admissible even though the OBJECTIVE already carries real charges.
-	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+	// A ceiling the carried charge already meets is refused with rescope's
+	// own exhaustion sentinel, never a reused generic one, and refuses
+	// BEFORE mutation.
+	_, exhaustedErr := store.Rescope(context.Background(), RescopeObjectiveRequest{
 		ExpectedRevision: interrupted.Revision, RequestID: "bind-rescope-1",
 		WorkUnit: "narrower-consumed-scope", EvidenceGoal: "prove carried budget binds narrower",
 		MaxAttempts: 3, MaxChangedLines: consumed - 1,
 		Reason: "maintainer narrowed the ceiling below what is already consumed", Actor: "maintainer",
 	})
-	if err != nil {
-		t.Fatalf("rescope with a ceiling below consumed history was refused: %v", err)
+	if !errors.Is(exhaustedErr, ErrRuntimeRescopeExhausted) {
+		t.Fatalf("rescope with a ceiling below consumed history = %v, want ErrRuntimeRescopeExhausted", exhaustedErr)
 	}
-	if rescoped.CumulativeChangedLines != consumed {
-		t.Fatalf("rescope did not carry the consumed charge forward exactly: got %d, want %d", rescoped.CumulativeChangedLines, consumed)
+	if errors.Is(exhaustedErr, ErrRuntimeRescopeWidened) || errors.Is(exhaustedErr, ErrRuntimeRescopeNotAllowed) {
+		t.Fatalf("exhaustion refusal reused a generic sentinel: %v", exhaustedErr)
+	}
+	for _, want := range []string{
+		"--max-changed-lines " + strconv.Itoa(consumed-1),
+		"carried " + strconv.Itoa(consumed),
+		"at most 400",
+	} {
+		if !strings.Contains(exhaustedErr.Error(), want) {
+			t.Fatalf("exhaustion refusal does not name %q: %v", want, exhaustedErr)
+		}
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil || status.Revision != interrupted.Revision || countRuntimeRecords(t, store.Dir) != 2 {
+		t.Fatalf("refused exhausted rescope mutated the ledger: status=%#v err=%v records=%d", status, statusErr, countRuntimeRecords(t, store.Dir))
 	}
 
-	_, err = store.Begin(context.Background(), BeginAttemptRequest{
-		ExpectedRevision: rescoped.Revision, RequestID: "bind-begin-2", WorkUnit: "narrower-consumed-scope",
-		EvidenceGoal: "prove carried budget binds narrower", MaxAttempts: 3, MaxChangedLines: consumed - 1,
+	// The runnable range the refusal names is executed: one line above the
+	// carried charge is admitted, carries the charge forward exactly, and
+	// its first begin proceeds instead of dying budget-exhausted.
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: interrupted.Revision, RequestID: "bind-rescope-2",
+		WorkUnit: "narrower-consumed-scope", EvidenceGoal: "prove carried budget binds narrower",
+		MaxAttempts: 3, MaxChangedLines: consumed + 1,
+		Reason: "maintainer narrowed the ceiling to the smallest runnable allowance", Actor: "maintainer",
 	})
-	if !errors.Is(err, ErrRuntimeBudgetExhausted) {
-		t.Fatalf("begin after a rescope whose ceiling is already consumed = %v, want ErrRuntimeBudgetExhausted", err)
+	if err != nil {
+		t.Fatalf("the runnable rescope this refusal names was refused: %v", err)
+	}
+	if rescoped.CumulativeChangedLines != consumed || rescoped.DecisionRequired || rescoped.NextAction != RuntimeActionBegin {
+		t.Fatalf("runnable rescope status = %#v", rescoped)
+	}
+	next, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: rescoped.Revision, RequestID: "bind-begin-2", WorkUnit: "narrower-consumed-scope",
+		EvidenceGoal: "prove carried budget binds narrower", MaxAttempts: 3, MaxChangedLines: consumed + 1,
+	})
+	if err != nil {
+		t.Fatalf("begin under the runnable rescoped ceiling was refused: %v", err)
+	}
+	if next.ActiveAttempt == nil || next.ActiveAttempt.ObjectiveID != rescoped.Objective.ID {
+		t.Fatalf("post-rescope begin status = %#v", next)
+	}
+}
+
+// TestRuntimeLedgerRescopeRefusesExhaustedAttemptAllowance is #2804's
+// write-time guard: rescope carries cumulative_attempts forward unchanged, so
+// a successor whose max_attempts the carried count already meets has no
+// runnable ordinal. Before this guard it was committed anyway: status
+// advertised begin, acquire refused budget-exhausted, reset refused for zero
+// drift, and a second rescope could not widen -- a published successor with
+// no admitted continuation. The refusal now lands before mutation and names
+// the exact runnable range, which is then executed.
+func TestRuntimeLedgerRescopeRefusesExhaustedAttemptAllowance(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "rescope-2804")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "2804-begin-1", WorkUnit: "failing-verification",
+		EvidenceGoal: "independently verify the applied change", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "2804-finish-1", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('9'), Diagnosis: "verification failed with the workspace unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification harness exited cleanly",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.CumulativeAttempts != 1 || failed.DecisionRequired || failed.Complete {
+		t.Fatalf("pre-rescope failed status = %#v", failed)
+	}
+
+	// max_attempts equal to the carried cumulative_attempts is the exact
+	// #2804 reproduction: narrowing-valid, and immediately exhausted.
+	_, exhaustedErr := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "2804-rescope-1",
+		WorkUnit: "narrower-correction", EvidenceGoal: "prove the bounded correction",
+		MaxAttempts: 1, MaxChangedLines: 120,
+		Reason: "maintainer narrowed to a correction objective", Actor: "maintainer",
+	})
+	if !errors.Is(exhaustedErr, ErrRuntimeRescopeExhausted) {
+		t.Fatalf("exhausted-allowance rescope error = %v, want ErrRuntimeRescopeExhausted", exhaustedErr)
+	}
+	if errors.Is(exhaustedErr, ErrRuntimeRescopeWidened) || errors.Is(exhaustedErr, ErrRuntimeRescopeNotAllowed) {
+		t.Fatalf("exhaustion refusal reused a generic sentinel: %v", exhaustedErr)
+	}
+	for _, want := range []string{"--max-attempts 1", "carried 1", "at most 2"} {
+		if !strings.Contains(exhaustedErr.Error(), want) {
+			t.Fatalf("exhaustion refusal does not name %q: %v", want, exhaustedErr)
+		}
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil || status.Revision != failed.Revision || countRuntimeRecords(t, store.Dir) != 2 {
+		t.Fatalf("refused exhausted rescope mutated the ledger: status=%#v err=%v records=%d", status, statusErr, countRuntimeRecords(t, store.Dir))
+	}
+
+	// The runnable allowance the refusal names is executed: one attempt above
+	// the carried count is admitted and its first begin proceeds.
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "2804-rescope-2",
+		WorkUnit: "narrower-correction", EvidenceGoal: "prove the bounded correction",
+		MaxAttempts: 2, MaxChangedLines: 120,
+		Reason: "maintainer narrowed to a runnable correction objective", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("the runnable rescope this refusal names was refused: %v", err)
+	}
+	if rescoped.CumulativeAttempts != 1 || rescoped.DecisionRequired || rescoped.NextAction != RuntimeActionBegin {
+		t.Fatalf("runnable rescope status = %#v", rescoped)
+	}
+	next, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: rescoped.Revision, RequestID: "2804-begin-2", WorkUnit: "narrower-correction",
+		EvidenceGoal: "prove the bounded correction", MaxAttempts: 2, MaxChangedLines: 120,
+	})
+	if err != nil {
+		t.Fatalf("begin under the runnable rescoped allowance was refused: %v", err)
+	}
+	if next.ActiveAttempt == nil || next.ActiveAttempt.ObjectiveID != rescoped.Objective.ID {
+		t.Fatalf("post-rescope begin status = %#v", next)
+	}
+}
+
+// TestProjectLegacyExhaustedSuccessorIsScopedToTheFreshRescopeWedge pins the
+// projection's scope instead of asserting it in prose: only the exact
+// publication wedge -- the last transition is the rescope that opened the
+// current objective, and the successor has no attempt of its own -- may be
+// converted to decision-required. Every other exhausted shape must keep its
+// replayed projection, so an objective legitimately holding unused allowance
+// is never silently converted into a demanded reset.
+func TestProjectLegacyExhaustedSuccessorIsScopedToTheFreshRescopeWedge(t *testing.T) {
+	objective := &RuntimeObjective{ID: "objective-b", MaxAttempts: 1, MaxChangedLines: 10}
+
+	// Exhausted with no rescope transition at all: not the wedge.
+	noRescope := RuntimeStatus{Objective: objective, CumulativeAttempts: 1, NextAction: RuntimeActionBegin}
+	projectLegacyExhaustedSuccessor(&noRescope)
+	if noRescope.DecisionRequired || noRescope.NextAction != RuntimeActionBegin {
+		t.Fatalf("non-rescope exhausted state was converted: %#v", noRescope)
+	}
+
+	// Exhausted successor that already owns an attempt: not the wedge either
+	// (the pre-guard writer could never publish this -- its begin was refused).
+	ownAttempt := RuntimeStatus{
+		Objective: objective, CumulativeAttempts: 1, NextAction: RuntimeActionBegin,
+		LastRescope: &RuntimeRescope{ObjectiveID: objective.ID},
+		Attempts:    []RuntimeAttempt{{ObjectiveID: objective.ID, Outcome: AttemptFailed}},
+	}
+	projectLegacyExhaustedSuccessor(&ownAttempt)
+	if ownAttempt.DecisionRequired || ownAttempt.NextAction != RuntimeActionBegin {
+		t.Fatalf("successor with its own attempt was converted: %#v", ownAttempt)
+	}
+
+	// The publication wedge itself projects to decision-required/reset.
+	wedge := RuntimeStatus{
+		Objective: objective, CumulativeAttempts: 1, NextAction: RuntimeActionBegin,
+		LastRescope: &RuntimeRescope{ObjectiveID: objective.ID},
+		Attempts:    []RuntimeAttempt{{ObjectiveID: "objective-a", Outcome: AttemptFailed}},
+	}
+	projectLegacyExhaustedSuccessor(&wedge)
+	if !wedge.DecisionRequired || wedge.NextAction != RuntimeActionReset {
+		t.Fatalf("the publication wedge did not project: %#v", wedge)
+	}
+}
+
+// TestRuntimeLedgerLegacyExhaustedRescopeReplaysToDecisionRequired is #2804's
+// recovery half: builds before the write-time guard PUBLISHED exhausted
+// successors, and prevention alone does not repair them (the fresh occurrence
+// on #2804 says exactly that). The immutable record stays valid -- replay
+// never rewrites history -- but the projected state must tell the truth: an
+// objective with no runnable ordinal is a maintainer decision, exactly as
+// applyRuntimeConsecutiveRescopeRepairEvent already projects for the same
+// shape. Status stops advertising a begin acquire refuses, and the reset that
+// decision-required admits is executed all the way to a wider fresh budget.
+func TestRuntimeLedgerLegacyExhaustedRescopeReplaysToDecisionRequired(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "rescope-2804-legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "legacy-begin-1", WorkUnit: "failing-verification",
+		EvidenceGoal: "independently verify the applied change", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "legacy-finish-1", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('8'), Diagnosis: "verification failed with the workspace unchanged",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "verification harness exited cleanly",
+		ProcessEvidence: "post-verification process scan found no descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	objective := failed.Objective
+	last := failed.Attempts[len(failed.Attempts)-1]
+
+	// Publish the exact record a pre-guard writer committed for the #2804
+	// occurrence: internally consistent, truthfully narrowing, and already
+	// exhausted (max_attempts equal to the carried cumulative_attempts).
+	generation := failed.ObjectiveGeneration + 1
+	legacyObjectiveID := runtimeObjectiveID(store.Change, "narrower-correction", "prove the bounded correction", last.FinishCandidateIdentity, generation)
+	request := RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "legacy-rescope-1",
+		WorkUnit: "narrower-correction", EvidenceGoal: "prove the bounded correction",
+		MaxAttempts: 1, MaxChangedLines: 120,
+		Reason: "maintainer narrowed to a correction objective", Actor: "maintainer",
+	}
+	legacyRecord := runtimeRecord{
+		Schema: runtimeRecordSchema, Change: store.Change, PreviousRevision: failed.Revision,
+		Operation: runtimeOperationRescope, RequestID: request.RequestID,
+		RequestDigest: runtimeValueHash("gentle-ai.sdd-runtime-rescope-request/v1", request),
+		Rescope: &runtimeRescopeEvent{
+			PreviousObjectiveID: objective.ID, PreviousGeneration: objective.Generation,
+			PreviousMaxAttempts: objective.MaxAttempts, PreviousMaxChangedLines: objective.MaxChangedLines,
+			RescopeCandidateIdentity: last.FinishCandidateIdentity, RescopeCandidateTree: last.FinishCandidateTree,
+			ObjectiveID: legacyObjectiveID, ObjectiveGeneration: generation,
+			WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal,
+			MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines,
+			Reason: request.Reason, Actor: request.Actor,
+		},
+	}
+	revision, payload, err := runtimeRecordRevision(legacyRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ensureDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishRecord(revision, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishHead(revision); err != nil {
+		t.Fatal(err)
+	}
+
+	// The wedge is gone: replay projects the truth instead of an unusable
+	// begin. History, the successor objective, and the carried charges all
+	// survive untouched.
+	status, err := store.Status()
+	if err != nil {
+		t.Fatalf("replaying the published legacy exhausted rescope failed: %v", err)
+	}
+	if !status.DecisionRequired || status.Complete || status.NextAction != RuntimeActionReset {
+		t.Fatalf("legacy exhausted successor status = %#v, want decision-required with next_action reset", status)
+	}
+	if status.Objective == nil || status.Objective.ID != legacyObjectiveID || status.Objective.MaxAttempts != 1 ||
+		status.CumulativeAttempts != 1 || len(status.Attempts) != 1 {
+		t.Fatalf("legacy exhausted successor projection = %#v", status)
+	}
+
+	// Begin stays refused -- truthfully now, with status in agreement.
+	if _, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: status.Revision, RequestID: "legacy-begin-2", WorkUnit: "narrower-correction",
+		EvidenceGoal: "prove the bounded correction", MaxAttempts: 1, MaxChangedLines: 120,
+	}); !errors.Is(err, ErrRuntimeBudgetExhausted) {
+		t.Fatalf("begin under the legacy exhausted successor = %v, want ErrRuntimeBudgetExhausted", err)
+	}
+
+	// The decision-required reset is admitted and opens the wider fresh
+	// budget the wedged reporter could never reach.
+	after, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: status.Revision, RequestID: "legacy-reset-1",
+		Reason: "recover the published exhausted successor with a fresh budget", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("reset of the legacy exhausted successor was refused: %v", err)
+	}
+	wider, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: after.Revision, RequestID: "legacy-begin-3", WorkUnit: "recovered-correction",
+		EvidenceGoal: "prove the recovered correction", MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatalf("begin after recovering the legacy exhausted successor was refused: %v", err)
+	}
+	if wider.Objective == nil || wider.Objective.MaxAttempts != 2 || wider.CumulativeAttempts != 1 {
+		t.Fatalf("post-recovery objective = %#v", wider)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2804

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- **Write-time guard**: `Rescope` now refuses `max_attempts <= cumulative_attempts` and `max_changed_lines <= cumulative_changed_lines` before mutation, with its own `ErrRuntimeRescopeExhausted` sentinel naming the exact runnable range. Rescope carries cumulative charges forward unchanged, so a ceiling the carried charge already meets would publish a successor with no runnable ordinal: status advertised `begin`, acquire refused budget-exhausted, reset was refused for zero drift, and a second rescope could not widen (the exact wedge in the fresh occurrence reported on #2804).
- **Recovery for already-published wedges**: `projectLegacyExhaustedSuccessor` runs only on the terminal `load()` projection (never inside per-record replay, never in `loadRevision`) and projects `decision_required: true` / `next_action: reset` for the pinned publication-wedge shape: the last transition is the rescope that opened the current objective and the successor has no attempt of its own. Reset — already admitted at decision-required — then opens the fresh budget. The consecutive-rescope repair keeps validating against the exact historical writer prefix, and existing repaired chains replay unchanged.
- The carried-budget mutation proof moves to rescope admission, and the repair test publishes its historical exhausted A→B record directly because the writer now refuses that shape.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_ledger.go` | New `ErrRuntimeRescopeExhausted` sentinel + `runtimeRescopeExhaustedRefusal`; exhaustion guard in `Rescope` after the widening checks; `projectLegacyExhaustedSuccessor` terminal projection wired into `load()` |
| `internal/sddstatus/runtime_ledger_rescope_test.go` | New write-guard test executing the named exit; mutation proof (d) reworked to bind at admission; projection-scope pinning test; legacy-record recovery test walking status → reset → wider begin |
| `internal/sddstatus/runtime_ledger_repair_test.go` | Historical exhausted A→B rescope now published as a hand-crafted record (the guarded writer refuses the shape) |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Reproduction analysis of #2804 on main, implementation of the guard and projection, and the test suite, under maintainer direction and review.

**Verification performed:** Full `go test ./internal/sddstatus` suite; targeted CLI sdd-attempt/rescope tests; bench module compile/tests; `go build ./...`; `go run ./internal/gofmtcheck`; receipt-driven review (4-lens high-risk) with one bounded correction validated by the native targeted validator.

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/sddstatus` — full suite green, includes the three new/reworked tests)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Bench corpus compiles and passes statically (`cd bench && go test ./...`); journeys j79/j80 use runnable allowances (`3>1`, `2>1`, lines `>0`) and are unaffected by the new guard
- [x] Benchmark validation: not applicable beyond the static check above — this change tightens ledger admission and adds a terminal projection; no journey drives an exhausted-allowance rescope (the guarded writer now refuses that shape before publication)
- [x] Legacy recovery proven by publishing the exact pre-guard exhausted rescope record and walking status → reset → wider begin
- Note: the full `internal/cli` suite has 99 pre-existing environment-specific failures on the development machine (installer/sync/review families: sandbox lock `not a directory`, `/private/var` symlink resolution, git op timeouts); reproduced identically on clean `main` with the fix stashed. CI is authoritative for `go test ./...`.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferred to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

**`size:exception` rationale:** 411 changed lines. 57 of them are the bounded correction mandated by the receipt-driven review (scoping `projectLegacyExhaustedSuccessor` to the pinned wedge shape plus its pinning test). Splitting would separate the guard from the recovery projection and its test evidence, which reviewers need together to challenge the projection's scope.

---

## 💬 Notes for Reviewers

- Receipt-driven review ran on this candidate: high-risk, canonical 4-lens. One CRITICAL resilience finding (`R4-projection-unscoped`: the recovery projection was not scoped to the legacy wedge) was corrected within the frozen budget and validated by the native targeted validator; the projection is now pinned to `LastRescope.ObjectiveID == Objective.ID` with no own attempt, and the scope is enforced by `TestProjectLegacyExhaustedSuccessorIsScopedToTheFreshRescopeWedge` rather than asserted in prose.
- Guard-population: the new exhaustion guard in `Rescope` is an SDD attempt-budget admission boundary; it does not belong to any of the ten registered `guard:population` families (v2.2.1), so no declaration is added and `.guard-population-baseline.txt` is unchanged. Please challenge that classification.
- The projection deliberately lives in `load()` and not in `applyRuntimeRescopeEvent`: per-record replay must keep the exact historical writer state so `validateConsecutiveRescopeRepairCandidate` (via `loadRevision`) and already-repaired chains stay valid. Reset replay remains valid mid-chain because `runtimeResetStructurallyPermitted` accepts a terminal failed/interrupted attempt without decision-required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rescoping now refuses budgets that are already exhausted by carried-over usage.
  * Prevents publishing successors that cannot run any attempts or changes.
  * Older exhausted successors are now surfaced as requiring a reset, with recovery through a wider fresh budget.
* **Reliability**
  * Improved runtime ledger handling and recovery for previously published exhausted successors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->