### PR TITLE
fix(sdd): block cross-repository runtime targets

### DIFF
--- a/e2e/organicruntime/sdd_consent_wiring_e2e_test.go
+++ b/e2e/organicruntime/sdd_consent_wiring_e2e_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 )
 
-// Issue #2563 (S4b of #2540): the built-binary consent loop. A blocked
-// multi-repository change's status carries the typed consent envelope; the
-// agent executes the envelope's EXACT grant invocation verbatim; the next
-// status projects the granted roots into allowedEditRoots and apply becomes
-// ready. Declining runs the envelope's decline invocation and the change
+// Issue #2849: the built-binary consent loop. A blocked multi-repository
+// change's status carries the typed consent envelope; the agent executes the
+// envelope's EXACT grant invocation verbatim; the next status projects the
+// granted roots into allowedEditRoots but blocks before any runtime actor can
+// acquire an attempt because independent repositories do not share candidate
+// accounting. Declining runs the envelope's decline invocation and the change
 // stays blocked under the same instance identity. A single-repository change
 // stays byte-identical with zero consent footprint.
 
@@ -209,14 +210,17 @@ func TestSDDEditAuthorityConsentGrantLoop(t *testing.T) {
 	// binary, verbatim.
 	runConsentInvocation(t, environment, planning, grantInvocation)
 
-	// Post-grant status: the covering grant clears detection, apply is ready,
-	// and allowedEditRoots = planning + granted roots.
+	// Post-grant status: the grant clears edit authority and projects its roots,
+	// but must block before any apply actor can acquire against a foreign Git
+	// common directory. A grant authorizes edits; it does not supply candidate
+	// accounting for an independent repository.
 	granted, grantedPayload := consentStatus(t, environment, planning, change)
-	if granted.ApplyState != "ready" || granted.NextRecommended != "apply" {
-		t.Fatalf("post-grant status is not ready/apply: %s", grantedPayload)
+	if granted.ApplyState != "blocked" || granted.NextRecommended != "resolve-blockers" {
+		t.Fatalf("post-grant status did not block runtime actor launch: %s", grantedPayload)
 	}
-	if strings.Contains(strings.Join(granted.BlockedReasons, "\n"), "edit_authority_missing") {
-		t.Fatalf("post-grant status still blocked on edit authority: %s", grantedPayload)
+	reasons := strings.Join(granted.BlockedReasons, "\n")
+	if strings.Contains(reasons, "edit_authority_missing") || !strings.Contains(reasons, "blocked(cross_common_dir_runtime_target)") {
+		t.Fatalf("post-grant status did not replace edit authority with the topology blocker: %s", grantedPayload)
 	}
 	wantRoots := []string{planning, wantA, wantB}
 	if len(granted.ActionContext.AllowedEditRoots) != len(wantRoots) {

--- a/internal/sddstatus/edit_authority.go
+++ b/internal/sddstatus/edit_authority.go
@@ -1,6 +1,7 @@
 package sddstatus
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -197,4 +198,103 @@ func applyEditAuthorityBlock(applyState ApplyState, reasons *blockerReasons, tas
 	}
 	reasons.genuine = append(reasons.genuine, editAuthorityBlockedReason(roots))
 	return ApplyBlocked, roots
+}
+
+// applyRuntimeTopologyBlock stops only a currently routed runtime actor when a
+// task target belongs to a different Git common directory. Edit authority is
+// deliberately checked first: a grant can authorize a path, but it cannot make
+// an independent repository share the planning change's candidate accounting.
+func applyRuntimeTopologyBlock(ctx context.Context, applyState *ApplyState, dependencies *Dependencies, nextRecommended *string, reasons *blockerReasons, tasksText, workspaceRoot, change string) {
+	if applyState == nil || dependencies == nil || nextRecommended == nil {
+		return
+	}
+	switch *nextRecommended {
+	case string(PhaseApply), string(PhaseVerify), string(PhaseRemediate):
+	default:
+		return
+	}
+	roots, err := foreignRuntimeTopologyRoots(ctx, tasksText, workspaceRoot, change)
+	if err != nil {
+		reasons.genuine = append(reasons.genuine, runtimeTopologyBlockedReason(nil, err))
+	} else if len(roots) == 0 {
+		return
+	} else {
+		reasons.genuine = append(reasons.genuine, runtimeTopologyBlockedReason(roots, nil))
+	}
+	if *applyState == ApplyReady {
+		*applyState = ApplyBlocked
+		dependencies.Apply = DependencyBlocked
+	}
+	dependencies.Verify = DependencyBlocked
+	dependencies.Archive = DependencyBlocked
+	*nextRecommended = "resolve-blockers"
+}
+
+func foreignRuntimeTopologyRoots(ctx context.Context, tasksText, workspaceRoot, change string) ([]string, error) {
+	planningStore, err := OpenRuntimeStore(ctx, workspaceRoot, change)
+	if err != nil {
+		return nil, fmt.Errorf("resolve the planning repository Git common directory: %w", err)
+	}
+	foreign := map[string]bool{}
+	for _, line := range strings.Split(tasksText, "\n") {
+		if len(taskCheckbox.FindStringSubmatch(line)) == 0 {
+			continue
+		}
+		for _, token := range pathLikeTokens(line) {
+			resolved := token
+			if !filepath.IsAbs(resolved) {
+				resolved = filepath.Join(workspaceRoot, resolved)
+			}
+			target := gitRootOf(resolveExistingPath(filepath.Clean(resolved)))
+			if target == "" {
+				continue
+			}
+			targetStore, err := OpenRuntimeStore(ctx, target, change)
+			if err != nil {
+				return nil, fmt.Errorf("resolve the target repository Git common directory for %s: %w", pathquote.Quote(target), err)
+			}
+			same, err := sameRuntimeCommonDirectory(planningStore.commonDir, targetStore.commonDir)
+			if err != nil {
+				return nil, err
+			}
+			if !same {
+				foreign[target] = true
+			}
+		}
+	}
+	roots := make([]string, 0, len(foreign))
+	for root := range foreign {
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	return roots, nil
+}
+
+func sameRuntimeCommonDirectory(left, right string) (bool, error) {
+	leftInfo, err := os.Stat(left)
+	if err != nil {
+		return false, fmt.Errorf("read planning repository Git common directory: %w", err)
+	}
+	rightInfo, err := os.Stat(right)
+	if err != nil {
+		return false, fmt.Errorf("read task target Git common directory: %w", err)
+	}
+	return os.SameFile(leftInfo, rightInfo), nil
+}
+
+func runtimeTopologyBlockedReason(roots []string, err error) string {
+	detail := ""
+	if err != nil {
+		detail = fmt.Sprintf("cannot verify Git common-dir identity: %v", err)
+	} else {
+		quoted := make([]string, 0, len(roots))
+		for _, root := range roots {
+			quoted = append(quoted, pathquote.Quote(root))
+		}
+		detail = fmt.Sprintf("tasks.md targets repositories with a different Git common directory: %s", strings.Join(quoted, ", "))
+	}
+	return fmt.Sprintf(
+		"blocked(cross_common_dir_runtime_target): %s; keep runtime work in the planning repository or a shared linked worktree with the same Git common directory, or split independent repositories into separately planned and runtime-accounted SDD changes; an edit-authority grant does not supply candidate accounting",
+		detail,
+	)
 }

--- a/internal/sddstatus/edit_authority_test.go
+++ b/internal/sddstatus/edit_authority_test.go
@@ -404,14 +404,16 @@ func TestRecreatedChangeNameDoesNotInheritGrantedRoots(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The covering grant clears detection and expands the single assignment
-	// site: AllowedEditRoots = planning + granted roots, apply is ready.
+	// The covering grant clears edit authority and expands the single assignment
+	// site, but an independent repository still cannot acquire the planning
+	// repository's candidate accounting.
 	granted, err := Resolve(ResolveOptions{CWD: planning, ChangeName: "multi-repo-rollout"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if granted.ApplyState != ApplyReady || granted.NextRecommended != "apply" {
-		t.Fatalf("post-grant status = %q/%q with reasons %v, want ready/apply",
+	if granted.ApplyState != ApplyBlocked || granted.NextRecommended != "resolve-blockers" ||
+		!strings.Contains(strings.Join(granted.BlockedReasons, "\n"), "blocked(cross_common_dir_runtime_target)") {
+		t.Fatalf("post-grant status = %q/%q with reasons %v, want topology block",
 			granted.ApplyState, granted.NextRecommended, granted.BlockedReasons)
 	}
 	if !reflect.DeepEqual(granted.ActionContext.AllowedEditRoots, []string{planning, wantA}) {

--- a/internal/sddstatus/runtime_topology_guard_test.go
+++ b/internal/sddstatus/runtime_topology_guard_test.go
@@ -1,0 +1,194 @@
+package sddstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeTopologyGuardBlocksForeignRuntimeActors(t *testing.T) {
+	tests := []struct {
+		name               string
+		linkedWorktree     bool
+		aliasTarget        bool
+		completeTasks      bool
+		incompletePlanning bool
+		remediationRoute   bool
+		wantApplyState     ApplyState
+		wantApply          DependencyState
+		wantVerify         DependencyState
+		wantNext           string
+		wantTopologyHit    bool
+	}{
+		{
+			name:               "incomplete planning preserves proposal route",
+			incompletePlanning: true,
+		},
+		{
+			name:            "independent repository blocks apply after edit grant",
+			wantApplyState:  ApplyBlocked,
+			wantApply:       DependencyBlocked,
+			wantVerify:      DependencyBlocked,
+			wantNext:        "resolve-blockers",
+			wantTopologyHit: true,
+		},
+		{
+			name:            "independent repository blocks verification after tasks complete",
+			completeTasks:   true,
+			wantApplyState:  ApplyAllDone,
+			wantApply:       DependencyAllDone,
+			wantVerify:      DependencyBlocked,
+			wantNext:        "resolve-blockers",
+			wantTopologyHit: true,
+		},
+		{
+			name:             "independent repository blocks remediation after failed verification",
+			completeTasks:    true,
+			remediationRoute: true,
+			wantApplyState:   ApplyAllDone,
+			wantApply:        DependencyAllDone,
+			wantVerify:       DependencyBlocked,
+			wantNext:         "resolve-blockers",
+			wantTopologyHit:  true,
+		},
+		{
+			name:           "registered linked worktree shares candidate accounting",
+			linkedWorktree: true,
+			wantApplyState: ApplyReady,
+			wantApply:      DependencyReady,
+			wantVerify:     DependencyBlocked,
+			wantNext:       "apply",
+		},
+		{
+			name:           "canonical alias to linked worktree shares candidate accounting",
+			linkedWorktree: true,
+			aliasTarget:    true,
+			wantApplyState: ApplyReady,
+			wantApply:      DependencyReady,
+			wantVerify:     DependencyBlocked,
+			wantNext:       "apply",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			planning := filepath.Join(workspace, "planning")
+			initEditAuthorityGitRepo(t, planning, true)
+			target := filepath.Join(workspace, "target")
+			if tt.linkedWorktree {
+				target = filepath.Join(t.TempDir(), "linked-worktree")
+				runRuntimeLedgerGit(t, planning, "worktree", "add", "-q", "-b", "topology-guard", target)
+			} else {
+				initEditAuthorityGitRepo(t, target, false)
+			}
+			planning = realPath(t, planning)
+			target = realPath(t, target)
+			taskTarget := target
+			if tt.aliasTarget {
+				aliasParent := filepath.Join(t.TempDir(), "linked-worktree-alias")
+				if err := os.Symlink(filepath.Dir(target), aliasParent); err != nil {
+					t.Skipf("symlink fixture unavailable: %v", err)
+				}
+				taskTarget = filepath.Join(aliasParent, filepath.Base(target))
+			}
+
+			const change = "runtime-topology-guard"
+			taskPath := filepath.Join(taskTarget, "internal", "api", "handler.go")
+			tasks := "- [ ] 1.1 Update `" + taskPath + "`\n"
+			changeRoot := filepath.Join(planning, "openspec", "changes", change)
+			if tt.incompletePlanning {
+				write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Expected behavior\n")
+				write(t, filepath.Join(changeRoot, "design.md"), "# Design\n")
+				write(t, filepath.Join(changeRoot, "tasks.md"), tasks)
+			} else {
+				changeRoot = seedReadyChange(t, planning, change, tasks)
+			}
+			initial, err := Resolve(ResolveOptions{CWD: planning, ChangeName: change})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.incompletePlanning {
+				if initial.ApplyState != ApplyBlocked || initial.Dependencies.Proposal != DependencyBlocked ||
+					initial.NextRecommended != "propose" || strings.Contains(strings.Join(initial.BlockedReasons, "\n"), "cross_common_dir_runtime_target") {
+					t.Fatalf("incomplete-planning status = %#v, want blocked/propose without topology blocker", initial)
+				}
+				return
+			}
+			initialReasons := strings.Join(initial.BlockedReasons, "\n")
+			if initial.ApplyState != ApplyBlocked || initial.Consent == nil ||
+				!strings.Contains(initialReasons, "blocked(edit_authority_missing)") ||
+				strings.Contains(initialReasons, "cross_common_dir_runtime_target") {
+				t.Fatalf("pre-grant status = %#v, want blocked edit-authority consent without topology blocker", initial)
+			}
+
+			instance, err := readChangeInstanceMarker(changeRoot)
+			if err != nil || instance == "" {
+				t.Fatalf("read change instance marker = %q, %v", instance, err)
+			}
+			opened, err := OpenRuntimeStore(context.Background(), planning, change)
+			if err != nil {
+				t.Fatal(err)
+			}
+			store, err := opened.ForInstance(instance)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.Grant(context.Background(), GrantRootsRequest{
+				RequestID: "grant-runtime-topology-guard", Roots: []string{target},
+				Reason: "test the status topology guard", Actor: "test",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if tt.completeTasks {
+				write(t, filepath.Join(changeRoot, "tasks.md"), "- [x] 1.1 Update `"+taskPath+"`\n")
+			}
+			if tt.remediationRoute {
+				write(t, filepath.Join(changeRoot, "verify-report.md"), "```yaml\nschema: gentle-ai.verify-result/v1\nevidence_revision: sha256:"+strings.Repeat("a", 64)+"\nverdict: fail\nblockers: 1\ncritical_findings: 0\nrequirements: 1/1\nscenarios: 1/1\ntest_command: go test ./...\ntest_exit_code: 0\ntest_output_hash: sha256:"+strings.Repeat("b", 64)+"\nbuild_command: go vet ./...\nbuild_exit_code: 0\nbuild_output_hash: sha256:"+strings.Repeat("c", 64)+"\n```")
+			}
+			beforeTask, err := os.ReadFile(filepath.Join(changeRoot, "tasks.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err := store.Status()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			status, err := Resolve(ResolveOptions{CWD: planning, ChangeName: change})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.ApplyState != tt.wantApplyState || status.Dependencies.Apply != tt.wantApply ||
+				status.Dependencies.Verify != tt.wantVerify || status.NextRecommended != tt.wantNext ||
+				(tt.remediationRoute && !status.RemediationState.Required) {
+				t.Fatalf("post-grant status = %#v, want applyState=%q dependencies apply/verify=%q/%q next=%q", status, tt.wantApplyState, tt.wantApply, tt.wantVerify, tt.wantNext)
+			}
+
+			reasons := strings.Join(status.BlockedReasons, "\n")
+			if tt.wantTopologyHit {
+				if !strings.Contains(reasons, "blocked(cross_common_dir_runtime_target)") ||
+					!strings.Contains(reasons, "shared linked worktree") ||
+					!strings.Contains(reasons, "separately planned and runtime-accounted SDD changes") {
+					t.Fatalf("topology blocker lacks its typed code or actionable exits: %s", reasons)
+				}
+			} else if strings.Contains(reasons, "cross_common_dir_runtime_target") {
+				t.Fatalf("same-common-dir linked worktree was blocked: %s", reasons)
+			}
+
+			after, err := store.Status()
+			if err != nil {
+				t.Fatal(err)
+			}
+			afterTask, err := os.ReadFile(filepath.Join(changeRoot, "tasks.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after.Revision != before.Revision || len(after.Attempts) != len(before.Attempts) || string(afterTask) != string(beforeTask) {
+				t.Fatalf("status topology guard mutated runtime or task state: before=%#v after=%#v", before, after)
+			}
+		})
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -496,6 +496,9 @@ func Resolve(options ResolveOptions) (Status, error) {
 		nextRecommended = "verify"
 		remediationState = RemediationState{}
 	}
+	if len(unauthorizedRoots) == 0 && runtimeStatus != nil && runtimeStatusErr == nil {
+		applyRuntimeTopologyBlock(context.Background(), &applyState, &dependencies, &nextRecommended, &blockedReasons, readText(firstPath(artifactPaths.Tasks)), workspaceRoot, changeName)
+	}
 	if remediationState.Reason != "" {
 		blockedReasons.genuine = append(blockedReasons.genuine, remediationState.Reason)
 	}
@@ -729,7 +732,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	if artifacts["verifyReport"] == ArtifactDone && verifyResult.Incomplete {
 		blockedReasons.genuine = append(blockedReasons.genuine, verifyResult.Reason)
 	}
-	applyState, _ = applyEditAuthorityBlock(applyState, &blockedReasons, artifactsByType["tasks"].Content, workspaceRoot, []string{workspaceRoot})
+	applyState, unauthorizedRoots := applyEditAuthorityBlock(applyState, &blockedReasons, artifactsByType["tasks"].Content, workspaceRoot, []string{workspaceRoot})
 	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult)
 	// Stale or incomplete evidence always re-enters independent SDD verification.
 	verifyReportCurrent := artifacts["verifyReport"] == ArtifactDone && !verifyResult.Stale && !verifyResult.Incomplete
@@ -749,6 +752,9 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
 		remediationState = RemediationState{}
+	}
+	if len(unauthorizedRoots) == 0 && runtimeStatus != nil && runtimeStatusErr == nil {
+		applyRuntimeTopologyBlock(context.Background(), &applyState, &dependencies, &nextRecommended, &blockedReasons, artifactsByType["tasks"].Content, workspaceRoot, changeName)
 	}
 	changeRoot := fmt.Sprintf("engram:sdd/%s", changeName)
 	status := baseStatus(ArtifactStoreEngram, workspaceRoot, nil, &changeName, &changeRoot, nextRecommended, append([]string{}, blockedReasons.genuine...))


### PR DESCRIPTION
## Summary

- stop runtime-bearing SDD routes before attempt acquisition when a task target resolves to an independent Git common directory
- preserve planning and edit-authority consent precedence
- keep same-repository aliases and linked worktrees sharing a Git common directory supported
- provide deterministic safe exits: run from the planning repository/shared linked worktree, or split independent repositories into separately planned and runtime-accounted changes

Fixes #2849

## Scope

- 5 files
- 322 additions, 16 deletions (338 changed lines)
- no distributed handoff, second runtime ledger, persisted state, command, or configuration

## Verification

- `go test ./internal/sddstatus -count=1`
- `go test -race ./internal/sddstatus -run '^TestRuntimeTopologyGuardBlocksForeignRuntimeActors$' -count=1`
- built-binary organic-runtime tests for edit-authority grant, same-parent repository, and zero-consent-footprint flows
- `go run ./internal/gofmtcheck`
- check-only `gofmt`, `git diff --check`, and `gopls check`

The full organic-runtime suite still has the existing environmental failure in `TestOrganicConfiguredAgentReceivesRoutingGuidanceCursor` (`review store lock could not be acquired: not a directory`). The identical failure was reproduced against clean baseline code and is outside this candidate's paths.

## Review

- Native RDD: `review-c10791d0895fab0a`
- Result: approved
- Receipt revision: `sha256:5eb68ac402d71d131aa374a2e336e1c8206500fa9e51f40b4a415a1e3670e93a`
- Two informational, non-blocking follow-ups were recorded for Engram artifact wording and Engram topology coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime topology checks that prevent apply, verification, or remediation when work targets a different Git common directory.
  * Status now reports the actionable `cross_common_dir_runtime_target` blocker and recommends resolving blockers.
  * Granted edit authority no longer bypasses independent repository candidate-accounting requirements.

* **Bug Fixes**
  * Corrected post-grant status handling so cross-repository changes remain blocked until runtime blockers are resolved.

* **Tests**
  * Added coverage for apply, verification, remediation, linked worktrees, symlink aliases, and incomplete planning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->