### PR TITLE
fix(opencode): keep SDD phase commands in the primary orchestrator session

### DIFF
--- a/internal/assets/opencode/commands/sdd-apply.md
+++ b/internal/assets/opencode/commands/sdd-apply.md
@@ -1,7 +1,6 @@
 ---
 description: Implement SDD tasks — writes code following specs and design
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command is allowed to launch the hidden `sdd-apply` sub-agent only after the orchestration gates below pass.

--- a/internal/assets/opencode/commands/sdd-archive.md
+++ b/internal/assets/opencode/commands/sdd-archive.md
@@ -1,7 +1,6 @@
 ---
 description: Archive a completed SDD change — syncs specs and closes the cycle
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command may launch the hidden `sdd-archive` sub-agent only after the orchestration gates below pass.

--- a/internal/assets/opencode/commands/sdd-explore.md
+++ b/internal/assets/opencode/commands/sdd-explore.md
@@ -1,7 +1,6 @@
 ---
 description: Explore and investigate an idea or feature — reads codebase and compares approaches
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command may launch the hidden `sdd-explore` sub-agent only after the orchestration gates below pass.

--- a/internal/assets/opencode/commands/sdd-init.md
+++ b/internal/assets/opencode/commands/sdd-init.md
@@ -1,7 +1,6 @@
 ---
 description: Initialize SDD context — detects project stack and bootstraps persistence backend
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command may launch the hidden `sdd-init` sub-agent only after the SDD Session Preflight gate passes.

--- a/internal/assets/opencode/commands/sdd-onboard.md
+++ b/internal/assets/opencode/commands/sdd-onboard.md
@@ -1,7 +1,6 @@
 ---
 description: Guided SDD walkthrough — onboard a user through the full SDD cycle using their real codebase
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command may launch the hidden `sdd-onboard` sub-agent only after the orchestration gates below pass.

--- a/internal/assets/opencode/commands/sdd-research.md
+++ b/internal/assets/opencode/commands/sdd-research.md
@@ -1,7 +1,6 @@
 ---
 description: Collect source-backed evidence for a selected SDD research lane
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not the executor. This command may launch the hidden `sdd-research` sub-agent only after these gates pass.

--- a/internal/assets/opencode/commands/sdd-verify.md
+++ b/internal/assets/opencode/commands/sdd-verify.md
@@ -1,7 +1,6 @@
 ---
 description: Validate implementation matches specs, design, and tasks
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command may launch the hidden `sdd-verify` sub-agent only after the orchestration gates below pass.

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -591,26 +591,11 @@ func decodeInstalledCommandFrontmatter(t *testing.T, path string) openCodeComman
 	return meta
 }
 
