### PR TITLE
feat(install): configure global review mode

### DIFF
--- a/docs/non-interactive.md
+++ b/docs/non-interactive.md
@@ -16,6 +16,7 @@ go run ./cmd/gentle-ai install [flags]
 - `--persona`: explicit persona id.
 - `--preset`: explicit preset id.
 - `--sdd-mode`: `single` or `multi`.
+- `--review-mode`: `on` or `off`; after a successful install, persists the global review mode.
 - `--scope`: `global` (default, writes to each selected agent's global config directory) or `workspace` (writes agent-scoped files to the current project root `./`).
 - `--dry-run`: render plan without executing.
 
@@ -26,6 +27,8 @@ go run ./cmd/gentle-ai install [flags]
 | `GENTLE_AI_INSTALL_SCOPE` | `global` \| `workspace` | Sets the install scope without a flag. Useful in CI. Equivalent to `--scope`. Default: `global`. |
 
 `workspace` scope is not Claude-only: it applies to the selected agents' agent-scoped files such as system prompts, skills, SDD agents, and persona files. Global-only integrations, like package installs or agent settings that must live in the tool's global config, remain global.
+
+Omitting `--review-mode` preserves the existing global setting; a fresh install leaves it unconfigured and effectively off. The flag does not change clone-local review mode or review authority state, and `--dry-run` never persists it.
 
 ## Platform behavior
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -243,6 +243,7 @@ gentle-ai -v
 | `--persona`                   | Persona mode: `gentleman`, `neutral`, `custom` (`custom` keeps your existing persona unmanaged)                   |
 | `--preset`                    | Preset: `full-gentleman`, `ecosystem-only`, `minimal`, `custom` (`custom` means manual component/skill selection) |
 | `--sdd-mode`                  | SDD orchestrator mode: `single` or `multi`                                                                        |
+| `--review-mode`               | Persist global review mode after a successful install: `on` or `off`. Omit to preserve the existing global setting. |
 | `--scope`                     | Install scope for agent-scoped files: `global` (default, writes to each selected agent's global config directory) or `workspace` (writes to the current project root). Also settable via `GENTLE_AI_INSTALL_SCOPE` env var for CI/non-interactive use. |
 | `--dry-run`                   | Preview the install plan without applying changes                                                                 |
 

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -26,6 +26,12 @@ func RenderDryRun(result InstallResult) string {
 	_, _ = fmt.Fprintf(b, "Platform decision: %s\n", formatPlatformDecision(result.Review.PlatformDecision))
 	_, _ = fmt.Fprintf(b, "Prepare steps: %d\n", len(result.Plan.Prepare))
 	_, _ = fmt.Fprintf(b, "Apply steps: %d\n", len(result.Plan.Apply))
+	switch result.ReviewModeOperation {
+	case "enable":
+		_, _ = fmt.Fprintln(b, "Global Review Mode: on (would be persisted globally after a successful non-dry-run install)")
+	case "disable":
+		_, _ = fmt.Fprintln(b, "Global Review Mode: off (would be persisted globally after a successful non-dry-run install)")
+	}
 	if containsAgent(result.Resolved.Agents, model.AgentOpenCode) {
 		_, _ = fmt.Fprintf(b, "OpenCode background intent: %s (policy effective: %s)\n", result.Background.Intent, result.Background.Effective)
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -16,7 +16,10 @@ type InstallFlags struct {
 	SDDMode    string
 	Scope      string
 	Channel    string
+	ReviewMode string
 	DryRun     bool
+
+	ReviewModeSet bool
 
 	OpenCodeBackgroundSubagents    string
 	OpenCodeBackgroundSubagentsSet bool
@@ -40,6 +43,7 @@ FLAGS
   --sdd-mode single|multi            SDD orchestrator mode
   --scope global|workspace           Install scope (env: GENTLE_AI_INSTALL_SCOPE)
   --channel stable|beta|nightly      Release channel; nightly is an alias for beta (env: GENTLE_AI_CHANNEL)
+  --review-mode on|off               Persist the global review mode after a successful install
   --opencode-background-subagents=auto|on|off
                                      Resolve OpenCode capability and manage a launcher when eligible; env: GENTLE_AI_OPENCODE_BACKGROUND_SUBAGENTS
                                      auto inherits managed on/off, unsupported/unknown stays foreground, off removes only owned launchers
@@ -67,6 +71,7 @@ func ParseInstallFlags(args []string) (InstallFlags, error) {
 	fs.StringVar(&opts.SDDMode, "sdd-mode", "", "SDD orchestrator mode: single or multi (default: single)")
 	fs.StringVar(&opts.Scope, "scope", "", "install scope: global (default) or workspace — env: GENTLE_AI_INSTALL_SCOPE")
 	fs.StringVar(&opts.Channel, "channel", "", installChannelHelp)
+	fs.StringVar(&opts.ReviewMode, "review-mode", "", "persist global review mode after a successful install: on or off")
 	fs.StringVar(&opts.OpenCodeBackgroundSubagents, "opencode-background-subagents", "", "--opencode-background-subagents=auto|on|off; env: GENTLE_AI_OPENCODE_BACKGROUND_SUBAGENTS; eligible versions use a managed launcher")
 	fs.StringVar(&opts.PiBackgroundSubagents, "pi-background-subagents", "", "--pi-background-subagents=auto|on|off; env: GENTLE_AI_PI_BACKGROUND_SUBAGENTS; the resolved policy is projected for gentle-pi")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "preview plan without executing")
@@ -84,6 +89,8 @@ func ParseInstallFlags(args []string) (InstallFlags, error) {
 			opts.OpenCodeBackgroundSubagentsSet = true
 		case "pi-background-subagents":
 			opts.PiBackgroundSubagentsSet = true
+		case "review-mode":
+			opts.ReviewModeSet = true
 		}
 	})
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -41,6 +41,61 @@ func TestParseInstallFlagsSupportsCSVAndRepeated(t *testing.T) {
 	}
 }
 
+func TestParseInstallFlagsReviewMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantSet bool
+		wantErr bool
+	}{
+		{name: "omitted", args: []string{"--agent", "opencode"}},
+		{name: "on", args: []string{"--review-mode", "on"}, want: "on", wantSet: true},
+		{name: "off", args: []string{"--review-mode", "off"}, want: "off", wantSet: true},
+		{name: "missing value", args: []string{"--review-mode"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags, err := ParseInstallFlags(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseInstallFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if flags.ReviewMode != tt.want || flags.ReviewModeSet != tt.wantSet {
+				t.Fatalf("review mode = %q (set %t), want %q (set %t)", flags.ReviewMode, flags.ReviewModeSet, tt.want, tt.wantSet)
+			}
+		})
+	}
+}
+
+func TestNormalizeInstallReviewMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		set     bool
+		want    string
+		wantErr bool
+	}{
+		{name: "omitted", want: ""},
+		{name: "on", value: "on", set: true, want: "enable"},
+		{name: "off", value: "off", set: true, want: "disable"},
+		{name: "empty explicit value", set: true, wantErr: true},
+		{name: "invalid", value: "invalid", set: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeInstallReviewMode(tt.value, tt.set)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeInstallReviewMode(%q, %t) error = %v, wantErr %v", tt.value, tt.set, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeInstallReviewMode(%q, %t) = %q, want %q", tt.value, tt.set, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInstallChannelHelpMentionsNightly(t *testing.T) {
 	if !strings.Contains(installChannelHelp, "nightly") {
 		t.Fatalf("installChannelHelp = %q, want nightly mentioned", installChannelHelp)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -301,6 +301,11 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		}
 		return result, persistErr
 	}
+	if input.ReviewModeOperation != "" {
+		if err := writeGlobalRDDMode(input.ReviewModeOperation); err != nil {
+			return result, fmt.Errorf("persist global review mode: %w", err)
+		}
+	}
 
 	return result, nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -45,15 +45,16 @@ import (
 )
 
 type InstallResult struct {
-	Selection    model.Selection
-	Resolved     planner.ResolvedPlan
-	Review       planner.ReviewPayload
-	Plan         pipeline.StagePlan
-	Execution    pipeline.ExecutionResult
-	Verify       verify.Report
-	Dependencies system.DependencyReport
-	PiCodeGraph  *communitytool.PiCodeGraphResult
-	DryRun       bool
+	Selection           model.Selection
+	Resolved            planner.ResolvedPlan
+	Review              planner.ReviewPayload
+	Plan                pipeline.StagePlan
+	Execution           pipeline.ExecutionResult
+	Verify              verify.Report
+	Dependencies        system.DependencyReport
+	PiCodeGraph         *communitytool.PiCodeGraphResult
+	ReviewModeOperation string
+	DryRun              bool
 
 	Background              OpenCodeBackgroundResolution
 	BackgroundPolicyEnabled bool
@@ -175,14 +176,15 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	}
 
 	result := InstallResult{
-		Selection:    input.Selection,
-		Resolved:     resolved,
-		Review:       review,
-		Plan:         stagePlan,
-		Dependencies: detection.Dependencies,
-		DryRun:       input.DryRun,
-		Background:   background,
-		PiBackground: piBackground,
+		Selection:           input.Selection,
+		Resolved:            resolved,
+		Review:              review,
+		Plan:                stagePlan,
+		Dependencies:        detection.Dependencies,
+		ReviewModeOperation: input.ReviewModeOperation,
+		DryRun:              input.DryRun,
+		Background:          background,
+		PiBackground:        piBackground,
 	}
 	result.Background.activationPlan = backgroundActivation
 	if backgroundActivation != nil {

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -49,6 +50,157 @@ func stringSliceContains(items []string, want string) bool {
 }
 
 const engramInitCommandForTest = "npm exec --yes --package gentle-engram@latest -- pi-engram init"
+
+func configureInstallReviewModeTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = missingBinaryLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+	return home
+}
+
+func TestRunInstallReviewModePersistsOnlyExplicitRequest(t *testing.T) {
+	home := configureInstallReviewModeTest(t)
+	installArgs := []string{"--agent", "opencode", "--component", "permissions"}
+
+	if _, err := RunInstall(installArgs, system.DetectionResult{}); err != nil {
+		t.Fatalf("fresh install without review mode: %v", err)
+	}
+	persisted, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("read fresh install state: %v", err)
+	}
+	if persisted.RDDMode != "" || persisted.RDDModeRecordedAt != nil {
+		t.Fatalf("fresh omitted review mode = %q at %v, want unconfigured", persisted.RDDMode, persisted.RDDModeRecordedAt)
+	}
+
+	if _, err := RunInstall(append(installArgs, "--review-mode", "on"), system.DetectionResult{}); err != nil {
+		t.Fatalf("install with review mode on: %v", err)
+	}
+	persisted, err = state.Read(home)
+	if err != nil {
+		t.Fatalf("read enabled review mode: %v", err)
+	}
+	if persisted.RDDMode != string(reviewtransaction.RDDModeOn) || persisted.RDDModeRecordedAt == nil {
+		t.Fatalf("enabled review mode = %q at %v, want on with timestamp", persisted.RDDMode, persisted.RDDModeRecordedAt)
+	}
+
+	if _, err := RunInstall(installArgs, system.DetectionResult{}); err != nil {
+		t.Fatalf("reinstall without review mode: %v", err)
+	}
+	persisted, err = state.Read(home)
+	if err != nil {
+		t.Fatalf("read preserved review mode: %v", err)
+	}
+	if persisted.RDDMode != string(reviewtransaction.RDDModeOn) {
+		t.Fatalf("reinstall without review mode = %q, want on preserved", persisted.RDDMode)
+	}
+
+	if _, err := RunInstall(append(installArgs, "--review-mode", "off"), system.DetectionResult{}); err != nil {
+		t.Fatalf("install with review mode off: %v", err)
+	}
+	persisted, err = state.Read(home)
+	if err != nil {
+		t.Fatalf("read disabled review mode: %v", err)
+	}
+	if persisted.RDDMode != string(reviewtransaction.RDDModeOff) || persisted.RDDModeRecordedAt == nil {
+		t.Fatalf("disabled review mode = %q at %v, want off with timestamp", persisted.RDDMode, persisted.RDDModeRecordedAt)
+	}
+}
+
+func TestRunInstallReviewModeDryRunDoesNotPersist(t *testing.T) {
+	installArgs := []string{"--agent", "opencode", "--component", "permissions", "--dry-run"}
+
+	t.Run("fresh install remains unconfigured", func(t *testing.T) {
+		home := configureInstallReviewModeTest(t)
+		if _, err := RunInstall(append(installArgs, "--review-mode", "on"), system.DetectionResult{}); err != nil {
+			t.Fatalf("dry-run with review mode on: %v", err)
+		}
+		if _, err := os.Stat(state.Path(home)); !os.IsNotExist(err) {
+			t.Fatalf("state after fresh dry-run stat error = %v, want absent", err)
+		}
+	})
+
+	t.Run("existing mode is preserved", func(t *testing.T) {
+		home := configureInstallReviewModeTest(t)
+		if err := writeGlobalRDDMode("enable"); err != nil {
+			t.Fatalf("enable initial review mode: %v", err)
+		}
+		before, err := state.Read(home)
+		if err != nil {
+			t.Fatalf("read review mode before dry-run: %v", err)
+		}
+
+		if _, err := RunInstall(append(installArgs, "--review-mode", "off"), system.DetectionResult{}); err != nil {
+			t.Fatalf("dry-run with review mode off: %v", err)
+		}
+		after, err := state.Read(home)
+		if err != nil {
+			t.Fatalf("read review mode after dry-run: %v", err)
+		}
+		if after.RDDMode != before.RDDMode || !after.RDDModeRecordedAt.Equal(*before.RDDModeRecordedAt) {
+			t.Fatalf("review mode after dry-run = %q at %v, want %q at %v", after.RDDMode, after.RDDModeRecordedAt, before.RDDMode, before.RDDModeRecordedAt)
+		}
+	})
+}
+
+func TestRunInstallReviewModeRejectsInvalidOrMissingValueBeforeMutation(t *testing.T) {
+	for _, args := range [][]string{
+		{"--review-mode", "invalid"},
+		{"--review-mode"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			home := configureInstallReviewModeTest(t)
+
+			if _, err := RunInstall(args, system.DetectionResult{}); err == nil {
+				t.Fatal("RunInstall() error = nil, want invalid review mode error")
+			}
+			if _, err := os.Stat(state.Path(home)); !os.IsNotExist(err) {
+				t.Fatalf("state after invalid review mode stat error = %v, want absent", err)
+			}
+			configPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+			if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+				t.Fatalf("config after invalid review mode stat error = %v, want absent", err)
+			}
+		})
+	}
+}
+
+func TestRunInstallReviewModePreservesPriorValueOnInstallationFailure(t *testing.T) {
+	home := configureInstallReviewModeTest(t)
+	if err := writeGlobalRDDMode("enable"); err != nil {
+		t.Fatalf("enable initial review mode: %v", err)
+	}
+	runCommand = func(name string, args ...string) error {
+		if name == "brew" && len(args) == 2 && args[0] == "install" && args[1] == "engram" {
+			return os.ErrPermission
+		}
+		return nil
+	}
+
+	if _, err := RunInstall([]string{"--agent", "opencode", "--component", "engram", "--review-mode", "off"}, macOSDetectionResult()); err == nil {
+		t.Fatal("RunInstall() error = nil, want installation failure")
+	}
+	persisted, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("read review mode after failed install: %v", err)
+	}
+	if persisted.RDDMode != string(reviewtransaction.RDDModeOn) {
+		t.Fatalf("review mode after failed install = %q, want on preserved", persisted.RDDMode)
+	}
+}
 
 func TestRunInstallAppliesFilesystemChanges(t *testing.T) {
 	home := t.TempDir()

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -123,10 +123,25 @@ func TestRunInstallReviewModePersistsOnlyExplicitRequest(t *testing.T) {
 func TestRunInstallReviewModeDryRunDoesNotPersist(t *testing.T) {
 	installArgs := []string{"--agent", "opencode", "--component", "permissions", "--dry-run"}
 
+	t.Run("omitted request is not rendered", func(t *testing.T) {
+		configureInstallReviewModeTest(t)
+		result, err := RunInstall(installArgs, system.DetectionResult{})
+		if err != nil {
+			t.Fatalf("dry-run without review mode: %v", err)
+		}
+		if output := RenderDryRun(result); strings.Contains(output, "Global Review Mode:") {
+			t.Fatalf("dry-run output claimed a global review mode change without a request:\n%s", output)
+		}
+	})
+
 	t.Run("fresh install remains unconfigured", func(t *testing.T) {
 		home := configureInstallReviewModeTest(t)
-		if _, err := RunInstall(append(installArgs, "--review-mode", "on"), system.DetectionResult{}); err != nil {
+		result, err := RunInstall(append(installArgs, "--review-mode", "on"), system.DetectionResult{})
+		if err != nil {
 			t.Fatalf("dry-run with review mode on: %v", err)
+		}
+		if output := RenderDryRun(result); !strings.Contains(output, "Global Review Mode: on (would be persisted globally after a successful non-dry-run install)") {
+			t.Fatalf("dry-run output missing requested global review mode on:\n%s", output)
 		}
 		if _, err := os.Stat(state.Path(home)); !os.IsNotExist(err) {
 			t.Fatalf("state after fresh dry-run stat error = %v, want absent", err)
@@ -143,8 +158,12 @@ func TestRunInstallReviewModeDryRunDoesNotPersist(t *testing.T) {
 			t.Fatalf("read review mode before dry-run: %v", err)
 		}
 
-		if _, err := RunInstall(append(installArgs, "--review-mode", "off"), system.DetectionResult{}); err != nil {
+		result, err := RunInstall(append(installArgs, "--review-mode", "off"), system.DetectionResult{})
+		if err != nil {
 			t.Fatalf("dry-run with review mode off: %v", err)
+		}
+		if output := RenderDryRun(result); !strings.Contains(output, "Global Review Mode: off (would be persisted globally after a successful non-dry-run install)") {
+			t.Fatalf("dry-run output missing requested global review mode off:\n%s", output)
 		}
 		after, err := state.Read(home)
 		if err != nil {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -182,7 +182,7 @@ func normalizeInstallReviewMode(value string, set bool) (string, error) {
 	case "off":
 		return "disable", nil
 	default:
-		return "", fmt.Errorf("unsupported review-mode %q (valid: on, off)", value)
+		return "", fmt.Errorf("unsupported review-mode %q (valid: on, off); rerun `gentle-ai install --review-mode on` or `gentle-ai install --review-mode off`", value)
 	}
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -13,10 +13,11 @@ import (
 )
 
 type InstallInput struct {
-	Selection model.Selection
-	Scope     InstallScope
-	Channel   InstallChannel
-	DryRun    bool
+	Selection           model.Selection
+	Scope               InstallScope
+	Channel             InstallChannel
+	ReviewModeOperation string
+	DryRun              bool
 }
 
 func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult) (InstallInput, error) {
@@ -79,7 +80,12 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 		return InstallInput{}, err
 	}
 
-	return InstallInput{Selection: selection, Scope: scope, Channel: channel, DryRun: flags.DryRun}, nil
+	reviewModeOperation, err := normalizeInstallReviewMode(flags.ReviewMode, flags.ReviewModeSet)
+	if err != nil {
+		return InstallInput{}, err
+	}
+
+	return InstallInput{Selection: selection, Scope: scope, Channel: channel, ReviewModeOperation: reviewModeOperation, DryRun: flags.DryRun}, nil
 }
 
 // personaAliasRemapNotice is printed whenever the legacy
@@ -163,6 +169,21 @@ func normalizeSkills(values []string) ([]model.SkillID, error) {
 	}
 
 	return unique(skills), nil
+}
+
+func normalizeInstallReviewMode(value string, set bool) (string, error) {
+	if !set {
+		return "", nil
+	}
+
+	switch value {
+	case "on":
+		return "enable", nil
+	case "off":
+		return "disable", nil
+	default:
+		return "", fmt.Errorf("unsupported review-mode %q (valid: on, off)", value)
+	}
 }
 
 func normalizeSDDMode(value string) (model.SDDModeID, error) {

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -71,3 +71,15 @@ func TestNormalizeInstallFlagsAcceptsSupportedAgent(t *testing.T) {
 		t.Fatalf("Selection.Agents = %v, want [claude-code]", input.Selection.Agents)
 	}
 }
+
+func TestNormalizeInstallReviewModeRejectsInvalidValueWithInstallContinuation(t *testing.T) {
+	_, err := normalizeInstallReviewMode("invalid", true)
+	if err == nil {
+		t.Fatal("normalizeInstallReviewMode(\"invalid\", true) error = nil, want an error")
+	}
+
+	want := "unsupported review-mode \"invalid\" (valid: on, off); rerun `gentle-ai install --review-mode on` or `gentle-ai install --review-mode off`"
+	if err.Error() != want {
+		t.Fatalf("normalizeInstallReviewMode(\"invalid\", true) error = %q, want %q", err, want)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3786

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add `gentle-ai install --review-mode on|off` for explicit global Review Mode configuration.
- Preserve existing global state when the flag is omitted, and persist explicit changes only after installation succeeds.
- Keep dry-run output, validation, tests, help, and installation documentation aligned with the new behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go`, `validate.go` | Parse and validate the optional mode while preserving omission semantics. |
| `internal/cli/install.go` | Persist explicit global Review Mode only after a successful installation. |
| `internal/cli/dryrun.go` | Render explicit `on`/`off` intent without mutating global state. |
| `internal/cli/*_test.go` | Cover validation, success/failure preservation, omission, explicit off, and dry-run behavior. |
| `docs/usage.md`, `docs/non-interactive.md` | Document the option and its state-preserving semantics. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent; NaN DeepSeek and MiMo for independent QA; Gentle AI native four-lens RDD review.

**Material scope:** Implementation, tests, documentation, focused analysis, and independent review of this installer change.

**Verification performed:** The 315-line behavior candidate at commit `6b0d8f98431f84ea5f50e74b1096c578cba29c2f` was inspected against the approved issue scope; focused installer, Review Mode, and dry-run tests passed, as did gofmtcheck, vet, and build. DeepSeek returned `PASS_WITH_CONCERNS` with LOW-only observations and MiMo returned `PASS`. After CI identified the refusal-resolution ratchet gap, commit `92ecd66dd4a1d44b77f91483ac7234d5e5136e79` added a runnable continuation and exact test; the narrow ratchet test, focused normalization test, gofmtcheck, and a fresh native four-lens RDD review passed on the updated 327-line candidate. Qwen produced no evidence after repeated timeouts and is not claimed as a pass.

---

## 🧪 Test Plan

**Verified locally on commit `92ecd66dd4a1d44b77f91483ac7234d5e5136e79`:**

- Focused `internal/cli` tests for installer Review Mode and `RenderDryRun` behavior passed.
- `TestEveryProductionRefusalNamesResolutionOrDeclaresByDesign` and `TestNormalizeInstallReviewMode*` passed after the CI correction.
- `go run ./internal/gofmtcheck` passed.
- `go vet ./...` passed.
- `go build ./...` passed.
- External NaN QA on preceding behavior commit `6b0d8f98431f84ea5f50e74b1096c578cba29c2f`: DeepSeek `PASS_WITH_CONCERNS` (LOW only), MiMo `PASS`, Qwen unavailable after repeated timeouts.
- Fresh native four-lens RDD review approved the exact updated candidate `92ecd66dd4a1d44b77f91483ac7234d5e5136e79`.

The first CI run passed every runtime and E2E job but its Unit Tests job found the new refusal-resolution ratchet gap. This candidate fixes that exact failure with focused RED/GREEN evidence. The full rerun on the current commit passed Unit Tests, Windows, Darwin, the required Claude network-none runtime, every E2E and organic-runtime job, format and policy checks, and CodeRabbit.

Benchmark validation is not claimed locally; the change does not modify the benchmark corpus or classifier, and CI/reviewer policy remains authoritative for any lifecycle applicability.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The input boundary deliberately distinguishes omission from explicit `off`: omission preserves existing global state, while either explicit mode is applied only after the installer succeeds. Dry-run renders explicit intent but never persists it.

The added input guard accepts only omitted, `on`, or `off`; tests challenge invalid values and confirm that rejected input produces no installation side effects. No `guard:population` declaration or `.guard-population-baseline.txt` entry was added or changed.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--review-mode` install option to enable or disable global Review Mode after a successful installation.
  - Omitting the option preserves the existing setting.
  - Dry runs display pending changes without saving them.
  - Invalid or missing values are rejected before installation changes are made.
  - Clone-local review settings and authority state remain unaffected.

- **Documentation**
  - Updated CLI usage and non-interactive mode documentation.

- **Tests**
  - Added coverage for parsing, persistence, reinstalls, dry runs, validation, and failed installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

