### PR TITLE
feat(sdd): bind native attempt input identities

### DIFF
--- a/internal/sddstatus/native_attempt_profile.go
+++ b/internal/sddstatus/native_attempt_profile.go
@@ -33,7 +33,7 @@ type nativeAttemptFileIdentity struct {
 func ResolveNativeAttemptIdentity(ctx context.Context, repo string) (NativeAttemptIdentity, error) {
 	lease, err := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
 	if err != nil {
-		return NativeAttemptIdentity{}, errors.New("native attempt repository is unavailable")
+		return NativeAttemptIdentity{}, errors.New("native attempt repository is unavailable") // refusal:by-design world-action: repository discovery must succeed before an immutable identity can be captured
 	}
 	value := lease.Identity()
 	return NativeAttemptIdentity{Root: value.RepositoryRoot, RepositoryRef: value.RepositoryRef, lease: lease}, nil
@@ -41,12 +41,12 @@ func ResolveNativeAttemptIdentity(ctx context.Context, repo string) (NativeAttem
 
 func (identity NativeAttemptIdentity) Validate(ctx context.Context) error {
 	if identity.lease == nil || identity.Root == "" || identity.RepositoryRef == "" || identity.lease.Validate(ctx) != nil {
-		return errors.New("native attempt repository identity changed")
+		return errors.New("native attempt repository identity changed") // refusal:by-design world-action: repository drift must be repaired before validation
 	}
 	for _, input := range identity.inputs {
 		live, err := captureNativeAttemptFileIdentity(identity.Root, input.path)
 		if err != nil || !nativeAttemptSameFileIdentity(input, live) {
-			return errors.New("native attempt input identity changed")
+			return errors.New("native attempt input identity changed") // refusal:by-design world-action: a changed immutable input must be restored or recaptured
 		}
 	}
 	return nil
@@ -54,13 +54,13 @@ func (identity NativeAttemptIdentity) Validate(ctx context.Context) error {
 
 func nativeAttemptInputIdentities(ctx context.Context, identity NativeAttemptIdentity, paths ...string) (NativeAttemptIdentity, error) {
 	if identity.lease == nil || identity.Validate(ctx) != nil {
-		return NativeAttemptIdentity{}, errors.New("native attempt repository identity changed")
+		return NativeAttemptIdentity{}, errors.New("native attempt repository identity changed") // refusal:by-design world-action: repository drift must be repaired before input capture
 	}
 	identity.inputs = nil
 	for _, path := range paths {
 		input, err := captureNativeAttemptFileIdentity(identity.Root, path)
 		if err != nil {
-			return NativeAttemptIdentity{}, errors.New("native attempt input is invalid")
+			return NativeAttemptIdentity{}, errors.New("native attempt input is invalid") // refusal:by-design world-action: the requested input must be made safe before capture
 		}
 		identity.inputs = append(identity.inputs, input)
 	}
@@ -92,7 +92,7 @@ func captureNativeAttemptFileIdentity(root, path string) (nativeAttemptFileIdent
 		return value, nil
 	}
 	if !info.Mode().IsRegular() {
-		return nativeAttemptFileIdentity{}, errors.New("unsafe input type")
+		return nativeAttemptFileIdentity{}, errors.New("unsafe input type") // refusal:by-design world-action: a captured input must be a regular file or directory
 	}
 	file, err := os.Open(nativeAttemptPath(root, path))
 	if err != nil {
@@ -101,7 +101,7 @@ func captureNativeAttemptFileIdentity(root, path string) (nativeAttemptFileIdent
 	defer file.Close()
 	opened, err := file.Stat()
 	if err != nil || !os.SameFile(info, opened) {
-		return nativeAttemptFileIdentity{}, errors.New("input changed while opening")
+		return nativeAttemptFileIdentity{}, errors.New("input changed while opening") // refusal:by-design world-action: the input must remain stable during capture
 	}
 	hash := sha256.New()
 	if _, err = io.Copy(hash, file); err != nil {
@@ -110,7 +110,7 @@ func captureNativeAttemptFileIdentity(root, path string) (nativeAttemptFileIdent
 	after, err := file.Stat()
 	latest, latestErr := nativeAttemptLstat(root, path)
 	if err != nil || latestErr != nil || !os.SameFile(info, after) || !os.SameFile(info, latest) || !nativeAttemptMetadataEqual(info, after) || !nativeAttemptMetadataEqual(info, latest) {
-		return nativeAttemptFileIdentity{}, errors.New("input changed while reading")
+		return nativeAttemptFileIdentity{}, errors.New("input changed while reading") // refusal:by-design world-action: the input must remain stable during capture
 	}
 	copy(value.digest[:], hash.Sum(nil))
 	return value, nil
@@ -132,10 +132,11 @@ func nativeAttemptCanonicalPath(root, path string) (string, error) {
 	path = filepath.Clean(path)
 	relative, err := filepath.Rel(root, path)
 	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return "", errors.New("unsafe input path")
+		return "", errors.New("unsafe input path") // refusal:by-design world-action: only paths below the repository root can be captured
 	}
-	if relative == ".git" || strings.HasPrefix(relative, ".git"+string(filepath.Separator)) {
-		return "", errors.New("unsafe input path")
+	first, _, _ := strings.Cut(relative, string(filepath.Separator))
+	if strings.EqualFold(first, ".git") {
+		return "", errors.New("unsafe input path") // refusal:by-design world-action: repository control files cannot be captured as inputs
 	}
 	return relative, nil
 }
@@ -146,7 +147,7 @@ func nativeAttemptLstat(root, path string) (fs.FileInfo, error) {
 		current = filepath.Join(current, part)
 		info, err := os.Lstat(current)
 		if err != nil || info.Mode()&os.ModeSymlink != 0 {
-			return nil, errors.New("unsafe input path")
+			return nil, errors.New("unsafe input path") // refusal:by-design world-action: symlinked paths cannot be captured safely
 		}
 	}
 	return os.Lstat(current)

--- a/internal/sddstatus/native_attempt_profile.go
+++ b/internal/sddstatus/native_attempt_profile.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
-// NativeAttemptIdentity binds a repository and immutable input snapshots before authority opens.
+// NativeAttemptIdentity binds a repository and immutable input snapshots before authority opens; input capture fails closed on symlinks at any depth.
 type NativeAttemptIdentity struct {
 	Root, RepositoryRef string
 	lease               *reviewtransaction.RepositoryIdentityLease
@@ -23,9 +23,6 @@ type NativeAttemptIdentity struct {
 type nativeAttemptFileIdentity struct {
 	path     string
 	info     fs.FileInfo
-	mode     fs.FileMode
-	size     int64
-	mtime    int64
 	digest   [sha256.Size]byte
 	children []nativeAttemptFileIdentity
 }
@@ -33,6 +30,9 @@ type nativeAttemptFileIdentity struct {
 func ResolveNativeAttemptIdentity(ctx context.Context, repo string) (NativeAttemptIdentity, error) {
 	lease, err := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return NativeAttemptIdentity{}, ctxErr
+		}
 		return NativeAttemptIdentity{}, errors.New("native attempt repository is unavailable") // refusal:by-design world-action: repository discovery must succeed before an immutable identity can be captured
 	}
 	value := lease.Identity()
@@ -76,9 +76,9 @@ func captureNativeAttemptFileIdentity(root, path string) (nativeAttemptFileIdent
 	if err != nil {
 		return nativeAttemptFileIdentity{}, err
 	}
-	value := nativeAttemptFileIdentity{path: path, info: info, mode: info.Mode(), size: info.Size(), mtime: info.ModTime().UnixNano()}
+	value := nativeAttemptFileIdentity{path: path, info: info}
 	if info.IsDir() {
-		entries, err := os.ReadDir(nativeAttemptPath(root, path))
+		entries, err := os.ReadDir(filepath.Join(root, path))
 		if err != nil {
 			return nativeAttemptFileIdentity{}, err
 		}
@@ -89,12 +89,15 @@ func captureNativeAttemptFileIdentity(root, path string) (nativeAttemptFileIdent
 			}
 			value.children = append(value.children, child)
 		}
+		if latest, err := nativeAttemptLstat(root, path); err != nil || !os.SameFile(info, latest) || !nativeAttemptMetadataEqual(info, latest) {
+			return nativeAttemptFileIdentity{}, errors.New("input changed while reading") // refusal:by-design world-action: the input must remain stable during capture
+		}
 		return value, nil
 	}
 	if !info.Mode().IsRegular() {
 		return nativeAttemptFileIdentity{}, errors.New("unsafe input type") // refusal:by-design world-action: a captured input must be a regular file or directory
 	}
-	file, err := os.Open(nativeAttemptPath(root, path))
+	file, err := os.Open(filepath.Join(root, path))
 	if err != nil {
 		return nativeAttemptFileIdentity{}, err
 	}
@@ -142,26 +145,22 @@ func nativeAttemptCanonicalPath(root, path string) (string, error) {
 }
 
 func nativeAttemptLstat(root, path string) (fs.FileInfo, error) {
-	current := filepath.VolumeName(nativeAttemptPath(root, path)) + string(filepath.Separator)
-	for _, part := range strings.Split(strings.TrimPrefix(nativeAttemptPath(root, path), current), string(filepath.Separator)) {
+	current := root
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
 		current = filepath.Join(current, part)
 		info, err := os.Lstat(current)
-		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
 			return nil, errors.New("unsafe input path") // refusal:by-design world-action: symlinked paths cannot be captured safely
 		}
 	}
 	return os.Lstat(current)
 }
 
-func nativeAttemptPath(root, path string) string {
-	if filepath.IsAbs(path) {
-		return path
-	}
-	return filepath.Join(root, path)
-}
-
 func nativeAttemptSameFileIdentity(left, right nativeAttemptFileIdentity) bool {
-	if left.path != right.path || !os.SameFile(left.info, right.info) || left.mode != right.mode || left.size != right.size || left.mtime != right.mtime || left.digest != right.digest || len(left.children) != len(right.children) {
+	if left.path != right.path || !os.SameFile(left.info, right.info) || !nativeAttemptMetadataEqual(left.info, right.info) || left.digest != right.digest || len(left.children) != len(right.children) {
 		return false
 	}
 	for index := range left.children {

--- a/internal/sddstatus/native_attempt_profile.go
+++ b/internal/sddstatus/native_attempt_profile.go
@@ -1,0 +1,176 @@
+package sddstatus
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// NativeAttemptIdentity binds a repository and immutable input snapshots before authority opens.
+type NativeAttemptIdentity struct {
+	Root, RepositoryRef string
+	lease               *reviewtransaction.RepositoryIdentityLease
+	inputs              []nativeAttemptFileIdentity
+}
+
+type nativeAttemptFileIdentity struct {
+	path     string
+	info     fs.FileInfo
+	mode     fs.FileMode
+	size     int64
+	mtime    int64
+	digest   [sha256.Size]byte
+	children []nativeAttemptFileIdentity
+}
+
+func ResolveNativeAttemptIdentity(ctx context.Context, repo string) (NativeAttemptIdentity, error) {
+	lease, err := reviewtransaction.OpenRepositoryIdentityLease(ctx, repo)
+	if err != nil {
+		return NativeAttemptIdentity{}, errors.New("native attempt repository is unavailable")
+	}
+	value := lease.Identity()
+	return NativeAttemptIdentity{Root: value.RepositoryRoot, RepositoryRef: value.RepositoryRef, lease: lease}, nil
+}
+
+func (identity NativeAttemptIdentity) Validate(ctx context.Context) error {
+	if identity.lease == nil || identity.Root == "" || identity.RepositoryRef == "" || identity.lease.Validate(ctx) != nil {
+		return errors.New("native attempt repository identity changed")
+	}
+	for _, input := range identity.inputs {
+		live, err := captureNativeAttemptFileIdentity(identity.Root, input.path)
+		if err != nil || !nativeAttemptSameFileIdentity(input, live) {
+			return errors.New("native attempt input identity changed")
+		}
+	}
+	return nil
+}
+
+func nativeAttemptInputIdentities(ctx context.Context, identity NativeAttemptIdentity, paths ...string) (NativeAttemptIdentity, error) {
+	if identity.lease == nil || identity.Validate(ctx) != nil {
+		return NativeAttemptIdentity{}, errors.New("native attempt repository identity changed")
+	}
+	identity.inputs = nil
+	for _, path := range paths {
+		input, err := captureNativeAttemptFileIdentity(identity.Root, path)
+		if err != nil {
+			return NativeAttemptIdentity{}, errors.New("native attempt input is invalid")
+		}
+		identity.inputs = append(identity.inputs, input)
+	}
+	return identity, nil
+}
+
+func captureNativeAttemptFileIdentity(root, path string) (nativeAttemptFileIdentity, error) {
+	path, err := nativeAttemptCanonicalPath(root, path)
+	if err != nil {
+		return nativeAttemptFileIdentity{}, err
+	}
+	info, err := nativeAttemptLstat(root, path)
+	if err != nil {
+		return nativeAttemptFileIdentity{}, err
+	}
+	value := nativeAttemptFileIdentity{path: path, info: info, mode: info.Mode(), size: info.Size(), mtime: info.ModTime().UnixNano()}
+	if info.IsDir() {
+		entries, err := os.ReadDir(nativeAttemptPath(root, path))
+		if err != nil {
+			return nativeAttemptFileIdentity{}, err
+		}
+		for _, entry := range entries {
+			child, err := captureNativeAttemptFileIdentity(root, filepath.Join(path, entry.Name()))
+			if err != nil {
+				return nativeAttemptFileIdentity{}, err
+			}
+			value.children = append(value.children, child)
+		}
+		return value, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nativeAttemptFileIdentity{}, errors.New("unsafe input type")
+	}
+	file, err := os.Open(nativeAttemptPath(root, path))
+	if err != nil {
+		return nativeAttemptFileIdentity{}, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(info, opened) {
+		return nativeAttemptFileIdentity{}, errors.New("input changed while opening")
+	}
+	hash := sha256.New()
+	if _, err = io.Copy(hash, file); err != nil {
+		return nativeAttemptFileIdentity{}, err
+	}
+	after, err := file.Stat()
+	latest, latestErr := nativeAttemptLstat(root, path)
+	if err != nil || latestErr != nil || !os.SameFile(info, after) || !os.SameFile(info, latest) || !nativeAttemptMetadataEqual(info, after) || !nativeAttemptMetadataEqual(info, latest) {
+		return nativeAttemptFileIdentity{}, errors.New("input changed while reading")
+	}
+	copy(value.digest[:], hash.Sum(nil))
+	return value, nil
+}
+
+func nativeAttemptCanonicalPath(root, path string) (string, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	root = filepath.Clean(root)
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	path = filepath.Clean(path)
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", errors.New("unsafe input path")
+	}
+	if relative == ".git" || strings.HasPrefix(relative, ".git"+string(filepath.Separator)) {
+		return "", errors.New("unsafe input path")
+	}
+	return relative, nil
+}
+
+func nativeAttemptLstat(root, path string) (fs.FileInfo, error) {
+	current := filepath.VolumeName(nativeAttemptPath(root, path)) + string(filepath.Separator)
+	for _, part := range strings.Split(strings.TrimPrefix(nativeAttemptPath(root, path), current), string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+			return nil, errors.New("unsafe input path")
+		}
+	}
+	return os.Lstat(current)
+}
+
+func nativeAttemptPath(root, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(root, path)
+}
+
+func nativeAttemptSameFileIdentity(left, right nativeAttemptFileIdentity) bool {
+	if left.path != right.path || !os.SameFile(left.info, right.info) || left.mode != right.mode || left.size != right.size || left.mtime != right.mtime || left.digest != right.digest || len(left.children) != len(right.children) {
+		return false
+	}
+	for index := range left.children {
+		if !nativeAttemptSameFileIdentity(left.children[index], right.children[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func nativeAttemptMetadataEqual(left, right fs.FileInfo) bool {
+	return left.Mode() == right.Mode() && left.Size() == right.Size() && left.ModTime().UnixNano() == right.ModTime().UnixNano()
+}

--- a/internal/sddstatus/native_attempt_profile_test.go
+++ b/internal/sddstatus/native_attempt_profile_test.go
@@ -162,7 +162,7 @@ func TestNativeAttemptInputIdentitiesRejectsUnsafePaths(t *testing.T) {
 	if _, err := nativeAttemptInputIdentities(t.Context(), identity, "missing"); err == nil {
 		t.Fatal("accepted missing input")
 	}
-	if _, err := nativeAttemptInputIdentities(t.Context(), identity, ".git"); err == nil {
+	if _, err := nativeAttemptCanonicalPath(repo, ".GIT"); err == nil {
 		t.Fatal("accepted unsupported repository control directory")
 	}
 }

--- a/internal/sddstatus/native_attempt_profile_test.go
+++ b/internal/sddstatus/native_attempt_profile_test.go
@@ -24,6 +24,11 @@ func TestResolveNativeAttemptIdentityRepositorySelection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := ResolveNativeAttemptIdentity(ctx, repo); err != context.Canceled {
+		t.Fatalf("ResolveNativeAttemptIdentity canceled error = %v, want %v", err, context.Canceled)
+	}
 	before := nativeAttemptTreeSnapshot(t, repo)
 	first, err := ResolveNativeAttemptIdentity(t.Context(), repo)
 	if err != nil {
@@ -49,9 +54,6 @@ func TestResolveNativeAttemptIdentityRepositorySelection(t *testing.T) {
 func TestNativeAttemptInputIdentities(t *testing.T) {
 	t.Run("capture and validation are non-mutating", func(t *testing.T) {
 		repo := nativeAttemptIdentityFixture(t)
-		if err := os.Symlink("static.json", filepath.Join(repo, "snapshot-link")); err != nil {
-			t.Fatal(err)
-		}
 		identity, err := ResolveNativeAttemptIdentity(t.Context(), repo)
 		if err != nil {
 			t.Fatal(err)
@@ -121,13 +123,9 @@ func TestNativeAttemptInputIdentities(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			before := nativeAttemptTreeSnapshot(t, repo)
 			mutate(t, repo)
 			if err := identity.Validate(t.Context()); err == nil {
 				t.Fatal("Validate accepted input drift")
-			}
-			if name == "recursive directory drift" && before == nativeAttemptTreeSnapshot(t, repo) {
-				t.Fatal("mutation fixture did not change the recursive snapshot")
 			}
 		})
 	}
@@ -139,10 +137,10 @@ func TestNativeAttemptInputIdentitiesRejectsUnsafePaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink(filepath.Join(repo, "static.json"), filepath.Join(repo, "static-link")); err == nil {
+	if err := os.Symlink("one.ts", filepath.Join(repo, "src", "migrations", "link")); err == nil {
 		before := nativeAttemptTreeSnapshot(t, repo)
-		if _, err := nativeAttemptInputIdentities(t.Context(), identity, "static-link"); err == nil {
-			t.Fatal("accepted symlink input")
+		if _, err := nativeAttemptInputIdentities(t.Context(), identity, "src"); err == nil {
+			t.Fatal("accepted directory containing a symlink")
 		}
 		if got := nativeAttemptTreeSnapshot(t, repo); got != before {
 			t.Fatalf("rejection mutated repository: %q != %q", got, before)
@@ -152,15 +150,15 @@ func TestNativeAttemptInputIdentitiesRejectsUnsafePaths(t *testing.T) {
 	}
 	outside := filepath.Join(t.TempDir(), "existing-outside")
 	write(t, outside, "outside\n")
-	before := nativeAttemptTreeSnapshot(t, repo)
 	if _, err := nativeAttemptInputIdentities(t.Context(), identity, outside); err == nil {
 		t.Fatal("accepted existing absolute input outside repository")
 	}
-	if got := nativeAttemptTreeSnapshot(t, repo); got != before {
-		t.Fatalf("outside-path rejection mutated repository: %q != %q", got, before)
+	rootLink := repo + "-link"
+	if err := os.Symlink(repo, rootLink); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
 	}
-	if _, err := nativeAttemptInputIdentities(t.Context(), identity, "missing"); err == nil {
-		t.Fatal("accepted missing input")
+	if _, err := nativeAttemptLstat(rootLink, "missing"); !os.IsNotExist(err) {
+		t.Fatalf("nativeAttemptLstat missing error = %v, want not exist", err)
 	}
 	if _, err := nativeAttemptCanonicalPath(repo, ".GIT"); err == nil {
 		t.Fatal("accepted unsupported repository control directory")

--- a/internal/sddstatus/native_attempt_profile_test.go
+++ b/internal/sddstatus/native_attempt_profile_test.go
@@ -1,0 +1,223 @@
+package sddstatus
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestResolveNativeAttemptIdentityRepositorySelection(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	nested := filepath.Join(repo, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relative, err := filepath.Rel(wd, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := nativeAttemptTreeSnapshot(t, repo)
+	first, err := ResolveNativeAttemptIdentity(t.Context(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, selection := range []string{relative, filepath.Join(repo, "."), nested} { // git -C accepts all three spellings.
+		got, err := ResolveNativeAttemptIdentity(t.Context(), selection)
+		if err != nil || got.Root != first.Root || got.RepositoryRef != first.RepositoryRef {
+			t.Fatalf("ResolveNativeAttemptIdentity(%q) = %#v, %v", selection, got, err)
+		}
+	}
+	if got := nativeAttemptTreeSnapshot(t, repo); got != before {
+		t.Fatalf("read-only identity resolution mutated repository: %q != %q", got, before)
+	}
+	if err := os.Rename(filepath.Join(repo, ".git"), filepath.Join(repo, "git-before-swap")); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Validate(context.Background()); err == nil {
+		t.Fatal("Validate accepted repository identity drift")
+	}
+}
+
+func TestNativeAttemptInputIdentities(t *testing.T) {
+	t.Run("capture and validation are non-mutating", func(t *testing.T) {
+		repo := nativeAttemptIdentityFixture(t)
+		if err := os.Symlink("static.json", filepath.Join(repo, "snapshot-link")); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := ResolveNativeAttemptIdentity(t.Context(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		beforeCapture := nativeAttemptTreeSnapshot(t, repo)
+		identity, err = nativeAttemptInputIdentities(t.Context(), identity, "node", "static.json", "src")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := nativeAttemptTreeSnapshot(t, repo); got != beforeCapture {
+			t.Fatalf("successful capture mutated repository: %q != %q", got, beforeCapture)
+		}
+		beforeValidate := nativeAttemptTreeSnapshot(t, repo)
+		if err := identity.Validate(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if got := nativeAttemptTreeSnapshot(t, repo); got != beforeValidate {
+			t.Fatalf("successful validation mutated repository: %q != %q", got, beforeValidate)
+		}
+	})
+
+	for name, mutate := range map[string]func(*testing.T, string){
+		"content drift": func(t *testing.T, root string) { write(t, filepath.Join(root, "static.json"), "changed\n") },
+		"metadata drift": func(t *testing.T, root string) {
+			if err := os.Chtimes(filepath.Join(root, "static.json"), time.Now(), time.Now().Add(time.Second)); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"executable drift": func(t *testing.T, root string) {
+			if err := os.Chmod(filepath.Join(root, "node"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"replacement TOCTOU": func(t *testing.T, root string) {
+			write(t, filepath.Join(root, "node.replacement"), "new\n")
+			if err := os.Rename(filepath.Join(root, "node.replacement"), filepath.Join(root, "node")); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"symlink TOCTOU": func(t *testing.T, root string) {
+			if err := os.Remove(filepath.Join(root, "static.json")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(filepath.Join(root, "node"), filepath.Join(root, "static.json")); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+		},
+		"type drift": func(t *testing.T, root string) {
+			if err := os.Remove(filepath.Join(root, "static.json")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(filepath.Join(root, "static.json"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"recursive directory drift": func(t *testing.T, root string) {
+			write(t, filepath.Join(root, "src", "migrations", "added.ts"), "new\n")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := nativeAttemptIdentityFixture(t)
+			identity, err := ResolveNativeAttemptIdentity(t.Context(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity, err = nativeAttemptInputIdentities(t.Context(), identity, "node", "static.json", "src")
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := nativeAttemptTreeSnapshot(t, repo)
+			mutate(t, repo)
+			if err := identity.Validate(t.Context()); err == nil {
+				t.Fatal("Validate accepted input drift")
+			}
+			if name == "recursive directory drift" && before == nativeAttemptTreeSnapshot(t, repo) {
+				t.Fatal("mutation fixture did not change the recursive snapshot")
+			}
+		})
+	}
+}
+
+func TestNativeAttemptInputIdentitiesRejectsUnsafePaths(t *testing.T) {
+	repo := nativeAttemptIdentityFixture(t)
+	identity, err := ResolveNativeAttemptIdentity(t.Context(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(repo, "static.json"), filepath.Join(repo, "static-link")); err == nil {
+		before := nativeAttemptTreeSnapshot(t, repo)
+		if _, err := nativeAttemptInputIdentities(t.Context(), identity, "static-link"); err == nil {
+			t.Fatal("accepted symlink input")
+		}
+		if got := nativeAttemptTreeSnapshot(t, repo); got != before {
+			t.Fatalf("rejection mutated repository: %q != %q", got, before)
+		}
+	} else {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "existing-outside")
+	write(t, outside, "outside\n")
+	before := nativeAttemptTreeSnapshot(t, repo)
+	if _, err := nativeAttemptInputIdentities(t.Context(), identity, outside); err == nil {
+		t.Fatal("accepted existing absolute input outside repository")
+	}
+	if got := nativeAttemptTreeSnapshot(t, repo); got != before {
+		t.Fatalf("outside-path rejection mutated repository: %q != %q", got, before)
+	}
+	if _, err := nativeAttemptInputIdentities(t.Context(), identity, "missing"); err == nil {
+		t.Fatal("accepted missing input")
+	}
+	if _, err := nativeAttemptInputIdentities(t.Context(), identity, ".git"); err == nil {
+		t.Fatal("accepted unsupported repository control directory")
+	}
+}
+
+func nativeAttemptIdentityFixture(t *testing.T) string {
+	t.Helper()
+	repo := initRuntimeLedgerRepo(t)
+	write(t, filepath.Join(repo, "node"), "node\n")
+	if err := os.Chmod(filepath.Join(repo, "node"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(repo, "static.json"), "{}\n")
+	write(t, filepath.Join(repo, "src", "migrations", "one.ts"), "export {}\n")
+	return repo
+}
+
+func nativeAttemptTreeSnapshot(t *testing.T, root string) string {
+	t.Helper()
+	hash := sha256.New()
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(hash, "%q %v %d\n", filepath.ToSlash(relative), info.Mode(), info.ModTime().UnixNano())
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(hash, "link %q\n", target)
+		case info.Mode().IsRegular():
+			payload, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(hash, "file %d\n", len(payload))
+			_, _ = hash.Write(payload)
+		case info.IsDir():
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				return err
+			}
+			for _, entry := range entries {
+				_, _ = fmt.Fprintf(hash, "entry %q %v\n", entry.Name(), entry.Type())
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(hash.Sum(nil))
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3152

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add an authority-free identity substrate for native SDD attempts.
- Bind repository identity and recursively snapshot executable/static inputs so path, symlink, type, metadata, content, and TOCTOU drift fail closed.
- Keep profile acceptance and execution authority out of this slice; those remain follow-up PRs.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/native_attempt_profile.go` | Adds read-only repository/input identity capture and revalidation. |
| `internal/sddstatus/native_attempt_profile_test.go` | Proves repository aliases, containment, recursive drift detection, TOCTOU rejection, and zero mutation. |

Review budget: **399 additions / 0 deletions**. Rollback removes only these two new files.

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with `openai/gpt-5.6-sol`

**Material scope:** SDD planning, implementation, test authoring, bounded verification, and native reliability review orchestration.

**Verification performed:** Focused/package tests, full build and vet, format/diff checks, targeted independent verification, exact candidate hashing, and a native reliability review over the frozen two-file candidate.

---

## 🧪 Test Plan

**Passed**

```bash
go test ./internal/sddstatus -run 'Test(ResolveNativeAttemptIdentity|NativeAttemptInputIdentities)' -count=1
go test ./internal/sddstatus -count=1
go build ./...
go vet ./...
go run ./internal/gofmtcheck
git diff --check
```

**Full-suite note**

`go test ./...` completed after 446.619s with two unrelated `internal/cli` failures. A focused rerun of both tests passed on this candidate; the exact clean base reproduced `TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture`. `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign` did not reproduce in the focused candidate rerun, so it is reported as a full-suite interaction/flaky result rather than claimed green.

**E2E:** N/A — PR1A is an authority-free identity library with no runtime or Docker boundary.

**Benchmark validation:** N/A — this slice changes no benchmark, review lifecycle, gate, recovery, delivery, corpus/classifier, or measured behavior surface.

- [ ] Unit tests pass (`go test ./...`) — see full-suite note above
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not applicable
- [x] Manually verified the focused identity and drift behaviors locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — see full-suite note
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not applicable
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained above)
- [x] I have updated documentation if necessary — no user-facing documentation changes in this foundation slice
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

### Chain context

Merge order, each independently targeting `main`:

```text
main ← 📍 PR1A identity substrate
     ← PR1B closed profile validation
     ← PR3 execution authority
     ← PR4 runtime projection and assets
     ← PR5 organic TypeORM/Postgres acceptance
```

- **Prior dependency:** none; this is the foundation slice.
- **Ends with:** reusable, read-only repository/input identity capture and revalidation.
- **Follow-up work:** profile acceptance, authority execution, runtime projection, and organic acceptance remain out of scope.
- **Native review:** the exact 399-line candidate passed the selected reliability lens and its authority was burned before commit; the post-commit source hash remained unchanged.

### Guard population challenge

- [x] Qualifying integrity guards were challenged against legitimate inputs: clean existing files/directories inside the selected repository, with `.git`, outside-root paths, symlinked components, unsupported types, and identity drift excluded.
- [x] This slice introduces a new identity substrate rather than changing an existing registered `guard:population` declaration; `.guard-population-baseline.txt` is intentionally unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repository-attempt identity tracking to verify repositories and input files before reuse.
  - Records file contents, metadata, permissions, directory structure, and link information for reliable validation.
- **Bug Fixes**
  - Prevents stale or unsafe attempt reuse when tracked inputs change, disappear, are replaced, or include unsupported paths such as symbolic links or `.git` content.
  - Detects repository identity changes before continuing an attempt.
  - Rejects unsafe, external, missing, or non-regular input paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->