### PR TITLE
fix(opencode): block sensitive path egress

### DIFF
--- a/e2e/organicruntime/opencode_sensitive_path_permissions_test.go
+++ b/e2e/organicruntime/opencode_sensitive_path_permissions_test.go
@@ -1,0 +1,116 @@
+//go:build real_agent_e2e
+
+package organicruntime_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/permissions"
+)
+
+func TestOpenCodeSensitivePathPermissions(t *testing.T) {
+	if os.Getenv(realAgentE2EEnvironment) != "1" {
+		t.Skip("set GENTLE_AI_REAL_AGENT_E2E=1 to run the pinned OpenCode sensitive-path journey")
+	}
+	requireOrganicExecutableVersion(t, "opencode", "1.18.21")
+	workspace := t.TempDir()
+	const secret, safe = "SECRET_CANARY_787", "SAFE_CANARY_787"
+	if err := os.Mkdir(filepath.Join(workspace, "config"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, value := range map[string]string{".env": secret, "config/.env": secret, "safe.txt": safe} {
+		if err := os.WriteFile(filepath.Join(workspace, name), []byte(value+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(".env", filepath.Join(workspace, "env-alias.txt")); err != nil {
+		t.Fatal(err)
+	}
+	dependencies, home := prepareOpenCodeConfig(t), t.TempDir()
+	pluginRoot := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(pluginRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dependencies, "opencode", "node_modules"), filepath.Join(pluginRoot, "node_modules")); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"HOME", "USERPROFILE"} {
+		t.Setenv(key, home)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Dir(pluginRoot))
+	settingsPath := filepath.Join(pluginRoot, "opencode.json")
+
+	for _, tt := range []struct {
+		name, tool, canary string
+		arguments          map[string]any
+		denied             bool
+	}{
+		{"read .env denied", "read", secret, map[string]any{"filePath": ".env"}, true},
+		{"grep .env denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": ".env"}, true},
+		{"grep nested .env denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": "nested/../.env"}, true},
+		{"grep .env.local denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": ".env.local"}, true},
+		{"grep *.env include denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": "safe.txt", "include": "*.env"}, true},
+		{"grep symlink to .env denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": "env-alias.txt"}, true},
+		{"grep pathless denied", "grep", secret, map[string]any{"pattern": "SECRET_"}, true},
+		{"grep broad scan denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": "."}, true},
+		{"grep named directory denied", "grep", secret, map[string]any{"pattern": "SECRET_", "path": "config"}, true},
+		{"bash quoted .env piped denied", "bash", secret, map[string]any{"command": "grep SECRET_ '.env' | cat"}, true},
+		{"grep safe file allowed", "grep", safe, map[string]any{"pattern": safe, "path": "safe.txt"}, false},
+		{"bash grep safe file allowed", "bash", safe, map[string]any{"command": "grep " + safe + " safe.txt"}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newOpenCodeFixtureServer(t, []openCodeTurn{{tool: tt.tool, arguments: tt.arguments}}, "")
+			defer fixture.Close()
+			if err := os.WriteFile(settingsPath, []byte(sensitivePathOpenCodeConfig(t, fixture.URL)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := permissions.Inject(home, opencode.NewAdapter()); err != nil {
+				t.Fatal(err)
+			}
+			output := runOpenCodeSensitivePathTool(t, workspace, home)
+			fixture.assertComplete(t, false)
+			if tt.denied {
+				if strings.Contains(output, `"status":"completed"`) || !strings.Contains(output, `"status":"error"`) || strings.Contains(output, tt.canary) {
+					t.Fatalf("%s did not fail closed without leakage:\n%s", tt.name, output)
+				}
+			} else if !strings.Contains(output, `"status":"completed"`) || !strings.Contains(output, tt.canary) {
+				t.Fatalf("%s did not disclose safe canary:\n%s", tt.name, output)
+			}
+		})
+	}
+}
+
+func sensitivePathOpenCodeConfig(t *testing.T, serverURL string) string {
+	t.Helper()
+	config := map[string]any{
+		"provider": map[string]any{"fixture": map[string]any{"npm": "@ai-sdk/openai-compatible", "name": "Sensitive-path fixture", "options": map[string]any{"baseURL": serverURL + "/v1", "apiKey": "fixture"}, "models": map[string]any{"fixture": map[string]any{"name": "Fixture"}}}},
+		"agent":    map[string]any{"organic": map[string]any{"description": "Sensitive-path permission E2E", "mode": "primary", "model": "fixture/fixture"}}, "compaction": map[string]any{"auto": false},
+	}
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}
+
+func runOpenCodeSensitivePathTool(t *testing.T, workspace, home string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), organicAgentTimeout)
+	defer cancel()
+	command := organicCommandContext(ctx, "opencode", "run", "--format", "json", "--agent", "organic", "--model", "fixture/fixture", "--dir", workspace, "run the requested tool")
+	command.Dir = workspace
+	command.Env = append(os.Environ(), "OPENCODE_TEST_HOME="+filepath.Join(home, "opencode"), "OPENCODE_AUTH_CONTENT={}", "OPENCODE_DISABLE_PROJECT_CONFIG=1", "OPENCODE_DISABLE_AUTOUPDATE=1", "OPENCODE_DISABLE_AUTOCOMPACT=1", "OPENCODE_DISABLE_CLAUDE_CODE=1", "OPENCODE_DISABLE_DEFAULT_PLUGINS=1", "OPENCODE_DISABLE_EXTERNAL_SKILLS=1", "OPENCODE_DISABLE_LSP_DOWNLOAD=1", "OPENCODE_DISABLE_MODELS_FETCH=1", "OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=1", "OPENCODE_FAST_BOOT=1")
+	var stdout, stderr bytes.Buffer
+	command.Stdout, command.Stderr = &stdout, &stderr
+	if err := command.Run(); err != nil {
+		t.Fatalf("opencode run: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	return stdout.String() + stderr.String()
+}

--- a/e2e/organicruntime/opencode_sensitive_path_permissions_test.go
+++ b/e2e/organicruntime/opencode_sensitive_path_permissions_test.go
@@ -19,7 +19,7 @@ func TestOpenCodeSensitivePathPermissions(t *testing.T) {
 	if os.Getenv(realAgentE2EEnvironment) != "1" {
 		t.Skip("set GENTLE_AI_REAL_AGENT_E2E=1 to run the pinned OpenCode sensitive-path journey")
 	}
-	requireOrganicExecutableVersion(t, "opencode", "1.18.21")
+	requireOrganicExecutableVersion(t, "opencode", "1.18.10")
 	workspace := t.TempDir()
 	const secret, safe = "SECRET_CANARY_787", "SAFE_CANARY_787"
 	if err := os.Mkdir(filepath.Join(workspace, "config"), 0o700); err != nil {

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -602,10 +602,10 @@ func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadDir(opencode/plugins) error = %v", err)
 	}
-	if len(pluginEntries) != 4 {
-		t.Fatalf("opencode plugins count = %d, want 4", len(pluginEntries))
+	if len(pluginEntries) != 5 {
+		t.Fatalf("opencode plugins count = %d, want 5", len(pluginEntries))
 	}
-	wantPlugins := map[string]bool{"model-variants.ts": true, "opencode-review-transport.ts": true, "sdd-task-result-artifacts.ts": true, "skill-registry.ts": true}
+	wantPlugins := map[string]bool{"model-variants.ts": true, "opencode-review-transport.ts": true, "opencode-sensitive-path-guard.ts": true, "sdd-task-result-artifacts.ts": true, "skill-registry.ts": true}
 	for _, entry := range pluginEntries {
 		if !wantPlugins[entry.Name()] {
 			t.Fatalf("unexpected plugin entry = %q", entry.Name())
@@ -631,6 +631,15 @@ func TestOpenCodeBackgroundPolicyMarkersAreBalanced(t *testing.T) {
 // TestOpenCodeReviewTransportPluginContract pins the adapter-minimality
 // boundary: the plugin correlates one host Task with one Go process, while Go
 // owns all prompt, schema, admission, and capture semantics.
+func TestOpenCodeSensitivePathGuardPluginContract(t *testing.T) {
+	source := MustRead("opencode/plugins/opencode-sensitive-path-guard.ts")
+	for _, want := range []string{`"tool.execute.before"`, `input.tool !== "grep"`, `opencode_sensitive_path_guard_refused`, `path`, `include`} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("sensitive-path guard missing %q", want)
+		}
+	}
+}
+
 func TestOpenCodeReviewTransportPluginContract(t *testing.T) {
 	source, err := Read("opencode/plugins/opencode-review-transport.ts")
 	if err != nil {

--- a/internal/assets/opencode/plugins/opencode-sensitive-path-guard.ts
+++ b/internal/assets/opencode/plugins/opencode-sensitive-path-guard.ts
@@ -1,0 +1,54 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { lstat } from "node:fs/promises"
+import { resolve } from "node:path"
+const REFUSAL = "opencode_sensitive_path_guard_refused"
+const PATH_FIELDS = ["path", "include"] as const
+function pathStrings(value: unknown): string[] {
+  return typeof value === "string" ? [value] : Array.isArray(value) ? value.flatMap(pathStrings) : []
+}
+function normalize(value: string): string {
+  const absolute = value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value)
+  const parts: string[] = []
+  for (const part of value.replaceAll("\\", "/").split("/")) {
+    if (part === "" || part === ".") continue
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") parts.pop()
+      else if (!absolute) parts.push(part)
+      continue
+    }
+    parts.push(part)
+  }
+  return (absolute ? "/" : "") + parts.join("/")
+}
+function sensitivePath(value: string): boolean {
+  const path = normalize(value)
+  return /(^|\/)\.env(?:\..*)?$/i.test(path) || /(^|\/)\*\.env\*?$/i.test(path) || /(^|\/)secrets(?:\/|$)/i.test(path) ||
+    /(^|\/)credentials\.json$/i.test(path) || /(^|\/)\.ssh(?:\/|$)/i.test(path) ||
+    /(^|\/)\.credentials(?:\/|$)/i.test(path) || /(^|\/)Library\/Keychains(?:\/|$)/i.test(path) ||
+    /(^|\/)\.aws\/credentials$/i.test(path) || /(^|\/)\.config\/gh\/hosts\.yml$/i.test(path) || /\.(pem|key)$/i.test(path)
+}
+async function broadTarget(value: string, root: string): Promise<boolean> {
+  const path = normalize(value)
+  if (path === "" || path === "." || path === "/" || path.endsWith("/")) return true
+  if (!path.includes("*")) {
+    try { const info = await lstat(resolve(root, path)); return info.isDirectory() || info.isSymbolicLink() } catch { return true }
+  }
+  const basename = path.slice(path.lastIndexOf("/") + 1)
+  return path.includes("**") || !/^\*[^/]*\.[A-Za-z0-9]+$/.test(basename)
+}
+function grepTargets(args: unknown): string[] {
+  return args !== null && typeof args === "object" && !Array.isArray(args)
+    ? PATH_FIELDS.flatMap((field) => pathStrings((args as Record<string, unknown>)[field])) : []
+}
+export const OpenCodeSensitivePathGuard: Plugin = async (plugin) => ({
+  "tool.execute.before": async (input, output) => {
+    if (input.tool !== "grep") return
+    const targets = grepTargets(output.args)
+    const root = plugin.directory || plugin.worktree
+    const broad = await Promise.all(targets.map((target) => broadTarget(target, root)))
+    if (targets.length === 0 || targets.some((target, index) => sensitivePath(target) || broad[index])) {
+      throw new Error(REFUSAL)
+    }
+  },
+})
+export default OpenCodeSensitivePathGuard

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2328,6 +2328,9 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if p := permissions.TargetPath(homeDir, adapter); p != "" {
 				paths = append(paths, p)
 			}
+			if adapter.Agent() == model.AgentOpenCode {
+				paths = append(paths, permissions.OpenCodeSensitivePathGuardPath(homeDir))
+			}
 		case model.ComponentGGA:
 			paths = append(paths, gga.ConfigPath(homeDir))
 			paths = append(paths, gga.AgentsTemplatePath(homeDir))

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -574,6 +574,17 @@ func TestComponentPathsPermissionsSkipsAgentsWithoutInjectionTarget(t *testing.T
 	}
 }
 
+func TestComponentPathsPermissionsIncludesOpenCodeSensitivePathGuard(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentOpenCode})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentPermission)
+	guard := filepath.Join(home, ".config", "opencode", "plugins", "opencode-sensitive-path-guard.ts")
+	if !containsPath(paths, guard) {
+		t.Fatalf("componentPaths(permissions,opencode) missing managed guard %q\npaths=%v", guard, paths)
+	}
+}
+
 func TestComponentPathsPermissionsIncludesAgentsWithInjectionTarget(t *testing.T) {
 	home := t.TempDir()
 	adapters := resolveAdapters([]model.AgentID{

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -3,8 +3,10 @@ package permissions
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
@@ -60,7 +62,7 @@ var claudeCodeOverlayJSON = []byte(`{
 }
 `)
 
-// openCodeOverlayJSON uses the OpenCode "permission" key with bash/read granularity.
+// openCodeOverlayJSON uses OpenCode's permission key; Bash patterns match commands.
 var openCodeOverlayJSON = []byte(`{
   "permission": {
     "bash": {
@@ -70,7 +72,20 @@ var openCodeOverlayJSON = []byte(`{
       "git push": "ask",
       "git push --force *": "ask",
       "git rebase *": "ask",
-      "git reset --hard *": "ask"
+      "git reset --hard *": "ask",
+      "* *.env*": "deny",
+      "* '*.env'*": "deny",
+      "* \"*.env\"*": "deny",
+      "* **/.env*": "deny",
+      "* **/secrets/**": "deny",
+      "* **/credentials.json": "deny",
+      "* **/.ssh/**": "deny",
+      "* **/.credentials/**": "deny",
+      "* **/Library/Keychains/**": "deny",
+      "* **/.aws/credentials": "deny",
+      "* **/.config/gh/hosts.yml": "deny",
+      "* **/*.pem": "deny",
+      "* **/*.key": "deny"
     },
     "read": {
       "*": "allow",
@@ -152,6 +167,12 @@ func agentOverlay(id model.AgentID) []byte {
 	}
 }
 
+const openCodeSensitivePathGuardAsset = "opencode/plugins/opencode-sensitive-path-guard.ts"
+
+func OpenCodeSensitivePathGuardPath(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "opencode", "plugins", "opencode-sensitive-path-guard.ts")
+}
+
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	settingsPath := adapter.SettingsPath(homeDir)
 	if settingsPath == "" {
@@ -167,8 +188,41 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	if err != nil {
 		return InjectionResult{}, err
 	}
+	result := InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}
+	if adapter.Agent() != model.AgentOpenCode {
+		return result, nil
+	}
 
-	return InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}, nil
+	changed, err := installOpenCodeSensitivePathGuard(homeDir)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+	result.Changed = result.Changed || changed
+	result.Files = append(result.Files, OpenCodeSensitivePathGuardPath(homeDir))
+	return result, nil
+}
+
+func installOpenCodeSensitivePathGuard(homeDir string) (bool, error) {
+	content, err := assets.Read(openCodeSensitivePathGuardAsset)
+	if err != nil {
+		return false, fmt.Errorf("read embedded OpenCode sensitive-path guard: %w", err)
+	}
+	path := OpenCodeSensitivePathGuardPath(homeDir)
+	existing, err := os.ReadFile(path)
+	if err == nil {
+		if string(existing) == content {
+			return false, nil
+		}
+		return false, fmt.Errorf("refuse to overwrite modified OpenCode sensitive-path guard %q", path)
+	}
+	if !os.IsNotExist(err) {
+		return false, fmt.Errorf("read OpenCode sensitive-path guard %q: %w", path, err)
+	}
+	writeResult, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
+	if err != nil {
+		return false, err
+	}
+	return writeResult.Changed, nil
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -646,8 +646,53 @@ func TestInjectClaudeCodeDefaultDenyRulesApplied(t *testing.T) {
 	}
 }
 
-// TestInjectOpenCodePreservesExistingDenyRules ensures that user-managed read deny
-// entries already present in settings.json are not removed when the overlay is applied.
+func TestInjectOpenCodeInstallsSensitivePathGuardWithoutRewritingUserPlugins(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"plugin":["user-plugin.ts"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Inject(home, opencodeAdapter())
+	if err != nil || !first.Changed {
+		t.Fatalf("first Inject() = %#v, %v", first, err)
+	}
+	guard, err := os.ReadFile(OpenCodeSensitivePathGuardPath(home))
+	if err != nil || !strings.Contains(string(guard), `"tool.execute.before"`) {
+		t.Fatalf("guard = %q, error = %v", guard, err)
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if got := settings["plugin"].([]any); len(got) != 1 || got[0] != "user-plugin.ts" {
+		t.Fatalf("user plugins = %#v", got)
+	}
+	permission := settings["permission"].(map[string]any)
+	for _, section := range []string{"grep", "removed-grep"} {
+		if _, exists := permission[section]; exists {
+			t.Fatalf("ignored permission.%s policy installed", section)
+		}
+	}
+	for _, pattern := range []string{"* *.env*", "* '*.env'*", `* "*.env"*`, "* **/secrets/**", "* **/*.pem"} {
+		if got := permission["bash"].(map[string]any)[pattern]; got != "deny" {
+			t.Errorf("bash %q = %q, want deny", pattern, got)
+		}
+	}
+	second, err := Inject(home, opencodeAdapter())
+	if err != nil || second.Changed {
+		t.Fatalf("second Inject() = %#v, %v", second, err)
+	}
+}
+
 func TestInjectOpenCodePreservesExistingDenyRules(t *testing.T) {
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/opencodedefault"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/permissions"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/theme"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -687,6 +688,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 				ops = append(ops, rewriteJSONFile(path, jsonPath{"permissions"}))
 			case model.AgentOpenCode:
 				ops = append(ops, rewriteJSONFile(path, jsonPath{"permission"}))
+				guardPath := permissions.OpenCodeSensitivePathGuardPath(homeDir)
+				targets = append(targets, guardPath)
+				ops = append(ops, removeManagedOpenCodeSensitivePathGuard(guardPath), removeDirIfEmpty(filepath.Dir(guardPath)))
 			case model.AgentGeminiCLI:
 				ops = append(ops, rewriteJSONFile(path, jsonPath{"general", "defaultApprovalMode"}))
 			case model.AgentVSCodeCopilot:
@@ -1323,6 +1327,33 @@ func isManagedContext7ServerJSON(content []byte) bool {
 		strings.HasPrefix(args[1], "--package=@upstash/context7-mcp@") &&
 		args[2] == "--" &&
 		args[3] == "context7-mcp"
+}
+
+func removeManagedOpenCodeSensitivePathGuard(path string) operation {
+	return operation{
+		typeID: opRemoveFile,
+		path:   path,
+		apply: func(path string) (bool, bool, error) {
+			data, err := os.ReadFile(path)
+			if os.IsNotExist(err) {
+				return false, false, nil
+			}
+			if err != nil {
+				return false, false, err
+			}
+			managed, err := assets.Read("opencode/plugins/opencode-sensitive-path-guard.ts")
+			if err != nil {
+				return false, false, fmt.Errorf("read embedded OpenCode sensitive-path guard: %w", err)
+			}
+			if string(data) != managed {
+				return false, false, fmt.Errorf("refuse to remove modified OpenCode sensitive-path guard %q", path)
+			}
+			if err := os.Remove(path); err != nil {
+				return false, false, err
+			}
+			return true, true, nil
+		},
+	}
 }
 
 func removeFile(path string) operation {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/permissions"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	opencodeactivation "github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
@@ -366,6 +367,66 @@ func TestPartialUninstallClaudeThemeRemovesOnlyThemeAssets(t *testing.T) {
 	}
 	if got, err := os.ReadFile(logoPath); err != nil || string(got) != "// managed logo" {
 		t.Fatalf("OpenCode logo = %q, %v", got, err)
+	}
+}
+
+func TestComponentOperationsPermissionsOpenCodeSensitivePathGuardOwnership(t *testing.T) {
+	for _, tt := range []struct {
+		name, content string
+		managed       bool
+	}{
+		{name: "managed guard removed", managed: true},
+		{name: "modified guard preserved", content: "user modified guard"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			svc, err := NewService(home, t.TempDir(), "dev")
+			if err != nil {
+				t.Fatal(err)
+			}
+			adapter, _ := svc.registry.Get(model.AgentOpenCode)
+			guardPath := permissions.OpenCodeSensitivePathGuardPath(home)
+			if tt.managed {
+				if _, err := permissions.Inject(home, adapter); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.MkdirAll(filepath.Dir(guardPath), 0o755); err != nil {
+				t.Fatal(err)
+			} else if err := os.WriteFile(guardPath, []byte(tt.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			userPlugin := filepath.Join(filepath.Dir(guardPath), "user-plugin.ts")
+			if err := os.WriteFile(userPlugin, []byte("user plugin"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			ops, targets, err := svc.componentOperations(adapter, model.ComponentPermission)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(targets, guardPath) {
+				t.Fatalf("permission targets = %v, missing %q", targets, guardPath)
+			}
+			for _, op := range ops {
+				if op.path != guardPath && !tt.managed {
+					continue
+				}
+				_, _, err := op.apply(op.path)
+				if (err != nil) != !tt.managed {
+					t.Fatalf("op.apply(%q) error = %v", op.path, err)
+				}
+			}
+			if tt.managed {
+				if _, err := os.Stat(guardPath); !os.IsNotExist(err) {
+					t.Fatalf("managed guard should be removed: %v", err)
+				}
+			} else if got, err := os.ReadFile(guardPath); err != nil || string(got) != tt.content {
+				t.Fatalf("modified guard = %q, err = %v", got, err)
+			}
+			if got, err := os.ReadFile(userPlugin); err != nil || string(got) != "user plugin" {
+				t.Fatalf("user plugin = %q, err = %v", got, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #787

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Install a managed OpenCode plugin that denies sensitive-path grep targets while preserving explicit benign file searches.
- Deny sensitive-file Bash commands, including quoted and piped `.env` access.
- Manage the plugin through install, rollback, transaction-path, and uninstall lifecycles.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| OpenCode sensitive-path plugin | Reject sensitive paths, broad scans, named directories, symlinks, and sensitive include globs. |
| Permissions injection | Install the managed plugin and add Bash deny patterns without globally disabling safe commands. |
| CLI and uninstall lifecycle | Register transactional ownership and remove only unchanged managed plugin bytes. |
| Tests | Add unit, asset, lifecycle, rollback, and real OpenCode 1.18.10 E2E coverage. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenAI Codex through Pi Coding Agent

**Material scope:** Repository investigation, implementation, tests, and adversarial review support.

**Verification performed:** Full Go suite, gofmt contract, real pinned OpenCode 1.18.10 E2E matrix, independent dual review, and candidate hash/integrity checks.

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] Real OpenCode 1.18.10 E2E: 12 sensitive and benign control scenarios
- [x] Manually tested locally
- [ ] `cd e2e && ./docker-test.sh` — blocked locally because Docker is unavailable (`docker: command not found`); no platform suite started. CI must provide this result.

Benchmark validation: N/A. This change does not modify review lifecycle, gates, recovery, delivery, or benchmark implementation/corpus/classification.

---

## 🤖 Automated Checks

The repository checks remain authoritative, including the Docker E2E result unavailable in the local environment.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (392 additions + 8 deletions)
- [x] I have added the appropriate `type:bug` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E Docker suite passes locally — Docker is unavailable; CI result pending
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation updates are not necessary for this internal enforcement fix
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please focus on fail-closed path classification, the safe-file negative controls, and managed-file ownership during update/uninstall. Adversarial review found and resolved named-directory, sensitive-glob, symlink, and quoted/piped Bash bypasses before submission.

The `internal/cli/run.go` change only registers the plugin transaction path; it does not add a qualifying admission or governance guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenCode protection against searches and commands targeting sensitive files, including secrets, credentials, keys, and certificates.
  - Added safeguards against broad or wildcard searches that could expose protected data.
  - Existing user plugins remain intact during setup and cleanup.

- **Bug Fixes**
  - Improved permission handling for sensitive paths and destructive Git operations.
  - Protection setup is now repeatable without unnecessary changes.
  - Safely preserves modified protection files during uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->