### PR TITLE
fix(sdd): skip CodeGraph tool grant for empty tools contracts

### DIFF
--- a/internal/components/sdd/prompts.go
+++ b/internal/components/sdd/prompts.go
@@ -166,6 +166,12 @@ func injectCodeGraphToolGrantIntoPrompt(prompt string, agentID model.AgentID, gu
 		if strings.Contains(line, grant) {
 			return prompt
 		}
+		// A deliberately empty tools contract (tool-free reviewers, issue
+		// #3168/#3648) must stay empty: appending the grant would produce
+		// unparseable frontmatter and contradict the agent's own contract.
+		if value := strings.TrimSpace(strings.TrimPrefix(line, "tools:")); value == "" || value == "[]" {
+			return prompt
+		}
 		if agentID == model.AgentClaudeCode {
 			lines[i] = line + ", " + grant
 		} else if strings.HasSuffix(line, "]") {

--- a/internal/components/sdd/prompts_test.go
+++ b/internal/components/sdd/prompts_test.go
@@ -627,6 +627,7 @@ func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.
 			}
 
 			foundRefuter := false
+			foundEmptyTools := false
 			for _, fileName := range nativeMarkdownSubAgentFilesForCodeGraphTest(t, adapter) {
 				foundRefuter = foundRefuter || fileName == "review-refuter.md"
 				path := filepath.Join(adapter.SubAgentsDir(home), fileName)
@@ -640,11 +641,20 @@ func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.
 				}
 
 				source := renderBoundedReviewAsset(adapter.Agent(), adapter.EmbeddedSubAgentsDir()+"/"+fileName)
+				emptyToolsContract := false
 				if tc.toolGrant != "" {
 					sourceTools := nativeToolsLineForCodeGraphTest(t, source)
+					emptyToolsContract = strings.TrimSpace(strings.TrimPrefix(sourceTools, "tools:")) == "[]"
+					foundEmptyTools = foundEmptyTools || emptyToolsContract
 					wantTools := sourceTools + ", " + tc.toolGrant
 					if tc.agentID == model.AgentKiroIDE {
 						wantTools = strings.TrimSuffix(sourceTools, "]") + `, "` + tc.toolGrant + `"]`
+					}
+					if emptyToolsContract {
+						// Tool-free reviewers keep their empty tools contract:
+						// appending the grant would corrupt the frontmatter and
+						// refuse every lens spawn (issues #3168, #3648).
+						wantTools = sourceTools
 					}
 					if got := nativeToolsLineForCodeGraphTest(t, text); got != wantTools {
 						t.Fatalf("%s tools = %q, want %q", fileName, got, wantTools)
@@ -652,7 +662,7 @@ func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.
 				}
 				for _, grant := range []string{claudeCodeGraphToolGrant, kiroCodeGraphToolGrant} {
 					wantCount := 0
-					if grant == tc.toolGrant {
+					if grant == tc.toolGrant && !emptyToolsContract {
 						wantCount = 1
 					}
 					if count := strings.Count(text, grant); count != wantCount {
@@ -666,6 +676,9 @@ func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.
 			if !foundRefuter {
 				t.Fatal("dynamic native asset coverage missing review-refuter.md")
 			}
+			if tc.agentID == model.AgentClaudeCode && !foundEmptyTools {
+				t.Fatal("dynamic native asset coverage missing an empty-tools review lens")
+			}
 
 			second, err := Inject(home, adapter, model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: guidance})
 			if err != nil {
@@ -673,6 +686,25 @@ func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.
 			}
 			if second.Changed {
 				t.Fatalf("Inject(%s) second changed = true, want idempotent output", tc.name)
+			}
+		})
+	}
+}
+
+func TestInjectCodeGraphToolGrantPreservesEmptyToolsContract(t *testing.T) {
+	guidance := communitytool.CodeGraphGuidanceMarkdown()
+	for _, tc := range []struct {
+		name    string
+		agentID model.AgentID
+		prompt  string
+	}{
+		{name: "claude empty flow sequence", agentID: model.AgentClaudeCode, prompt: "---\ntools: []\n---\nBody\n"},
+		{name: "claude empty value", agentID: model.AgentClaudeCode, prompt: "---\ntools:\n---\nBody\n"},
+		{name: "kiro empty flow sequence", agentID: model.AgentKiroIDE, prompt: "---\ntools: []\n---\nBody\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := injectCodeGraphToolGrantIntoPrompt(tc.prompt, tc.agentID, guidance); got != tc.prompt {
+				t.Fatalf("empty tools contract changed: got %q, want %q", got, tc.prompt)
 			}
 		})
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3168
Closes #3648

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Stop the CodeGraph tool-grant injection from corrupting agents that ship a deliberately empty `tools` contract.

`injectCodeGraphToolGrantIntoPrompt` appended `", mcp__codegraph__codegraph_explore"` to the `tools:` frontmatter line of every managed Claude Code agent. The four review lens agents (`review-risk`, `review-resilience`, `review-readability`, `review-reliability`) ship the empty flow sequence `tools: []` on purpose — they are tool-free reviewers — so the append produced the unparseable `tools: [], mcp__codegraph__codegraph_explore`, which resolves to zero tools and refuses every lens spawn. The red test also proved the Kiro branch would corrupt an empty list into the equally invalid `tools: [, "@codegraph"]`.

An empty tools value (`""` or `[]`) now keeps its contract: the grant is not injected. Non-empty lists keep the existing append behavior unchanged.

Material AI assistance was used for implementation, test execution, and review orchestration. Maintainer inspection of the complete diff remains required before merge.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/prompts.go` | Guard in `injectCodeGraphToolGrantIntoPrompt`: an empty tools value (`""` or `[]`) returns the prompt unchanged before any agent-specific append |
| `internal/components/sdd/prompts_test.go` | New `TestInjectCodeGraphToolGrantPreservesEmptyToolsContract` (Claude `[]`, Claude bare `tools:`, Kiro `[]`); corrected `TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled`, which had codified the buggy append for empty-tools lenses, and added coverage proof that a real embedded empty-tools lens is exercised |

## 🧪 Test Plan

```bash
go test ./internal/components/sdd/
go test ./internal/components/ ./internal/assets/...
go build ./...
```

All passed. Strict TDD: the new test and corrected expectations were verified red against the buggy injector before the fix, then green after.

- Native medium-risk review approved lineage `review-2d2a466091ed7e18` (lens `review-reliability`, zero findings) on the exact committed candidate.
- Reproduced field evidence: 2.3.0 (#3168, Windows), 2.4.0 (#3648, macOS/Linux), and 2.5.0-rc.1 built from current main.
- No shell scripts modified — shellcheck not applicable.

Affected installs need a `gentle-ai sync` with a fixed build to repair the four corrupted `~/.claude/agents/review-*.md` files; manual repairs are overwritten by sync until then.

https://claude.ai/code/session_01Em7rGynLACFj2odLYvB35i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved deliberately tool-free agent configurations when CodeGraph guidance is enabled.
  * Prevented invalid frontmatter from being generated for agents with an empty tools list.

* **Tests**
  * Added coverage confirming empty tool contracts remain unchanged across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->