### PR TITLE
fix(sdd): preserve selected-untracked rescope continuation

### DIFF
--- a/bench/journeys_sdd_untracked.go
+++ b/bench/journeys_sdd_untracked.go
@@ -49,6 +49,7 @@ func driveSelectedUntrackedSDDAttempt(r *journeyRun) error {
 		return fmt.Errorf("selected settle = %#v parse=%v exit=%d", result, err, settled.ExitCode)
 	}
 	var status struct {
+		Revision string `json:"revision"`
 		Attempts []struct {
 			ChangedLines      int      `json:"changed_lines"`
 			IntendedUntracked []string `json:"intended_untracked"`
@@ -60,14 +61,55 @@ func driveSelectedUntrackedSDDAttempt(r *journeyRun) error {
 	if len(status.Attempts) != 1 || status.Attempts[0].ChangedLines != 6 || len(status.Attempts[0].IntendedUntracked) != 1 || status.Attempts[0].IntendedUntracked[0] != "docs/selected.md" {
 		return fmt.Errorf("selected SDD lifecycle status = %#v", status)
 	}
+	rescoped := r.run([]string{
+		"sdd-attempt", "rescope", "--cwd", r.sandbox.Repo, "--change", sddChange, "--expected-revision", status.Revision,
+		"--request-id", "bench-selected-rescope", "--work-unit", "selected untracked continuation",
+		"--evidence-goal", "prove the rescope successor preserves selected bytes", "--max-attempts", "2", "--max-changed-lines", "20",
+		"--reason", "maintainer narrowed the failed selected-untracked objective", "--actor", "bench",
+	}, false)
+	if rescoped.ExitCode != 0 {
+		return fmt.Errorf("selected rescope = exit=%d stderr=%s", rescoped.ExitCode, firstLine(rescoped.Stderr))
+	}
+	admission := r.run([]string{
+		"sdd-attempt", "status", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--work-unit", "selected untracked continuation", "--evidence-goal", "prove the rescope successor preserves selected bytes",
+		"--max-attempts", "2", "--max-changed-lines", "20",
+	}, false)
+	var continuationStatus struct {
+		BlockedReason string `json:"blocked_reason"`
+		BlockedExit   string `json:"blocked_exit"`
+	}
+	if err := json.Unmarshal([]byte(admission.Stdout), &continuationStatus); err != nil || admission.ExitCode != 0 || continuationStatus.BlockedReason != "" || continuationStatus.BlockedExit != "" {
+		return fmt.Errorf("declaration-free selected rescope status = %#v parse=%v exit=%d", continuationStatus, err, admission.ExitCode)
+	}
+	continued := r.run([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "bench-selected-acquire-successor",
+		"--work-unit", "selected untracked continuation", "--evidence-goal", "prove the rescope successor preserves selected bytes",
+		"--max-attempts", "2", "--max-changed-lines", "20",
+	}, false)
+	var successor sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(continued.Stdout), &successor); err != nil || continued.ExitCode != 0 || successor.State != "proceed" || successor.Token == "" {
+		return fmt.Errorf("declaration-free selected rescope acquire = %#v parse=%v exit=%d", successor, err, continued.ExitCode)
+	}
+	var continuedStatus struct {
+		ActiveAttempt *struct {
+			IntendedUntracked []string `json:"intended_untracked"`
+		} `json:"active_attempt"`
+	}
+	if err := proveJSON(r.sandbox, &continuedStatus, "sdd-attempt", "status", "--cwd", r.sandbox.Repo, "--change", sddChange); err != nil {
+		return err
+	}
+	if continuedStatus.ActiveAttempt == nil || len(continuedStatus.ActiveAttempt.IntendedUntracked) != 1 || continuedStatus.ActiveAttempt.IntendedUntracked[0] != "docs/selected.md" {
+		return fmt.Errorf("selected rescope successor swept untracked paths: %#v", continuedStatus)
+	}
 	return nil
 }
 
 func selectedUntrackedSDDJourneys() []Journey {
 	return []Journey{{
 		ID:     "j84-sdd-attempt-selected-untracked-lifecycle",
-		Title:  "SDD attempt: inventory-selected untracked bytes remain candidate provenance and accounting",
-		Source: "issue #2716: SDD must not issue authority for undeclared untracked candidate scope",
+		Title:  "SDD attempt: selected untracked scope survives a zero-drift rescope continuation",
+		Source: "issues #2716 and #3801: explicit selected scope remains provenance and a fresh rescope successor must continue it without sweeping workspace files",
 		Steps: []Step{
 			{Name: "fixture: runtime repository", Fixture: sddRuntimeRepo},
 			{Name: "fixture: selected untracked candidate", Fixture: sddSelectedUntrackedCandidate},

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -97,15 +97,32 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	var intended []string
 	declaredUntracked := reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory)
-	if operation == "begin" || (operation == "acquire" && (*token == "" || declaredUntracked)) {
-		scope, scopeErr := intendedUntrackedScopeForTarget(ctx, reviewtransaction.SnapshotBuilder{Repo: *cwd}, untrackedScope, intendedUntracked, expectedUntrackedInventory, "gentle-ai review status --next-transition", "gentle-ai sdd-attempt "+operation)
-		if scopeErr != nil {
-			return scopeErr
+	skipAcquireUntrackedPreflight := false
+	if operation == "acquire" && !declaredUntracked && *token == "" {
+		status, statusErr := store.Status()
+		skipAcquireUntrackedPreflight = statusErr == nil && status.ActiveAttempt != nil
+	}
+	if operation == "begin" || (operation == "acquire" && (*token == "" || declaredUntracked) && !skipAcquireUntrackedPreflight) {
+		inheritsRescopeSelection := false
+		if !declaredUntracked {
+			inheritsRescopeSelection, err = store.FreshRescopeSuccessorInheritsIntendedUntracked()
+			if err != nil && operation == "begin" {
+				return fmt.Errorf("read rescope successor untracked scope: %w", err)
+			}
+			if err != nil {
+				inheritsRescopeSelection = false
+			}
 		}
-		if scope.NeedsSelection {
-			return intendedUntrackedSelectionRequired(scope, "gentle-ai review status --next-transition", "gentle-ai sdd-attempt "+operation)
+		if !inheritsRescopeSelection {
+			scope, scopeErr := intendedUntrackedScopeForTarget(ctx, reviewtransaction.SnapshotBuilder{Repo: *cwd}, untrackedScope, intendedUntracked, expectedUntrackedInventory, "gentle-ai review status --next-transition", "gentle-ai sdd-attempt "+operation)
+			if scopeErr != nil {
+				return scopeErr
+			}
+			if scope.NeedsSelection {
+				return intendedUntrackedSelectionRequired(scope, "gentle-ai review status --next-transition", "gentle-ai sdd-attempt "+operation)
+			}
+			intended = scope.Intended
 		}
-		intended = scope.Intended
 	}
 	var result any
 	switch operation {

--- a/internal/cli/sdd_attempt_untracked_test.go
+++ b/internal/cli/sdd_attempt_untracked_test.go
@@ -107,6 +107,130 @@ func TestRunSDDAttemptAcquireTokenReusesSelectedUntrackedScope(t *testing.T) {
 	}
 }
 
+func TestRunSDDAttemptRescopeSuccessorInheritsSelectedUntrackedScope(t *testing.T) {
+	for _, operation := range []string{"begin", "acquire"} {
+		t.Run(operation, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			change := "rescoped-selected-" + operation
+			writeUndeclaredWorkspaceFile(t, repo, "selected.txt", "selected\n", 0o644)
+			writeUndeclaredWorkspaceFile(t, repo, "unrelated.txt", "unrelated\n", 0o644)
+			_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			acquired, _ := runCompactSDDAttempt(t, []string{
+				"acquire", "--cwd", repo, "--change", change, "--request-id", "selected-acquire-a",
+				"--work-unit", "objective A", "--evidence-goal", "prove selected scope", "--max-attempts", "2", "--max-changed-lines", "20",
+				"--untracked-scope", "select", "--expected-untracked-inventory", digest, "--intended-untracked", "selected.txt",
+			})
+			failed, _ := runCompactSDDAttempt(t, append([]string{
+				"settle", "--cwd", repo, "--change", change, "--token", acquired.Token, "--request-id", "selected-settle-a",
+				"--outcome", "failed", "--evidence-revision", cliAttemptHash('a'),
+			}, "--diagnosis", "zero-drift failure", "--harness-disposition", "reused", "--cleanup-evidence", "cleanup complete", "--process-evidence", "process scan clean"))
+			if failed.State != "proceed" {
+				t.Fatalf("zero-drift selected settlement = %#v", failed)
+			}
+			settled := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+			rescoped := runSDDAttemptStatus(t, []string{
+				"rescope", "--cwd", repo, "--change", change, "--expected-revision", settled.Revision, "--request-id", "selected-rescope-b",
+				"--work-unit", "objective B", "--evidence-goal", "prove inherited selected scope", "--max-attempts", "2", "--max-changed-lines", "20",
+				"--reason", "maintainer narrowed the failed zero-drift objective", "--actor", "maintainer",
+			})
+
+			status := runSDDAttemptStatus(t, []string{
+				"status", "--cwd", repo, "--change", change, "--work-unit", "objective B", "--evidence-goal", "prove inherited selected scope",
+				"--max-attempts", "2", "--max-changed-lines", "20",
+			})
+			if status.BlockedReason != "" || status.BlockedExit != "" {
+				t.Fatalf("declaration-free rescope-successor status = reason %q exit %q, want an executable continuation", status.BlockedReason, status.BlockedExit)
+			}
+
+			continuation := []string{
+				operation, "--cwd", repo, "--change", change, "--request-id", "selected-" + operation + "-b",
+				"--work-unit", "objective B", "--evidence-goal", "prove inherited selected scope", "--max-attempts", "2", "--max-changed-lines", "20",
+			}
+			if operation == "begin" {
+				continuation = append(continuation, "--expected-revision", rescoped.Revision)
+			}
+			store, err := sddstatus.OpenRuntimeStore(context.Background(), repo, change)
+			if err != nil {
+				t.Fatal(err)
+			}
+			divergent := append(append([]string{}, continuation...), "--untracked-scope", "select", "--expected-untracked-inventory", digest, "--intended-untracked", "unrelated.txt")
+			if operation == "acquire" {
+				result, _ := runCompactSDDAttempt(t, divergent)
+				if result.State != "blocked" || result.Reason != string(sddstatus.CompactBlockMaintainerDecision) {
+					t.Fatalf("divergent rescope-successor acquire = %#v", result)
+				}
+			} else if err := RunSDDAttempt(divergent, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "objective changed") {
+				t.Fatalf("divergent rescope-successor begin = %v", err)
+			}
+			afterDivergence, err := store.Status()
+			if err != nil || afterDivergence.Revision != rescoped.Revision || afterDivergence.ActiveAttempt != nil {
+				t.Fatalf("divergent rescope-successor declaration mutated authority: status=%#v err=%v", afterDivergence, err)
+			}
+			if operation == "acquire" {
+				result, _ := runCompactSDDAttempt(t, continuation)
+				if result.State != "proceed" || result.Token == "" {
+					t.Fatalf("declaration-free rescope-successor acquire = %#v", result)
+				}
+			}
+			if operation == "begin" {
+				started := runSDDAttemptStatus(t, continuation)
+				if started.ActiveAttempt == nil || len(started.ActiveAttempt.IntendedUntracked) != 1 || started.ActiveAttempt.IntendedUntracked[0] != "selected.txt" {
+					t.Fatalf("declaration-free rescope-successor begin = %#v", started)
+				}
+			}
+			current, err := store.Status()
+			if err != nil || current.ActiveAttempt == nil || len(current.ActiveAttempt.IntendedUntracked) != 1 || current.ActiveAttempt.IntendedUntracked[0] != "selected.txt" {
+				t.Fatalf("rescope successor swept unrelated untracked paths: status=%#v err=%v", current, err)
+			}
+		})
+	}
+}
+
+func TestRunSDDAttemptAcquireReplayPreservesInheritedRescopeSelection(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const change = "rescoped-replay"
+	writeUndeclaredWorkspaceFile(t, repo, "selected.txt", "selected\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, "unrelated.txt", "unrelated\n", 0o644)
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	acquired, _ := runCompactSDDAttempt(t, []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", "selected-acquire-a",
+		"--work-unit", "objective A", "--evidence-goal", "prove selected scope", "--max-attempts", "2", "--max-changed-lines", "20",
+		"--untracked-scope", "select", "--expected-untracked-inventory", digest, "--intended-untracked", "selected.txt",
+	})
+	runCompactSDDAttempt(t, append(compactSettleArgs(repo, change, acquired.Token, "selected-settle-a", "failed"), "--evidence-revision", cliAttemptHash('a')))
+	settled := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	runSDDAttemptStatus(t, []string{
+		"rescope", "--cwd", repo, "--change", change, "--expected-revision", settled.Revision, "--request-id", "selected-rescope-b",
+		"--work-unit", "objective B", "--evidence-goal", "prove inherited selected scope", "--max-attempts", "2", "--max-changed-lines", "20",
+		"--reason", "maintainer narrowed the failed zero-drift objective", "--actor", "maintainer",
+	})
+	args := []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", "selected-acquire-b",
+		"--work-unit", "objective B", "--evidence-goal", "prove inherited selected scope", "--max-attempts", "2", "--max-changed-lines", "20",
+	}
+	first, _ := runCompactSDDAttempt(t, args)
+	store, err := sddstatus.OpenRuntimeStore(context.Background(), repo, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotRuntimeAuthorityFiles(t, store.Dir)
+	replayed, _ := runCompactSDDAttempt(t, args)
+	if first.State != "proceed" || first.Token == "" || replayed.State != first.State || replayed.Token != first.Token || !reflect.DeepEqual(before, snapshotRuntimeAuthorityFiles(t, store.Dir)) {
+		t.Fatalf("declaration-free replay = %#v, want %#v without authority mutation", replayed, first)
+	}
+	divergent, _ := runCompactSDDAttempt(t, append(append([]string{}, args...), "--untracked-scope", "select", "--expected-untracked-inventory", digest, "--intended-untracked", "unrelated.txt"))
+	if divergent.State != "blocked" || divergent.Reason != string(sddstatus.CompactBlockInvalidContinuation) || !reflect.DeepEqual(before, snapshotRuntimeAuthorityFiles(t, store.Dir)) {
+		t.Fatalf("divergent replay = %#v, want invalid_continuation without authority mutation", divergent)
+	}
+}
+
 func TestRunSDDAttemptBeginSelectsInventoryValidatedPaths(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	writeUndeclaredWorkspaceFile(t, repo, "selected.txt", "selected\n", 0o644)

--- a/internal/sddstatus/runtime_admission.go
+++ b/internal/sddstatus/runtime_admission.go
@@ -17,6 +17,35 @@ type runtimeBeginAdmissionResult struct {
 	Snapshot   reviewtransaction.Snapshot
 }
 
+// runtimeRescopeSuccessorIntendedUntracked recovers only the exact selection
+// whose zero-drift candidate opened a fresh rescope successor. The successor
+// has no attempt of its own yet, so its predecessor's recorded selection is
+// the sole inventory-validated scope that can reproduce InitialCandidate*.
+func runtimeRescopeSuccessorIntendedUntracked(status RuntimeStatus) ([]string, bool) {
+	if status.Objective == nil || status.ActiveAttempt != nil || status.LastRescope == nil ||
+		status.LastRescope.ObjectiveID != status.Objective.ID || runtimeObjectiveHasRecordedAttempt(status) ||
+		len(status.Attempts) == 0 {
+		return nil, false
+	}
+	predecessor := status.Attempts[len(status.Attempts)-1]
+	if predecessor.ObjectiveID != status.LastRescope.PreviousObjectiveID ||
+		predecessor.ObjectiveGeneration != status.LastRescope.PreviousGeneration ||
+		predecessor.Outcome == AttemptRunning {
+		return nil, false
+	}
+	return slices.Clone(predecessor.IntendedUntracked), true
+}
+
+func runtimeRescopeSuccessorRequest(status RuntimeStatus, request BeginAttemptRequest, inherit bool) BeginAttemptRequest {
+	if !inherit {
+		return request
+	}
+	if intended, ok := runtimeRescopeSuccessorIntendedUntracked(status); ok {
+		request.IntendedUntracked = intended
+	}
+	return request
+}
+
 // runtimeBeginAdmission is the ONE evaluator of every precondition Begin must
 // satisfy before it can record an attempt, ledger-side and repository-side
 // alike. It mutates nothing: it reads the replayed status the caller hands it
@@ -146,12 +175,14 @@ func (store RuntimeStore) AdmissionStatus(ctx context.Context, request BeginAtte
 	// exactly when the operator is looking hardest.
 	status.SettleObligation = runtimeSettleObligation(status)
 
+	inheritIntendedUntracked := request.IntendedUntracked == nil
 	normalized, err := normalizeBeginAttemptRequest(request)
 	if err != nil {
 		status.BlockedReason = CompactBlockInvalidContinuation
 		status.BlockedExit = err.Error()
 		return status, nil
 	}
+	normalized = runtimeRescopeSuccessorRequest(status, normalized, inheritIntendedUntracked)
 	if result, terminal := runtimeReadiness(runtimeReadinessInput{
 		Status: status, AttemptTokens: replay.AttemptTokens, Request: normalized,
 	}); terminal && result.State == CompactStateBlocked {

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -207,10 +207,13 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 			return compactBlockedByUnreadableAuthority(loadErr), nil
 		}
 		begin.ExpectedRevision = record.PreviousRevision
-		if inheritIntendedUntracked && record.Begin != nil && record.Begin.IntendedUntracked != nil {
-			begin.IntendedUntracked = slices.Clone(*record.Begin.IntendedUntracked)
+		if inheritIntendedUntracked && record.Begin != nil {
+			begin.IntendedUntracked = nil
+			if record.Begin.IntendedUntracked != nil {
+				begin.IntendedUntracked = slices.Clone(*record.Begin.IntendedUntracked)
+			}
 		}
-		if !compactAcquireMatches(record, begin) {
+		if !compactAcquireMatches(record, begin, inheritIntendedUntracked) {
 			return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 		}
 		if request.Token != "" && request.Token != receipt.Revision {
@@ -353,11 +356,14 @@ func normalizeCompactSettleRequest(request CompactSettleRequest) error {
 	return nil
 }
 
-func compactAcquireMatches(record runtimeRecord, request BeginAttemptRequest) bool {
+func compactAcquireMatches(record runtimeRecord, request BeginAttemptRequest, inheritsIntendedUntracked bool) bool {
 	if (record.Operation != runtimeOperationBegin && record.Operation != runtimeOperationAdvance) || record.Begin == nil {
 		return false
 	}
 	event := record.Begin
+	if !inheritsIntendedUntracked && event.IntendedUntracked == nil {
+		return false
+	}
 	var intendedUntracked []string
 	if event.IntendedUntracked != nil {
 		intendedUntracked = *event.IntendedUntracked

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -188,7 +188,7 @@ func runtimeReadiness(in runtimeReadinessInput) (CompactAttemptResult, bool) {
 // Acquire claims one native attempt without exposing the growing runtime
 // history. The returned token identifies that exact begin record for Settle.
 func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireRequest) (CompactAttemptResult, error) {
-	recoverIntendedUntracked := request.Token != "" && request.IntendedUntracked == nil
+	inheritIntendedUntracked := request.IntendedUntracked == nil
 	begin, err := normalizeBeginAttemptRequest(request.BeginAttemptRequest)
 	if err != nil {
 		return CompactAttemptResult{}, err
@@ -207,14 +207,8 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 			return compactBlockedByUnreadableAuthority(loadErr), nil
 		}
 		begin.ExpectedRevision = record.PreviousRevision
-		// A token is the committed begin record's ownership proof. A tokenized
-		// retry that omitted selection recovers that record's population; an
-		// explicit declaration must still match it exactly below.
-		if recoverIntendedUntracked && request.Token == receipt.Revision && record.Begin != nil {
-			begin.IntendedUntracked = nil
-			if record.Begin.IntendedUntracked != nil {
-				begin.IntendedUntracked = slices.Clone(*record.Begin.IntendedUntracked)
-			}
+		if inheritIntendedUntracked && record.Begin != nil && record.Begin.IntendedUntracked != nil {
+			begin.IntendedUntracked = slices.Clone(*record.Begin.IntendedUntracked)
 		}
 		if !compactAcquireMatches(record, begin) {
 			return compactBlocked(CompactBlockInvalidContinuation, ""), nil
@@ -222,15 +216,9 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 		if request.Token != "" && request.Token != receipt.Revision {
 			return compactBlocked(CompactBlockInvalidContinuation, ""), nil
 		}
-		if _, err := store.Begin(ctx, begin); err != nil {
-			return store.compactMutationFailure(err, false, begin), nil
-		}
-		current, loadErr := store.load()
-		if loadErr != nil {
-			return compactBlockedByUnreadableAuthority(loadErr), nil
-		}
-		return compactAcquireResult(current, begin, receipt.Revision), nil
+		return compactAcquireResult(replay, begin, receipt.Revision), nil
 	}
+	begin = runtimeRescopeSuccessorRequest(replay.Status, begin, inheritIntendedUntracked)
 
 	if result, terminal := runtimeReadiness(runtimeReadinessInput{
 		Status: replay.Status, AttemptTokens: replay.AttemptTokens,

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -698,6 +698,17 @@ func (store RuntimeStore) Status() (RuntimeStatus, error) {
 	return replay.Status, err
 }
 
+// FreshRescopeSuccessorInheritsIntendedUntracked reports whether the current
+// fresh rescope successor can reuse its predecessor's recorded selection.
+func (store RuntimeStore) FreshRescopeSuccessorInheritsIntendedUntracked() (bool, error) {
+	replay, err := store.load()
+	if err != nil {
+		return false, err
+	}
+	_, inherited := runtimeRescopeSuccessorIntendedUntracked(replay.Status)
+	return inherited, nil
+}
+
 // runtimeObjectiveHasRecordedAttempt reports whether ANY attempt in the
 // replayed history was recorded under status.Objective's exact ID. Before
 // Rescope existed, status.Objective != nil always implied at least one
@@ -723,10 +734,18 @@ func runtimeObjectiveHasRecordedAttempt(status RuntimeStatus) bool {
 }
 
 func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest) (RuntimeStatus, error) {
-	legacyRequest := request.IntendedUntracked == nil
+	inheritIntendedUntracked := request.IntendedUntracked == nil
+	legacyRequest := inheritIntendedUntracked
 	request, err := normalizeBeginAttemptRequest(request)
 	if err != nil {
 		return RuntimeStatus{}, err
+	}
+	if inheritIntendedUntracked {
+		replay, loadErr := store.load()
+		if loadErr != nil {
+			return RuntimeStatus{}, loadErr
+		}
+		request = runtimeRescopeSuccessorRequest(replay.Status, request, true)
 	}
 	digest := runtimeValueHash("gentle-ai.sdd-runtime-begin-request/v1", request)
 	legacyDigest := ""

--- a/internal/sddstatus/runtime_ledger_untracked_test.go
+++ b/internal/sddstatus/runtime_ledger_untracked_test.go
@@ -256,7 +256,7 @@ func TestRuntimeLegacyEmptyPopulationStillReplays(t *testing.T) {
 	}, Token: revision}
 	result, err := store.Acquire(context.Background(), retry)
 	status, statusErr := store.Status()
-	if err != nil || statusErr != nil || !synced || result.State != CompactStateProceed || result.Token != revision || status.Revision != revision || status.ActiveAttempt == nil || countRuntimeRecords(t, store.Dir) != beforeRecords {
+	if err != nil || statusErr != nil || synced || result.State != CompactStateProceed || result.Token != revision || status.Revision != revision || status.ActiveAttempt == nil || countRuntimeRecords(t, store.Dir) != beforeRecords {
 		t.Fatalf("legacy tokenized replay = %#v, status=%#v err=%v/%v records=%d", result, status, err, statusErr, countRuntimeRecords(t, store.Dir))
 	}
 	foreign := retry


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3801

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Makes selected-untracked rescope continuations executable and retry-safe. A fresh successor inherits only its immediate predecessor's inventory-validated selection, while Acquire replays return the existing receipt before recomputing inheritance or workspace selection.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus` | Inherit proven rescope selection, preserve replay identity, and distinguish absent legacy selection from explicit empty selection. |
| `internal/cli` | Allow declaration-free successor continuations and active Acquire retries without weakening fresh-objective declaration requirements. |
| `bench/` | Extend j84 with driven rescope-continuation proof. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi with OpenAI Codex GPT-5.6 Terra and GPT-5.6 Sol

**Material scope:** Reproduction, implementation, test authoring, verification, and native RDD coordination.

**Verification performed:** Strict TDD, uncached affected-package tests, check-only formatting, CI-shaped driven j84 execution, and native bounded RDD with targeted correction validation.

---

## 🧪 Test Plan

**Affected Package Tests**
```bash
go test ./internal/cli ./internal/sddstatus -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Driven Benchmark Validation**
```bash
gentle-ai-bench run --binary "$RUNNER_TEMP/gentle-ai" --only j84-sdd-attempt-selected-untracked-lifecycle --out "$RUNNER_TEMP/bench-j84.json"
```

Result: `1 completed, 0 unsupported, 0 failed`.

**E2E Tests**

Not run locally. Required repository CI must pass before merge.

- [ ] Unit tests pass (`go test ./...`) — full CI suite pending
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI pending
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — CI pending
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — CI pending
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please focus on the fresh-successor guards, receipt replay ordering, and the distinction between legacy absent selection and explicit empty selection.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identified the admission and replay guards and challenged their legitimate input populations against the reproduced rescope and lost-response flows.
- [x] Confirmed guard direction and claims remain adjacent and accurate; `.guard-population-baseline.txt` did not require a semantic change.
- [x] Did not treat declaration or registry checks as semantic proof; focused tests and driven execution cover the behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rescope successors can now inherit the previously selected untracked-file scope without requiring it to be declared again.
  * Added zero-drift rescope continuation support for acquiring successor attempts.

* **Bug Fixes**
  * Prevented active attempts from unnecessarily recalculating untracked-file selections.
  * Replayed acquisitions now return committed results without mutating stored authority.
  * Divergent untracked-file selections are rejected while preserving existing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->