### PR TITLE
ci(policy): detect merge ruleset drift

### DIFF
--- a/.github/scripts/check-ruleset-drift.test.cjs
+++ b/.github/scripts/check-ruleset-drift.test.cjs
@@ -1,0 +1,159 @@
+'use strict';
+
+const { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const root = join(__dirname, '..', '..');
+const checker = join(root, 'scripts', 'check-ruleset-drift.sh');
+
+const manifest = JSON.parse(
+  readFileSync(join(root, 'scripts', 'merge-blocking-status-contexts.json'), 'utf8'),
+);
+
+function fixture(rulesetEntries = manifest.required_status_checks) {
+  const directory = mkdtempSync(join(tmpdir(), 'gentle-ai-policy-drift-'));
+  const bin = join(directory, 'bin');
+  mkdirSync(bin);
+  const callsPath = join(directory, 'calls.log');
+  const ruleset = {
+      id: 13932547,
+      enforcement: 'active',
+      rules: [
+        {
+          type: 'required_status_checks',
+          parameters: { required_status_checks: rulesetEntries },
+        },
+      ],
+  };
+  writeFileSync(
+    join(bin, 'gh'),
+    `#!/bin/sh
+printf '%s\\n' "$*" >> "$GH_CALLS"
+case "$*" in
+  *'rulesets?includes_parents=false'*) printf '%s' "$GH_LIST" ;;
+  *'rulesets/13932547'*) printf '%s' "$GH_RULESET" ;;
+  *) exit 1 ;;
+esac
+`,
+  );
+  chmodSync(join(bin, 'gh'), 0o755);
+  return {
+    directory,
+    callsPath,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      GH_LIST: JSON.stringify([{ id: 13932547, enforcement: 'active' }]),
+      GH_RULESET: JSON.stringify(ruleset),
+      GH_CALLS: callsPath,
+      GH_TOKEN: 'test-secret-that-must-not-leak',
+      GITHUB_REPOSITORY: 'Gentleman-Programming/gentle-ai',
+      POLICY_MANIFEST: join(root, 'scripts', 'merge-blocking-status-contexts.json'),
+    },
+  };
+}
+
+function run(options = {}) {
+  const testFixture = fixture(options.entries);
+  if (options.list) {
+    testFixture.env.GH_LIST = JSON.stringify(options.list);
+  }
+  if (options.ruleset) {
+    testFixture.env.GH_RULESET = JSON.stringify(options.ruleset);
+  }
+  if (options.manifest) {
+    const manifestPath = join(testFixture.directory, 'manifest.json');
+    writeFileSync(manifestPath, JSON.stringify(options.manifest));
+    testFixture.env.POLICY_MANIFEST = manifestPath;
+  }
+  if (options.missingToken) {
+    delete testFixture.env.GH_TOKEN;
+  }
+  if (options.ghFailure) {
+    writeFileSync(
+      join(testFixture.directory, 'bin', 'gh'),
+      '#!/bin/sh\nprintf \'gh failed test-secret-that-must-not-leak\\n\' >&2\nexit 1\n',
+    );
+    chmodSync(join(testFixture.directory, 'bin', 'gh'), 0o755);
+  }
+  const result = spawnSync(checker, [], {
+    cwd: root,
+    env: testFixture.env,
+    encoding: 'utf8',
+  });
+  return {
+    ...result,
+    fixture: testFixture,
+    output: `${result.stdout || ''}${result.stderr || ''}`,
+  };
+}
+
+test('an exact active ruleset match passes using only GET API calls', () => {
+  const result = run();
+
+  assert.equal(result.status, 0, result.output);
+  assert.match(result.stdout, /merge policy verified/);
+  assert.doesNotMatch(result.output, /test-secret/);
+  const calls = readFileSync(result.fixture.callsPath, 'utf8').trim().split('\n');
+  assert.deepEqual(calls, [
+    'api --method GET repos/Gentleman-Programming/gentle-ai/rulesets?includes_parents=false',
+    'api --method GET repos/Gentleman-Programming/gentle-ai/rulesets/13932547',
+  ]);
+  assert.doesNotMatch(calls.join('\n'), /POST|PATCH|PUT|DELETE/);
+});
+
+test('a required context mismatch is typed policy_drift', () => {
+  const result = run({
+    entries: manifest.required_status_checks.filter(({ context }) => context !== 'Darwin Runtime'),
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.output, /policy_drift/);
+  assert.doesNotMatch(result.output, /test-secret/);
+});
+
+test('an API failure is typed policy_unverifiable without exposing credentials', () => {
+  const result = run({ ghFailure: true });
+
+  assert.equal(result.status, 2);
+  assert.match(result.output, /policy_unverifiable/);
+  assert.doesNotMatch(result.output, /test-secret/);
+});
+
+test('missing repository-admin credentials are typed policy_unverifiable', () => {
+  const result = run({ missingToken: true });
+
+  assert.equal(result.status, 2);
+  assert.match(result.output, /policy_unverifiable: GH_TOKEN is required/);
+});
+
+test('zero active rulesets is not treated as an empty policy', () => {
+  const result = run({ list: [] });
+
+  assert.equal(result.status, 2);
+  assert.match(result.output, /policy_unverifiable: no active rulesets/);
+});
+
+test('an unknown ruleset schema is typed policy_unverifiable', () => {
+  const result = run({
+    ruleset: {
+      id: 13932547,
+      enforcement: 'active',
+      rules: [{ type: 'required_status_checks', parameters: {} }],
+    },
+  });
+
+  assert.equal(result.status, 2);
+  assert.match(result.output, /policy_unverifiable: ruleset response has an unknown schema/);
+});
+
+test('an unknown manifest schema is typed policy_unverifiable', () => {
+  const result = run({ manifest: { required_status_checks: [] } });
+
+  assert.equal(result.status, 2);
+  assert.match(result.output, /policy_unverifiable: policy manifest has an unknown schema/);
+});

--- a/.github/workflows/policy-drift.yml
+++ b/.github/workflows/policy-drift.yml
@@ -1,0 +1,65 @@
+name: Merge Policy Drift
+
+# pull_request_target runs this workflow from the trusted base revision. The
+# fork's manifest is read as data through the Contents API; it is never checked
+# out or executed. Only the final checker step receives the repository-admin
+# read credential, and that step performs GET requests only.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Merge Policy Drift
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted policy checker
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Materialize source-controlled policy manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          manifest="$RUNNER_TEMP/merge-blocking-status-contexts.json"
+          if [[ "$EVENT_NAME" == pull_request_target ]]; then
+            if ! [[ "$PR_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+              ! [[ "$PR_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              printf 'policy_unverifiable: pull request identity is invalid\n' >&2
+              exit 2
+            fi
+            if ! gh api \
+              --method GET \
+              "repos/$PR_REPOSITORY/contents/scripts/merge-blocking-status-contexts.json?ref=$PR_SHA" \
+              --jq '.content' 2>/dev/null \
+              | tr -d '\n' \
+              | base64 --decode >"$manifest"; then
+              printf 'policy_unverifiable: could not read proposed policy manifest\n' >&2
+              exit 2
+            fi
+          else
+            cp -- scripts/merge-blocking-status-contexts.json "$manifest"
+          fi
+          printf 'POLICY_MANIFEST=%s\n' "$manifest" >>"$GITHUB_ENV"
+
+      - name: Check active ruleset without mutation
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_READ_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/check-ruleset-drift.sh

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - name: Run workflow script tests
-        run: node --test .github/scripts/parse-linked-issues.test.cjs
+        run: node --test .github/scripts/parse-linked-issues.test.cjs .github/scripts/check-ruleset-drift.test.cjs
 
   check-issue-reference:
     name: Check Issue Reference

--- a/docs/CODEBASE-GUIDE.md
+++ b/docs/CODEBASE-GUIDE.md
@@ -47,6 +47,7 @@ Golden rule: **agent-specific paths belong in adapters; reusable behavior belong
 | [Dashboard](codebase/dashboard.md) | Know what dashboard code is absent from this repo and how to avoid inventing it. |
 | [Integrations](codebase/integrations.md) | Change agent adapters, plugins, and setup boundaries safely. |
 | [Maintainer playbook](codebase/maintainer-playbook.md) | Use checklists by change type and PR review guardrails. |
+| [CI policy](ci-policy.md) | Maintain merge-blocking status contexts and verify ruleset drift. |
 | [Reference map](codebase/reference-map.md) | Trace docs and source files to responsibilities. |
 
 ## Recommended reading path

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -1,0 +1,20 @@
+# CI policy
+
+`scripts/merge-blocking-status-contexts.json` is the source-controlled list of
+merge-blocking GitHub Actions status contexts. It includes the exact Darwin
+entry `{"context":"Darwin Runtime","integration_id":15368}`.
+
+`.github/workflows/policy-drift.yml` compares that list with active ruleset
+`13932547`. It performs only authenticated `GET` requests and fails closed:
+
+- `policy_drift` (exit 1) means the readable ruleset differs from the manifest.
+- `policy_unverifiable` (exit 2) means authentication, API availability, rate
+  limits, response schema, or active-ruleset discovery prevented verification.
+
+The workflow runs from trusted base code on `pull_request_target`. It reads a
+pull request's manifest through the Contents API as data; it never checks out
+or executes fork code. Configure the repository secret `RULESET_READ_TOKEN`
+with a GitHub App or equivalent credential limited to repository ruleset
+administration read access. The checker never creates, updates, or deletes a
+ruleset. Adding `Darwin Runtime` to the live ruleset remains a maintainer-owned
+manual action.

--- a/scripts/check-ruleset-drift.sh
+++ b/scripts/check-ruleset-drift.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly ruleset_id=13932547
+readonly expected_repository='Gentleman-Programming/gentle-ai'
+readonly expected_schema='gentle-ai.merge-blocking-status-contexts/v1'
+policy_drift() {
+  printf 'policy_drift: %s\n' "$*" >&2
+  exit 1
+}
+policy_unverifiable() {
+  printf 'policy_unverifiable: %s\n' "$*" >&2
+  exit 2
+}
+[[ -n "${GITHUB_REPOSITORY:-}" ]] || policy_unverifiable 'GITHUB_REPOSITORY is required'
+[[ "$GITHUB_REPOSITORY" == "$expected_repository" ]] ||
+  policy_unverifiable 'unexpected repository'
+[[ -n "${GH_TOKEN:-}" ]] || policy_unverifiable 'GH_TOKEN is required'
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+manifest=${POLICY_MANIFEST:-"$script_dir/merge-blocking-status-contexts.json"}
+[[ -f "$manifest" ]] || policy_unverifiable 'policy manifest is missing'
+work=$(mktemp -d)
+trap 'rm -rf -- "$work"' EXIT
+declared="$work/declared.json"
+rulesets="$work/rulesets.json"
+ruleset="$work/ruleset.json"
+
+if ! jq -e -c --arg schema "$expected_schema" '
+  def valid_entry:
+    type == "object" and
+    (keys | sort) == ["context", "integration_id"] and
+    (.context | type == "string" and length > 0) and
+    (.integration_id | type == "number" and floor == . and . >= 0);
+  def valid_manifest:
+    type == "object" and
+    .schema == $schema and
+    (.required_status_checks | type == "array" and length > 0) and
+    all(.required_status_checks[]; valid_entry) and
+    ((.required_status_checks | map([.context, .integration_id]) | unique | length)
+      == (.required_status_checks | length));
+  if valid_manifest then
+    [.required_status_checks[]] | sort_by(.context, .integration_id)
+  else
+    error("unknown schema")
+  end
+' "$manifest" >"$declared" 2>/dev/null; then
+  policy_unverifiable 'policy manifest has an unknown schema'
+fi
+
+if ! gh api --method GET "repos/$GITHUB_REPOSITORY/rulesets?includes_parents=false" \
+  >"$rulesets" 2>/dev/null; then
+  policy_unverifiable 'could not read repository rulesets'
+fi
+
+if ! jq -e '
+  type == "array" and
+  all(.[];
+    type == "object" and
+    (.id | type == "number" and floor == . and . >= 1) and
+    (.enforcement | type == "string")
+  )
+' "$rulesets" >/dev/null 2>&1; then
+  policy_unverifiable 'ruleset list response has an unknown schema'
+fi
+
+active_count=$(jq '[.[] | select(.enforcement == "active")] | length' "$rulesets" 2>/dev/null) ||
+  policy_unverifiable 'ruleset list response could not be inspected'
+if [[ "$active_count" == 0 ]]; then
+  policy_unverifiable 'no active rulesets were returned'
+fi
+
+if ! gh api --method GET "repos/$GITHUB_REPOSITORY/rulesets/$ruleset_id" \
+  >"$ruleset" 2>/dev/null; then
+  policy_unverifiable "could not read ruleset $ruleset_id"
+fi
+
+if ! jq -e -c --argjson id "$ruleset_id" '
+  def valid_entry:
+    type == "object" and
+    (keys | sort) == ["context", "integration_id"] and
+    (.context | type == "string" and length > 0) and
+    (.integration_id | type == "number" and floor == . and . >= 0);
+  ([.rules[]? | select(type == "object" and .type == "required_status_checks")]) as $required |
+  def valid_ruleset:
+    type == "object" and
+    .id == $id and
+    .enforcement == "active" and
+    (.rules | type == "array") and
+    ($required | length == 1) and
+    ($required[0].parameters | type == "object") and
+    ($required[0].parameters.required_status_checks | type == "array") and
+    all($required[0].parameters.required_status_checks[]; valid_entry) and
+    (($required[0].parameters.required_status_checks
+        | map([.context, .integration_id]) | unique | length)
+      == ($required[0].parameters.required_status_checks | length));
+  if valid_ruleset then
+    $required[0].parameters.required_status_checks | sort_by(.context, .integration_id)
+  else
+    error("unknown schema")
+  end
+' "$ruleset" >"$work/observed.json" 2>/dev/null; then
+  policy_unverifiable 'ruleset response has an unknown schema'
+fi
+
+if ! cmp -s "$declared" "$work/observed.json"; then
+  printf 'policy_drift: required status contexts differ for ruleset %s\n' "$ruleset_id" >&2
+  printf 'declared: ' >&2
+  jq -c . "$declared" >&2
+  printf 'observed: ' >&2
+  jq -c . "$work/observed.json" >&2
+  exit 1
+fi
+
+printf 'merge policy verified: %s required status contexts match ruleset %s\n' \
+  "$(jq 'length' "$declared")" "$ruleset_id"

--- a/scripts/merge-blocking-status-contexts.json
+++ b/scripts/merge-blocking-status-contexts.json
@@ -1,0 +1,38 @@
+{
+  "schema": "gentle-ai.merge-blocking-status-contexts/v1",
+  "required_status_checks": [
+    {
+      "context": "Check Issue Has status:approved",
+      "integration_id": 15368
+    },
+    {
+      "context": "Check Issue Reference",
+      "integration_id": 15368
+    },
+    {
+      "context": "Check PR Has type:* Label",
+      "integration_id": 15368
+    },
+    {
+      "context": "Unit Tests",
+      "integration_id": 15368
+    },
+    {
+      "context": "E2E Tests (ubuntu)",
+      "integration_id": 15368
+    },
+    {
+      "context": "E2E Tests (arch)",
+      "integration_id": 15368
+    },
+    {
+      "context": "E2E Tests (fedora)",
+      "integration_id": 15368
+    },
+    {
+      "context": "Darwin Runtime",
+      "integration_id": 15368
+    },
+    {"context": "Merge Policy Drift", "integration_id": 15368}
+  ]
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1853

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Define the source-controlled merge-blocking status context manifest, including `Darwin Runtime` and `Merge Policy Drift`.
- Add a read-only, fail-closed checker for active ruleset `13932547`.
- Run policy drift checks from trusted base code without executing fork code or exposing repository-admin credentials.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `scripts/merge-blocking-status-contexts.json` | Declares exact required contexts and integration identities. |
| `scripts/check-ruleset-drift.sh` | Compares the declared policy with the active GitHub ruleset using GET requests only. |
| `.github/workflows/policy-drift.yml` | Runs the checker from trusted base code with an isolated read credential. |
| `.github/scripts/check-ruleset-drift.test.cjs` | Covers matches, drift, API failures, credentials, and unknown schemas. |
| `docs/ci-policy.md` | Documents activation, outcomes, and maintainer-owned steps. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model:** OpenCode / GPT-5.6

**Material scope:** Implementation, focused tests, documentation, and PR preparation.

**Verification performed:** Independent four-lens Gentle AI review with one bounded correction and targeted validation; focused Node tests; Bash syntax; JSON/YAML parsing; and diff checks.

---

## 🧪 Test Plan

- [x] `node --test .github/scripts/check-ruleset-drift.test.cjs` — 7/7 passed.
- [x] `bash -n scripts/check-ruleset-drift.sh`.
- [x] `git diff --check`.
- [x] Manual live read-only check reports `policy_drift` while the ruleset still omits Darwin.
- [ ] `shellcheck` — unavailable locally; CI will run the repository check.
- [ ] Full `go test ./...` — unrelated existing macOS path/lock/E2E failures and local timeout; no Go files changed.

Benchmark validation: N/A. This change affects repository CI policy, not benchmark implementation, corpus, classifier, review lifecycle, gates, recovery, or delivery behavior.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines: 399 additions + 1 deletion.
- [x] I have added exactly one appropriate `type:*` label.
- [ ] Full unit test suite passes locally; focused affected tests pass and CI will run the complete suite.
- [x] Go format is unaffected; no Go files changed.
- [ ] E2E suite was not run locally; no runtime product path changed.
- [x] Benchmark validation is not applicable, as explained above.
- [x] Documentation is updated.
- [x] Commits follow Conventional Commits.
- [x] I understand, reviewed, and take responsibility for the complete submission.
- [x] I selected exactly one AI-assistance option and completed the declaration.
- [x] Commits do not include `Co-Authored-By` trailers.

---

## 💬 Notes for Reviewers

After merge, a maintainer must add both `Darwin Runtime` and `Merge Policy Drift` with integration ID `15368` to active ruleset `13932547`, and configure `RULESET_READ_TOKEN` with repository-ruleset read permission. The workflow intentionally performs no ruleset mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated detection of merge-policy drift against required status checks.
  * Added read-only CI validation for pull requests, default-branch updates, and manual runs.
  * Defined nine required merge-blocking status checks, including policy drift verification.

* **Documentation**
  * Added guidance covering CI policy, verification behavior, required permissions, and policy maintenance.

* **Tests**
  * Added coverage for successful validation, policy changes, API failures, missing credentials, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->