### PR TITLE
fix(review): make two lifecycle refusals report what actually happened

### DIFF
--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -223,5 +224,51 @@ func TestCaptureRefusalEmitFailurePreservesNativeRefusal(t *testing.T) {
 	}
 	if !strings.HasPrefix(err.Error(), typed.Error()) {
 		t.Fatalf("refusal is not the primary error: %q", err.Error())
+	}
+}
+
+// TestOverBudgetCorrectionPlanRefusalIsClassifiedAsNotStarted pins the envelope
+// an over-budget pre-edit forecast earns. The flag exists so an operator can
+// declare a size BEFORE editing, and the refusal is a pure precondition on
+// caller input: BeginCorrection returns before it records a proposal or
+// advances the capture phase, and the command returns before its store.Replace,
+// so nothing is written. Reporting that as operation_outcome_unknown with
+// retry_safe:false tells the operator the store may have moved when it provably
+// did not, and it routes them to recovery instead of to a smaller forecast.
+func TestOverBudgetCorrectionPlanRefusalIsClassifiedAsNotStarted(t *testing.T) {
+	repo, started, store, record, request := correctionRequiredForPlanCapture(t)
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	err = RunReview([]string{
+		"capture-correction-plan", "--cwd", repo, "--lineage", started.LineageID,
+		"--target", request.TargetIdentity, "--expected-revision", record.State.CapturePhaseRevision,
+		"--request-hash", request.RequestHash, "--correction-lines", strconv.Itoa(request.CorrectionBudget + 1),
+	}, &output)
+
+	// Only an outcome that stays unknown after classification earns a defect
+	// report. An operator who forecast too many lines has not found a product
+	// defect, and should not be told to file one.
+	reports, _ := filepath.Glob(filepath.Join(filepath.Dir(reviewCLIAuthorityRoot(t, repo)), reviewDefectReportDirName, "*"))
+	if len(reports) != 0 {
+		t.Fatalf("over-budget forecast wrote %d defect report(s) for ordinary caller input", len(reports))
+	}
+
+	failure := decodeCaptureRefusalEnvelope(t, err, output.Bytes())
+	if failure.Code == "operation_outcome_unknown" {
+		t.Fatalf("over-budget forecast reported an unknown outcome for a refusal that never started: %#v", failure)
+	}
+	if failure.Phase != "preflight" || failure.MutationOutcome != ReviewMutationNotStarted || !failure.RetrySafe {
+		t.Fatalf("over-budget forecast envelope = %#v, want a retry-safe preflight refusal that never started", failure)
+	}
+	if !strings.Contains(failure.Cause, "exceeding the remaining budget") {
+		t.Fatalf("over-budget forecast envelope hides its cause: %#v", failure)
+	}
+	after, err := store.Load()
+	if err != nil || after.Revision != before.Revision || after.State.ProposedCorrectionLines != nil {
+		t.Fatalf("over-budget forecast mutated authority: %#v, %v", after, err)
 	}
 }