-// TestInjectOpenCodeSDDCommandsRemainParentOwned is the #2939 installation
-// ratchet: after Inject materializes the OpenCode command set, every SDD
-// command that routes through the primary `gentle-orchestrator` agent must
-// be installed WITHOUT `subtask: true` in its frontmatter. With that field,
-// OpenCode forces even a primary-mode agent into a sub-agent invocation, so
-// the command would spawn an orchestrator child that must delegate again to
-// the hidden phase worker — one avoidable model hop and a nested path that
-// can be refused at the default subagent depth.
-//
-// The agent binding itself must survive the fix: removing `subtask: true`
-// must only keep the command in the primary orchestrator session, never
-// detach it from `gentle-orchestrator`. The source-asset twin of this guard
-// is TestNoSubtaskOnSDDOpenCodeCommands in internal/components.
-func TestInjectOpenCodeSDDCommandsRemainParentOwned(t *testing.T) {
-	mockNoPackageManager(t)
-	home := t.TempDir()
-
-	if _, err := Inject(home, opencodeAdapter(), ""); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
+// assertSDDCommandsParentOwned asserts that every delegating SDD command
+// installed under home keeps the gentle-orchestrator routing and carries no
+// forced-subtask field.
+func assertSDDCommandsParentOwned(t *testing.T, home string) {
+	t.Helper()
 
 	for _, name := range []string{
 		"sdd-init.md",
@@ -630,6 +615,60 @@ func TestInjectOpenCodeSDDCommandsRemainParentOwned(t *testing.T) {
 			t.Errorf("installed %s declares `subtask: true`; OpenCode forces gentle-orchestrator into a sub-agent invocation — remove the field so the command stays in the primary orchestrator session", name)
 		}
 	}
+}
+
+// TestInjectOpenCodeSDDCommandsRemainParentOwned is the #2939 installation
+// ratchet: after Inject materializes the OpenCode command set, every SDD
+// command that routes through the primary `gentle-orchestrator` agent must
+// be installed WITHOUT `subtask: true` in its frontmatter. With that field,
+// OpenCode forces even a primary-mode agent into a sub-agent invocation, so
+// the command would spawn an orchestrator child that must delegate again to
+// the hidden phase worker — one avoidable model hop and a nested path that
+// can be refused at the default subagent depth.
+//
+// It covers both install paths. Fresh install: a clean home gets the fixed
+// assets. Upgrade: a pre-fix install whose sdd-init.md still declares
+// `subtask: true` must be overwritten, never preserved — a user upgrading
+// from an affected version reaches the fixed state through a re-sync. A
+// repeat Inject must then be a no-op that leaves the parent-owned state in
+// place.
+//
+// The agent binding itself must survive the fix: removing `subtask: true`
+// must only keep the command in the primary orchestrator session, never
+// detach it from `gentle-orchestrator`. The source-asset twin of this guard
+// is TestNoSubtaskOnSDDOpenCodeCommands in internal/components.
+func TestInjectOpenCodeSDDCommandsRemainParentOwned(t *testing.T) {
+	mockNoPackageManager(t)
+	home := t.TempDir()
+
+	// Seed one stale command from a pre-fix install: a re-sync must replace
+	// it, not keep the forced-subtask metadata on disk.
+	commandsDir := filepath.Join(home, ".config", "opencode", "commands")
+	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(commands): %v", err)
+	}
+	stale := "---\ndescription: stale pre-fix install\nagent: gentle-orchestrator\nsubtask: true\n---\nstale body\n"
+	if err := os.WriteFile(filepath.Join(commandsDir, "sdd-init.md"), []byte(stale), 0o644); err != nil {
+		t.Fatalf("seed stale sdd-init.md: %v", err)
+	}
+
+	first, err := Inject(home, opencodeAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject() over a stale install must report changes")
+	}
+	assertSDDCommandsParentOwned(t, home)
+
+	second, err := Inject(home, opencodeAdapter(), "")
+	if err != nil {
+		t.Fatalf("second Inject() error = %v", err)
+	}
+	if second.Changed {
+		t.Error("second Inject() reported changes; a repeat install must be a no-op")
+	}
+	assertSDDCommandsParentOwned(t, home)
 }
 
 func TestInjectOpenCodeIsIdempotent(t *testing.T) {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -552,6 +552,69 @@ func TestInjectOpenCodeWritesCommandFiles(t *testing.T) {
 	}
 }
 
