### PR TITLE
test(review): prove the validation-request copies gate refuses

### DIFF
--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -347,9 +347,15 @@ func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
 	// Routing is only half of it. The lineage was stranded because nothing could
 	// drive it forward, so declaring the artifact has to put the review back
 	// where it was: waiting on the same validation.
+	if status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("untracked selection offered no single collect input: %#v", status.NextTransition.Collect)
+	}
 	inventory := ""
 	for _, argument := range status.NextTransition.Collect.Inputs[0].Arguments {
 		if argument.Name == "expected_untracked_inventory" {
+			if inventory != "" {
+				t.Fatalf("untracked selection repeated its inventory argument: %#v", status.NextTransition.Collect.Inputs[0].Arguments)
+			}
 			inventory = argument.Value
 		}
 	}
@@ -395,6 +401,9 @@ func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
 // however it collects.
 func TestReviewValidationRequestCopiesAgree(t *testing.T) {
 	one := reviewtransaction.TargetedValidationRequest{LineageID: "review-copies", RequestHash: "sha256:" + strings.Repeat("a", 64)}
+	// A separate value that equals `one`. Passing the same pointer twice would
+	// make the equal cases hold on identity and prove nothing about comparison.
+	sameAsOne := reviewtransaction.TargetedValidationRequest{LineageID: "review-copies", RequestHash: "sha256:" + strings.Repeat("a", 64)}
 	other := reviewtransaction.TargetedValidationRequest{LineageID: "review-copies", RequestHash: "sha256:" + strings.Repeat("b", 64)}
 	for _, tt := range []struct {
 		name                  string
@@ -403,14 +412,14 @@ func TestReviewValidationRequestCopiesAgree(t *testing.T) {
 		agree                 bool
 	}{
 		{name: "neither present", agree: true},
-		{name: "both present and equal", transition: &one, status: &one, agree: true},
+		{name: "both present and equal", transition: &one, status: &sameAsOne, agree: true},
 		{name: "both present and different", transition: &one, status: &other},
 		{name: "status only, ordinary transition", status: &one},
 		{name: "status only, transition collecting something else", status: &one, collectsSomethingElse: true, agree: true},
 		{name: "transition only", transition: &one},
 		{name: "transition only, collecting something else", transition: &one, collectsSomethingElse: true},
 		{name: "both present and different, collecting something else", transition: &one, status: &other, collectsSomethingElse: true},
-		{name: "both present and equal, collecting something else", transition: &one, status: &one, collectsSomethingElse: true, agree: true},
+		{name: "both present and equal, collecting something else", transition: &one, status: &sameAsOne, collectsSomethingElse: true, agree: true},
 		{name: "neither present, collecting something else", collectsSomethingElse: true, agree: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -350,6 +350,16 @@ func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
 	if status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
 		t.Fatalf("untracked selection offered no single collect input: %#v", status.NextTransition.Collect)
 	}
+	// This input is a decision the operator owns, so it carries values and no
+	// runnable tokens: the product names the exact flags in its own refusal
+	// rather than issuing an invocation. Composing them here is therefore the
+	// real route, and this assertion makes a future change that starts issuing
+	// tokens fail rather than let the test keep hand-building them.
+	for _, argument := range status.NextTransition.Collect.Inputs[0].Arguments {
+		if argument.Token != "" {
+			t.Fatalf("untracked selection now issues runnable tokens; replay them instead of composing flags: %#v", argument)
+		}
+	}
 	inventory := ""
 	for _, argument := range status.NextTransition.Collect.Inputs[0].Arguments {
 		if argument.Name == "expected_untracked_inventory" {

--- a/internal/cli/review_capture_refusal_envelope_test.go
+++ b/internal/cli/review_capture_refusal_envelope_test.go
@@ -343,6 +343,49 @@ func TestCorrectionStatusRoutesWithAnUntrackedArtifactPresent(t *testing.T) {
 	if !reflect.DeepEqual(*status.ValidationRequest, *beforeStatus.ValidationRequest) {
 		t.Fatalf("the untracked artifact changed the pending validation request: %#v vs %#v", status.ValidationRequest, beforeStatus.ValidationRequest)
 	}
+
+	// Routing is only half of it. The lineage was stranded because nothing could
+	// drive it forward, so declaring the artifact has to put the review back
+	// where it was: waiting on the same validation.
+	inventory := ""
+	for _, argument := range status.NextTransition.Collect.Inputs[0].Arguments {
+		if argument.Name == "expected_untracked_inventory" {
+			inventory = argument.Value
+		}
+	}
+	if inventory == "" {
+		t.Fatalf("untracked selection offered no inventory to declare against: %#v", status.NextTransition.Collect.Inputs[0].Arguments)
+	}
+	var recovered bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2,
+		"--agent", "claude-code", "--lineage", started.LineageID, "--next-transition",
+		"--untracked-scope=exclude", "--expected-untracked-inventory=" + inventory,
+	}, &recovered); err != nil {
+		t.Fatalf("declaring the artifact did not recover the correction: %v\n%s", err, recovered.String())
+	}
+	var recoveredStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, recovered.Bytes(), &recoveredStatus)
+	if recoveredStatus.NextTransition == nil || recoveredStatus.NextTransition.ReasonCode != "targeted_validation_required" {
+		t.Fatalf("declared artifact left the correction unable to proceed: %#v", recoveredStatus.NextTransition)
+	}
+	if recoveredStatus.ValidationRequest == nil || !reflect.DeepEqual(*recoveredStatus.ValidationRequest, *beforeStatus.ValidationRequest) {
+		t.Fatalf("recovery changed the pending validation request: %#v", recoveredStatus.ValidationRequest)
+	}
+
+	// The exemption relaxes presence parity, so the gate it sits in must still
+	// refuse two copies that genuinely disagree. Nothing else proves that the
+	// gate is wired to the helper at all.
+	// PolicyContent is chosen deliberately: the earlier submission-descriptor and
+	// binding guards pin the request hash, target and trees, so tampering one of
+	// those never reaches this gate. This one only the copies check compares.
+	tampered := beforeStatus
+	disagreeing := *beforeStatus.ValidationRequest
+	disagreeing.PolicyContent = disagreeing.PolicyContent + "\ndrifted"
+	tampered.ValidationRequest = &disagreeing
+	if err := tampered.Validate(); err == nil || !strings.Contains(err.Error(), "validation request copies differ") {
+		t.Fatalf("disagreeing validation request copies validated = %v", err)
+	}
 }
 
 // TestReviewValidationRequestCopiesAgree pins exactly how far the untracked
@@ -367,6 +410,8 @@ func TestReviewValidationRequestCopiesAgree(t *testing.T) {
 		{name: "transition only", transition: &one},
 		{name: "transition only, collecting something else", transition: &one, collectsSomethingElse: true},
 		{name: "both present and different, collecting something else", transition: &one, status: &other, collectsSomethingElse: true},
+		{name: "both present and equal, collecting something else", transition: &one, status: &one, collectsSomethingElse: true, agree: true},
+		{name: "neither present, collecting something else", collectsSomethingElse: true, agree: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := reviewValidationRequestCopiesAgree(tt.transition, tt.status, tt.collectsSomethingElse); got != tt.agree {


### PR DESCRIPTION
Closes #3859.

## PR Type

- [x] Bug fix

## Summary

- The validation-request copies gate is shown to refuse. It had no negative coverage at all: deleting it left the suite green.
- Recovery from an untracked artifact is shown to work, which is the half of #3647 the merged test did not reach.
- The helper table carries all eight of its combinations, and compares values rather than pointers.

## Why the gate matters

`#3647` narrowed that gate so a transition collecting something else relaxes presence parity while two copies that both exist still have to agree. The relaxation was pinned by a helper table; the gate that calls the helper was not. Nothing showed the two were wired together, so the narrowing was a claim with no test behind it.

The new assertion tampers `PolicyContent` deliberately: the earlier submission-descriptor and binding guards pin the request hash, target and trees, so tampering one of those never reaches this gate. Verified by removing the gate, which changes the failure to `negotiated status validation request is invalid` rather than leaving the test green.

## Why recovery matters

The merged test proved STATUS routes to the untracked-selection transition. That is half of it. The lineage in #3647 was stranded because nothing could drive it forward, so declaring the artifact has to return the review to waiting on the same validation request. That is now asserted, with the request compared to the one held before the artifact appeared.

The recovery flags are composed rather than replayed, because that input is a decision the operator owns: it carries values and no runnable tokens, and the product names the exact flags in its own refusal. The test asserts that, so a future change that starts issuing tokens fails here instead of leaving it hand-building flags the product no longer expects.

## Adversarial review of this branch

Two passes, approved both times, with the findings from the first acted on:

- The equal cases passed the same pointer as both copies, so they held on identity and proved nothing about comparison. They now pass a separate value that equals the first.
- The recovery assertions indexed the collect input without checking the shape, so a changed transition would panic instead of reporting what it found.
- A repeated inventory argument was silently taking the last one; it is now named.

The second pass raised the composed-flags question answered above. The authority was acknowledged and burned after each pass.

## Test Plan

- [x] The gate assertion verified failing without the gate
- [x] `go test ./...` — pass
- [x] `go vet ./...` on `linux` and `windows` — clean
- [x] `gofmt -l` clean; `bench` builds, vets and tests clean
- [x] Driven corpus: `55` counted, `0` failed, `0` dead_end

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation safeguards for recovery workflows involving untracked artifacts.
  - Requests with altered validation details are now correctly rejected.

- **Tests**
  - Expanded coverage for recovery status transitions, untracked-artifact handling, validation request consistency, and edge cases involving missing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->