### PR TITLE
fix(agent): correct Codex workspace instruction routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,8 +400,8 @@ jobs:
         # real Claude Code / OpenCode detection.
         shell: pwsh
         run: |
-          $tests = go test -tags real_agent_e2e -list '^TestOrganicConfiguredAgentReceivesRoutingGuidanceRealAgents$' ./e2e/organicruntime
-          if ($LASTEXITCODE -ne 0 -or $tests -notcontains 'TestOrganicConfiguredAgentReceivesRoutingGuidanceRealAgents') {
+          $tests = go test -tags real_agent_e2e -list '^(TestOrganicConfiguredAgentReceivesRoutingGuidanceRealAgents|TestOrganicCodexWorkspaceInstructionsAreDiscoverable)$' ./e2e/organicruntime
+          if ($LASTEXITCODE -ne 0 -or $tests -notcontains 'TestOrganicConfiguredAgentReceivesRoutingGuidanceRealAgents' -or $tests -notcontains 'TestOrganicCodexWorkspaceInstructionsAreDiscoverable') {
             throw 'Real-agent detection E2E is missing'
           }
 

--- a/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
+++ b/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
@@ -149,7 +149,7 @@ func prepareOrganicCodexHome(t *testing.T) string {
 		t.Skip("native Codex discovery skipped: no usable Codex authentication source")
 	}
 	info, err := os.Stat(authPath)
-	if err != nil || info.IsDir() {
+	if err != nil || !info.Mode().IsRegular() {
 		t.Skipf("native Codex discovery skipped: Codex authentication source is unavailable at %s", authPath)
 	}
 	authContents, err := os.ReadFile(authPath)

--- a/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
+++ b/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
@@ -135,8 +135,8 @@ func TestOrganicCodexWorkspaceInstructionsAreDiscoverable(t *testing.T) {
 	}
 }
 
-// prepareOrganicCodexHome creates an isolated Codex home linked to an existing
-// auth.json without copying or exposing credential contents in test output.
+// prepareOrganicCodexHome creates an isolated Codex home with a copy of an
+// existing auth.json without exposing credential contents in test output.
 func prepareOrganicCodexHome(t *testing.T) string {
 	t.Helper()
 	authPath := ""
@@ -152,9 +152,21 @@ func prepareOrganicCodexHome(t *testing.T) string {
 	if err != nil || info.IsDir() {
 		t.Skipf("native Codex discovery skipped: Codex authentication source is unavailable at %s", authPath)
 	}
+	authContents, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Skipf("native Codex discovery skipped: Codex authentication source cannot be read at %s", authPath)
+	}
 	codexHome := t.TempDir()
-	if err := os.Symlink(authPath, filepath.Join(codexHome, "auth.json")); err != nil {
-		t.Fatalf("isolate Codex authentication source: %v", err)
+	destination := filepath.Join(codexHome, "auth.json")
+	if err := os.WriteFile(destination, authContents, 0o600); err != nil {
+		t.Fatalf("copy Codex authentication source: %v", err)
+	}
+	destinationInfo, err := os.Stat(destination)
+	if err != nil {
+		t.Fatalf("verify isolated Codex authentication source: %v", err)
+	}
+	if !destinationInfo.Mode().IsRegular() || destinationInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("isolated Codex authentication source has unexpected file mode %s", destinationInfo.Mode())
 	}
 	return codexHome
 }

--- a/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
+++ b/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
@@ -102,10 +102,15 @@ func TestOrganicCodexWorkspaceInstructionsAreDiscoverable(t *testing.T) {
 	}
 	workspace := t.TempDir()
 	home := t.TempDir()
+	codexHome := prepareOrganicCodexHome(t)
+	codexEnvironment := append(organicEnvironment(home), "CODEX_HOME="+codexHome)
+	if err := os.MkdirAll(filepath.Join(home, ".gentle-ai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := organicGitOutput(context.Background(), workspace, "init", "--quiet", "--initial-branch=main", "."); err != nil {
 		t.Fatal(err)
 	}
-	if _, stderr, err := runOrganicCommand(t, organicBinary, workspace, organicEnvironment(home), "install", "--agent", "codex", "--scope", "workspace", "--components", "permissions"); err != nil {
+	if _, stderr, err := runOrganicCommand(t, organicBinary, workspace, codexEnvironment, "install", "--agent", "codex", "--scope", "workspace", "--components", "permissions"); err != nil {
 		t.Fatalf("Codex workspace install: %v\nstderr:\n%s", err, stderr)
 	}
 	rootAgents := filepath.Join(workspace, "AGENTS.md")
@@ -119,7 +124,7 @@ func TestOrganicCodexWorkspaceInstructionsAreDiscoverable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "codex", "exec", "--cd", workspace, "--sandbox", "read-only", "--ephemeral", "--ignore-user-config", "--color", "never", "Without opening or searching the filesystem, report only the first Markdown heading from project instructions automatically loaded before this prompt. State whether this repository supplied project instructions.")
-	cmd.Env = organicEnvironment(home)
+	cmd.Env = codexEnvironment
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("native Codex discovery smoke: %v\noutput:\n%s", err, output)
@@ -128,4 +133,28 @@ func TestOrganicCodexWorkspaceInstructionsAreDiscoverable(t *testing.T) {
 	if !strings.Contains(text, "implementation routing") || !strings.Contains(text, "supplied project instructions") {
 		t.Fatalf("native Codex did not report the repository AGENTS.md instructions:\n%s", output)
 	}
+}
+
+// prepareOrganicCodexHome creates an isolated Codex home linked to an existing
+// auth.json without copying or exposing credential contents in test output.
+func prepareOrganicCodexHome(t *testing.T) string {
+	t.Helper()
+	authPath := ""
+	if configuredHome := os.Getenv("CODEX_HOME"); configuredHome != "" {
+		authPath = filepath.Join(configuredHome, "auth.json")
+	} else if userHome, err := os.UserHomeDir(); err == nil {
+		authPath = filepath.Join(userHome, ".codex", "auth.json")
+	}
+	if authPath == "" {
+		t.Skip("native Codex discovery skipped: no usable Codex authentication source")
+	}
+	info, err := os.Stat(authPath)
+	if err != nil || info.IsDir() {
+		t.Skipf("native Codex discovery skipped: Codex authentication source is unavailable at %s", authPath)
+	}
+	codexHome := t.TempDir()
+	if err := os.Symlink(authPath, filepath.Join(codexHome, "auth.json")); err != nil {
+		t.Fatalf("isolate Codex authentication source: %v", err)
+	}
+	return codexHome
 }

--- a/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
+++ b/e2e/organicruntime/organic_runtime_real_agent_detection_test.go
@@ -30,8 +30,11 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestOrganicConfiguredAgentReceivesRoutingGuidanceRealAgents proves the
@@ -89,5 +92,40 @@ func TestOrganicConfiguredAgentReceivesRoutingGuidanceRealAgents(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestOrganicCodexWorkspaceInstructionsAreDiscoverable verifies native Codex discovers workspace instructions.
+func TestOrganicCodexWorkspaceInstructionsAreDiscoverable(t *testing.T) {
+	if os.Getenv("GENTLE_AI_CODEX_DISCOVERY_E2E") != "1" {
+		t.Skip("set GENTLE_AI_CODEX_DISCOVERY_E2E=1 to run the authenticated native Codex discovery smoke test")
+	}
+	workspace := t.TempDir()
+	home := t.TempDir()
+	if _, err := organicGitOutput(context.Background(), workspace, "init", "--quiet", "--initial-branch=main", "."); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := runOrganicCommand(t, organicBinary, workspace, organicEnvironment(home), "install", "--agent", "codex", "--scope", "workspace", "--components", "permissions"); err != nil {
+		t.Fatalf("Codex workspace install: %v\nstderr:\n%s", err, stderr)
+	}
+	rootAgents := filepath.Join(workspace, "AGENTS.md")
+	if _, err := os.Stat(rootAgents); err != nil {
+		t.Fatalf("workspace Codex instructions missing at repository root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("workspace Codex instructions stranded in .codex/AGENTS.md (stat err = %v)", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "codex", "exec", "--cd", workspace, "--sandbox", "read-only", "--ephemeral", "--ignore-user-config", "--color", "never", "Without opening or searching the filesystem, report only the first Markdown heading from project instructions automatically loaded before this prompt. State whether this repository supplied project instructions.")
+	cmd.Env = organicEnvironment(home)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("native Codex discovery smoke: %v\noutput:\n%s", err, output)
+	}
+	text := strings.ToLower(string(output))
+	if !strings.Contains(text, "implementation routing") || !strings.Contains(text, "supplied project instructions") {
+		t.Fatalf("native Codex did not report the repository AGENTS.md instructions:\n%s", output)
 	}
 }

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -93,6 +93,12 @@ func (a *Adapter) SystemPromptFile(homeDir string) string {
 	return filepath.Join(homeDir, ".codex", "AGENTS.md")
 }
 
+// WorkspaceSystemPromptFile returns the workspace-level AGENTS.md discovered
+// by Codex. Unlike the global file, it is rooted directly in the workspace.
+func (a *Adapter) WorkspaceSystemPromptFile(workspaceDir string) string {
+	return filepath.Join(workspaceDir, "AGENTS.md")
+}
+
 func (a *Adapter) SkillsDir(homeDir string) string {
 	return filepath.Join(homeDir, ".codex", "skills")
 }

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -132,6 +132,8 @@ func TestInstallCommand(t *testing.T) {
 	}
 }
 
+// TestConfigPathsCrossPlatform verifies Codex configuration paths use the
+// expected layout on the current platform.
 func TestConfigPathsCrossPlatform(t *testing.T) {
 	a := NewAdapter()
 	home := "/tmp/home"

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -147,6 +147,10 @@ func TestConfigPathsCrossPlatform(t *testing.T) {
 	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".codex", "AGENTS.md") {
 		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".codex", "AGENTS.md"))
 	}
+	workspace := filepath.Join(home, "repo")
+	if got := a.WorkspaceSystemPromptFile(workspace); got != filepath.Join(workspace, "AGENTS.md") {
+		t.Fatalf("WorkspaceSystemPromptFile() = %q, want %q", got, filepath.Join(workspace, "AGENTS.md"))
+	}
 
 	// Codex has no settings path.
 	if got := a.SettingsPath(home); got != "" {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -445,6 +445,7 @@ var readyAgentRunCommands = []struct {
 }{
 	{model.AgentClaudeCode, "claude"},
 	{model.AgentOpenCode, "opencode"},
+	{model.AgentCodex, "codex"},
 }
 
 // withReadyAgentRunNote replaces the generic verify.ReadyMessage with one

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -873,12 +873,16 @@ func (s agentRoutingGuidanceStep) Run() error {
 	// Strip first: an installation upgraded from an older release still carries
 	// the retired block, and leaving it beside fresh guidance would hand the
 	// agent two conflicting sets of instructions.
-	stripped, err := stripLegacyTriggerRules(targetDir, adapter)
+	stripped, err := stripLegacyTriggerRules(targetDir, adapter, s.scope == ScopeWorkspace && s.agent == model.AgentCodex)
 	if err != nil {
 		return err
 	}
 
-	injected, err := agentguidance.InjectRouting(targetDir, s.agent)
+	inject := agentguidance.InjectRouting
+	if s.scope == ScopeWorkspace && s.agent == model.AgentCodex {
+		inject = agentguidance.InjectRoutingForWorkspace
+	}
+	injected, err := inject(targetDir, s.agent)
 	if err != nil {
 		return fmt.Errorf("inject routing guidance for %q: %w", s.agent, err)
 	}
@@ -901,14 +905,24 @@ func (s agentRoutingGuidanceStep) recordChanged(result agentguidance.Result) {
 // Removal reuses filemerge.InjectMarkdownSection with empty content, which is
 // already the defined "delete this section" operation, so no second merge
 // implementation exists that could drift from the injector.
-func stripLegacyTriggerRules(targetDir string, adapter agents.Adapter) (agentguidance.Result, error) {
+func stripLegacyTriggerRules(targetDir string, adapter agents.Adapter, workspaceCodex bool) (agentguidance.Result, error) {
 	switch {
 	case adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode:
 		return stripLegacyTriggerRulesFromOrchestrator(adapter.SettingsPath(targetDir))
 	case adapter.SystemPromptStrategy() == model.StrategyJinjaModules:
 		return removeLegacyTriggerRulesModule(filepath.Join(adapter.GlobalConfigDir(targetDir), legacyTriggerRulesSection+".md"))
 	default:
-		return stripLegacyTriggerRulesFromPrompt(adapter.SystemPromptFile(targetDir))
+		promptPath := adapter.SystemPromptFile(targetDir)
+		if workspaceCodex {
+			paths, err := agentguidance.RoutingPathsForWorkspace(targetDir, adapter.Agent())
+			if err != nil {
+				return agentguidance.Result{}, err
+			}
+			if len(paths) > 0 {
+				promptPath = paths[0]
+			}
+		}
+		return stripLegacyTriggerRulesFromPrompt(promptPath)
 	}
 }
 
@@ -2133,6 +2147,9 @@ func routingGuidancePaths(homeDir, workspaceDir string, scope InstallScope, adap
 	for _, adapter := range adapters {
 		targetDir := routingGuidanceDir(homeDir, workspaceDir, scope, adapter)
 		routing, err := agentguidance.RoutingPaths(targetDir, adapter.Agent())
+		if scope == ScopeWorkspace && adapter.Agent() == model.AgentCodex {
+			routing, err = agentguidance.RoutingPathsForWorkspace(targetDir, adapter.Agent())
+		}
 		if err != nil {
 			// The guidance step resolves the same delivery and fails loudly when
 			// it runs. Declaring a target we could not resolve would only add a
@@ -2545,6 +2562,16 @@ func runPostApplyVerification(input postApplyVerificationInput) verify.Report {
 			seenPath[path] = struct{}{}
 			uniqueFilePaths = append(uniqueFilePaths, path)
 		}
+	}
+	for _, path := range routingGuidancePaths(input.HomeDir, input.WorkspaceDir, input.Scope, adapters) {
+		if path == "" {
+			continue
+		}
+		if _, dup := seenPath[path]; dup {
+			continue
+		}
+		seenPath[path] = struct{}{}
+		uniqueFilePaths = append(uniqueFilePaths, path)
 	}
 
 	for _, currentPath := range uniqueFilePaths {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -863,6 +863,8 @@ type agentRoutingGuidanceStep struct {
 
 func (s agentRoutingGuidanceStep) ID() string { return s.id }
 
+// Run removes retired routing rules and installs current guidance for the
+// configured agent and scope.
 func (s agentRoutingGuidanceStep) Run() error {
 	adapter, err := agents.NewAdapter(s.agent)
 	if err != nil {
@@ -2545,6 +2547,7 @@ type postApplyVerificationInput struct {
 	State        *runtimeState
 }
 
+// runPostApplyVerification builds checks for files expected after installation.
 func runPostApplyVerification(input postApplyVerificationInput) verify.Report {
 	checks := make([]verify.Check, 0)
 	adapters := resolveAdapters(input.Resolved.Agents)

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1007,6 +1007,25 @@ func TestBackupTargetsIncludeRoutingGuidancePathsWithoutAnyComponent(t *testing.
 	}
 }
 
+func TestBackupTargetsWorkspaceCodexUsesRootAGENTS(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	selection := model.Selection{Agents: []model.AgentID{model.AgentCodex}}
+	resolved := planner.ResolvedPlan{Agents: selection.Agents}
+
+	targets, err := backupTargets(home, workspace, ScopeWorkspace, selection, resolved)
+	if err != nil {
+		t.Fatalf("backupTargets() error = %v", err)
+	}
+	want := filepath.Join(workspace, "AGENTS.md")
+	if !containsPath(targets, want) {
+		t.Fatalf("backupTargets missing workspace Codex route %q; targets=%v", want, targets)
+	}
+	if containsPath(targets, filepath.Join(workspace, ".codex", "AGENTS.md")) {
+		t.Fatal("backupTargets included the undiscoverable workspace Codex route")
+	}
+}
+
 func TestBackupTargetsEngramClaudeIncludeRegistryAndLegacyMigrationSource(t *testing.T) {
 	home := t.TempDir()
 	selection := model.Selection{Agents: []model.AgentID{model.AgentClaudeCode}, Components: []model.ComponentID{model.ComponentEngram}}

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -868,6 +869,65 @@ func TestInstallRoutingGuidanceSecondRunIsByteIdentical(t *testing.T) {
 		if second[label] != before {
 			t.Fatalf("second install rewrote %s; routing delivery is not idempotent", label)
 		}
+	}
+}
+
+// TestInstallCodexRoutingIsIdempotentInBothScopes verifies byte-stable Codex routing in both scopes.
+func TestInstallCodexRoutingIsIdempotentInBothScopes(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		scope InstallScope
+	}{
+		{name: "global", scope: ScopeGlobal},
+		{name: "workspace", scope: ScopeWorkspace},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			target := filepath.Join(home, ".codex", "AGENTS.md")
+			if tt.scope == ScopeWorkspace {
+				target = filepath.Join(workspace, "AGENTS.md")
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			const userContent = "# User instructions\n"
+			if err := os.WriteFile(target, []byte(userContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			changed := []string{}
+			step := agentRoutingGuidanceStep{
+				id: "agent-guidance:codex", agent: model.AgentCodex,
+				homeDir: home, workspaceDir: workspace, scope: tt.scope,
+				changedFiles: &changed,
+			}
+			if err := step.Run(); err != nil {
+				t.Fatalf("first Run() error = %v", err)
+			}
+			first, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(first, []byte(userContent)) {
+				t.Fatalf("first routing removed user content: %q", first)
+			}
+
+			changed = nil
+			if err := step.Run(); err != nil {
+				t.Fatalf("second Run() error = %v", err)
+			}
+			second, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(first, second) || len(changed) != 0 {
+				t.Fatalf("second routing changed bytes or reported changes: bytesEqual=%v changed=%v", bytes.Equal(first, second), changed)
+			}
+			if _, err := os.Stat(filepath.Join(workspace, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+				t.Fatalf("workspace routing created undiscoverable %q (stat err = %v)", filepath.Join(workspace, ".codex", "AGENTS.md"), err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1007,6 +1007,8 @@ func TestBackupTargetsIncludeRoutingGuidancePathsWithoutAnyComponent(t *testing.
 	}
 }
 
+// TestBackupTargetsWorkspaceCodexUsesRootAGENTS verifies workspace Codex
+// backups target the root AGENTS.md file.
 func TestBackupTargetsWorkspaceCodexUsesRootAGENTS(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/internal/cli/run_ready_agent_note_test.go
+++ b/internal/cli/run_ready_agent_note_test.go
@@ -21,10 +21,12 @@ func TestWithPostInstallNotesNamesOnlyTheInstalledRunnableAgents(t *testing.T) {
 		agents     []model.AgentID
 		wantClaude bool
 		wantOpen   bool
+		wantCodex  bool
 	}{
 		{name: "opencode only", agents: []model.AgentID{model.AgentOpenCode}, wantClaude: false, wantOpen: true},
 		{name: "claude only", agents: []model.AgentID{model.AgentClaudeCode}, wantClaude: true, wantOpen: false},
-		{name: "both", agents: []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode}, wantClaude: true, wantOpen: true},
+		{name: "codex only", agents: []model.AgentID{model.AgentCodex}, wantCodex: true},
+		{name: "all runnable agents", agents: []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentCodex}, wantClaude: true, wantOpen: true, wantCodex: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -34,11 +36,15 @@ func TestWithPostInstallNotesNamesOnlyTheInstalledRunnableAgents(t *testing.T) {
 			updated := withPostInstallNotes(report, resolved)
 			hasClaude := strings.Contains(updated.FinalNote, "`claude`")
 			hasOpenCode := strings.Contains(updated.FinalNote, "`opencode`")
+			hasCodex := strings.Contains(updated.FinalNote, "`codex`")
 			if hasClaude != tt.wantClaude {
 				t.Fatalf("FinalNote names claude = %v, want %v: %q", hasClaude, tt.wantClaude, updated.FinalNote)
 			}
 			if hasOpenCode != tt.wantOpen {
 				t.Fatalf("FinalNote names opencode = %v, want %v: %q", hasOpenCode, tt.wantOpen, updated.FinalNote)
+			}
+			if hasCodex != tt.wantCodex {
+				t.Fatalf("FinalNote names codex = %v, want %v: %q", hasCodex, tt.wantCodex, updated.FinalNote)
 			}
 		})
 	}

--- a/internal/components/agentguidance/inject.go
+++ b/internal/components/agentguidance/inject.go
@@ -75,6 +75,7 @@ func InjectRoutingForWorkspace(targetDir string, agent model.AgentID) (Result, e
 	return injectRouting(targetDir, agent, true)
 }
 
+// injectRouting renders and delivers routing guidance for the requested scope.
 func injectRouting(targetDir string, agent model.AgentID, workspace bool) (Result, error) {
 	// Render before resolving the delivery so an unsupported agent is rejected
 	// without having touched the filesystem.
@@ -148,16 +149,17 @@ type routingDelivery struct {
 	paths        []string
 }
 
+// workspacePromptAdapter exposes an adapter's workspace-level prompt file.
+type workspacePromptAdapter interface {
+	WorkspaceSystemPromptFile(string) string
+}
+
 // resolveRoutingDelivery selects the delivery strategy and its target paths.
 //
 // It fails closed on anything that would make the guidance unreachable, because
 // an unreachable target is exactly the failure this component exists to
 // prevent — and reporting a path the injector cannot write is the same defect
 // seen from the backup side.
-type workspacePromptAdapter interface {
-	WorkspaceSystemPromptFile(string) string
-}
-
 func resolveRoutingDelivery(targetDir string, agent model.AgentID, workspace bool) (routingDelivery, error) {
 	if strings.TrimSpace(targetDir) == "" {
 		return routingDelivery{}, fmt.Errorf("%w: %q", ErrInvalidTarget, targetDir)

--- a/internal/components/agentguidance/inject.go
+++ b/internal/components/agentguidance/inject.go
@@ -65,6 +65,17 @@ type templateBootstrapper interface {
 // Only the marked section is owned by Gentle AI: everything a user wrote around
 // it is preserved verbatim, and a second identical injection is a no-op.
 func InjectRouting(targetDir string, agent model.AgentID) (Result, error) {
+	return injectRouting(targetDir, agent, false)
+}
+
+// InjectRoutingForWorkspace installs routing guidance in the workspace-level
+// instruction file when an adapter exposes one. Global routing remains the
+// default path used by InjectRouting.
+func InjectRoutingForWorkspace(targetDir string, agent model.AgentID) (Result, error) {
+	return injectRouting(targetDir, agent, true)
+}
+
+func injectRouting(targetDir string, agent model.AgentID, workspace bool) (Result, error) {
 	// Render before resolving the delivery so an unsupported agent is rejected
 	// without having touched the filesystem.
 	rendered, err := RenderRouting(agent)
@@ -72,7 +83,7 @@ func InjectRouting(targetDir string, agent model.AgentID) (Result, error) {
 		return Result{}, err
 	}
 
-	delivery, err := resolveRoutingDelivery(targetDir, agent)
+	delivery, err := resolveRoutingDelivery(targetDir, agent, workspace)
 	if err != nil {
 		return Result{}, err
 	}
@@ -97,7 +108,16 @@ func InjectRouting(targetDir string, agent model.AgentID) (Result, error) {
 // same delivery resolution, so the backup contract cannot drift away from what
 // the injector actually writes.
 func RoutingPaths(targetDir string, agent model.AgentID) ([]string, error) {
-	delivery, err := resolveRoutingDelivery(targetDir, agent)
+	return routingPaths(targetDir, agent, false)
+}
+
+// RoutingPathsForWorkspace reports the workspace-level routing target.
+func RoutingPathsForWorkspace(targetDir string, agent model.AgentID) ([]string, error) {
+	return routingPaths(targetDir, agent, true)
+}
+
+func routingPaths(targetDir string, agent model.AgentID, workspace bool) ([]string, error) {
+	delivery, err := resolveRoutingDelivery(targetDir, agent, workspace)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +154,11 @@ type routingDelivery struct {
 // an unreachable target is exactly the failure this component exists to
 // prevent — and reporting a path the injector cannot write is the same defect
 // seen from the backup side.
-func resolveRoutingDelivery(targetDir string, agent model.AgentID) (routingDelivery, error) {
+type workspacePromptAdapter interface {
+	WorkspaceSystemPromptFile(string) string
+}
+
+func resolveRoutingDelivery(targetDir string, agent model.AgentID, workspace bool) (routingDelivery, error) {
 	if strings.TrimSpace(targetDir) == "" {
 		return routingDelivery{}, fmt.Errorf("%w: %q", ErrInvalidTarget, targetDir)
 	}
@@ -170,6 +194,11 @@ func resolveRoutingDelivery(targetDir string, agent model.AgentID) (routingDeliv
 
 	default:
 		promptPath := adapter.SystemPromptFile(targetDir)
+		if workspace {
+			if workspaceAdapter, ok := adapter.(workspacePromptAdapter); ok {
+				promptPath = workspaceAdapter.WorkspaceSystemPromptFile(targetDir)
+			}
+		}
 		if strings.TrimSpace(promptPath) == "" {
 			return routingDelivery{}, fmt.Errorf("%w: adapter %q exposes no system prompt file", ErrInvalidTarget, agent)
 		}

--- a/internal/components/agentguidance/inject.go
+++ b/internal/components/agentguidance/inject.go
@@ -117,6 +117,7 @@ func RoutingPathsForWorkspace(targetDir string, agent model.AgentID) ([]string, 
 	return routingPaths(targetDir, agent, true)
 }
 
+// routingPaths resolves the files InjectRouting writes for the requested scope.
 func routingPaths(targetDir string, agent model.AgentID, workspace bool) ([]string, error) {
 	delivery, err := resolveRoutingDelivery(targetDir, agent, workspace)
 	if err != nil {

--- a/internal/components/agentguidance/inject_test.go
+++ b/internal/components/agentguidance/inject_test.go
@@ -194,6 +194,31 @@ func TestInjectRoutingPreservesUnmanagedUserContent(t *testing.T) {
 	}
 }
 
+func TestInjectRoutingForWorkspaceUsesRootAGENTSAndPreservesContent(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	const userContent = "# Workspace rules\n\nKeep this content.\n"
+	path := filepath.Join(workspace, "AGENTS.md")
+	if err := os.WriteFile(path, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	result, err := InjectRoutingForWorkspace(workspace, model.AgentCodex)
+	if err != nil {
+		t.Fatalf("InjectRoutingForWorkspace() error = %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0] != path {
+		t.Fatalf("InjectRoutingForWorkspace() files = %v, want [%q]", result.Files, path)
+	}
+	if got := readFile(t, path); !strings.Contains(got, userContent) {
+		t.Fatalf("workspace user content was not preserved:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("workspace routing created .codex/AGENTS.md; stat err = %v", err)
+	}
+}
+
 func TestInjectRoutingRejectsUnregisteredAgent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/components/agentguidance/inject_test.go
+++ b/internal/components/agentguidance/inject_test.go
@@ -194,6 +194,8 @@ func TestInjectRoutingPreservesUnmanagedUserContent(t *testing.T) {
 	}
 }
 
+// TestInjectRoutingForWorkspaceUsesRootAGENTSAndPreservesContent verifies
+// workspace Codex guidance uses the root file without losing user content.
 func TestInjectRoutingForWorkspaceUsesRootAGENTSAndPreservesContent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
@@ -735,8 +736,15 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			path := adapter.SystemPromptFile(homeDir)
 			targets = append(targets, path)
 			ops = append(ops, rewriteMarkdownFile(path, func(content string) (string, bool) {
-				return removeMarkdownSections(content, "sdd-orchestrator", "strict-tdd-mode")
+				return removeMarkdownSections(content, "sdd-orchestrator", "strict-tdd-mode", agentguidance.RoutingSectionID)
 			}))
+			if adapter.Agent() == model.AgentCodex && s.workspaceDir != "" {
+				workspacePath := filepath.Join(s.workspaceDir, "AGENTS.md")
+				targets = append(targets, workspacePath)
+				ops = append(ops, rewriteMarkdownFile(workspacePath, func(content string) (string, bool) {
+					return removeMarkdownSections(content, agentguidance.RoutingSectionID)
+				}))
+			}
 		}
 		if adapter.SupportsSlashCommands() {
 			commandsDir := adapter.CommandsDir(homeDir)

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1207,6 +1207,8 @@ func TestComponentOperationsEngram_CodexRemovesConsolidatedProtocolAssetsWithNoO
 	}
 }
 
+// TestComponentOperationsSDD_CodexKeepsGlobalAGENTSRoute verifies global SDD
+// uninstall does not remove the workspace Codex route.
 func TestComponentOperationsSDD_CodexKeepsGlobalAGENTSRoute(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceDir := t.TempDir()

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1207,6 +1207,31 @@ func TestComponentOperationsEngram_CodexRemovesConsolidatedProtocolAssetsWithNoO
 	}
 }
 
+func TestComponentOperationsSDD_CodexKeepsGlobalAGENTSRoute(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	adapter, ok := svc.registry.Get(model.AgentCodex)
+	if !ok {
+		t.Fatal("codex adapter not found in registry")
+	}
+
+	_, targets, err := svc.componentOperations(adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	global := filepath.Join(homeDir, ".codex", "AGENTS.md")
+	if !slices.Contains(targets, global) {
+		t.Fatalf("componentOperations() targets missing global Codex route %q; got %v", global, targets)
+	}
+	if slices.Contains(targets, filepath.Join(workspaceDir, "AGENTS.md")) || slices.Contains(targets, filepath.Join(workspaceDir, ".codex", "AGENTS.md")) {
+		t.Fatalf("global uninstall unexpectedly targeted workspace Codex route: %v", targets)
+	}
+}
+
 func TestComponentOperationsSDD_ClaudeRemovesSkillRegistryHook(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceDir := t.TempDir()

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -1207,9 +1208,9 @@ func TestComponentOperationsEngram_CodexRemovesConsolidatedProtocolAssetsWithNoO
 	}
 }
 
-// TestComponentOperationsSDD_CodexKeepsGlobalAGENTSRoute verifies global SDD
-// uninstall does not remove the workspace Codex route.
-func TestComponentOperationsSDD_CodexKeepsGlobalAGENTSRoute(t *testing.T) {
+// TestComponentOperationsSDD_CodexRemovesBothAGENTSRoutes verifies global and
+// workspace uninstall remove only their managed routing sections.
+func TestComponentOperationsSDD_CodexRemovesBothAGENTSRoutes(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceDir := t.TempDir()
 	svc, err := NewService(homeDir, workspaceDir, "dev")
@@ -1221,16 +1222,44 @@ func TestComponentOperationsSDD_CodexKeepsGlobalAGENTSRoute(t *testing.T) {
 		t.Fatal("codex adapter not found in registry")
 	}
 
-	_, targets, err := svc.componentOperations(adapter, model.ComponentSDD)
+	globalPath := filepath.Join(homeDir, ".codex", "AGENTS.md")
+	workspacePath := filepath.Join(workspaceDir, "AGENTS.md")
+	const userContent = "# User rules\n\nKeep this content.\n"
+	for path := range map[string]struct{}{globalPath: {}, workspacePath: {}} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(userContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := agentguidance.InjectRouting(homeDir, model.AgentCodex); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agentguidance.InjectRoutingForWorkspace(workspaceDir, model.AgentCodex); err != nil {
+		t.Fatal(err)
+	}
+
+	ops, targets, err := svc.componentOperations(adapter, model.ComponentSDD)
 	if err != nil {
 		t.Fatalf("componentOperations() error = %v", err)
 	}
-	global := filepath.Join(homeDir, ".codex", "AGENTS.md")
-	if !slices.Contains(targets, global) {
-		t.Fatalf("componentOperations() targets missing global Codex route %q; got %v", global, targets)
+	if !slices.Contains(targets, globalPath) || !slices.Contains(targets, workspacePath) {
+		t.Fatalf("componentOperations() targets = %v, want global and workspace routes", targets)
 	}
-	if slices.Contains(targets, filepath.Join(workspaceDir, "AGENTS.md")) || slices.Contains(targets, filepath.Join(workspaceDir, ".codex", "AGENTS.md")) {
-		t.Fatalf("global uninstall unexpectedly targeted workspace Codex route: %v", targets)
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		}
+	}
+	for _, path := range []string{globalPath, workspacePath} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		if !strings.Contains(string(got), userContent) || strings.Contains(string(got), agentguidance.RoutingSectionID) {
+			t.Fatalf("Codex route cleanup changed user content or left managed content in %q: %s", path, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1841

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (or feature that changes existing behavior)

---

## 📝 Summary

- Route workspace-scoped Codex instructions to the discoverable workspace `AGENTS.md`.
- Preserve global Codex routing at `~/.codex/AGENTS.md`.
- Keep injection, backup, uninstall, verification, and user-authored content handling aligned.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/agents/codex/adapter.go` | Added the workspace-level Codex instruction path. |
| `internal/components/agentguidance/` | Shared workspace routing resolution between injection and path reporting. |
| `internal/cli/run.go` | Applied the corrected route to installation, legacy cleanup, backups, and verification. |
| `internal/components/uninstall/service_test.go` | Regression coverage for the unchanged global uninstall route. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Implementation and verification were assisted by OpenCode agents; the maintainer reviewed the resulting diff and test output.

**Tool/model (if known):** OpenCode, openai/gpt-5.6-luna

**Material scope:** Repository inspection, implementation, regression tests, and verification.

**Verification performed:** Focused Go tests, relevant CLI tests, Go format check, diff check, and manual diff review.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/agents/codex ./internal/components/agentguidance ./internal/components/uninstall
go test ./internal/cli -run 'TestBackupTargetsWorkspaceCodexUsesRootAGENTS|TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome|TestBackupTargetsIncludeRoutingGuidancePathsWithoutAnyComponent|TestRunPostApplyVerification|TestComponentPathsWorkspaceScoped|TestComponentPathsSDDIncludesSystemPromptForAllSupportedAgents' -count=1\n```\n\n**Go Format**\n```bash\ngo run ./internal/gofmtcheck\n```\n\n**E2E Tests** (Docker required)\n```bash\ncd e2e && ./docker-test.sh\n```\n\n- [x] Unit tests pass (focused affected packages and routing tests)\n- [x] Go format passes (`go run ./internal/gofmtcheck`)\n- [ ] E2E tests pass — Docker is not installed in this environment.\n- [x] Manually tested locally (filesystem routing assertions)\n\nBenchmark validation: N/A; this change is limited to Codex instruction routing.\n\n---\n\n## ✅ Contributor Checklist\n\n- [x] PR is linked to an issue with `status:approved`\n- [x] PR stays within 400 changed lines\n- [x] I have added the appropriate `type:bug` label\n- [x] Unit tests pass (focused affected packages and routing tests)\n- [x] Go format passes (`go run ./internal/gofmtcheck`)\n- [ ] E2E tests pass — Docker is not installed in this environment.\n- [x] Benchmark validation is not applicable to this change.\n- [x] Documentation update is not necessary for this internal routing fix.\n- [x] Commits follow Conventional Commits format\n- [x] No `Co-Authored-By` trailer is present\n- [x] AI-assistance declaration is completed\n\n---\n\n## 💬 Notes for Reviewers\n\n- The full CLI regex also exercises three existing Codex sync tests that fail because the review store lock reports `not a directory`; the new focused routing tests pass independently.\n- E2E was not run because Docker is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-scoped Codex guidance is installed in the workspace root `AGENTS.md`.
  * Codex is included in post-install ready-agent notifications.
  * Workspace instructions are discoverable by Codex.

* **Bug Fixes**
  * Existing workspace content is preserved, while global guidance remains in its global location.
  * Backup, verification, and uninstall operations correctly distinguish workspace and global guidance files.
  * Repeated installations are idempotent and do not create duplicate changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->