### PR TITLE
fix(sdd): type the settlement untracked refusal instead of authority_failure

### DIFF
--- a/internal/cli/sdd_attempt_untracked_test.go
+++ b/internal/cli/sdd_attempt_untracked_test.go
@@ -346,8 +346,8 @@ func TestRunSDDAttemptSettleDeclaresUntrackedFilesBornDuringTheAttempt(t *testin
 				"--cleanup-evidence", "cleanup completed", "--process-evidence", "process scan clean",
 			}
 			blocked, _ := runCompactSDDAttempt(t, settle)
-			if blocked.State != "blocked" {
-				t.Fatalf("undeclared born-during settlement = %#v", blocked)
+			if blocked.State != "blocked" || blocked.Reason != string(sddstatus.CompactBlockUndeclaredUntracked) {
+				t.Fatalf("undeclared born-during settlement = %#v, want blocked/%s", blocked, sddstatus.CompactBlockUndeclaredUntracked)
 			}
 			if !strings.Contains(blocked.Exit, "born.txt") ||
 				!strings.Contains(blocked.Exit, "--untracked-scope=select") ||

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -36,6 +36,15 @@ const (
 	// was declared), so the settlement that declaration promises is
 	// structurally impossible and no token may be issued for it.
 	CompactBlockRemediationUnsatisfiable CompactBlockReason = "remediation_unsatisfiable"
+	// CompactBlockUndeclaredUntracked is the settlement-side untracked ruling
+	// block (#3881): the attempt authority is intact and unmutated, and what
+	// refused is the settlement's untracked declaration -- missing for files
+	// the attempt itself created (#3806), stale, naming an ineligible path,
+	// narrowing a begin selection, or offered to a pre-inventory legacy
+	// record. Every exit is a corrected rerun of settle/finish, so a consumer
+	// routing on this reason continues, where authority_failure would tell it
+	// to stop.
+	CompactBlockUndeclaredUntracked CompactBlockReason = "undeclared_untracked"
 )
 
 // CompactAttemptResult is the bounded orchestration projection. RuntimeStatus
@@ -482,6 +491,13 @@ func (store RuntimeStore) compactMutationFailure(err error, settle bool, begin B
 	case errors.Is(err, ErrRuntimeRevisionConflict), errors.Is(err, ErrRuntimeConcurrentUpdate),
 		errors.Is(err, ErrRuntimeRequestConflict), errors.Is(err, ErrRuntimeNoActiveAttempt):
 		reason = CompactBlockInvalidContinuation
+	// ErrRuntimeUndeclaredUntracked is the sentinel behind every
+	// settlementUntrackedSelection refusal (#3881): the settlement needs an
+	// untracked ruling the request does not carry. Caller-actionable -- the
+	// wrapped text names the exact rerun -- so it must not report as
+	// authority_failure, which the contract reserves for what its name says.
+	case errors.Is(err, ErrRuntimeUndeclaredUntracked):
+		reason = CompactBlockUndeclaredUntracked
 	// ErrRuntimeWorktreeMismatch is the sentinel behind
 	// runtimeWorktreeMismatchRefusal (#2296 part 1): Finish is running from a
 	// different linked worktree than the one Begin recorded. Left

--- a/internal/sddstatus/runtime_compact_sentinel_test.go
+++ b/internal/sddstatus/runtime_compact_sentinel_test.go
@@ -47,6 +47,7 @@ func TestCompactMutationFailureClassifiesEveryReachableLedgerSentinel(t *testing
 		{name: "ErrRuntimeNoActiveAttempt", err: ErrRuntimeNoActiveAttempt, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockInvalidContinuation},
 		{name: "ErrRuntimeWorktreeMismatch", err: ErrRuntimeWorktreeMismatch, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockWorktreeMismatch},
 		{name: "ErrRuntimeCandidateUnavailable", err: ErrRuntimeCandidateUnavailable, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockCandidateUnavailable},
+		{name: "ErrRuntimeUndeclaredUntracked", err: ErrRuntimeUndeclaredUntracked, reachable: true, wantState: CompactStateBlocked, wantReason: CompactBlockUndeclaredUntracked},
 		// Reset is the only mutation that can produce these two; Begin/Finish
 		// never do, so Acquire/Settle never route them into
 		// compactMutationFailure. They stay intentionally unclassified.

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -128,7 +128,20 @@ var (
 	// refusal as the cause, because that cause is the only thing that knows
 	// the runnable repository exit. This sentinel classifies; the cause
 	// continues.
-	ErrRuntimeCandidateUnavailable    = errors.New("SDD runtime candidate could not be captured from the repository")                        // refusal:by-design world-action: the exit is a repository-state change (stage the candidate, gitignore an untracked nested checkout, restore a pruned object), which no command of this product can decide or perform; every wrap keeps the snapshot builder's own refusal as the cause and that cause names the exact action
+	ErrRuntimeCandidateUnavailable = errors.New("SDD runtime candidate could not be captured from the repository") // refusal:by-design world-action: the exit is a repository-state change (stage the candidate, gitignore an untracked nested checkout, restore a pruned object), which no command of this product can decide or perform; every wrap keeps the snapshot builder's own refusal as the cause and that cause names the exact action
+	// ErrRuntimeUndeclaredUntracked classifies every
+	// settlementUntrackedSelection refusal (#3881): the attempt authority is
+	// intact and unmutated, and what refused is the settlement's untracked
+	// ruling -- missing for files the attempt created (#3806's headline
+	// case), made against a stale inventory, naming a path outside the
+	// eligible inventory, narrowing a begin selection, or offered to a legacy
+	// record that has no inventory to accept one against. Every exit is a
+	// corrected rerun of settle/finish, so the caller can always continue;
+	// left unclassified these fell through to compactMutationFailure's opaque
+	// authority_failure default, which its own contract reserves for what its
+	// name says. Like its siblings it never travels alone: every wrap keeps
+	// the refusal text that names the runnable continuation.
+	ErrRuntimeUndeclaredUntracked     = errors.New("SDD runtime settlement requires an untracked ruling this request does not carry")        // refusal:by-design operator-knowledge: only the caller can choose whether to select or exclude the eligible untracked paths, and every wrap names the exact settle/finish rerun that carries that choice
 	ErrRuntimeHandoffSource           = errors.New("SDD runtime handoff source does not equal the active attempt's effective worktree")      // refusal:by-design operator-knowledge: the RuntimeStore wrapper names the active attempt's actual status command
 	ErrRuntimeHandoffDestination      = errors.New("SDD runtime handoff destination is not a registered linked worktree of this repository") // refusal:by-design operator-knowledge: the RuntimeStore wrapper names the active attempt's actual status command
 	ErrRuntimeHandoffAlreadyPerformed = errors.New("SDD runtime attempt has already been handed off")                                        // refusal:by-design operator-knowledge: the RuntimeStore wrapper names the active attempt's actual status command
@@ -799,7 +812,7 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 		intendedUntracked := slices.Clone(snapshot.IntendedUntracked)
 		_, eligibleInventory, err := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).IntendedUntrackedInventory(ctx)
 		if err != nil {
-			return runtimeRecord{}, fmt.Errorf("read the eligible untracked inventory this attempt begins against: %w", err)
+			return runtimeRecord{}, fmt.Errorf("%w while reading the eligible untracked inventory this attempt begins against: %w", ErrRuntimeCandidateUnavailable, err)
 		}
 		event := &runtimeBeginEvent{
 			ObjectiveID: objectiveID, ObjectiveGeneration: generation, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal,
@@ -953,13 +966,13 @@ func (store RuntimeStore) settlementUntrackedSelection(ctx context.Context, acti
 		// what the caller saw, so no decision can honestly be demanded of them
 		// now and none may be accepted either.
 		if request.IntendedUntracked != nil {
-			return nil, "", errors.New("this attempt began before settle-time untracked declarations existed, so it has no inventory to declare against; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` without --untracked-scope")
+			return nil, "", fmt.Errorf("%w: this attempt began before settle-time untracked declarations existed, so it has no inventory to declare against; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` without --untracked-scope", ErrRuntimeUndeclaredUntracked)
 		}
 		return active.IntendedUntracked, "", nil
 	}
 	inventory, digest, err := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).IntendedUntrackedInventory(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("read the eligible untracked inventory before settling: %w", err)
+		return nil, "", fmt.Errorf("%w while reading the eligible untracked inventory before settling: %w", ErrRuntimeCandidateUnavailable, err)
 	}
 	undecided := make([]string, 0, len(inventory))
 	for _, path := range inventory {
@@ -977,12 +990,12 @@ func (store RuntimeStore) settlementUntrackedSelection(ctx context.Context, acti
 		return nil, "", runtimeBornDuringUntrackedRefusal(undecided, digest)
 	}
 	if request.ExpectedUntrackedInventory != digest {
-		return nil, "", fmt.Errorf("this declaration was made against untracked inventory %s but the workspace now holds %s; rerun `gentle-ai review status --next-transition` for the current inventory, then rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --expected-untracked-inventory=%s", request.ExpectedUntrackedInventory, digest, digest)
+		return nil, "", fmt.Errorf("%w: this declaration was made against untracked inventory %s but the workspace now holds %s; rerun `gentle-ai review status --next-transition` for the current inventory, then rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --expected-untracked-inventory=%s", ErrRuntimeUndeclaredUntracked, request.ExpectedUntrackedInventory, digest, digest)
 	}
 	selection := *request.IntendedUntracked
 	for _, path := range selection {
 		if !slices.Contains(inventory, path) {
-			return nil, "", fmt.Errorf("intended-untracked path %q is not in the current eligible inventory; rerun `gentle-ai review status --next-transition` to see what is eligible, then rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with only those paths", path)
+			return nil, "", fmt.Errorf("%w: intended-untracked path %q is not in the current eligible inventory; rerun `gentle-ai review status --next-transition` to see what is eligible, then rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with only those paths", ErrRuntimeUndeclaredUntracked, path)
 		}
 	}
 	// A path selected at begin is already in the begin tree. Dropping it here
@@ -990,7 +1003,7 @@ func (store RuntimeStore) settlementUntrackedSelection(ctx context.Context, acti
 	// settlement may widen the selection but never narrow it.
 	for _, path := range active.IntendedUntracked {
 		if slices.Contains(inventory, path) && !slices.Contains(selection, path) {
-			return nil, "", fmt.Errorf("this attempt began with %q in its candidate, and a settlement cannot take it back out; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --intended-untracked=%s included", path, path)
+			return nil, "", fmt.Errorf("%w: this attempt began with %q in its candidate, and a settlement cannot take it back out; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --intended-untracked=%s included", ErrRuntimeUndeclaredUntracked, path, path)
 		}
 	}
 	return selection, digest, nil
@@ -1007,7 +1020,7 @@ func runtimeBornDuringUntrackedRefusal(undecided []string, digest string) error 
 		remainder = fmt.Sprintf(" and %d more", len(listed)-runtimeUndeclaredUntrackedListLimit)
 		listed = listed[:runtimeUndeclaredUntrackedListLimit]
 	}
-	return fmt.Errorf("this attempt left eligible untracked files its candidate does not include, so settling now would record them as no change at all: %s%s; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --untracked-scope=select --intended-untracked=<repo-relative-path> --expected-untracked-inventory=%s to account them, or --untracked-scope=exclude --expected-untracked-inventory=%s to leave them out on the record", strings.Join(listed, ", "), remainder, digest, digest)
+	return fmt.Errorf("%w: this attempt left eligible untracked files its candidate does not include, so settling now would record them as no change at all: %s%s; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --untracked-scope=select --intended-untracked=<repo-relative-path> --expected-untracked-inventory=%s to account them, or --untracked-scope=exclude --expected-untracked-inventory=%s to leave them out on the record", ErrRuntimeUndeclaredUntracked, strings.Join(listed, ", "), remainder, digest, digest)
 }
 
 // captureFinalVerifyReport derives the final verification attestation from the

--- a/internal/sddstatus/runtime_undeclared_untracked_reason_test.go
+++ b/internal/sddstatus/runtime_undeclared_untracked_reason_test.go
@@ -1,0 +1,99 @@
+package sddstatus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// Tests for #3881: every settlementUntrackedSelection refusal is a
+// caller-actionable demand for an untracked ruling, not an authority failure,
+// so each one must carry ErrRuntimeUndeclaredUntracked for
+// compactMutationFailure to classify. Without the sentinel they all fall
+// through to the opaque authority_failure default the contract reserves for
+// what its name says -- exactly the fallthrough class candidate_unavailable
+// (#2114) and worktree_mismatch (#2296 part 1) were added to close.
+
+func TestSettlementUntrackedSelectionRefusalsCarryTheUndeclaredSentinel(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "born.txt"), []byte("born\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleDigest := "sha256:" + strings.Repeat("0", 64)
+	selection := func(paths ...string) *[]string { return &paths }
+
+	tests := []struct {
+		name    string
+		active  RuntimeAttempt
+		request FinishAttemptRequest
+	}{
+		{
+			name:    "legacy record refuses any declaration",
+			active:  RuntimeAttempt{},
+			request: FinishAttemptRequest{IntendedUntracked: selection()},
+		},
+		{
+			name:   "undecided born-during path",
+			active: RuntimeAttempt{EligibleUntrackedInventory: staleDigest},
+		},
+		{
+			name:   "declaration against a stale inventory",
+			active: RuntimeAttempt{EligibleUntrackedInventory: staleDigest},
+			request: FinishAttemptRequest{
+				IntendedUntracked: selection("born.txt"), ExpectedUntrackedInventory: staleDigest,
+			},
+		},
+		{
+			name:   "selected path outside the eligible inventory",
+			active: RuntimeAttempt{EligibleUntrackedInventory: digest},
+			request: FinishAttemptRequest{
+				IntendedUntracked: selection("missing.txt"), ExpectedUntrackedInventory: digest,
+			},
+		},
+		{
+			name:   "narrowing a begin selection",
+			active: RuntimeAttempt{EligibleUntrackedInventory: digest, IntendedUntracked: []string{"born.txt"}},
+			request: FinishAttemptRequest{
+				IntendedUntracked: selection(), ExpectedUntrackedInventory: digest,
+			},
+		},
+	}
+	store := RuntimeStore{Repo: repo}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := store.settlementUntrackedSelection(ctx, tt.active, tt.request)
+			if err == nil {
+				t.Fatal("settlement untracked refusal did not refuse")
+			}
+			if !errors.Is(err, ErrRuntimeUndeclaredUntracked) {
+				t.Fatalf("refusal %v does not carry ErrRuntimeUndeclaredUntracked, so Settle reports it as authority_failure", err)
+			}
+		})
+	}
+}
+
+// The eligible-inventory read is a Git capture with the attempt authority
+// intact and unmutated, which is the classification candidate_unavailable
+// already owns; authority_failure would be exactly the misreport its own
+// contract comment rules out.
+func TestSettlementInventoryReadFailureClassifiesCandidateUnavailable(t *testing.T) {
+	store := RuntimeStore{Repo: t.TempDir()}
+	active := RuntimeAttempt{EligibleUntrackedInventory: "sha256:" + strings.Repeat("a", 64)}
+	_, _, err := store.settlementUntrackedSelection(context.Background(), active, FinishAttemptRequest{})
+	if err == nil {
+		t.Fatal("inventory read against a non-repository did not refuse")
+	}
+	if !errors.Is(err, ErrRuntimeCandidateUnavailable) {
+		t.Fatalf("inventory read failure %v does not carry ErrRuntimeCandidateUnavailable", err)
+	}
+}