+// installedCommandFrontmatter extracts the raw YAML frontmatter block of a
+// command file materialized under an injected OpenCode configuration.
+func installedCommandFrontmatter(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+
+	trimmed := strings.TrimLeft(string(data), "\n")
+	const open = "---\n"
+	if !strings.HasPrefix(trimmed, open) {
+		t.Fatalf("%s: installed without YAML frontmatter", path)
+	}
+	rest := trimmed[len(open):]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		t.Fatalf("%s: no closing frontmatter delimiter", path)
+	}
+	return rest[:end]
+}
+
+// TestInjectOpenCodeSDDCommandsRemainParentOwned is the #2939 installation
+// ratchet: after Inject materializes the OpenCode command set, every SDD
+// command that routes through the primary `gentle-orchestrator` agent must
+// be installed WITHOUT `subtask: true` in its frontmatter. With that field,
+// OpenCode forces even a primary-mode agent into a sub-agent invocation, so
+// the command would spawn an orchestrator child that must delegate again to
+// the hidden phase worker — one avoidable model hop and a nested path that
+// can be refused at the default subagent depth.
+//
+// The agent binding itself must survive the fix: removing `subtask: true`
+// must only keep the command in the primary orchestrator session, never
+// detach it from `gentle-orchestrator`. The source-asset twin of this guard
+// is TestNoSubtaskOnSDDOpenCodeCommands in internal/components.
+func TestInjectOpenCodeSDDCommandsRemainParentOwned(t *testing.T) {
+	mockNoPackageManager(t)
+	home := t.TempDir()
+
+	if _, err := Inject(home, opencodeAdapter(), ""); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	for _, name := range []string{
+		"sdd-init.md",
+		"sdd-explore.md",
+		"sdd-apply.md",
+		"sdd-verify.md",
+		"sdd-archive.md",
+		"sdd-onboard.md",
+	} {
+		path := filepath.Join(home, ".config", "opencode", "commands", name)
+		fm := installedCommandFrontmatter(t, path)
+		if !strings.Contains(fm, "agent: gentle-orchestrator") {
+			t.Errorf("installed %s lost `agent: gentle-orchestrator` routing; the fix must remove only `subtask: true`", name)
+		}
+		if strings.Contains(fm, "subtask: true") {
+			t.Errorf("installed %s declares `subtask: true`; OpenCode forces gentle-orchestrator into a sub-agent invocation — remove the field so the command stays in the primary orchestrator session", name)
+		}
+	}
+}
+
 func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	mockNoPackageManager(t)
 	home := t.TempDir()

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kilocode"
-	"gopkg.in/yaml.v3"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
@@ -25,6 +24,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	opencodemodel "github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
+	"gopkg.in/yaml.v3"
 	// agents/cursor, agents/gemini, agents/vscode used via agents.NewAdapter()
 )
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -603,6 +603,7 @@ func TestInjectOpenCodeSDDCommandsRemainParentOwned(t *testing.T) {
 		"sdd-verify.md",
 		"sdd-archive.md",
 		"sdd-onboard.md",
+		"sdd-research.md",
 	} {
 		path := filepath.Join(home, ".config", "opencode", "commands", name)
 		fm := installedCommandFrontmatter(t, path)

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kilocode"
+	"gopkg.in/yaml.v3"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
@@ -552,9 +553,19 @@ func TestInjectOpenCodeWritesCommandFiles(t *testing.T) {
 	}
 }
 
