### PR TITLE
fix(review): preserve Pi host relay runtime binding

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -146,7 +146,10 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		return nil
 	}
 	providerRuntime := model.AgentID(strings.TrimSpace(*runtimeAgent))
-	providerExecution := providerRuntime != ""
+	providerRuntimeSupplied := providerRuntime != ""
+	rawInputSupplied := strings.TrimSpace(*input) != ""
+	providerExecution := providerRuntimeSupplied && !rawInputSupplied
+	hostRelaySubmission := providerRuntimeSupplied && rawInputSupplied
 	if *materialize {
 		if *preflight || strings.TrimSpace(*input) != "" {
 			return reviewPreflightError(errors.New("review capture-result --materialize only prints the Go-materialized provider task and cannot be combined with --input or --preflight")) // refusal:by-design world-action: materialization is read-only and never authors or admits reviewer output
@@ -156,11 +159,11 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		}
 	}
 	if flags.NArg() != 0 || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*target) == "" ||
-		strings.TrimSpace(*lens) == "" || *order < 0 || (!*preflight && strings.TrimSpace(*input) == "" && !providerExecution) {
+		strings.TrimSpace(*lens) == "" || *order < 0 || (!*preflight && !rawInputSupplied && !providerExecution) {
 		return reviewPreflightError(errors.New("review capture-result requires an exact repository context, --lineage, --target, --lens, --order, and either --input or --agent (or --preflight); `gentle-ai review status --contract gentle-ai.review-integration/v1 --next-transition` prints the exact bindings and `gentle-ai review schema reviewer` emits the result schema with a working example"))
 	}
-	if providerExecution && (strings.TrimSpace(*input) != "" || *preflight) {
-		return reviewPreflightError(errors.New("review capture-result --agent requires no --input and cannot be combined with --preflight")) // refusal:by-design world-action: provider invocation and caller input cannot both author reviewer output
+	if providerRuntimeSupplied && *preflight {
+		return reviewPreflightError(errors.New("review capture-result --agent cannot be combined with --preflight")) // refusal:by-design world-action: a provider runtime identity belongs only to a real materialize, capture, or host-relay submission
 	}
 	contextHandle := strings.TrimSpace(*repositoryContext)
 	if contextHandle != "" && reviewFlagWasProvided(flags, "cwd") {
@@ -169,9 +172,9 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	if contextHandle != "" && strings.TrimSpace(*revision) == "" {
 		return reviewPreflightError(errors.New("review capture-result with --repository-context requires --expected-revision"))
 	}
-	if providerExecution {
+	if providerRuntimeSupplied {
 		if contextHandle == "" {
-			return reviewPreflightError(errors.New("review capture-result --agent requires the provider-issued --repository-context")) // refusal:by-design operator-knowledge: provider invocation must use negotiated opaque context
+			return reviewPreflightError(errors.New("review capture-result --agent requires the provider-issued --repository-context")) // refusal:by-design operator-knowledge: provider invocation and host-relay submission must use negotiated opaque context
 		}
 		if _, err := reviewRuntimeWithImmutableTransport(string(providerRuntime)); err != nil {
 			return reviewPreflightError(err)
@@ -189,6 +192,10 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 			}
 			if !reviewProviderHostRelayMaterializeRuntime(providerRuntime) {
 				return reviewPreflightError(fmt.Errorf("review capture-result --materialize is unavailable for %q: printing the Go-materialized provider task is the host-relay form, and this runtime's compiled transport is %q; collect its reviewer result through that live host transport instead", providerRuntime, providerTransport)) // refusal:by-design world-action: only the Pi host relay collects a printed provider task
+			}
+		} else if hostRelaySubmission {
+			if !reviewProviderHostRelayMaterializeRuntime(providerRuntime) {
+				return reviewPreflightError(fmt.Errorf("review capture-result --agent %q with --input is unavailable: only a compiled host-relay runtime may submit its raw reviewer result with the provider-owned runtime binding; this runtime's compiled transport is %q", providerRuntime, providerTransport)) // refusal:by-design world-action: caller input cannot impersonate an in-process provider runtime
 			}
 		} else if !reviewProviderCaptureRuntime(providerRuntime) {
 			if reviewProviderHostRelayMaterializeRuntime(providerRuntime) {
@@ -339,7 +346,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		}
 		return reviewPreflightError(err)
 	}
-	if providerExecution {
+	if providerExecution || hostRelaySubmission {
 		if err := reviewtransaction.PublishLensContextEmission(store.Dir, reviewtransaction.LensContextEmission{
 			Schema: reviewtransaction.LensContextEmissionSchema, LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity,
 			AuthorityRevision: record.Revision, Lens: *lens, SelectedOrder: *order, SubjectHash: captured.Subject.SubjectHash,

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -135,7 +135,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	order := flags.Int("order", -1, "zero-based selected lens order")
 	revision := flags.String("expected-revision", "", "exact reviewing authority revision")
 	subjectHash := flags.String("subject-hash", "", "provider-issued artifact subject hash for native-Git context")
-	runtimeAgent := flags.String("agent", "", "compiled reviewer runtime that invokes the provider-owned request; mutually exclusive with --input and --preflight")
+	runtimeAgent := flags.String("agent", "", "compiled reviewer runtime that invokes the provider-owned request; may be combined with --input only for compiled host-relay submissions and remains mutually exclusive with --preflight")
 	input := flags.String("input", "", "raw reviewer result JSON file or - for stdin; `gentle-ai review schema reviewer` emits the schema and a working example")
 	preflight := flags.Bool("preflight", false, "validate the capture binding and, when --input is supplied, the result admission without persisting anything")
 	materialize := flags.Bool("materialize", false, "print the exact Go-materialized opaque provider task for a host-relay --agent runtime without capturing anything; mutually exclusive with --input and --preflight")

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -482,14 +482,21 @@ func reviewCaptureInput(binding ReviewTransitionBinding, lens string, order int,
 			// The Pi host relay learns the whole flow from this one input: the
 			// materialize arguments are only the prelude that prints the
 			// Go-issued opaque prompt bytes for its fresh locked-down reviewer
-			// subprocess, and the submission descriptor -- the same binding
-			// tokens with the raw result substituted into --input -- is what
-			// actually advances reviewing authority.
-			tokens := make([]string, 0, len(input.Arguments)+1)
-			for _, argument := range input.Arguments {
+			// subprocess, and the submission descriptor -- the same binding and
+			// runtime tokens with the raw result substituted into --input -- is
+			// what actually advances reviewing authority. Keeping the runtime in
+			// the provider-owned submission lets a terminal closure issue its exact
+			// runtime-bound STATUS continuation without host reconstruction.
+			// Snapshot only the binding arguments; runtime and materialize are appended after the submission is complete.
+			bindingArguments := input.Arguments
+			tokens := make([]string, 0, len(bindingArguments)+2)
+			for _, argument := range bindingArguments {
 				tokens = append(tokens, reviewTransitionArgumentToken(argument))
 			}
-			tokens = append(tokens, "--input="+reviewSubmissionValuePlaceholder)
+			tokens = append(tokens,
+				reviewTransitionArgumentToken(ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])}),
+				"--input="+reviewSubmissionValuePlaceholder,
+			)
 			input.Submission = &ReviewTransitionSubmission{
 				OperationToken: "capture-result", ArgumentTokens: tokens,
 				Value: &ReviewTransitionSubmissionValue{

--- a/internal/cli/review_provider_materialize_test.go
+++ b/internal/cli/review_provider_materialize_test.go
@@ -90,7 +90,7 @@ func TestReviewCaptureResultMaterializedPiTaskSubmitsThroughExistingInputPath(t 
 		t.Fatal(err)
 	}
 	var output bytes.Buffer
-	if err := RunReviewCaptureResult(append(slices.Clone(binding), "--input", input), &output); err != nil {
+	if err := RunReviewCaptureResult(append(slices.Clone(binding), "--agent", string(model.AgentPi), "--input", input), &output); err != nil {
 		t.Fatal(err)
 	}
 	var terminal reviewLastEventClosureResult
@@ -148,6 +148,11 @@ func TestReviewCaptureResultMaterializeRefusals(t *testing.T) {
 			want: "cannot be combined with --input or --preflight",
 		},
 		{
+			name: "compiled runtime cannot label caller input", env: reviewPiHostRelayContract,
+			argv: append(slices.Clone(fakeBinding), "--agent", string(model.AgentClaudeCode), "--input", "-"),
+			want: "only a compiled host-relay runtime may submit its raw reviewer result",
+		},
+		{
 			name: "without agent", env: reviewPiHostRelayContract,
 			argv: append(slices.Clone(fakeBinding), "--materialize=true"),
 			want: "requires --agent",
@@ -201,9 +206,9 @@ func TestNegotiatedStatusRendersPiHostRelayMaterializeCaptureInput(t *testing.T)
 	if tokens["agent"] != "--agent="+string(model.AgentPi) || tokens["materialize"] != "--materialize=true" {
 		t.Fatalf("pi host relay capture arguments = %#v", input.Arguments)
 	}
-	wantTokens := make([]string, 0, len(input.Arguments)-1)
+	wantTokens := make([]string, 0, len(input.Arguments))
 	for _, argument := range input.Arguments {
-		if argument.Name != "agent" && argument.Name != "materialize" {
+		if argument.Name != "materialize" {
 			wantTokens = append(wantTokens, argument.Token)
 		}
 	}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -1026,7 +1026,7 @@ func (transition ReviewNextTransition) Validate() error {
 					argumentCount += 2
 					expected := make([]string, 0, len(input.Arguments)-1)
 					for _, argument := range input.Arguments {
-						if argument.Name != "agent" && argument.Name != "materialize" {
+						if argument.Name != "materialize" {
 							expected = append(expected, reviewTransitionArgumentToken(argument))
 						}
 					}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2411

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Preserve the provider-owned `--agent=pi` binding when Pi materializes a host-relay review capture.
- Admit `--agent` with existing `--input` only for compiled host-relay runtimes; in-process runtimes still fail closed.
- Keep preflight validation aligned with the exact submission command by excluding only the materialization-only flag.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_artifact.go` | Validates host-relay agent/input submissions without weakening in-process input ownership. |
| `internal/cli/review_next_transition.go` | Preserves the Pi runtime binding in provider-owned materialization arguments. |
| `internal/cli/review_status_contract.go` | Documents the host-relay runtime identity carried by the binding. |
| `internal/cli/review_provider_materialize_test.go` | Covers successful Pi submission plus fail-closed runtime and argument cases. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model:** Pi coding agent with `openai-codex/gpt-5.6-sol`

**Material scope:** Root-cause investigation, implementation, tests, cross-repository integration analysis, and review evidence collection.

**Verification performed:** Focused RED/GREEN tests, full Go suite, exact CI benchmark harness, runtime integration against Gentle Pi, formatting, and diff integrity checks.

---

## 🧪 Test Plan

**Unit and format checks**

- [x] `go test ./... -count=1` — 75 packages; 71 passed, 4 without tests.
- [x] `test -z "$(gofmt -d ...)"`
- [x] `git diff --check`
- [ ] `cd e2e && ./docker-test.sh` — not run locally; required CI will execute it.

**Cross-repository integration**

- [x] Gentle Pi dev-binary suite with both binary overrides — 7 passed, 0 failed, 0 skipped.

**Benchmark validation**

- [x] Benchmark module build, vet, and tests passed.
- [x] CI-equivalent driven portable run — 54 completed, 0 unsupported, 0 failed.
- [x] Provider capture run — 1 completed, 0 unsupported, 0 failed.
- [x] Transition axis — 65 completed, 0 unsupported, 0 failed; all 11 transition journeys completed.
- [x] Model-picker untagged/tagged expectations and all exact CI `jq` gates passed.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #2411 with `status:approved`.
- [x] PR stays within 400 changed lines.
- [x] Exactly one `type:*` label is applied.
- [x] Unit tests and Go formatting pass.
- [ ] Docker E2E passes locally; deferred to required CI.
- [x] Benchmark validation completed.
- [x] Documentation is unchanged because the external contract is unchanged.
- [x] Commit follows Conventional Commits.
- [x] I understand, reviewed, and take responsibility for the complete submission.
- [x] Material AI assistance is disclosed.
- [x] Commit has no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

Review `review_next_transition.go` first: it now keeps the runtime identity attached to the exact provider-owned binding. Then review `review_artifact.go`, where the input-mode guard permits that shape only for compiled host-relay runtimes.

- [x] The qualifying admission guard was challenged against the real Pi host-relay command and an in-process negative case.
- [x] The adjacent `guard:population` claim matches the accepted runtime population.
- [x] `.guard-population-baseline.txt` is intentionally unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for submitting captured review results through compiled host-relay runtimes while specifying the runtime agent.
  - Provider context is now published consistently for direct provider execution and host-relay submissions.
  - Host-relay submissions retain agent information for improved status and execution tracking.

- **Bug Fixes**
  - Prevented compiled runtimes from incorrectly labeling ordinary caller input.
  - Preserved validation for incompatible preflight and agent options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->