### PR TITLE
fix(installer): defer GGA when Homebrew is unavailable

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -227,6 +227,8 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	if result.Execution.Err != nil {
 		return result, fmt.Errorf("execute install pipeline: %w", result.Execution.Err)
 	}
+	result.Execution.DeferredComponents = append(result.Execution.DeferredComponents, runtime.state.deferredComponents...)
+	result.Execution.ManualActions = append(result.Execution.ManualActions, runtime.state.manualActions...)
 	result.PiCodeGraph = runtime.state.piCodeGraph
 	result.Verify = runPostApplyVerification(postApplyVerificationInput{
 		HomeDir:      homeDir,
@@ -236,7 +238,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		Resolved:     resolved,
 		State:        runtime.state,
 	})
-	result.Verify = withPostInstallNotes(result.Verify, resolved)
+	result.Verify = withPostInstallNotesForDeferredComponents(result.Verify, resolved, result.Execution.DeferredComponents)
 	result.Verify = withOpenCodeBackgroundPending(result.Verify, background, runtime.runtimeReady, resolved.Agents)
 	result.Verify = withOpenCodeBackgroundActivationNote(result.Verify, background, resolved.Agents)
 	if plan := piBackground.projectionPlan; plan != nil && plan.skipReason != "" {
@@ -422,13 +424,26 @@ func mergeExplicitAgentInstallState(homeDir string, newState state.InstallState,
 }
 
 func withPostInstallNotes(report verify.Report, resolved planner.ResolvedPlan) verify.Report {
+	return withPostInstallNotesForDeferredComponents(report, resolved, nil)
+}
+
+func withPostInstallNotesForDeferredComponents(report verify.Report, resolved planner.ResolvedPlan, deferredComponents []string) verify.Report {
 	report = withReadyAgentRunNote(report, resolved)
 	report = withFailedVerificationNote(report, resolved)
-	if hasComponent(resolved.OrderedComponents, model.ComponentGGA) && report.Ready {
+	if hasComponent(resolved.OrderedComponents, model.ComponentGGA) && !containsDeferredComponent(deferredComponents, string(model.ComponentGGA)) && report.Ready {
 		report.FinalNote = report.FinalNote + "\n\nGGA is now installed globally. To enable project hooks, run in each repo:\n- gga init\n- gga install"
 	}
 	report = withGoInstallPathNote(report, resolved)
 	return report
+}
+
+func containsDeferredComponent(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 // readyAgentRunCommands is the fixed, ordered set of installable agents that
@@ -661,6 +676,8 @@ type runtimeState struct {
 	rollbackSnapshotDir      string
 	piCodeGraph              *communitytool.PiCodeGraphResult
 	compatibilityTransaction compatibilityRefreshTransaction
+	deferredComponents       []string
+	manualActions            []string
 
 	// engramVersionResolved, engramVersion, and engramVersionErr cache the
 	// single `engram version` invocation performed by componentApplyStep.Run
@@ -1670,28 +1687,20 @@ func (s componentApplyStep) Run() error {
 	case model.ComponentGGA:
 		if !ggaAvailable(s.profile) {
 			// GGA not found on any known PATH — install it.
-			if s.profile.OS == "windows" {
+			if s.profile.OS == "darwin" && s.profile.PackageManager == "brew" {
+				if _, err := cmdLookPath("brew"); err != nil {
+					s.deferGGAForMissingHomebrew()
+				} else if err := s.installGGA(); err != nil {
+					return err
+				}
+			} else if s.profile.OS == "windows" {
 				if err := cleanupGGAInstallDir(); err != nil {
 					return err
 				}
 			}
-			commands, err := gga.InstallCommand(s.profile)
-			if err != nil {
-				return fmt.Errorf("resolve install command for component %q: %w", s.component, err)
-			}
-			installErr := runCommandSequence(commands)
-			if installErr != nil {
-				if ggaAvailable(s.profile) {
-					// The GGA install script uses `set -e` and `read -p` for
-					// the "already installed" confirmation. Without a TTY
-					// (common in automated/re-run scenarios), `read` fails
-					// with exit code 1 and `set -e` kills the script before
-					// it can exit 0. If GGA is actually available after the
-					// script ran, the install succeeded functionally — treat
-					// as success but warn the user.
-					fmt.Fprintf(os.Stderr, "WARNING: gga install command reported an error but gga is available — continuing. Error was: %v\n", installErr)
-				} else {
-					return installErr
+			if s.profile.OS != "darwin" || s.profile.PackageManager != "brew" {
+				if err := s.installGGA(); err != nil {
+					return err
 				}
 			}
 		}
@@ -1739,6 +1748,34 @@ func (s componentApplyStep) Run() error {
 	default:
 		return fmt.Errorf("component %q is not supported in install runtime", s.component)
 	}
+}
+
+func (s componentApplyStep) installGGA() error {
+	commands, err := gga.InstallCommand(s.profile)
+	if err != nil {
+		return fmt.Errorf("resolve install command for component %q: %w", s.component, err)
+	}
+	installErr := runCommandSequence(commands)
+	if installErr == nil {
+		return nil
+	}
+	if ggaAvailable(s.profile) {
+		// The GGA install script uses `set -e` and `read -p` for the
+		// "already installed" confirmation. Without a TTY, `read` fails
+		// even though the binary is already usable.
+		fmt.Fprintf(os.Stderr, "WARNING: gga install command reported an error but gga is available — continuing. Error was: %v\n", installErr)
+		return nil
+	}
+	return installErr
+}
+
+func (s componentApplyStep) deferGGAForMissingHomebrew() {
+	if s.state == nil || containsDeferredComponent(s.state.deferredComponents, string(model.ComponentGGA)) {
+		return
+	}
+	s.state.deferredComponents = append(s.state.deferredComponents, string(model.ComponentGGA))
+	s.state.manualActions = append(s.state.manualActions,
+		"GGA installation deferred because Homebrew is unavailable. Install it manually with: brew tap Gentleman-Programming/homebrew-tap && brew install gga. Then retry: gentle-ai install --component gga.")
 }
 
 func ensureGoAvailableAfterInstall(profile system.PlatformProfile) error {
@@ -1817,6 +1854,8 @@ func executeTUIInstallWithBackground(homeDir string, selection model.Selection, 
 	orchestrator := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy(), pipeline.WithFailurePolicy(pipeline.ContinueOnError), pipeline.WithProgressFunc(onProgress))
 	result := orchestrator.Execute(tuiInstallStagePlan(runtime))
 	runtime.state.cleanupRollbackSnapshot()
+	result.DeferredComponents = append(result.DeferredComponents, runtime.state.deferredComponents...)
+	result.ManualActions = append(result.ManualActions, runtime.state.manualActions...)
 	if runtime.state.piCodeGraph != nil {
 		result.ManualActions = append(result.ManualActions, runtime.state.piCodeGraph.ManualActions...)
 	}
@@ -1826,10 +1865,14 @@ func executeTUIInstallWithBackground(homeDir string, selection model.Selection, 
 // RenderInstallManualActions renders non-fatal completion actions after the
 // normal verification report so CLI users receive the same drift guidance.
 func RenderInstallManualActions(result InstallResult) string {
-	if result.PiCodeGraph == nil || len(result.PiCodeGraph.ManualActions) == 0 {
+	actions := append([]string(nil), result.Execution.ManualActions...)
+	if result.PiCodeGraph != nil {
+		actions = append(actions, result.PiCodeGraph.ManualActions...)
+	}
+	if len(actions) == 0 {
 		return ""
 	}
-	return "\nManual actions required:\n- " + strings.Join(result.PiCodeGraph.ManualActions, "\n- ") + "\n"
+	return "\nManual actions required:\n- " + strings.Join(actions, "\n- ") + "\n"
 }
 
 // ResolveInstallProfile returns the platform profile from detection, defaulting to darwin/brew.

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -416,6 +416,13 @@ func TestRenderInstallManualActionsIncludesPiCodeGraphDrift(t *testing.T) {
 	}
 }
 
+func TestRenderInstallManualActionsIncludesPipelineActions(t *testing.T) {
+	out := RenderInstallManualActions(InstallResult{Execution: pipeline.ExecutionResult{ManualActions: []string{"GGA installation deferred because Homebrew is unavailable."}}})
+	if !strings.Contains(out, "Manual actions required") || !strings.Contains(out, "GGA installation deferred") {
+		t.Fatalf("CLI manual action missing: %q", out)
+	}
+}
+
 func TestCodeGraphGuidanceMarkdownForSDDOnlyWhenSelected(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -1393,6 +1393,100 @@ func TestRunInstallGGASkipsInstallWhenAlreadyOnPath(t *testing.T) {
 	}
 }
 
+func TestRunInstallMacOSDefersGGAWhenHomebrewIsUnavailable(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreGGAAvailableCheck := ggaAvailableCheck
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		ggaAvailableCheck = restoreGGAAvailableCheck
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(name string) (string, error) {
+		switch name {
+		case "brew", "gga":
+			return "", exec.ErrNotFound
+		default:
+			return "/usr/local/bin/" + name, nil
+		}
+	}
+	ggaAvailableCheck = func(system.PlatformProfile) bool { return false }
+	runCommand = func(name string, args ...string) error {
+		if name == "brew" {
+			t.Fatalf("unexpected Homebrew command: %s %s", name, strings.Join(args, " "))
+		}
+		return nil
+	}
+
+	result, err := RunInstall(
+		[]string{"--agent", "opencode", "--component", "gga"},
+		macOSDetectionResult(),
+	)
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v, want a deferred GGA install", err)
+	}
+	if !stringSliceContains(result.Execution.DeferredComponents, string(model.ComponentGGA)) {
+		t.Fatalf("DeferredComponents = %v, want %q", result.Execution.DeferredComponents, model.ComponentGGA)
+	}
+	if got := strings.Join(result.Execution.ManualActions, "\n"); !strings.Contains(got, "brew install gga") || !strings.Contains(got, "gentle-ai install --component gga") {
+		t.Fatalf("manual actions = %q, want Homebrew install and retry commands", got)
+	}
+	if strings.Contains(result.Verify.FinalNote, "GGA is now installed globally") {
+		t.Fatalf("verification note falsely reports GGA as installed: %q", result.Verify.FinalNote)
+	}
+
+	persisted, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read() error = %v", err)
+	}
+	if !hasComponent(persisted.Components, model.ComponentGGA) {
+		t.Fatalf("persisted components = %v, want GGA selection preserved", persisted.Components)
+	}
+	assertFileContains(t, filepath.Join(home, ".config", "gga", "config"), `PROVIDER="opencode"`)
+}
+
+func TestRunInstallMacOSReturnsGGAInstallErrorsWhenHomebrewExists(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreGGAAvailableCheck := ggaAvailableCheck
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		ggaAvailableCheck = restoreGGAAvailableCheck
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(name string) (string, error) {
+		if name == "gga" {
+			return "", exec.ErrNotFound
+		}
+		return "/usr/local/bin/" + name, nil
+	}
+	ggaAvailableCheck = func(system.PlatformProfile) bool { return false }
+	runCommand = func(name string, args ...string) error {
+		if name == "brew" {
+			return errors.New("tap failed")
+		}
+		return nil
+	}
+
+	_, err := RunInstall(
+		[]string{"--agent", "opencode", "--component", "gga"},
+		macOSDetectionResult(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "tap failed") {
+		t.Fatalf("RunInstall() error = %v, want Homebrew tap failure", err)
+	}
+}
+
 func TestRunInstallGGALinuxIncludesTempCleanupBeforeClone(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir

--- a/internal/pipeline/result.go
+++ b/internal/pipeline/result.go
@@ -33,6 +33,9 @@ type ExecutionResult struct {
 	Apply    StageResult
 	Rollback StageResult
 	Err      error
+	// DeferredComponents identifies selected components whose configuration was
+	// applied but whose external binary installation requires manual follow-up.
+	DeferredComponents []string
 	// ManualActions are non-fatal but actionable outcomes propagated by runtime
 	// steps to both CLI and TUI completion renderers.
 	ManualActions []string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1431,8 +1431,8 @@ func (m Model) View() string {
 	case ScreenComplete:
 		return screens.RenderComplete(screens.CompletePayload{
 			ConfiguredAgents:    len(m.Selection.Agents),
-			InstalledComponents: len(m.Selection.Components),
-			GGAInstalled:        hasSelectedComponent(m.Selection.Components, model.ComponentGGA),
+			InstalledComponents: installedComponentCount(m.Selection.Components, m.Execution.DeferredComponents),
+			GGAInstalled:        hasSelectedComponent(m.Selection.Components, model.ComponentGGA) && !hasDeferredComponent(m.Execution.DeferredComponents, model.ComponentGGA),
 			FailedSteps:         extractFailedSteps(m.Execution),
 			RollbackPerformed:   len(m.Execution.Rollback.Steps) > 0,
 			RollbackComplete:    m.Execution.Rollback.Success,
@@ -4870,6 +4870,25 @@ func hasSelectedComponent(components []model.ComponentID, target model.Component
 		}
 	}
 	return false
+}
+
+func hasDeferredComponent(components []string, target model.ComponentID) bool {
+	for _, component := range components {
+		if component == string(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func installedComponentCount(components []model.ComponentID, deferredComponents []string) int {
+	count := 0
+	for _, component := range components {
+		if !hasDeferredComponent(deferredComponents, component) {
+			count++
+		}
+	}
+	return count
 }
 
 func hasSelectedAgent(agents []model.AgentID, target model.AgentID) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2484,6 +2484,32 @@ func TestCompleteViewShowsPipelineManualActions(t *testing.T) {
 	}
 }
 
+func TestCompleteViewDoesNotClaimDeferredGGAWasInstalled(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenComplete
+	m.Selection.Components = []model.ComponentID{model.ComponentGGA}
+	m.Execution.DeferredComponents = []string{string(model.ComponentGGA)}
+	m.Execution.ManualActions = []string{"GGA installation deferred because Homebrew is unavailable."}
+
+	out := m.View()
+	if strings.Contains(out, "Installed components  1") {
+		t.Fatalf("completion output counts deferred GGA as installed: %q", out)
+	}
+	if strings.Contains(out, "GGA was installed globally") {
+		t.Fatalf("completion output falsely reports GGA as installed: %q", out)
+	}
+	if !strings.Contains(out, "GGA installation deferred") {
+		t.Fatalf("completion output missing deferred GGA action: %q", out)
+	}
+}
+
+func TestInstalledComponentCountSkipsDeferredComponents(t *testing.T) {
+	components := []model.ComponentID{model.ComponentGGA, model.ComponentSDD}
+	if got := installedComponentCount(components, []string{string(model.ComponentGGA)}); got != 1 {
+		t.Fatalf("installedComponentCount() = %d, want 1", got)
+	}
+}
+
 func TestUninstallConfirm_CleanInstallRunsSyncAfterUninstall(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenUninstallConfirm


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation handling when Homebrew is unavailable on macOS.
  * Deferred installations now preserve component configuration while clearly indicating required manual follow-up.
  * Completion screens no longer count deferred components as installed.

* **User Experience**
  * Installation results now display manual actions, including deferred GGA installation instructions.
  * Improved accuracy of installed component counts and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->