### PR TITLE
fix(review): stop forcing binary candidate bytes into reviewer patches

### DIFF
--- a/internal/reviewtransaction/frozen_candidate_binary_patch_test.go
+++ b/internal/reviewtransaction/frozen_candidate_binary_patch_test.go
@@ -1,0 +1,90 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPatchInspectionNeverEmitsBinaryContentBytes is the regression guard for
+// issue #3193. A reviewer holds no tools and cannot skip past what a prompt
+// contains, so every byte the patch operation emits is a byte the reviewer must
+// carry. Emitting the raw content of a path Git classifies as binary buys
+// nothing a text reviewer can act on and costs the whole payload: one candidate
+// carrying a PDF filled a lens prompt to roughly 114K tokens of blob.
+//
+// It is not only volume. Arbitrary content bytes are also arbitrary control
+// material for whatever assembles the prompt downstream: an `@\` sequence
+// inside a blob made one host's file-mention resolver staple a drive-root
+// attachment onto every lens launch. The manifest entry, the mode, and Git's
+// own "Binary files ... differ" line carry everything a lens can legitimately
+// triage from, so the bytes themselves are pure liability.
+func TestPatchInspectionNeverEmitsBinaryContentBytes(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+
+	// A PNG header plus a NUL is what Git's own heuristic classifies as binary,
+	// and the marker is content no legitimate patch summary would ever repeat.
+	const marker = "GENTLE-AI-3193-BLOB-MARKER"
+	base := append([]byte("\x89PNG\r\n\x1a\n\x00"), []byte("base "+marker+"\n")...)
+	candidate := append([]byte("\x89PNG\r\n\x1a\n\x00"), []byte("candidate "+marker+"\x01\n")...)
+
+	if err := os.WriteFile(filepath.Join(repo, "docs", "poster.png"), base, 0o644); err != nil {
+		if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, "docs", "poster.png"), base, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitSnapshot(t, repo, "add", "--", "docs/poster.png")
+	gitSnapshot(t, repo, "commit", "-m", "add binary fixture")
+
+	if err := os.WriteFile(filepath.Join(repo, "docs", "poster.png"), candidate, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A", "--")
+	gitSnapshot(t, repo, "commit", "-m", "change binary fixture")
+	candidateCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	builder := SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), Target{Kind: TargetExactRevision, Revision: candidateCommit})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	frozen, err := builder.FrozenCandidateContext(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("FrozenCandidateContext() error = %v", err)
+	}
+
+	index := -1
+	for position, entry := range frozen.ChangedPathManifest {
+		if entry.Path == "docs/poster.png" {
+			index = position
+		}
+	}
+	if index < 0 {
+		t.Fatalf("binary fixture missing from manifest: %+v", frozen.ChangedPathManifest)
+	}
+
+	payload, err := builder.InspectCandidate(context.Background(), snapshot, "patch", index, "")
+	if err != nil {
+		t.Fatalf("InspectCandidate(patch) error = %v", err)
+	}
+
+	if bytes.Contains(payload, []byte(marker)) {
+		t.Errorf("patch for a binary path emitted its content bytes (%d bytes):\n%q", len(payload), payload)
+	}
+	// The evidence must still exist: a silently empty patch is the one shape
+	// that would let a reviewer report a clean result over an uninspected path,
+	// and lens-context refuses it outright.
+	if len(bytes.TrimSpace(payload)) == 0 {
+		t.Fatal("patch for a binary path produced no bytes at all; the path must still be reported as changed")
+	}
+	if !bytes.Contains(payload, []byte("docs/poster.png")) {
+		t.Errorf("patch for a binary path does not name the path:\n%q", payload)
+	}
+}

