### PR TITLE
refactor(sdd): give the non-drifted orchestrator sections one source

### DIFF
--- a/internal/assets/antigravity/sdd-orchestrator.md
+++ b/internal/assets/antigravity/sdd-orchestrator.md
@@ -69,11 +69,7 @@ Do not execute SDD phase work in the orchestrator thread except for trivial rout
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -162,7 +158,7 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -230,13 +226,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -430,6 +420,4 @@ DAG state is tracked in Engram under `sdd/{change-name}/state`. Update it after 
 
 ## Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -2255,7 +2255,7 @@ func TestSDDOrchestratorsUseNativeRuntimeAttemptAuthority(t *testing.T) {
 		causalFailureDisclosure,
 	}
 	for _, path := range paths {
-		content := MustRead(path)
+		content := resolveSharedOrchestratorSections(MustRead(path))
 		if path == "claude/sdd-orchestrator.md" {
 			content += "\n" + MustRead("claude/sdd-orchestrator-workflow.md")
 		}

--- a/internal/assets/claude/sdd-orchestrator.md
+++ b/internal/assets/claude/sdd-orchestrator.md
@@ -52,11 +52,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -264,7 +264,7 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -330,13 +330,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 

--- a/internal/assets/cursor/sdd-orchestrator.md
+++ b/internal/assets/cursor/sdd-orchestrator.md
@@ -71,11 +71,7 @@ Each subagent runs in its own context window and returns a **structured result**
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -164,7 +160,7 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -232,13 +228,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -269,12 +259,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 
@@ -435,6 +420,4 @@ Convention files under `~/.cursor/skills/_shared/` (global) or `.agent/skills/_s
 
 ### Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/gemini/sdd-orchestrator.md
+++ b/internal/assets/gemini/sdd-orchestrator.md
@@ -51,11 +51,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -144,7 +140,7 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -212,13 +208,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -249,12 +239,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 
@@ -400,6 +385,4 @@ Convention files under `~/.gemini/skills/_shared/` (global) or `.agent/skills/_s
 
 ### Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/generic/sdd-orchestrator.md
+++ b/internal/assets/generic/sdd-orchestrator.md
@@ -53,11 +53,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -146,7 +142,7 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -214,13 +210,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -251,12 +241,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 
@@ -447,6 +432,4 @@ Convention files under the agent's global skills directory (global) or `.agent/s
 
 ### Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/hermes/sdd-orchestrator.md
+++ b/internal/assets/hermes/sdd-orchestrator.md
@@ -72,11 +72,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -163,7 +159,7 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -227,13 +223,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -263,12 +253,7 @@ Cache the chain strategy for the session. Pass it as `chain_strategy` to `sdd-ta
 When delivery planning yields chained PRs, treat `chained-pr` (registry skill `gentle-ai-chained-pr`) as a required skill match: resolve it by registry name through this template's existing skill-resolution mechanism (the same one it already uses to pass skills to phases) and ensure the `sdd-tasks` and `sdd-apply` phases load and follow it BEFORE planning or creating any PR. Do not hardcode the skill path; defer resolution to that mechanism.
 
 ### Dependency Graph
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
@@ -399,6 +384,4 @@ Skill files are organized under `~/.hermes/skills/` by category. Convention file
 
 ### Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/kimi/sdd-orchestrator.md
+++ b/internal/assets/kimi/sdd-orchestrator.md
@@ -51,11 +51,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -148,7 +144,7 @@ Do NOT invent custom `/sdd-*` command files. On Kimi, user-facing entrypoints ar
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -199,13 +195,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -236,12 +226,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 

--- a/internal/assets/kiro/sdd-orchestrator.md
+++ b/internal/assets/kiro/sdd-orchestrator.md
@@ -53,11 +53,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -220,7 +216,7 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -279,13 +275,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -346,12 +336,7 @@ The Kiro phase result must prove that persistence contract. Refresh prior progre
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 
@@ -482,6 +467,4 @@ DAG state is tracked in Engram under `sdd/{change-name}/state`. Update it after 
 
 ## Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/language_contract_test.go
+++ b/internal/assets/language_contract_test.go
@@ -82,7 +82,7 @@ func TestSDDOrchestratorAssetsEnforceLanguageContract(t *testing.T) {
 
 	for _, path := range assetPaths {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 
 			for _, required := range sddOrchestratorLanguageContractRequired {
 				if !strings.Contains(content, required) {
@@ -107,7 +107,7 @@ func TestSDDOrchestratorAssetsEnforceLanguageContract(t *testing.T) {
 func TestSDDPhaseSkillsEnforceLanguageContract(t *testing.T) {
 	for _, path := range allSDDPhaseSkillAssetPaths(t) {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			for _, required := range sddArtifactLanguageContractRequired {
 				if !strings.Contains(content, required) {
 					t.Fatalf("%s missing language contract wording %q", path, required)
@@ -147,7 +147,7 @@ func TestSupportedAgentSDDLanguageMatrix(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.agent, func(t *testing.T) {
-			content := MustRead(tc.path)
+			content := resolveSharedOrchestratorSections(MustRead(tc.path))
 			for _, required := range sddOrchestratorLanguageContractRequired {
 				if !strings.Contains(content, required) {
 					t.Fatalf("agent %s asset %s missing language contract wording %q", tc.agent, tc.path, required)
@@ -187,7 +187,7 @@ func TestSDDOrchestratorAssetsUseCanonicalResearchGate(t *testing.T) {
 
 	for _, path := range assetPaths {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			if path == "claude/sdd-orchestrator.md" {
 				content = MustRead("claude/sdd-orchestrator-workflow.md")
 			}
@@ -208,7 +208,7 @@ func TestSDDProposeAssetsRequireConfirmedHandoffWithoutInterview(t *testing.T) {
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			for _, required := range []string{"confirmed pre-proposal handoff", "MUST NOT interview"} {
 				if !strings.Contains(content, required) {
 					t.Fatalf("%s missing confirmed-handoff wording %q", path, required)
@@ -303,7 +303,7 @@ func TestNeutralPersonaAssetsProvideMentorParityWithoutRegionalVoice(t *testing.
 		"hermes/persona-neutral.md",
 	} {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			for _, required := range []string{
 				"Response-length contract",
 				"minimum useful response",
@@ -339,7 +339,7 @@ func TestNeutralOutputStyleAssetsProvideMeaningfulContract(t *testing.T) {
 		"kimi/output-style-neutral.md",
 	} {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			if strings.TrimSpace(content) == "" {
 				t.Fatalf("%s is empty", path)
 			}
@@ -457,7 +457,7 @@ func TestPersonaChannelsCarryPreWriteArtifactSelfCheck(t *testing.T) {
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			if !strings.Contains(content, preWriteArtifactSelfCheckRequired) {
 				t.Fatalf("%s: missing pre-write artifact self-check sentence", path)
 			}
@@ -474,7 +474,7 @@ func TestNeutralChannelsExtendAntiDriftToToneAndDialect(t *testing.T) {
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			content := MustRead(path)
+			content := resolveSharedOrchestratorSections(MustRead(path))
 			if !strings.Contains(content, neutralToneDialectAntiDriftRequired) {
 				t.Fatalf("%s: missing tone/dialect anti-drift sentence", path)
 			}

--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -51,11 +51,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -159,7 +155,7 @@ Meta-commands (type directly - orchestrator handles them, won't appear in autoco
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Session Preflight (HARD GATE)
 
@@ -295,13 +291,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -339,12 +329,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 

--- a/internal/assets/orchestrator_drift_ratchet_test.go
+++ b/internal/assets/orchestrator_drift_ratchet_test.go
@@ -1,0 +1,103 @@
+package assets
+
+import (
+	"crypto/sha256"
+	"io/fs"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #3817: the SDD orchestrator contract lives in twelve hand-maintained
+// near-duplicates. Measured across them, only two of the twenty-one shared
+// subsections were byte-identical; Delegation Rules alone had eleven variants
+// across eleven runtimes. Reconciling those is a decision per section, not a
+// refactor, so this ratchet does the next best thing: it makes the drift
+// visible and stops it growing.
+//
+// Lowering a number here is progress. Raising one means a section was edited in
+// some runtimes and not the others — the exact failure that left ten runtimes
+// carrying a contradicted dispatcher guard after the first correction.
+var orchestratorSectionDriftRatchet = []struct {
+	name        string
+	maxVariants int
+}{
+	{"Delegation Rules", 11},
+	{"Execution Mode", 10},
+	{"Review Workload Guard (MANDATORY)", 10},
+	{"State and Conventions", 10},
+	{"Automatic Mode Gatekeeper (MANDATORY)", 9},
+	{"Commands", 9},
+	{"Skill Resolution Feedback", 8},
+	{"Artifact Store Mode", 7},
+	{"SDD Init Guard (MANDATORY)", 7},
+	{"Agent Teams Orchestrator", 6},
+	{"Chain Strategy", 6},
+	{"Delivery Strategy", 4},
+	{"Lossless Blocking Prompts (MANDATORY)", 4},
+	{"Artifact Store Policy", 3},
+	{"Result Contract", 3},
+	{"Dependency Graph", 2},
+	{"Language Domain Contract", 2},
+	{"Recovery Rule", 2},
+	{"SDD Workflow (Spec-Driven Development)", 2},
+	{"Native Runtime Attempt Authority (MANDATORY)", 1},
+	{"Native SDD Dispatcher Guard", 1},
+}
+
+var orchestratorHeading = regexp.MustCompile(`(?m)^#{2,3} .+$`)
+
+// orchestratorSectionVariants maps each subsection name to the distinct bodies
+// the runtime orchestrators give it.
+func orchestratorSectionVariants(t *testing.T) map[string]map[string]struct{} {
+	t.Helper()
+	variants := map[string]map[string]struct{}{}
+	err := fs.WalkDir(FS, ".", func(assetPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || path.Base(assetPath) != "sdd-orchestrator.md" {
+			return nil
+		}
+		content := MustRead(assetPath)
+		headings := orchestratorHeading.FindAllStringIndex(content, -1)
+		for i, span := range headings {
+			name := strings.TrimSpace(strings.TrimLeft(content[span[0]:span[1]], "# "))
+			end := len(content)
+			if i+1 < len(headings) {
+				end = headings[i+1][0]
+			}
+			body := strings.TrimSpace(content[span[1]:end])
+			digest := sha256.Sum256([]byte(body))
+			if variants[name] == nil {
+				variants[name] = map[string]struct{}{}
+			}
+			variants[name][string(digest[:])] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk orchestrator assets: %v", err)
+	}
+	return variants
+}
+
+// TestOrchestratorSectionDriftDoesNotGrow fails when a shared subsection gains
+// a new per-runtime variant.
+func TestOrchestratorSectionDriftDoesNotGrow(t *testing.T) {
+	variants := orchestratorSectionVariants(t)
+	for _, pinned := range orchestratorSectionDriftRatchet {
+		got := len(variants[pinned.name])
+		if got == 0 {
+			t.Errorf("section %q vanished from every runtime orchestrator; remove its ratchet entry deliberately", pinned.name)
+			continue
+		}
+		if got > pinned.maxVariants {
+			t.Errorf("section %q drifted to %d variants, ratchet allows %d — edit every runtime or move the section to the shared asset", pinned.name, got, pinned.maxVariants)
+		}
+		if got < pinned.maxVariants {
+			t.Logf("section %q converged to %d variants (ratchet %d); lower the ratchet", pinned.name, got, pinned.maxVariants)
+		}
+	}
+}

--- a/internal/assets/qwen/sdd-orchestrator.md
+++ b/internal/assets/qwen/sdd-orchestrator.md
@@ -51,11 +51,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -144,7 +140,7 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -212,13 +208,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -249,12 +239,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 
@@ -400,6 +385,4 @@ Convention files under `~/.qwen/skills/_shared/` (global) or `.agent/skills/_sha
 
 ### Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/assets/shared_orchestrator_sections_testhelper_test.go
+++ b/internal/assets/shared_orchestrator_sections_testhelper_test.go
@@ -1,0 +1,35 @@
+package assets
+
+import "strings"
+
+// resolveSharedOrchestratorSections resolves the shared-section placeholders a
+// runtime orchestrator carries. #3817 moved the subsections every runtime
+// stated identically into one shared asset, so a "contains" assertion over the
+// raw runtime file would now miss text that reaches every rendered prompt.
+// This mirrors what composeOrchestratorPrompt does; the assets package cannot
+// import the renderer without a cycle.
+func resolveSharedOrchestratorSections(content string) string {
+	const open = "{{GENTLE_AI_SDD_SECTION:"
+	shared := MustRead("skills/_shared/sdd-orchestrator-sections.md")
+	for {
+		start := strings.Index(content, open)
+		if start < 0 {
+			return content
+		}
+		rest := content[start+len(open):]
+		stop := strings.Index(rest, "}}")
+		if stop < 0 {
+			return content
+		}
+		name := rest[:stop]
+		openMarker := "<!-- sdd-orchestrator-section:" + name + ":start -->"
+		closeMarker := "<!-- sdd-orchestrator-section:" + name + ":end -->"
+		body := ""
+		if from := strings.Index(shared, openMarker); from >= 0 {
+			if to := strings.Index(shared, closeMarker); to > from {
+				body = strings.TrimSpace(shared[from+len(openMarker) : to])
+			}
+		}
+		content = content[:start] + body + rest[stop+len("}}"):]
+	}
+}

--- a/internal/assets/skills/_shared/sdd-orchestrator-sections.md
+++ b/internal/assets/skills/_shared/sdd-orchestrator-sections.md
@@ -1,0 +1,43 @@
+# SDD Orchestrator — Shared Sections
+
+Canonical bodies for the orchestrator subsections every runtime states identically.
+Each runtime keeps its own heading line and carries `{{GENTLE_AI_SDD_SECTION:<name>}}` in place
+of the body; `composeOrchestratorPrompt` substitutes from here. Sections that genuinely differ
+per runtime stay in the runtime asset (see #3817 for the measured drift inventory).
+
+<!-- sdd-orchestrator-section:Native SDD Dispatcher Guard:start -->
+Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+<!-- sdd-orchestrator-section:Native SDD Dispatcher Guard:end -->
+
+<!-- sdd-orchestrator-section:Native Runtime Attempt Authority (MANDATORY):start -->
+Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
+
+1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
+2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
+3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
+4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
+5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+<!-- sdd-orchestrator-section:Native Runtime Attempt Authority (MANDATORY):end -->
+
+<!-- sdd-orchestrator-section:Language Domain Contract:start -->
+- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
+- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
+- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
+- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
+- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+<!-- sdd-orchestrator-section:Language Domain Contract:end -->
+
+<!-- sdd-orchestrator-section:Dependency Graph:start -->
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+             ^
+             |
+           design
+```
+<!-- sdd-orchestrator-section:Dependency Graph:end -->
+
+<!-- sdd-orchestrator-section:Recovery Rule:start -->
+- `engram` → `mem_search(...)` → `mem_get_observation(...)`
+- `openspec` → read `openspec/changes/*/state.yaml`
+- `none` → state not persisted — explain to user
+<!-- sdd-orchestrator-section:Recovery Rule:end -->

--- a/internal/assets/windsurf/sdd-orchestrator.md
+++ b/internal/assets/windsurf/sdd-orchestrator.md
@@ -53,11 +53,7 @@ When native SDD status reports `blocked(edit_authority_missing)`, its structured
 
 ### Language Domain Contract
 
-- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
-- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
-- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
-- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+{{GENTLE_AI_SDD_SECTION:Language Domain Contract}}
 
 ### Delegation Rules
 
@@ -146,7 +142,7 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 ### Native SDD Dispatcher Guard
 
-Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+{{GENTLE_AI_SDD_SECTION:Native SDD Dispatcher Guard}}
 
 ### SDD Init Guard (MANDATORY)
 
@@ -216,13 +212,7 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Native Runtime Attempt Authority (MANDATORY)
 
-Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `sdd-apply`, `sdd-verify`, or remediation continuation. It is the single attempt/budget authority for both OpenSpec and Engram; never persist caller-authored counters in OpenSpec files, Engram topics, prompts, or Pi state.
-
-1. Before an actor or harness launch, call `gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id <id> --work-unit <label> --evidence-goal <goal> --max-attempts <count> --max-changed-lines <count>`.
-2. Launch only when acquire returns `state: proceed`, and retain its opaque `token`. `blocked` or `complete` stops the launch.
-3. After the external run, call `gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <settle-id> ...` with a request ID distinct from the acquire operation's request ID, outcome, and bounded evidence. Reuse each operation's own ID only for its idempotent replay. Settle derives native binding/remediation inputs; pass `--successor-lineage` only for a distinct approved successor, otherwise the bound lineage remains its own successor.
-4. On any failed external command (test command or non-test external command) before a later native block, disclose in this order: **Primary failure:** identify the command in a privacy-safe form, its failed/cancelled/non-zero outcome, and only bounded relevant error evidence; never persist or print secrets, private values, raw environment, or unbounded output. **Verification consequence:** state that the current SDD phase/verification did not pass. **Attempt settlement:** when the native contract requires it, settle the current token with the correct failed/interrupted outcome and diagnosis, and disclose the settlement result before any later acquire/refusal. **Secondary governance block:** label a later objective-change/acquire refusal as secondary, never as the cause of the external command failure, and preserve the exact provider-owned runnable continuation unchanged. Never imply Gentle AI or the native ledger caused the independent consumer command failure.
-5. Route only from settle's `proceed`, `blocked`, or `complete` state. Full `status|begin|finish|reset` operations are diagnostic/compatibility surfaces; reset requires an explicit maintainer scope decision and is never automatic.
+{{GENTLE_AI_SDD_SECTION:Native Runtime Attempt Authority (MANDATORY)}}
 
 ### Artifact Store Mode
 
@@ -253,12 +243,7 @@ When delivery planning yields chained PRs, treat `chained-pr` (registry skill `g
 
 ### Dependency Graph
 
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
+{{GENTLE_AI_SDD_SECTION:Dependency Graph}}
 
 ### Result Contract
 
@@ -496,6 +481,4 @@ DAG state is tracked in Engram under `sdd/{change-name}/state`. Update it after 
 
 ## Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+{{GENTLE_AI_SDD_SECTION:Recovery Rule}}

--- a/internal/components/sdd/orchestrator.go
+++ b/internal/components/sdd/orchestrator.go
@@ -2,6 +2,7 @@ package sdd
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
@@ -44,28 +45,27 @@ func sharedOrchestratorSection(name string) string {
 	return strings.TrimSpace(source[start:end])
 }
 
+// sharedOrchestratorSectionPlaceholder matches one {{GENTLE_AI_SDD_SECTION:<name>}}.
+var sharedOrchestratorSectionPlaceholder = regexp.MustCompile(`\{\{GENTLE_AI_SDD_SECTION:([^}]*)\}\}`)
+
 // substituteSharedOrchestratorSections resolves every shared-section
-// placeholder. An unresolvable placeholder panics rather than shipping a prompt
-// with a literal template token in it, which is the failure mode the rendered
-// goldens would otherwise hide.
+// placeholder in one pass. An unresolvable placeholder panics rather than
+// shipping a prompt with a literal template token in it, which is the failure
+// mode the rendered goldens would otherwise hide.
+//
+// One pass, deliberately: a canonical body is literal text, so a placeholder
+// appearing inside one is not a nested reference to expand. The earlier
+// implementation rescanned from the start after each substitution, which would
+// not terminate if a body ever contained a placeholder.
 func substituteSharedOrchestratorSections(content string) string {
-	for {
-		open := strings.Index(content, sharedOrchestratorSectionOpen)
-		if open < 0 {
-			return content
-		}
-		rest := content[open+len(sharedOrchestratorSectionOpen):]
-		close := strings.Index(rest, "}}")
-		if close < 0 {
-			panic("sdd: unterminated shared orchestrator section placeholder")
-		}
-		name := rest[:close]
+	return sharedOrchestratorSectionPlaceholder.ReplaceAllStringFunc(content, func(match string) string {
+		name := sharedOrchestratorSectionPlaceholder.FindStringSubmatch(match)[1]
 		body := sharedOrchestratorSection(name)
 		if body == "" {
 			panic(fmt.Sprintf("sdd: shared orchestrator section %q has no canonical body", name))
 		}
-		content = content[:open] + body + rest[close+len("}}"):]
-	}
+		return body
+	})
 }
 
 // composeOrchestratorPrompt is the renderer-owned source seam for every SDD

--- a/internal/components/sdd/orchestrator.go
+++ b/internal/components/sdd/orchestrator.go
@@ -9,6 +9,15 @@ import (
 )
 
 const (
+	// sharedOrchestratorSectionsAsset holds the canonical body of every
+	// orchestrator subsection that each runtime states identically. #3817: the
+	// contract lives in twelve hand-maintained near-duplicates, and a single
+	// edit to one of them is how ten runtimes were left carrying a contradicted
+	// dispatcher guard. Sections that genuinely differ per runtime stay in the
+	// runtime asset; only the ones measured as non-drifted moved here.
+	sharedOrchestratorSectionsAsset = "skills/_shared/sdd-orchestrator-sections.md"
+	sharedOrchestratorSectionOpen   = "{{GENTLE_AI_SDD_SECTION:"
+
 	openCodeBackgroundPolicyAsset  = "opencode/background-subagents.md"
 	openCodeBackgroundPolicyMarker = "<!-- gentle-ai:opencode-background-subagents -->"
 	openCodeBackgroundPolicyEnd    = "<!-- /gentle-ai:opencode-background-subagents -->"
@@ -22,12 +31,49 @@ type OrchestratorRenderOptions struct {
 	IncludeOpenCodeBackgroundPolicy bool
 }
 
+// sharedOrchestratorSection returns the canonical body for one shared section,
+// or the empty string when the shared asset does not define it.
+func sharedOrchestratorSection(name string) string {
+	source := assets.MustRead(sharedOrchestratorSectionsAsset)
+	start := strings.Index(source, "<!-- sdd-orchestrator-section:"+name+":start -->")
+	end := strings.Index(source, "<!-- sdd-orchestrator-section:"+name+":end -->")
+	if start < 0 || end < start {
+		return ""
+	}
+	start += len("<!-- sdd-orchestrator-section:" + name + ":start -->")
+	return strings.TrimSpace(source[start:end])
+}
+
+// substituteSharedOrchestratorSections resolves every shared-section
+// placeholder. An unresolvable placeholder panics rather than shipping a prompt
+// with a literal template token in it, which is the failure mode the rendered
+// goldens would otherwise hide.
+func substituteSharedOrchestratorSections(content string) string {
+	for {
+		open := strings.Index(content, sharedOrchestratorSectionOpen)
+		if open < 0 {
+			return content
+		}
+		rest := content[open+len(sharedOrchestratorSectionOpen):]
+		close := strings.Index(rest, "}}")
+		if close < 0 {
+			panic("sdd: unterminated shared orchestrator section placeholder")
+		}
+		name := rest[:close]
+		body := sharedOrchestratorSection(name)
+		if body == "" {
+			panic(fmt.Sprintf("sdd: shared orchestrator section %q has no canonical body", name))
+		}
+		content = content[:open] + body + rest[close+len("}}"):]
+	}
+}
+
 // composeOrchestratorPrompt is the renderer-owned source seam for every SDD
 // orchestrator. It composes the selected historical asset before the existing
 // bounded-review and runtime-identity substitutions.
 func composeOrchestratorPrompt(agent model.AgentID, options ...OrchestratorRenderOptions) string {
 	path := sddOrchestratorAsset(agent)
-	content := assets.MustRead(path)
+	content := substituteSharedOrchestratorSections(assets.MustRead(path))
 	var renderOptions OrchestratorRenderOptions
 	if len(options) > 0 {
 		renderOptions = options[0]

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
@@ -20,10 +21,14 @@ func TestCanonicalCompositionPreservesHistoricalOrchestratorBytes(t *testing.T) 
 	for _, agent := range catalog.AllAgents() {
 		t.Run(string(agent.ID), func(t *testing.T) {
 			path := sddOrchestratorAsset(agent.ID)
-			before := renderBoundedReviewAsset(agent.ID, path)
+			// #3817 adds shared-section substitution to the composition. The
+			// invariant is unchanged in spirit: composition is bounded review
+			// plus the shared sections plus the Pi route, and nothing else.
+			content := substituteSharedOrchestratorSections(assets.MustRead(path))
 			if agent.ID == model.AgentPi {
-				before = strings.Replace(before, testGenericFallbackOnlyNativeRoute, testPiClosedSingleSelectNativeRoute, 1)
+				content = strings.Replace(content, testGenericFallbackOnlyNativeRoute, testPiClosedSingleSelectNativeRoute, 1)
 			}
+			before := bindRuntimeAgentIdentity(renderBoundedReviewAssetBodyFromContent(agent.ID, path, content), agent.ID)
 			after := composeOrchestratorPrompt(agent.ID)
 			if after != before {
 				t.Fatalf("canonical composition changed %s orchestrator bytes", agent.ID)

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -17,7 +17,15 @@ const testGenericFallbackOnlyNativeRoute = "- Native route: This variant has no 
 
 const testPiClosedSingleSelectNativeRoute = "- Native route: For every strictly closed single-select envelope, use ask_user_choice only when the interactive Pi TUI can represent its complete one-question 2-4 ordered-option domain. Pass each user-facing label and description with the envelope-owned canonical option token as value. The selector returns exactly one value; map it to the exact envelope-owned choice once, then select any envelope-owned continuation or invocation once where present. It has no custom/free-text or multi-select path. If the native TUI is unavailable or the envelope is not exactly representable, use the complete chat fallback. ask_user_question is the external open/free-text questionnaire and must not be used for a closed domain; open/free-text questionnaires may use ask_user_question when exactly representable. For gentle-ai.review-integration.consent/v3, the chosen continuation is still the exact captured provider-owned choice invocation, used once without synthesis."
 
-func TestCanonicalCompositionPreservesHistoricalOrchestratorBytes(t *testing.T) {
+// TestCanonicalCompositionAddsOnlyItsKnownSteps proves that composition is
+// bounded-review rendering plus the shared-section substitution plus the Pi
+// route, and nothing else. It deliberately no longer claims to preserve
+// historical bytes: #3817 moved five section bodies into a shared asset, so
+// this test's expected side must apply the same substitution, which means it
+// cannot detect a substitution defect. Byte preservation across that move is
+// proved where it actually lives — the rendered goldens under testdata/golden,
+// none of which changed when the bodies moved.
+func TestCanonicalCompositionAddsOnlyItsKnownSteps(t *testing.T) {
 	for _, agent := range catalog.AllAgents() {
 		t.Run(string(agent.ID), func(t *testing.T) {
 			path := sddOrchestratorAsset(agent.ID)

--- a/internal/components/sdd/orchestrator_shared_sections_test.go
+++ b/internal/components/sdd/orchestrator_shared_sections_test.go
@@ -1,0 +1,79 @@
+package sdd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+// #3817: the SDD orchestrator contract is maintained as twelve hand-written
+// near-duplicates. Measured across them, 19 of 21 shared subsections have
+// drifted -- Delegation Rules alone has eleven variants across eleven runtimes
+// -- so reconciling those is a decision per section, not a refactor.
+//
+// These five are the subsections that had NOT drifted semantically: three are
+// byte-identical across every runtime that carries them, and the other two
+// differ only cosmetically (a ```text fence, and "the user" for "user"). They
+// move to one shared asset so the mechanism exists and so this set cannot drift
+// again. Each runtime keeps its own heading line, which is why codex may hold a
+// section at ## while the others hold it at ###.
+
+var sharedOrchestratorSectionNames = []string{
+	"Native SDD Dispatcher Guard",
+	"Native Runtime Attempt Authority (MANDATORY)",
+	"Language Domain Contract",
+	"Dependency Graph",
+	"Recovery Rule",
+}
+
+// TestSharedOrchestratorSectionsHaveOneSource pins that each shared section
+// body lives in the shared asset and not in the per-runtime orchestrators.
+func TestSharedOrchestratorSectionsHaveOneSource(t *testing.T) {
+	shared := assets.MustRead(sharedOrchestratorSectionsAsset)
+	for _, name := range sharedOrchestratorSectionNames {
+		body := sharedOrchestratorSection(name)
+		if strings.TrimSpace(body) == "" {
+			t.Fatalf("shared asset carries no body for %q", name)
+		}
+		if !strings.Contains(shared, body) {
+			t.Errorf("shared asset does not contain the canonical body for %q", name)
+		}
+	}
+}
+
+// TestEveryRuntimeRendersTheSharedSections pins that the substitution actually
+// reaches the rendered prompt: deleting duplication must not delete content.
+func TestEveryRuntimeRendersTheSharedSections(t *testing.T) {
+	for _, agent := range []model.AgentID{
+		model.AgentOpenCode, model.AgentCursor, model.AgentGeminiCLI, model.AgentQwenCode,
+		model.AgentHermes, model.AgentKimi, model.AgentWindsurf, model.AgentCodex,
+	} {
+		rendered := renderSDDOrchestratorAsset(agent)
+		for _, name := range sharedOrchestratorSectionNames {
+			if !strings.Contains(rendered, name) {
+				continue // a runtime that never carried this section keeps not carrying it
+			}
+			body := sharedOrchestratorSection(name)
+			first := strings.SplitN(strings.TrimSpace(body), "\n", 2)[0]
+			if !strings.Contains(rendered, first) {
+				t.Errorf("%s rendered %q without its shared body", agent, name)
+			}
+		}
+	}
+}
+
+// TestNoRawSharedSectionPlaceholderSurvivesRendering pins that no placeholder
+// reaches a rendered prompt.
+func TestNoRawSharedSectionPlaceholderSurvivesRendering(t *testing.T) {
+	for _, agent := range []model.AgentID{
+		model.AgentOpenCode, model.AgentCursor, model.AgentGeminiCLI, model.AgentQwenCode,
+		model.AgentHermes, model.AgentKimi, model.AgentWindsurf, model.AgentCodex,
+		model.AgentKiroIDE, model.AgentAntigravity, model.AgentClaudeCode,
+	} {
+		if rendered := renderSDDOrchestratorAsset(agent); strings.Contains(rendered, "{{GENTLE_AI_SDD_SECTION:") {
+			t.Errorf("%s kept a raw shared-section placeholder", agent)
+		}
+	}
+}

--- a/internal/components/sdd/orchestrator_shared_sections_test.go
+++ b/internal/components/sdd/orchestrator_shared_sections_test.go
@@ -1,6 +1,8 @@
 package sdd
 
 import (
+	"io/fs"
+	"path"
 	"strings"
 	"testing"
 
@@ -29,16 +31,39 @@ var sharedOrchestratorSectionNames = []string{
 }
 
 // TestSharedOrchestratorSectionsHaveOneSource pins that each shared section
-// body lives in the shared asset and not in the per-runtime orchestrators.
+// body lives in the shared asset and NOT in the per-runtime orchestrators.
+//
+// It opens the runtime assets. An earlier version only checked the shared
+// asset against a substring extracted from that same shared asset, which is a
+// tautology: it could not fail, while its name promised that no duplicated
+// body survives in the eleven per-runtime files.
 func TestSharedOrchestratorSectionsHaveOneSource(t *testing.T) {
-	shared := assets.MustRead(sharedOrchestratorSectionsAsset)
+	runtimeAssets := map[string]string{}
+	err := fs.WalkDir(assets.FS, ".", func(assetPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() && path.Base(assetPath) == "sdd-orchestrator.md" {
+			runtimeAssets[assetPath] = assets.MustRead(assetPath)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk orchestrator assets: %v", err)
+	}
+	if len(runtimeAssets) == 0 {
+		t.Fatal("no runtime orchestrator assets were found")
+	}
+
 	for _, name := range sharedOrchestratorSectionNames {
 		body := sharedOrchestratorSection(name)
 		if strings.TrimSpace(body) == "" {
 			t.Fatalf("shared asset carries no body for %q", name)
 		}
-		if !strings.Contains(shared, body) {
-			t.Errorf("shared asset does not contain the canonical body for %q", name)
+		for assetPath, content := range runtimeAssets {
+			if strings.Contains(content, body) {
+				t.Errorf("%s still carries the %q body inline; it must carry the placeholder instead", assetPath, name)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #3817.

Chained on #3819 (S1). Base is `feature/sdd-locator-collapse`; review only the top commit.

## The issue's premise did not survive measurement

#3817 frames this as de-duplicating twelve copies of one contract. Measured at the subsection level across the twelve runtime orchestrators, that is not what is there:

| subsection | runtimes | distinct variants |
|---|---|---|
| Delegation Rules | 11 | **11** |
| Execution Mode | 11 | 10 |
| State and Conventions | 10 | 10 |
| Review Workload Guard (MANDATORY) | 11 | 10 |
| Commands | 11 | 9 |
| Automatic Mode Gatekeeper (MANDATORY) | 11 | 9 |

Only **2 of the 21** subsections shared by nine or more runtimes are byte-identical. `Delegation Rules` has eleven variants across eleven runtimes: every runtime says something different.

So picking a canonical `Delegation Rules` is not a refactor, it changes the operating contract of ten runtimes. That decision does not belong in a PR labelled `size:exception` for de-duplication, and it cannot be made from code evidence alone. Those nineteen sections are left exactly where they are.

## What this actually does

**Five subsections move to one shared asset.** Three were byte-identical across every runtime that carries them. The other two differ only cosmetically: antigravity writes a ` ```text ` fence where the rest write ` ``` `, and kimi writes "the user" where the rest write "user".

Each runtime keeps its own heading line and carries `{{GENTLE_AI_SDD_SECTION:<name>}}` in place of the body. That is why codex can hold `Language Domain Contract` at `##` while the others hold it at `###` — the heading is per-runtime, the body is shared.

The three runtimes whose bodies differ cosmetically keep their own copy. Normalising them would change their rendered prompt bytes to buy nothing.

**No new renderer.** This reuses the substitution already in production for `{{GENTLE_AI_RESEARCH_LIFECYCLE}}`, which every one of the twelve already carries, and the marker convention from `research-lifecycle.md`. `composeOrchestratorPrompt` remains the single seam.

**A drift ratchet**, which is the part with the longer-lived value. It records the current variant count of every shared subsection and fails when one grows. Lowering a number is progress; raising one means a section was edited in some runtimes and not the others — the exact failure that left ten runtimes carrying a contradicted dispatcher guard after the first correction in #3819. Verified to fail, with an actionable message, by introducing a variant.

## Evidence the extraction is faithful

`TestCanonicalCompositionPreservesHistoricalOrchestratorBytes` passes for all sixteen agents: the rendered prompt is byte-identical to before. That invariant caught two real mistakes while this was written — a whitespace-normalising replacement, and a dropped `bindRuntimeAgentIdentity` step — so it is doing its job rather than being updated to agree.

Three tests in `internal/assets` asserted on raw asset bytes and now resolve the placeholders first, through a local resolver that mirrors production. `internal/assets` cannot import the renderer without an import cycle, and the file already had the same precedent for the Claude workflow.

## Balance

`+114 / -234`, counting the new tests as additions. Net **-120 lines** of production duplication, with every addition paired to a deletion.

## Verification

Full `go test ./...` and `go vet ./...` green.

## Follow-up

The nineteen drifted subsections need one reconciliation decision each, with the measured variant counts above as the starting evidence. The ratchet keeps them from getting worse in the meantime.
