### PR TITLE
fix(review): admit a reviewer citation that names a candidate file by basename

### DIFF
--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -396,7 +396,17 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 				findingAdmissionDiagnostic("invalid_finding_location", finding.ID, finding.Location, reason), locationErr)
 		}
 		if stringIndex(wantPaths, location.Path) < 0 {
-			return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
+			// The same citation shape reaches a finding's own location, and
+			// resolving it in evidence and proofs but not here would refuse the
+			// exact artifact the rest of this admission just accepted.
+			resolved, unique, resolveErr := resolveBasename(location.Path)
+			if resolveErr != nil {
+				return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup failed")
+			}
+			if !unique || stringIndex(wantPaths, resolved) < 0 {
+				return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
+			}
+			location.Path = resolved
 		}
 		for _, proof := range finding.ProofRefs {
 			outside, offender, lookupErr := referenceOutsideRepository(proof, repository.contains, resolveBasename)

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -406,7 +406,10 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 			if !unique || stringIndex(wantPaths, resolved) < 0 {
 				return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
 			}
-			location.Path = resolved
+			// The citation is left as the reviewer wrote it. Normalizing it here
+			// would rewrite the reviewer's own text for no consumer: nothing
+			// downstream reads this location, and an unobserved rewrite is a
+			// claim no test can hold.
 		}
 		for _, proof := range finding.ProofRefs {
 			outside, offender, lookupErr := referenceOutsideRepository(proof, repository.contains, resolveBasename)

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -363,13 +363,14 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 		return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup is unavailable")
 	}
 	defer cleanup()