--- a/internal/cli/review_correction_plan_capture.go
+++ b/internal/cli/review_correction_plan_capture.go
@@ -83,7 +83,13 @@ func RunReviewCaptureCorrectionPlan(args []string, stdout io.Writer) error {
 	}
 	state := record.State
 	if err := state.BeginCorrection(*correctionLines); err != nil {
-		return err
+		// The forecast is pre-edit caller input, and BeginCorrection refuses it
+		// before recording a proposal or advancing the capture phase, so the
+		// store is provably untouched here. Falling through untyped would earn
+		// the generic operation_outcome_unknown envelope: a false claim that the
+		// outcome is unknown, which sends the operator to recovery instead of to
+		// a smaller forecast.
+		return reviewPreflightError(err)
 	}
 	nextRevision, err := store.Replace(record.Revision, "review/begin-fix", state)
 	if err != nil {

--- a/internal/cli/review_correction_plan_capture.go
+++ b/internal/cli/review_correction_plan_capture.go
@@ -89,6 +89,15 @@ func RunReviewCaptureCorrectionPlan(args []string, stdout io.Writer) error {
 		// the generic operation_outcome_unknown envelope: a false claim that the
 		// outcome is unknown, which sends the operator to recovery instead of to
 		// a smaller forecast.
+		//
+		// The budget overrun is the only refusal that reaches this line. Every
+		// other BeginCorrection precondition is already excluded above: a
+		// non-positive forecast by the flag check, a wrong state, revision or
+		// target by the binding check, and a proposal already recorded by the
+		// revision it advanced. The typing is still written for the branch
+		// rather than for the one error, because all of them describe the same
+		// fact -- the command returns before store.Replace, so none of them
+		// started.
 		return reviewPreflightError(err)
 	}
 	nextRevision, err := store.Replace(record.Revision, "review/begin-fix", state)

--- a/internal/reviewtransaction/compact_burn.go
+++ b/internal/reviewtransaction/compact_burn.go
@@ -162,7 +162,12 @@ func AcknowledgeApprovedCompactAuthority(ctx context.Context, repo, lineageID, t
 	store := CompactStore{Dir: filepath.Join(base, "v2", lineageID), lineageID: lineageID}
 	record, err := store.loadCompactRecordLocked()
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		// Narrow on the fact, not on the error class: the absent-authority
+		// refusal is only honest when this lineage's state file is the thing
+		// that is missing. An ErrNotExist raised anywhere else inside the load
+		// keeps its wrapped cause rather than being reported as an already
+		// acknowledged lineage.
+		if _, statErr := os.Lstat(store.StatePath()); errors.Is(err, fs.ErrNotExist) && errors.Is(statErr, fs.ErrNotExist) {
 			return ErrApprovedAcknowledgementAuthorityAbsent
 		}
 		return fmt.Errorf("load compact authority: %w", err)

--- a/internal/reviewtransaction/compact_burn.go
+++ b/internal/reviewtransaction/compact_burn.go
@@ -117,6 +117,14 @@ func CommitApprovedCompactAcknowledgement(ctx context.Context, store CompactStor
 	}, nil
 }
 
+// ErrApprovedAcknowledgementAuthorityAbsent reports that the acknowledgement
+// names no live authority in this repository. The ordinary way to reach it is a
+// replay: the caller's own earlier acknowledgement already burned the lineage it
+// names. It is deliberately path-free, like every other refusal on this surface,
+// because a caller learns nothing useful from the store layout and a relayed
+// error should not carry it.
+var ErrApprovedAcknowledgementAuthorityAbsent = errors.New("approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it") // refusal:by-design operator-knowledge: an acknowledged lineage is terminal, so start a new review instead of replaying its acknowledgement
+
 // AcknowledgeApprovedCompactAuthority verifies one exact pending acknowledgement
 // and burns the authority while the existing maintenance and version locks remain
 // held. It never writes an acknowledged state, so a failure leaves the pending
@@ -154,6 +162,9 @@ func AcknowledgeApprovedCompactAuthority(ctx context.Context, repo, lineageID, t
 	store := CompactStore{Dir: filepath.Join(base, "v2", lineageID), lineageID: lineageID}
 	record, err := store.loadCompactRecordLocked()
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ErrApprovedAcknowledgementAuthorityAbsent
+		}
 		return fmt.Errorf("load compact authority: %w", err)
 	}
 	if record.Revision != expectedRevision {

--- a/internal/reviewtransaction/compact_burn_test.go
+++ b/internal/reviewtransaction/compact_burn_test.go
@@ -207,3 +207,40 @@ func TestApprovedCompactAcknowledgementTokenDoesNotLeakOutsideAuthorityOrReturnV
 		t.Fatalf("raw acknowledgement token persisted outside compact authority: %v", tokenPaths)
 	}
 }
+
+// TestAcknowledgeApprovedCompactAuthorityReplayRefusesWithoutLeakingAPath pins
+// the refusal shape every other check on this surface already uses. A replayed
+// acknowledgement is an ordinary, expected outcome: the authority it names was
+// burned by the caller's own previous call. Surfacing the raw *os.PathError
+// from the missing state file both leaks the repository layout to whoever reads
+// the error and describes the condition as a filesystem problem rather than as
+// the already-burned authority it is.
+func TestAcknowledgeApprovedCompactAuthorityReplayRefusesWithoutLeakingAPath(t *testing.T) {
+	const lineage = "pending-acknowledgement-replay-refusal"
+	repo, base, store, acknowledgement := approvedCompactAcknowledgementFixture(t, lineage)
+
+	if err := AcknowledgeApprovedCompactAuthority(context.Background(), repo, lineage,
+		acknowledgement.TargetIdentity, acknowledgement.ExpectedRevision, acknowledgement.Token); err != nil {
+		t.Fatalf("first acknowledgement: %v", err)
+	}
+	if _, err := os.Stat(store.Dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("acknowledgement left authority behind: %v", err)
+	}
+
+	err := AcknowledgeApprovedCompactAuthority(context.Background(), repo, lineage,
+		acknowledgement.TargetIdentity, acknowledgement.ExpectedRevision, acknowledgement.Token)
+	if err == nil {
+		t.Fatal("replayed acknowledgement succeeded against burned authority")
+	}
+	for _, secret := range []string{repo, base, store.Dir, store.StatePath()} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("replayed acknowledgement refusal leaked %q: %v", secret, err)
+		}
+	}
+	if strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("replayed acknowledgement refusal surfaced a raw filesystem error: %v", err)
+	}
+	if !errors.Is(err, ErrApprovedAcknowledgementAuthorityAbsent) {
+		t.Fatalf("replayed acknowledgement refusal = %v, want the typed absent-authority refusal", err)
+	}
+}