-// installedCommandFrontmatter extracts the raw YAML frontmatter block of a
-// command file materialized under an injected OpenCode configuration.
-func installedCommandFrontmatter(t *testing.T, path string) string {
+// openCodeCommandMeta carries the installed frontmatter fields the #2939
+// ratchet asserts on. Decoding the YAML (instead of substring-matching the
+// raw block) makes the assertions exact: a description or comment that
+// mentions the literal `agent:` or `subtask:` values cannot produce a false
+// pass or a false failure.
+type openCodeCommandMeta struct {
+	Agent   string `yaml:"agent"`
+	Subtask bool   `yaml:"subtask"`
+}
+
+// decodeInstalledCommandFrontmatter reads a command file materialized under
+// an injected OpenCode configuration and decodes its YAML frontmatter block.
+func decodeInstalledCommandFrontmatter(t *testing.T, path string) openCodeCommandMeta {
 	t.Helper()
 
 	data, err := os.ReadFile(path)
@@ -572,7 +583,12 @@ func installedCommandFrontmatter(t *testing.T, path string) string {
 	if end == -1 {
 		t.Fatalf("%s: no closing frontmatter delimiter", path)
 	}
-	return rest[:end]
+
+	var meta openCodeCommandMeta
+	if err := yaml.Unmarshal([]byte(rest[:end]), &meta); err != nil {
+		t.Fatalf("%s: invalid frontmatter YAML: %v", path, err)
+	}
+	return meta
 }
 
 // TestInjectOpenCodeSDDCommandsRemainParentOwned is the #2939 installation
@@ -606,11 +622,11 @@ func TestInjectOpenCodeSDDCommandsRemainParentOwned(t *testing.T) {
 		"sdd-research.md",
 	} {
 		path := filepath.Join(home, ".config", "opencode", "commands", name)
-		fm := installedCommandFrontmatter(t, path)
-		if !strings.Contains(fm, "agent: gentle-orchestrator") {
-			t.Errorf("installed %s lost `agent: gentle-orchestrator` routing; the fix must remove only `subtask: true`", name)
+		meta := decodeInstalledCommandFrontmatter(t, path)
+		if meta.Agent != "gentle-orchestrator" {
+			t.Errorf("installed %s lost `agent: gentle-orchestrator` routing (got %q); the fix must remove only `subtask: true`", name, meta.Agent)
 		}
-		if strings.Contains(fm, "subtask: true") {
+		if meta.Subtask {
 			t.Errorf("installed %s declares `subtask: true`; OpenCode forces gentle-orchestrator into a sub-agent invocation — remove the field so the command stays in the primary orchestrator session", name)
 		}
 	}

--- a/internal/components/sdd_opencode_subtask_test.go
+++ b/internal/components/sdd_opencode_subtask_test.go
@@ -7,34 +7,70 @@ import (
 	"testing"
 )
 
-// TestNoSubtaskOnSDDOpenCodeCommands ensures the six SDD phase commands in
-// internal/assets/opencode/commands/ do not carry `subtask: true` in their
-// YAML frontmatter. OpenCode treats `subtask: true` as a forced sub-agent
-// invocation, which conflicts with the primary-session routing contract
-// (see openspec/changes/2939-keep-sdd-commands-primary/specs/sdd-opencode-subtask-primary/spec.md).
+// delegatingSDDCommands lists every OpenCode SDD command whose frontmatter
+// routes through the primary `gentle-orchestrator` agent and then delegates
+// to a hidden phase sub-agent. Per #2939, none of them may carry
+// `subtask: true`: OpenCode treats that field as a forced sub-agent
+// invocation even for a primary-mode agent, adding an avoidable orchestrator
+// child (or a nested path refused at the default subagent-depth boundary)
+// before the real phase worker launches. The parent-owned controls
+// (`sdd-status`, `sdd-new`, `sdd-continue`, `sdd-ff`) never delegate and are
+// intentionally absent from this list.
 //
-// The orchestrator's permission.task allowlist already covers every phase
-// worker, so adding `subtask: true` back would only change session topology
-// without granting any extra delegation. This is a static, byte-level check;
-// it does not parse YAML — simple substring is sufficient because the literal
-// `subtask: true` is the only way to express the field in this asset tree.
+// `sdd-research` joined this family after the original approval in #2939
+// (same root shape: agent + hidden phase sub-agent); it is kept here so the
+// ratchet covers the current command set, not the 2026-08 snapshot.
+var delegatingSDDCommands = []string{
+	"sdd-init.md",
+	"sdd-explore.md",
+	"sdd-apply.md",
+	"sdd-verify.md",
+	"sdd-archive.md",
+	"sdd-onboard.md",
+}
+
+// commandFrontmatterText extracts the raw YAML frontmatter block (between
+// the opening and closing `---` delimiters) of a command asset. Assertions
+// about metadata must be scoped to this block: the literal `subtask: true`
+// appearing in a command body (for example, when the body documents the
+// field) is prose, not a routing regression.
+func commandFrontmatterText(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	trimmed := strings.TrimLeft(string(data), "\n")
+	const open = "---\n"
+	if !strings.HasPrefix(trimmed, open) {
+		t.Fatalf("%s: does not open with YAML frontmatter", path)
+	}
+	rest := trimmed[len(open):]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		t.Fatalf("%s: no closing frontmatter delimiter", path)
+	}
+	return rest[:end]
+}
+
+// TestNoSubtaskOnSDDOpenCodeCommands is the #2939 source-asset ratchet: the
+// delegating SDD command assets must not declare `subtask: true` in their
+// YAML frontmatter. The orchestrator's permission `task` allowlist already
+// covers every phase worker, so the field only changes session topology —
+// it never grants extra delegation capability. The installation-level twin
+// of this guard is TestInjectOpenCodeSDDCommandsRemainParentOwned in
+// internal/components/sdd.
 func TestNoSubtaskOnSDDOpenCodeCommands(t *testing.T) {
 	root := filepath.Join("..", "..", "internal", "assets", "opencode", "commands")
-	files := []string{
-		"sdd-init.md",
-		"sdd-explore.md",
-		"sdd-apply.md",
-		"sdd-verify.md",
-		"sdd-archive.md",
-		"sdd-onboard.md",
-	}
-	for _, name := range files {
-		data, err := os.ReadFile(filepath.Join(root, name))
-		if err != nil {
-			t.Fatalf("read %s: %v", name, err)
+	for _, name := range delegatingSDDCommands {
+		fm := commandFrontmatterText(t, filepath.Join(root, name))
+		if !strings.Contains(fm, "agent: gentle-orchestrator") {
+			t.Errorf("%s lost `agent: gentle-orchestrator` routing; the fix must remove only `subtask: true`", name)
 		}
-		if strings.Contains(string(data), "subtask: true") {
-			t.Errorf("%s still declares `subtask: true`; OpenCode will force it into a sub-agent invocation. Remove the line from YAML frontmatter (the orchestrator `task` allowlist already covers every phase worker).", name)
+		if strings.Contains(fm, "subtask: true") {
+			t.Errorf("%s still declares `subtask: true`; OpenCode will force gentle-orchestrator into a sub-agent invocation. Remove the line from the YAML frontmatter (the orchestrator `task` allowlist already covers every phase worker).", name)
 		}
 	}
 }

--- a/internal/components/sdd_opencode_subtask_test.go
+++ b/internal/components/sdd_opencode_subtask_test.go
@@ -27,6 +27,7 @@ var delegatingSDDCommands = []string{
 	"sdd-verify.md",
 	"sdd-archive.md",
 	"sdd-onboard.md",
+	"sdd-research.md",
 }
 
 // commandFrontmatterText extracts the raw YAML frontmatter block (between

--- a/internal/components/sdd_opencode_subtask_test.go
+++ b/internal/components/sdd_opencode_subtask_test.go
@@ -1,0 +1,39 @@
+package components_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoSubtaskOnSDDOpenCodeCommands ensures the five SDD phase commands in
+// internal/assets/opencode/commands/ do not carry `subtask: true` in their
+// YAML frontmatter. OpenCode treats `subtask: true` as a forced sub-agent
+// invocation, which conflicts with the primary-session routing contract
+// (see openspec/changes/2939-keep-sdd-commands-primary/specs/sdd-opencode-subtask-primary/spec.md).
+//
+// The orchestrator's permission.task allowlist already covers every phase
+// worker, so adding `subtask: true` back would only change session topology
+// without granting any extra delegation. This is a static, byte-level check;
+// it does not parse YAML — simple substring is sufficient because the literal
+// `subtask: true` is the only way to express the field in this asset tree.
+func TestNoSubtaskOnSDDOpenCodeCommands(t *testing.T) {
+	root := filepath.Join("..", "..", "internal", "assets", "opencode", "commands")
+	files := []string{
+		"sdd-init.md",
+		"sdd-explore.md",
+		"sdd-apply.md",
+		"sdd-verify.md",
+		"sdd-archive.md",
+	}
+	for _, name := range files {
+		data, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if strings.Contains(string(data), "subtask: true") {
+			t.Errorf("%s still declares `subtask: true`; OpenCode will force it into a sub-agent invocation. Remove the line from YAML frontmatter (the orchestrator `task` allowlist already covers every phase worker).", name)
+		}
+	}
+}

--- a/internal/components/sdd_opencode_subtask_test.go
+++ b/internal/components/sdd_opencode_subtask_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// TestNoSubtaskOnSDDOpenCodeCommands ensures the five SDD phase commands in
+// TestNoSubtaskOnSDDOpenCodeCommands ensures the six SDD phase commands in
 // internal/assets/opencode/commands/ do not carry `subtask: true` in their
 // YAML frontmatter. OpenCode treats `subtask: true` as a forced sub-agent
 // invocation, which conflicts with the primary-session routing contract
@@ -26,6 +26,7 @@ func TestNoSubtaskOnSDDOpenCodeCommands(t *testing.T) {
 		"sdd-apply.md",
 		"sdd-verify.md",
 		"sdd-archive.md",
+		"sdd-onboard.md",
 	}
 	for _, name := range files {
 		data, err := os.ReadFile(filepath.Join(root, name))

--- a/internal/components/sdd_opencode_subtask_test.go
+++ b/internal/components/sdd_opencode_subtask_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // delegatingSDDCommands lists every OpenCode SDD command whose frontmatter
@@ -30,12 +32,18 @@ var delegatingSDDCommands = []string{
 	"sdd-research.md",
 }
 
-// commandFrontmatterText extracts the raw YAML frontmatter block (between
-// the opening and closing `---` delimiters) of a command asset. Assertions
-// about metadata must be scoped to this block: the literal `subtask: true`
-// appearing in a command body (for example, when the body documents the
-// field) is prose, not a routing regression.
-func commandFrontmatterText(t *testing.T, path string) string {
+// openCodeCommandMeta carries the frontmatter fields the #2939 ratchet
+// asserts on. Decoding the YAML (instead of substring-matching the raw file)
+// makes the assertions exact: prose or comments that mention the literal
+// `agent:` or `subtask:` values cannot produce a false pass or failure.
+type openCodeCommandMeta struct {
+	Agent   string `yaml:"agent"`
+	Subtask bool   `yaml:"subtask"`
+}
+
+// decodeCommandFrontmatter reads a command asset and decodes its YAML
+// frontmatter block (between the opening and closing `---` delimiters).
+func decodeCommandFrontmatter(t *testing.T, path string) openCodeCommandMeta {
 	t.Helper()
 
 	data, err := os.ReadFile(path)
@@ -53,7 +61,12 @@ func commandFrontmatterText(t *testing.T, path string) string {
 	if end == -1 {
 		t.Fatalf("%s: no closing frontmatter delimiter", path)
 	}
-	return rest[:end]
+
+	var meta openCodeCommandMeta
+	if err := yaml.Unmarshal([]byte(rest[:end]), &meta); err != nil {
+		t.Fatalf("%s: invalid frontmatter YAML: %v", path, err)
+	}
+	return meta
 }
 
 // TestNoSubtaskOnSDDOpenCodeCommands is the #2939 source-asset ratchet: the
@@ -66,11 +79,11 @@ func commandFrontmatterText(t *testing.T, path string) string {
 func TestNoSubtaskOnSDDOpenCodeCommands(t *testing.T) {
 	root := filepath.Join("..", "..", "internal", "assets", "opencode", "commands")
 	for _, name := range delegatingSDDCommands {
-		fm := commandFrontmatterText(t, filepath.Join(root, name))
-		if !strings.Contains(fm, "agent: gentle-orchestrator") {
-			t.Errorf("%s lost `agent: gentle-orchestrator` routing; the fix must remove only `subtask: true`", name)
+		meta := decodeCommandFrontmatter(t, filepath.Join(root, name))
+		if meta.Agent != "gentle-orchestrator" {
+			t.Errorf("%s lost `agent: gentle-orchestrator` routing (got %q); the fix must remove only `subtask: true`", name, meta.Agent)
 		}
-		if strings.Contains(fm, "subtask: true") {
+		if meta.Subtask {
 			t.Errorf("%s still declares `subtask: true`; OpenCode will force gentle-orchestrator into a sub-agent invocation. Remove the line from the YAML frontmatter (the orchestrator `task` allowlist already covers every phase worker).", name)
 		}
 	}

--- a/testdata/golden/sdd-opencode-cmd-sdd-apply.golden
+++ b/testdata/golden/sdd-opencode-cmd-sdd-apply.golden
@@ -1,7 +1,6 @@
 ---
 description: Implement SDD tasks — writes code following specs and design
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command is allowed to launch the hidden `sdd-apply` sub-agent only after the orchestration gates below pass.

--- a/testdata/golden/sdd-opencode-cmd-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-cmd-sdd-init.golden
@@ -1,7 +1,6 @@
 ---
 description: Initialize SDD context — detects project stack and bootstraps persistence backend
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not an SDD executor. This command may launch the hidden `sdd-init` sub-agent only after the SDD Session Preflight gate passes.

--- a/testdata/golden/sdd-opencode-cmd-sdd-research.golden
+++ b/testdata/golden/sdd-opencode-cmd-sdd-research.golden
@@ -1,7 +1,6 @@
 ---
 description: Collect source-backed evidence for a selected SDD research lane
 agent: gentle-orchestrator
-subtask: true
 ---
 
 You are the `gentle-orchestrator`, not the executor. This command may launch the hidden `sdd-research` sub-agent only after these gates pass.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2939

Carries and completes PR #3023 — thanks @ardelperal, this branch includes your two commits rebased onto current main.

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Completes the outstanding items from @decode2's review on #3023:

1. **Installation ratchet added.** The #2939 coverage was source-asset-only. `TestInjectOpenCodeSDDCommandsRemainParentOwned` runs `Inject` for the OpenCode adapter and asserts every installed delegating SDD command keeps `agent: gentle-orchestrator` and carries no `subtask: true` in its installed frontmatter — so no injection path can reintroduce the forced-subtask hop without failing the suite.
2. **Frontmatter-scoped source ratchet.** `TestNoSubtaskOnSDDOpenCodeCommands` now asserts on the YAML frontmatter block only (addressing the CodeRabbit finding), and pins that removing the field never detaches a command from `gentle-orchestrator` routing.
3. **Rebased onto current main** — the original branch was 193 commits behind.
4. **Scope note — `sdd-research`:** upstream added a seventh delegating SDD command (74cc41ba, after the #2939 approval) with the identical shape: `agent: gentle-orchestrator` + `subtask: true`, body launching the hidden `sdd-research` phase sub-agent. The same one-line correction is applied to it in a **separate commit** (`fix(opencode): keep sdd-research parent-owned`) so it can be dropped with a single revert if maintainers prefer the strictly approved six-command set. Both ratchets enumerate the full current delegating set; the parent-owned controls (`sdd-status`, `sdd-new`, `sdd-continue`, `sdd-ff`) remain untouched, and `skill-creator.md`/`skill-registry.md` stay out of scope per the approved root correction.

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/assets/opencode/commands/sdd-{init,explore,apply,verify,archive,onboard}.md` | `subtask: true` removed (from #3023, rebased) |
| `internal/assets/opencode/commands/sdd-research.md` | `subtask: true` removed (new sibling command, same root shape) |
| `internal/components/sdd/inject_test.go` | installation ratchet `TestInjectOpenCodeSDDCommandsRemainParentOwned` |
| `internal/components/sdd_opencode_subtask_test.go` | source ratchet scoped to frontmatter; enumerates the current delegating set |
| `testdata/golden/sdd-opencode-cmd-*.golden` | regenerated — the removed line only (3 files) |

## 🧪 Test Plan

**Unit Tests**
```
go test ./internal/components/ ./internal/components/sdd/ ./internal/assets/ ./internal/catalog/ ./internal/skillregistry/
```
All green. RED/GREEN proof: re-adding `subtask: true` to any listed asset fails both ratchets with a targeted message; removing it passes.

**Go Format**
```
go run ./internal/gofmtcheck
```
Green.

**E2E Tests** (Docker required)
```
cd e2e && ./docker-test.sh
```
3/3 platforms passed (81 tests).

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (151 additions + deletions)
- [ ] I have added the appropriate `type:*` label to this PR — no label permission from a fork; requesting `type:bug`
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SDD commands so they are no longer marked as subtasks.
  * Preserved existing command routing and behavior.

* **Tests**
  * Added coverage verifying all SDD commands retain their intended routing without subtask declarations.
  * Added regression checks for upgrades and repeated command installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->