### PR TITLE
test(review): prove Codex committed correction re-entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,8 @@ jobs:
             completed_once("j110-untracked-terminal-burn-and-unmanaged-staged-validation") and
             completed_once("j111-approved-transaction-burns-and-shipped-gates-are-unmanaged") and
             completed_once("j113-correction-removes-candidate-only-path") and
-            completed_once("j114-last-reviewer-capture-closes-and-burns")
+            completed_once("j114-last-reviewer-capture-closes-and-burns") and
+            completed_once("j116-codex-committed-correction-runs-returned-status-continuation")
           ' "$RUNNER_TEMP/bench-portable.json"
           "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j105-compiled-provider-capture-retries-same-binding --out "$RUNNER_TEMP/bench-provider-capture.json"
           jq -e '

--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -823,6 +823,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue3564Journeys()...)
 	journeys = append(journeys, issue3321Journeys()...)
 	journeys = append(journeys, issue3587Journeys()...)
+	journeys = append(journeys, issue3748Journeys()...)
 	journeys = append(journeys, handoffJourneys()...)
 	journeys = removeRetiredAtomicJourneys(journeys)
 	return declareCoreJourneyReviewModes(journeys)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -65,6 +65,7 @@ func journeySources() []journeySource {
 		{"journeys_issue3564.go", issue3564Journeys()},
 		{"journeys_issue3321.go", issue3321Journeys()},
 		{"journeys_issue3587.go", issue3587Journeys()},
+		{"journeys_issue3748.go", issue3748Journeys()},
 	}
 	for index := range sources {
 		sources[index].Journeys = removeRetiredAtomicJourneys(sources[index].Journeys)

--- a/bench/journeys_issue3748.go
+++ b/bench/journeys_issue3748.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const issue3748CodexLineage = "issue-3748-codex-committed-continuation"
+
+var issue3748CodexCaptureCapability = &Capability{Verb: []string{"review", "capture-result"}, Flags: []string{
+	"--agent", "--repository-context", "--expected-revision", "--lineage", "--target", "--lens", "--order",
+}}
+
+func issue3748Journeys() []Journey {
+	return []Journey{{
+		ID:     "j116-codex-committed-correction-runs-returned-status-continuation",
+		Review: reviewOptedIn,
+		Title:  "Codex committed correction executes the provider-returned STATUS continuation unchanged",
+		Source: "issue #3748 follow-up to PR #3751: Codex parity for committed correction re-entry",
+		Steps: []Step{
+			{Name: "fixture: committed medium-risk candidate and isolated Codex runtime", Fixture: issue3748CodexFixture},
+			{Name: "negotiate and start the committed Codex review", Requires: statusCapability, Composite: issue3748StartCodexReview},
+			{Name: "Codex reports a candidate-caused blocker and returns correction_required", Requires: issue3748CodexCaptureCapability, Composite: issue3748CaptureCodexBlocker},
+			{Name: "the returned ordered STATUS tokens re-enter the frozen committed correction", Requires: statusCapability, Composite: issue3748ExecuteCodexContinuation},
+		},
+	}}
+}
+
+func issue3748CodexFixture(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	baseTree, err := gitOut(sandbox, sandbox.Repo, "rev-parse", "HEAD^{tree}")
+	if err != nil {
+		return err
+	}
+	sandbox.Scratch["issue-3748-base-tree"] = baseTree
+	const candidate = "package candidate\n\nfunc value() int {\n\treturn 1\n}\n"
+	if err := sandbox.write(filepath.Join(sandbox.Repo, "candidate.go"), candidate); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "candidate.go"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "feat: committed Codex candidate"); err != nil {
+		return err
+	}
+
+	bin := filepath.Join(sandbox.Root, "codex-bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		return err
+	}
+	const codex = `#!/bin/sh
+set -eu
+prompt="$0.prompt"
+cat > "$prompt"
+output=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-last-message) output=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+subject=$(sed -n 's/.*"subject_hash"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$prompt" | head -n 1)
+test -n "$subject" && test -n "$output"
+printf '{"subject_hash":"%s","inspection":{"status":"completed","paths":["candidate.go"]},"lens":"review-reliability","findings":[{"location":"candidate.go:4","severity":"CRITICAL","claim":"the committed candidate returns the wrong value","proof_refs":["candidate.go:4 is introduced by the committed candidate"],"evidence_class":"deterministic","causal_disposition":"introduced"}],"evidence":["the frozen committed candidate returns 1 instead of the required value"]}\n' "$subject" > "$output"
+`
+	if err := os.WriteFile(filepath.Join(bin, "codex"), []byte(codex), 0o755); err != nil {
+		return err
+	}
+	sandbox.PathOverride = bin
+	return nil
+}
+
+func issue3748Status(r *journeyRun) (statusEnvelope, error) {
+	return readStatusForContract(r, reviewContractV2,
+		"--agent", "codex", "--lineage", issue3748CodexLineage,
+		"--base-ref", r.sandbox.Scratch["issue-3748-base-tree"], "--committed-only")
+}
+
+func issue3748StartCodexReview(r *journeyRun) error {
+	status, err := issue3748Status(r)
+	if err != nil || status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("committed Codex START transition = %+v, %v", status.NextTransition, err)
+	}
+	for name, want := range map[string]string{
+		"agent": "codex", "lineage": issue3748CodexLineage,
+		"base-ref": r.sandbox.Scratch["issue-3748-base-tree"], "committed-only": "true",
+	} {
+		if status.executeArgument(name) != want {
+			return fmt.Errorf("committed Codex START %s = %q, want %q", name, status.executeArgument(name), want)
+		}
+	}
+	relay, err := runPrintedTransition(r, status)
+	if err != nil {
+		return err
+	}
+	started, err := resolveAtomicStartConsentAt(r, r.sandbox.Repo, status, relay)
+	if err != nil {
+		return err
+	}
+	var result atomicReviewStartResult
+	if err := json.Unmarshal([]byte(started.Stdout), &result); err != nil {
+		return err
+	}
+	if result.LineageID != issue3748CodexLineage || result.State != "reviewing" || len(result.SelectedLenses) != 1 {
+		return fmt.Errorf("committed Codex START = %+v", result)
+	}
+	return nil
+}
+
+func issue3748CaptureCodexBlocker(r *journeyRun) error {
+	status, err := issue3748Status(r)
+	if err != nil || status.NextTransition.Kind != "collect" || len(status.NextTransition.Collect.Inputs) != 1 {
+		return fmt.Errorf("committed Codex capture transition = %+v, %v", status.NextTransition, err)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.Name != "reviewer_result" || input.CaptureOperation != "review.capture-result" {
+		return fmt.Errorf("committed Codex capture input = %+v", input)
+	}
+	arguments := []string{"review", "capture-result"}
+	for _, argument := range input.Arguments {
+		if argument.Token == "" {
+			return errors.New("committed Codex capture omitted an ordered argument token")
+		}
+		arguments = append(arguments, argument.Token)
+	}
+	closure := r.run(arguments, true)
+	if closure.ExitCode != 0 {
+		return fmt.Errorf("committed Codex capture: %s", firstLine(closure.Stderr))
+	}
+	var result lastEventClosure
+	if err := json.Unmarshal([]byte(strings.TrimSpace(closure.Stdout)), &result); err != nil {
+		return err
+	}
+	if result.LineageID != issue3748CodexLineage || result.State != "correction_required" || result.StatusContinuation == nil {
+		return fmt.Errorf("committed Codex closure = %+v", result)
+	}
+	r.sandbox.Scratch["issue-3748-closure"] = closure.Stdout
+	return nil
+}
+
+func issue3748ExecuteCodexContinuation(r *journeyRun) error {
+	closure := Observation{Stdout: r.sandbox.Scratch["issue-3748-closure"]}
+	var result lastEventClosure
+	if err := json.Unmarshal([]byte(closure.Stdout), &result); err != nil {
+		return err
+	}
+	want := map[string]bool{
+		"--lineage=" + issue3748CodexLineage:                      false,
+		"--base-ref=" + r.sandbox.Scratch["issue-3748-base-tree"]: false,
+		"--committed-only=true":                                   false,
+		"--agent=codex":                                           false,
+	}
+	for _, argument := range result.StatusContinuation.Arguments {
+		if _, found := want[argument.Token]; found {
+			want[argument.Token] = true
+		}
+	}
+	for token, found := range want {
+		if !found {
+			return fmt.Errorf("Codex correction continuation omitted %q", token)
+		}
+	}
+	status, terminal, err := correctionStatusFromLastEventCapture(r, closure)
+	if err != nil || !terminal {
+		return fmt.Errorf("execute Codex correction continuation: terminal=%t err=%v", terminal, err)
+	}
+	if status.Authority.LineageID != issue3748CodexLineage || status.Authority.State != "correction_required" ||
+		status.Projection.BaseTree != r.sandbox.Scratch["issue-3748-base-tree"] || status.NextTransition.ReasonCode != "correction_plan_required" {
+		return fmt.Errorf("Codex committed correction STATUS = authority=%+v projection=%+v transition=%+v", status.Authority, status.Projection, status.NextTransition)
+	}
+	return nil
+}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -112,6 +112,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j98-sdd-flat-root-spec-is-discovered":                                      reviewUntouched,
 	"j99-issue-2906-finalize-missing-contract":                                  reviewOptedIn,
 	"j115-recovery-selector-is-collected-before-authorization":                  reviewOptedIn,
+	"j116-codex-committed-correction-runs-returned-status-continuation":         reviewOptedIn,
 }
 
 func declareCoreJourneyReviewModes(journeys []Journey) []Journey {

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -12,6 +12,7 @@ j112-sdd-attempt-settle-survives-review-mode-transition
 j113-correction-removes-candidate-only-path
 j114-last-reviewer-capture-closes-and-burns
 j115-recovery-selector-is-collected-before-authorization
+j116-codex-committed-correction-runs-returned-status-continuation
 j12-rejected-capture-then-recapture
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token

--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -344,10 +344,41 @@ func TestCodexProviderAdapterUsesPinnedLocalRuntime(t *testing.T) {
 		t.Fatalf("Codex version = %q, %v", strings.TrimSpace(string(version)), err)
 	}
 	harness := newOrganicHarness(t)
+	baseTree := strings.TrimSpace(harness.git("rev-parse", "HEAD^{tree}"))
 	harness.writeFiles(map[string]string{"internal/provider/candidate.go": "package provider\n\nfunc Value() int { return 1 }\n"})
+	harness.git("add", "--", "internal/provider/candidate.go")
+	harness.git("commit", "-qm", "feat: committed Codex correction candidate")
 	const lineage = "codex-loopback-egress-proof"
-	_ = organicProviderStart(t, harness, lineage, "codex")
-	binding := organicProviderBinding(t, organicProviderStatus(t, harness, lineage, "codex"))
+	statusPayload := harness.gentle(
+		"review", "status", "--cwd", harness.repo.worktree, "--contract", "gentle-ai.review-integration/v2",
+		"--agent", "codex", "--lineage", lineage, "--base-ref", baseTree, "--committed-only", "--next-transition",
+	)
+	var negotiated organicProviderStatusResult
+	if err := json.Unmarshal(statusPayload, &negotiated); err != nil || negotiated.NextTransition == nil || negotiated.NextTransition.Execute == nil {
+		t.Fatalf("decode committed Codex START: %v\n%s", err, statusPayload)
+	}
+	start := negotiated.NextTransition.Execute
+	stdout, stderr, err := harness.gentleAllowFailure(
+		"review", "start", "--cwd", harness.repo.worktree, "--contract", "gentle-ai.review-integration/v2",
+		"--target", start.argument("target"), "--projection", start.argument("projection"), "--base-ref", baseTree, "--committed-only",
+		"--lineage", lineage, "--agent", "codex", "--consent", "granted", "--focus", "reliability",
+	)
+	if err != nil {
+		t.Fatalf("committed Codex START: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	var started organicStartResult
+	if err := json.Unmarshal([]byte(stdout), &started); err != nil || started.State != "reviewing" || len(started.SelectedLenses) != 1 {
+		t.Fatalf("committed Codex START = %#v, %v\n%s", started, err, stdout)
+	}
+	statusPayload = harness.gentle(
+		"review", "status", "--cwd", harness.repo.worktree, "--contract", "gentle-ai.review-integration/v2",
+		"--agent", "codex", "--lineage", lineage, "--base-ref", baseTree, "--committed-only", "--next-transition",
+	)
+	var reviewing organicProviderStatusResult
+	if err := json.Unmarshal(statusPayload, &reviewing); err != nil {
+		t.Fatalf("decode committed Codex capture STATUS: %v\n%s", err, statusPayload)
+	}
+	binding := organicProviderBinding(t, reviewing)
 	order, err := strconv.Atoi(binding["order"])
 	if err != nil {
 		t.Fatal(err)
@@ -356,8 +387,13 @@ func TestCodexProviderAdapterUsesPinnedLocalRuntime(t *testing.T) {
 		"subject_hash": binding["subject-hash"],
 		"inspection":   map[string]any{"status": "completed", "paths": []string{"internal/provider/candidate.go"}},
 		"lens":         binding["lens"],
-		"findings":     []any{},
-		"evidence":     []string{"loopback inspected the frozen candidate"},
+		"findings": []any{map[string]any{
+			"location": "internal/provider/candidate.go:3", "severity": "CRITICAL",
+			"claim":          "the committed candidate returns the wrong value",
+			"proof_refs":     []string{"internal/provider/candidate.go:3 is introduced by the committed candidate"},
+			"evidence_class": "deterministic", "causal_disposition": "introduced",
+		}},
+		"evidence": []string{"loopback found a candidate-caused blocker in the frozen committed candidate"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -423,7 +459,7 @@ exec "$GENTLE_AI_RUNTIME_TRACE_BINARY" -ff -o "$GENTLE_AI_RUNTIME_TRACE_LOG" -e 
 		"--repository-context", binding["repository-context"], "--expected-revision", binding["expected-revision"],
 		"--lineage", binding["lineage"], "--target", binding["target"], "--lens", binding["lens"], "--order", strconv.Itoa(order),
 	}
-	stdout, stderr, err := runOrganicCommand(t, organicBinary, harness.repo.worktree, environment, arguments...)
+	stdout, stderr, err = runOrganicCommand(t, organicBinary, harness.repo.worktree, environment, arguments...)
 	if err != nil {
 		t.Fatalf("registered Codex provider route: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
@@ -444,14 +480,45 @@ exec "$GENTLE_AI_RUNTIME_TRACE_BINARY" -ff -o "$GENTLE_AI_RUNTIME_TRACE_LOG" -e 
 		}
 	}
 	t.Logf("Codex egress proof: %d external attempts denied by the loopback proxy; strace observed %d Internet-socket connects, all loopback: %v", denied, len(connections), connections)
-	var terminal organicFinalizeResult
+	var terminal struct {
+		organicFinalizeResult
+		StatusContinuation *organicProviderExecute `json:"status_continuation"`
+	}
 	if err := json.Unmarshal([]byte(stdout), &terminal); err != nil {
 		t.Fatalf("decode terminal Codex provider capture: %v\n%s", err, stdout)
 	}
-	if terminal.Operation != "review/capture-result" || terminal.State != organicStateApproved {
-		t.Fatalf("registered Codex provider capture did not close the clean review: %#v", terminal)
+	if terminal.Operation != "review/capture-result" || terminal.State != organicStateCorrectionRequired || terminal.StatusContinuation == nil {
+		t.Fatalf("registered Codex provider capture did not open committed correction: %#v", terminal)
 	}
-	harness.assertReviewBurned(lineage, terminal)
+	if terminal.StatusContinuation.Operation != "review.status" {
+		t.Fatalf("Codex committed correction continuation operation = %q, want review.status", terminal.StatusContinuation.Operation)
+	}
+	wantTokens := map[string]bool{
+		"--lineage=" + lineage: false, "--base-ref=" + baseTree: false,
+		"--committed-only=true": false, "--agent=codex": false,
+	}
+	continuationArguments := []string{"review", "status"}
+	for _, argument := range terminal.StatusContinuation.Arguments {
+		continuationArguments = append(continuationArguments, argument.Token)
+		if _, found := wantTokens[argument.Token]; found {
+			wantTokens[argument.Token] = true
+		}
+	}
+	for token, found := range wantTokens {
+		if !found {
+			t.Fatalf("Codex committed correction continuation omitted %q: %#v", token, terminal.StatusContinuation)
+		}
+	}
+	continuationPayload := harness.gentle(continuationArguments...)
+	var correction organicProviderStatusResult
+	if err := json.Unmarshal(continuationPayload, &correction); err != nil {
+		t.Fatalf("decode returned Codex correction STATUS: %v\n%s", err, continuationPayload)
+	}
+	if correction.Authority.LineageID != lineage || correction.Authority.State != organicStateCorrectionRequired ||
+		correction.Projection.BaseTree != baseTree || correction.NextTransition == nil ||
+		correction.NextTransition.ReasonCode != "correction_plan_required" {
+		t.Fatalf("returned Codex committed correction STATUS = %#v", correction)
+	}
 }
 
 // codexTracedConnectAddresses parses one trace per child process. strace -ff
@@ -1467,6 +1534,13 @@ type organicProviderStatusResult struct {
 	TargetIdentity string                     `json:"target_identity"`
 	Applicability  string                     `json:"applicability"`
 	NextTransition *organicProviderTransition `json:"next_transition"`
+	Authority      struct {
+		LineageID string `json:"lineage_id"`
+		State     string `json:"state"`
+	} `json:"authority"`
+	Projection struct {
+		BaseTree string `json:"base_tree"`
+	} `json:"projection"`
 }
 
 type organicProviderTransition struct {
@@ -1499,6 +1573,7 @@ type organicProviderArtifact struct {
 type organicProviderArgument struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+	Token string `json:"token"`
 }
 
 func (execute organicProviderExecute) argument(name string) string {

--- a/internal/cli/review_committed_correction_test.go
+++ b/internal/cli/review_committed_correction_test.go
@@ -121,7 +121,7 @@ func TestCommittedBaseDiffLastReviewerCapturePublishesExactStatusContinuation(t 
 }
 
 func TestCommittedBaseDiffCorrectionReentryRunsReturnedContinuationForAdvertisedLanes(t *testing.T) {
-	for _, runtime := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode} {
+	for _, runtime := range []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex} {
 		t.Run(string(runtime), func(t *testing.T) {
 			reviewEnabledHome(t)
 			repo := initReviewCLIRepo(t)
@@ -170,10 +170,10 @@ func TestCommittedBaseDiffCorrectionReentryRunsReturnedContinuationForAdvertised
 			}
 			var terminal []byte
 			switch runtime {
-			case model.AgentClaudeCode:
+			case model.AgentClaudeCode, model.AgentCodex:
 				previous := reviewProviderAdapterFor
 				reviewProviderAdapterFor = func(_ reviewerprovider.Contract, agent model.AgentID) (reviewerprovider.Adapter, error) {
-					if agent != model.AgentClaudeCode {
+					if agent != runtime {
 						return nil, errors.New("unexpected runtime")
 					}
 					return providerTestAdapter{raw: payload}, nil

--- a/scripts/crosslane/codex.go
+++ b/scripts/crosslane/codex.go
@@ -25,12 +25,14 @@ done
 [ "$scratch" = "$PWD" ] && [ -z "$(ls -A "$PWD")" ] && [ "$output" = "$PWD/result" ]
 hash=$(sed -n 's/.*"subject_hash"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$log/stdin" | head -n 1)
 [ -n "$hash" ]
-printf '{"subject_hash":"%s","inspection":{"status":"completed","paths":["src/add.js"]},"evidence":["deterministic Codex model completed immutable inspection"],"findings":[]}' "$hash" | tee "$output" > "$log/raw"
+printf '{"subject_hash":"%s","inspection":{"status":"completed","paths":["src/add.js"]},"evidence":["double is introduced by the committed candidate and violates the required behavior"],"findings":[{"claim":"double returns an incorrect committed candidate result","severity":"CRITICAL","evidence_class":"deterministic","causal_disposition":"introduced","lens":"review-reliability","location":"src/add.js:5","proof_refs":["src/add.js:4-6 is an introduced committed candidate hunk"]}]}' "$hash" | tee "$output" > "$log/raw"
 `
 
 func (b *battery) runCodexLane() {
-	repo, ok := b.hostMediumCandidate(codexLane, "codex-lane")
-	if !ok {
+	base := "export function add(a, b) {\n  return a + b;\n}\n"
+	candidate := base + "export function double(a) {\n  return add(a, a);\n}\n"
+	repo, baseTree, ok := b.committedMediumCandidate(codexLane, "codex-committed", "src/add.js", base, candidate)
+	if !ok || !b.startCommittedMedium(codexLane, repo, "codex", baseTree) {
 		return
 	}
 	log := filepath.Join(b.workRoot, "codex-model")
@@ -43,9 +45,6 @@ func (b *battery) runCodexLane() {
 		return
 	}
 	env := []string{"CROSSLANE_CODEX_LOG=" + log, "PATH=" + filepath.Join(log, "bin") + string(os.PathListSeparator) + os.Getenv("PATH")}
-	if !b.hostNegotiatedMediumStart(codexLane, repo, "codex", env) {
-		return
-	}
 	status, stderr, _ := b.statusEnv(repo, "codex", env)
 	input := collectInput(status)
 	if input == nil || input["capture_operation"] != "review.capture-result" {
@@ -66,11 +65,21 @@ func (b *battery) runCodexLane() {
 	if !b.checkCodexBoundary(log, subject) {
 		return
 	}
-	if operationState(capture) != "approved" {
-		b.fail(codexLane, "final capture and burned lifecycle", fmt.Sprintf("terminal state = %q, want approved", operationState(capture)))
+	if operationState(capture) != "correction_required" {
+		b.fail(codexLane, "committed Codex correction capture", fmt.Sprintf("terminal state = %q, want correction_required", operationState(capture)))
 		return
 	}
-	b.burnApproved(codexLane, "final capture and burned lifecycle", repo, "codex", env, capture)
+	continuation := getMap(capture, "status_continuation")
+	if getString(continuation, "operation") != "review.status" ||
+		!transitionCarriesToken(continuation, "--lineage="+operationLineage(capture)) ||
+		!transitionCarriesToken(continuation, "--base-ref="+baseTree) ||
+		!transitionCarriesToken(continuation, "--committed-only=true") ||
+		!transitionCarriesToken(continuation, "--agent=codex") {
+		b.fail(codexLane, "committed Codex correction continuation", "closure did not preserve lineage, frozen base, committed-only mode, and Codex binding")
+		return
+	}
+	b.pass(codexLane, "committed Codex correction continuation", "closure preserved lineage, frozen base, committed-only mode, and Codex binding in ordered tokens")
+	b.hostCorrectionReentry(codexLane, "committed Codex correction re-entry", repo, env, capture)
 }
 
 func (b *battery) checkCodexBoundary(log, subject string) bool {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3748

---

## 🏷️ PR Type

- [x] `type:chore` — Build, CI, or tooling changes

---

## 📝 Summary

Add the missing Codex-specific executable proof for the committed correction continuation introduced by #3748. The new coverage drives `correction_required` through the provider-returned `status_continuation` unchanged and verifies committed STATUS re-entry.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench` | Added active journey j116 and complete corpus/CI registration |
| `scripts/crosslane` | Added deterministic Codex committed correction process proof |
| `e2e/organicruntime` | Extended pinned Codex 0.147.0 runtime proof with committed continuation re-entry |
| `internal/cli` | Added Codex to advertised-lane committed correction coverage |

---

## 🤖 AI Assistance

- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenAI Codex agent.

**Material scope:** Repository exploration, test design, implementation, RDD review orchestration, verification, and PR drafting.

**Verification performed:** Behavior-first RED evidence; independent root, benchmark, driven-journey, deterministic crosslane, pinned-real-runtime, formatting, diff, and Docker E2E verification. Native four-lens RDD review approved the exact committed tree.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**
```bash
cd bench && go test ./... -count=1
gentle-ai-bench run --binary gentle-ai --only j116-codex-committed-correction-runs-returned-status-continuation
scripts/cross-lane-battery.sh --binary gentle-ai
```

- [x] Unit tests pass
- [x] Go format passes
- [x] E2E tests pass
- [x] Manually tested locally

Driven j116: 1 completed, 0 unsupported, 0 failed. Crosslane: 32 checks, 0 failed. Pinned Codex E2E made exactly one Responses request and kept every traced connection loopback-only. Docker E2E: Ubuntu, Arch, and Fedora each 79 passed, 0 failed, 2 skipped.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 311 changed lines, within the 400-line budget |
| Check Issue Reference | ⏳ | Body links approved issue #3748 |
| Check Issue Has `status:approved` | ⏳ | Issue #3748 retains the approval label |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:chore` |
| Unit Tests | ⏳ | CI must confirm |
| Go Format | ⏳ | CI must confirm |
| E2E Tests | ⏳ | CI must confirm |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E tests pass
- [x] Benchmark validation completed
- [x] Documentation is not required; this is executable parity coverage
- [x] Commit follows Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance is declared
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Review the Codex proof at three boundaries: active bench journey, deterministic compiled-adapter crosslane, and pinned real-runtime E2E. All three execute the provider-returned ordered continuation rather than reconstructing selectors.

Native RDD lineage `review-e4e9b27cdc871c45` approved tree `3141c28e1f6be802ce40f905ac79876c982ea5a5`. No production guard was added or changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for Codex reviews of committed changes that require correction.
  * Codex correction flows now support status-based continuation while preserving review context and settings.

* **Bug Fixes**
  * Improved validation of committed-correction re-entry across supported review providers.
  * Expanded end-to-end checks to ensure critical findings correctly return a correction-required status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->