### PR TITLE
fix(pi): route closed choices through native selector

### DIFF
--- a/internal/components/sdd/bounded_review_contract_test.go
+++ b/internal/components/sdd/bounded_review_contract_test.go
@@ -168,6 +168,25 @@ func TestBoundedReviewConsentLocalizationPreservesMachineDomain(t *testing.T) {
 	}
 }
 
+func TestPiRenderedReviewContractUsesOnlyTheClosedChoiceRoute(t *testing.T) {
+	content := renderSDDOrchestratorAsset(model.AgentPi)
+	for _, clause := range []string{
+		"ask_user_choice",
+		"2-4 ordered-option domain",
+		"envelope-owned canonical option token as value",
+		"returns exactly one value; map it to the exact envelope-owned choice once",
+		"ask_user_question is the external open/free-text questionnaire and must not be used for a closed domain",
+		"open/free-text questionnaires may use ask_user_question",
+	} {
+		if !strings.Contains(content, clause) {
+			t.Errorf("Pi closed-choice route missing %q", clause)
+		}
+	}
+	if strings.Contains(renderSDDOrchestratorAsset(model.AgentKilocode), "ask_user_choice") {
+		t.Fatal("generic fallback-only runtime received the Pi-only closed choice route")
+	}
+}
+
 func TestBoundedReviewContractRequiresRuntimeBoundReviewerContext(t *testing.T) {
 	content := boundedReviewContract()
 	for _, want := range []string{

--- a/internal/components/sdd/orchestrator.go
+++ b/internal/components/sdd/orchestrator.go
@@ -35,7 +35,23 @@ func composeOrchestratorPrompt(agent model.AgentID, options ...OrchestratorRende
 	if policy := renderOpenCodeBackgroundPolicy(agent, renderOptions); policy != "" {
 		content = appendOpenCodeBackgroundPolicy(content, policy)
 	}
-	return bindRuntimeAgentIdentity(renderBoundedReviewAssetBodyFromContent(agent, path, content), agent)
+	content = replacePiClosedSingleSelectRoute(content, agent)
+	content = renderBoundedReviewAssetBodyFromContent(agent, path, content)
+	return bindRuntimeAgentIdentity(content, agent)
+}
+
+const genericFallbackOnlyNativeRoute = "- Native route: This variant has no classified native question UI for this contract; always use the plain chat or terminal fallback below. When the closed domain of a single-select envelope is unrepresentable here, fall through to the Fallback clause below."
+
+const piClosedSingleSelectNativeRoute = "- Native route: For every strictly closed single-select envelope, use ask_user_choice only when the interactive Pi TUI can represent its complete one-question 2-4 ordered-option domain. Pass each user-facing label and description with the envelope-owned canonical option token as value. The selector returns exactly one value; map it to the exact envelope-owned choice once, then select any envelope-owned continuation or invocation once where present. It has no custom/free-text or multi-select path. If the native TUI is unavailable or the envelope is not exactly representable, use the complete chat fallback. ask_user_question is the external open/free-text questionnaire and must not be used for a closed domain; open/free-text questionnaires may use ask_user_question when exactly representable. For gentle-ai.review-integration.consent/v3, the chosen continuation is still the exact captured provider-owned choice invocation, used once without synthesis."
+
+func replacePiClosedSingleSelectRoute(content string, agent model.AgentID) string {
+	if agent != model.AgentPi {
+		return content
+	}
+	if count := strings.Count(content, genericFallbackOnlyNativeRoute); count != 1 {
+		panic(fmt.Sprintf("sdd: Pi native route source clause count = %d, want 1", count))
+	}
+	return strings.Replace(content, genericFallbackOnlyNativeRoute, piClosedSingleSelectNativeRoute, 1)
 }
 
 func renderOpenCodeBackgroundPolicy(agent model.AgentID, options ...OrchestratorRenderOptions) string {

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -1,6 +1,7 @@
 package sdd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,15 +12,64 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
+const testGenericFallbackOnlyNativeRoute = "- Native route: This variant has no classified native question UI for this contract; always use the plain chat or terminal fallback below. When the closed domain of a single-select envelope is unrepresentable here, fall through to the Fallback clause below."
+
+const testPiClosedSingleSelectNativeRoute = "- Native route: For every strictly closed single-select envelope, use ask_user_choice only when the interactive Pi TUI can represent its complete one-question 2-4 ordered-option domain. Pass each user-facing label and description with the envelope-owned canonical option token as value. The selector returns exactly one value; map it to the exact envelope-owned choice once, then select any envelope-owned continuation or invocation once where present. It has no custom/free-text or multi-select path. If the native TUI is unavailable or the envelope is not exactly representable, use the complete chat fallback. ask_user_question is the external open/free-text questionnaire and must not be used for a closed domain; open/free-text questionnaires may use ask_user_question when exactly representable. For gentle-ai.review-integration.consent/v3, the chosen continuation is still the exact captured provider-owned choice invocation, used once without synthesis."
+
 func TestCanonicalCompositionPreservesHistoricalOrchestratorBytes(t *testing.T) {
 	for _, agent := range catalog.AllAgents() {
 		t.Run(string(agent.ID), func(t *testing.T) {
 			path := sddOrchestratorAsset(agent.ID)
 			before := renderBoundedReviewAsset(agent.ID, path)
+			if agent.ID == model.AgentPi {
+				before = strings.Replace(before, testGenericFallbackOnlyNativeRoute, testPiClosedSingleSelectNativeRoute, 1)
+			}
 			after := composeOrchestratorPrompt(agent.ID)
 			if after != before {
 				t.Fatalf("canonical composition changed %s orchestrator bytes", agent.ID)
 			}
+		})
+	}
+}
+
+func TestPiClosedChoiceRouteReplacesTheGenericFallback(t *testing.T) {
+	pi := composeOrchestratorPrompt(model.AgentPi)
+	if got := strings.Count(pi, testGenericFallbackOnlyNativeRoute); got != 0 {
+		t.Fatalf("Pi composition contains %d generic fallback-only route clauses, want 0", got)
+	}
+	if got := strings.Count(pi, testPiClosedSingleSelectNativeRoute); got != 1 {
+		t.Fatalf("Pi composition contains %d closed-choice route clauses, want 1", got)
+	}
+
+	generic := renderBoundedReviewAsset(model.AgentPi, sddOrchestratorAsset(model.AgentPi))
+	if got := strings.Count(generic, testGenericFallbackOnlyNativeRoute); got != 1 {
+		t.Fatalf("generic source contains %d fallback-only route clauses, want 1", got)
+	}
+	if strings.Contains(generic, testPiClosedSingleSelectNativeRoute) {
+		t.Fatal("generic source contains the Pi closed-choice route")
+	}
+
+	if strings.Contains(composeOrchestratorPrompt(model.AgentKilocode), testPiClosedSingleSelectNativeRoute) {
+		t.Fatal("Kilo composition received the Pi closed-choice route")
+	}
+}
+
+func TestPiClosedChoiceRouteFailsClosedWhenGenericSourceClauseIsNotUnique(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		content string
+	}{
+		{name: "absent", content: "- Native route: custom runtime route"},
+		{name: "duplicated", content: testGenericFallbackOnlyNativeRoute + "\n" + testGenericFallbackOnlyNativeRoute},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				recovered := recover()
+				if recovered == nil || !strings.Contains(fmt.Sprint(recovered), "Pi native route source clause count") {
+					t.Fatalf("replacePiClosedSingleSelectRoute() panic = %v, want source clause count failure", recovered)
+				}
+			}()
+			replacePiClosedSingleSelectRoute(tt.content, model.AgentPi)
 		})
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Fixes #3070

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## 📝 Summary

- Classifies the Pi-owned closed selector for every strictly closed single-select envelope.
- Replaces Pi's generic chat-only fallback at render time without changing other agent assets or consent contracts.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/orchestrator.go` | Replaces the generic fallback clause only for AgentPi. |
| SDD contract tests | Prove one coherent Pi route and unchanged non-Pi rendering. |

## 🧪 Test Plan

- [x] `go run ./internal/gofmtcheck`
- [x] `go test ./internal/components/sdd`
- [x] `go test ./internal/assets`
- [x] LSP diagnostics report zero errors in changed files
- [x] Native RDD review approved the exact candidate
- [ ] `go test ./...` — local environment retains pre-existing `/var` canonicalization, review-store lock, and timeout failures outside changed packages; GitHub CI is the merge gate
- [ ] E2E — deferred to required GitHub checks

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (87 lines)
- [x] Exactly one `type:*` label is applied
- [x] Focused tests and runtime contract checks pass
- [x] Documentation/contract text is updated with the behavior
- [x] Commit follows Conventional Commits
- [x] Commit contains no `Co-Authored-By` trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved closed-choice review handling for the Pi runtime.
  * Ensured Pi uses the appropriate ordered-option route, while other runtimes continue using the generic fallback behavior.
  * Prevented incorrect route combinations during review interactions.

* **Tests**
  * Added coverage validating runtime-specific review routes and composition behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->