### PR TITLE
fix(review): let a correction survive an untracked artifact

### DIFF
--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -270,5 +271,67 @@ func TestOverBudgetCorrectionPlanRefusalIsClassifiedAsNotStarted(t *testing.T) {
 	after, err := store.Load()
 	if err != nil || after.Revision != before.Revision || after.State.ProposedCorrectionLines != nil {
 		t.Fatalf("over-budget forecast mutated authority: %#v, %v", after, err)
+	}
+}
+
+// TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent covers the way a
+// correction actually happens: the operator edits, and the tools they run while
+// editing leave files behind. A test artifact, a build output, a coverage
+// profile -- any untracked file appearing during the correction switched STATUS
+// to the untracked-selection transition, which legitimately carries no
+// validation request while the status still carried one, and the consistency
+// check read that as two copies disagreeing.
+//
+// The result was a lineage with no way forward: the exact-lineage STATUS the
+// contract names as the only re-entry refused, and its read-only envelope is
+// content-free by design, so the refusal advertised "retry" and named nothing.
+func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
+	repo, started, _, record, request := correctionRequiredForPlanCapture(t)
+	if err := RunReview([]string{
+		"capture-correction-plan", "--cwd", repo, "--lineage", started.LineageID,
+		"--target", request.TargetIdentity, "--expected-revision", record.State.CapturePhaseRevision,
+		"--request-hash", request.RequestHash, "--correction-lines", "2",
+	}, io.Discard); err != nil {
+		t.Fatalf("capture correction plan: %v", err)
+	}
+	// Correct the candidate the way an operator would, then confirm the review
+	// is waiting on validation: that is the state whose validation request the
+	// untracked file has to survive.
+	corrected := "package auth\n\n// CheckToken reports whether a session token is present.\nfunc CheckToken(token string) bool {\n\treturn len(token) > 0\n}\n"
+	if err := os.WriteFile(filepath.Join(repo, "internal", "auth", "session.go"), []byte(corrected), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var beforeArtifact bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code", "--lineage", started.LineageID, "--next-transition",
+	}, &beforeArtifact); err != nil {
+		t.Fatalf("corrected STATUS before the artifact: %v\n%s", err, beforeArtifact.String())
+	}
+	var beforeStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, beforeArtifact.Bytes(), &beforeStatus)
+	if beforeStatus.ValidationRequest == nil {
+		t.Fatalf("corrected STATUS carries no validation request, so this test proves nothing: %s", beforeArtifact.String())
+	}
+
+	// One artifact from the tools the operator ran while correcting.
+	if err := os.WriteFile(filepath.Join(repo, "results.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code", "--lineage", started.LineageID, "--next-transition",
+	}, &output); err != nil {
+		t.Fatalf("correction STATUS with an untracked artifact present: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.NextTransition == nil {
+		t.Fatalf("correction STATUS offered no transition: %s", output.String())
+	}
+	if status.NextTransition.ReasonCode != "intended_untracked_selection_required" {
+		t.Fatalf("correction STATUS reason = %q, want the untracked selection the new file requires", status.NextTransition.ReasonCode)
 	}
 }

--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -344,3 +344,34 @@ func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
 		t.Fatalf("the untracked artifact changed the pending validation request: %#v vs %#v", status.ValidationRequest, beforeStatus.ValidationRequest)
 	}
 }
+
+// TestReviewValidationRequestCopiesAgree pins exactly how far the untracked
+// exemption reaches. It relaxes presence parity and nothing else, so a
+// transition that does carry a request is still held to matching the status
+// one, and a transition that carries one the status does not is still wrong
+// however it collects.
+func TestReviewValidationRequestCopiesAgree(t *testing.T) {
+	one := reviewtransaction.TargetedValidationRequest{LineageID: "review-copies", RequestHash: "sha256:" + strings.Repeat("a", 64)}
+	other := reviewtransaction.TargetedValidationRequest{LineageID: "review-copies", RequestHash: "sha256:" + strings.Repeat("b", 64)}
+	for _, tt := range []struct {
+		name                  string
+		transition, status    *reviewtransaction.TargetedValidationRequest
+		collectsSomethingElse bool
+		agree                 bool
+	}{
+		{name: "neither present", agree: true},
+		{name: "both present and equal", transition: &one, status: &one, agree: true},
+		{name: "both present and different", transition: &one, status: &other},
+		{name: "status only, ordinary transition", status: &one},
+		{name: "status only, transition collecting something else", status: &one, collectsSomethingElse: true, agree: true},
+		{name: "transition only", transition: &one},
+		{name: "transition only, collecting something else", transition: &one, collectsSomethingElse: true},
+		{name: "both present and different, collecting something else", transition: &one, status: &other, collectsSomethingElse: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewValidationRequestCopiesAgree(tt.transition, tt.status, tt.collectsSomethingElse); got != tt.agree {
+				t.Fatalf("reviewValidationRequestCopiesAgree() = %v, want %v", got, tt.agree)
+			}
+		})
+	}
+}