### PR DESCRIPTION
Closes #3852.

## PR Type

- [x] Bug fix

## Summary

- An over-budget pre-edit correction forecast no longer reports an unknown outcome for a refusal that provably never wrote anything, and no longer auto-files a defect report for ordinary caller input.
- A replayed acknowledgement now earns the same typed, path-free refusal as every other check on that surface, instead of surfacing the raw `*os.PathError` from the missing state file.

Both are pre-existing on `main` and were found by driving the review lifecycle against a locally built binary.

## Changes

| File | Change |
|------|--------|
| `internal/cli/review_correction_plan_capture.go` | The budget refusal from `BeginCorrection` is typed as a preflight refusal, so it keeps its cause and reports `not_started` / `retry_safe: true` instead of falling through to `operation_outcome_unknown` |
| `internal/reviewtransaction/compact_burn.go` | New `ErrApprovedAcknowledgementAuthorityAbsent`; a missing authority on the acknowledgement path returns it rather than wrapping the filesystem error |
| `internal/cli/review_capture_refusal_envelope_test.go` | Pins the forecast envelope and that no defect report is written |
| `internal/reviewtransaction/compact_burn_test.go` | Pins the replay refusal as typed and free of the repository, store and state paths |

## Why the forecast refusal was wrong, precisely

`CompactState.BeginCorrection` returns the budget error before it records a proposal or advances the capture phase, and `RunReviewCaptureCorrectionPlan` returns before its `store.Replace`. Nothing is written. Reporting `mutation_outcome: unknown` with `retry_safe: false` claims the opposite, and routes an operator to recovery when the correct next step is a smaller forecast.

The codebase already treats this as a known failure mode: `newReviewIntegrationFailure` carries a comment saying that falling through to the generic default "would report MutationOutcome: unknown — a false safety claim for an operation that provably never started". This refusal is the same case and now gets the same treatment.

**Note on the linked issue:** its first draft claimed the over-budget forecast also consumes the bounded correction attempt. It does not, and the issue has been corrected. In the session that produced the report the edits had already been applied before the forecast was declared, so the following STATUS rebuilt an over-budget correction from the repository and routed to recovery on that evidence, which is correct behaviour. Only the refusal metadata is defective.

## Advisory review

The candidate was driven through the review lifecycle with a binary built from this branch: medium risk, one `review-reliability` lens, **approved with no blocking findings**, acknowledged and burned. It raised two non-blocking warnings, both about typing a branch from a single case, and both are addressed in the second commit:

- `errors.Is(fs.ErrNotExist)` alone asserted an error class where the code only knows a fact. It now also requires that this lineage's state file is the missing thing, so an `ErrNotExist` raised elsewhere in the load keeps its wrapped cause.
- The correction-plan typing covers a branch whose only reachable refusal is the budget overrun. That reachability is now written down where the typing happens.

A third suggestion asked for coverage of the other `BeginCorrection` preconditions. Writing those tests showed they pass without the fix, because the flag and binding checks exclude them before that line: the test was vacuous, so it was removed and replaced with the reachability note above.

## Test Plan

- [x] Both tests verified failing without their fix: the forecast test on the `operation_outcome_unknown` classification and on `wrote 1 defect report`, the replay test on the leaked path
- [x] `go test ./...` — pass
- [x] `go vet ./...` on `linux`, `windows` and `darwin`, plus the `bench` module — clean
- [x] `gofmt -l` clean in both modules
- [x] `bench`: `go build`, `go vet ./...`, `go test ./...` — pass
- [x] Driven corpus against a locally built binary: portable `55` counted / `0` failed / `0` unsupported / `0` dead_end; `--axis transition` `66` counted / `0` failed
- [x] Candidate reviewed through its own lifecycle (START, capture, acknowledgement, burn) and approved

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correction-plan capture refusals are now clearly identified as safe to retry.
  * Original failure details are preserved without starting a review mutation or generating a defect report.
  * Repeated acknowledgement of an already-processed review lineage now returns a clear, dedicated refusal.
  * Replay errors no longer expose internal filesystem paths or low-level system messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->