+	resolveBasename := candidateBasenameResolver(request.FrozenContext.ChangedPathManifest)
 	seenFindingIDs := make(map[string]struct{}, len(canonical.Findings))
 	wantCandidateCausalIDs := make([]string, 0)
 	for _, evidence := range canonical.Evidence {
 		if evidenceReportsUnavailableInspection(evidence) {
 			return fail(ArtifactAdmissionIncomplete, "reviewer evidence reports that candidate inspection was unavailable")
 		}
-		outside, offender, lookupErr := referenceOutsideRepository(evidence, repository.contains)
+		outside, offender, lookupErr := referenceOutsideRepository(evidence, repository.contains, resolveBasename)
 		if lookupErr != nil {
 			return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup failed")
 		}
@@ -398,7 +399,7 @@ func AdmitArtifact(ctx context.Context, request ArtifactAdmissionRequest) (LensR
 			return fail(ArtifactAdmissionOutOfScope, "reviewer finding location is outside the frozen candidate")
 		}
 		for _, proof := range finding.ProofRefs {
-			outside, offender, lookupErr := referenceOutsideRepository(proof, repository.contains)
+			outside, offender, lookupErr := referenceOutsideRepository(proof, repository.contains, resolveBasename)
 			if lookupErr != nil {
 				return fail(ArtifactAdmissionBindingMismatch, "frozen repository path lookup failed")
 			}
@@ -516,12 +517,53 @@ type artifactReferenceToken struct {
 	quoted bool
 }
 
+// frozenRepositoryPathListingLimit bounds the one full path listing the
+// basename index needs. The frozen trees are a reviewed candidate, not an
+// arbitrary repository, and an unbounded listing here would be a way to make
+// admission allocate on a caller's schedule.
 type frozenRepositoryPathLookup struct {
 	ctx       context.Context
 	repo      string
 	isolation []string
 	trees     []string
 	cache     map[string]bool
+}
+
+// candidateBasenameResolver answers the one citation shape a Go-owned reviewer
+// produces that a literal lookup cannot satisfy (#3042): a file of the
+// candidate named by its basename rather than its repository-relative path. The
+// path IS in the frozen candidate, so refusing it as outside is both wrong and
+// unrecoverable -- the reviewer is locked down, so no caller can correct the
+// citation and every retry reproduces it.
+//
+// It resolves against the frozen changed-path manifest rather than the tree:
+// that is the exact set the reviewer was shown, it is bounded by construction,
+// and it costs no Git call on a path that is deliberately bounded.
+//
+// Exactly one match resolves. Two or more do not, because choosing between them
+// would attach a finding to a file the reviewer never read, which is worse than
+// the refusal. A citation that already carries a directory prefix said where it
+// meant, so it is not eligible: being wrong about that is not ambiguity.
+func candidateBasenameResolver(manifest []ChangedPathManifestEntry) func(string) (string, bool, error) {
+	index := make(map[string]string, len(manifest))
+	for _, entry := range manifest {
+		base := entry.Path[strings.LastIndex(entry.Path, "/")+1:]
+		if base == "" || base == entry.Path {
+			continue
+		}
+		if existing, seen := index[base]; seen && existing != entry.Path {
+			index[base] = ""
+			continue
+		}
+		index[base] = entry.Path
+	}
+	return func(name string) (string, bool, error) {
+		if name == "" || strings.ContainsRune(name, '/') {
+			return "", false, nil
+		}
+		resolved := index[name]
+		return resolved, resolved != "", nil
+	}
 }
 
 func newFrozenRepositoryPathLookup(ctx context.Context, frozen FrozenCandidateContext) (*frozenRepositoryPathLookup, func(), error) {
@@ -585,7 +627,7 @@ func (lookup *frozenRepositoryPathLookup) contains(logicalPath string) (bool, er
 // The offender return names the first malformed or unknown token verbatim so
 // a rejection is diagnosable after the fact; detection semantics are
 // unchanged.
-func referenceOutsideRepository(value string, lookup func(string) (bool, error)) (outside bool, offender string, err error) {
+func referenceOutsideRepository(value string, lookup func(string) (bool, error), resolveBasename func(string) (string, bool, error)) (outside bool, offender string, err error) {
 	for _, token := range artifactReferenceTokens(value) {
 		path, malformed := artifactRepositoryPathReference(token)
 		if malformed {
@@ -595,6 +637,22 @@ func referenceOutsideRepository(value string, lookup func(string) (bool, error))
 			continue
 		}
 		known, err := lookup(path)
+		if err != nil {
+			return false, "", err
+		}
+		if known {
+			continue
+		}
+		// A literal miss is not yet proof the citation left the candidate: it
+		// may be a bare basename that exactly one candidate path answers.
+		resolved, unique, err := resolveBasename(path)
+		if err != nil {
+			return false, "", err
+		}
+		if !unique {
+			return true, token.value, nil
+		}
+		known, err = lookup(resolved)
 		if err != nil {
 			return false, "", err
 		}

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -518,7 +518,10 @@ func TestReferenceOutsideRepositoryRecognizesOnlyCanonicalRepositoryPaths(t *tes
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := referenceOutsideRepository(tt.value, lookup)
+			// No basename resolution in this unit: it pins the literal token
+			// grammar on its own, so a citation that misses stays outside.
+			noBasename := func(string) (string, bool, error) { return "", false, nil }
+			got, _, err := referenceOutsideRepository(tt.value, lookup, noBasename)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -527,4 +530,78 @@ func TestReferenceOutsideRepositoryRecognizesOnlyCanonicalRepositoryPaths(t *tes
 			}
 		})
 	}
+}
+
+// TestAdmitArtifactResolvesUnambiguousBasenameCitations covers the citation
+// shape a real reviewer produces (#3042): it names a file of the candidate by
+// its basename instead of its repository-relative path. The path IS in the
+// frozen candidate, so refusing it as "outside the frozen repository" is both
+// wrong and unrecoverable -- the reviewer is Go-owned, so no caller can correct
+// the citation, and every retry reproduces it.
+//
+// Ambiguity is the line: one candidate path may answer a basename, two may not,
+// because guessing which file a reviewer meant is how a finding gets attached
+// to code it never read.
+func TestAdmitArtifactResolvesUnambiguousBasenameCitations(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "internal/a.go", "package internal\n\nconst value = 1\n")
+	writeSnapshotFile(t, repo, "internal/deep/dup.go", "package deep\n")
+	writeSnapshotFile(t, repo, "other/dup.go", "package other\n")
+	gitSnapshot(t, repo, "add", "-A", "--")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	// Both dup.go files change too, so the ambiguity is real inside the frozen
+	// manifest rather than an accident of one of them being unchanged.
+	writeSnapshotFile(t, repo, "internal/a.go", "package internal\n\nconst value = 2\n")
+	writeSnapshotFile(t, repo, "internal/deep/dup.go", "package deep\n\nconst v = 1\n")
+	writeSnapshotFile(t, repo, "other/dup.go", "package other\n\nconst v = 1\n")
+	gitSnapshot(t, repo, "add", "-A", "--")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(t.Context(), Target{Kind: TargetExactRevision, Revision: strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frozen, err := (SnapshotBuilder{Repo: repo}).FrozenCandidateContext(t.Context(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := CompactState{LineageID: "review-basename-citation", SelectedLenses: []string{LensReliability}, InitialSnapshot: snapshot}
+	subject, err := NewArtifactSubject(state, "sha256:"+strings.Repeat("3", 64), frozen, LensReliability, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newRequest := func(evidence string) ArtifactAdmissionRequest {
+		return ArtifactAdmissionRequest{
+			ExpectedSubject:   subject,
+			FrozenContext:     frozen,
+			EchoedSubjectHash: subject.SubjectHash,
+			Inspection:        ArtifactInspection{Status: ArtifactInspectionCompleted, Paths: []string{"internal/a.go", "internal/deep/dup.go", "other/dup.go"}},
+			Result: LensResult{
+				Lens:     LensReliability,
+				Findings: []Finding{},
+				Evidence: []string{evidence},
+			},
+			RawPayload:       []byte("review complete\n{\"subject_hash\":\"" + subject.SubjectHash + "\"}"),
+			CanonicalPayload: []byte("{\"findings\":[],\"evidence\":[\"inspection\"]}\n"),
+		}
+	}
+
+	t.Run("unambiguous basename is the candidate path it names", func(t *testing.T) {
+		_, admission, err := AdmitArtifact(t.Context(), newRequest("inspection: a.go:3"))
+		if err != nil || admission.Decision != ArtifactAdmissionCompleted {
+			t.Fatalf("basename citation admission = %q, %v; want completed", admission.Decision, err)
+		}
+	})
+	t.Run("ambiguous basename stays out of scope", func(t *testing.T) {
+		_, admission, err := AdmitArtifact(t.Context(), newRequest("inspection: dup.go:1"))
+		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {
+			t.Fatalf("ambiguous basename admission = %q, %v; want out of scope", admission.Decision, err)
+		}
+	})
+	t.Run("unknown basename stays out of scope", func(t *testing.T) {
+		_, admission, err := AdmitArtifact(t.Context(), newRequest("inspection: nowhere.go:1"))
+		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {
+			t.Fatalf("unknown basename admission = %q, %v; want out of scope", admission.Decision, err)
+		}
+	})
 }

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -598,6 +598,47 @@ func TestAdmitArtifactResolvesUnambiguousBasenameCitations(t *testing.T) {
 			t.Fatalf("ambiguous basename admission = %q, %v; want out of scope", admission.Decision, err)
 		}
 	})
+	t.Run("a finding location resolves the same way its evidence does", func(t *testing.T) {
+		request := newRequest("inspection: internal/a.go:3")
+		request.Result.Findings = []Finding{{
+			ID: "R3-001", Lens: "reliability", Location: "a.go:3", Severity: "WARNING",
+			Claim: "the candidate loses the retry error", ProofRefs: []string{"diff: a.go:3"},
+		}}
+		_, admission, err := AdmitArtifact(t.Context(), request)
+		if err != nil || admission.Decision != ArtifactAdmissionCompleted {
+			t.Fatalf("basename finding location admission = %q, %v; want completed", admission.Decision, err)
+		}
+	})
+	t.Run("an ambiguous finding location stays out of scope", func(t *testing.T) {
+		request := newRequest("inspection: internal/a.go:3")
+		request.Result.Findings = []Finding{{
+			ID: "R3-001", Lens: "reliability", Location: "dup.go:1", Severity: "WARNING",
+			Claim: "ambiguous", ProofRefs: []string{"diff: internal/a.go:3"},
+		}}
+		_, admission, err := AdmitArtifact(t.Context(), request)
+		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {
+			t.Fatalf("ambiguous finding location admission = %q, %v; want out of scope", admission.Decision, err)
+		}
+	})
+	t.Run("a proof reference resolves the same way evidence does", func(t *testing.T) {
+		request := newRequest("inspection: internal/a.go:3")
+		request.Result.Findings = []Finding{{
+			ID: "R3-001", Lens: "reliability", Location: "internal/a.go:3", Severity: "WARNING",
+			Claim: "the candidate loses the retry error", ProofRefs: []string{"diff: a.go:3"},
+		}}
+		_, admission, err := AdmitArtifact(t.Context(), request)
+		if err != nil || admission.Decision != ArtifactAdmissionCompleted {
+			t.Fatalf("basename proof admission = %q, %v; want completed", admission.Decision, err)
+		}
+	})
+	t.Run("a citation carrying a directory prefix is not a basename", func(t *testing.T) {
+		// It said where it meant. Being wrong about that is not ambiguity to
+		// resolve, so it stays refused even though its last segment is unique.
+		_, admission, err := AdmitArtifact(t.Context(), newRequest("inspection: wrong/a.go:3"))
+		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {
+			t.Fatalf("prefixed citation admission = %q, %v; want out of scope", admission.Decision, err)
+		}
+	})
 	t.Run("unknown basename stays out of scope", func(t *testing.T) {
 		_, admission, err := AdmitArtifact(t.Context(), newRequest("inspection: nowhere.go:1"))
 		if err == nil || admission.Decision != ArtifactAdmissionOutOfScope {


### PR DESCRIPTION
Closes #3042.

## PR Type

- [x] Bug fix

## Summary

- A reviewer citation that names a file of the candidate by its basename is now resolved to that file, instead of being refused as a path outside the frozen repository.
- The resolution is unambiguous or nothing: one candidate path may answer a basename, two may not.

## The defect

A Go-owned reviewer cites files by basename rather than by repository-relative path. Admission looked the citation up literally, found no such path, and refused the artifact. The path was inside the candidate: in the reported occurrence the cited file was entry 7 of the frozen changed-path manifest.

The refusal was unrecoverable, which is what made it worth fixing rather than tolerating:

1. The reviewer is locked down, so no caller can correct the citation.
2. The refusal carries `retry_safe: true` and exact-lineage STATUS reoffers the same bound slot, so the contract's recovery rule says to relaunch.
3. Every relaunch is a full reviewer run that reproduces it. Three consecutive attempts on the reported occurrence.

The original report could not converge on a cause because the 2.3.0 refusal emitted no diagnostic. The diagnostic added since names the offending token, which is what identified the shape.

## Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/artifact_admission.go` | `candidateBasenameResolver` resolves a bare basename against the frozen changed-path manifest; evidence, proof references and finding locations all use it |
| `internal/reviewtransaction/artifact_admission_test.go` | Seven subtests: the resolved case for evidence, proofs and locations, plus ambiguous, prefixed and unknown citations |

## Decisions worth reviewing

**Ambiguity refuses.** Choosing between two candidate paths that share a basename would attach a finding to a file the reviewer never read, which is worse than the refusal.

**A prefixed citation is not a basename.** It said where it meant; being wrong about that is not ambiguity to resolve.

**Resolution runs against the changed-path manifest, not the tree.** That is the exact set the reviewer was shown and it is bounded by construction. An earlier attempt listed the tree and broke the large-repository bounded-admission guard, which is what pointed at the manifest. A `git ls-tree` pathspec query was also tried and does not work: `ls-tree` rejects `:(glob)` magic and its wildcard matching is prefix-based.

**`retry_safe: true` is left alone.** The issue also asks for that classification to change. With this fix the deterministic case is gone: what remains is a citation genuinely outside the candidate or genuinely ambiguous, and re-running the lens is a real exit there because the reviewer is a model that can cite differently. Changing the classification would be altering behaviour this change has not shown to be wrong.

## Adversarial review of this branch

Driven through the review lifecycle with a binary built from this branch. The first pass approved with advisories; acting on two of them (a finding location that took the literal check alone, and untested proof/prefix paths) produced a second pass that **blocked**:

> the candidate rewrites the parsed finding location to the resolved manifest path, but no added test observes that rewrite [...] deleting the assignment would leave every added subtest passing

Correct, and unfixable by adding a test: nothing downstream reads that location, so no test can observe the rewrite. The assignment was removed rather than asserted. Rewriting a reviewer's own text for no consumer is a claim no test can hold.

After that bounded correction the review ran targeted validation and approved, and the authority was acknowledged and burned.

## Test Plan

- [x] The location subtest verified failing without its fix
- [x] `go test ./...` — pass
- [x] `go vet ./...` on `linux`, `windows` and `darwin` — clean
- [x] `gofmt -l` clean; `bench` builds, vets and tests clean
- [x] Driven corpus: `55` counted, `0` failed, `0` dead_end
- [x] Candidate reviewed through its own lifecycle: blocked, corrected, validated, approved, acknowledged, burned

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifact references can now use a file’s basename when it uniquely identifies a changed file.
  * Evidence, finding locations, and proof references support unambiguous basename citations.

* **Bug Fixes**
  * Ambiguous, prefixed, or unknown file references continue to be rejected as out of scope.
  * Improved handling of valid file citations during artifact review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->