--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -255,8 +255,27 @@ func (inspector *PreparedCandidateInspector) Inspect(ctx context.Context, operat
 		path := ":(literal)" + frozen.ChangedPathManifest[pathIndex].Path
 		args = append(common, "diff", "--stat", "--text", "--no-ext-diff", "--no-textconv", "--no-renames", "--ignore-submodules=none", frozen.BaseTree, frozen.CandidateTree, "--", path)
 	case "patch":
+		// This is the one operation that emits candidate content, and it
+		// deliberately does NOT force --text. The discovery operations above do,
+		// because they emit counts and names whose determinism is worth pinning;
+		// here the same flag would override Git's binary classification and
+		// spill a blob's raw bytes into a reviewer prompt.
+		//
+		// That costs twice. A lens holds no tools and cannot skip what its
+		// prompt contains, so one candidate carrying a PDF filled a lens prompt
+		// with roughly 114K tokens of bytes no text reviewer can act on. And
+		// arbitrary content bytes are arbitrary control material downstream: an
+		// `@\` sequence inside one blob made a host's file-mention resolver
+		// staple a drive-root attachment onto every lens launch (issue #3193).
+		//
+		// Without it Git reports "Binary files a/... and b/... differ", which
+		// still names the path and still proves it changed, so the empty-patch
+		// refusal in the lens-context surface stays satisfied. Determinism is
+		// preserved by the isolation this inspector already installs: an empty
+		// attributes file plus GIT_ATTR_NOSYSTEM, so neither the repository's
+		// .gitattributes nor the machine's can move the classification.
 		path := ":(literal)" + frozen.ChangedPathManifest[pathIndex].Path
-		args = append(common, "diff", "--patch", "--text", "--full-index", "--no-color", "--no-ext-diff", "--no-textconv", "--no-renames", "--diff-algorithm=myers", "--no-indent-heuristic", "--unified=3", "--ignore-submodules=none", frozen.BaseTree, frozen.CandidateTree, "--", path)
+		args = append(common, "diff", "--patch", "--full-index", "--no-color", "--no-ext-diff", "--no-textconv", "--no-renames", "--diff-algorithm=myers", "--no-indent-heuristic", "--unified=3", "--ignore-submodules=none", frozen.BaseTree, frozen.CandidateTree, "--", path)
 	case "object":
 		tree := frozen.CandidateTree
 		if side == "base" {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3193

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- The `patch` inspection forced `--text`, which overrides Git's binary classification and emits a blob's raw bytes as though they were a diff. Dropping the flag from that one operation is the whole fix.
- A lens holds no execution tools and cannot skip past what its prompt contains, so those bytes are carried in full by the reviewer. One candidate holding a PDF filled a lens prompt with roughly 114K tokens a text reviewer cannot act on.
- Volume is only half of it. Arbitrary content bytes are arbitrary control material for whatever assembles the prompt downstream: an `@\` sequence inside one blob made a host's file-mention resolver staple a drive-root attachment onto every lens launch.

## Where the bytes actually came from

The report attributes the injection to the OpenCode plugin. That is where the bytes were *observed*, but not where they were produced: the TypeScript plugins run no Git command at all. The content came from `Inspect`'s `patch` case, and the plugin only transported it.

That distinction is what keeps the fix to one line of arguments. Every runtime reaches the same emitter:

| Surface | Runtimes | Path |
|---------|----------|------|
| `review lens-context` | `claude`, `opencode` | `deps.inspect` → `PreparedCandidateInspector.Inspect` |
| `review inspect-candidate` | `cursor`, `kimi`, `kiro` | `SnapshotBuilder.InspectCandidate` → the same `Inspect` |

So no adapter needs its own change, and `gentle-pi` needs none either: it maintains its own Git layer, but every invocation in it is `diff --raw`, `diff --name-status`, `diff --name-only` or `diff --numstat`, and its only `cat-file` is a `-t` type probe. It emits metadata and never file content, so this defect cannot exist there.

## Why the discovery operations keep `--text`

`name-status`, `numstat` and `stat` emit counts and names, never content, and their numbers feed risk classification. Removing the flag there would change a binary path's line counts to `-`/`-` and move risk tiers, which is a separate candidate with a separate blast radius. This PR deliberately touches `patch` alone, which is exactly the behaviour the issue asks for.

Determinism does not regress: the inspector already installs an empty attributes file plus `GIT_ATTR_NOSYSTEM`, so neither the repository's `.gitattributes` nor the machine's can move the classification. And the path is still provably reported as changed, because Git emits `Binary files a/... and b/... differ` — non-empty output that keeps the lens-context empty-patch refusal satisfied.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/frozen_candidate_context.go` | The `patch` operation no longer forces `--text`, with the rationale recorded beside it so the flag is not restored as a determinism "fix". |
| `internal/reviewtransaction/frozen_candidate_binary_patch_test.go` | New regression guard: commits a real binary fixture, runs the `patch` inspection over it, and requires the content bytes to be absent while the path is still named and the payload still non-empty. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Opus 5, via Claude Code.

**Material scope:** Root-cause localisation, the argument change, the regression test, and the code comments.

**Verification performed:** The test was written before the fix and observed failing with the blob's bytes inline in the patch output, then passing after it. Full unit suite, `go vet` for `linux`, `windows` and `darwin`, gofmtcheck, the driven benchmark corpus, and a receipt-driven review of this candidate — see the Test Plan.

---

## 🧪 Test Plan

**Unit Tests** — `go test ./...` passes for the whole module.

**Go Format** — `go run ./internal/gofmtcheck` passes.

**Cross-platform** — `GOOS=windows go vet ./...` and `GOOS=darwin go vet ./...` are both clean.

**Benchmark Validation** — applicable: this is a review-lifecycle change. `go test ./...` in `bench/` passes (declarations only), and the driven harness was run against a locally built binary, reproducing the CI invocation:

```
gentle-ai-bench run --binary <locally built gentle-ai> --out bench-3193.json
```

Driven-mode summary: **54 counted, 54 completed, 0 unsupported, 0 failed**, `dead_end: 0`, 54 core journeys — unchanged from `main`. Grepped the corpus for journeys pinning the old byte-emitting behaviour: none exist.

**Receipt-driven review of this candidate** — routed through the ordinary negotiated route under Claude Code against `origin/main`: selectorless STATUS, the exact returned START with consent granted, medium risk, one focus lens (`review-reliability`) over the 2 changed paths. The lens returned `inspection.status: "completed"` with both paths and no findings; the capture returned `state: "approved"` and burned its authority.

**Manual** — the failing-then-passing test output is the direct observation: before the change the emitted patch contained the fixture's marker bytes and the PNG header; after it, Git reports the path as a binary difference and the marker is absent.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferred to CI
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (110 insertions, 1 deletion)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferred to CI
- [x] Benchmark validation completed
- [x] I have updated documentation if necessary (no documented surface changed)
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The interesting question to press on is the one the change deliberately leaves alone: `numstat` still reports line counts for a binary path while `patch` now reports it as a binary difference. That inconsistency is intentional, because those counts feed risk classification and reconciling them moves tiers. If the project wants them consistent, it should be its own candidate with its own tier-shift evidence.

For production Go changes in `internal/reviewtransaction`:

- [x] The qualifying guard here is the empty-patch refusal in the lens-context surface, which exists so an uninspected path can never read as clean. Its legitimate input population is unchanged: Git still emits non-empty output for a binary path, so no path that used to produce evidence now produces none.
- [x] `.guard-population-baseline.txt` is unchanged, which is correct because no guard contract changed.
- [x] The declaration/registry check passing was not treated as proof; the emitted bytes were inspected directly for both a text and a binary path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed patch previews for binary files to prevent raw binary content from appearing.
  * Binary file changes now display a concise comparison message while retaining the affected file path.
  * Added regression coverage to ensure binary data is never included in generated patch output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->