--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -333,5 +334,13 @@ func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
 	}
 	if status.NextTransition.ReasonCode != "intended_untracked_selection_required" {
 		t.Fatalf("correction STATUS reason = %q, want the untracked selection the new file requires", status.NextTransition.ReasonCode)
+	}
+	// The point of the exemption: the pending validation is still true while the
+	// operator declares the file, so the status must keep reporting it.
+	if status.ValidationRequest == nil {
+		t.Fatal("correction STATUS dropped the pending validation request the review is still waiting on")
+	}
+	if !reflect.DeepEqual(*status.ValidationRequest, *beforeStatus.ValidationRequest) {
+		t.Fatalf("the untracked artifact changed the pending validation request: %#v vs %#v", status.ValidationRequest, beforeStatus.ValidationRequest)
 	}
 }

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -361,8 +361,15 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 		// exact-lineage STATUS is its only re-entry (#3647).
 		collectsUntrackedSelection := result.NextTransition.Kind == reviewNextTransitionCollect &&
 			result.NextTransition.ReasonCode == "intended_untracked_selection_required"
-		if !providerTargetedValidation && !collectsUntrackedSelection && ((transitionRequest == nil) != (result.ValidationRequest == nil) ||
-			transitionRequest != nil && !reflect.DeepEqual(*transitionRequest, *result.ValidationRequest)) {
+		// The exemption relaxes presence parity only. If the untracked-selection
+		// transition does carry a request, it is still two copies of the same
+		// thing and they still have to agree.
+		mismatchedPresence := (transitionRequest == nil) != (result.ValidationRequest == nil)
+		if collectsUntrackedSelection && transitionRequest == nil {
+			mismatchedPresence = false
+		}
+		if !providerTargetedValidation && (mismatchedPresence ||
+			transitionRequest != nil && result.ValidationRequest != nil && !reflect.DeepEqual(*transitionRequest, *result.ValidationRequest)) {
 			return errors.New("negotiated status validation request copies differ")
 		}
 		if request := result.NextTransition.CorrectionRequest; request != nil {

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -361,15 +361,7 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 		// exact-lineage STATUS is its only re-entry (#3647).
 		collectsUntrackedSelection := result.NextTransition.Kind == reviewNextTransitionCollect &&
 			result.NextTransition.ReasonCode == "intended_untracked_selection_required"
-		// The exemption relaxes presence parity only. If the untracked-selection
-		// transition does carry a request, it is still two copies of the same
-		// thing and they still have to agree.
-		mismatchedPresence := (transitionRequest == nil) != (result.ValidationRequest == nil)
-		if collectsUntrackedSelection && transitionRequest == nil {
-			mismatchedPresence = false
-		}
-		if !providerTargetedValidation && (mismatchedPresence ||
-			transitionRequest != nil && result.ValidationRequest != nil && !reflect.DeepEqual(*transitionRequest, *result.ValidationRequest)) {
+		if !providerTargetedValidation && !reviewValidationRequestCopiesAgree(transitionRequest, result.ValidationRequest, collectsUntrackedSelection) {
 			return errors.New("negotiated status validation request copies differ")
 		}
 		if request := result.NextTransition.CorrectionRequest; request != nil {
@@ -975,6 +967,30 @@ func manifestPathsForStatus(entries []reviewtransaction.ChangedPathManifestEntry
 		paths[index] = entry.Path
 	}
 	return paths
+}
+
+// reviewValidationRequestCopiesAgree decides whether the transition's copy of
+// the targeted validation request and the status's copy are consistent.
+//
+// The invariant being enforced is that two copies of the same request must not
+// disagree. Presence parity is a stronger rule than that, and it is only right
+// while every transition that omits a request is asserting there is none. A
+// transition collecting something else first is not asserting anything about
+// it: an untracked file appearing mid-correction has to be declared before the
+// validator can run, and the pending request does not stop being true meanwhile
+// (#3647). That case relaxes presence parity and nothing else -- two copies that
+// both exist still have to agree.
+func reviewValidationRequestCopiesAgree(transitionRequest, statusRequest *reviewtransaction.TargetedValidationRequest, transitionCollectsSomethingElse bool) bool {
+	if transitionRequest == nil && statusRequest == nil {
+		return true
+	}
+	if transitionRequest == nil {
+		return transitionCollectsSomethingElse
+	}
+	if statusRequest == nil {
+		return false
+	}
+	return reflect.DeepEqual(*transitionRequest, *statusRequest)
 }
 
 func reviewTransitionValidationRequest(transition *ReviewNextTransition) *reviewtransaction.TargetedValidationRequest {

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -352,7 +352,16 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 			(result.NextTransition.ReasonCode == "targeted_validation_required" ||
 				result.NextTransition.ReasonCode == reviewInconclusiveTargetedValidationReason) && result.NextTransition.Collect != nil &&
 			len(result.NextTransition.Collect.Inputs) == 1 && result.NextTransition.Collect.Inputs[0].ProviderTask != nil
-		if !providerTargetedValidation && ((transitionRequest == nil) != (result.ValidationRequest == nil) ||
+		// A transition that collects something else first legitimately carries no
+		// validation request while the status still reports the one the review
+		// is waiting on. An untracked file appearing mid-correction is the
+		// ordinary way to reach that: the operator has to declare it before the
+		// validator can run, and the pending request does not stop being true
+		// meanwhile. Requiring presence parity there stranded the lineage, since
+		// exact-lineage STATUS is its only re-entry (#3647).
+		collectsUntrackedSelection := result.NextTransition.Kind == reviewNextTransitionCollect &&
+			result.NextTransition.ReasonCode == "intended_untracked_selection_required"
+		if !providerTargetedValidation && !collectsUntrackedSelection && ((transitionRequest == nil) != (result.ValidationRequest == nil) ||
 			transitionRequest != nil && !reflect.DeepEqual(*transitionRequest, *result.ValidationRequest)) {
 			return errors.New("negotiated status validation request copies differ")
 		}


### PR DESCRIPTION
Closes #3647.

## PR Type

- [x] Bug fix

## Summary

- A correction can now survive an untracked file appearing while it is made, instead of stranding the lineage.
- The consistency check that stranded it is narrowed to the invariant it actually names: two copies of the same request must not disagree.

## The defect, with a reproduction

A correction is made by editing, and the tools an operator runs while editing leave files behind: a test artifact, a build output, a coverage profile. Any untracked file appearing mid-correction switched STATUS to the untracked-selection transition, which legitimately carries no validation request while the status still reported the one the review was waiting on. The consistency check required presence parity between the two and read that as a provider bug.

The lineage was then stranded, and unusually hard to diagnose:

- exact-lineage STATUS is its only re-entry, and it refused identically on every attempt;
- the read-only failure envelope is content-free by design, so the refusal advertised `retry`, named no cause, and reproduced forever;
- selectorless STATUS does not route to a correction lineage, so nothing admitted the shape.

On a binary built from `main`:

1. drive any candidate to `correction_required` and capture its plan
2. apply the correction
3. create one untracked file
4. ask exact-lineage STATUS

Before this change step 4 refuses with `operation_failed` / `retry_safe: true` / no cause. The real reason, recovered only by instrumenting the binary locally, is `negotiated status validation request copies differ`.

## Changes

| File | Change |
|------|--------|
| `internal/cli/review_status_contract.go` | `reviewValidationRequestCopiesAgree` holds the invariant; a transition collecting something else first relaxes presence parity and nothing else |
| `internal/cli/review_capture_refusal_envelope_test.go` | End-to-end: correction, artifact, STATUS routes and the pending request survives unchanged. Plus eight cases pinning the helper's reach |

## Adversarial review of this branch

Driven through the review lifecycle three times with a binary built from this branch, approved each time, with advisories acted on between passes.

- Pass 1 found the exemption skipped the whole check, so two copies that both exist would no longer be compared, and the test asserted the transition but not the request surviving.
- Pass 2 found the narrowing itself unproved: nothing observed that both-present copies are still compared. The comparison moved behind a named helper with a table that pins its reach.
- Pass 3 approved with three remaining advisories, left as follow-ups: negative coverage for the gate, recovery-path coverage, and one missing table combination. Advisory findings are separate later work by contract, and three passes is where the returns stopped.

The authority was acknowledged and burned after each pass.

## Test Plan

- [x] The end-to-end test verified failing without its fix, with the exact envelope from the report
- [x] `go test ./...` — pass
- [x] `go vet ./...` on `linux`, `windows` and `darwin` — clean
- [x] `gofmt -l` clean; `bench` builds, vets and tests clean
- [x] Driven corpus: `55` counted, `0` failed, `0` dead_end
- [x] The live stranded lineage from the reproduction routes again with the fixed binary

## A note on the report

The linked issue is from `2.2.4` and reproduces through `finalize`, a verb this lifecycle no longer has, which makes it easy to read as fixed by the FINALIZE retirement. It was not: the same lineage class was still unresolvable on `main`, and its refusal named less than the 2.2.4 one did.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review status handling when untracked artifacts require selection before validation.
  * Preserved pending validation requests during the untracked-artifact selection step.
  * Strengthened consistency checks for validation requests while allowing the intended selection exception.

* **Tests**
  * Added coverage for review status transitions involving untracked artifacts.
  * Added validation checks to confirm matching request information is enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->