### PR DESCRIPTION
Closes #3881

## Summary

- Every `settlementUntrackedSelection` refusal now carries `ErrRuntimeUndeclaredUntracked` and classifies as `reason: "undeclared_untracked"` instead of falling through `compactMutationFailure`'s opaque `authority_failure` default, so a consumer routing on the typed reason can tell "declare your untracked ruling and rerun settle" from "authority is broken, stop".
- The begin- and settle-side eligible-inventory Git reads classify as the already-defined `candidate_unavailable` (intact authority, refused Git capture), per its own contract comment.
- `exit`/`detail` text still names the exact settle/finish rerun; the sentinel prefixes it, matching the `ErrRuntimeObjectiveDone`/`ErrRuntimeWorktreeMismatch` idiom.

## Changes

| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go` | New `ErrRuntimeUndeclaredUntracked` sentinel (with `refusal:by-design` marker); wraps the five settlement declaration refusals; `candidate_unavailable` wraps for both eligible-inventory reads |
| `internal/sddstatus/runtime_compact.go` | New `CompactBlockUndeclaredUntracked = "undeclared_untracked"` and its `compactMutationFailure` classification case |
| `internal/sddstatus/runtime_compact_sentinel_test.go` | New sentinel row in the reachable-sentinel enumeration |
| `internal/sddstatus/runtime_undeclared_untracked_reason_test.go` | New: all five refusal shapes carry the sentinel; inventory-read failure carries `ErrRuntimeCandidateUnavailable` |
| `internal/cli/sdd_attempt_untracked_test.go` | Born-during live-route test now pins `blocked/undeclared_untracked` |

## Test Plan

- [x] `go test ./internal/sddstatus/ ./internal/cli/ -count=1` — green (including the refusal-resolution ratchet)
- [x] `GOOS=windows go vet ./internal/sddstatus/ ./internal/cli/` and `go build ./...` — clean
- [x] Live-route smoke with the built binary: clean acquire → file born mid-attempt → settle returns `{"state":"blocked","reason":"undeclared_untracked",...}`; declared `select`/`exclude` reruns settle `complete`
- [x] TDD: both new assertions were red before the sentinel existed

## Notes

The born-during bench journey (`bench/journeys_sdd_untracked.go`) asserts `state: "blocked"` plus exit text and is unaffected; pinning the new reason there is a possible follow-up.

https://claude.ai/code/session_01Ue1EbGwZF4VrP3RLe9yQuT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Settlement failures caused by undeclared or invalid untracked files now receive a distinct blocked reason.
  - Improved classification distinguishes unavailable candidates from untracked-file declaration issues.
  - Error messages provide clearer guidance when settlement cannot proceed.

- **Tests**
  - Added coverage for legacy, stale, out-of-inventory, narrowed, and unavailable candidate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->