### PR TITLE
fix(review): bootstrap local Git for a genuinely unversioned workspace

### DIFF
--- a/internal/cli/review_bare_repository_test.go
+++ b/internal/cli/review_bare_repository_test.go
@@ -80,16 +80,24 @@ func TestReviewStartInABareRepositoryNamesAWorkingTreeThatActuallyWorks(t *testi
 func TestReviewStartOutsideAnyRepositoryStillSurfacesItsCause(t *testing.T) {
 	reviewModeHome(t)
 	outside := t.TempDir()
+	// #3880: a genuinely unversioned workspace is now bootstrapped instead of
+	// refused, so present-but-invalid Git metadata is the scenario that must
+	// still surface the cause it came with: the bootstrap never overwrites an
+	// existing .git entry, and the refusal must never claim the repository is
+	// bare.
+	if err := os.WriteFile(filepath.Join(outside, ".git"), []byte("not a git directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	var output bytes.Buffer
 	err := RunReview([]string{"start", "--cwd", outside}, &output)
 	if err == nil {
-		t.Fatalf("review start outside a repository was allowed: %s", output.String())
+		t.Fatalf("review start over invalid Git metadata was allowed: %s", output.String())
 	}
 	if message := err.Error(); strings.Contains(message, "bare") {
 		t.Fatalf("a non-bare failure was misclassified as bare: %s", message)
 	}
-	if message := err.Error(); !strings.Contains(message, "not a git repository") {
+	if message := err.Error(); !strings.Contains(message, "invalid gitfile format") {
 		t.Fatalf("an unexpected git failure lost its cause: %s", err)
 	}
 }

--- a/internal/cli/review_status_cwd_test.go
+++ b/internal/cli/review_status_cwd_test.go
@@ -58,8 +58,15 @@ func TestReviewStatusSelectorFreeResolvesRepositoryRoot(t *testing.T) {
 		}
 	})
 
-	if err := RunReview([]string{"status", "--cwd", t.TempDir()}, &bytes.Buffer{}); err == nil {
-		t.Fatal("review status accepted a path outside a repository")
+	// #3880: a genuinely unversioned workspace bootstraps local Git instead
+	// of failing; status then reports an empty authority list exactly like any
+	// other repository with no lineages.
+	unversioned := t.TempDir()
+	if err := RunReview([]string{"status", "--cwd", unversioned}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("review status on an unversioned workspace error = %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(unversioned, ".git")); statErr != nil {
+		t.Fatalf("unversioned workspace was not bootstrapped: %v", statErr)
 	}
 
 	nestedRepository := filepath.Join(repo, "nested-repository")

--- a/internal/cli/review_status_cwd_test.go
+++ b/internal/cli/review_status_cwd_test.go
@@ -9,6 +9,12 @@ import (
 	"testing"
 )
 
+// Selector-free STATUS (`--cwd` without explicit Git selectors) must resolve
+// the enclosing repository root wherever inside it the caller stands: nested
+// directories and safe symlinks report the same authority entries as the root.
+// It also pins #3880: an unversioned workspace bootstraps local Git and reports
+// an empty authority list, while a nested independent repository never
+// inherits the parent's lineages.
 func TestReviewStatusSelectorFreeResolvesRepositoryRoot(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate behavior\n"), 0o644); err != nil {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -619,7 +619,21 @@ func (builder SnapshotBuilder) ResolveRepositoryRoot(ctx context.Context) (strin
 	}
 	root, err := resolveGitDirectory(ctx, abs, "--show-toplevel")
 	if err != nil {
-		return "", err
+		// #3880: a genuinely unversioned workspace is bootstrappable, not a
+		// dead end. Local Git is all ordinary review needs, and initializing it
+		// lets the negotiated lifecycle proceed exactly as it does for a
+		// manually initialized unborn repository.
+		bootstrapped, bootstrapErr := bootstrapUnversionedWorkspace(ctx, abs, err)
+		if bootstrapErr != nil {
+			return "", bootstrapErr
+		}
+		if !bootstrapped {
+			return "", err
+		}
+		root, err = resolveGitDirectory(ctx, abs, "--show-toplevel")
+		if err != nil {
+			return "", err
+		}
 	}
 	// 1773 boundary 2: filepath.Rel decided containment by comparing strings,
 	// so on a default case-insensitive APFS volume the requested path and the
@@ -923,6 +937,38 @@ func RebuildCommittedBaseDiffCorrectionCandidate(ctx context.Context, repo strin
 		return Snapshot{}, fmt.Errorf("rebuild committed correction: %w", &CorrectionBudgetExceededError{Actual: actual, Remaining: remaining})
 	}
 	return live, nil
+}
+
+// bootstrapUnversionedWorkspace initializes local Git for a genuinely
+// unversioned workspace (#3880). Review freezes and diffs candidates with
+// local Git, but ordinary review needs no remote: after the bootstrap the
+// negotiated lifecycle proceeds exactly as it does for a manually initialized
+// unborn repository.
+//
+// The bootstrap is deliberately narrow. It fires only when root resolution
+// failed as a Git command failure while no `.git` entry exists at the
+// workspace: `rev-parse --show-toplevel` walks ancestor directories, so its
+// failure with no `.git` here proves no ancestor holds a repository either.
+// A bare repository keeps its own refusal, and a workspace whose `.git` entry
+// exists but does not resolve carries present-but-invalid metadata that the
+// bootstrap must never overwrite. `git init` alone stages nothing, commits
+// nothing, and configures no remote.
+func bootstrapUnversionedWorkspace(ctx context.Context, workspace string, resolveErr error) (bool, error) {
+	var bare *BareRepositoryError
+	if errors.As(resolveErr, &bare) {
+		return false, nil
+	}
+	var gitFailure *GitCommandError
+	if !errors.As(resolveErr, &gitFailure) {
+		return false, nil
+	}
+	if _, statErr := os.Lstat(filepath.Join(workspace, ".git")); !os.IsNotExist(statErr) {
+		return false, nil
+	}
+	if _, initErr := runGit(ctx, workspace, nil, nil, "init"); initErr != nil {
+		return false, fmt.Errorf("local Git bootstrap for the unversioned workspace failed: %w", initErr)
+	}
+	return true, nil
 }
 
 func canonicalRepositoryPath(path string) (string, error) {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -978,16 +978,24 @@ func bootstrapUnversionedWorkspace(ctx context.Context, workspace string, resolv
 	return true, nil
 }
 
+// ancestorGitLstat is the lookup seam for ancestor `.git` entries so tests can
+// pin the fail-closed decision without a real permission failure, which root
+// CI containers would silently forgive.
+var ancestorGitLstat = os.Lstat
+
 // ancestorHoldsGitEntry reports whether any strict ancestor directory of the
 // workspace holds a `.git` entry. Reaching this check with an ancestor entry
 // proves that entry unusable -- usable ancestor metadata would have made
 // `rev-parse --show-toplevel` succeed and no bootstrap decision would run --
 // so callers must refuse instead of initializing a nested repository beneath
 // broken metadata. Lstat mirrors the workspace-level check: a `.git` symlink
-// counts as an entry even if its target is gone.
+// counts as an entry even if its target is gone, and any lookup error other
+// than "does not exist" counts as an entry too, so an unreadable ancestor
+// fails closed instead of letting `git init` run beneath an entry it could
+// not inspect.
 func ancestorHoldsGitEntry(workspace string) bool {
 	for dir := filepath.Dir(workspace); ; dir = filepath.Dir(dir) {
-		if _, statErr := os.Lstat(filepath.Join(dir, ".git")); statErr == nil {
+		if _, statErr := ancestorGitLstat(filepath.Join(dir, ".git")); !os.IsNotExist(statErr) {
 			return true
 		}
 		if parent := filepath.Dir(dir); parent == dir {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -947,12 +947,16 @@ func RebuildCommittedBaseDiffCorrectionCandidate(ctx context.Context, repo strin
 //
 // The bootstrap is deliberately narrow. It fires only when root resolution
 // failed as a Git command failure while no `.git` entry exists at the
-// workspace: `rev-parse --show-toplevel` walks ancestor directories, so its
-// failure with no `.git` here proves no ancestor holds a repository either.
-// A bare repository keeps its own refusal, and a workspace whose `.git` entry
-// exists but does not resolve carries present-but-invalid metadata that the
-// bootstrap must never overwrite. `git init` alone stages nothing, commits
-// nothing, and configures no remote.
+// workspace and no ancestor directory holds a `.git` entry either. A bare
+// repository keeps its own refusal, and a workspace whose `.git` entry exists
+// but does not resolve carries present-but-invalid metadata that the
+// bootstrap must never overwrite. An ancestor `.git` entry refuses too: a
+// failing `rev-parse --show-toplevel` cannot distinguish "no ancestor holds a
+// repository" from "ancestor metadata is present but corrupt" -- both
+// surface as a Git command failure -- and initializing beneath broken
+// metadata would carve an unintended nested repository whose scope boundary
+// silently differs from the one the ancestor declares. `git init` alone
+// stages nothing, commits nothing, and configures no remote.
 func bootstrapUnversionedWorkspace(ctx context.Context, workspace string, resolveErr error) (bool, error) {
 	var bare *BareRepositoryError
 	if errors.As(resolveErr, &bare) {
@@ -965,10 +969,31 @@ func bootstrapUnversionedWorkspace(ctx context.Context, workspace string, resolv
 	if _, statErr := os.Lstat(filepath.Join(workspace, ".git")); !os.IsNotExist(statErr) {
 		return false, nil
 	}
+	if ancestorHoldsGitEntry(workspace) {
+		return false, nil
+	}
 	if _, initErr := runGit(ctx, workspace, nil, nil, "init"); initErr != nil {
 		return false, fmt.Errorf("local Git bootstrap for the unversioned workspace failed: %w", initErr)
 	}
 	return true, nil
+}
+
+// ancestorHoldsGitEntry reports whether any strict ancestor directory of the
+// workspace holds a `.git` entry. Reaching this check with an ancestor entry
+// proves that entry unusable -- usable ancestor metadata would have made
+// `rev-parse --show-toplevel` succeed and no bootstrap decision would run --
+// so callers must refuse instead of initializing a nested repository beneath
+// broken metadata. Lstat mirrors the workspace-level check: a `.git` symlink
+// counts as an entry even if its target is gone.
+func ancestorHoldsGitEntry(workspace string) bool {
+	for dir := filepath.Dir(workspace); ; dir = filepath.Dir(dir) {
+		if _, statErr := os.Lstat(filepath.Join(dir, ".git")); statErr == nil {
+			return true
+		}
+		if parent := filepath.Dir(dir); parent == dir {
+			return false
+		}
+	}
 }
 
 func canonicalRepositoryPath(path string) (string, error) {

--- a/internal/reviewtransaction/unversioned_workspace_bootstrap_test.go
+++ b/internal/reviewtransaction/unversioned_workspace_bootstrap_test.go
@@ -102,6 +102,42 @@ func TestResolveRepositoryRootKeepsUnbornRepositoryUntouched(t *testing.T) {
 	}
 }
 
+// An ancestor's corrupt `.git` entry must not be silently bypassed by a
+// bootstrap `git init`. `rev-parse --show-toplevel` fails identically for "no
+// repository anywhere" and "ancestor repository metadata corrupt", so the
+// guard has to inspect the ancestor chain itself: initializing beneath broken
+// metadata would carve an unintended nested repository whose scope boundary
+// silently differs from the one the ancestor declares.
+func TestResolveRepositoryRootRefusesBootstrapUnderCorruptAncestorMetadata(t *testing.T) {
+	root := canonicalTempDir(t)
+	workspace := filepath.Join(root, "workspace", "nested")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ancestorGit := filepath.Join(root, "workspace", ".git")
+	if err := os.WriteFile(ancestorGit, []byte("not a git directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(ancestorGit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resRoot, resolveErr := (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(context.Background()); resolveErr == nil {
+		t.Fatalf("ResolveRepositoryRoot() = %q, want a refusal under corrupt ancestor metadata", resRoot)
+	}
+	if _, statErr := os.Lstat(filepath.Join(workspace, ".git")); !os.IsNotExist(statErr) {
+		t.Fatal("bootstrap must not initialize a nested repository beneath corrupt ancestor metadata")
+	}
+	after, err := os.ReadFile(ancestorGit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("corrupt ancestor .git was modified: before %q after %q", before, after)
+	}
+}
+
 // Present-but-invalid Git metadata must fail with the original error and keep
 // the invalid entry byte-for-byte intact: the bootstrap never overwrites.
 func TestResolveRepositoryRootRefusesInvalidGitMetadata(t *testing.T) {

--- a/internal/reviewtransaction/unversioned_workspace_bootstrap_test.go
+++ b/internal/reviewtransaction/unversioned_workspace_bootstrap_test.go
@@ -1,0 +1,129 @@
+package reviewtransaction
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathidentity"
+)
+
+// #3880: a genuinely unversioned local workspace is bootstrappable, not a
+// dead end. Ordinary review needs local Git to freeze and diff candidates but
+// no remote, no staged files, and no commits — after `git init` the negotiated
+// lifecycle proceeds exactly as it does for a manually initialized unborn
+// repository. The guards below pin each side of that contract.
+func TestResolveRepositoryRootBootstrapsUnversionedWorkspace(t *testing.T) {
+	workspace := canonicalTempDir(t)
+	if err := os.WriteFile(filepath.Join(workspace, "candidate.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveRepositoryRoot() on an unversioned workspace error = %v", err)
+	}
+	if !pathidentity.SameDirectory(root, workspace) {
+		t.Fatalf("ResolveRepositoryRoot() = %q, want the bootstrapped workspace %q", root, workspace)
+	}
+
+	ctx := context.Background()
+	if _, statErr := os.Lstat(filepath.Join(workspace, ".git")); statErr != nil {
+		t.Fatalf("bootstrap did not initialize local Git: %v", statErr)
+	}
+
+	// No commit: the bootstrapped repository stays unborn, so the lifecycle
+	// enters the intended-untracked collect route instead of freezing a
+	// bootstrap commit as review content.
+	if _, headErr := runGit(ctx, workspace, nil, nil, "rev-parse", "--verify", "HEAD^{commit}"); headErr == nil {
+		t.Fatal("bootstrap must not create a commit; HEAD resolves to a commit")
+	}
+
+	// No staging: the index stays empty, so nothing the user did not declare
+	// becomes review scope by the bootstrap itself.
+	staged, stagedErr := runGit(ctx, workspace, nil, nil, "ls-files", "--cached")
+	if stagedErr != nil {
+		t.Fatalf("ls-files --cached error = %v", stagedErr)
+	}
+	if len(strings.TrimSpace(string(staged))) != 0 {
+		t.Fatalf("bootstrap must not stage files; index holds %q", string(staged))
+	}
+
+	// No remote: ordinary review never contacts one, and the bootstrap must
+	// not configure remotes the operator never asked for.
+	remotes, remoteErr := runGit(ctx, workspace, nil, nil, "remote")
+	if remoteErr != nil {
+		t.Fatalf("git remote error = %v", remoteErr)
+	}
+	if len(strings.TrimSpace(string(remotes))) != 0 {
+		t.Fatalf("bootstrap must not configure a remote; found %q", string(remotes))
+	}
+
+	// The second resolve now flows through the ordinary repository path with
+	// no bootstrap decision at all.
+	again, err := (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		t.Fatalf("second ResolveRepositoryRoot() error = %v", err)
+	}
+	if !pathidentity.SameDirectory(again, workspace) {
+		t.Fatalf("second ResolveRepositoryRoot() = %q, want %q", again, workspace)
+	}
+}
+
+// An unborn repository (valid .git, no commits) must keep flowing through the
+// normal lifecycle untouched: the bootstrap exists only for workspaces with
+// no repository at all.
+func TestResolveRepositoryRootKeepsUnbornRepositoryUntouched(t *testing.T) {
+	workspace := canonicalTempDir(t)
+	if _, err := runGit(context.Background(), workspace, nil, nil, "init"); err != nil {
+		t.Fatalf("git init fixture error = %v", err)
+	}
+	created, err := os.Stat(filepath.Join(workspace, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveRepositoryRoot() on an unborn repository error = %v", err)
+	}
+	if !pathidentity.SameDirectory(root, workspace) {
+		t.Fatalf("ResolveRepositoryRoot() = %q, want %q", root, workspace)
+	}
+
+	after, err := os.Stat(filepath.Join(workspace, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(created, after) {
+		t.Fatal("unborn repository .git was recreated; the bootstrap must not fire for existing repositories")
+	}
+}
+
+// Present-but-invalid Git metadata must fail with the original error and keep
+// the invalid entry byte-for-byte intact: the bootstrap never overwrites.
+func TestResolveRepositoryRootRefusesInvalidGitMetadata(t *testing.T) {
+	workspace := canonicalTempDir(t)
+	control := filepath.Join(workspace, ".git")
+	if err := os.WriteFile(control, []byte("not a git directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(control)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if root, resolveErr := (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(context.Background()); resolveErr == nil {
+		t.Fatalf("ResolveRepositoryRoot() = %q, want a refusal for invalid Git metadata", root)
+	}
+
+	after, err := os.ReadFile(control)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("invalid .git metadata was overwritten: %q -> %q", string(before), string(after))
+	}
+}

--- a/internal/reviewtransaction/unversioned_workspace_bootstrap_test.go
+++ b/internal/reviewtransaction/unversioned_workspace_bootstrap_test.go
@@ -138,6 +138,31 @@ func TestResolveRepositoryRootRefusesBootstrapUnderCorruptAncestorMetadata(t *te
 	}
 }
 
+// A `.git` lookup on an ancestor that fails with anything other than "does
+// not exist" must count as present metadata: falling through would let the
+// bootstrap run `git init` beneath an ancestor entry it could not inspect.
+// The seam stubs EACCES because a real permission failure is invisible to
+// root CI containers.
+func TestAncestorHoldsGitEntryFailsClosedOnLookupError(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := ancestorGitLstat
+	t.Cleanup(func() { ancestorGitLstat = orig })
+	ancestorGitLstat = func(name string) (os.FileInfo, error) {
+		if filepath.Base(name) == ".git" {
+			return nil, &os.PathError{Op: "lstat", Path: name, Err: os.ErrPermission}
+		}
+		return orig(name)
+	}
+
+	if !ancestorHoldsGitEntry(workspace) {
+		t.Fatal("ancestorHoldsGitEntry() = false under a non-ENOENT .git lookup error, want fail-closed true")
+	}
+}
+
 // Present-but-invalid Git metadata must fail with the original error and keep
 // the invalid entry byte-for-byte intact: the bootstrap never overwrites.
 func TestResolveRepositoryRootRefusesInvalidGitMetadata(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3880

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

An unversioned local workspace dead-ended `review status --cwd` at `pre_native` with `git_command_failed`, forcing a manual `git init` even though ordinary review needs local Git but no remote. Per the approved scope, `ResolveRepositoryRoot` now bootstraps a genuinely unversioned workspace with `git init` and retries the resolution, so the negotiated lifecycle proceeds exactly as it does for a manually initialized unborn repository (the intended-untracked collect route, matching the issue's post-`git init` output).

The bootstrap is deliberately narrow, per the issue's constraints:

- **Fires only when genuinely unversioned**: root resolution must have failed as a Git command failure AND no `.git` entry exists at the workspace. `rev-parse --show-toplevel` walks ancestor directories, so its failure with no `.git` here proves no ancestor holds a repository either.
- **Never touches existing metadata**: bare repositories keep their refusal; existing repositories (unborn ones included) never reach the bootstrap; present-but-invalid `.git` entries fail with the original cause and stay byte-identical on disk.
- **`git init` only**: stages nothing, commits nothing, configures no remote.

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/reviewtransaction/snapshot.go` | `bootstrapUnversionedWorkspace` classifier + retry hook in `ResolveRepositoryRoot` |
| `internal/reviewtransaction/unversioned_workspace_bootstrap_test.go` | bootstrap ratchet (unborn, no staging, no remote, no commit, clean second resolve); unborn repository untouched; invalid `.git` metadata refused and unchanged |
| `internal/cli/review_status_cwd_test.go` | status on an unversioned workspace now bootstraps and succeeds (approved behavior change) |
| `internal/cli/review_bare_repository_test.go` | cause-surfacing guard re-pinned through invalid gitfile metadata — the vehicle the #3880 approval made bootstrappable |

## 🧪 Test Plan

**Unit Tests**
```
go test ./internal/reviewtransaction/ ./internal/cli/
```
Both green. RED/GREEN proof: with the fix reverted, `TestResolveRepositoryRootBootstrapsUnversionedWorkspace` fails while the two no-regression guards (unborn untouched, invalid metadata refused) pass, pinning the pre-existing behavior they protect.

**Go Format**
```
go run ./internal/gofmtcheck
```
Green.

**E2E Tests** (Docker required)
```
cd e2e && ./docker-test.sh
```
3/3 platforms passed.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (195 additions + 5 deletions)
- [ ] I have added the appropriate `type:*` label to this PR — no label permission from a fork; requesting `type:bug`
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review commands now automatically initialize a local Git repository in unversioned workspaces.
  * Repository status now succeeds in previously unversioned directories.
  * Newly initialized repositories remain empty, with no commits, staged files, or remotes.

* **Bug Fixes**
  * Existing repositories without commits remain unchanged.
  * Invalid or corrupt Git metadata is detected and reported without modifying the workspace.
  * Workspaces under invalid repository metadata are not initialized accidentally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->