### PR TITLE
fix(sdd): make an attempt account for the files it creates

### DIFF
--- a/bench/journeys_issue3094.go
+++ b/bench/journeys_issue3094.go
@@ -55,7 +55,10 @@ func issue3094Acquire(r *journeyRun) error {
 	if acquired.State != "proceed" || acquired.Token == "" {
 		return fmt.Errorf("acquire result = %#v, want proceed with a token", acquired)
 	}
-	return r.sandbox.write(filepath.Join(r.sandbox.Repo, ".issue3094-token"), acquired.Token)
+	// The token is harness state, not repository content: writing it inside
+	// the repo under test would leave an untracked file the settlement then has
+	// to rule on, which is this journey's subject nowhere near.
+	return r.sandbox.write(filepath.Join(r.sandbox.Root, ".issue3094-token"), acquired.Token)
 }
 
 func issue3094ObserveActive(r *journeyRun) error {
@@ -70,7 +73,7 @@ func issue3094ObserveActive(r *journeyRun) error {
 }
 
 func issue3094SettleInterrupted(r *journeyRun) error {
-	tokenBytes, err := os.ReadFile(filepath.Join(r.sandbox.Repo, ".issue3094-token"))
+	tokenBytes, err := os.ReadFile(filepath.Join(r.sandbox.Root, ".issue3094-token"))
 	if err != nil {
 		return err
 	}
@@ -111,7 +114,7 @@ func issue3094ReplaySettlement(r *journeyRun) error {
 	if err != nil {
 		return err
 	}
-	tokenBytes, err := os.ReadFile(filepath.Join(r.sandbox.Repo, ".issue3094-token"))
+	tokenBytes, err := os.ReadFile(filepath.Join(r.sandbox.Root, ".issue3094-token"))
 	if err != nil {
 		return err
 	}

--- a/bench/journeys_sdd_untracked.go
+++ b/bench/journeys_sdd_untracked.go
@@ -6,6 +6,11 @@ import (
 	"path/filepath"
 )
 
+var sddBornDuringUntrackedCapability = &Capability{
+	Verb:  []string{"sdd-attempt", "settle"},
+	Flags: []string{"--untracked-scope", "--expected-untracked-inventory", "--intended-untracked"},
+}
+
 var sddSelectedUntrackedCapability = &Capability{
 	Verb:  []string{"sdd-attempt", "acquire"},
 	Flags: []string{"--untracked-scope", "--expected-untracked-inventory", "--intended-untracked"},
@@ -105,6 +110,97 @@ func driveSelectedUntrackedSDDAttempt(r *journeyRun) error {
 	return nil
 }
 
+// driveBornDuringUntrackedSDDAttempt drives #3806 end to end. The attempt
+// begins against a workspace with nothing eligible, creates its implementation
+// as untracked files while it runs, and must say what they are before it can
+// settle. The settled selection is then what the rescope successor inherits,
+// which is the half of the issue a declaration-free begin used to dead-end on.
+func driveBornDuringUntrackedSDDAttempt(r *journeyRun) error {
+	acquire := r.run([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "bench-born-acquire",
+		"--work-unit", "born during lifecycle", "--evidence-goal", "account files the attempt creates",
+		"--max-attempts", "2", "--max-changed-lines", "20",
+	}, false)
+	var claimed sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(acquire.Stdout), &claimed); err != nil || acquire.ExitCode != 0 || claimed.State != "proceed" || claimed.Token == "" {
+		return fmt.Errorf("clean acquire = %#v parse=%v exit=%d", claimed, err, acquire.ExitCode)
+	}
+	// The attempt's own product, created under its admitted authority.
+	if err := r.sandbox.write(filepath.Join(r.sandbox.Repo, "docs", "born.md"), "born during the attempt\n"); err != nil {
+		return err
+	}
+	settle := append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange, "--token", claimed.Token,
+		"--request-id", "bench-born-settle", "--outcome", "failed", "--evidence-revision", sddFailedEvidence,
+	}, sddTerminalEvidence...)
+	blocked := r.run(settle, false)
+	var refusal sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(blocked.Stdout), &refusal); err != nil || refusal.State != "blocked" {
+		return fmt.Errorf("undeclared born-during settlement = %#v parse=%v exit=%d", refusal, err, blocked.ExitCode)
+	}
+	selection, err := readStatusForContract(r, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	digest := selection.argument("expected_untracked_inventory")
+	if digest == "" {
+		return fmt.Errorf("review status did not publish the canonical untracked inventory: %+v", selection.NextTransition)
+	}
+	settled := r.run(append(append([]string{}, settle...),
+		"--untracked-scope", "select", "--intended-untracked", "docs/born.md", "--expected-untracked-inventory", digest), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(settled.Stdout), &result); err != nil || settled.ExitCode != 0 || result.State != "proceed" {
+		return fmt.Errorf("declared born-during settlement = %#v parse=%v exit=%d", result, err, settled.ExitCode)
+	}
+	var status struct {
+		Revision string `json:"revision"`
+		Attempts []struct {
+			ChangedLines      int      `json:"changed_lines"`
+			IntendedUntracked []string `json:"intended_untracked"`
+		} `json:"attempts"`
+	}
+	if err := proveJSON(r.sandbox, &status, "sdd-attempt", "status", "--cwd", r.sandbox.Repo, "--change", sddChange); err != nil {
+		return err
+	}
+	if len(status.Attempts) != 1 || status.Attempts[0].ChangedLines != 1 ||
+		len(status.Attempts[0].IntendedUntracked) != 1 || status.Attempts[0].IntendedUntracked[0] != "docs/born.md" {
+		return fmt.Errorf("born-during settlement accounting = %#v", status)
+	}
+	rescoped := r.run([]string{
+		"sdd-attempt", "rescope", "--cwd", r.sandbox.Repo, "--change", sddChange, "--expected-revision", status.Revision,
+		"--request-id", "bench-born-rescope", "--work-unit", "born during continuation",
+		"--evidence-goal", "prove the successor inherits what the attempt created", "--max-attempts", "2", "--max-changed-lines", "20",
+		"--reason", "maintainer narrowed the failed born-during objective", "--actor", "bench",
+	}, false)
+	if rescoped.ExitCode != 0 {
+		return fmt.Errorf("born-during rescope = exit=%d stderr=%s", rescoped.ExitCode, firstLine(rescoped.Stderr))
+	}
+	// The half #3806 reported: this declaration-free command is the one the
+	// provider advertises, and it used to have no runnable form at all.
+	continued := r.run([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "bench-born-successor",
+		"--work-unit", "born during continuation", "--evidence-goal", "prove the successor inherits what the attempt created",
+		"--max-attempts", "2", "--max-changed-lines", "20",
+	}, false)
+	var successor sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(continued.Stdout), &successor); err != nil || continued.ExitCode != 0 || successor.State != "proceed" || successor.Token == "" {
+		return fmt.Errorf("declaration-free born-during successor = %#v parse=%v exit=%d", successor, err, continued.ExitCode)
+	}
+	var continuedStatus struct {
+		ActiveAttempt *struct {
+			IntendedUntracked []string `json:"intended_untracked"`
+		} `json:"active_attempt"`
+	}
+	if err := proveJSON(r.sandbox, &continuedStatus, "sdd-attempt", "status", "--cwd", r.sandbox.Repo, "--change", sddChange); err != nil {
+		return err
+	}
+	if continuedStatus.ActiveAttempt == nil || len(continuedStatus.ActiveAttempt.IntendedUntracked) != 1 ||
+		continuedStatus.ActiveAttempt.IntendedUntracked[0] != "docs/born.md" {
+		return fmt.Errorf("born-during successor lost the settled selection: %#v", continuedStatus)
+	}
+	return nil
+}
+
 func selectedUntrackedSDDJourneys() []Journey {
 	return []Journey{{
 		ID:     "j84-sdd-attempt-selected-untracked-lifecycle",
@@ -114,6 +210,14 @@ func selectedUntrackedSDDJourneys() []Journey {
 			{Name: "fixture: runtime repository", Fixture: sddRuntimeRepo},
 			{Name: "fixture: selected untracked candidate", Fixture: sddSelectedUntrackedCandidate},
 			{Name: "acquire, settle, and prove selected-path accounting", Requires: sddSelectedUntrackedCapability, Composite: driveSelectedUntrackedSDDAttempt},
+		},
+	}, {
+		ID:     "j99-sdd-attempt-born-during-untracked-lifecycle",
+		Title:  "SDD attempt: files born during an attempt are declared, accounted, and inherited",
+		Source: "issue #3806: a settlement silently recorded the attempt's own untracked product as zero, and the rescope successor it left behind had no runnable begin",
+		Steps: []Step{
+			{Name: "fixture: runtime repository", Fixture: sddRuntimeRepo},
+			{Name: "acquire clean, create, declare at settle, and continue", Requires: sddBornDuringUntrackedCapability, Composite: driveBornDuringUntrackedSDDAttempt},
 		},
 	}}
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -1,748 +1,13 @@
 {
   "schema": "gentle-ai-bench.results/v1",
   "mode": "driven",
-  "binary": "/Users/alanbuscaglia/.local/bin/gentle-ai",
-  "binary_version": "gentle-ai 2.2.2",
+  "binary": "/tmp/claude-1000/-home-gentleman-work-gentle-ai/1ae2fe2e-8ac6-4ab6-ae89-fb010eab12d7/scratchpad/gentle-ai-3806",
+  "binary_version": "gentle-ai dev",
   "journeys": [
     {
-      "id": "j01-docs-happy-path",
-      "title": "Documentation change: review, approve, commit, push gate",
-      "source": "guide flow 3 + flow 9 step 2",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 5,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j01-docs-happy-path-609610672/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j01-docs-happy-path-609610672/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 502,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j01-docs-happy-path-609610672/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j01-docs-happy-path-609610672/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "gate pre-push",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-push",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j01-docs-happy-path-609610672/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1355,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j02-high-risk-four-lens",
-      "title": "High-risk code change: four lenses, evidence, approval",
-      "source": "guide flow 4 + the full native bounded review contract",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 16,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 4,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 670,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1218,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 15787,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-risk",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 737,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 12415,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-resilience",
-            "--order",
-            "1",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/reviewer-1.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 749,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 9025,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-readability",
-            "--order",
-            "2",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/reviewer-2.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 751,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5632,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "3",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/reviewer-3.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 751,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 10,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5676,
-          "git_calls": 0
-        },
-        {
-          "sequence": 11,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 12,
-          "step": "finalize without evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 268,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: finalize for lineage \"review-2c792679b788b673\" had no verification evidence to consume and made no transition; capture it first with `gentle-ai review capture-evidence`, then run `gentle-ai review finalize --lineage review-2c792679b7"
-        },
-        {
-          "sequence": 13,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3178,
-          "git_calls": 0
-        },
-        {
-          "sequence": 14,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:d51c2118086f0941e6eff420da9a807b3bef38664fa8bfa49337d68964fa69c5",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/final-evidence.txt"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 785,
-          "git_calls": 0
-        },
-        {
-          "sequence": 15,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 507,
-          "git_calls": 0
-        },
-        {
-          "sequence": 16,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j02-high-risk-four-lens-1788915041/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j03-kill-switch",
-      "title": "Kill switch: disable, start refused, re-enable, review",
-      "source": "guide flow 2",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 7,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 175,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "mode status",
-          "args": [
-            "review",
-            "mode",
-            "status",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 240,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "mode disable",
-          "args": [
-            "review",
-            "mode",
-            "disable",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 246,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "mode status after disable",
-          "args": [
-            "review",
-            "mode",
-            "status",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 243,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "review start while disabled",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 175,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: receipt-driven development is disabled: start is rejected because the global mode source keeps it off; turn it back on with gentle-ai review mode enable --scope=global"
-        },
-        {
-          "sequence": 5,
-          "step": "mode enable",
-          "args": [
-            "review",
-            "mode",
-            "enable",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 243,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "review start after enable",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j03-kill-switch-1259624648/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 499,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j04-size-does-not-escalate",
-      "title": "1200 lines of prose still reviews as low risk",
-      "source": "guide flow 4 step 3",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j04-size-does-not-escalate-2972068068/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 423,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j04-size-does-not-escalate-2972068068/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 510,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j04-size-does-not-escalate-2972068068/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
       "id": "j05-gate-without-any-review",
-      "title": "Failure path: lifecycle gate before any review exists",
-      "source": "community failure path: receipt missing",
+      "title": "#3417: lifecycle validation before review is informational and unmanaged",
+      "source": "#3417 removes ordinary-path receipt gates; delivery remains under repository policy",
       "status": "completed",
       "metrics": {
         "human_prompts": {
@@ -761,8 +26,8 @@
         },
         "blocks": {
           "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
+          "in_band": 0,
+          "out_of_band": 1,
           "by_design": 0,
           "dead_end": 0
         },
@@ -776,7 +41,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 139,
+          "value": 0,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -788,651 +53,21 @@
       "commands": [
         {
           "sequence": 1,
-          "step": "gate pre-commit with no receipt",
+          "step": "pre-commit validation is informational without a review",
           "args": [
             "review",
             "validate",
             "--gate",
             "pre-commit",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j05-gate-without-any-review-935452980/home/demo"
+            "/tmp/gentle-ai-bench-j05-gate-without-any-review-1404897120/home/demo"
           ],
-          "exit_code": 1,
-          "stderr_bytes": 139,
-          "stdout_bytes": 593,
-          "block": "in_band",
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
           "git_calls": 0,
-          "message": "Error: review lifecycle gate denied: invalidated: no terminal review receipt governs this candidate; review it with gentle-ai review start"
-        }
-      ]
-    },
-    {
-      "id": "j06-pre-push-after-publication",
-      "title": "Failure path: pre-push after the reviewed commit was already pushed",
-      "source": "guide flow 9",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 5,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j06-pre-push-after-publication-1396710478/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j06-pre-push-after-publication-1396710478/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 514,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j06-pre-push-after-publication-1396710478/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "gate pre-push before publishing",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-push",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j06-pre-push-after-publication-1396710478/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1355,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "gate pre-push after publishing",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-push",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j06-pre-push-after-publication-1396710478/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 595,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j07-disabled-with-stale-receipts",
-      "title": "Failure path: reviews disabled with two stale receipts present",
-      "source": "guide flow 6 + flow 9 step 5",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 6,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start (first)",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j07-disabled-with-stale-receipts-88850247/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize (first)",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j07-disabled-with-stale-receipts-88850247/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 514,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "review start (second)",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j07-disabled-with-stale-receipts-88850247/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "review finalize (second)",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j07-disabled-with-stale-receipts-88850247/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 514,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "mode disable",
-          "args": [
-            "review",
-            "mode",
-            "disable",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j07-disabled-with-stale-receipts-88850247/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 246,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "gate pre-push while disabled",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-push",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j07-disabled-with-stale-receipts-88850247/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 691,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j08-finalize-without-reviewer-results",
-      "title": "Failure path: finalize a high-risk review with no reviewer results",
-      "source": "community failure path",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 2,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 688,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j08-finalize-without-reviewer-results-1045185803/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1218,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "finalize with no results",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j08-finalize-without-reviewer-results-1045185803/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 286,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: review finalize requires all 4 original reviewer result(s); capture each missing one with `gentle-ai review capture-result` (see `gentle-ai review status --cwd \u003crepo\u003e --contract gentle-ai.review-integration/v1 --next-transition` for "
-        }
-      ]
-    },
-    {
-      "id": "j09-finalize-without-evidence",
-      "title": "Failure path: finalize with results but no captured evidence",
-      "source": "guide flow 12",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 12,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 4,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 670,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1218,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 15787,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-risk",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 742,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 12415,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-resilience",
-            "--order",
-            "1",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/reviewer-1.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 754,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 9025,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-readability",
-            "--order",
-            "2",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/reviewer-2.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 756,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5632,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "3",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/reviewer-3.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 756,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 10,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5676,
-          "git_calls": 0
-        },
-        {
-          "sequence": 11,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 12,
-          "step": "finalize without evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j09-finalize-without-evidence-290602963/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 268,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: finalize for lineage \"review-2c792679b788b673\" had no verification evidence to consume and made no transition; capture it first with `gentle-ai review capture-evidence`, then run `gentle-ai review finalize --lineage review-2c792679b7"
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
         }
       ]
     },
@@ -1458,8 +93,8 @@
         },
         "blocks": {
           "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
+          "in_band": 0,
+          "out_of_band": 1,
           "by_design": 0,
           "dead_end": 0
         },
@@ -1473,7 +108,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 583,
+          "value": 392,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -1494,25 +129,25 @@
             "--base-ref",
             "HEAD",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j10-invalid-flag-combination-2940599798/home/demo"
+            "/tmp/gentle-ai-bench-j10-invalid-flag-combination-2716565310/home/demo"
           ],
           "exit_code": 1,
-          "stderr_bytes": 583,
+          "stderr_bytes": 392,
           "stdout_bytes": 0,
-          "block": "in_band",
+          "block": "out_of_band",
           "git_calls": 0,
-          "message": "Error: review start with --projection staged and --base-ref is refused because intent is ambiguous: for a staged-index review rerun with \"gentle-ai review start --projection staged\"; for a base-diff review rerun with \"gentle-ai review start"
+          "message": "Error: review start with --base-ref omits dirty tracked changes; rerun with --committed-only to acknowledge committed-only review scope A defect report was saved at /tmp/gentle-ai-bench-j10-invalid-flag-combination-2716565310/home/demo/.git"
         }
       ]
     },
     {
-      "id": "j11-unborn-head",
-      "title": "Failure path: first commit in a repository with no history",
-      "source": "guide flow 10",
+      "id": "j101-zero-path-base-diff-stops-before-start",
+      "title": "Committed-only STATUS stops an empty base-diff instead of offering a START that preflight rejects",
+      "source": "issue #3102: #1641's authorized empty-root bootstrap reaches a base-diff whose selected base can equal the candidate; STATUS must return typed STOP, not fresh_target_ready",
       "status": "completed",
       "metrics": {
         "human_prompts": {
-          "value": 1,
+          "value": 0,
           "derivation": "measured",
           "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
         },
@@ -1522,13 +157,13 @@
           "note": "invocations carrying a hand-assembled --maintainer-authorization value"
         },
         "commands_to_completion": {
-          "value": 8,
+          "value": 1,
           "derivation": "measured"
         },
         "blocks": {
           "self_recovered": 0,
           "in_band": 0,
-          "out_of_band": 0,
+          "out_of_band": 1,
           "by_design": 0,
           "dead_end": 0
         },
@@ -1538,11 +173,11 @@
           "derivation": "measured"
         },
         "model_runs": {
-          "value": 1,
+          "value": 0,
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 402,
+          "value": 0,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -1554,161 +189,157 @@
       "commands": [
         {
           "sequence": 1,
-          "step": "review start on unborn HEAD",
+          "step": "committed-only STATUS with the root as base returns the empty-root bootstrap STOP",
           "args": [
             "review",
-            "start",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn"
+            "/tmp/gentle-ai-bench-j101-zero-path-base-diff-stops-before-start-2659543032/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--base-ref",
+            "a95dc800221d0687f805e147895f86b798f5d9ef",
+            "--committed-only"
           ],
           "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1044,
-          "prompts": 1,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2047,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "{"
+        }
+      ]
+    },
+    {
+      "id": "j102-status-stops-oversized-lens-context",
+      "title": "An unrepresentable immutable reviewer context is refused by START instead of becoming a dead lineage",
+      "source": "issues #2773 and #3367: a frozen candidate whose complete reviewer evidence exceeds the native budget must be refused before any authority is created",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 1,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 217,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "clear any clone-local review override (a clone may only ever assert off)",
+          "args": [
+            "review",
+            "mode",
+            "enable",
+            "--scope",
+            "clone",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j102-status-stops-oversized-lens-context-4079264111/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 242,
           "git_calls": 0
         },
         {
           "sequence": 2,
-          "step": "capture every lens",
+          "step": "negotiated START refuses the oversized frozen reviewer context without persisting authority",
           "args": [
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn",
+            "/tmp/gentle-ai-bench-j102-status-stops-oversized-lens-context-4079264111/home/demo",
             "--contract",
-            "gentle-ai.review-integration/v1",
+            "gentle-ai.review-integration/v2",
             "--next-transition"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 6039,
+          "stdout_bytes": 3922,
           "git_calls": 0
         },
         {
           "sequence": 3,
-          "step": "capture every lens",
+          "step": "negotiated START refuses the oversized frozen reviewer context without persisting authority",
           "args": [
             "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn",
-            "--lineage",
-            "review-f7db5001a6ead6dd",
-            "--target",
-            "sha256:f7db5001a6ead6dd21d214340be7cdcb9e77421e5054f3bdee019eca100f9cd4",
-            "--expected-revision",
-            "sha256:706514bbaece96c16eef71be68dca37764afcf0690d0820a2be0b2d2af0df472",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/reviewer-0.json"
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j102-status-stops-oversized-lens-context-4079264111/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:ca06b0de7a1bb653663c422f988e9965359b737ba3b0306d29bf04315aa54d33",
+            "--projection=workspace",
+            "--lineage=review-8105a68cb1e3bc8b",
+            "--consent=granted"
           ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 744,
-          "model_run": true,
-          "git_calls": 0
+          "exit_code": 1,
+          "stderr_bytes": 217,
+          "stdout_bytes": 1238,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "Error: The candidate's complete reviewer evidence exceeds the native context budget, so no review authority was created; review this change as smaller candidates that each fit under it. [lens_context_budget_exceeded]"
         },
         {
           "sequence": 4,
-          "step": "capture every lens",
+          "step": "negotiated START refuses the oversized frozen reviewer context without persisting authority",
           "args": [
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn",
+            "/tmp/gentle-ai-bench-j102-status-stops-oversized-lens-context-4079264111/home/demo",
             "--contract",
-            "gentle-ai.review-integration/v1",
+            "gentle-ai.review-integration/v2",
             "--next-transition"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 3880,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3183,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn",
-            "--lineage",
-            "review-f7db5001a6ead6dd",
-            "--target",
-            "sha256:f7db5001a6ead6dd21d214340be7cdcb9e77421e5054f3bdee019eca100f9cd4",
-            "--expected-revision",
-            "sha256:06c8cb4372c25e344ed181742eeef6979cddf31be2d04bca51a484d666971f20",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/final-evidence.txt"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 786,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j11-unborn-head-434802436/home/unborn"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 500,
+          "stdout_bytes": 3922,
           "git_calls": 0
         }
       ]
     },
     {
-      "id": "j12-rejected-capture-then-recapture",
-      "title": "Failure path: a reviewer result the product rejects, then a recapture",
-      "source": "community failure path: binding mismatch",
+      "id": "j103-sdd-interrupted-settlement-omits-evidence",
+      "title": "Interrupted runtime settlement omits evidence and replays without a second record",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/issues/3094",
       "status": "completed",
       "metrics": {
         "human_prompts": {
-          "value": 1,
+          "value": 0,
           "derivation": "measured",
           "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
         },
@@ -1734,11 +365,11 @@
           "derivation": "measured"
         },
         "model_runs": {
-          "value": 2,
+          "value": 0,
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 795,
+          "value": 137,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -1750,195 +381,4205 @@
       "commands": [
         {
           "sequence": 1,
-          "step": "review start",
+          "step": "acquire through the public compact CLI and retain its token",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "issue3094-acquire",
+            "--work-unit",
+            "bench runtime objective",
+            "--evidence-goal",
+            "bench proves the corrected candidate",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "observe the active running attempt with empty evidence",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2507,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "settle interrupted without caller evidence",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2507,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "settle interrupted without caller evidence",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:71a198e31d53b0232ef4a3a1779e3ed92890daa57bc7bd2a1f446083cf9f25ce",
+            "--request-id",
+            "issue3094-settle",
+            "--outcome",
+            "interrupted",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 137,
+          "stdout_bytes": 0,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "Error: sdd-attempt settle: interrupted evidence_revision must be empty; rerun `gentle-ai sdd-attempt settle` without --evidence-revision"
+        },
+        {
+          "sequence": 5,
+          "step": "settle interrupted without caller evidence",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2507,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "settle interrupted without caller evidence",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:71a198e31d53b0232ef4a3a1779e3ed92890daa57bc7bd2a1f446083cf9f25ce",
+            "--request-id",
+            "issue3094-settle",
+            "--outcome",
+            "interrupted",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "verify no active attempt and one empty-evidence terminal record",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2118,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "replay the identical compact settlement without publishing another record",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2118,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "replay the identical compact settlement without publishing another record",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:71a198e31d53b0232ef4a3a1779e3ed92890daa57bc7bd2a1f446083cf9f25ce",
+            "--request-id",
+            "issue3094-settle",
+            "--outcome",
+            "interrupted",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        },
+        {
+          "sequence": 10,
+          "step": "replay the identical compact settlement without publishing another record",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j103-sdd-interrupted-settlement-omits-evidence-2003945456/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2118,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j104-repository-context-survives-fresh-process",
+      "title": "#3797: opaque rctx2 digest preserves target, repository/worktree, and subject integrity across fresh START and STATUS processes",
+      "source": "issue #3797: active rctx2 is an opaque authority-derived digest across fresh processes, carrying no filesystem path; rctx1 locators remain historical read-only only",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 6,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 4,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 215,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "drive fresh START, exact active-lineage STATUS retries, and foreign-handle refusal",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j104-repository-context-survives-fresh-process-1008796720/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3950,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "drive fresh START, exact active-lineage STATUS retries, and foreign-handle refusal",
           "args": [
             "review",
             "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo"
+            "--cwd=/tmp/gentle-ai-bench-j104-repository-context-survives-fresh-process-1008796720/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--projection=workspace",
+            "--lineage=review-3569538c11473d71",
+            "--consent=granted"
           ],
           "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1057,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2168,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "drive fresh START, exact active-lineage STATUS retries, and foreign-handle refusal",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--lineage",
+            "review-3569538c11473d71",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j104-repository-context-survives-fresh-process-1008796720/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6013,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "drive fresh START, exact active-lineage STATUS retries, and foreign-handle refusal",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--lineage",
+            "review-3569538c11473d71",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j104-repository-context-survives-fresh-process-1008796720/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6013,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "drive fresh START, exact active-lineage STATUS retries, and foreign-handle refusal",
+          "args": [
+            "review",
+            "capture-result",
+            "--lineage",
+            "review-3569538c11473d71",
+            "--target",
+            "sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision",
+            "sha256:b90e1cb6f8d4adc0990a85823753b26a8185afd8afa9d687bfe09013d8377a8e",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--repository-context",
+            "rctx2_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "--input",
+            "/tmp/gentle-ai-bench-j104-repository-context-survives-fresh-process-1008796720/foreign-context-reviewer.json"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 215,
+          "stdout_bytes": 708,
+          "block": "in_band",
+          "model_run": true,
+          "git_calls": 0,
+          "message": "Error: repository_context_unavailable: provider-issued review repository context operation failed; cause: invalid rctx2 repository context; refresh the exact native next_transition before retrying [invalid_request]"
+        },
+        {
+          "sequence": 6,
+          "step": "drive fresh START, exact active-lineage STATUS retries, and foreign-handle refusal",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--lineage",
+            "review-3569538c11473d71",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j104-repository-context-survives-fresh-process-1008796720/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6013,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        }
+      ]
+    },
+    {
+      "id": "j105-compiled-provider-capture-retries-same-binding",
+      "title": "Compiled provider capture retries the same pending binding after a transport failure",
+      "source": "issue #3138: Go owns provider capture binding and retry lifecycle",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 14,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 7,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 333,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "negotiate and start the Claude provider review",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--agent",
+            "claude-code",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4090,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "negotiate and start the Claude provider review",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--projection=workspace",
+            "--lineage=compiled-provider-capture-retry",
+            "--agent=claude-code",
+            "--consent=granted",
+            "--focus",
+            "reliability"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1980,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "failed provider capture preserves the exact pending binding and its retry closes",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--agent",
+            "claude-code",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5937,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "failed provider capture preserves the exact pending binding and its retry closes",
+          "args": [
+            "review",
+            "capture-result",
+            "--agent",
+            "claude-code",
+            "--repository-context",
+            "rctx2_71325636b621f01b070e6a523ea664a1a7fc04aed3710e563afe1f48823c95d3",
+            "--expected-revision",
+            "sha256:134e5b7ddaea9f8c39f47d7d81415b0c3f23573caab520d2b05d48c1ee45cb92",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--target",
+            "sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 101,
+          "stdout_bytes": 601,
+          "block": "in_band",
+          "model_run": true,
+          "git_calls": 0,
+          "message": "Error: invoke provider reviewer: claude reviewer transport failed: exit status 1:  [invalid_request]"
+        },
+        {
+          "sequence": 5,
+          "step": "failed provider capture preserves the exact pending binding and its retry closes",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--agent",
+            "claude-code",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5937,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "failed provider capture preserves the exact pending binding and its retry closes",
+          "args": [
+            "review",
+            "capture-result",
+            "--agent",
+            "claude-code",
+            "--repository-context",
+            "rctx2_71325636b621f01b070e6a523ea664a1a7fc04aed3710e563afe1f48823c95d3",
+            "--expected-revision",
+            "sha256:134e5b7ddaea9f8c39f47d7d81415b0c3f23573caab520d2b05d48c1ee45cb92",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--target",
+            "sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2430,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "failed provider capture preserves the exact pending binding and its retry closes",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--agent",
+            "claude-code",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4526,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--agent",
+            "claude-code"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4526,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 9,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--agent",
+            "claude-code"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4526,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 10,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--lineage=compiled-provider-capture-retry",
+            "--target=sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--expected-revision=sha256:e0be55290d0b9b737129d9fdd25479b93104fb60d1bae40ec1e45e31c46a00d9",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 11,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--lineage",
+            "compiled-provider-capture-retry",
+            "--agent",
+            "claude-code"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4526,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--lineage=compiled-provider-capture-retry",
+            "--target=sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--expected-revision=sha256:e0be55290d0b9b737129d9fdd25479b93104fb60d1bae40ec1e45e31c46a00d9",
+            "--token=4459d9560b16a45443cb6e46eff8735245c4a39005aedbdfe9fc9c66b9b477db"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo",
+            "--lineage=compiled-provider-capture-retry",
+            "--target=sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--expected-revision=sha256:e0be55290d0b9b737129d9fdd25479b93104fb60d1bae40ec1e45e31c46a00d9",
+            "--token=4459d9560b16a45443cb6e46eff8735245c4a39005aedbdfe9fc9c66b9b477db"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 14,
+          "step": "the final provider capture awaits exact acknowledgement before it burns the completed lineage",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j105-compiled-provider-capture-retries-same-binding-1958586266/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 546,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j106-captured-provider-validator-terminal-capture",
+      "title": "#3587: captured provider validator closes only through its exact active lineage",
+      "source": "#3587 provider-slot continuation: an occupied Go-admitted validator slot is an exact active-lineage provider fact, and its capture is the terminal event",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 15,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 7,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 449,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "start correction review with an exact active lineage",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "captured-provider-validator",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 715,
           "prompts": 1,
           "git_calls": 0
         },
         {
           "sequence": 2,
-          "step": "rejected capture then recapture",
+          "step": "capture correction finding and the full selected lens set for the exact active lineage",
           "args": [
             "review",
             "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
             "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage",
+            "captured-provider-validator"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 5700,
-          "git_calls": 0
+          "stdout_bytes": 5778,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
         },
         {
           "sequence": 3,
-          "step": "rejected capture then recapture",
+          "step": "capture correction finding and the full selected lens set for the exact active lineage",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage",
+            "captured-provider-validator"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5778,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "capture correction finding and the full selected lens set for the exact active lineage",
           "args": [
             "review",
             "capture-result",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
             "--lineage",
-            "review-df69a1bfdb395403",
+            "captured-provider-validator",
             "--target",
-            "sha256:df69a1bfdb3954036cd484911873bb832f6e3a573f865f8df3d31519f325a62b",
+            "sha256:13ef258a8559e3da58443784227fa6500d29031b1edb759d42e21ee89cb010ed",
             "--expected-revision",
-            "sha256:f9190f66d4eee95d9952b6135ebec88a6d4b3e2074db6076f3d5851fc2ef0b46",
+            "sha256:5cdb4d14080fa63efe40e0433a221c98575db36458886a381df17ec44ea516eb",
             "--lens",
             "review-reliability",
             "--order",
             "0",
             "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/reviewer-rejected.json"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 393,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "model_run": true,
-          "git_calls": 0,
-          "message": "Error: reviewer artifact admission binding_mismatch: reviewer result echoed a different artifact subject: the rejected admission did not consume the lens slot, so re-run the lens and invoke gentle-ai review capture-result again on the same "
-        },
-        {
-          "sequence": 4,
-          "step": "rejected capture then recapture",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/exact-selected-reviewer-0.json"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 5700,
+          "stdout_bytes": 1759,
+          "model_run": true,
           "git_calls": 0
         },
         {
           "sequence": 5,
-          "step": "rejected capture then recapture",
+          "step": "capture correction finding and the full selected lens set for the exact active lineage",
+          "args": [
+            "review",
+            "status",
+            "--cwd=/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--next-transition=true",
+            "--lineage=captured-provider-validator"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6260,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "capture the Go-issued bounded correction plan",
+          "args": [
+            "review",
+            "capture-correction-plan",
+            "--cwd=/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage=captured-provider-validator",
+            "--expected-revision=sha256:45518fbda468e1c15c0354f671e09f9fb6092d34338ea56ffdd24fa20f39a68c",
+            "--target=sha256:13ef258a8559e3da58443784227fa6500d29031b1edb759d42e21ee89cb010ed",
+            "--repository-context=rctx2_261eb03d1bcfe3a774adcd475922294f81597a19f1779a84e1ca33024e912a57",
+            "--request-hash=sha256:21f1be6e1802246a590c8e9f0d34b63265d13a08d04228095df7cc1df8a10395",
+            "--correction-lines=2"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 496,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "capture the Go-issued validator Task through the native relay protocol",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "captured-provider-validator",
+            "--agent",
+            "opencode",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8008,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "capture the Go-issued validator Task through the native relay protocol",
+          "args": [
+            "review",
+            "opencode-transport"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 9301,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage",
+            "captured-provider-validator"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4500,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 10,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage",
+            "captured-provider-validator"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4500,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 11,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage=captured-provider-validator",
+            "--target=sha256:dedeb191bb7d6d44ca658d0169d708935efb0912ce683083369ec7c9b3cde9f4",
+            "--expected-revision=sha256:8aa04d54ccb73138fe5e1cd8669b8e532520f06dd92c3f5e9d5dc546e82b62e9",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 12,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage",
+            "captured-provider-validator"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4500,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 13,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage=captured-provider-validator",
+            "--target=sha256:dedeb191bb7d6d44ca658d0169d708935efb0912ce683083369ec7c9b3cde9f4",
+            "--expected-revision=sha256:8aa04d54ccb73138fe5e1cd8669b8e532520f06dd92c3f5e9d5dc546e82b62e9",
+            "--token=3a33e6ed1f3466b8b3a2d999dffc26e6f652e07a898c6db0e0d310e2bf8c579d"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 14,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo",
+            "--lineage=captured-provider-validator",
+            "--target=sha256:dedeb191bb7d6d44ca658d0169d708935efb0912ce683083369ec7c9b3cde9f4",
+            "--expected-revision=sha256:8aa04d54ccb73138fe5e1cd8669b8e532520f06dd92c3f5e9d5dc546e82b62e9",
+            "--token=3a33e6ed1f3466b8b3a2d999dffc26e6f652e07a898c6db0e0d310e2bf8c579d"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 15,
+          "step": "the terminal validator capture exposes acknowledgement before the exact lineage burns",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j106-captured-provider-validator-terminal-capture-2217247495/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 542,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j110-untracked-terminal-burn-and-unmanaged-staged-validation",
+      "title": "#3797: an untracked intended candidate awaits acknowledgement before burn and staged validation stays unmanaged",
+      "source": "#3797 preserves explicit intended-untracked START selection while requiring exact acknowledgement before terminal burn",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 12,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 3,
+          "out_of_band": 4,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 5,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 232,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "select every untracked path and execute printed zero-lens START",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--agent",
+            "opencode"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3167,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "select every untracked path and execute printed zero-lens START",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--agent",
+            "opencode",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:af42134736792f0ef3d0b18408455c14c8cb6538f42d30e06657317bc145f7a0",
+            "--intended-untracked=docs/unborn-candidate.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4897,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "select every untracked path and execute printed zero-lens START",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:47bf51e3f14959563c00bb7ecfde3655ad3c2eb8dc6e64e15dd83a6bad4ce409",
+            "--projection=workspace",
+            "--lineage=review-7eb8b248156707d6",
+            "--agent=opencode",
+            "--consent=relay",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:af42134736792f0ef3d0b18408455c14c8cb6538f42d30e06657317bc145f7a0",
+            "--intended-untracked=docs/unborn-candidate.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2549,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--lineage",
+            "review-7eb8b248156707d6",
+            "--agent",
+            "opencode",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:af42134736792f0ef3d0b18408455c14c8cb6538f42d30e06657317bc145f7a0",
+            "--intended-untracked=docs/unborn-candidate.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4560,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--lineage",
+            "review-7eb8b248156707d6",
+            "--agent",
+            "opencode",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:af42134736792f0ef3d0b18408455c14c8cb6538f42d30e06657317bc145f7a0",
+            "--intended-untracked=docs/unborn-candidate.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4560,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--lineage=review-7eb8b248156707d6",
+            "--target=sha256:47bf51e3f14959563c00bb7ecfde3655ad3c2eb8dc6e64e15dd83a6bad4ce409",
+            "--expected-revision=sha256:fd4f75cd73db47b48bc62ace2781c6323a5d5c616b73ad70cceb42426ced3c5d",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 7,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--lineage",
+            "review-7eb8b248156707d6",
+            "--agent",
+            "opencode",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:af42134736792f0ef3d0b18408455c14c8cb6538f42d30e06657317bc145f7a0",
+            "--intended-untracked=docs/unborn-candidate.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4560,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--lineage=review-7eb8b248156707d6",
+            "--target=sha256:47bf51e3f14959563c00bb7ecfde3655ad3c2eb8dc6e64e15dd83a6bad4ce409",
+            "--expected-revision=sha256:fd4f75cd73db47b48bc62ace2781c6323a5d5c616b73ad70cceb42426ced3c5d",
+            "--token=971293f59896de9e8786912e0627c10656c7b829fa93913ddc79678b288b45c5"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo",
+            "--lineage=review-7eb8b248156707d6",
+            "--target=sha256:47bf51e3f14959563c00bb7ecfde3655ad3c2eb8dc6e64e15dd83a6bad4ce409",
+            "--expected-revision=sha256:fd4f75cd73db47b48bc62ace2781c6323a5d5c616b73ad70cceb42426ced3c5d",
+            "--token=971293f59896de9e8786912e0627c10656c7b829fa93913ddc79678b288b45c5"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 10,
+          "step": "the zero-lens terminal event emits acknowledgement before burning the unborn transaction",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 564,
+          "git_calls": 0
+        },
+        {
+          "sequence": 11,
+          "step": "unstaged unborn pre-commit validation is informational and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-commit",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 12,
+          "step": "staged unborn pre-commit validation remains informational and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-commit",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j110-untracked-terminal-burn-and-unmanaged-staged-validation-1809398367/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        }
+      ]
+    },
+    {
+      "id": "j111-approved-transaction-burns-and-shipped-gates-are-unmanaged",
+      "title": "#3797: selectorless STATUS renders a printed START, the last lens emits acknowledgement, and repeat START follows the exact burn",
+      "source": "#3797: selectorless STATUS owns compact binding; terminal approval awaits exact acknowledgement, leaves no receipt or sidecar, and delivery gates remain informational",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 28,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 9,
+          "out_of_band": 7,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 15,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 232,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "selectorless STATUS renders and executes the initial printed START",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3985,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "selectorless STATUS renders and executes the initial printed START",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--projection=workspace",
+            "--lineage=review-26aaa99722a8cfd0",
+            "--consent=relay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2322,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "selectorless STATUS renders and executes the initial printed START",
+          "args": [
+            "review",
+            "start",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--projection",
+            "workspace",
+            "--lineage",
+            "review-26aaa99722a8cfd0",
+            "--consent",
+            "granted"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4527,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "selectorless STATUS renders and executes the initial printed START",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 15386,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 15386,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
           "args": [
             "review",
             "capture-result",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
             "--lineage",
-            "review-df69a1bfdb395403",
+            "review-26aaa99722a8cfd0",
             "--target",
-            "sha256:df69a1bfdb3954036cd484911873bb832f6e3a573f865f8df3d31519f325a62b",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
             "--expected-revision",
-            "sha256:f9190f66d4eee95d9952b6135ebec88a6d4b3e2074db6076f3d5851fc2ef0b46",
+            "sha256:cb3a5fe7e8f863f13ec9c8dfc582a56d065b5c71f92c45631ceb49547eef1861",
+            "--lens",
+            "review-risk",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/atomic-reviewer-0.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 596,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 12263,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:cb3a5fe7e8f863f13ec9c8dfc582a56d065b5c71f92c45631ceb49547eef1861",
+            "--lens",
+            "review-resilience",
+            "--order",
+            "1",
+            "--input",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/atomic-reviewer-1.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 602,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 9122,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 10,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:cb3a5fe7e8f863f13ec9c8dfc582a56d065b5c71f92c45631ceb49547eef1861",
+            "--lens",
+            "review-readability",
+            "--order",
+            "2",
+            "--input",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/atomic-reviewer-2.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 603,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 11,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5978,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:cb3a5fe7e8f863f13ec9c8dfc582a56d065b5c71f92c45631ceb49547eef1861",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "3",
+            "--input",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/atomic-reviewer-3.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2426,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4554,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 14,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4554,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 15,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage=review-26aaa99722a8cfd0",
+            "--target=sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision=sha256:ead707a4293bd127a8cfe8d78b5d0cbbda45aa3d2d2c818189cc2b929323b773",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 16,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4554,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 17,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage=review-26aaa99722a8cfd0",
+            "--target=sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision=sha256:ead707a4293bd127a8cfe8d78b5d0cbbda45aa3d2d2c818189cc2b929323b773",
+            "--token=d35a67db8315d531bb64991c7e0d6e30d882753d9e8aa101fc588c1090e5fb4b"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 18,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage=review-26aaa99722a8cfd0",
+            "--target=sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision=sha256:ead707a4293bd127a8cfe8d78b5d0cbbda45aa3d2d2c818189cc2b929323b773",
+            "--token=d35a67db8315d531bb64991c7e0d6e30d882753d9e8aa101fc588c1090e5fb4b"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 19,
+          "step": "the exact acknowledgement leaves no reusable authority, receipt, or evidence",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 570,
+          "git_calls": 0
+        },
+        {
+          "sequence": 20,
+          "step": "all shipped gates are informational, non-deciding, and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "post-apply",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 21,
+          "step": "all shipped gates are informational, non-deciding, and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-commit",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 22,
+          "step": "all shipped gates are informational, non-deciding, and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-push",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 340,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 23,
+          "step": "all shipped gates are informational, non-deciding, and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-pr",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 338,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 24,
+          "step": "all shipped gates are informational, non-deciding, and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "release",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 339,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 25,
+          "step": "repeat the selectorless STATUS request and execute its printed START as a new transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3985,
+          "git_calls": 0
+        },
+        {
+          "sequence": 26,
+          "step": "repeat the selectorless STATUS request and execute its printed START as a new transaction",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--projection=workspace",
+            "--lineage=review-26aaa99722a8cfd0",
+            "--consent=relay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2322,
+          "git_calls": 0
+        },
+        {
+          "sequence": 27,
+          "step": "repeat the selectorless STATUS request and execute its printed START as a new transaction",
+          "args": [
+            "review",
+            "start",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--projection",
+            "workspace",
+            "--lineage",
+            "review-26aaa99722a8cfd0",
+            "--consent",
+            "granted"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4527,
+          "git_calls": 0
+        },
+        {
+          "sequence": 28,
+          "step": "repeat the selectorless STATUS request and execute its printed START as a new transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j111-approved-transaction-burns-and-shipped-gates-are-unmanaged-2904803273/home/demo",
+            "--lineage",
+            "review-26aaa99722a8cfd0"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 15386,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        }
+      ]
+    },
+    {
+      "id": "j112-sdd-attempt-settle-survives-review-mode-transition",
+      "title": "A failed-evidence correction token settles after review turns on",
+      "source": "#3564 Slice 1: SDD attempt authority is independent of receipt-driven development mode",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 8,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "review mode starts off",
+          "args": [
+            "review",
+            "mode",
+            "status",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 241,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "fail and reset the bounded verification objective",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "issue3564-failed-acquire",
+            "--work-unit",
+            "bench chain verification",
+            "--evidence-goal",
+            "admit the verification failure",
+            "--max-attempts",
+            "1",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "fail and reset the bounded verification objective",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:0c59865b09b0928df54361d4a679926eda35a3d0f5c51c20dc58a522fba38701",
+            "--request-id",
+            "issue3564-failed-settle",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1396,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "fail and reset the bounded verification objective",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2297,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "fail and reset the bounded verification objective",
+          "args": [
+            "sdd-attempt",
+            "reset",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:f60e4072254ce204b215692407084c4f057c1dbf279f2a663c092d616f942549",
+            "--request-id",
+            "issue3564-reset",
+            "--reason",
+            "maintainer authorizes exact failed-evidence remediation",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2286,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "acquire the exact failed-evidence correction while review is off",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "issue3564-correction-acquire",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--work-unit",
+            "bench chain verification",
+            "--evidence-goal",
+            "admit the verification failure",
+            "--max-attempts",
+            "1",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "turn review on after the correction token is issued",
+          "args": [
+            "review",
+            "mode",
+            "enable",
+            "--scope",
+            "global",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 243,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "settle the exact token using only failed SDD evidence",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j112-sdd-attempt-settle-survives-review-mode-transition-554127598/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:f4707979e8cfe5622a9076102c88ba3c94ef564477c357cf616615ebe32e077d",
+            "--request-id",
+            "issue3564-correction-settle",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 26,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j113-correction-removes-candidate-only-path",
+      "title": "A bounded correction may remove a candidate-only file and continue through STATUS",
+      "source": "issue #3321 under #3587 and #3797: correction paths are frozen-to-current deltas, and the terminal validator capture exposes acknowledgement before the corrected lineage burns",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 14,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 6,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 8,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 449,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "start the exact review lineage",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "issue-3321-base-equivalent-correction",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 726,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "capture the blocking candidate-only finding and finish selected lenses",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3321-base-equivalent-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5903,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "capture the blocking candidate-only finding and finish selected lenses",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage",
+            "issue-3321-base-equivalent-correction",
+            "--target",
+            "sha256:c5722ec0ddca7b618227b7e2e51c633970a1d5cd659e7a5984776a38b24e170f",
+            "--expected-revision",
+            "sha256:f3429b11c2f6e017e4008bfd9c5fc265b1143b484e42b5eb5b617e07087895f3",
             "--lens",
             "review-reliability",
             "--order",
             "0",
             "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/reviewer-0.json"
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/blocking-reviewer.json"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 763,
+          "stdout_bytes": 1791,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "capture the blocking candidate-only finding and finish selected lenses",
+          "args": [
+            "review",
+            "status",
+            "--cwd=/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--next-transition=true",
+            "--lineage=issue-3321-base-equivalent-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6333,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "capture the three-line deletion plan from STATUS",
+          "args": [
+            "review",
+            "capture-correction-plan",
+            "--cwd=/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage=issue-3321-base-equivalent-correction",
+            "--expected-revision=sha256:ad9b51e1becc104bd89ea84b099faf6c11e52c5f2fa9ac480d0a46e9ad781bf9",
+            "--target=sha256:c5722ec0ddca7b618227b7e2e51c633970a1d5cd659e7a5984776a38b24e170f",
+            "--repository-context=rctx2_33a056e0f37bc8031281058a374c41302589a3c8bf0619c7107f07ff8d0e203f",
+            "--request-hash=sha256:485d971f1686807a784ad7ab1882c247ef618e46abefa88c1cc0cf6a7024cbf3",
+            "--correction-lines=3"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 506,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "targeted validator approves and exposes acknowledgement before the corrected lineage burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "issue-3321-base-equivalent-correction",
+            "--agent",
+            "opencode",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8049,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 7,
+          "step": "targeted validator approves and exposes acknowledgement before the corrected lineage burns",
+          "args": [
+            "review",
+            "opencode-transport"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 9335,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage",
+            "issue-3321-base-equivalent-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4533,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 9,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage",
+            "issue-3321-base-equivalent-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4533,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 10,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage=issue-3321-base-equivalent-correction",
+            "--target=sha256:122883f0a1fa025ce5ec22013b01cfabb3442dcb9331a74f1e47fec9a5cce756",
+            "--expected-revision=sha256:6902fee101361e3c1a0a6b297f25d3a3144f68435e11c72003812fbb8174fc7f",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 11,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage",
+            "issue-3321-base-equivalent-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4533,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage=issue-3321-base-equivalent-correction",
+            "--target=sha256:122883f0a1fa025ce5ec22013b01cfabb3442dcb9331a74f1e47fec9a5cce756",
+            "--expected-revision=sha256:6902fee101361e3c1a0a6b297f25d3a3144f68435e11c72003812fbb8174fc7f",
+            "--token=47d012af42c99c3b4e9945d6335524900a155ea734e3e409cbe266c51b602094"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo",
+            "--lineage=issue-3321-base-equivalent-correction",
+            "--target=sha256:122883f0a1fa025ce5ec22013b01cfabb3442dcb9331a74f1e47fec9a5cce756",
+            "--expected-revision=sha256:6902fee101361e3c1a0a6b297f25d3a3144f68435e11c72003812fbb8174fc7f",
+            "--token=47d012af42c99c3b4e9945d6335524900a155ea734e3e409cbe266c51b602094"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 14,
+          "step": "no correction authority survives the terminal validator capture",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j113-correction-removes-candidate-only-path-1705013265/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 530,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j114-last-reviewer-capture-closes-and-burns",
+      "title": "The last admitted reviewer capture closes a clean 4R review with pending acknowledgement",
+      "source": "issue #3797: FINALIZE is not a public phase; exact acknowledgement is the only approved terminal continuation",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 16,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 7,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 449,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "start exact high-risk lineage",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "issue-3587-last-event-closure",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 991,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3587-last-event-closure"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 15252,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage",
+            "issue-3587-last-event-closure",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:7af7eec12085873df9451955dbefea28d0cb2e29ba6c25a32d52d5d2811c9b7a",
+            "--lens",
+            "review-risk",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/issue-3587-reviewer-0.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 602,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3587-last-event-closure"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 12003,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage",
+            "issue-3587-last-event-closure",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:7af7eec12085873df9451955dbefea28d0cb2e29ba6c25a32d52d5d2811c9b7a",
+            "--lens",
+            "review-resilience",
+            "--order",
+            "1",
+            "--input",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/issue-3587-reviewer-1.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 608,
           "model_run": true,
           "git_calls": 0
         },
         {
           "sequence": 6,
-          "step": "rejected capture then recapture",
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
           "args": [
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
             "--contract",
             "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "--next-transition",
+            "--lineage",
+            "issue-3587-last-event-closure"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 3876,
-          "git_calls": 0
+          "stdout_bytes": 8736,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
         },
         {
           "sequence": 7,
-          "step": "finalize with captured results",
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
           "args": [
             "review",
-            "finalize",
-            "--captured-results=true",
+            "capture-result",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo"
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage",
+            "issue-3587-last-event-closure",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:7af7eec12085873df9451955dbefea28d0cb2e29ba6c25a32d52d5d2811c9b7a",
+            "--lens",
+            "review-readability",
+            "--order",
+            "2",
+            "--input",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/issue-3587-reviewer-2.json"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 249,
+          "stdout_bytes": 609,
+          "model_run": true,
           "git_calls": 0
         },
         {
           "sequence": 8,
-          "step": "capture final evidence",
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
           "args": [
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
             "--contract",
             "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "--next-transition",
+            "--lineage",
+            "issue-3587-last-event-closure"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 3179,
-          "git_calls": 0
+          "stdout_bytes": 5466,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
         },
         {
           "sequence": 9,
-          "step": "capture final evidence",
+          "step": "capture every lens; the final capture reduces and emits acknowledgement",
           "args": [
             "review",
-            "capture-evidence",
+            "capture-result",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
             "--lineage",
-            "review-df69a1bfdb395403",
+            "issue-3587-last-event-closure",
             "--target",
-            "sha256:df69a1bfdb3954036cd484911873bb832f6e3a573f865f8df3d31519f325a62b",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
             "--expected-revision",
-            "sha256:1c1ac4c70357403fc1fd88a5b880d76d36726e0a226ec20bea9b09fe9e108a7e",
-            "--outcome",
-            "passed",
+            "sha256:7af7eec12085873df9451955dbefea28d0cb2e29ba6c25a32d52d5d2811c9b7a",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "3",
             "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/final-evidence.txt"
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/issue-3587-reviewer-3.json"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 784,
+          "stdout_bytes": 2396,
+          "model_run": true,
           "git_calls": 0
         },
         {
           "sequence": 10,
-          "step": "finalize with captured evidence",
+          "step": "no review authority survives the exact acknowledgement",
           "args": [
             "review",
-            "finalize",
-            "--captured-evidence=true",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j12-rejected-capture-then-recapture-1803065603/home/demo"
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage",
+            "issue-3587-last-event-closure"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 519,
+          "stdout_bytes": 4502,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 11,
+          "step": "no review authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage",
+            "issue-3587-last-event-closure"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4502,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "no review authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage=issue-3587-last-event-closure",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision=sha256:400c1c844fc7df625656bb08dea5673a7ce846eeb750ac9f343a318cdb9ae749",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 13,
+          "step": "no review authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage",
+            "issue-3587-last-event-closure"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4502,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 14,
+          "step": "no review authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage=issue-3587-last-event-closure",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision=sha256:400c1c844fc7df625656bb08dea5673a7ce846eeb750ac9f343a318cdb9ae749",
+            "--token=2e20b63a7d04adbbe726efe984c73a6cc7d1cc2fe1b5c751c1f5503851c51040"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 15,
+          "step": "no review authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo",
+            "--lineage=issue-3587-last-event-closure",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision=sha256:400c1c844fc7df625656bb08dea5673a7ce846eeb750ac9f343a318cdb9ae749",
+            "--token=2e20b63a7d04adbbe726efe984c73a6cc7d1cc2fe1b5c751c1f5503851c51040"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 16,
+          "step": "no review authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j114-last-reviewer-capture-closes-and-burns-3414106143/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 530,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j115-recovery-selector-is-collected-before-authorization",
+      "title": "Default workspace-overlay recovery collects an unrepresentable selector before authorization",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/issues/3065",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 19,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 7,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 7,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "start escalated predecessor review",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-escalated-predecessor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--committed-only"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3988,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "start escalated predecessor review",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract=gentle-ai.review-integration/v1",
+            "--target=sha256:35e75bd4a38375d4d1f70356add941fa41821c1812f47aebc5179a0ad01a65cb",
+            "--projection=workspace",
+            "--base-ref=05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only=true",
+            "--lineage=issue-3065-escalated-predecessor"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2353,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "capture predecessor finding",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-escalated-predecessor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--committed-only"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5290,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "capture predecessor finding",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--lineage",
+            "issue-3065-escalated-predecessor",
+            "--target",
+            "sha256:35e75bd4a38375d4d1f70356add941fa41821c1812f47aebc5179a0ad01a65cb",
+            "--expected-revision",
+            "sha256:20fc6a057d20461e89f73e3b86153b3cd19e376cf5759d637512925ac96d79a8",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/blocking-reviewer.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2200,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "capture predecessor finding",
+          "args": [
+            "review",
+            "status",
+            "--cwd=/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract=gentle-ai.review-integration/v2",
+            "--next-transition=true",
+            "--lineage=issue-3065-escalated-predecessor",
+            "--base-ref=05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only=true"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6279,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "capture predecessor correction plan",
+          "args": [
+            "review",
+            "capture-correction-plan",
+            "--cwd=/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--lineage=issue-3065-escalated-predecessor",
+            "--expected-revision=sha256:b00213ad9514cc0f3f4c962bccd271b39fa8c5470f168acc41decddddc572a05",
+            "--target=sha256:35e75bd4a38375d4d1f70356add941fa41821c1812f47aebc5179a0ad01a65cb",
+            "--repository-context=rctx2_5c14651b3be387288256abeba8dcd244bbd107f14fcc0334bbb6e9e005c939da",
+            "--request-hash=sha256:47b3ba3735dc91ce4494ed5442ff6011f9b8461b9751d93854e879313289e539",
+            "--correction-lines=3"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 501,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "failed predecessor validation escalates authority",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-escalated-predecessor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--committed-only",
+            "--agent",
+            "opencode",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8022,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "failed predecessor validation escalates authority",
+          "args": [
+            "review",
+            "opencode-transport"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 7498,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "execute staged-overlay recovery successor",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--action-eligibility",
+            "--lineage",
+            "issue-3065-escalated-predecessor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--projection",
+            "staged",
+            "--workspace-overlay",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5017,
+          "git_calls": 0
+        },
+        {
+          "sequence": 10,
+          "step": "execute staged-overlay recovery successor",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-escalated-predecessor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--projection",
+            "staged",
+            "--workspace-overlay",
+            "--recovery-successor-lineage",
+            "issue-3065-staged-escalated-successor",
+            "--recovery-reason",
+            "authorize staged correction scope expansion",
+            "--recovery-actor",
+            "bench-maintainer",
+            "--recovery-authorization",
+            "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=issue-3065-escalated-predecessor\npredecessor_revision=sha256:c3ef21e124cd2566e382650906218be475bd2979e09bf4e0be1247681f936bf6\ntarget_identity=sha256:2b1edcb298326ebb375d72c2f9c48c225c12f594ab4f9c77e300b41302a1012e\nsuccessor_lineage=issue-3065-staged-escalated-successor\nactor=bench-maintainer\nreason=authorize staged correction scope expansion"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6650,
+          "git_calls": 0
+        },
+        {
+          "sequence": 11,
+          "step": "execute staged-overlay recovery successor",
+          "args": [
+            "review",
+            "recover",
+            "--predecessor-lineage=issue-3065-escalated-predecessor",
+            "--expected-predecessor-revision=sha256:c3ef21e124cd2566e382650906218be475bd2979e09bf4e0be1247681f936bf6",
+            "--successor-lineage=issue-3065-staged-escalated-successor",
+            "--disposition=escalated",
+            "--reason=authorize staged correction scope expansion",
+            "--actor=bench-maintainer",
+            "--maintainer-authorization=gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=issue-3065-escalated-predecessor\npredecessor_revision=sha256:c3ef21e124cd2566e382650906218be475bd2979e09bf4e0be1247681f936bf6\ntarget_identity=sha256:2b1edcb298326ebb375d72c2f9c48c225c12f594ab4f9c77e300b41302a1012e\nsuccessor_lineage=issue-3065-staged-escalated-successor\nactor=bench-maintainer\nreason=authorize staged correction scope expansion",
+            "--base-ref=e49e7686933f5f4942364a0698130b1190956a23",
+            "--projection=staged",
+            "--workspace-overlay=true"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1094,
+          "manual_token": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 12,
+          "step": "execute staged-overlay recovery successor",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-staged-escalated-successor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--projection",
+            "staged",
+            "--workspace-overlay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5836,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 13,
+          "step": "capture successor finding",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-staged-escalated-successor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--projection",
+            "staged",
+            "--workspace-overlay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5836,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 14,
+          "step": "capture successor finding",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--lineage",
+            "issue-3065-staged-escalated-successor",
+            "--target",
+            "sha256:2b1edcb298326ebb375d72c2f9c48c225c12f594ab4f9c77e300b41302a1012e",
+            "--expected-revision",
+            "sha256:be5a0f5a334c30e9d388bfaa75ea23b3127110ce43d2473afcf2032f15d21a4e",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/issue3065-successor-reviewer.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2367,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 15,
+          "step": "capture successor finding",
+          "args": [
+            "review",
+            "status",
+            "--cwd=/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--contract=gentle-ai.review-integration/v2",
+            "--next-transition=true",
+            "--lineage=issue-3065-staged-escalated-successor",
+            "--base-ref=05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--workspace-overlay=true",
+            "--projection=staged"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6337,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 16,
+          "step": "capture successor correction plan",
+          "args": [
+            "review",
+            "capture-correction-plan",
+            "--cwd=/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree",
+            "--lineage=issue-3065-staged-escalated-successor",
+            "--expected-revision=sha256:7f2ae6290eb396422f00e7843fe40688ed4439a174f485361c40e48ef05d6337",
+            "--target=sha256:2b1edcb298326ebb375d72c2f9c48c225c12f594ab4f9c77e300b41302a1012e",
+            "--repository-context=rctx2_009511053b789d46f2ddedcf0301c7d819446118abd33332146d27ffb0aad19b",
+            "--request-hash=sha256:3af641d236b719a36f25a0cfce49bfed7a69c99b6a83fbad14d7a6d6a8169d38",
+            "--correction-lines=3"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 506,
+          "git_calls": 0
+        },
+        {
+          "sequence": 17,
+          "step": "failed successor validation escalates authority",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-staged-escalated-successor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--projection",
+            "staged",
+            "--workspace-overlay",
+            "--agent",
+            "opencode",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8072,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 18,
+          "step": "failed successor validation escalates authority",
+          "args": [
+            "review",
+            "opencode-transport"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 7510,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 19,
+          "step": "default workspace-overlay STATUS collects target before authorization",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--lineage",
+            "issue-3065-staged-escalated-successor",
+            "--base-ref",
+            "e49e7686933f5f4942364a0698130b1190956a23",
+            "--workspace-overlay",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j115-recovery-selector-is-collected-before-authorization-2807510436/home/demo-worktree"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3146,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j116-codex-committed-correction-runs-returned-status-continuation",
+      "title": "Codex committed correction executes the provider-returned STATUS continuation unchanged",
+      "source": "issue #3748 follow-up to PR #3751: Codex parity for committed correction re-entry",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 6,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 2,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "negotiate and start the committed Codex review",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j116-codex-committed-correction-runs-returned-status-continuation-1196656081/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--agent",
+            "codex",
+            "--lineage",
+            "issue-3748-codex-committed-continuation",
+            "--base-ref",
+            "05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4528,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "negotiate and start the committed Codex review",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j116-codex-committed-correction-runs-returned-status-continuation-1196656081/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:35e75bd4a38375d4d1f70356add941fa41821c1812f47aebc5179a0ad01a65cb",
+            "--projection=workspace",
+            "--base-ref=05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only=true",
+            "--lineage=issue-3748-codex-committed-continuation",
+            "--agent=codex",
+            "--consent=relay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2521,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "negotiate and start the committed Codex review",
+          "args": [
+            "review",
+            "start",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j116-codex-committed-correction-runs-returned-status-continuation-1196656081/home/demo",
+            "--target",
+            "sha256:35e75bd4a38375d4d1f70356add941fa41821c1812f47aebc5179a0ad01a65cb",
+            "--projection",
+            "workspace",
+            "--agent",
+            "codex",
+            "--lineage",
+            "issue-3748-codex-committed-continuation",
+            "--base-ref",
+            "05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only",
+            "--consent",
+            "granted"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1996,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "Codex reports a candidate-caused blocker and returns correction_required",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j116-codex-committed-correction-runs-returned-status-continuation-1196656081/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--agent",
+            "codex",
+            "--lineage",
+            "issue-3748-codex-committed-continuation",
+            "--base-ref",
+            "05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5951,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "Codex reports a candidate-caused blocker and returns correction_required",
+          "args": [
+            "review",
+            "capture-result",
+            "--lineage=issue-3748-codex-committed-continuation",
+            "--expected-revision=sha256:e7a85964a0d2f66c884f2ab5c8cb9a02c0ab6ffe2977419de190055384bd0a4f",
+            "--target=sha256:35e75bd4a38375d4d1f70356add941fa41821c1812f47aebc5179a0ad01a65cb",
+            "--repository-context=rctx2_56781267147300eb82f2a9df20ef624f83e03ee06548ec26436defbf1c85c878",
+            "--lens=review-reliability",
+            "--order=0",
+            "--subject-hash=sha256:9cc1e5fc3a5931c36c86f7b33cfdc95901d7477e937a2324d94b8a5af5b1f8b1",
+            "--agent=codex"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2350,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "the returned ordered STATUS tokens re-enter the frozen committed correction",
+          "args": [
+            "review",
+            "status",
+            "--cwd=/tmp/gentle-ai-bench-j116-codex-committed-correction-runs-returned-status-continuation-1196656081/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--next-transition=true",
+            "--lineage=issue-3748-codex-committed-continuation",
+            "--agent=codex",
+            "--base-ref=05721190fac02ac4f4316a72ca70b5521b9b86fc",
+            "--committed-only=true"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6336,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        }
+      ]
+    },
+    {
+      "id": "j117-doctor-dangling-managed-config",
+      "title": "Doctor identifies a dangling managed config symlink without recommending sync",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/issues/3557",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "doctor reports manual repair and preserves the filesystem",
+          "args": [
+            "doctor"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2067,
+          "git_calls": 1
+        }
+      ]
+    },
+    {
+      "id": "j118-doctor-dangling-config-ancestor",
+      "title": "Doctor identifies a dangling ancestor of a managed config path without recommending sync",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/pull/3561",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "doctor reports manual repair and preserves the filesystem",
+          "args": [
+            "doctor"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2181,
+          "git_calls": 1
+        }
+      ]
+    },
+    {
+      "id": "j119-global-review-mode-status-reports-persisted-source",
+      "title": "#3772: global review mode status reports persisted source across fresh processes",
+      "source": "#3772: status must truthfully expose the persisted global source after enable and disable",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "enable global review mode",
+          "args": [
+            "review",
+            "mode",
+            "enable",
+            "--scope",
+            "global",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j119-global-review-mode-status-reports-persisted-source-3454527937/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 243,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "fresh status reports enabled global source",
+          "args": [
+            "review",
+            "mode",
+            "status",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j119-global-review-mode-status-reports-persisted-source-3454527937/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 241,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "disable global review mode",
+          "args": [
+            "review",
+            "mode",
+            "disable",
+            "--scope",
+            "global",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j119-global-review-mode-status-reports-persisted-source-3454527937/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 246,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "fresh status reports disabled global source",
+          "args": [
+            "review",
+            "mode",
+            "status",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j119-global-review-mode-status-reports-persisted-source-3454527937/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 243,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j12-rejected-capture-then-recapture",
+      "title": "#3587: an exact active-lineage reviewer result is rejected, then the full selected set recaptures",
+      "source": "#2614 under #3587: incomplete inspection coverage refuses on its exact active lineage, then an unordered complete manifest recaptures",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 14,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 8,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 10,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 699,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "review start with an exact active lineage",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "rejected-capture-recapture",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 726,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "exact active-lineage rejected capture then full selected-set recapture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6025,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "exact active-lineage rejected capture then full selected-set recapture",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture",
+            "--target",
+            "sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision",
+            "sha256:11ec8a18707f31ed79a4911f86a903fdccb1adaf174cebbce6b2d755a95524de",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/reviewer-rejected.json"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 250,
+          "stdout_bytes": 756,
+          "block": "in_band",
+          "model_run": true,
+          "git_calls": 0,
+          "message": "Error: reviewer artifact admission incomplete: reviewer inspection did not cover the complete frozen path manifest; admission_diagnostic={\"code\":\"inspection_coverage\",\"reason\":\"missing_frozen_manifest_paths\",\"missing_path_count\":2} [invalid"
+        },
+        {
+          "sequence": 4,
+          "step": "exact active-lineage rejected capture then full selected-set recapture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6025,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "exact active-lineage rejected capture then full selected-set recapture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6025,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "exact active-lineage rejected capture then full selected-set recapture",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture",
+            "--target",
+            "sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision",
+            "sha256:11ec8a18707f31ed79a4911f86a903fdccb1adaf174cebbce6b2d755a95524de",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/exact-selected-reviewer-0.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2357,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "exact active-lineage rejected capture then full selected-set recapture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4504,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4504,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 9,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4504,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 10,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage=rejected-capture-recapture",
+            "--target=sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision=sha256:d9f0bfb69824f425fa02a4bf7821502782dd3a43986ce351b0f0fe656422338b",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 11,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage",
+            "rejected-capture-recapture"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4504,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage=rejected-capture-recapture",
+            "--target=sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision=sha256:d9f0bfb69824f425fa02a4bf7821502782dd3a43986ce351b0f0fe656422338b",
+            "--token=053c0638110eff52552639dc76f96ff198dc57d408782fce8a0c467d5e2132ba"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo",
+            "--lineage=rejected-capture-recapture",
+            "--target=sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision=sha256:d9f0bfb69824f425fa02a4bf7821502782dd3a43986ce351b0f0fe656422338b",
+            "--token=053c0638110eff52552639dc76f96ff198dc57d408782fce8a0c467d5e2132ba"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 14,
+          "step": "the final accepted capture exposes acknowledgement before the exact active-lineage transaction burns",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j12-rejected-capture-then-recapture-3235200806/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 514,
           "git_calls": 0
         }
       ]
@@ -1960,7 +4601,7 @@
           "note": "invocations carrying a hand-assembled --maintainer-authorization value"
         },
         "commands_to_completion": {
-          "value": 12,
+          "value": 4,
           "derivation": "measured"
         },
         "blocks": {
@@ -1976,11 +4617,11 @@
           "derivation": "measured"
         },
         "model_runs": {
-          "value": 4,
+          "value": 0,
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 402,
+          "value": 217,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -1997,11 +4638,11 @@
             "review",
             "start",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo"
+            "/tmp/gentle-ai-bench-j13-next-transition-runs-verbatim-1907981151/home/demo"
           ],
           "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1218,
+          "stderr_bytes": 217,
+          "stdout_bytes": 985,
           "prompts": 1,
           "git_calls": 0
         },
@@ -2012,235 +4653,60 @@
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
+            "/tmp/gentle-ai-bench-j13-next-transition-runs-verbatim-1907981151/home/demo",
             "--contract",
             "gentle-ai.review-integration/v1",
             "--next-transition"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 15787,
+          "stdout_bytes": 3486,
           "git_calls": 0
         },
         {
           "sequence": 3,
-          "step": "capture every lens",
+          "step": "run the printed transition verbatim",
           "args": [
             "review",
-            "capture-result",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-risk",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/reviewer-0.json"
+            "/tmp/gentle-ai-bench-j13-next-transition-runs-verbatim-1907981151/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 747,
-          "model_run": true,
+          "stdout_bytes": 3486,
           "git_calls": 0
         },
         {
           "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 12415,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-resilience",
-            "--order",
-            "1",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/reviewer-1.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 759,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 9025,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-readability",
-            "--order",
-            "2",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/reviewer-2.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 761,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5632,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--lineage",
-            "review-2c792679b788b673",
-            "--target",
-            "sha256:2c792679b788b67307c492b5bffc9d169fdc5d850536cb60b5cfc41891a3a692",
-            "--expected-revision",
-            "sha256:40fca37c48a00cc04b14a49a833124f97b88f1722686eb1e7c30800634e0498d",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "3",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/reviewer-3.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 761,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 10,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5676,
-          "git_calls": 0
-        },
-        {
-          "sequence": 11,
           "step": "run the printed transition verbatim",
           "args": [
             "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j13-next-transition-runs-verbatim-1907981151/home/demo",
+            "--contract=gentle-ai.review-integration/v1",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--projection=workspace",
+            "--lineage=review-4fa43bffd1c88ad7"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 5676,
-          "git_calls": 0
-        },
-        {
-          "sequence": 12,
-          "step": "run the printed transition verbatim",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j13-next-transition-runs-verbatim-1783859784/home/demo",
-            "--lineage=review-2c792679b788b673",
-            "--captured-results=true"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
+          "stdout_bytes": 4685,
           "git_calls": 0
         }
       ]
     },
     {
       "id": "j14-abandon-needs-a-hand-built-token",
-      "title": "Maintainer path: abandoning a pristine lineage needs an assembled authorization",
+      "title": "Maintainer path: abandoning a non-terminal lineage binds its discarded work",
       "source": "review abandon contract",
       "status": "completed",
       "metrics": {
         "human_prompts": {
-          "value": 0,
+          "value": 1,
           "derivation": "measured",
           "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
         },
@@ -2255,14 +4721,14 @@
         },
         "blocks": {
           "self_recovered": 0,
-          "in_band": 1,
+          "in_band": 2,
           "out_of_band": 0,
           "by_design": 0,
           "dead_end": 0
         },
         "blocks_derivation": "measured",
         "recovery_round_trips": {
-          "value": 1,
+          "value": 0,
           "derivation": "measured"
         },
         "model_runs": {
@@ -2270,7 +4736,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 892,
+          "value": 2459,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -2287,49 +4753,47 @@
             "review",
             "start",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-264566416/home/demo"
+            "/tmp/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-2486367444/home/demo"
           ],
           "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
+          "stderr_bytes": 217,
+          "stdout_bytes": 985,
+          "prompts": 1,
           "git_calls": 0
         },
         {
           "sequence": 2,
-          "step": "abandon a pristine lineage",
+          "step": "abandon a non-terminal lineage with its V2 binding",
           "args": [
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-264566416/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "/tmp/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-2486367444/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 3235,
+          "stdout_bytes": 1144,
           "git_calls": 0
         },
         {
           "sequence": 3,
-          "step": "abandon a pristine lineage",
+          "step": "abandon a non-terminal lineage with its V2 binding",
           "args": [
             "review",
             "abandon",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-264566416/home/demo",
+            "/tmp/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-2486367444/home/demo",
             "--lineage",
-            "review-3beae9ac2074fec1",
+            "review-3f6f885ec7bdd68c",
             "--expected-revision",
-            "sha256:ad08b7bc0295227ccc02d3a28eefc21f7a8895c2805f036053062b59cf492e82",
+            "sha256:c2ba6590d3a6883ba47ba9403ceff110c7ab4214a3e768c7d3fc611795956738",
             "--reason",
-            "benchmark abandons a pristine lineage",
+            "operator_disposition",
             "--actor",
             "bench"
           ],
           "exit_code": 1,
-          "stderr_bytes": 892,
+          "stderr_bytes": 1159,
           "stdout_bytes": 0,
           "block": "in_band",
           "git_calls": 0,
@@ -2337,274 +4801,30 @@
         },
         {
           "sequence": 4,
-          "step": "abandon a pristine lineage",
+          "step": "abandon a non-terminal lineage with its V2 binding",
           "args": [
             "review",
             "abandon",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-264566416/home/demo",
+            "/tmp/gentle-ai-bench-j14-abandon-needs-a-hand-built-token-2486367444/home/demo",
             "--lineage",
-            "review-3beae9ac2074fec1",
+            "review-3f6f885ec7bdd68c",
             "--expected-revision",
-            "sha256:ad08b7bc0295227ccc02d3a28eefc21f7a8895c2805f036053062b59cf492e82",
+            "sha256:c2ba6590d3a6883ba47ba9403ceff110c7ab4214a3e768c7d3fc611795956738",
             "--reason",
-            "benchmark abandons a pristine lineage",
+            "operator_disposition",
             "--actor",
             "bench",
             "--maintainer-authorization",
-            "gentle-ai.review-abandon-authorization/v1\nlineage=review-3beae9ac2074fec1\nrevision=sha256:ad08b7bc0295227ccc02d3a28eefc21f7a8895c2805f036053062b59cf492e82\nsnapshot_identity=sha256:3beae9ac2074fec14bb6ddbac9108f33b280adefbaa6fab42d452bd92f521859\nactor=bench\nreason=benchmark abandons a pristine lineage"
+            "gentle-ai.review-abandon-authorization/v2\nlineage=review-3f6f885ec7bdd68c\nrevision=sha256:c2ba6590d3a6883ba47ba9403ceff110c7ab4214a3e768c7d3fc611795956738\nsnapshot_identity=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875\nreason=operator_disposition\ncaptured_lens_results=\nfindings_present=false\nevidence_records_present=false\nactor=bench"
           ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1113,
+          "exit_code": 1,
+          "stderr_bytes": 1083,
+          "stdout_bytes": 0,
+          "block": "in_band",
           "manual_token": true,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j15-linked-worktree",
-      "title": "Linked worktree shares the review store: both trees review, approve and gate independently",
-      "source": "shape 1 (asymmetric comparison) + shape 5 (two sources of truth about repository identity)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 7,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start in the linked worktree",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo-worktree"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize in the linked worktree",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo-worktree"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 503,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate post-apply in the linked worktree",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo-worktree"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "review start in the main worktree",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "review finalize in the main worktree",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 503,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "gate pre-commit in the main worktree",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "gate pre-commit in the linked worktree again",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j15-linked-worktree-3595118464/home/demo-worktree"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j16-detached-head",
-      "title": "Detached HEAD: the whole cycle works with no branch at all",
-      "source": "shape 3 (a guard gated on HEAD being a branch, which is not its own precondition)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j16-detached-head-2987658738/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j16-detached-head-2987658738/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 501,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j16-detached-head-2987658738/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
+          "git_calls": 0,
+          "message": "Error: review abandon requires an exact maintainer authorization binding (schema gentle-ai.review-abandon-authorization/v2 over lineage review-3f6f885ec7bdd68c@sha256:c2ba6590d3a6883ba47ba9403ceff110c7ab4214a3e768c7d3fc611795956738, snapsho"
         }
       ]
     },
@@ -2645,7 +4865,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 351,
+          "value": 300,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -2662,10 +4882,10 @@
             "review",
             "start",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j17-bare-repository-295350709/home/bare.git"
+            "/tmp/gentle-ai-bench-j17-bare-repository-3044689617/home/bare.git"
           ],
           "exit_code": 1,
-          "stderr_bytes": 351,
+          "stderr_bytes": 300,
           "stdout_bytes": 0,
           "block": "by_design",
           "by_design": {
@@ -2674,14 +4894,14 @@
             "applied": true
           },
           "git_calls": 0,
-          "message": "Error: resolve review repository root: review needs a working tree: /private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j17-bare-repository-295350709/home/bare.git is a bare repository, and a review candidate is a worki"
+          "message": "Error: resolve review repository root: review needs a working tree: /tmp/gentle-ai-bench-j17-bare-repository-3044689617/home/bare.git is a bare repository, and a review candidate is a working-tree diff; run the same command again from a che"
         }
       ]
     },
     {
-      "id": "j18-space-and-non-ascii-path",
-      "title": "Repository path with spaces and non-ASCII: the whole cycle works",
-      "source": "shape 1 (one operand path-canonicalized, the other not)",
+      "id": "j2138-opencode-native-fallback-boundary",
+      "title": "Zero-config OpenCode install emits bounded native fallback agents",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/issues/2138",
       "status": "completed",
       "metrics": {
         "human_prompts": {
@@ -2695,7 +4915,7 @@
           "note": "invocations carrying a hand-assembled --maintainer-authorization value"
         },
         "commands_to_completion": {
-          "value": 3,
+          "value": 2,
           "derivation": "measured"
         },
         "blocks": {
@@ -2715,528 +4935,11 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 0,
+          "value": 632,
           "derivation": "measured"
         },
         "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j18-space-and-non-ascii-path-1389249075/home/demo repo ñ 日本 dir"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j18-space-and-non-ascii-path-1389249075/home/demo repo ñ 日本 dir"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 531,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j18-space-and-non-ascii-path-1389249075/home/demo repo ñ 日本 dir"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j19-submodule-gitlink",
-      "title": "Gitlink in the candidate: a tree entry with no blob behind it",
-      "source": "shape 1 (comparing a 160000 entry as if it had content)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 9,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 402,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1045,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 6263,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo",
-            "--lineage",
-            "review-e54da57c8e5862d8",
-            "--target",
-            "sha256:e54da57c8e5862d830dbc6db6f5898a06728ad1a6e49ac46d636c53fded05373",
-            "--expected-revision",
-            "sha256:b216db99935f81e42770b1ea2557d34cc2bff1121afbdeeccf2a029488c0daf1",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 749,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3884,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3187,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo",
-            "--lineage",
-            "review-e54da57c8e5862d8",
-            "--target",
-            "sha256:e54da57c8e5862d830dbc6db6f5898a06728ad1a6e49ac46d636c53fded05373",
-            "--expected-revision",
-            "sha256:74cd819014afbe4d86be242238425a80bb69265b62ccdc303aaf53a6eb3452a0",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/final-evidence.txt"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 790,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 505,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j19-submodule-gitlink-1177519402/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j20-symlink-candidate",
-      "title": "Symlink in the candidate: mode 120000 whose blob is a path",
-      "source": "shape 1 (link target read as file content on one side only)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 9,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 402,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1041,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5396,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo",
-            "--lineage",
-            "review-aef6e3a7df3bd5dd",
-            "--target",
-            "sha256:aef6e3a7df3bd5dda77731f3cdaeeeca0dd3ac1a14345656761e40e51189b5b1",
-            "--expected-revision",
-            "sha256:bd766d6085167eb54c8c3ddf7ad61b135063a5d6242ffc1a8ac7cbb3eab58712",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 749,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3860,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3163,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo",
-            "--lineage",
-            "review-aef6e3a7df3bd5dd",
-            "--target",
-            "sha256:aef6e3a7df3bd5dda77731f3cdaeeeca0dd3ac1a14345656761e40e51189b5b1",
-            "--expected-revision",
-            "sha256:4569ff9bc1218f7493f6bf633152e0a58a56950fe194c2ca40c687af0c0f1bd1",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/final-evidence.txt"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 768,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 505,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j20-symlink-candidate-1848758213/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j21-mode-only-change",
-      "title": "Mode-only change 100644 to 100755: identical blob on both sides",
-      "source": "shape 1 (a content-only comparison sees no change at all)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 15,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
           "value": 4,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 402,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
           "derivation": "measured",
           "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
         }
@@ -3244,305 +4947,48 @@
       "commands": [
         {
           "sequence": 1,
-          "step": "review start",
+          "step": "public multi-mode install",
           "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo"
+            "install",
+            "--agent",
+            "opencode",
+            "--component",
+            "sdd",
+            "--sdd-mode",
+            "multi",
+            "--scope",
+            "global"
           ],
           "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1218,
-          "prompts": 1,
-          "git_calls": 0
+          "stderr_bytes": 316,
+          "stdout_bytes": 8904,
+          "git_calls": 2
         },
         {
           "sequence": 2,
-          "step": "capture every lens",
+          "step": "public single-mode install",
           "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "install",
+            "--agent",
+            "opencode",
+            "--component",
+            "sdd",
+            "--sdd-mode",
+            "single",
+            "--scope",
+            "global"
           ],
           "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 14030,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-risk",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 734,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 11093,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-resilience",
-            "--order",
-            "1",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/reviewer-1.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 746,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 8138,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-readability",
-            "--order",
-            "2",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/reviewer-2.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 748,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5180,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "3",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/reviewer-3.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 748,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 10,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5659,
-          "git_calls": 0
-        },
-        {
-          "sequence": 11,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 12,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3161,
-          "git_calls": 0
-        },
-        {
-          "sequence": 13,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:a2d5022bd41b75a37204fc460348dc9bcab366971370024b0826f71223924ac1",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/final-evidence.txt"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 768,
-          "git_calls": 0
-        },
-        {
-          "sequence": 14,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 504,
-          "git_calls": 0
-        },
-        {
-          "sequence": 15,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j21-mode-only-change-3046804549/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
+          "stderr_bytes": 316,
+          "stdout_bytes": 7144,
+          "git_calls": 2
         }
       ]
     },
     {
-      "id": "j22-pure-rename",
-      "title": "Pure rename: every byte identical, only the path moved",
-      "source": "shape 1 (a rename read as one deletion plus one creation)",
+      "id": "j3043-opencode-managed-background-activation",
+      "title": "OpenCode background subagents activate through a managed launcher",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/issues/3043",
       "status": "completed",
       "metrics": {
         "human_prompts": {
@@ -3556,407 +5002,9 @@
           "note": "invocations carrying a hand-assembled --maintainer-authorization value"
         },
         "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j22-pure-rename-1585014795/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j22-pure-rename-1585014795/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 499,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j22-pure-rename-1585014795/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j23-deletion-only",
-      "title": "Deletion-only candidate: nothing added anywhere",
-      "source": "shape 1 (a candidate whose new side is empty)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j23-deletion-only-583740797/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j23-deletion-only-583740797/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 500,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j23-deletion-only-583740797/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j24-empty-file",
-      "title": "Empty file: zero bytes, zero changed lines",
-      "source": "shape 4 (a message describing content that is not there)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 9,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
           "value": 1,
           "derivation": "measured"
         },
-        "human_surface_bytes": {
-          "value": 402,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1079,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5280,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo",
-            "--lineage",
-            "review-80a627113df945d8",
-            "--target",
-            "sha256:80a627113df945d8d7ee4cd693b2a8457e30876e58ac88540118b62f99f114d9",
-            "--expected-revision",
-            "sha256:26a5a4ba604a9cd71a3a244c03d0f8153cc41f45d6aa700f118b2162fb984f95",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 742,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3858,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3161,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo",
-            "--lineage",
-            "review-80a627113df945d8",
-            "--target",
-            "sha256:80a627113df945d8d7ee4cd693b2a8457e30876e58ac88540118b62f99f114d9",
-            "--expected-revision",
-            "sha256:fdca32b3e97def7905d85413c4e9d73ac700c2577f7908f5f2f9dd12fa1949db",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/final-evidence.txt"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 766,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 498,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "gate post-apply",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "post-apply",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j24-empty-file-2431077589/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j25-no-trailing-newline",
-      "title": "File with no trailing newline: the last line has no terminator",
-      "source": "shape 1 (one side line-terminated, the other not)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
         "blocks": {
           "self_recovered": 0,
           "in_band": 0,
@@ -3974,11 +5022,11 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 0,
+          "value": 316,
           "derivation": "measured"
         },
         "git_subprocesses": {
-          "value": 0,
+          "value": 2,
           "derivation": "measured",
           "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
         }
@@ -3986,560 +5034,19 @@
       "commands": [
         {
           "sequence": 1,
-          "step": "review start",
+          "step": "install reports managed activation",
           "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j25-no-trailing-newline-4094949536/home/demo"
+            "install",
+            "--agent",
+            "opencode",
+            "--component",
+            "sdd",
+            "--opencode-background-subagents=on"
           ],
           "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j25-no-trailing-newline-4094949536/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 507,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j25-no-trailing-newline-4094949536/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j26-crlf-content",
-      "title": "CRLF content: carriage returns survive into the staged blob",
-      "source": "shape 1 (line endings normalized on one operand only)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j26-crlf-content-4195623217/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j26-crlf-content-4195623217/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 500,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j26-crlf-content-4195623217/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j27-merge-in-progress",
-      "title": "Merge in progress: review a conflict resolution before the merge commit exists",
-      "source": "shape 3 (a guard gated on a clean git state rather than on its own precondition)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j27-merge-in-progress-2722385250/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j27-merge-in-progress-2722385250/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 505,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j27-merge-in-progress-2722385250/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j28-rebase-in-progress",
-      "title": "Rebase in progress: detached HEAD plus a rebase state directory",
-      "source": "shape 3 (a guard gated on a clean git state)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j28-rebase-in-progress-1432494689/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j28-rebase-in-progress-1432494689/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 506,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j28-rebase-in-progress-1432494689/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j29-cherry-pick-in-progress",
-      "title": "Cherry-pick in progress: CHERRY_PICK_HEAD present throughout",
-      "source": "shape 3 (a guard gated on a clean git state)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 3,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 0,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j29-cherry-pick-in-progress-1984821429/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j29-cherry-pick-in-progress-1984821429/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 511,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j29-cherry-pick-in-progress-1984821429/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j30-kill-switch-flipped-mid-review",
-      "title": "Kill switch flipped between START and FINALIZE: the documented answer is that FINALIZE is refused",
-      "source": "shape 3 (the mutate guard sits behind the start path) + shape 5 (rdd_mode.go documents a rejection the code never issues)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 6,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 277,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start with reviews on",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j30-kill-switch-flipped-mid-review-2800508400/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "mode disable mid-review",
-          "args": [
-            "review",
-            "mode",
-            "disable",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j30-kill-switch-flipped-mid-review-2800508400/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 246,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "mode status confirms off",
-          "args": [
-            "review",
-            "mode",
-            "status",
-            "--json",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j30-kill-switch-flipped-mid-review-2800508400/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 243,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "review finalize while reviews are off",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j30-kill-switch-flipped-mid-review-2800508400/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 277,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: receipt-driven development is disabled: advancing an existing review is rejected because the global mode source keeps it off; the review is frozen, not discarded; turn reviews back on with gentle-ai review mode enable --scope=global "
-        },
-        {
-          "sequence": 5,
-          "step": "review status while reviews are off",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j30-kill-switch-flipped-mid-review-2800508400/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1188,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "gate pre-commit while reviews are off",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j30-kill-switch-flipped-mid-review-2800508400/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 691,
-          "git_calls": 0
+          "stderr_bytes": 316,
+          "stdout_bytes": 7567,
+          "git_calls": 2
         }
       ]
     },
@@ -4580,7 +5087,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 1221,
+          "value": 1065,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -4599,14 +5106,14 @@
             "status",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j31-nonsense-mode-value-1629950513/home/demo"
+            "/tmp/gentle-ai-bench-j31-nonsense-mode-value-1585653574/home/demo"
           ],
           "exit_code": 1,
-          "stderr_bytes": 459,
+          "stderr_bytes": 407,
           "stdout_bytes": 240,
           "block": "in_band",
           "git_calls": 0,
-          "message": "Error: the global value in /private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j31-nonsense-mode-value-1629950513/home/.gentle-ai/state.json is not a mode this product can read; an unreadable switch is not a disabled sw"
+          "message": "Error: the global value in /tmp/gentle-ai-bench-j31-nonsense-mode-value-1585653574/home/.gentle-ai/state.json is not a mode this product can read; an unreadable switch is not a disabled switch, so receipt-driven development stays managed un"
         },
         {
           "sequence": 2,
@@ -4615,247 +5122,30 @@
             "review",
             "start",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j31-nonsense-mode-value-1629950513/home/demo"
+            "/tmp/gentle-ai-bench-j31-nonsense-mode-value-1585653574/home/demo"
           ],
           "exit_code": 1,
-          "stderr_bytes": 762,
+          "stderr_bytes": 658,
           "stdout_bytes": 0,
           "block": "in_band",
           "git_calls": 0,
-          "message": "Error: the global value in /private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j31-nonsense-mode-value-1629950513/home/.gentle-ai/state.json is not a mode this product can read; an unreadable switch is not a disabled sw"
+          "message": "Error: the global value in /tmp/gentle-ai-bench-j31-nonsense-mode-value-1585653574/home/.gentle-ai/state.json is not a mode this product can read; an unreadable switch is not a disabled switch, so receipt-driven development stays managed un"
         }
       ]
     },
     {
-      "id": "j32-recovery-of-a-recovery",
-      "title": "Recovery of a recovery: the named continuation has to work twice",
-      "source": "shape 4 (guide flow 9 step 7 — the message named a recovery that landed you back at the same denial)",
+      "id": "j34-abandon-then-start-again",
+      "title": "Abandon a non-terminal lineage, then start a fresh review of the same candidate",
+      "source": "shape 2 (an abandoned lineage must not poison the repository permanently)",
       "status": "completed",
       "metrics": {
         "human_prompts": {
-          "value": 0,
+          "value": 1,
           "derivation": "measured",
           "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
         },
         "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 10,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 2,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
           "value": 2,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 496,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 4,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "review finalize",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 510,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "first recovery, following exactly what the gate named",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 248,
-          "stdout_bytes": 2843,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: review lifecycle gate denied: scope-changed: 1 path in this candidate that no terminal receipt covers: recover via gentle-ai review recover (requires: predecessor_lineage_id, expected_predecessor_revision, successor_lineage_id, dispo"
-        },
-        {
-          "sequence": 4,
-          "step": "first recovery, following exactly what the gate named",
-          "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-a43c89773e594091",
-            "--expected-predecessor-revision",
-            "sha256:02d85456adf7605557cd348fda779c9078c47db4c9042c8660329b183be520e6",
-            "--successor-lineage",
-            "review-successor-one",
-            "--disposition",
-            "scope_changed",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1140,
-          "git_calls": 2
-        },
-        {
-          "sequence": 5,
-          "step": "first recovery, following exactly what the gate named",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 504,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "first recovery, following exactly what the gate named",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1354,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "second recovery, of the successor the first one created",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 248,
-          "stdout_bytes": 2891,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: review lifecycle gate denied: scope-changed: 1 path in this candidate that no terminal receipt covers: recover via gentle-ai review recover (requires: predecessor_lineage_id, expected_predecessor_revision, successor_lineage_id, dispo"
-        },
-        {
-          "sequence": 8,
-          "step": "second recovery, of the successor the first one created",
-          "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-successor-one",
-            "--expected-predecessor-revision",
-            "sha256:a2fbcb76d39e4c16d9d42b669e14578db8c645f17bad3a33f04f243901d947f2",
-            "--successor-lineage",
-            "review-successor-two",
-            "--disposition",
-            "scope_changed",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1135,
-          "git_calls": 2
-        },
-        {
-          "sequence": 9,
-          "step": "second recovery, of the successor the first one created",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 504,
-          "git_calls": 0
-        },
-        {
-          "sequence": 10,
-          "step": "second recovery, of the successor the first one created",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j32-recovery-of-a-recovery-3262033413/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1354,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j33-escalate-then-recover",
-      "title": "Escalate on a failed verification, then recover once the candidate is fixed",
-      "source": "shape 2 (an escalation is recoverable, not terminal) + shape 4 (the refusal must say the candidate has to change)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
           "derivation": "measured",
           "note": "invocations carrying a hand-assembled --maintainer-authorization value"
         },
@@ -4865,9 +5155,9 @@
         },
         "blocks": {
           "self_recovered": 0,
-          "in_band": 1,
+          "in_band": 4,
           "out_of_band": 0,
-          "by_design": 1,
+          "by_design": 0,
           "dead_end": 0
         },
         "blocks_derivation": "measured",
@@ -4880,200 +5170,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 1164,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 4,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "finalize binding a FAILED verification",
-          "args": [
-            "review",
-            "finalize",
-            "--evidence",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/failed-verification.txt",
-            "--failed=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 510,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "gate pre-commit on an escalated lineage",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 429,
-          "stdout_bytes": 1337,
-          "block": "by_design",
-          "by_design": {
-            "shape": "operator-knowledge",
-            "next_action": "change the candidate and review the fix as a successor",
-            "applied": true
-          },
-          "git_calls": 0,
-          "message": "Error: review lifecycle gate denied: escalated: transaction or external evidence is terminally escalated; this lineage is terminal, so change the candidate and review the fix as a successor: gentle-ai review recover --predecessor-lineage re"
-        },
-        {
-          "sequence": 4,
-          "step": "recover before and after fixing the candidate",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1167,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "recover before and after fixing the candidate",
-          "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-d6bd76251f1f4ed3",
-            "--expected-predecessor-revision",
-            "sha256:b8468fa058edd71a29e2184d902a01e04739f6c386a9905a02beab3b4a01b3e3",
-            "--successor-lineage",
-            "review-after-escalation",
-            "--disposition",
-            "escalated",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 1,
-          "stderr_bytes": 735,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 2,
-          "message": "Error: escalated recovery successor target has not changed: the candidate is byte-identical to the escalated predecessor, so this successor would carry the exact content whose verification failed and there is nothing to re-review; change th"
-        },
-        {
-          "sequence": 6,
-          "step": "recover before and after fixing the candidate",
-          "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-d6bd76251f1f4ed3",
-            "--expected-predecessor-revision",
-            "sha256:b8468fa058edd71a29e2184d902a01e04739f6c386a9905a02beab3b4a01b3e3",
-            "--successor-lineage",
-            "review-after-escalation",
-            "--disposition",
-            "escalated",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1120,
-          "git_calls": 2
-        },
-        {
-          "sequence": 7,
-          "step": "recover before and after fixing the candidate",
-          "args": [
-            "review",
-            "finalize",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 509,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "recover before and after fixing the candidate",
-          "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j33-escalate-then-recover-1506877380/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j34-abandon-then-start-again",
-      "title": "Abandon a lineage, then start a fresh review of the same candidate",
-      "source": "shape 2 (an abandoned lineage must not poison the repository permanently)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 7,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 0,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 885,
+          "value": 4665,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -5090,49 +5187,47 @@
             "review",
             "start",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo"
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo"
           ],
           "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 418,
+          "stderr_bytes": 217,
+          "stdout_bytes": 985,
+          "prompts": 1,
           "git_calls": 0
         },
         {
           "sequence": 2,
-          "step": "abandon a pristine lineage",
+          "step": "abandon a non-terminal lineage with its V2 discarded-work binding",
           "args": [
             "review",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 3235,
+          "stdout_bytes": 1117,
           "git_calls": 0
         },
         {
           "sequence": 3,
-          "step": "abandon a pristine lineage",
+          "step": "abandon a non-terminal lineage with its V2 discarded-work binding",
           "args": [
             "review",
             "abandon",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo",
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo",
             "--lineage",
-            "review-3beae9ac2074fec1",
+            "review-aa353b320c7f40d7",
             "--expected-revision",
-            "sha256:ad08b7bc0295227ccc02d3a28eefc21f7a8895c2805f036053062b59cf492e82",
+            "sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45",
             "--reason",
-            "benchmark abandons a pristine lineage",
+            "operator_disposition",
             "--actor",
             "bench"
           ],
           "exit_code": 1,
-          "stderr_bytes": 885,
+          "stderr_bytes": 1150,
           "stdout_bytes": 0,
           "block": "in_band",
           "git_calls": 0,
@@ -5140,28 +5235,30 @@
         },
         {
           "sequence": 4,
-          "step": "abandon a pristine lineage",
+          "step": "abandon a non-terminal lineage with its V2 discarded-work binding",
           "args": [
             "review",
             "abandon",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo",
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo",
             "--lineage",
-            "review-3beae9ac2074fec1",
+            "review-aa353b320c7f40d7",
             "--expected-revision",
-            "sha256:ad08b7bc0295227ccc02d3a28eefc21f7a8895c2805f036053062b59cf492e82",
+            "sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45",
             "--reason",
-            "benchmark abandons a pristine lineage",
+            "operator_disposition",
             "--actor",
             "bench",
             "--maintainer-authorization",
-            "gentle-ai.review-abandon-authorization/v1\nlineage=review-3beae9ac2074fec1\nrevision=sha256:ad08b7bc0295227ccc02d3a28eefc21f7a8895c2805f036053062b59cf492e82\nsnapshot_identity=sha256:3beae9ac2074fec14bb6ddbac9108f33b280adefbaa6fab42d452bd92f521859\nactor=bench\nreason=benchmark abandons a pristine lineage"
+            "gentle-ai.review-abandon-authorization/v2\nlineage=review-aa353b320c7f40d7\nrevision=sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45\nsnapshot_identity=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875\nreason=operator_disposition\ncaptured_lens_results=\nfindings_present=false\nevidence_records_present=false\nactor=bench"
           ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1099,
+          "exit_code": 1,
+          "stderr_bytes": 1074,
+          "stdout_bytes": 0,
+          "block": "in_band",
           "manual_token": true,
-          "git_calls": 0
+          "git_calls": 0,
+          "message": "Error: review abandon requires an exact maintainer authorization binding (schema gentle-ai.review-abandon-authorization/v2 over lineage review-aa353b320c7f40d7@sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45, snapsho"
         },
         {
           "sequence": 5,
@@ -5170,388 +5267,77 @@
             "review",
             "start",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo"
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 418,
+          "stdout_bytes": 986,
           "git_calls": 0
         },
         {
           "sequence": 6,
-          "step": "review finalize",
+          "step": "fresh active lineage remains abandonable instead of reusing the quarantined authority",
           "args": [
             "review",
-            "finalize",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo"
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 512,
+          "stdout_bytes": 1117,
           "git_calls": 0
         },
         {
           "sequence": 7,
-          "step": "gate pre-commit",
+          "step": "fresh active lineage remains abandonable instead of reusing the quarantined authority",
           "args": [
             "review",
-            "validate",
-            "--gate",
-            "pre-commit",
+            "abandon",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j34-abandon-then-start-again-3950223627/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 1357,
-          "git_calls": 0
-        }
-      ]
-    },
-    {
-      "id": "j35-correction-budget-exactly-zero",
-      "title": "Correction budget of exactly zero: forecasting a correction against it",
-      "source": "shape 3 (the budget check sitting behind a different precondition) + shape 4 (guide flow 17 promises spent/remaining/total)",
-      "status": "completed",
-      "metrics": {
-        "human_prompts": {
-          "value": 1,
-          "derivation": "measured",
-          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
-        },
-        "manual_tokens": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
-        },
-        "commands_to_completion": {
-          "value": 15,
-          "derivation": "measured"
-        },
-        "blocks": {
-          "self_recovered": 0,
-          "in_band": 1,
-          "out_of_band": 0,
-          "by_design": 0,
-          "dead_end": 0
-        },
-        "blocks_derivation": "measured",
-        "recovery_round_trips": {
-          "value": 1,
-          "derivation": "measured"
-        },
-        "model_runs": {
-          "value": 4,
-          "derivation": "measured"
-        },
-        "human_surface_bytes": {
-          "value": 670,
-          "derivation": "measured"
-        },
-        "git_subprocesses": {
-          "value": 0,
-          "derivation": "measured",
-          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
-        }
-      },
-      "commands": [
-        {
-          "sequence": 1,
-          "step": "review start reporting correction_budget 0",
-          "args": [
-            "review",
-            "start",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 402,
-          "stdout_bytes": 1218,
-          "prompts": 1,
-          "git_calls": 0
-        },
-        {
-          "sequence": 2,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 14030,
-          "git_calls": 0
-        },
-        {
-          "sequence": 3,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo",
             "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
+            "review-aa353b320c7f40d7",
             "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-risk",
-            "--order",
-            "0",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/reviewer-0.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 748,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 4,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 11093,
-          "git_calls": 0
-        },
-        {
-          "sequence": 5,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-resilience",
-            "--order",
-            "1",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/reviewer-1.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 760,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 6,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 8138,
-          "git_calls": 0
-        },
-        {
-          "sequence": 7,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-readability",
-            "--order",
-            "2",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/reviewer-2.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 762,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 8,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5180,
-          "git_calls": 0
-        },
-        {
-          "sequence": 9,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "capture-result",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
-            "--expected-revision",
-            "sha256:8dffc9ae882f635f767d5c49aeda9d2f2bf7b983bd083d13bc0869e94d64e99f",
-            "--lens",
-            "review-reliability",
-            "--order",
-            "3",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/reviewer-3.json"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 762,
-          "model_run": true,
-          "git_calls": 0
-        },
-        {
-          "sequence": 10,
-          "step": "capture every lens",
-          "args": [
-            "review",
-            "status",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 5659,
-          "git_calls": 0
-        },
-        {
-          "sequence": 11,
-          "step": "finalize with captured results",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-results=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 249,
-          "git_calls": 0
-        },
-        {
-          "sequence": 12,
-          "step": "forecast one correction line against a budget of zero",
-          "args": [
-            "review",
-            "finalize",
-            "--correction-lines",
-            "1",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo"
+            "sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45",
+            "--reason",
+            "operator_disposition",
+            "--actor",
+            "bench"
           ],
           "exit_code": 1,
-          "stderr_bytes": 268,
+          "stderr_bytes": 1150,
           "stdout_bytes": 0,
           "block": "in_band",
           "git_calls": 0,
-          "message": "Error: finalize for lineage \"review-c65a4ce5f831560b\" had no verification evidence to consume and made no transition; capture it first with `gentle-ai review capture-evidence`, then run `gentle-ai review finalize --lineage review-c65a4ce5f8"
+          "message": "Error: review abandon requires --lineage, --expected-revision, --reason, --actor, and --maintainer-authorization."
         },
         {
-          "sequence": 13,
-          "step": "capture final evidence",
+          "sequence": 8,
+          "step": "fresh active lineage remains abandonable instead of reusing the quarantined authority",
           "args": [
             "review",
-            "status",
+            "abandon",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
-            "--contract",
-            "gentle-ai.review-integration/v1",
-            "--next-transition"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 3161,
-          "git_calls": 0
-        },
-        {
-          "sequence": 14,
-          "step": "capture final evidence",
-          "args": [
-            "review",
-            "capture-evidence",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo",
+            "/tmp/gentle-ai-bench-j34-abandon-then-start-again-343648088/home/demo",
             "--lineage",
-            "review-c65a4ce5f831560b",
-            "--target",
-            "sha256:c65a4ce5f831560b0d0f77412c21dc452a69feefbe15c3a2bb215a800eb46324",
+            "review-aa353b320c7f40d7",
             "--expected-revision",
-            "sha256:a2d5022bd41b75a37204fc460348dc9bcab366971370024b0826f71223924ac1",
-            "--outcome",
-            "passed",
-            "--input",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/final-evidence.txt"
+            "sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45",
+            "--reason",
+            "operator_disposition",
+            "--actor",
+            "bench",
+            "--maintainer-authorization",
+            "gentle-ai.review-abandon-authorization/v2\nlineage=review-aa353b320c7f40d7\nrevision=sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45\nsnapshot_identity=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875\nreason=operator_disposition\ncaptured_lens_results=\nfindings_present=false\nevidence_records_present=false\nactor=bench"
           ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 768,
-          "git_calls": 0
-        },
-        {
-          "sequence": 15,
-          "step": "finalize with captured evidence",
-          "args": [
-            "review",
-            "finalize",
-            "--captured-evidence=true",
-            "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j35-correction-budget-exactly-zero-3918062948/home/demo"
-          ],
-          "exit_code": 0,
-          "stderr_bytes": 0,
-          "stdout_bytes": 518,
-          "git_calls": 0
+          "exit_code": 1,
+          "stderr_bytes": 1074,
+          "stdout_bytes": 0,
+          "block": "in_band",
+          "manual_token": true,
+          "git_calls": 0,
+          "message": "Error: review abandon requires an exact maintainer authorization binding (schema gentle-ai.review-abandon-authorization/v2 over lineage review-aa353b320c7f40d7@sha256:935e84534514d017e3c664381b6ad88d81eaa6c031e40b1d92abcf54496e1e45, snapsho"
         }
       ]
     },
@@ -5611,7 +5397,7 @@
             "--contract",
             "gentle-ai.review-integration/v2",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j36-contract-right-name-wrong-version-2447684345/home/demo"
+            "/tmp/gentle-ai-bench-j36-contract-right-name-wrong-version-1081459569/home/demo"
           ],
           "exit_code": 1,
           "stderr_bytes": 67,
@@ -5659,7 +5445,7 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 798,
+          "value": 694,
           "derivation": "measured"
         },
         "git_subprocesses": {
@@ -5676,13 +5462,13 @@
             "sdd-attempt",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 412,
+          "stdout_bytes": 386,
           "git_calls": 0
         },
         {
@@ -5692,7 +5478,7 @@
             "sdd-attempt",
             "begin",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change",
             "--expected-revision",
@@ -5710,7 +5496,7 @@
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1842,
+          "stdout_bytes": 2456,
           "git_calls": 0
         },
         {
@@ -5720,13 +5506,13 @@
             "sdd-attempt",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1842,
+          "stdout_bytes": 2456,
           "git_calls": 0
         },
         {
@@ -5736,17 +5522,15 @@
             "sdd-attempt",
             "finish",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change",
             "--expected-revision",
-            "sha256:3193d7140bfca69c22b0d266980ea021006370423ba322666377769b8a32e227",
+            "sha256:4498015da6190c327c0e1ad9c2ef25930413ada5628fedc96c571bb0c5e9e033",
             "--request-id",
             "bench-finish-one",
             "--outcome",
             "interrupted",
-            "--evidence-revision",
-            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "--diagnosis",
             "the benchmark drove this attempt to a terminal outcome",
             "--harness-disposition",
@@ -5758,7 +5542,7 @@
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1969,
+          "stdout_bytes": 2093,
           "git_calls": 0
         },
         {
@@ -5768,13 +5552,13 @@
             "sdd-attempt",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1969,
+          "stdout_bytes": 2093,
           "git_calls": 0
         },
         {
@@ -5784,11 +5568,11 @@
             "sdd-attempt",
             "begin",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change",
             "--expected-revision",
-            "sha256:438253ba7f53110546c852ff994d91d91997c0454d8dbac7eee5d2d45efb1d91",
+            "sha256:6062b22cc2be4def8f251cfef169b0fe816ef7c30e9af09048233f02783849cb",
             "--request-id",
             "bench-begin-drifted",
             "--work-unit",
@@ -5801,11 +5585,11 @@
             "600"
           ],
           "exit_code": 1,
-          "stderr_bytes": 798,
+          "stderr_bytes": 694,
           "stdout_bytes": 0,
           "block": "in_band",
           "git_calls": 0,
-          "message": "Error: sdd-attempt begin: SDD runtime objective changed without an explicit reset: reset the objective, then begin again — `gentle-ai sdd-attempt reset --cwd \"/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sd"
+          "message": "Error: sdd-attempt begin: SDD runtime objective changed without an explicit reset: reset the objective, then begin again — `gentle-ai sdd-attempt reset --cwd \"/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo\" --"
         },
         {
           "sequence": 7,
@@ -5814,13 +5598,13 @@
             "sdd-attempt",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1969,
+          "stdout_bytes": 2093,
           "git_calls": 0
         },
         {
@@ -5830,11 +5614,11 @@
             "sdd-attempt",
             "reset",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change",
             "--expected-revision",
-            "sha256:438253ba7f53110546c852ff994d91d91997c0454d8dbac7eee5d2d45efb1d91",
+            "sha256:6062b22cc2be4def8f251cfef169b0fe816ef7c30e9af09048233f02783849cb",
             "--request-id",
             "bench-reset-one",
             "--reason",
@@ -5844,7 +5628,7 @@
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1947,
+          "stdout_bytes": 2142,
           "git_calls": 0
         },
         {
@@ -5854,13 +5638,13 @@
             "sdd-attempt",
             "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1947,
+          "stdout_bytes": 2142,
           "git_calls": 0
         },
         {
@@ -5870,11 +5654,11 @@
             "sdd-attempt",
             "begin",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2655818459/home/demo",
+            "/tmp/gentle-ai-bench-j40-sdd-attempt-reset-after-drift-2844022788/home/demo",
             "--change",
             "bench-change",
             "--expected-revision",
-            "sha256:3deb551d8ceffa14e46aa8564893f2ab1ef82fdf2d2f45dc42a8d5b7b924331a",
+            "sha256:cb9d85545c152c817224052fe3d1a185998913136219976e44f6baae5796aac9",
             "--request-id",
             "bench-begin-three",
             "--work-unit",
@@ -5888,15 +5672,15 @@
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 3304,
+          "stdout_bytes": 4139,
           "git_calls": 0
         }
       ]
     },
     {
       "id": "j41-kill-switch-versus-sdd-pre-verify",
-      "title": "Reviews off at the pre-verify decision: the router steps aside instead of naming a command the operator cannot run",
-      "source": "shape 5 (the kill switch and the pre-verify router disagreeing) + a limitation this corpus measured closed",
+      "title": "Pre-verify: RDD supervises nothing, on or off, before verify runs",
+      "source": "shape 5 (the kill switch and the pre-verify router) + Wave 4's own removal of pre-verify review supervision",
       "status": "completed",
       "metrics": {
         "human_prompts": {
@@ -5948,11 +5732,11 @@
             "bench-change",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-320163095/home/demo"
+            "/tmp/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-1930457059/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 4165,
+          "stdout_bytes": 2896,
           "git_calls": 0
         },
         {
@@ -5964,7 +5748,7 @@
             "disable",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-320163095/home/demo"
+            "/tmp/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-1930457059/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
@@ -5979,11 +5763,11 @@
             "bench-change",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-320163095/home/demo"
+            "/tmp/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-1930457059/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 4015,
+          "stdout_bytes": 2896,
           "git_calls": 0
         },
         {
@@ -5995,7 +5779,7 @@
             "enable",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-320163095/home/demo"
+            "/tmp/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-1930457059/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
@@ -6010,19 +5794,19 @@
             "bench-change",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-320163095/home/demo"
+            "/tmp/gentle-ai-bench-j41-kill-switch-versus-sdd-pre-verify-1930457059/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 4165,
+          "stdout_bytes": 2896,
           "git_calls": 0
         }
       ]
     },
     {
       "id": "j42-kill-switch-versus-sdd-archive",
-      "title": "Reviews off at the archive decision: the product defers and never fabricates an approval",
-      "source": "shape 5 (a shipped agent contract and the product disagreeing about the same fact)",
+      "title": "The offer is an invitation, never a gate: archive proceeds with reviews on or off",
+      "source": "shape 5 (a shipped agent contract and the product disagreeing about the same fact) + corrective verify cycle 4 BLOCKER-1",
       "status": "completed",
       "metrics": {
         "human_prompts": {
@@ -6074,11 +5858,11 @@
             "bench-change",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j42-kill-switch-versus-sdd-archive-2842762652/home/demo"
+            "/tmp/gentle-ai-bench-j42-kill-switch-versus-sdd-archive-1845927691/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 4676,
+          "stdout_bytes": 3310,
           "git_calls": 0
         },
         {
@@ -6090,7 +5874,7 @@
             "disable",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j42-kill-switch-versus-sdd-archive-2842762652/home/demo"
+            "/tmp/gentle-ai-bench-j42-kill-switch-versus-sdd-archive-1845927691/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
@@ -6105,19 +5889,3338 @@
             "bench-change",
             "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j42-kill-switch-versus-sdd-archive-2842762652/home/demo"
+            "/tmp/gentle-ai-bench-j42-kill-switch-versus-sdd-archive-1845927691/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 4738,
+          "stdout_bytes": 3133,
           "git_calls": 0
         }
       ]
     },
     {
-      "id": "j43-recovery-guard-rails-as-an-operator-meets-them",
-      "title": "Three correct refusals around healthy approved authority, and the one exit that works",
-      "source": "shape 4 (a correct refusal that names nothing runnable) + community deadlock report",
+      "id": "j44-sdd-historical-requirement-stale-pass",
+      "title": "Historical change-local requirement heading: stale PASS restarts verification instead of failed remediation",
+      "source": "issue #2137 (historical OpenSpec requirement compatibility and stale verification routing)",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "sdd-status routes stale PASS to fresh verification",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j44-sdd-historical-requirement-stale-pass-3844506366/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3229,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j47-disabled-mode-archives-discovered-scope-changed-authority",
+      "title": "Disabled clone mode: explicit-CWD SDD status v2 reports archive readiness",
+      "source": "issue #3564 V2: completed SDD tasks and verification route directly to archive",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "disable review mode for the clone",
+          "args": [
+            "review",
+            "mode",
+            "disable",
+            "--scope",
+            "clone",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j47-disabled-mode-archives-discovered-scope-changed-authority-3173501100/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 365,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "explicit-CWD disabled V2 status is archive-ready and read-only",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--contract",
+            "gentle-ai.sdd-status/v2",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j47-disabled-mode-archives-discovered-scope-changed-authority-3173501100/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3511,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j49-status-without-cwd-honors-kill-switch",
+      "title": "SDD status without CWD: repository resolution and the kill switch share one workspace",
+      "source": "issue #2129",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 3,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "disable review mode for the clone",
+          "args": [
+            "review",
+            "mode",
+            "disable",
+            "--scope",
+            "clone",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j49-status-without-cwd-honors-kill-switch-2470706118/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 365,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "explicit CWD honors disabled mode",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j49-status-without-cwd-honors-kill-switch-2470706118/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3231,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "omitted CWD honors the same disabled mode",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3231,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j51-negotiated-status-correction-continuation",
+      "title": "#3587: selectorless STATUS starts only a fresh candidate; correction continues through its exact active lineage",
+      "source": "issue #2044 under #3587: selectorless STATUS is fresh by design, while every active correction continuation carries its exact lineage",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 16,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 7,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 449,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "fresh negotiated status offers review start without authority history",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v1",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3507,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "review start with an exact active lineage",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "wave-one-corrected-delivery",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 715,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "capture one blocking finding and finish the full selected lens set for the exact active lineage",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage",
+            "wave-one-corrected-delivery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5778,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "capture one blocking finding and finish the full selected lens set for the exact active lineage",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage",
+            "wave-one-corrected-delivery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5778,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "capture one blocking finding and finish the full selected lens set for the exact active lineage",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage",
+            "wave-one-corrected-delivery",
+            "--target",
+            "sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--expected-revision",
+            "sha256:d1cf022aadc604e36f8bc6eb5c0bcb9da0989c3526e6f99a203b868ff2d26c8d",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/exact-selected-reviewer-0.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1744,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "capture one blocking finding and finish the full selected lens set for the exact active lineage",
+          "args": [
+            "review",
+            "status",
+            "--cwd=/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--next-transition=true",
+            "--lineage=wave-one-corrected-delivery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6260,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 7,
+          "step": "capture the bounded correction plan from the exact STATUS binding",
+          "args": [
+            "review",
+            "capture-correction-plan",
+            "--cwd=/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage=wave-one-corrected-delivery",
+            "--expected-revision=sha256:197feccad4378547f0b552139c7669bcd3d7f9d5d7ee2902a14a0910e3bece0f",
+            "--target=sha256:8df6f4eea7001418fcc9e88dd2cea90e0084e4528ec5256dba68cd25db0f68dd",
+            "--repository-context=rctx2_238a03e598c6620c665f8b14a4b82f0c0ce83a2c5b1b46ac03978a487fe32d95",
+            "--request-hash=sha256:9a4009792d9a0fec60c5e8f22a8cd89ce5d49d77042ab26e5bc8fbeac50008af",
+            "--correction-lines=2"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 496,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "post-correction exact active-lineage validator capture emits acknowledgement on completion",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "wave-one-corrected-delivery",
+            "--agent",
+            "opencode",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8008,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 9,
+          "step": "post-correction exact active-lineage validator capture emits acknowledgement on completion",
+          "args": [
+            "review",
+            "opencode-transport"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 9286,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 10,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage",
+            "wave-one-corrected-delivery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4485,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 11,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage",
+            "wave-one-corrected-delivery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4485,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage=wave-one-corrected-delivery",
+            "--target=sha256:dedeb191bb7d6d44ca658d0169d708935efb0912ce683083369ec7c9b3cde9f4",
+            "--expected-revision=sha256:c2f37190d23595550f7681876860728257cccecf27d9232587bd3205809f37ae",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 13,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage",
+            "wave-one-corrected-delivery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4485,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 14,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage=wave-one-corrected-delivery",
+            "--target=sha256:dedeb191bb7d6d44ca658d0169d708935efb0912ce683083369ec7c9b3cde9f4",
+            "--expected-revision=sha256:c2f37190d23595550f7681876860728257cccecf27d9232587bd3205809f37ae",
+            "--token=b59728874c289817acd4b078bfc242b4688ab4a192fc7ab072c8402db99b466f"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 15,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo",
+            "--lineage=wave-one-corrected-delivery",
+            "--target=sha256:dedeb191bb7d6d44ca658d0169d708935efb0912ce683083369ec7c9b3cde9f4",
+            "--expected-revision=sha256:c2f37190d23595550f7681876860728257cccecf27d9232587bd3205809f37ae",
+            "--token=b59728874c289817acd4b078bfc242b4688ab4a192fc7ab072c8402db99b466f"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 16,
+          "step": "no correction authority survives exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j51-negotiated-status-correction-continuation-241757589/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 532,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j59-current-status-and-start-ignore-sibling-worktree-transaction",
+      "title": "#3587: selectorless current STATUS and START ignore an unrelated sibling worktree transaction",
+      "source": "#3587: compact atomic review is bound to the selected worktree and candidate, never ambient sibling authority",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 7,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 1,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/atomic-sibling-worktree"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4002,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/atomic-sibling-worktree",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:0967cbe25b621521c45365ac406abdae4bec550bebed53bb9931a56c39904161",
+            "--projection=workspace",
+            "--lineage=review-fded28f6458175af",
+            "--consent=relay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2213,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "start",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/atomic-sibling-worktree",
+            "--target",
+            "sha256:0967cbe25b621521c45365ac406abdae4bec550bebed53bb9931a56c39904161",
+            "--projection",
+            "workspace",
+            "--lineage",
+            "review-fded28f6458175af",
+            "--consent",
+            "granted"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4229,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3960,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:0967cbe25b621521c45365ac406abdae4bec550bebed53bb9931a56c39904161",
+            "--projection=workspace",
+            "--lineage=review-552fcc54799ed131",
+            "--consent=relay"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2185,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "start",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/home/demo",
+            "--target",
+            "sha256:0967cbe25b621521c45365ac406abdae4bec550bebed53bb9931a56c39904161",
+            "--projection",
+            "workspace",
+            "--lineage",
+            "review-552fcc54799ed131",
+            "--consent",
+            "granted"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4229,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "selectorless STATUS and current-worktree START ignore the sibling worktree transaction",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j59-current-status-and-start-ignore-sibling-worktree-transaction-34554293/home/demo",
+            "--lineage",
+            "review-552fcc54799ed131"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 14676,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        }
+      ]
+    },
+    {
+      "id": "j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow",
+      "title": "#3587: explicit active lineage keeps its exact four lenses through correction and validator flow",
+      "source": "#3587: active compact authority continues only through its bound four-lens correction plan and terminal validator capture",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 21,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 10,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 12,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 5,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 449,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "START the compact high-risk transaction",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "atomic-four-lens-correction",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 1058,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "explicit active STATUS exposes exactly four compact lenses",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 15438,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 15438,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:d36d71f1b417c459e5217b3508c5a9b6cc35abbf04128a781be3606c13879f0c",
+            "--lens",
+            "review-risk",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/atomic-reviewer-0.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 600,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 12303,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:d36d71f1b417c459e5217b3508c5a9b6cc35abbf04128a781be3606c13879f0c",
+            "--lens",
+            "review-resilience",
+            "--order",
+            "1",
+            "--input",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/atomic-reviewer-1.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 606,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 9150,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 8,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:d36d71f1b417c459e5217b3508c5a9b6cc35abbf04128a781be3606c13879f0c",
+            "--lens",
+            "review-readability",
+            "--order",
+            "2",
+            "--input",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/atomic-reviewer-2.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 607,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5994,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 10,
+          "step": "capture a correction finding and every remaining compact lens",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction",
+            "--target",
+            "sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--expected-revision",
+            "sha256:d36d71f1b417c459e5217b3508c5a9b6cc35abbf04128a781be3606c13879f0c",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "3",
+            "--input",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/atomic-reviewer-3.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1828,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 11,
+          "step": "capture the status-bound bounded correction plan",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6285,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "capture the status-bound bounded correction plan",
+          "args": [
+            "review",
+            "capture-correction-plan",
+            "--cwd=/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage=atomic-four-lens-correction",
+            "--expected-revision=sha256:1ec79e15be12fbd551c9ec59627d0a3373c5de2cb7420e4eb2381652f5f257c6",
+            "--target=sha256:e48ee9d21543e4a2423bc0fd61cb59c10fe87d9e037f56e714e0eaf4cbba2007",
+            "--repository-context=rctx2_b55baca9c4bdd54de4ab4f0a4f7361594087385eeba2189fce8b108a69236b4a",
+            "--request-hash=sha256:b6318bf27da5fa76a0a90110821f37b00269ff871ffe4bee03f0d327b1476e88",
+            "--correction-lines=2"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 496,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "capture the Go-issued targeted validator that closes with pending acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "atomic-four-lens-correction",
+            "--agent",
+            "opencode",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8033,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 14,
+          "step": "capture the Go-issued targeted validator that closes with pending acknowledgement",
+          "args": [
+            "review",
+            "opencode-transport"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 9363,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 15,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4601,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 16,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4601,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 17,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage=atomic-four-lens-correction",
+            "--target=sha256:ee2592de5c4447fe440e84f4e7421215e82789ed12602d68a749d42bb7cdc19f",
+            "--expected-revision=sha256:cb875e446f9d13bec70b31fd0a6e5b043b5511a49a32173b13fecdab5b5026e1",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 18,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage",
+            "atomic-four-lens-correction"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4601,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 19,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage=atomic-four-lens-correction",
+            "--target=sha256:ee2592de5c4447fe440e84f4e7421215e82789ed12602d68a749d42bb7cdc19f",
+            "--expected-revision=sha256:cb875e446f9d13bec70b31fd0a6e5b043b5511a49a32173b13fecdab5b5026e1",
+            "--token=101cea0f675c03585646799a7f1841c2861393b690461a18bdf6ae5af6e7f10c"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 20,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo",
+            "--lineage=atomic-four-lens-correction",
+            "--target=sha256:ee2592de5c4447fe440e84f4e7421215e82789ed12602d68a749d42bb7cdc19f",
+            "--expected-revision=sha256:cb875e446f9d13bec70b31fd0a6e5b043b5511a49a32173b13fecdab5b5026e1",
+            "--token=101cea0f675c03585646799a7f1841c2861393b690461a18bdf6ae5af6e7f10c"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 21,
+          "step": "no correction authority survives the exact acknowledgement",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow-331272669/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 588,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j62-sdd-settle-canonicalizes-unambiguous-evidence-revision",
+      "title": "Compact settle: the PowerShell uppercase digest and the canonical form settle identically",
+      "source": "issue #2523 + the maintainer scoping comment on PR #2308 (idea: @decode2; uppercase report: @adgarboc on #2294)",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "settle with the PowerShell-style uppercase digest",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j62-sdd-settle-canonicalizes-unambiguous-evidence-revision-80747738/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-canon-upper-acquire",
+            "--work-unit",
+            "canonical evidence spelling objective",
+            "--evidence-goal",
+            "both SHA-256 spellings settle identically",
+            "--max-attempts",
+            "4",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "settle with the PowerShell-style uppercase digest",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j62-sdd-settle-canonicalizes-unambiguous-evidence-revision-80747738/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:8e3376e41f89d4e7d248b1dcd61a940d5f56b928f63f80738f7a3e98b2c23660",
+            "--request-id",
+            "bench-canon-upper-settle",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "27A44AD82D6E4F1D9F2C3B4A5D6E7F8091A2B3C4D5E6F70818293A4B5C6D7E8F",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "settle with the canonical lowercase prefixed digest",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j62-sdd-settle-canonicalizes-unambiguous-evidence-revision-80747738/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-canon-lower-acquire",
+            "--work-unit",
+            "canonical evidence spelling objective",
+            "--evidence-goal",
+            "both SHA-256 spellings settle identically",
+            "--max-attempts",
+            "4",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "settle with the canonical lowercase prefixed digest",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j62-sdd-settle-canonicalizes-unambiguous-evidence-revision-80747738/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:8872cc39b9ae9a8aa8a4525ba890cf18ca7d0ae1130991edcd66f1a293f12151",
+            "--request-id",
+            "bench-canon-lower-settle",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:27a44ad82d6e4f1d9f2c3b4a5d6e7f8091a2b3c4d5e6f70818293a4b5c6d7e8f",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j63-disabled-failed-verification-unmanaged-remediation",
+      "title": "Failed verification gets one evidence-bound correction; re-enabled review context remains informational",
+      "source": "#3417: failed, unknown, and pending review evidence remains visible but never gates completed SDD archive routing",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 16,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "enabled failed verification records missing remediation authority",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3854,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "mode disable",
+          "args": [
+            "review",
+            "mode",
+            "disable",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 246,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "failed verification enters unmanaged remediation",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 386,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "failed verification enters unmanaged remediation",
+          "args": [
+            "sdd-attempt",
+            "begin",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "",
+            "--request-id",
+            "bench-unmanaged-begin-verification",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2548,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "failed verification enters unmanaged remediation",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2548,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "failed verification enters unmanaged remediation",
+          "args": [
+            "sdd-attempt",
+            "finish",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:855e770d5440e756ae652f71f20d9f3d899484d0227c9ffd40cb5534ce6a7039",
+            "--request-id",
+            "bench-unmanaged-finish-verification",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2308,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "disabled status names remediation without review authority",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--instructions",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 13716,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "acquire the one bounded correction",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-unmanaged-acquire",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "unchanged candidate cannot satisfy correction",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:df1afc5bbeca241863b3a5b236f71df7a0e449372062de62ef08ff55b8f0cfc1",
+            "--request-id",
+            "bench-unmanaged-unchanged",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 222,
+          "git_calls": 0
+        },
+        {
+          "sequence": 10,
+          "step": "wrong failed evidence cannot satisfy correction",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:df1afc5bbeca241863b3a5b236f71df7a0e449372062de62ef08ff55b8f0cfc1",
+            "--request-id",
+            "bench-unmanaged-wrong-evidence",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 567,
+          "git_calls": 0
+        },
+        {
+          "sequence": 11,
+          "step": "settle the evidence-bound correction",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:df1afc5bbeca241863b3a5b236f71df7a0e449372062de62ef08ff55b8f0cfc1",
+            "--request-id",
+            "bench-unmanaged-correct",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 26,
+          "git_calls": 0
+        },
+        {
+          "sequence": 12,
+          "step": "replay cannot acquire another correction",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-unmanaged-replay",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 26,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "fresh verification is required before archive",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3411,
+          "git_calls": 0
+        },
+        {
+          "sequence": 14,
+          "step": "archive is ready without review authority",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3413,
+          "git_calls": 0
+        },
+        {
+          "sequence": 15,
+          "step": "mode enable after unmanaged correction",
+          "args": [
+            "review",
+            "mode",
+            "enable",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 243,
+          "git_calls": 0
+        },
+        {
+          "sequence": 16,
+          "step": "re-enabled ordinary delivery remains archive-ready",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j63-disabled-failed-verification-unmanaged-remediation-1059894334/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3610,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j64-unmanaged-remediation-survives-audited-reset",
+      "title": "An audited reset between the failed settle and the correction acquire no longer orphans the correction",
+      "source": "#1974 slice 2 (#2565): chain-derived failed-evidence binding",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "mode disable",
+          "args": [
+            "review",
+            "mode",
+            "disable",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 246,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "failed verification exhausts its objective budget",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-chain-acquire-verification",
+            "--work-unit",
+            "bench chain verification",
+            "--evidence-goal",
+            "admit the verification failure",
+            "--max-attempts",
+            "1",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "failed verification exhausts its objective budget",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:0821f6306c4266a653e464a8debca890de7e3b0beac3207f5e72ed69aaf674e5",
+            "--request-id",
+            "bench-chain-settle-verification",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1396,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "audited reset records the maintainer decision",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2285,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "audited reset records the maintainer decision",
+          "args": [
+            "sdd-attempt",
+            "reset",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:0e44ee249fb4820b94feb64d17c7c5ce7e20489d0c8e8bf0636eaa216e7a556f",
+            "--request-id",
+            "bench-chain-reset",
+            "--reason",
+            "maintainer decision: remediate the admitted failure under a fresh objective",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2294,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "acquire the one bounded correction after the reset",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-unmanaged-acquire",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "settle the evidence-bound correction across the reset",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:1bfc0bec32c3041271cc1c8988181170aed4248d1e25a4b3ca07b2521aeb64c9",
+            "--request-id",
+            "bench-unmanaged-correct",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 26,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "replay cannot acquire another correction",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-unmanaged-replay",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 26,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "archive is ready without review authority",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j64-unmanaged-remediation-survives-audited-reset-3172165355/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3329,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j72-direct-review-start-refuses-empty-candidate",
+      "title": "Direct (non-negotiated) `review start` on a clean, fully-committed worktree refuses instead of minting a zero-delta receipt",
+      "source": "issue #2586: a plain `review start` (no --contract) on a clean worktree used to create a lineage and finalize an approved receipt that inspected nothing; the empty-candidate refusal was previously negotiated-route-only",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 1,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 170,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "direct review start on a clean worktree refuses, naming --base-ref",
+          "args": [
+            "review",
+            "start",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j72-direct-review-start-refuses-empty-candidate-788517355/home/demo"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 170,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: the candidate has no pending changes; already-committed work can be reviewed by rerunning review start with --base-ref \u003ccommit\u003e naming the base to compare against"
+        }
+      ]
+    },
+    {
+      "id": "j74-sdd-attempt-explicit-linked-worktree-handoff",
+      "title": "Delegated linked worktree: settlement refuses until one explicit handoff binds it",
+      "source": "issue #2469: preserve Begin provenance while moving only effective execution worktree",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 5,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 2,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "acquire in A, refuse B, hand off A to B, and settle B once",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j74-sdd-attempt-explicit-linked-worktree-handoff-1808072185/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-handoff-acquire",
+            "--work-unit",
+            "delegated worktree proof",
+            "--evidence-goal",
+            "prove explicit handoff preserves begin provenance",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "acquire in A, refuse B, hand off A to B, and settle B once",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j74-sdd-attempt-explicit-linked-worktree-handoff-1808072185/delegated-worktree",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:3fcbd7d52b0123498d94507336ef96761c9b0871b65c98710570c99168b55908",
+            "--request-id",
+            "bench-handoff-before",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark settles the delegated worktree once",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1336,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "acquire in A, refuse B, hand off A to B, and settle B once",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j74-sdd-attempt-explicit-linked-worktree-handoff-1808072185/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2531,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "acquire in A, refuse B, hand off A to B, and settle B once",
+          "args": [
+            "sdd-attempt",
+            "handoff",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j74-sdd-attempt-explicit-linked-worktree-handoff-1808072185/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:3fcbd7d52b0123498d94507336ef96761c9b0871b65c98710570c99168b55908",
+            "--request-id",
+            "bench-handoff-a-to-b",
+            "--destination-worktree",
+            "/tmp/gentle-ai-bench-j74-sdd-attempt-explicit-linked-worktree-handoff-1808072185/delegated-worktree"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 2
+        },
+        {
+          "sequence": 5,
+          "step": "acquire in A, refuse B, hand off A to B, and settle B once",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j74-sdd-attempt-explicit-linked-worktree-handoff-1808072185/delegated-worktree",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:3fcbd7d52b0123498d94507336ef96761c9b0871b65c98710570c99168b55908",
+            "--request-id",
+            "bench-handoff-after",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark settles the delegated worktree once",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j75-intended-untracked-selection-executes-printed-start",
+      "title": "Mixed workspace candidate: STATUS collects explicit untracked intent and its printed START executes exactly",
+      "source": "issue #2652: intended untracked files require explicit inventory-bound admission; #2394 keeps unrelated local bytes excluded",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 3,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "STATUS collects selection and printed START freezes only chosen paths",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j75-intended-untracked-selection-executes-printed-start-2831982373/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3271,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "STATUS collects selection and printed START freezes only chosen paths",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j75-intended-untracked-selection-executes-printed-start-2831982373/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:aabaed5f4e2d6f0343c3774281855d6e016c30144f38f57270afe5803f70c219",
+            "--intended-untracked=docs/chosen, file.md",
+            "--intended-untracked=docs/second file,with comma.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5090,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "STATUS collects selection and printed START freezes only chosen paths",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j75-intended-untracked-selection-executes-printed-start-2831982373/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:a94b05bce6c41f5191aac4f02e6794c28692463bb3e0cf7042a8a456d1fd1aa4",
+            "--projection=workspace",
+            "--lineage=review-0cf06268b08ea900",
+            "--consent=relay",
+            "--untracked-scope=select",
+            "--expected-untracked-inventory=sha256:aabaed5f4e2d6f0343c3774281855d6e016c30144f38f57270afe5803f70c219",
+            "--intended-untracked=docs/chosen, file.md",
+            "--intended-untracked=docs/second file,with comma.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2757,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j77-capture-result-input-preflight-is-read-only",
+      "title": "#3417: capture-result preflight validates an exact active-lineage admission without persistence",
+      "source": "issue #2630 under #3417: preflight validates the exact active lineage, revision, target, and reviewer input without persistence",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 7,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 4,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 3,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 467,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "review start with an exact active lineage",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "capture-result-dry-run",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 722,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "exact active-lineage dry-run admission then real capture",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "capture-result-dry-run"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6009,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "exact active-lineage dry-run admission then real capture",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo",
+            "--lineage",
+            "capture-result-dry-run",
+            "--target",
+            "sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision",
+            "sha256:a4728e969714347479d6d0e924a53547209f6ef11bc39ee033860758edf38245",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--preflight",
+            "--input",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/dry-run-invalid.json"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 250,
+          "stdout_bytes": 752,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "Error: reviewer artifact admission incomplete: reviewer inspection did not cover the complete frozen path manifest; admission_diagnostic={\"code\":\"inspection_coverage\",\"reason\":\"missing_frozen_manifest_paths\",\"missing_path_count\":2} [invalid"
+        },
+        {
+          "sequence": 4,
+          "step": "exact active-lineage dry-run admission then real capture",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo",
+            "--lineage",
+            "capture-result-dry-run",
+            "--target",
+            "sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision",
+            "sha256:a4728e969714347479d6d0e924a53547209f6ef11bc39ee033860758edf38245",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--preflight",
+            "--input",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/dry-run-valid.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 356,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "exact active-lineage dry-run admission then real capture",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--lineage",
+            "capture-result-dry-run"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6009,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "exact active-lineage dry-run admission then real capture",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo",
+            "--lineage",
+            "capture-result-dry-run",
+            "--target",
+            "sha256:fe67b95fdefc1b90afcee08470f464a6826e7b93012514ae5b8c3dd90c5586a7",
+            "--expected-revision",
+            "sha256:a4728e969714347479d6d0e924a53547209f6ef11bc39ee033860758edf38245",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/dry-run-valid.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2373,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "exact active-lineage dry-run admission then real capture",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j77-capture-result-input-preflight-is-read-only-3893358436/home/demo",
+            "--lineage",
+            "capture-result-dry-run"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4520,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        }
+      ]
+    },
+    {
+      "id": "j78-lens-finding-id-prefix-discovery",
+      "title": "#3587: an exact active-lineage reviewer discovers lens finding-ID prefixes before native admission",
+      "source": "issue #1844 under #3587: exact active-lineage STATUS binds every discovered finding-ID prefix before native admission",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 1,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 16,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 7,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 4,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 449,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "review start with an exact active lineage discloses canonical prefixes",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "finding-id-prefix-discovery",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 217,
+          "stdout_bytes": 989,
+          "prompts": 1,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 14728,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:e62478765218a5adf4e33ffcbc0fbd9ad107550d0ace513c8dc3a8ceb0f9870e",
+            "--lens",
+            "review-risk",
+            "--order",
+            "0",
+            "--input",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/mapped-reviewer-0.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 600,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 11765,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 5,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:e62478765218a5adf4e33ffcbc0fbd9ad107550d0ace513c8dc3a8ceb0f9870e",
+            "--lens",
+            "review-resilience",
+            "--order",
+            "1",
+            "--input",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/mapped-reviewer-1.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 606,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 8784,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 7,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:e62478765218a5adf4e33ffcbc0fbd9ad107550d0ace513c8dc3a8ceb0f9870e",
+            "--lens",
+            "review-readability",
+            "--order",
+            "2",
+            "--input",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/mapped-reviewer-2.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 607,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5800,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 9,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "capture-result",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery",
+            "--target",
+            "sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision",
+            "sha256:e62478765218a5adf4e33ffcbc0fbd9ad107550d0ace513c8dc3a8ceb0f9870e",
+            "--lens",
+            "review-reliability",
+            "--order",
+            "3",
+            "--input",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/mapped-reviewer-3.json"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3506,
+          "model_run": true,
+          "git_calls": 0
+        },
+        {
+          "sequence": 10,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4471,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 11,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4471,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 12,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage=finding-id-prefix-discovery",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision=sha256:b094dcc322bdabe12f5e7d4d9ec9b64ec8bb65655e49e06bed07b9d995c249ec",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 13,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage",
+            "finding-id-prefix-discovery"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4471,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 14,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage=finding-id-prefix-discovery",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision=sha256:b094dcc322bdabe12f5e7d4d9ec9b64ec8bb65655e49e06bed07b9d995c249ec",
+            "--token=8a476e305b8b046d5b0c4f3d57b47a276d2b956b636e0261e8013aa9e64a25f1"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 15,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo",
+            "--lineage=finding-id-prefix-discovery",
+            "--target=sha256:8175ee456f3850efcf389c9c351646b22c9dd0f83031ad5957f91464a0d39875",
+            "--expected-revision=sha256:b094dcc322bdabe12f5e7d4d9ec9b64ec8bb65655e49e06bed07b9d995c249ec",
+            "--token=8a476e305b8b046d5b0c4f3d57b47a276d2b956b636e0261e8013aa9e64a25f1"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 16,
+          "step": "capture explicit IDs from the exact active-lineage STATUS prefixes",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j78-lens-finding-id-prefix-discovery-4092109325/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 516,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j79-consecutive-rescope-refuses-before-publication",
+      "title": "Failed zero-drift objective: a second rescope refuses before it can corrupt status",
+      "source": "issue #2830: rescope successors require their own terminal attempt",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 1,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 316,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 386,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "begin",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "",
+            "--request-id",
+            "bench-2830-begin-a",
+            "--work-unit",
+            "bench objective A",
+            "--evidence-goal",
+            "prove the original bounded objective",
+            "--max-attempts",
+            "3",
+            "--max-changed-lines",
+            "90"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2505,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2505,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "finish",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:9750efbc7fd7aff22997b8a29c62ffce77645a011f8b98740ec69142230dd760",
+            "--request-id",
+            "bench-2830-finish-a",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2282,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2282,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "rescope",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:f75b2b42642249d7422d487c5e9a2a10245342807b09fb4563f0cc6dc2bae5b8",
+            "--request-id",
+            "bench-2830-rescope-a-to-b",
+            "--work-unit",
+            "bench objective B",
+            "--evidence-goal",
+            "prove the narrower successor objective",
+            "--max-attempts",
+            "3",
+            "--max-changed-lines",
+            "60",
+            "--reason",
+            "maintainer narrowed A into B",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3031,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3031,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "rescope",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:d46306c7cb4b38376e3fcf8d6e52932cb9b5cb1bd26679b5d04a2017fa7ba816",
+            "--request-id",
+            "bench-2830-rescope-b-to-c",
+            "--work-unit",
+            "bench objective C",
+            "--evidence-goal",
+            "prove the still narrower successor objective",
+            "--max-attempts",
+            "3",
+            "--max-changed-lines",
+            "30",
+            "--reason",
+            "attempted B to C before B has an attempt",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 316,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: sdd-attempt rescope: SDD runtime objective rescope requires no active attempt, an existing objective that is not decision-required or complete, and a terminal attempt whose candidate has NOT drifted; run `gentle-ai sdd-attempt status"
+        },
+        {
+          "sequence": 9,
+          "step": "begin, fail zero-drift, rescope once, refuse a second rescope, and read status",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j79-consecutive-rescope-refuses-before-publication-3918359250/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3031,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j80-rescope-authorized-evidence-only-retry",
+      "title": "Audited rescope authorizes one unchanged evidence-only retry",
+      "source": "#2621: failed A -\u003e audited rescope B -\u003e unchanged PASS linked to A",
       "status": "completed",
       "metrics": {
         "human_prompts": {
@@ -6136,14 +9239,14 @@
         },
         "blocks": {
           "self_recovered": 0,
-          "in_band": 3,
+          "in_band": 0,
           "out_of_band": 0,
-          "by_design": 1,
+          "by_design": 0,
           "dead_end": 0
         },
         "blocks_derivation": "measured",
         "recovery_round_trips": {
-          "value": 4,
+          "value": 0,
           "derivation": "measured"
         },
         "model_runs": {
@@ -6151,11 +9254,11 @@
           "derivation": "measured"
         },
         "human_surface_bytes": {
-          "value": 2795,
+          "value": 0,
           "derivation": "measured"
         },
         "git_subprocesses": {
-          "value": 6,
+          "value": 0,
           "derivation": "measured",
           "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
         }
@@ -6163,189 +9266,2047 @@
       "commands": [
         {
           "sequence": 1,
-          "step": "review start",
+          "step": "mode disable",
           "args": [
             "review",
-            "start",
+            "mode",
+            "disable",
+            "--json",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 418,
+          "stdout_bytes": 246,
           "git_calls": 0
         },
         {
           "sequence": 2,
-          "step": "review finalize",
+          "step": "objective A fails with unused capacity",
           "args": [
-            "review",
-            "finalize",
+            "sdd-attempt",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 534,
+          "stdout_bytes": 386,
           "git_calls": 0
         },
         {
           "sequence": 3,
-          "step": "walk into the recovery guard rails",
+          "step": "objective A fails with unused capacity",
           "args": [
-            "review",
-            "status",
+            "sdd-attempt",
+            "begin",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "",
+            "--request-id",
+            "bench-rescope-evidence-begin-a",
+            "--work-unit",
+            "verification objective A",
+            "--evidence-goal",
+            "record the failed verification evidence",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1239,
+          "stdout_bytes": 2497,
           "git_calls": 0
         },
         {
           "sequence": 4,
-          "step": "walk into the recovery guard rails",
+          "step": "objective A fails with unused capacity",
           "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-93b64e4b876f5478",
-            "--expected-predecessor-revision",
-            "sha256:cca33fa851d42f5eb530c5e58edaf3cfeb39962628ae4e953ea1439a6815a6d4",
-            "--successor-lineage",
-            "review-unwanted-successor",
-            "--disposition",
-            "scope_changed",
+            "sdd-attempt",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change"
           ],
-          "exit_code": 1,
-          "stderr_bytes": 773,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 2,
-          "message": "Error: approved predecessor scope has not changed: lineage review-93b64e4b876f5478 already approved exactly the candidate in your working tree, so this successor would re-freeze bytes that are already approved and there is nothing to re-rev"
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2497,
+          "git_calls": 0
         },
         {
           "sequence": 5,
-          "step": "walk into the recovery guard rails",
+          "step": "objective A fails with unused capacity",
           "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-93b64e4b876f5478",
-            "--expected-predecessor-revision",
-            "sha256:cca33fa851d42f5eb530c5e58edaf3cfeb39962628ae4e953ea1439a6815a6d4",
-            "--successor-lineage",
-            "review-unwanted-successor",
-            "--disposition",
-            "invalidated",
+            "sdd-attempt",
+            "finish",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:0e9bc93dc0883432aeb0bed61eb5e85fe57d5cc0a1faa3a7657ef63d45442727",
+            "--request-id",
+            "bench-rescope-evidence-finish-a",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
           ],
-          "exit_code": 1,
-          "stderr_bytes": 877,
-          "stdout_bytes": 0,
-          "block": "in_band",
-          "git_calls": 2,
-          "message": "Error: recovery requires an invalidated predecessor: --disposition invalidated is only for a lineage that is already invalidated, and lineage review-93b64e4b876f5478 is approved; it cannot be invalidated on the way either, because its appro"
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2283,
+          "git_calls": 0
         },
         {
           "sequence": 6,
-          "step": "invalidate the healthy approved authority",
+          "step": "audited rescope carries A authority into B",
           "args": [
-            "review",
-            "invalidate",
-            "--lineage",
-            "review-93b64e4b876f5478",
-            "--expected-revision",
-            "sha256:cca33fa851d42f5eb530c5e58edaf3cfeb39962628ae4e953ea1439a6815a6d4",
-            "--gate",
-            "post-apply",
+            "sdd-attempt",
+            "rescope",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:95649f7eb8f28449bf658fd70f26759a0fe8545812526068ba121d4bbaea717e",
+            "--request-id",
+            "bench-rescope-evidence-a-to-b",
+            "--work-unit",
+            "runtime proof objective B",
+            "--evidence-goal",
+            "rerun evidence against objective A's unchanged candidate",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "10",
+            "--reason",
+            "maintainer authorized a narrower runtime proof for the unchanged candidate",
+            "--actor",
+            "bench"
           ],
-          "exit_code": 1,
-          "stderr_bytes": 897,
-          "stdout_bytes": 0,
-          "block": "by_design",
-          "by_design": {
-            "shape": "world-action",
-            "next_action": "change the candidate first",
-            "applied": true
-          },
-          "git_calls": 0,
-          "message": "Error: healthy approved authority cannot be invalidated: lineage \"review-93b64e4b876f5478\" still approves exactly the candidate in your working tree, and the post-apply check you asked for still lets it through, so there is no stale approva"
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3120,
+          "git_calls": 0
         },
         {
           "sequence": 7,
-          "step": "recover, following exactly what the gate then names",
+          "step": "unchanged evidence-only PASS for B links A and leaves complete status",
           "args": [
-            "review",
-            "validate",
-            "--gate",
-            "pre-commit",
+            "sdd-attempt",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change"
           ],
-          "exit_code": 1,
-          "stderr_bytes": 248,
-          "stdout_bytes": 2859,
-          "block": "in_band",
-          "git_calls": 0,
-          "message": "Error: review lifecycle gate denied: scope-changed: 1 path in this candidate that no terminal receipt covers: recover via gentle-ai review recover (requires: predecessor_lineage_id, expected_predecessor_revision, successor_lineage_id, dispo"
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3120,
+          "git_calls": 0
         },
         {
           "sequence": 8,
-          "step": "recover, following exactly what the gate then names",
+          "step": "unchanged evidence-only PASS for B links A and leaves complete status",
           "args": [
-            "review",
-            "recover",
-            "--predecessor-lineage",
-            "review-93b64e4b876f5478",
-            "--expected-predecessor-revision",
-            "sha256:cca33fa851d42f5eb530c5e58edaf3cfeb39962628ae4e953ea1439a6815a6d4",
-            "--successor-lineage",
-            "review-guardrail-successor",
-            "--disposition",
-            "scope_changed",
+            "sdd-attempt",
+            "begin",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:b371a2f54b719a3bd2f2ab580bc01ad2845cc654328cbde079c215805e9f9dd0",
+            "--request-id",
+            "bench-rescope-evidence-begin-b",
+            "--work-unit",
+            "runtime proof objective B",
+            "--evidence-goal",
+            "rerun evidence against objective A's unchanged candidate",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "10"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1147,
-          "git_calls": 2
+          "stdout_bytes": 4689,
+          "git_calls": 0
         },
         {
           "sequence": 9,
-          "step": "recover, following exactly what the gate then names",
+          "step": "unchanged evidence-only PASS for B links A and leaves complete status",
           "args": [
-            "review",
-            "finalize",
+            "sdd-attempt",
+            "status",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 540,
+          "stdout_bytes": 4689,
           "git_calls": 0
         },
         {
           "sequence": 10,
-          "step": "recover, following exactly what the gate then names",
+          "step": "unchanged evidence-only PASS for B links A and leaves complete status",
+          "args": [
+            "sdd-attempt",
+            "finish",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j80-rescope-authorized-evidence-only-retry-1618207001/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:e688c0f0f22b58d3c3b38416d6439584e27f675a9f2e2adf8eaa7a0852668fa0",
+            "--request-id",
+            "bench-rescope-evidence-finish-b",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4589,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j81-rc1-consecutive-rescope-repair-executes-printed-command",
+      "title": "RC-created poison: status names and executes the audited repair without rewriting C",
+      "source": "issue #2839; fixture extracted byte-for-byte from the v2.4.0-rc.1 RED run",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 5,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 1,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 657,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "run printed repair, audited reset, then begin",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j81-rc1-consecutive-rescope-repair-executes-printed-command-954682701/home/demo",
+            "--change",
+            "consecutive-rescope-repair"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 657,
+          "stdout_bytes": 0,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "Error: sdd-attempt status: published consecutive-rescope record sha256:da84114f95f9d1674cd23a3d06f5d92a3d5d36a029d5d40931500b91854ec622 is unreadable under normal replay; run this repair command:"
+        },
+        {
+          "sequence": 2,
+          "step": "run printed repair, audited reset, then begin",
+          "args": [
+            "sdd-attempt",
+            "repair",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j81-rc1-consecutive-rescope-repair-executes-printed-command-954682701/home/demo",
+            "--change",
+            "consecutive-rescope-repair",
+            "--expected-revision",
+            "sha256:da84114f95f9d1674cd23a3d06f5d92a3d5d36a029d5d40931500b91854ec622",
+            "--request-id",
+            "repair-da84114f95f9d167",
+            "--actor",
+            "sdd-runtime-repair",
+            "--reason",
+            "repair historical consecutive-rescope publication sha256:da84114f95f9d1674cd23a3d06f5d92a3d5d36a029d5d40931500b91854ec622"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3176,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "run printed repair, audited reset, then begin",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j81-rc1-consecutive-rescope-repair-executes-printed-command-954682701/home/demo",
+            "--change",
+            "consecutive-rescope-repair"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3176,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "run printed repair, audited reset, then begin",
+          "args": [
+            "sdd-attempt",
+            "reset",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j81-rc1-consecutive-rescope-repair-executes-printed-command-954682701/home/demo",
+            "--change",
+            "consecutive-rescope-repair",
+            "--expected-revision",
+            "sha256:31657a813654add6ce1c14d10316d36af0ad69cc53a62ca18be097cc07f24f2c",
+            "--request-id",
+            "bench-2839-reset",
+            "--actor",
+            "bench-maintainer",
+            "--reason",
+            "reset repaired exhausted objective"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3262,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "run printed repair, audited reset, then begin",
+          "args": [
+            "sdd-attempt",
+            "begin",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j81-rc1-consecutive-rescope-repair-executes-printed-command-954682701/home/demo",
+            "--change",
+            "consecutive-rescope-repair",
+            "--expected-revision",
+            "sha256:c8d6638e52fa9363f81534ac28448e49131fb07a7d2337f3c0efacbfdda07e34",
+            "--request-id",
+            "bench-2839-begin",
+            "--work-unit",
+            "objective-b",
+            "--evidence-goal",
+            "prove-b",
+            "--max-attempts",
+            "1",
+            "--max-changed-lines",
+            "10"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 5293,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j84-sdd-attempt-selected-untracked-lifecycle",
+      "title": "SDD attempt: selected untracked scope survives a zero-drift rescope continuation",
+      "source": "issues #2716 and #3801: explicit selected scope remains provenance and a fresh rescope successor must continue it without sweeping workspace files",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 6,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "acquire, settle, and prove selected-path accounting",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j84-sdd-attempt-selected-untracked-lifecycle-419108804/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3188,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "acquire, settle, and prove selected-path accounting",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j84-sdd-attempt-selected-untracked-lifecycle-419108804/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-selected-acquire",
+            "--work-unit",
+            "selected untracked lifecycle",
+            "--evidence-goal",
+            "account only declared untracked bytes",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20",
+            "--untracked-scope",
+            "select",
+            "--expected-untracked-inventory",
+            "sha256:6deb84122c65be83df1a24b15a89889c28df0029369e3d5460e02c33ef624994",
+            "--intended-untracked",
+            "docs/selected.md"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "acquire, settle, and prove selected-path accounting",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j84-sdd-attempt-selected-untracked-lifecycle-419108804/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:66e1160e86b6f372d5204d2a52dad14e3f50970330cd1f48df25de2024751798",
+            "--request-id",
+            "bench-selected-settle",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "acquire, settle, and prove selected-path accounting",
+          "args": [
+            "sdd-attempt",
+            "rescope",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j84-sdd-attempt-selected-untracked-lifecycle-419108804/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:28ac0d9a955cf9927167c5a221f5037e6bd7544f8475aea108d2328e6152fab6",
+            "--request-id",
+            "bench-selected-rescope",
+            "--work-unit",
+            "selected untracked continuation",
+            "--evidence-goal",
+            "prove the rescope successor preserves selected bytes",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20",
+            "--reason",
+            "maintainer narrowed the failed selected-untracked objective",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3181,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "acquire, settle, and prove selected-path accounting",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j84-sdd-attempt-selected-untracked-lifecycle-419108804/home/demo",
+            "--change",
+            "bench-change",
+            "--work-unit",
+            "selected untracked continuation",
+            "--evidence-goal",
+            "prove the rescope successor preserves selected bytes",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3796,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "acquire, settle, and prove selected-path accounting",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j84-sdd-attempt-selected-untracked-lifecycle-419108804/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-selected-acquire-successor",
+            "--work-unit",
+            "selected untracked continuation",
+            "--evidence-goal",
+            "prove the rescope successor preserves selected bytes",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j87-unmanaged-remediation-uses-chain-failed-evidence",
+      "title": "A reset-authorized correction settles against its failed evidence, not a later interruption",
+      "source": "#2871: compact settle must match the immutable failed-evidence chain",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 9,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "mode disable",
+          "args": [
+            "review",
+            "mode",
+            "disable",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 246,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "failed verification exhausts its objective budget",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-chain-acquire-verification",
+            "--work-unit",
+            "bench chain verification",
+            "--evidence-goal",
+            "admit the verification failure",
+            "--max-attempts",
+            "1",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "failed verification exhausts its objective budget",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:f745d0da12b95fa66869cc4873be88e79c1b1e8e776566149fa84b0ad0a5f7b1",
+            "--request-id",
+            "bench-chain-settle-verification",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1396,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "audited reset records the maintainer decision",
+          "args": [
+            "sdd-attempt",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2293,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "audited reset records the maintainer decision",
+          "args": [
+            "sdd-attempt",
+            "reset",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:5d9320cdf8862862a7781613faf547edbf7c73f50c434d147f03cf3ec564f92f",
+            "--request-id",
+            "bench-chain-reset",
+            "--reason",
+            "maintainer decision: remediate the admitted failure under a fresh objective",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2302,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "later interruption records distinct live evidence",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-chain-acquire-interruption",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "later interruption records distinct live evidence",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:d50fd56f437975fa47d56e6e9a1ea3d8fb86ed11872c87010daaea41fdd20bba",
+            "--request-id",
+            "bench-chain-settle-interruption",
+            "--outcome",
+            "interrupted",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        },
+        {
+          "sequence": 8,
+          "step": "acquire the correction bound to the original failed evidence",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-unmanaged-acquire",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--work-unit",
+            "bench unmanaged correction",
+            "--evidence-goal",
+            "repair admitted verification failure",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "settle the exact live remediation token against the failed evidence chain",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j87-unmanaged-remediation-uses-chain-failed-evidence-1107234905/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:768c09adc58b9ec849a375775efb418b14c373454b6c46b64ec97c6866c776c5",
+            "--request-id",
+            "bench-chain-correct",
+            "--outcome",
+            "passed",
+            "--evidence-revision",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "--remediates-evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 26,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j88-unborn-status-collects-untracked-selection",
+      "title": "Unborn repository: STATUS collects explicit untracked selection before snapshot assessment",
+      "source": "issue #2843: an unselected executable candidate must collect inventory-bound intent, never return generic retry or create authority",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "mode enable",
+          "args": [
+            "review",
+            "mode",
+            "enable",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j88-unborn-status-collects-untracked-selection-1430525323/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 243,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "v2 OpenCode STATUS collects the inventory-bound untracked selection",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j88-unborn-status-collects-untracked-selection-1430525323/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--agent",
+            "opencode",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j88-unborn-status-collects-untracked-selection-1430525323/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3170,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j89-staged-validation-is-informational-and-unmanaged",
+      "title": "#3587: staged validation is informational and unmanaged after the terminal burn",
+      "source": "#3587 replaces staged receipt reuse with a terminal event; no staged validation authorizes delivery",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 11,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 3,
+          "out_of_band": 5,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 5,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 232,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "review the staged workspace candidate; zero lenses expose acknowledgement at START before burn",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "staged-validation-terminal-burn",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2476,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo",
+            "--lineage",
+            "staged-validation-terminal-burn"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4544,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 3,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo",
+            "--lineage",
+            "staged-validation-terminal-burn"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4544,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 4,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo",
+            "--lineage=staged-validation-terminal-burn",
+            "--target=sha256:5b1e35df5904ab0ba54c59e7ca82a7e1a29c35d01929b33981eea9865275d9db",
+            "--expected-revision=sha256:ca6c5152977b44deadd5c7ac6770aa44b6baf9b16de92072d75eb8141bee5a2b",
+            "--token=0000000000000000000000000000000000000000000000000000000000000000"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 78,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement token does not match active compact authority"
+        },
+        {
+          "sequence": 5,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "status",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo",
+            "--lineage",
+            "staged-validation-terminal-burn"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4544,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "{"
+        },
+        {
+          "sequence": 6,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo",
+            "--lineage=staged-validation-terminal-burn",
+            "--target=sha256:5b1e35df5904ab0ba54c59e7ca82a7e1a29c35d01929b33981eea9865275d9db",
+            "--expected-revision=sha256:ca6c5152977b44deadd5c7ac6770aa44b6baf9b16de92072d75eb8141bee5a2b",
+            "--token=187ed93716935c56ea59bc508854fe41d846f77177411fa58e4522ab8e361214"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 0,
+          "git_calls": 0
+        },
+        {
+          "sequence": 7,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "acknowledge-approved",
+            "--cwd=/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo",
+            "--lineage=staged-validation-terminal-burn",
+            "--target=sha256:5b1e35df5904ab0ba54c59e7ca82a7e1a29c35d01929b33981eea9865275d9db",
+            "--expected-revision=sha256:ca6c5152977b44deadd5c7ac6770aa44b6baf9b16de92072d75eb8141bee5a2b",
+            "--token=187ed93716935c56ea59bc508854fe41d846f77177411fa58e4522ab8e361214"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 154,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: approved acknowledgement names no live compact authority; it was already acknowledged and burned, and no further lifecycle operation applies to it"
+        },
+        {
+          "sequence": 8,
+          "step": "the zero-lens terminal event leaves no staged authority",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 544,
+          "git_calls": 0
+        },
+        {
+          "sequence": 9,
+          "step": "empty index pre-commit validation remains informational and unmanaged",
           "args": [
             "review",
             "validate",
             "--gate",
             "pre-commit",
             "--cwd",
-            "/private/var/folders/k1/2nnhpdfx0wq8k6w8n2nqx9_h0000gn/T/gentle-ai-bench-j43-recovery-guard-rails-as-an-operator-meets-them-1414333517/home/demo"
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo"
           ],
           "exit_code": 0,
           "stderr_bytes": 0,
-          "stdout_bytes": 1360,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 10,
+          "step": "partial index pre-commit validation remains informational and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-commit",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        },
+        {
+          "sequence": 11,
+          "step": "different index pre-commit validation remains informational and unmanaged",
+          "args": [
+            "review",
+            "validate",
+            "--gate",
+            "pre-commit",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j89-staged-validation-is-informational-and-unmanaged-24133279/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 342,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "invalidated: review enforcement is enabled but no review authority governs this candidate, so delivery follows ordinary repository policy"
+        }
+      ]
+    },
+    {
+      "id": "j92-released-compact-history-quarantines-without-compatibility",
+      "title": "Released compact history is quarantined through the bound repair plan",
+      "source": "issue #2879 D-2879",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 14,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 1,
+          "out_of_band": 2,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 3,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 448,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "clear any clone-local review override (a clone may only ever assert off)",
+          "args": [
+            "review",
+            "mode",
+            "enable",
+            "--scope",
+            "clone",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 242,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "unrelated malformed entry blocks historical preflight",
+          "args": [
+            "review",
+            "inspect-authority",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 692,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "unrelated malformed entry blocks historical preflight",
+          "args": [
+            "review",
+            "repair",
+            "--preflight",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 695,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "inspect historical authority offers repair",
+          "args": [
+            "review",
+            "inspect-authority",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 708,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "preflight binds historical repair",
+          "args": [
+            "review",
+            "repair",
+            "--preflight",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 939,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "forged and stale repair bindings refuse unchanged",
+          "args": [
+            "review",
+            "repair",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo",
+            "--plan-digest",
+            "sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275",
+            "--inventory-revision",
+            "sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46",
+            "--actor",
+            "bench",
+            "--reason",
+            "quarantine released historical record",
+            "--authorization",
+            "gentle-ai.review-disposition-authorization/v1\nschema=gentle-ai.review-authority-disposition-plan/v1\nrepository=sha256:b048e24696aacae06fd75c9eb1103b3c69d8b31a44e9a28c839cb59e0894ec30\nclass=retired_compact_snapshot_identity\nplan_digest=sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275\ninventory_revision=sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46\nactor=bench\nreason=forged authorization"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 119,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: authority disposition plan refused: authorization does not bind to plan_digest and authority_inventory_revision"
+        },
+        {
+          "sequence": 7,
+          "step": "forged and stale repair bindings refuse unchanged",
+          "args": [
+            "review",
+            "repair",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo",
+            "--plan-digest",
+            "sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275",
+            "--inventory-revision",
+            "sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b460",
+            "--actor",
+            "bench",
+            "--reason",
+            "quarantine released historical record",
+            "--authorization",
+            "gentle-ai.review-disposition-authorization/v1\nschema=gentle-ai.review-authority-disposition-plan/v1\nrepository=sha256:b048e24696aacae06fd75c9eb1103b3c69d8b31a44e9a28c839cb59e0894ec30\nclass=retired_compact_snapshot_identity\nplan_digest=sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275\ninventory_revision=sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b460\nactor=bench\nreason=quarantine released historical record"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 210,
+          "stdout_bytes": 0,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "Error: review transaction changed concurrently: submitted plan_digest/inventory_revision does not match the current provider-derived plan; run `gentle-ai review repair --preflight` again for the current values"
+        },
+        {
+          "sequence": 8,
+          "step": "forged and stale repair bindings refuse unchanged",
+          "args": [
+            "review",
+            "repair",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo",
+            "--plan-digest",
+            "sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275",
+            "--inventory-revision",
+            "sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46",
+            "--actor",
+            "bench",
+            "--reason",
+            "quarantine released historical record",
+            "--authorization",
+            "gentle-ai.review-disposition-authorization/v1\nschema=gentle-ai.review-authority-disposition-plan/v1\nrepository=sha256:b048e24696aacae06fd75c9eb1103b3c69d8b31a44e9a28c839cb59e0894ec30\nclass=retired_compact_snapshot_identity\nplan_digest=sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275\ninventory_revision=sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46\nactor=bench\nreason=stale authorization"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 119,
+          "stdout_bytes": 0,
+          "block": "out_of_band",
+          "git_calls": 0,
+          "message": "Error: authority disposition plan refused: authorization does not bind to plan_digest and authority_inventory_revision"
+        },
+        {
+          "sequence": 9,
+          "step": "authorized repair quarantines exactly once",
+          "args": [
+            "review",
+            "repair",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo",
+            "--plan-digest",
+            "sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275",
+            "--inventory-revision",
+            "sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46",
+            "--actor",
+            "bench",
+            "--reason",
+            "quarantine released historical record",
+            "--authorization",
+            "gentle-ai.review-disposition-authorization/v1\nschema=gentle-ai.review-authority-disposition-plan/v1\nrepository=sha256:b048e24696aacae06fd75c9eb1103b3c69d8b31a44e9a28c839cb59e0894ec30\nclass=retired_compact_snapshot_identity\nplan_digest=sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275\ninventory_revision=sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46\nactor=bench\nreason=quarantine released historical record"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1229,
+          "git_calls": 0
+        },
+        {
+          "sequence": 10,
+          "step": "authorized repair quarantines exactly once",
+          "args": [
+            "review",
+            "repair",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo",
+            "--plan-digest",
+            "sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275",
+            "--inventory-revision",
+            "sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46",
+            "--actor",
+            "bench",
+            "--reason",
+            "quarantine released historical record",
+            "--authorization",
+            "gentle-ai.review-disposition-authorization/v1\nschema=gentle-ai.review-authority-disposition-plan/v1\nrepository=sha256:b048e24696aacae06fd75c9eb1103b3c69d8b31a44e9a28c839cb59e0894ec30\nclass=retired_compact_snapshot_identity\nplan_digest=sha256:1d4c04cebd5df1e0e9bbeaa9508c387254dd9ecb7d8a87143d6166176b525275\ninventory_revision=sha256:29b46fbcfbebce5a7012bec801806d98a9482ef81f1b70dae09ed9f17eaa2b46\nactor=bench\nreason=quarantine released historical record"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1226,
+          "git_calls": 0
+        },
+        {
+          "sequence": 11,
+          "step": "authorized repair quarantines exactly once",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 330,
+          "git_calls": 0
+        },
+        {
+          "sequence": 12,
+          "step": "unrelated current target remains routable",
+          "args": [
+            "review",
+            "start",
+            "--lineage",
+            "issue2879-current",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2442,
+          "git_calls": 0
+        },
+        {
+          "sequence": 13,
+          "step": "decoy impossible identity remains ineligible",
+          "args": [
+            "review",
+            "inspect-authority",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 602,
+          "git_calls": 0
+        },
+        {
+          "sequence": 14,
+          "step": "decoy impossible identity remains ineligible",
+          "args": [
+            "review",
+            "repair",
+            "--preflight",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j92-released-compact-history-quarantines-without-compatibility-2745990259/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 695,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j93-stale-managed-assets-start-is-not-unknown",
+      "title": "Stale managed assets: v2 OpenCode START stops before authority and STATUS remains usable",
+      "source": "issue #2822: a stale product-created managed-asset digest refuses before START can mutate; negotiated output must not claim native execution",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 3,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 1,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 1,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 112,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "v2 OpenCode START is typed not-started and reconciliation stays usable",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j93-stale-managed-assets-start-is-not-unknown-1467966599/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--agent",
+            "opencode"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4047,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "v2 OpenCode START is typed not-started and reconciliation stays usable",
+          "args": [
+            "review",
+            "start",
+            "--cwd=/tmp/gentle-ai-bench-j93-stale-managed-assets-start-is-not-unknown-1467966599/home/demo",
+            "--contract=gentle-ai.review-integration/v2",
+            "--target=sha256:71a8505343c314800919d406e8570d15ae3792a774f2e563b1de9f7b4e4a159a",
+            "--projection=workspace",
+            "--lineage=review-69b45dce0368b319",
+            "--agent=opencode",
+            "--consent=relay"
+          ],
+          "exit_code": 1,
+          "stderr_bytes": 112,
+          "stdout_bytes": 602,
+          "block": "in_band",
+          "git_calls": 0,
+          "message": "Error: Managed reviewer assets are outdated; synchronize them before starting review. [managed_assets_outdated]"
+        },
+        {
+          "sequence": 3,
+          "step": "v2 OpenCode START is typed not-started and reconciliation stays usable",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j93-stale-managed-assets-start-is-not-unknown-1467966599/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition",
+            "--agent",
+            "opencode"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 4047,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j96-sdd-same-parent-repository-edit-authority",
+      "title": "Nested planning workspace blocks a sibling directory in the same Git repository",
+      "source": "https://github.com/Gentleman-Programming/gentle-ai/issues/2891",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 3,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "sdd-status blocks the unauthorized same-parent target",
+          "args": [
+            "sdd-status",
+            "same-repo-rollout",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j96-sdd-same-parent-repository-edit-authority-3641191809/home/demo/subproject"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 6287,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "sdd-attempt grant executes the emitted consent invocation",
+          "args": [
+            "sdd-attempt",
+            "grant",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j96-sdd-same-parent-repository-edit-authority-3641191809/home/demo/subproject",
+            "--change",
+            "same-repo-rollout",
+            "--root",
+            "/tmp/gentle-ai-bench-j96-sdd-same-parent-repository-edit-authority-3641191809/home/demo/service-dir",
+            "--actor",
+            "maintainer",
+            "--reason",
+            "edit-authority-consent-granted",
+            "--request-id",
+            "grant-6d40b71d15f40da1",
+            "--change-instance",
+            "sdd-56c6d8813712dff5a5eb64ab022f650b"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 594,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "sdd-status re-entry projects the granted sibling edit root",
+          "args": [
+            "sdd-status",
+            "same-repo-rollout",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j96-sdd-same-parent-repository-edit-authority-3641191809/home/demo/subproject"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3275,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j98-sdd-flat-root-spec-is-discovered",
+      "title": "Flat-root spec is discovered consistently by status and continue",
+      "source": "issue #2696: approved flat-root spec.md artifact discovery contract",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 2,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "sdd-status reports the flat spec",
+          "args": [
+            "sdd-status",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j98-sdd-flat-root-spec-is-discovered-299908693/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 2844,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "sdd-continue reports the same state",
+          "args": [
+            "sdd-continue",
+            "bench-change",
+            "--json",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j98-sdd-flat-root-spec-is-discovered-299908693/home/demo"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 10016,
+          "git_calls": 0
+        }
+      ]
+    },
+    {
+      "id": "j99-sdd-attempt-born-during-untracked-lifecycle",
+      "title": "SDD attempt: files born during an attempt are declared, accounted, and inherited",
+      "source": "issue #3806: a settlement silently recorded the attempt's own untracked product as zero, and the rescope successor it left behind had no runnable begin",
+      "status": "completed",
+      "metrics": {
+        "human_prompts": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "non-TTY run: counts the consent-skipped stderr notice, i.e. times the flow WOULD have asked a human"
+        },
+        "manual_tokens": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "invocations carrying a hand-assembled --maintainer-authorization value"
+        },
+        "commands_to_completion": {
+          "value": 6,
+          "derivation": "measured"
+        },
+        "blocks": {
+          "self_recovered": 0,
+          "in_band": 0,
+          "out_of_band": 0,
+          "by_design": 0,
+          "dead_end": 0
+        },
+        "blocks_derivation": "measured",
+        "recovery_round_trips": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "model_runs": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "human_surface_bytes": {
+          "value": 0,
+          "derivation": "measured"
+        },
+        "git_subprocesses": {
+          "value": 0,
+          "derivation": "measured",
+          "note": "informational, not one of the seven dimensions: GIT_TRACE built-in lines; a lower bound if the build ever uses an in-process git"
+        }
+      },
+      "commands": [
+        {
+          "sequence": 1,
+          "step": "acquire clean, create, declare at settle, and continue",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j99-sdd-attempt-born-during-untracked-lifecycle-2908515106/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-born-acquire",
+            "--work-unit",
+            "born during lifecycle",
+            "--evidence-goal",
+            "account files the attempt creates",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 111,
+          "git_calls": 0
+        },
+        {
+          "sequence": 2,
+          "step": "acquire clean, create, declare at settle, and continue",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j99-sdd-attempt-born-during-untracked-lifecycle-2908515106/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:c73ca8fcb4aa8595ed37e5ed454a40e67b3ac19f99cd59e6a58c4ea232820645",
+            "--request-id",
+            "bench-born-settle",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 1248,
+          "git_calls": 0
+        },
+        {
+          "sequence": 3,
+          "step": "acquire clean, create, declare at settle, and continue",
+          "args": [
+            "review",
+            "status",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j99-sdd-attempt-born-during-untracked-lifecycle-2908515106/home/demo",
+            "--contract",
+            "gentle-ai.review-integration/v2",
+            "--next-transition"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3184,
+          "git_calls": 0
+        },
+        {
+          "sequence": 4,
+          "step": "acquire clean, create, declare at settle, and continue",
+          "args": [
+            "sdd-attempt",
+            "settle",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j99-sdd-attempt-born-during-untracked-lifecycle-2908515106/home/demo",
+            "--change",
+            "bench-change",
+            "--token",
+            "sha256:c73ca8fcb4aa8595ed37e5ed454a40e67b3ac19f99cd59e6a58c4ea232820645",
+            "--request-id",
+            "bench-born-settle",
+            "--outcome",
+            "failed",
+            "--evidence-revision",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--diagnosis",
+            "the benchmark drove this attempt to a terminal outcome",
+            "--harness-disposition",
+            "reused",
+            "--cleanup-evidence",
+            "workspace clean",
+            "--process-evidence",
+            "no stray processes",
+            "--untracked-scope",
+            "select",
+            "--intended-untracked",
+            "docs/born.md",
+            "--expected-untracked-inventory",
+            "sha256:473230b2c44597b6c611128ea801a0f2251f6b7d9d446bdd1575fa59a659d85e"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 25,
+          "git_calls": 0
+        },
+        {
+          "sequence": 5,
+          "step": "acquire clean, create, declare at settle, and continue",
+          "args": [
+            "sdd-attempt",
+            "rescope",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j99-sdd-attempt-born-during-untracked-lifecycle-2908515106/home/demo",
+            "--change",
+            "bench-change",
+            "--expected-revision",
+            "sha256:dae37b6b79c6b322f8bf6774277df6df182e8d065d334a5e38a88ef6166a68c5",
+            "--request-id",
+            "bench-born-rescope",
+            "--work-unit",
+            "born during continuation",
+            "--evidence-goal",
+            "prove the successor inherits what the attempt created",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20",
+            "--reason",
+            "maintainer narrowed the failed born-during objective",
+            "--actor",
+            "bench"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 3159,
+          "git_calls": 0
+        },
+        {
+          "sequence": 6,
+          "step": "acquire clean, create, declare at settle, and continue",
+          "args": [
+            "sdd-attempt",
+            "acquire",
+            "--cwd",
+            "/tmp/gentle-ai-bench-j99-sdd-attempt-born-during-untracked-lifecycle-2908515106/home/demo",
+            "--change",
+            "bench-change",
+            "--request-id",
+            "bench-born-successor",
+            "--work-unit",
+            "born during continuation",
+            "--evidence-goal",
+            "prove the successor inherits what the attempt created",
+            "--max-attempts",
+            "2",
+            "--max-changed-lines",
+            "20"
+          ],
+          "exit_code": 0,
+          "stderr_bytes": 0,
+          "stdout_bytes": 726,
           "git_calls": 0
         }
       ]
@@ -6357,44 +11318,45 @@
       "derivation": "measured"
     },
     "manual_tokens": {
-      "value": 3,
+      "value": 4,
       "derivation": "measured"
     },
     "commands_to_completion": {
-      "value": 298,
+      "value": 407,
       "derivation": "measured"
     },
     "blocks": {
       "self_recovered": 0,
-      "in_band": 26,
-      "out_of_band": 0,
-      "by_design": 3,
+      "in_band": 107,
+      "out_of_band": 39,
+      "by_design": 1,
       "dead_end": 0
     },
     "blocks_derivation": "measured",
     "recovery_round_trips": {
-      "value": 21,
+      "value": 122,
       "derivation": "measured"
     },
     "model_runs": {
-      "value": 26,
+      "value": 34,
       "derivation": "measured"
     },
     "human_surface_bytes": {
-      "value": 19907,
+      "value": 17968,
       "derivation": "measured"
     },
     "git_subprocesses": {
-      "value": 18,
+      "value": 10,
       "derivation": "measured"
     }
   },
-  "journeys_counted": 43,
+  "journeys_counted": 56,
   "journeys_unsupported": 0,
   "journeys_failed": 0,
-  "core_journeys": 43,
+  "core_journeys": 56,
   "notes": [
     "Driven mode: every journey ran in a fresh temp dir with its own HOME, XDG_*, throwaway git repo and local bare remote.",
+    "That HOME is a fresh install, so receipt-driven development starts off. Every journey declares its own precondition: one that reviews opted in first through `gentle-ai review mode enable --scope global`, uncounted; one whose subject is the switch touched it not at all.",
     "Reviewer results were synthesized from the binary's own collect envelope. No model was called.",
     "No wall-clock timing is measured or reported.",
     "by_design is a carve-out from out_of_band, not a subtraction from it: those blocks are still blocks and still in the total. Every one is listed with its declared shape and the verified quote of the product's own next-action text."

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -98,6 +98,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j82-reviewed-superset-pre-push-allows-unpublished-subset":                  reviewOptedIn,
 	"j83-pre-pr-moving-advertised-base-binds-merge-base":                        reviewOptedIn,
 	"j84-sdd-attempt-selected-untracked-lifecycle":                              reviewOptedIn,
+	"j99-sdd-attempt-born-during-untracked-lifecycle":                           reviewOptedIn,
 	"j85-review-parse-refusals-are-preflight":                                   reviewOptedIn,
 	"j86-approved-base-diff-local-parent-merge-preserves-approved-receipt":      reviewOptedIn,
 	"j87-unmanaged-remediation-uses-chain-failed-evidence":                      reviewUntouched,

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -53,3 +53,4 @@ j92-released-compact-history-quarantines-without-compatibility
 j93-stale-managed-assets-start-is-not-unknown
 j96-sdd-same-parent-repository-edit-authority
 j98-sdd-flat-root-spec-is-discovered
+j99-sdd-attempt-born-during-untracked-lifecycle

--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -124,6 +124,19 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			intended = scope.Intended
 		}
 	}
+	// The preflight above stays a begin/acquire concern: only those operations
+	// may be refused before any authority exists. A settlement resolves a
+	// declaration when the caller makes one, and lets the ledger -- the only
+	// reader of what the attempt began against -- decide whether one was owed.
+	var settlementUntracked *[]string
+	settlementInventory := ""
+	if (operation == "finish" || operation == "settle") && declaredUntracked {
+		scope, scopeErr := intendedUntrackedScopeForTarget(ctx, reviewtransaction.SnapshotBuilder{Repo: *cwd}, untrackedScope, intendedUntracked, expectedUntrackedInventory, "gentle-ai review status --next-transition", "gentle-ai sdd-attempt "+operation)
+		if scopeErr != nil {
+			return scopeErr
+		}
+		settlementUntracked, settlementInventory = &scope.Intended, scope.Digest
+	}
 	var result any
 	switch operation {
 	case "status":
@@ -159,6 +172,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			HarnessDisposition: sddstatus.HarnessDisposition(*harnessDisposition),
 			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
 			RemediatesEvidenceRevision: *remediatesEvidenceRevision,
+			IntendedUntracked:          settlementUntracked, ExpectedUntrackedInventory: settlementInventory,
 		})
 	case "handoff":
 		result, err = store.HandoffCompact(ctx, sddstatus.CompactHandoffRequest{
@@ -195,6 +209,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			HarnessDisposition: sddstatus.HarnessDisposition(*harnessDisposition),
 			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
 			RemediatesEvidenceRevision: *remediatesEvidenceRevision,
+			IntendedUntracked:          settlementUntracked, ExpectedUntrackedInventory: settlementInventory,
 		})
 	case "grant":
 		// --expected-revision stays optional, unlike begin/finish/reset: the
@@ -289,6 +304,9 @@ var sddAttemptOperationDefinitions = []sddAttemptOperationContract{
 		{name: "cleanup-evidence", required: true, usage: "required; trimmed single-line text, at most 500 bytes"},
 		{name: "process-evidence", required: true, usage: "required; trimmed single-line text, at most 500 bytes"},
 		{name: "remediates-evidence-revision", usage: "optional; repaired sha256:<64 lowercase hex> failed evidence"},
+		{name: "untracked-scope", usage: "required when this attempt left eligible untracked files; select or exclude"},
+		{name: "expected-untracked-inventory", usage: "required with untracked-scope; inventory digest"},
+		{name: "intended-untracked", kind: sddAttemptRepeatableStringFlag, usage: "repeatable selected repo-relative untracked path"},
 	}},
 	{name: "handoff", purpose: "Atomically move the active attempt to one linked worktree", flags: []sddAttemptFlagDefinition{
 		sddAttemptCWDFlag, sddAttemptChangeFlag,
@@ -345,6 +363,9 @@ var sddAttemptOperationDefinitions = []sddAttemptOperationContract{
 		{name: "cleanup-evidence", required: true, usage: "required; trimmed single-line text, at most 500 bytes"},
 		{name: "process-evidence", required: true, usage: "required; trimmed single-line text, at most 500 bytes"},
 		{name: "remediates-evidence-revision", usage: "optional; repaired sha256:<64 lowercase hex> failed evidence"},
+		{name: "untracked-scope", usage: "required when this attempt left eligible untracked files; select or exclude"},
+		{name: "expected-untracked-inventory", usage: "required with untracked-scope; inventory digest"},
+		{name: "intended-untracked", kind: sddAttemptRepeatableStringFlag, usage: "repeatable selected repo-relative untracked path"},
 	}},
 	{name: "grant", purpose: "Record per-change edit authority for roots", flags: []sddAttemptFlagDefinition{
 		sddAttemptCWDFlag, sddAttemptChangeFlag,

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -271,13 +271,13 @@ func TestRunSDDAttemptHelpContractsCoverEveryOperation(t *testing.T) {
 	}{
 		{"status", []string{"cwd", "change", "change-instance", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines"}, []string{"optional", "128 bytes"}},
 		{"begin", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"default 2", "default 200", "1..100", "1..1000000"}},
-		{"finish", []string{"cwd", "change", "expected-revision", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision"}, []string{"failed, interrupted, or passed", "reused or invalidated", "empty or canonical legacy sha256 revision", "500 bytes"}},
+		{"finish", []string{"cwd", "change", "expected-revision", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"failed, interrupted, or passed", "reused or invalidated", "empty or canonical legacy sha256 revision", "500 bytes"}},
 		{"handoff", []string{"cwd", "change", "expected-revision", "request-id", "destination-worktree"}, []string{"registered linked worktree", "Git common directory"}},
 		{"reset", []string{"cwd", "change", "expected-revision", "request-id", "reason", "actor"}, []string{"500 bytes", "128 bytes"}},
 		{"rescope", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor"}, []string{"explicit limit", "cannot exceed current objective"}},
 		{"acquire", []string{"cwd", "change", "token", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "remediates-evidence-revision", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"default 2", "default 200", "failed evidence correction"}},
 		{"repair", []string{"cwd", "change", "expected-revision", "request-id", "reason", "actor"}, []string{"unreadable sha256", "500 bytes", "128 bytes"}},
-		{"settle", []string{"cwd", "change", "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision"}, []string{"opaque token returned by acquire", "required for failed/passed; omit for interrupted"}},
+		{"settle", []string{"cwd", "change", "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"opaque token returned by acquire", "required for failed/passed; omit for interrupted"}},
 		{"grant", []string{"cwd", "change", "expected-revision", "root", "change-instance", "request-id", "actor", "reason"}, []string{"repeatable", "1..32", "4096 bytes"}},
 	}
 

--- a/internal/cli/sdd_attempt_untracked_test.go
+++ b/internal/cli/sdd_attempt_untracked_test.go
@@ -311,3 +311,78 @@ func TestRunSDDAttemptRejectsNestedRepositoryUntrackedScope(t *testing.T) {
 		t.Fatalf("nested repository refusal = %v, want an untracked nested-repository refusal", err)
 	}
 }
+
+// TestRunSDDAttemptSettleDeclaresUntrackedFilesBornDuringTheAttempt drives the
+// whole of #3806 through the real CLI: an attempt that starts against a
+// workspace with nothing eligible, creates a file while it runs, and then has
+// to say what that file is before it can settle.
+func TestRunSDDAttemptSettleDeclaresUntrackedFilesBornDuringTheAttempt(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		scope        string
+		selected     []string
+		changedLines int
+	}{
+		{"select accounts the file", "select", []string{"born.txt"}, 3},
+		{"exclude leaves it out on the record", "exclude", nil, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			change := "born-during-" + test.scope
+			acquired, _ := runCompactSDDAttempt(t, []string{
+				"acquire", "--cwd", repo, "--change", change, "--request-id", "born-acquire",
+				"--work-unit", "born during", "--evidence-goal", "account what the attempt creates",
+				"--max-attempts", "2", "--max-changed-lines", "20",
+			})
+			if acquired.State != "proceed" || acquired.Token == "" {
+				t.Fatalf("clean acquire = %#v", acquired)
+			}
+			writeUndeclaredWorkspaceFile(t, repo, "born.txt", "one\ntwo\nthree\n", 0o644)
+
+			settle := []string{
+				"settle", "--cwd", repo, "--change", change, "--token", acquired.Token, "--request-id", "born-settle",
+				"--outcome", "passed", "--evidence-revision", "sha256:" + strings.Repeat("a", 64),
+				"--diagnosis", "work unit complete", "--harness-disposition", "invalidated",
+				"--cleanup-evidence", "cleanup completed", "--process-evidence", "process scan clean",
+			}
+			blocked, _ := runCompactSDDAttempt(t, settle)
+			if blocked.State != "blocked" {
+				t.Fatalf("undeclared born-during settlement = %#v", blocked)
+			}
+			if !strings.Contains(blocked.Exit, "born.txt") ||
+				!strings.Contains(blocked.Exit, "--untracked-scope=select") ||
+				!strings.Contains(blocked.Exit, "--untracked-scope=exclude") {
+				t.Fatalf("refusal does not name the file and both exits: %#v", blocked)
+			}
+
+			_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			declared := append(append([]string{}, settle...), "--untracked-scope", test.scope, "--expected-untracked-inventory", digest)
+			for _, path := range test.selected {
+				declared = append(declared, "--intended-untracked", path)
+			}
+			settled, _ := runCompactSDDAttempt(t, declared)
+			if settled.State != "complete" {
+				t.Fatalf("declared settlement = %#v", settled)
+			}
+			store, err := sddstatus.OpenRuntimeStore(context.Background(), repo, change)
+			if err != nil {
+				t.Fatal(err)
+			}
+			status, err := store.Status()
+			if err != nil || len(status.Attempts) != 1 {
+				t.Fatalf("declared settlement did not settle one attempt: status=%#v err=%v", status, err)
+			}
+			settledAttempt := status.Attempts[0]
+			if settledAttempt.ChangedLines != test.changedLines {
+				t.Fatalf("changed lines = %d, want %d: %#v", settledAttempt.ChangedLines, test.changedLines, settledAttempt)
+			}
+			if len(settledAttempt.IntendedUntracked) != len(test.selected) ||
+				(len(test.selected) == 1 && settledAttempt.IntendedUntracked[0] != test.selected[0]) {
+				t.Fatalf("settlement provenance = %#v, want %#v", settledAttempt.IntendedUntracked, test.selected)
+			}
+		})
+	}
+}

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -107,6 +107,11 @@ type CompactSettleRequest struct {
 	ProcessEvidence    string
 
 	RemediatesEvidenceRevision string
+
+	// The settle-time untracked declaration, forwarded verbatim to Finish.
+	// Nil means the caller declared nothing.
+	IntendedUntracked          *[]string
+	ExpectedUntrackedInventory string
 }
 
 type CompactHandoffRequest struct {
@@ -297,7 +302,8 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		ExpectedRevision: status.Revision, RequestID: request.RequestID, Outcome: request.Outcome,
 		EvidenceRevision: request.EvidenceRevision, Diagnosis: request.Diagnosis,
 		HarnessDisposition: request.HarnessDisposition, CleanupEvidence: request.CleanupEvidence,
-		ProcessEvidence: request.ProcessEvidence,
+		ProcessEvidence: request.ProcessEvidence, IntendedUntracked: request.IntendedUntracked,
+		ExpectedUntrackedInventory: request.ExpectedUntrackedInventory,
 	}
 	failedEvidence, hasFailedEvidence := runtimeChainFailedEvidence(status.Attempts)
 	if request.RemediatesEvidenceRevision != "" && (!hasFailedEvidence || failedEvidence != request.RemediatesEvidenceRevision) {
@@ -345,7 +351,8 @@ func normalizeCompactSettleRequest(request CompactSettleRequest) error {
 		ExpectedRevision: request.Token, RequestID: request.RequestID, Outcome: request.Outcome,
 		EvidenceRevision: request.EvidenceRevision, Diagnosis: request.Diagnosis,
 		HarnessDisposition: request.HarnessDisposition, CleanupEvidence: request.CleanupEvidence,
-		ProcessEvidence: request.ProcessEvidence,
+		ProcessEvidence: request.ProcessEvidence, IntendedUntracked: request.IntendedUntracked,
+		ExpectedUntrackedInventory: request.ExpectedUntrackedInventory,
 	})
 	if err != nil {
 		return err
@@ -383,13 +390,35 @@ func compactSettleReplayRequest(replay runtimeReplay, record runtimeRecord, requ
 		request.Outcome == event.Outcome && request.EvidenceRevision == event.EvidenceRevision &&
 		request.Diagnosis == event.Diagnosis && request.HarnessDisposition == event.HarnessDisposition &&
 		request.CleanupEvidence == event.CleanupEvidence && request.ProcessEvidence == event.ProcessEvidence &&
-		request.RemediatesEvidenceRevision == event.RemediatesEvidenceRevision
+		request.RemediatesEvidenceRevision == event.RemediatesEvidenceRevision &&
+		request.ExpectedUntrackedInventory == event.DeclaredUntrackedInventory &&
+		compactSettleDeclarationMatches(request.IntendedUntracked, event)
 	return FinishAttemptRequest{
 		ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID, Outcome: event.Outcome,
 		EvidenceRevision: event.EvidenceRevision, Diagnosis: event.Diagnosis,
 		HarnessDisposition: event.HarnessDisposition, CleanupEvidence: event.CleanupEvidence,
 		ProcessEvidence: event.ProcessEvidence, RemediatesEvidenceRevision: event.RemediatesEvidenceRevision,
+		IntendedUntracked: replayedSettleDeclaration(event), ExpectedUntrackedInventory: event.DeclaredUntrackedInventory,
 	}, matches
+}
+
+// replayedSettleDeclaration recovers the selection the original request
+// carried. The event always records the selection the settlement used, but the
+// request carried one only when the caller declared, which the recorded digest
+// is what says.
+func replayedSettleDeclaration(event *runtimeFinishEvent) *[]string {
+	if event.DeclaredUntrackedInventory == "" {
+		return nil
+	}
+	return event.IntendedUntracked
+}
+
+func compactSettleDeclarationMatches(declared *[]string, event *runtimeFinishEvent) bool {
+	replayed := replayedSettleDeclaration(event)
+	if declared == nil || replayed == nil {
+		return declared == nil && replayed == nil
+	}
+	return slices.Equal(*declared, *replayed)
 }
 
 // compactAcquireResult reconciles a committed begin whose publication the

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -201,13 +201,14 @@ type RuntimeObjective struct {
 }
 
 type RuntimeAttempt struct {
-	Ordinal                int      `json:"ordinal"`
-	ObjectiveID            string   `json:"objective_id"`
-	ObjectiveGeneration    int      `json:"objective_generation"`
-	WorkUnit               string   `json:"work_unit"`
-	BeginCandidateIdentity string   `json:"begin_candidate_identity"`
-	BeginCandidateTree     string   `json:"begin_candidate_tree"`
-	IntendedUntracked      []string `json:"intended_untracked,omitempty"`
+	Ordinal                    int      `json:"ordinal"`
+	ObjectiveID                string   `json:"objective_id"`
+	ObjectiveGeneration        int      `json:"objective_generation"`
+	WorkUnit                   string   `json:"work_unit"`
+	BeginCandidateIdentity     string   `json:"begin_candidate_identity"`
+	BeginCandidateTree         string   `json:"begin_candidate_tree"`
+	IntendedUntracked          []string `json:"intended_untracked,omitempty"`
+	EligibleUntrackedInventory string   `json:"eligible_untracked_inventory,omitempty"`
 	// BeginWorktree is the canonical (absolute, symlink-evaluated) --cwd Begin
 	// ran under (#2296 part 1). It is empty for every chain recorded before
 	// this field existed — that emptiness IS the legacy signal, so replay and
@@ -374,6 +375,15 @@ type FinishAttemptRequest struct {
 	CleanupEvidence            string             `json:"cleanup_evidence"`
 	ProcessEvidence            string             `json:"process_evidence"`
 	RemediatesEvidenceRevision string             `json:"remediates_evidence_revision,omitempty"`
+
+	// A settle-time declaration about untracked files this attempt created.
+	// Both are omitempty so a request that declares nothing marshals exactly
+	// as it did before the fields existed, which keeps every legacy finish
+	// request digest byte-identical without a second hashing shape.
+	// IntendedUntracked is nil when nothing was declared and non-nil (possibly
+	// empty, from --untracked-scope=exclude) when something was.
+	IntendedUntracked          *[]string `json:"intended_untracked,omitempty"`
+	ExpectedUntrackedInventory string    `json:"expected_untracked_inventory,omitempty"`
 }
 
 type HandoffAttemptRequest struct {
@@ -546,6 +556,14 @@ type runtimeBeginEvent struct {
 	// A nil pointer preserves records written before candidate provenance was
 	// introduced; a non-nil empty slice is a modern, explicit empty selection.
 	IntendedUntracked *[]string `json:"intended_untracked,omitempty"`
+	// EligibleUntrackedInventory is the digest of the whole eligible untracked
+	// inventory this attempt began against -- what the caller saw when they
+	// declared. IntendedUntracked records only what they SELECTED, so without
+	// this the finish guard cannot tell a path the caller deliberately left
+	// out from one the attempt created afterwards (#3806). A nil pointer is a
+	// record written before the field existed, and the guard stays silent for
+	// it rather than re-asking a decision it cannot read.
+	EligibleUntrackedInventory *string `json:"eligible_untracked_inventory,omitempty"`
 	// BeginWorktree records store.Workspace at Begin time (#2296 part 1): the
 	// resolved, symlink-evaluated absolute path of the exact --cwd this begin
 	// ran under. omitempty is load-bearing — every record predating this field
@@ -609,6 +627,14 @@ type runtimeFinishEvent struct {
 	ProcessEvidence            string             `json:"process_evidence"`
 	RemediatesEvidenceRevision string             `json:"remediates_evidence_revision,omitempty"`
 	ChangedLineBudgetExceeded  bool               `json:"changed_line_budget_exceeded,omitempty"`
+
+	// IntendedUntracked is the selection this settlement actually overlaid,
+	// which is the begin selection unless the caller declared a new one here.
+	// DeclaredUntrackedInventory is the digest they declared against; it is
+	// empty exactly when they declared nothing, which is how replay knows
+	// whether the request carried a selection of its own.
+	IntendedUntracked          *[]string `json:"intended_untracked,omitempty"`
+	DeclaredUntrackedInventory string    `json:"declared_untracked_inventory,omitempty"`
 }
 
 type runtimeRequestReceipt struct {
@@ -771,12 +797,16 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 			objectiveID = status.Objective.ID
 		}
 		intendedUntracked := slices.Clone(snapshot.IntendedUntracked)
+		_, eligibleInventory, err := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).IntendedUntrackedInventory(ctx)
+		if err != nil {
+			return runtimeRecord{}, fmt.Errorf("read the eligible untracked inventory this attempt begins against: %w", err)
+		}
 		event := &runtimeBeginEvent{
 			ObjectiveID: objectiveID, ObjectiveGeneration: generation, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal,
 			MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines,
 			Ordinal: status.NextOrdinal, BeginCandidateIdentity: snapshot.Identity, BeginCandidateTree: snapshot.CandidateTree,
-			IntendedUntracked: &intendedUntracked,
-			BeginWorktree:     store.Workspace, EffectiveWorktree: store.Workspace,
+			IntendedUntracked: &intendedUntracked, EligibleUntrackedInventory: &eligibleInventory,
+			BeginWorktree: store.Workspace, EffectiveWorktree: store.Workspace,
 		}
 		if advancing {
 			return runtimeRecord{Operation: runtimeOperationAdvance, Begin: event, Advance: &runtimeAdvanceEvent{
@@ -835,13 +865,24 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		if request.Outcome == AttemptPassed && chainHasFailedEvidence && !evidenceRemediation {
 			return runtimeRecord{}, fmt.Errorf("passing correction for failed verification %q requires --remediates-evidence-revision %q; rerun `gentle-ai sdd-attempt settle` with that flag", chainFailedEvidence, chainFailedEvidence)
 		}
+		// The candidate is the begin tree overlaid with tracked changes, the
+		// index, and a selection of untracked paths. The selection made at
+		// begin was a decision about what already existed then, so a file the
+		// attempt itself created is in none of those and settling over it
+		// records the attempt's own product as no change at all (#3806). This
+		// resolves which selection this settlement overlays, and refuses while
+		// the caller can still act when the answer is nobody's decision yet.
+		intendedUntracked, declaredInventory, err := store.settlementUntrackedSelection(ctx, *active, request)
+		if err != nil {
+			return runtimeRecord{}, err
+		}
 		// Issue #2394: the runtime candidate is the same declared candidate
 		// review freezes -- tracked changes plus whatever the user put in the
 		// index. Sweeping the worktree here would make drift detection and
 		// review disagree about what the candidate even is.
 		snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).Build(ctx, reviewtransaction.Target{
 			Kind: reviewtransaction.TargetBaseWorkspaceOverlay, BaseRef: active.BeginCandidateTree,
-			Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: active.IntendedUntracked,
+			Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: intendedUntracked,
 		})
 		if err != nil {
 			return runtimeRecord{}, wrapRuntimeCandidateUnavailable("after attempt", err)
@@ -884,9 +925,89 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			CleanupEvidence: request.CleanupEvidence, ProcessEvidence: request.ProcessEvidence,
 			RemediatesEvidenceRevision: request.RemediatesEvidenceRevision,
 			ChangedLineBudgetExceeded:  runtimeChangedLineBudgetExceeded(status, changedLines),
+			IntendedUntracked:          &intendedUntracked,
+			DeclaredUntrackedInventory: declaredInventory,
 		}
 		return runtimeRecord{Operation: runtimeOperationFinish, Finish: event}, nil
 	})
+}
+
+// runtimeUndeclaredUntrackedListLimit bounds the paths a single refusal spells
+// out. The eligible inventory is unbounded, and a refusal nobody can read is
+// one nobody acts on.
+const runtimeUndeclaredUntrackedListLimit = 10
+
+// settlementUntrackedSelection answers which untracked paths this settlement
+// overlays onto the begin tree, and returns the inventory digest the caller
+// declared against (empty when they declared nothing).
+//
+// The question only has a new answer when the attempt created eligible
+// untracked files. Everything else the caller already ruled on: a path they
+// selected at begin is candidate bytes, and a path they saw in that same
+// inventory and did not select, they left out on purpose. Comparing today's
+// inventory against the one recorded at begin is what separates the two, and
+// it is why the begin record carries that digest at all.
+func (store RuntimeStore) settlementUntrackedSelection(ctx context.Context, active RuntimeAttempt, request FinishAttemptRequest) ([]string, string, error) {
+	if active.EligibleUntrackedInventory == "" {
+		// A record written before the begin inventory was captured cannot say
+		// what the caller saw, so no decision can honestly be demanded of them
+		// now and none may be accepted either.
+		if request.IntendedUntracked != nil {
+			return nil, "", errors.New("this attempt began before settle-time untracked declarations existed, so it has no inventory to declare against; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` without --untracked-scope")
+		}
+		return active.IntendedUntracked, "", nil
+	}
+	inventory, digest, err := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).IntendedUntrackedInventory(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("read the eligible untracked inventory before settling: %w", err)
+	}
+	undecided := make([]string, 0, len(inventory))
+	for _, path := range inventory {
+		if !slices.Contains(active.IntendedUntracked, path) {
+			undecided = append(undecided, path)
+		}
+	}
+	if request.IntendedUntracked == nil {
+		// Nothing eligible is undecided, or the inventory is the very one the
+		// caller declared against at begin. Either way this settlement asks
+		// them nothing new.
+		if len(undecided) == 0 || digest == active.EligibleUntrackedInventory {
+			return active.IntendedUntracked, "", nil
+		}
+		return nil, "", runtimeBornDuringUntrackedRefusal(undecided, digest)
+	}
+	if request.ExpectedUntrackedInventory != digest {
+		return nil, "", fmt.Errorf("this declaration was made against untracked inventory %s but the workspace now holds %s; rerun `gentle-ai review status --next-transition` for the current inventory, then rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --expected-untracked-inventory=%s", request.ExpectedUntrackedInventory, digest, digest)
+	}
+	selection := *request.IntendedUntracked
+	for _, path := range selection {
+		if !slices.Contains(inventory, path) {
+			return nil, "", fmt.Errorf("intended-untracked path %q is not in the current eligible inventory; rerun `gentle-ai review status --next-transition` to see what is eligible, then rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with only those paths", path)
+		}
+	}
+	// A path selected at begin is already in the begin tree. Dropping it here
+	// would make the overlay subtract bytes the attempt never touched, so a
+	// settlement may widen the selection but never narrow it.
+	for _, path := range active.IntendedUntracked {
+		if slices.Contains(inventory, path) && !slices.Contains(selection, path) {
+			return nil, "", fmt.Errorf("this attempt began with %q in its candidate, and a settlement cannot take it back out; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --intended-untracked=%s included", path, path)
+		}
+	}
+	return selection, digest, nil
+}
+
+// runtimeBornDuringUntrackedRefusal names the eligible untracked paths nobody
+// has ruled on yet, and both ways to rule on them. Selecting one makes it
+// candidate bytes and charges its lines; excluding it leaves it out, which is
+// what today's settlement does silently and what this refusal exists to put on
+// the record instead.
+func runtimeBornDuringUntrackedRefusal(undecided []string, digest string) error {
+	listed, remainder := undecided, ""
+	if len(listed) > runtimeUndeclaredUntrackedListLimit {
+		remainder = fmt.Sprintf(" and %d more", len(listed)-runtimeUndeclaredUntrackedListLimit)
+		listed = listed[:runtimeUndeclaredUntrackedListLimit]
+	}
+	return fmt.Errorf("this attempt left eligible untracked files its candidate does not include, so settling now would record them as no change at all: %s%s; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --untracked-scope=select --intended-untracked=<repo-relative-path> --expected-untracked-inventory=%s to account them, or --untracked-scope=exclude --expected-untracked-inventory=%s to leave them out on the record", strings.Join(listed, ", "), remainder, digest, digest)
 }
 
 // captureFinalVerifyReport derives the final verification attestation from the
@@ -1898,7 +2019,8 @@ func applyRuntimeBeginEvent(replay *runtimeReplay, revision string, record runti
 		Ordinal: event.Ordinal, ObjectiveID: event.ObjectiveID, ObjectiveGeneration: generation,
 		WorkUnit: event.WorkUnit, BeginCandidateIdentity: event.BeginCandidateIdentity,
 		BeginCandidateTree: event.BeginCandidateTree, IntendedUntracked: intendedUntracked, BeginWorktree: event.BeginWorktree,
-		EffectiveWorktree: event.EffectiveWorktree, Outcome: AttemptRunning,
+		EligibleUntrackedInventory: runtimeOptionalString(event.EligibleUntrackedInventory),
+		EffectiveWorktree:          event.EffectiveWorktree, Outcome: AttemptRunning,
 	}
 	replay.Status.Attempts = append(replay.Status.Attempts, attempt)
 	replay.AttemptTokens[event.Ordinal] = revision
@@ -2158,6 +2280,12 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 	attempt.ProcessEvidence = event.ProcessEvidence
 	attempt.RemediatesEvidenceRevision = event.RemediatesEvidenceRevision
 	attempt.ChangedLineBudgetExceeded = event.ChangedLineBudgetExceeded
+	// A rescope successor inherits its predecessor's recorded selection, so the
+	// settled attempt must report the one it actually settled with, not the one
+	// it began with (#3806).
+	if event.IntendedUntracked != nil {
+		attempt.IntendedUntracked = slices.Clone(*event.IntendedUntracked)
+	}
 	replay.Status.ActiveAttempt = nil
 	replay.Status.CumulativeChangedLines += event.ChangedLines
 	replay.Status.LifetimeChangedLines += event.ChangedLines
@@ -2249,8 +2377,18 @@ func applyRuntimeGrantEvent(replay *runtimeReplay, event *runtimeGrantEvent) {
 	}
 }
 
+func runtimeOptionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
 func validateRuntimeBeginEvent(record runtimeRecord) error {
 	event := record.Begin
+	if event.EligibleUntrackedInventory != nil && !runtimeRevisionPattern.MatchString(*event.EligibleUntrackedInventory) {
+		return rejectRuntimeRecord("invalid_eligible_untracked_inventory")
+	}
 	if !runtimeRevisionPattern.MatchString(event.ObjectiveID) || event.ObjectiveGeneration < 0 || validateRuntimeText(event.WorkUnit, 160) != nil ||
 		validateRuntimeText(event.EvidenceGoal, 240) != nil || event.MaxAttempts < 1 || event.MaxAttempts > maximumRuntimeAttemptLimit ||
 		event.MaxChangedLines < 1 || event.MaxChangedLines > maximumRuntimeChangedLines || event.Ordinal < 1 ||
@@ -2341,6 +2479,13 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			EvidenceRevision: event.EvidenceRevision, Diagnosis: event.Diagnosis, HarnessDisposition: event.HarnessDisposition,
 			CleanupEvidence: event.CleanupEvidence, ProcessEvidence: event.ProcessEvidence,
 			RemediatesEvidenceRevision: event.RemediatesEvidenceRevision,
+			ExpectedUntrackedInventory: event.DeclaredUntrackedInventory,
+		}
+		// The event records the selection this settlement used; the request
+		// carried one only when the caller declared, which is exactly when the
+		// event carries the digest they declared against.
+		if event.DeclaredUntrackedInventory != "" {
+			request.IntendedUntracked = event.IntendedUntracked
 		}
 		if runtimeValueHash("gentle-ai.sdd-runtime-finish-request/v1", request) != record.RequestDigest {
 			return rejectRuntimeRecord("finish_request_digest_match")
@@ -2566,6 +2711,19 @@ func normalizeFinishAttemptRequest(request FinishAttemptRequest) (FinishAttemptR
 	}
 	if err := validateRuntimeText(request.ProcessEvidence, 500); err != nil {
 		return FinishAttemptRequest{}, fmt.Errorf("invalid process_evidence: %w", err)
+	}
+	if (request.IntendedUntracked == nil) != (request.ExpectedUntrackedInventory == "") {
+		return FinishAttemptRequest{}, errors.New("an untracked declaration needs both its selection and the inventory digest it was made against; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --untracked-scope and --expected-untracked-inventory together")
+	}
+	if request.ExpectedUntrackedInventory != "" && !runtimeRevisionPattern.MatchString(request.ExpectedUntrackedInventory) {
+		return FinishAttemptRequest{}, errors.New("expected_untracked_inventory must be sha256:<64-lowercase-hex>; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with the digest `gentle-ai review status --next-transition` publishes")
+	}
+	if request.IntendedUntracked != nil {
+		canonical, canonicalErr := canonicalRuntimeIntendedUntracked(*request.IntendedUntracked)
+		if canonicalErr != nil {
+			return FinishAttemptRequest{}, canonicalErr
+		}
+		request.IntendedUntracked = &canonical
 	}
 	if request.RemediatesEvidenceRevision != "" {
 		// Every outcome is a truthful settlement of a declared correction

--- a/internal/sddstatus/runtime_ledger_untracked_test.go
+++ b/internal/sddstatus/runtime_ledger_untracked_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
 func TestRuntimeIntendedUntrackedRejectsInvalidPaths(t *testing.T) {
@@ -270,5 +272,253 @@ func TestRuntimeLegacyEmptyPopulationStillReplays(t *testing.T) {
 		if err != nil || result.State != CompactStateBlocked || result.Reason != CompactBlockInvalidContinuation || countRuntimeRecords(t, store.Dir) != beforeRecords {
 			t.Fatalf("legacy rejected continuation = %#v, err=%v records=%d", result, err, countRuntimeRecords(t, store.Dir))
 		}
+	}
+}
+
+// The three tests below are one argument in three parts, about files an
+// attempt creates while it runs (#3806). The declaration an attempt makes at
+// begin/acquire is a decision about what already existed then; it cannot cover
+// what the attempt itself produces, and producing files is the ordinary case
+// for a work unit rather than the exotic one.
+
+func TestRuntimeFinishRefusesUntrackedBornDuringTheAttempt(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-refuses")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "born-during-begin", WorkUnit: "born during", EvidenceGoal: "account what the attempt creates",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "born.txt"), []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "born-during-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "settling must not record the attempt's own file as nothing",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err == nil {
+		t.Fatal("settled a candidate that omits the file this attempt created")
+	}
+	if !strings.Contains(err.Error(), "born.txt") {
+		t.Fatalf("refusal does not name the omitted path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--untracked-scope=select") || !strings.Contains(err.Error(), "--untracked-scope=exclude") {
+		t.Fatalf("refusal does not name both exits: %v", err)
+	}
+	if !strings.Contains(err.Error(), currentUntrackedInventoryDigest(t, repo)) {
+		t.Fatalf("refusal does not name the inventory to declare against: %v", err)
+	}
+	// State-preserving: the caller decides, and the attempt is still theirs to
+	// close once they have.
+	status, err := store.Status()
+	if err != nil || status.Revision != started.Revision || status.ActiveAttempt == nil ||
+		status.ActiveAttempt.Outcome != AttemptRunning {
+		t.Fatalf("refusal mutated authority: status=%#v err=%v", status, err)
+	}
+}
+
+func TestRuntimeFinishAccountsBornDuringWorkOnceStaged(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-staged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "staged-begin", WorkUnit: "born during", EvidenceGoal: "account what the attempt creates",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "born.txt"), []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Staging remains the ordinary way to make new work candidate bytes: it
+	// leaves nothing eligible to decide, so the settlement asks nothing.
+	runRuntimeLedgerGit(t, repo, "add", "born.txt")
+	finished, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "staged-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "staged born-during work is candidate bytes",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(finished.Attempts) != 1 || finished.Attempts[0].ChangedLines != 3 {
+		t.Fatalf("staged born-during work was not charged: %#v", finished.Attempts)
+	}
+	if finished.Attempts[0].FinishCandidateTree == finished.Attempts[0].BeginCandidateTree {
+		t.Fatalf("staged born-during work left the candidate identity unchanged: %#v", finished.Attempts[0])
+	}
+}
+
+func TestRuntimeFinishAllowsDeclaredAndIgnoredUntrackedPaths(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "selected.txt"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("debris/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeLedgerGit(t, repo, "add", ".gitignore")
+	runRuntimeLedgerGit(t, repo, "commit", "-qm", "ignore debris")
+	store, err := OpenRuntimeStore(context.Background(), repo, "declared-and-ignored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "declared-begin", WorkUnit: "declared scope", EvidenceGoal: "declared paths stay candidate bytes",
+		MaxAttempts: 2, MaxChangedLines: 20, IntendedUntracked: []string{"selected.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A declared path stays untracked for the whole attempt, and an ignored
+	// path is not eligible at all. Neither is undeclared work, so neither may
+	// refuse: over-refusing here would make the guard unusable.
+	if err := os.WriteFile(filepath.Join(repo, "selected.txt"), []byte("initial\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "debris"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "debris", "scratch.log"), []byte("noise\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	finished, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "declared-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('c'), Diagnosis: "declared and ignored paths never block settlement",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(finished.Attempts) != 1 || finished.Attempts[0].ChangedLines != 1 {
+		t.Fatalf("declared untracked accounting = %#v", finished.Attempts)
+	}
+}
+
+func currentUntrackedInventoryDigest(t *testing.T, repo string) string {
+	t.Helper()
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+func TestRuntimeFinishSelectsBornDuringWorkIntoTheCandidate(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-selected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "select-begin", WorkUnit: "born during", EvidenceGoal: "account what the attempt creates",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "born.txt"), []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	selection := []string{"born.txt"}
+	finished, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "select-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('e'), Diagnosis: "selected born-during work is candidate bytes",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+		IntendedUntracked: &selection, ExpectedUntrackedInventory: currentUntrackedInventoryDigest(t, repo),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := finished.Attempts[0]
+	if settled.ChangedLines != 3 || settled.FinishCandidateTree == settled.BeginCandidateTree {
+		t.Fatalf("selected born-during work was not accounted: %#v", settled)
+	}
+	// The settled attempt reports the selection it settled with, which is what
+	// a rescope successor inherits.
+	if len(settled.IntendedUntracked) != 1 || settled.IntendedUntracked[0] != "born.txt" {
+		t.Fatalf("settlement selection is not recorded provenance: %#v", settled)
+	}
+}
+
+func TestRuntimeFinishExcludesBornDuringWorkOnTheRecord(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-excluded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "exclude-begin", WorkUnit: "born during", EvidenceGoal: "leave bookkeeping out of the candidate",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "born.txt"), []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	finished, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "exclude-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('f'), Diagnosis: "the file is not this work unit's product",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+		IntendedUntracked: &[]string{}, ExpectedUntrackedInventory: currentUntrackedInventoryDigest(t, repo),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := finished.Attempts[0]
+	// Excluding produces the same zero-change settlement the defect produced
+	// silently. The difference is the whole point: this one was decided.
+	if settled.ChangedLines != 0 || settled.FinishCandidateTree != settled.BeginCandidateTree {
+		t.Fatalf("exclusion changed the candidate: %#v", settled)
+	}
+}
+
+func TestRuntimeFinishRefusesADeclarationAgainstAStaleInventory(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-stale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "stale-begin", WorkUnit: "born during", EvidenceGoal: "a declaration binds the inventory it saw",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "born.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := currentUntrackedInventoryDigest(t, repo)
+	// A second file appears between reading the inventory and settling against it.
+	if err := os.WriteFile(filepath.Join(repo, "later.txt"), []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	selection := []string{"born.txt"}
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "stale-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "stale declarations must not settle",
+		HarnessDisposition: HarnessInvalidated, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+		IntendedUntracked: &selection, ExpectedUntrackedInventory: stale,
+	})
+	if err == nil {
+		t.Fatal("settled a declaration made against an inventory that no longer holds")
+	}
+	if !strings.Contains(err.Error(), currentUntrackedInventoryDigest(t, repo)) {
+		t.Fatalf("refusal does not name the inventory that now holds: %v", err)
+	}
+	status, err := store.Status()
+	if err != nil || status.Revision != started.Revision || status.ActiveAttempt == nil {
+		t.Fatalf("stale declaration mutated authority: status=%#v err=%v", status, err)
 	}
 }

--- a/internal/sddstatus/runtime_status_test.go
+++ b/internal/sddstatus/runtime_status_test.go
@@ -370,6 +370,11 @@ func (fixture evidenceOnlyRuntimeRemediationFixture) settle(t *testing.T) Runtim
 		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "verification passed against the unchanged candidate",
 		HarnessDisposition: HarnessReused, CleanupEvidence: "retry cleanup completed",
 		ProcessEvidence: "retry process scan completed", RemediatesEvidenceRevision: fixture.failedEvidence,
+		// The change artifacts this fixture writes during the attempt are SDD
+		// bookkeeping, not the work unit's product, and this scenario turns on
+		// the candidate staying byte-identical. Excluding them is now an
+		// explicit recorded decision rather than a silent omission (#3806).
+		IntendedUntracked: &[]string{}, ExpectedUntrackedInventory: currentUntrackedInventoryDigest(t, fixture.repo),
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Closes #3806.

## PR Type

- [x] Bug fix

## Summary

- A file an attempt creates while it runs is no longer invisible to the settlement that closes it.
- `settle` and `finish` take the same three declaration flags `acquire` takes, so born-during files either enter the candidate and are charged, or stay out **on the record**.
- What a settlement settles with is what a rescope successor inherits, which is the half of #3806 that had no runnable `begin` at all.

## The defect

An attempt declares its untracked scope when it starts. That is a decision about what already existed, and it cannot cover what the attempt itself produces — which for a work unit is the ordinary case, not the exotic one.

So a file born during an attempt was in none of the three things the finish candidate is built from: the begin tree, the tracked changes, or the frozen selection. Reproduced on `v2.5.0-rc.2`:

```
outcome: passed, changed_lines: 0
begin_candidate_tree:  cc6ad8ec6f37dfe24e46e12c29642051139a423f
finish_candidate_tree: cc6ad8ec6f37dfe24e46e12c29642051139a423f
```

with a three-line non-ignored source file sitting untracked in the worktree. The same file present *before* `acquire` refuses correctly and names the canonical inventory digest. That asymmetry is the whole bug.

Born-during work therefore consumed zero of `max_changed_lines` and contributed no candidate identity: a work unit could pass having written a whole file, with the ledger recording that nothing changed. The failed half of that left a rescope successor whose selection had never been recorded, so no `begin` the provider advertised would run — the shape this issue was filed for, and the occurrence reported on #2651.

## Design

Two things had to be separated that the ledger could not tell apart: a path the caller **saw and left out on purpose**, and a path **nobody has ruled on yet**.

`IntendedUntracked` records only what was selected, never what was seen. So the begin record now carries the digest of the whole eligible inventory the caller declared against. An unchanged inventory is a state already ruled on and asks nothing; only a changed one holds a path that needs a decision.

Staging alone was not a sufficient exit, and the suite proved it: an evidence-only remediation writes SDD artifacts while it runs and turns on the candidate staying byte-identical. Those files are real and legitimately not candidate bytes, so `exclude` has to exist. A settlement may widen the selection but never narrow it, since a path selected at begin is already in the begin tree.

## Changes

| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go` | `runtimeBeginEvent` records the begin-time eligible inventory digest; `settlementUntrackedSelection` resolves which selection a settlement overlays and refuses when the answer is undecided; the finish event records what it used, and the projection reports it |
| `internal/sddstatus/runtime_compact.go` | `Settle` forwards the declaration; its replay and idempotency comparison carry it |
| `internal/cli/sdd_attempt.go` | `--untracked-scope`, `--intended-untracked` and `--expected-untracked-inventory` on `settle` and `finish` |
| `bench/journeys_sdd_untracked.go` | `j99`, driving both faces end to end against the real binary |
| `bench/journeys_issue3094.go` | `j103` wrote its harness token inside the repo under test; moved out |

## Compatibility

Both request fields are `omitempty`, so a settlement that declares nothing marshals exactly as before and every legacy finish request digest stays byte-identical — no second hashing shape, no dual-hash acceptance. A record written before the begin inventory existed cannot say what its caller saw, so it is left alone rather than asked to re-decide, and a declaration against it is refused rather than silently honored.

## Test Plan

- [x] The refusal test verified failing before the fix
- [x] `go test ./...` — pass. `go vet ./...` on `linux` and `windows` — clean
- [x] Driven corpus against the built binary: **56 counted, 0 failed, 0 dead_end**
- [x] `j99` completes in 6 commands with 0 blocks; against unpatched `main` it reports `unsupported`, so the corpus refuses to fake a pass on a binary lacking the flags
- [x] `cd bench && go test ./...` — pass. Deadcode ratchet — no new unreachable functions. Refusal ratchet — clean; both new refusals name a runnable continuation
- [x] Adversarial review of this branch: four lenses, **approved**, no blocking findings and no correction opened

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

`size:exception` is requested for the regenerated `bench/results.json`; the hand-written change is under 700 lines across production and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `finish` and `settle` now account for untracked files created during an active attempt.
  - Explicitly select or exclude new files before settlement, or stage them as changes.
  - Settlement records untracked-file selections and validates inventory information to prevent stale declarations.
  - Status and attempt history now preserve untracked-file accounting and provenance.

- **Bug Fixes**
  - Prevented settlement from silently ignoring newly created untracked files.
  - Improved token handling so temporary data does not create files inside the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->