### PR TITLE
fix(release): let a local build report that it has no provenance

### DIFF
--- a/internal/releaseprovenance/provenance.go
+++ b/internal/releaseprovenance/provenance.go
@@ -11,7 +11,13 @@ import (
 )
 
 const (
-	schema              = "gentle-ai.release-provenance/v1"
+	schema = "gentle-ai.release-provenance/v1"
+	// localSchema marks a manifest produced outside GitHub Actions. It exists
+	// because the archive that packages the manifest needs the file to be there,
+	// not because a local build has provenance to report: prerelease tags do not
+	// trigger release.yml, so building one by hand is the documented path, and a
+	// local checkout knows no tag, run or workflow it could honestly name.
+	localSchema         = "gentle-ai.release-provenance/local-build"
 	repository          = "Gentleman-Programming/gentle-ai"
 	goReleaserVersion   = "v2.15.2"
 	providerArchiveKind = "provider-contract"
@@ -56,6 +62,11 @@ type workflow struct {
 	RunID      string `json:"run_id"`
 	RunAttempt int    `json:"run_attempt"`
 	Job        string `json:"job"`
+}
+
+type localManifest struct {
+	Schema string `json:"schema"`
+	Reason string `json:"reason"`
 }
 
 type toolchain struct {
@@ -113,18 +124,52 @@ func Build(config []byte, input Input) ([]byte, error) {
 
 // Write creates a manifest at output without replacing an existing file.
 func Write(output, configPath string, input Input) error {
-	info, err := os.Lstat(configPath)
-	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return errors.New("release provenance configuration is invalid")
-	}
-	config, err := os.ReadFile(configPath)
+	config, err := readReleaseConfiguration(configPath)
 	if err != nil {
-		return errors.New("release provenance configuration is unreadable")
+		return err
 	}
 	payload, err := Build(config, input)
 	if err != nil {
 		return err
 	}
+	return writeManifestOnce(output, payload)
+}
+
+// WriteLocal records that this build has no release provenance to report.
+//
+// The archive that packages the manifest needs the file to exist, and a
+// prerelease tag does not trigger release.yml, so building one by hand is the
+// documented path. A local checkout knows no tag, run, or workflow it could
+// honestly name, so this states only that, under its own schema. Every field the
+// canonical manifest binds is absent rather than invented, and no reader can
+// mistake it for the evidence a release carries.
+func WriteLocal(output, configPath string) error {
+	if _, err := readReleaseConfiguration(configPath); err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(localManifest{
+		Schema: localSchema,
+		Reason: "built outside GitHub Actions; this build reports no release provenance",
+	})
+	if err != nil {
+		return errors.New("release provenance encoding failed")
+	}
+	return writeManifestOnce(output, append(encoded, '\n'))
+}
+
+func readReleaseConfiguration(configPath string) ([]byte, error) {
+	info, err := os.Lstat(configPath)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, errors.New("release provenance configuration is invalid")
+	}
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, errors.New("release provenance configuration is unreadable")
+	}
+	return config, nil
+}
+
+func writeManifestOnce(output string, payload []byte) error {
 	parent, err := os.Stat(filepath.Dir(output))
 	if err != nil || !parent.IsDir() {
 		return errors.New("release provenance output parent is unavailable")
@@ -144,7 +189,7 @@ func Write(output, configPath string, input Input) error {
 	if err := file.Close(); err != nil {
 		return errors.New("release provenance output cannot be closed")
 	}
-	info, err = os.Lstat(output)
+	info, err := os.Lstat(output)
 	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0o644 {
 		return errors.New("release provenance output is invalid")
 	}

--- a/internal/releaseprovenancecmd/main.go
+++ b/internal/releaseprovenancecmd/main.go
@@ -18,6 +18,22 @@ func main() {
 	}
 }
 
+// releaseIdentityEnvironment lists every variable the canonical manifest binds.
+// One of them present is enough to mean a release build is being attempted.
+var releaseIdentityEnvironment = []string{
+	"GITHUB_ACTIONS", "GITHUB_REPOSITORY", "GITHUB_REF_NAME", "GITHUB_SHA",
+	"GITHUB_WORKFLOW", "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT", "GITHUB_JOB",
+}
+
+func anyReleaseIdentityPresent() bool {
+	for _, name := range releaseIdentityEnvironment {
+		if os.Getenv(name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func run(args []string) error {
 	flags := flag.NewFlagSet("releaseprovenancecmd", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
@@ -27,12 +43,17 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil || flags.NArg() != 0 || *output == "" || *config == "" || *goReleaser != "v2.15.2" {
 		return fmt.Errorf("usage: releaseprovenancecmd --out <file> --config <file> --goreleaser-version v2.15.2")
 	}
-	// Outside GitHub Actions there is no provenance to record. That is the
-	// documented prerelease path -- release.yml never runs for a prerelease tag,
-	// so its binaries are built by hand -- and a local checkout knows no run to
-	// name. Refusing here took the whole build down with it, including the
-	// snapshot a maintainer uses to check this configuration.
-	if os.Getenv("GITHUB_ACTIONS") != "true" {
+	// A build with no release identity at all has no provenance to record. That
+	// is the documented prerelease path -- release.yml never runs for a
+	// prerelease tag, so its binaries are built by hand -- and a local checkout
+	// knows no run to name. Refusing there took the whole build down with it,
+	// including the snapshot a maintainer uses to check this configuration.
+	//
+	// Absence has to be total. Keying this on GITHUB_ACTIONS alone would let a CI
+	// job that lost only that one variable downgrade to a local manifest and
+	// still publish, turning a hard failure into an archive that quietly claims
+	// nothing. Any release identity present means the strict path decides.
+	if !anyReleaseIdentityPresent() {
 		return releaseprovenance.WriteLocal(*output, *config)
 	}
 	if os.Getenv("GITHUB_REPOSITORY") != "Gentleman-Programming/gentle-ai" {

--- a/internal/releaseprovenancecmd/main.go
+++ b/internal/releaseprovenancecmd/main.go
@@ -27,6 +27,14 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil || flags.NArg() != 0 || *output == "" || *config == "" || *goReleaser != "v2.15.2" {
 		return fmt.Errorf("usage: releaseprovenancecmd --out <file> --config <file> --goreleaser-version v2.15.2")
 	}
+	// Outside GitHub Actions there is no provenance to record. That is the
+	// documented prerelease path -- release.yml never runs for a prerelease tag,
+	// so its binaries are built by hand -- and a local checkout knows no run to
+	// name. Refusing here took the whole build down with it, including the
+	// snapshot a maintainer uses to check this configuration.
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		return releaseprovenance.WriteLocal(*output, *config)
+	}
 	if os.Getenv("GITHUB_REPOSITORY") != "Gentleman-Programming/gentle-ai" {
 		return fmt.Errorf("release provenance input is invalid")
 	}

--- a/internal/releaseprovenancecmd/main_test.go
+++ b/internal/releaseprovenancecmd/main_test.go
@@ -54,8 +54,11 @@ func TestLocalBuildWritesNoReleaseClaim(t *testing.T) {
 	if err := json.Unmarshal(payload, &body); err != nil {
 		t.Fatalf("local manifest is not JSON: %v", err)
 	}
-	if body["schema"] == "gentle-ai.release-provenance/v1" {
-		t.Fatalf("a local build claimed release provenance: %s", payload)
+	if body["schema"] != "gentle-ai.release-provenance/local-build" {
+		t.Fatalf("local manifest schema = %v, want the local-build schema: %s", body["schema"], payload)
+	}
+	if reason, _ := body["reason"].(string); !strings.Contains(reason, "no release provenance") {
+		t.Fatalf("local manifest does not say why it claims nothing: %s", payload)
 	}
 	for _, claim := range []string{"tag", "source_sha", "workflow"} {
 		if _, present := body[claim]; present {
@@ -70,28 +73,33 @@ func TestLocalBuildWritesNoReleaseClaim(t *testing.T) {
 // archive whose manifest quietly claims nothing, which is the outcome the whole
 // guard exists to prevent.
 func TestPartialReleaseIdentityNeverDowngrades(t *testing.T) {
-	for _, missing := range []string{"GITHUB_ACTIONS", "GITHUB_REPOSITORY", "GITHUB_RUN_ID", "GITHUB_SHA", "GITHUB_REF_NAME", "GITHUB_WORKFLOW", "GITHUB_JOB", "GITHUB_RUN_ATTEMPT"} {
+	for _, missing := range releaseIdentityEnvironment {
 		t.Run("without "+missing, func(t *testing.T) {
 			out, args := provenanceArgs(t)
 			ciEnvironment(t)
 			t.Setenv(missing, "")
+			// GITHUB_ACTIONS is the one variable the canonical manifest does not
+			// bind, so losing it alone leaves every recorded fact real and the
+			// build still produces provenance. Losing any bound variable refuses.
+			// Neither outcome may ever be the local manifest: that downgrade is
+			// what this gate exists to prevent.
+			wantProvenance := missing == "GITHUB_ACTIONS"
 			err := run(args)
 			payload, readErr := os.ReadFile(out)
-			if err != nil {
-				if readErr == nil {
-					t.Fatalf("a refused release build missing %s still wrote a manifest", missing)
+			if wantProvenance {
+				if err != nil || readErr != nil {
+					t.Fatalf("losing %s alone must still record real provenance: %v, %v", missing, err, readErr)
+				}
+				if !strings.Contains(string(payload), `"schema":"gentle-ai.release-provenance/v1"`) {
+					t.Fatalf("a release build missing %s downgraded: %s", missing, payload)
 				}
 				return
 			}
-			// Succeeding is only acceptable while every field the manifest binds
-			// is real, which means it must be canonical provenance. The one thing
-			// it may never be is the local manifest: that is the downgrade this
-			// gate exists to prevent.
-			if readErr != nil {
-				t.Fatalf("a successful release build missing %s wrote nothing", missing)
+			if err == nil {
+				t.Fatalf("a release build missing the bound %s produced a manifest instead of refusing: %s", missing, payload)
 			}
-			if !strings.Contains(string(payload), `"schema":"gentle-ai.release-provenance/v1"`) {
-				t.Fatalf("a release build missing %s downgraded to a non-release manifest: %s", missing, payload)
+			if readErr == nil {
+				t.Fatalf("a refused release build missing %s still wrote a manifest: %s", missing, payload)
 			}
 		})
 	}

--- a/internal/releaseprovenancecmd/main_test.go
+++ b/internal/releaseprovenancecmd/main_test.go
@@ -64,6 +64,39 @@ func TestLocalBuildWritesNoReleaseClaim(t *testing.T) {
 	}
 }
 
+// TestPartialReleaseIdentityStillRefuses is the case the local path must never
+// swallow: a release build that lost one environment variable. Keying the local
+// route on GITHUB_ACTIONS alone would turn that hard failure into a published
+// archive whose manifest quietly claims nothing, which is the outcome the whole
+// guard exists to prevent.
+func TestPartialReleaseIdentityNeverDowngrades(t *testing.T) {
+	for _, missing := range []string{"GITHUB_ACTIONS", "GITHUB_REPOSITORY", "GITHUB_RUN_ID", "GITHUB_SHA", "GITHUB_REF_NAME", "GITHUB_WORKFLOW", "GITHUB_JOB", "GITHUB_RUN_ATTEMPT"} {
+		t.Run("without "+missing, func(t *testing.T) {
+			out, args := provenanceArgs(t)
+			ciEnvironment(t)
+			t.Setenv(missing, "")
+			err := run(args)
+			payload, readErr := os.ReadFile(out)
+			if err != nil {
+				if readErr == nil {
+					t.Fatalf("a refused release build missing %s still wrote a manifest", missing)
+				}
+				return
+			}
+			// Succeeding is only acceptable while every field the manifest binds
+			// is real, which means it must be canonical provenance. The one thing
+			// it may never be is the local manifest: that is the downgrade this
+			// gate exists to prevent.
+			if readErr != nil {
+				t.Fatalf("a successful release build missing %s wrote nothing", missing)
+			}
+			if !strings.Contains(string(payload), `"schema":"gentle-ai.release-provenance/v1"`) {
+				t.Fatalf("a release build missing %s downgraded to a non-release manifest: %s", missing, payload)
+			}
+		})
+	}
+}
+
 // TestCIBuildStillProducesReleaseProvenance keeps the guard the local path must
 // not weaken: inside Actions the manifest is the canonical v1 evidence, and an
 // input that cannot be trusted still refuses rather than degrading.

--- a/internal/releaseprovenancecmd/main_test.go
+++ b/internal/releaseprovenancecmd/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func provenanceArgs(t *testing.T) (string, []string) {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "manifest.json")
+	return out, []string{"--out", out, "--config", "../../.goreleaser.yaml", "--goreleaser-version", "v2.15.2"}
+}
+
+func ciEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_REPOSITORY", "Gentleman-Programming/gentle-ai")
+	t.Setenv("GITHUB_REF_NAME", "v1.2.3-rc.4")
+	t.Setenv("GITHUB_SHA", strings.Repeat("0123456789abcdef", 2)+strings.Repeat("0", 8))
+	t.Setenv("GITHUB_WORKFLOW", "Release candidate")
+	t.Setenv("GITHUB_RUN_ID", "42")
+	t.Setenv("GITHUB_RUN_ATTEMPT", "2")
+	t.Setenv("GITHUB_JOB", "publish")
+	t.Setenv("PROVIDER_CONTRACT_SEMVER", "1.4.0")
+}
+
+// TestLocalBuildWritesNoReleaseClaim covers the only path that reaches this
+// command outside GitHub Actions: a maintainer building a prerelease by hand, or
+// checking the GoReleaser configuration with a snapshot. Prerelease tags do not
+// trigger release.yml, so that build is the documented path, and it does not
+// need provenance at all -- but the archive that packages the manifest still
+// requires the file to exist.
+//
+// It must not invent one. The manifest it writes here says it is a local build
+// and claims no tag, run or commit, so nothing can mistake it for the evidence a
+// release carries.
+func TestLocalBuildWritesNoReleaseClaim(t *testing.T) {
+	out, args := provenanceArgs(t)
+	for _, name := range []string{"GITHUB_ACTIONS", "GITHUB_REPOSITORY", "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT", "GITHUB_REF_NAME", "GITHUB_SHA", "GITHUB_WORKFLOW", "GITHUB_JOB"} {
+		t.Setenv(name, "")
+	}
+	if err := run(args); err != nil {
+		t.Fatalf("local build refused to produce a manifest: %v", err)
+	}
+	payload, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("local build wrote no manifest, so the archive that packages it cannot be built: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("local manifest is not JSON: %v", err)
+	}
+	if body["schema"] == "gentle-ai.release-provenance/v1" {
+		t.Fatalf("a local build claimed release provenance: %s", payload)
+	}
+	for _, claim := range []string{"tag", "source_sha", "workflow"} {
+		if _, present := body[claim]; present {
+			t.Fatalf("a local manifest claims %q, which no local build can know: %s", claim, payload)
+		}
+	}
+}
+
+// TestCIBuildStillProducesReleaseProvenance keeps the guard the local path must
+// not weaken: inside Actions the manifest is the canonical v1 evidence, and an
+// input that cannot be trusted still refuses rather than degrading.
+func TestCIBuildStillProducesReleaseProvenance(t *testing.T) {
+	out, args := provenanceArgs(t)
+	ciEnvironment(t)
+	if err := run(args); err != nil {
+		t.Fatalf("CI build refused: %v", err)
+	}
+	payload, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), `"schema":"gentle-ai.release-provenance/v1"`) {
+		t.Fatalf("CI manifest is not release provenance: %s", payload)
+	}
+
+	t.Run("an untrusted run attempt still refuses", func(t *testing.T) {
+		out, args := provenanceArgs(t)
+		ciEnvironment(t)
+		t.Setenv("GITHUB_RUN_ATTEMPT", "not-a-number")
+		if err := run(args); err == nil {
+			t.Fatal("CI build accepted an unusable run attempt")
+		}
+		if _, err := os.Stat(out); err == nil {
+			t.Fatal("a refused CI build still wrote a manifest")
+		}
+	})
+	t.Run("another repository still refuses", func(t *testing.T) {
+		out, args := provenanceArgs(t)
+		ciEnvironment(t)
+		t.Setenv("GITHUB_REPOSITORY", "someone-else/gentle-ai")
+		if err := run(args); err == nil {
+			t.Fatal("CI build accepted another repository")
+		}
+		if _, err := os.Stat(out); err == nil {
+			t.Fatal("a refused CI build still wrote a manifest")
+		}
+	})
+}


### PR DESCRIPTION
Closes #3861.

## PR Type

- [x] Bug fix

## Summary

- A local GoReleaser run works again. It records that the build has no release provenance, under its own schema, instead of inventing one or killing the run.
- Inside GitHub Actions nothing changes: the canonical v1 manifest is still the only thing produced, and untrusted input still refuses without writing a file.

## The defect

The provenance hook refused outside GitHub Actions and sits in `before.hooks`, so it took every GoReleaser invocation down with it. That included the snapshot the release-candidate procedure runs to package the provider contract bundle, and any local run used to check this configuration. Prerelease tags never trigger `release.yml`, so building one by hand is the documented path, and it needs no provenance at all.

The refusal itself is right: a local checkout knows no run, tag or workflow it could honestly name. Only its placement is wrong.

Writing nothing was not available either. Skipping the hook fails later:

```
⨯ globbing failed for pattern .goreleaser-provenance/manifest.json: file does not exist
```

## Changes

| File | Change |
|------|--------|
| `internal/releaseprovenance/provenance.go` | `WriteLocal` records a build with no provenance to report, under `gentle-ai.release-provenance/local-build`, naming no tag, run, workflow or commit. `Write` and it share one config read and one write-once path |
| `internal/releaseprovenancecmd/main.go` | The local route is taken only when no release identity is present at all |
| `internal/releaseprovenancecmd/main_test.go` | The local manifest, the canonical one, refusal on untrusted input, and one case per identity variable |

## Adversarial review of this branch

Two passes. The first **blocked**:

> the new environment gate runs before every trust check, so any run where GITHUB_ACTIONS is not exactly the string "true" now succeeds by writing a local-build manifest instead of failing

Correct, and the exact outcome the guard exists to prevent, reached by the change meant to preserve it. Keying the local route on `GITHUB_ACTIONS` alone would let a release job that lost one variable publish an archive quietly claiming nothing. The route now requires that no release identity is present at all, and the assertion was verified against that regression: restoring the single-variable check makes it fail with the downgraded manifest in the message.

The second pass approved and raised three findings, all addressed: the test restated the identity list instead of reading it, the local manifest was ruled out rather than named, and each variable's outcome was asserted as a disjunction. `GITHUB_ACTIONS` is the only variable the manifest does not bind, so losing it alone still records real provenance; losing any bound one refuses.

## Test Plan

- [x] The downgrade assertion verified failing against the single-variable gate
- [x] `goreleaser release --snapshot --clean --skip=sign,publish` completes and produces the provider contract bundle
- [x] That bundle is content-identical to the one shipped in v2.5.0-rc.2: same entries, modes and sizes
- [x] `go test ./...` — pass. `go vet ./...` on `linux` and `windows` — clean
- [x] Driven corpus: `55` counted, `0` failed, `0` dead_end

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local builds now generate a provenance manifest identifying them as local builds without release claims.
  * Release builds continue to generate verified provenance manifests when complete CI release information is available.

* **Bug Fixes**
  * Builds with incomplete or untrusted release identity information are rejected instead of being incorrectly treated as local builds.

* **Tests**
  * Added coverage for local builds, valid CI builds, incomplete release metadata, untrusted runs, and repository mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->