### PR TITLE
fix(review): bootstrap local Git for RDD

### DIFF
--- a/internal/cli/review_bare_repository_test.go
+++ b/internal/cli/review_bare_repository_test.go
@@ -74,23 +74,31 @@ func TestReviewStartInABareRepositoryNamesAWorkingTreeThatActuallyWorks(t *testi
 	}
 }
 
-// Destroying diagnostic information is its own defect. Only the bare case gets
-// the product-voice message; any other rev-parse failure must still surface the
-// cause it came with, and must never claim the repository is bare.
-func TestReviewStartOutsideAnyRepositoryStillSurfacesItsCause(t *testing.T) {
+// A genuinely unversioned workspace gets local Git metadata before START
+// evaluates the same candidate lifecycle it would inside an existing repository.
+// With no candidate changes, that normal lifecycle refuses the empty candidate;
+// bootstrap itself neither remains a repository-root failure nor creates a remote.
+func TestReviewStartOutsideAnyRepositoryBootstrapsLocalGitAndContinuesToEmptyCandidateRefusal(t *testing.T) {
 	reviewModeHome(t)
-	outside := t.TempDir()
+	workspace := t.TempDir()
 
 	var output bytes.Buffer
-	err := RunReview([]string{"start", "--cwd", outside}, &output)
+	err := RunReview([]string{"start", "--cwd", workspace}, &output)
 	if err == nil {
-		t.Fatalf("review start outside a repository was allowed: %s", output.String())
+		t.Fatalf("review start without candidate changes was allowed: %s", output.String())
 	}
-	if message := err.Error(); strings.Contains(message, "bare") {
-		t.Fatalf("a non-bare failure was misclassified as bare: %s", message)
+	message := err.Error()
+	if strings.Contains(message, "bare") {
+		t.Fatalf("unversioned workspace was misclassified as bare: %s", message)
 	}
-	if message := err.Error(); !strings.Contains(message, "not a git repository") {
-		t.Fatalf("an unexpected git failure lost its cause: %s", err)
+	if !strings.Contains(message, "candidate has no pending changes") {
+		t.Fatalf("review start did not continue to the normal empty-candidate refusal: %s", message)
+	}
+	if info, statErr := os.Stat(filepath.Join(workspace, ".git")); statErr != nil || !info.IsDir() {
+		t.Fatalf("local Git metadata = %v (%v), want directory", info, statErr)
+	}
+	if remote := strings.TrimSpace(runReviewCLIGit(t, workspace, "remote")); remote != "" {
+		t.Fatalf("git remote = %q, want no remotes", remote)
 	}
 }
 

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -688,7 +688,7 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 }
 
 func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error {
-	flags := newReviewFlagSet("review status", stdout, "Read every compact-v2 and shipped legacy-v1 authority from the shared Git common directory without mutation.")
+	flags := newReviewFlagSet("review status", stdout, "Read every compact-v2 and shipped legacy-v1 authority from the shared Git common directory; initialize local Git only for a genuinely unversioned workspace.")
 	cwd := flags.String("cwd", ".", "repository path")
 	contract := flags.String("contract", "", "optional negotiated review integration contract")
 	runtimeAgent := flags.String("agent", "", "generated active runtime identity for negotiated lifecycle routing")
@@ -775,8 +775,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		if selectedBaseTree != "" && !validReviewGitTree(selectedBaseTree) {
 			return errors.New("--base-tree requires an exact Git tree object ID")
 		}
-		builder := reviewtransaction.SnapshotBuilder{Repo: *cwd}
-		root, err := builder.ResolveRepositoryRoot(ctx)
+		root, err := reviewtransaction.PrepareReviewRepositoryRoot(ctx, *cwd)
 		if err != nil {
 			return fmt.Errorf("resolve negotiated review repository root: %w", err)
 		}
@@ -784,7 +783,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		// operation must use the canonical worktree root it resolved. Leaving
 		// the nested selector here would make fresh target freezing reject a
 		// valid foreign repository before START can bind its lifecycle root.
-		builder.Repo = root
+		builder := reviewtransaction.SnapshotBuilder{Repo: root}
 		intendedScope := reviewIntendedUntrackedScope{Intended: []string{}}
 		if selectedProjection == reviewtransaction.ProjectionStaged {
 			if reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory) {
@@ -1139,7 +1138,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 	if strings.TrimSpace(*runtimeAgent) != "" || strings.TrimSpace(*lineage) != "" || strings.TrimSpace(*baseRef) != "" || strings.TrimSpace(*baseTree) != "" || committedOnlyProvided || *workspaceOverlay || *projection != string(reviewtransaction.ProjectionWorkspace) || *gate != string(reviewtransaction.GatePreCommit) || *recoverySuccessor != "" || *recoveryReason != "" || *recoveryActor != "" || *recoveryAuthorization != "" || *repairActor != "" || *repairReason != "" || *repairAuthorization != "" || reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory) {
 		return errors.New(reviewStatusTargetSelectorsRequireContractReason)
 	}
-	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
+	root, err := reviewtransaction.PrepareReviewRepositoryRoot(ctx, *cwd)
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)
 	}
@@ -1650,8 +1649,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	if err != nil {
 		return reviewPreflightError(err)
 	}
-	builder := reviewtransaction.SnapshotBuilder{Repo: *cwd}
-	root, err := builder.ResolveRepositoryRoot(ctx)
+	root, err := reviewtransaction.PrepareReviewRepositoryRoot(ctx, *cwd)
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)
 	}

--- a/internal/cli/review_repository_bootstrap_test.go
+++ b/internal/cli/review_repository_bootstrap_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReviewLifecycleBootstrapsGenuinelyUnversionedWorkspace(t *testing.T) {
+	reviewEnabledHome(t)
+	operations := map[string]func(*testing.T, string, *bytes.Buffer) error{
+		"negotiated status": func(t *testing.T, repo string, output *bytes.Buffer) error {
+			t.Helper()
+			if err := RunReview([]string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition"}, output); err != nil {
+				return err
+			}
+			var status ReviewTargetStatusResult
+			decodeStrictReviewJSON(t, output.Bytes(), &status)
+			if status.NextTransition == nil || status.NextTransition.ReasonCode != "intended_untracked_selection_required" {
+				t.Fatalf("negotiated status transition = %#v, want intended untracked selection", status.NextTransition)
+			}
+			return nil
+		},
+		"direct start": func(t *testing.T, repo string, output *bytes.Buffer) error {
+			t.Helper()
+			err := RunReview([]string{"start", "--cwd", repo}, output)
+			if err == nil || !strings.Contains(err.Error(), "--untracked-scope=exclude") {
+				t.Fatalf("direct start error = %v, want the normal untracked-selection refusal", err)
+			}
+			return nil
+		},
+	}
+
+	for name, operation := range operations {
+		t.Run(name, func(t *testing.T) {
+			repo := t.TempDir()
+			candidate := filepath.Join(repo, "candidate.txt")
+			if err := os.WriteFile(candidate, []byte("candidate\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			var output bytes.Buffer
+			if err := operation(t, repo, &output); err != nil {
+				t.Fatalf("review operation: %v\n%s", err, output.String())
+			}
+			assertLocalGitBootstrapPreservedWorkspace(t, repo, candidate)
+		})
+	}
+}
+
+func TestReviewStatusHelpDescribesLocalGitInitialization(t *testing.T) {
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--help"}, &output); err != nil {
+		t.Fatalf("review status help: %v", err)
+	}
+	if strings.Contains(output.String(), "without mutation") || !strings.Contains(output.String(), "initialize local Git") {
+		t.Fatalf("review status help = %q, want scoped local Git initialization", output.String())
+	}
+}
+
+func TestReviewStatusReusesContainingWorktreeWithoutNestedMetadata(t *testing.T) {
+	repo := initUnbornReviewCLIRepo(t)
+	nested := filepath.Join(repo, "nested", "workspace")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "candidate.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", nested, "--contract", ReviewIntegrationContractV2, "--next-transition"}, &output); err != nil {
+		t.Fatalf("review status from nested workspace: %v\n%s", err, output.String())
+	}
+	if _, err := os.Lstat(filepath.Join(nested, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("nested workspace metadata = %v, want no nested .git", err)
+	}
+	if root := strings.TrimSpace(runReviewCLIGit(t, nested, "rev-parse", "--show-toplevel")); root != repo {
+		t.Fatalf("nested workspace root = %q, want %q", root, repo)
+	}
+}
+
+func TestReviewStatusLeavesUnusableGitMetadataUnchanged(t *testing.T) {
+	repo := t.TempDir()
+	metadata := filepath.Join(repo, ".git")
+	before := []byte("not a git directory\n")
+	if err := os.WriteFile(metadata, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunReview([]string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("review status accepted unusable Git metadata")
+	}
+	after, readErr := os.ReadFile(metadata)
+	if readErr != nil {
+		t.Fatalf("read Git metadata after failed status: %v", readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("Git metadata changed after failed status:\nbefore: %q\nafter:  %q", before, after)
+	}
+}
+
+func assertLocalGitBootstrapPreservedWorkspace(t *testing.T, repo, candidate string) {
+	t.Helper()
+	if info, err := os.Stat(filepath.Join(repo, ".git")); err != nil || !info.IsDir() {
+		t.Fatalf("local Git metadata = %v (%v), want directory", info, err)
+	}
+	if content, err := os.ReadFile(candidate); err != nil || string(content) != "candidate\n" {
+		t.Fatalf("candidate after bootstrap = %q, %v", content, err)
+	}
+	remote := exec.Command("git", "-C", repo, "remote")
+	if output, err := remote.CombinedOutput(); err != nil || len(bytes.TrimSpace(output)) != 0 {
+		t.Fatalf("git remote = %q, %v; want no remotes", output, err)
+	}
+	status := exec.Command("git", "-C", repo, "status", "--short")
+	if output, err := status.CombinedOutput(); err != nil || string(output) != "?? candidate.txt\n" {
+		t.Fatalf("git status --short = %q, %v; want untracked candidate", output, err)
+	}
+	if output, err := exec.Command("git", "-C", repo, "rev-parse", "--verify", "HEAD").CombinedOutput(); err == nil {
+		t.Fatalf("bootstrap created HEAD %q, want unborn HEAD", output)
+	}
+}

--- a/internal/cli/review_status_cwd_test.go
+++ b/internal/cli/review_status_cwd_test.go
@@ -58,9 +58,30 @@ func TestReviewStatusSelectorFreeResolvesRepositoryRoot(t *testing.T) {
 		}
 	})
 
-	if err := RunReview([]string{"status", "--cwd", t.TempDir()}, &bytes.Buffer{}); err == nil {
-		t.Fatal("review status accepted a path outside a repository")
-	}
+	t.Run("unversioned directory", func(t *testing.T) {
+		workspace := t.TempDir()
+		candidate := filepath.Join(workspace, "candidate.txt")
+		if err := os.WriteFile(candidate, []byte("candidate\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var output bytes.Buffer
+		if err := RunReview([]string{"status", "--cwd", workspace}, &output); err != nil {
+			t.Fatalf("review status in unversioned directory: %v", err)
+		}
+		var report struct {
+			Entries []struct {
+				LineageID string `json:"lineage_id"`
+			} `json:"entries"`
+		}
+		if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if len(report.Entries) != 0 {
+			t.Fatalf("unversioned directory status entries = %#v, want none", report.Entries)
+		}
+		assertLocalGitBootstrapPreservedWorkspace(t, workspace, candidate)
+	})
 
 	nestedRepository := filepath.Join(repo, "nested-repository")
 	if err := os.Mkdir(nestedRepository, 0o755); err != nil {

--- a/internal/reviewtransaction/repository_bootstrap.go
+++ b/internal/reviewtransaction/repository_bootstrap.go
@@ -1,0 +1,89 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// PrepareReviewRepositoryRoot is the review lifecycle entry boundary for a
+// workspace that may not yet have local Git metadata. It reuses an existing
+// containing worktree and initializes Git only after both hardened discovery
+// and an isolated probe prove the workspace is genuinely unversioned.
+//
+// SnapshotBuilder and every lower-level repository boundary remain read-only:
+// callers that need lifecycle preparation must opt in at this boundary.
+func PrepareReviewRepositoryRoot(ctx context.Context, workspace string) (string, error) {
+	builder := SnapshotBuilder{Repo: workspace}
+	root, resolveErr := builder.ResolveRepositoryRoot(ctx)
+	if resolveErr == nil {
+		return root, nil
+	}
+	if !reviewRootResolutionReportsNoRepository(resolveErr) {
+		return "", resolveErr
+	}
+
+	workspace, pathErr := canonicalRepositoryPath(workspace)
+	if pathErr != nil {
+		return "", pathErr
+	}
+	info, statErr := os.Stat(workspace)
+	if statErr != nil || !info.IsDir() {
+		return "", resolveErr
+	}
+	metadataPresent, metadataErr := reviewWorkspaceHasGitMetadata(workspace)
+	if metadataErr != nil || metadataPresent {
+		return "", resolveErr
+	}
+
+	if _, probeErr := runGitIsolated(ctx, workspace, nil, nil, "rev-parse", "--is-inside-work-tree"); !reviewIsolatedProbeReportsNoRepository(probeErr) {
+		return "", resolveErr
+	}
+	if _, initErr := runGitIsolated(ctx, workspace, nil, nil, "init", "--quiet"); initErr != nil {
+		return "", initErr
+	}
+	return (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(ctx)
+}
+
+func reviewRootResolutionReportsNoRepository(err error) bool {
+	return reviewGitCommandExited128(err, "rev-parse", "--show-toplevel")
+}
+
+func reviewIsolatedProbeReportsNoRepository(err error) bool {
+	return reviewGitCommandExited128(err, "rev-parse", "--is-inside-work-tree")
+}
+
+func reviewGitCommandExited128(err error, args ...string) bool {
+	var commandErr *GitCommandError
+	if !errors.As(err, &commandErr) || commandErr.ExitCode != 128 || len(commandErr.Args) != len(args) {
+		return false
+	}
+	for index, arg := range args {
+		if commandErr.Args[index] != arg {
+			return false
+		}
+	}
+	return true
+}
+
+// reviewWorkspaceHasGitMetadata refuses initialization whenever a .git entry
+// already exists in the requested directory or one of its parents. A valid
+// containing worktree returned before this scan; reaching it here means the
+// existing metadata is unusable and must be left untouched.
+func reviewWorkspaceHasGitMetadata(workspace string) (bool, error) {
+	for directory := workspace; ; directory = filepath.Dir(directory) {
+		_, err := os.Lstat(filepath.Join(directory, ".git"))
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			return false, nil
+		}
+	}
+}

--- a/internal/reviewtransaction/repository_bootstrap_test.go
+++ b/internal/reviewtransaction/repository_bootstrap_test.go
@@ -1,0 +1,83 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrepareReviewRepositoryRootInitializesOnlyGenuinelyUnversionedWorkspace(t *testing.T) {
+	t.Run("initializes an unversioned workspace", func(t *testing.T) {
+		repo := t.TempDir()
+		candidate := filepath.Join(repo, "candidate.txt")
+		if err := os.WriteFile(candidate, []byte("candidate\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		root, err := PrepareReviewRepositoryRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatalf("prepare local Git repository: %v", err)
+		}
+		if root != repo {
+			t.Fatalf("prepared root = %q, want %q", root, repo)
+		}
+		if info, statErr := os.Stat(filepath.Join(repo, ".git")); statErr != nil || !info.IsDir() {
+			t.Fatalf("local Git metadata = %v (%v), want directory", info, statErr)
+		}
+		if content, readErr := os.ReadFile(candidate); readErr != nil || string(content) != "candidate\n" {
+			t.Fatalf("candidate after bootstrap = %q, %v", content, readErr)
+		}
+	})
+
+	t.Run("reuses a containing worktree", func(t *testing.T) {
+		repo := initUnbornSnapshotRepo(t)
+		nested := filepath.Join(repo, "nested", "workspace")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		root, err := PrepareReviewRepositoryRoot(context.Background(), nested)
+		if err != nil {
+			t.Fatalf("prepare containing repository: %v", err)
+		}
+		if root != repo {
+			t.Fatalf("prepared root = %q, want containing root %q", root, repo)
+		}
+		if _, statErr := os.Lstat(filepath.Join(nested, ".git")); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("nested metadata = %v, want no nested .git", statErr)
+		}
+	})
+
+	t.Run("refuses unusable metadata without modifying it", func(t *testing.T) {
+		repo := t.TempDir()
+		metadata := filepath.Join(repo, ".git")
+		before := []byte("not a git directory\n")
+		if err := os.WriteFile(metadata, before, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := PrepareReviewRepositoryRoot(context.Background(), repo); err == nil {
+			t.Fatal("prepare accepted unusable Git metadata")
+		}
+		after, err := os.ReadFile(metadata)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(after, before) {
+			t.Fatalf("Git metadata changed:\nbefore: %q\nafter:  %q", before, after)
+		}
+	})
+}
+
+func TestSnapshotBuilderResolveRepositoryRootDoesNotBootstrap(t *testing.T) {
+	repo := t.TempDir()
+	if _, err := (SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(context.Background()); err == nil {
+		t.Fatal("ResolveRepositoryRoot accepted an unversioned workspace")
+	}
+	if _, err := os.Lstat(filepath.Join(repo, ".git")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ResolveRepositoryRoot created metadata: %v", err)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3880

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Allow receipt-driven review STATUS and START entry points to work in genuinely unversioned workspaces by initializing local Git metadata when—and only when—no containing repository or existing Git marker is present.

The bootstrap never configures or contacts a remote, stages files, creates commits, or modifies user files. Existing repositories and worktrees are reused, while corrupt, bare, or otherwise unusable Git metadata is preserved and rejected rather than repaired.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/repository_bootstrap.go` | Added the bounded local Git bootstrap and existing-metadata safety checks. |
| `internal/cli/review_facade.go` | Applied bootstrap only at review STATUS/START lifecycle entry points. |
| `internal/cli/*_test.go` | Added CLI and black-box coverage for unversioned, local-only, bare, and corrupt repository states. |
| `internal/reviewtransaction/repository_bootstrap_test.go` | Added focused repository bootstrap invariants and mutation-boundary tests. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent

**Material scope:** Implementation, test authoring, verification orchestration, review evidence collection, and PR preparation.

**Verification performed:** Exact-base RED validation, focused and full Go tests, black-box lifecycle scenarios, format and diff checks, Docker E2E, CI-equivalent benchmark validation, byte-integrity checks, and native four-lens RDD review.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

```bash
cd bench && go vet ./... && go test ./...
go build -o "$RUNNER_TEMP/gentle-ai-bench" ./bench
go build -trimpath -o "$RUNNER_TEMP/gentle-ai" ./cmd/gentle-ai
"$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j17-bare-repository --out "$RUNNER_TEMP/bench-issue-3880.json"
```

Driven summary: `journeys: 1 completed, 0 unsupported, 0 failed`.

The journey corpus was audited for stale expectations that unversioned workspaces must fail before native review. No stale pin was found. `j17-bare-repository` continues to validate the adjacent requirement that existing bare Git metadata is rejected rather than repaired.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual scenarios covered a genuinely unversioned workspace, local Git without remotes, containing worktrees, and corrupt/bare Git metadata. Default E2E covered Ubuntu, Arch, and Fedora; opt-in Tier 2/3 suites were not enabled by the repository-required command.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR stays within 400 changed lines: 367 authored lines. |
| Check Issue Reference | ⏳ | PR body contains `Closes #3880`. |
| Check Issue Has `status:approved` | ⏳ | Linked issue was approved before implementation. |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:bug` label will be applied and read back. |
| Unit Tests | ⏳ | `go test ./...` must pass. |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass. |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- [x] Evaluated the repository-bootstrap admission boundary against legitimate repositories, containing worktrees, genuinely unversioned directories, bare repositories, and corrupt Git markers. No new qualifying `guard:population` declaration was introduced, and `.guard-population-baseline.txt` is unchanged.
- [x] Verified that only the absence of both a containing repository and existing Git metadata permits local initialization; existing metadata remains untouched and fails through the established validation path.

Native RDD review approved the exact candidate. It recorded two non-blocking follow-ups around concurrent bootstrap races and retry behavior; neither opened a correction or invalidated this delivery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review commands now initialize local Git automatically in genuinely unversioned workspaces.
  * Existing repositories and containing worktrees continue to be detected and reused.
  * Bootstrapped workspaces preserve files, remain without remotes, and retain untracked candidates.

* **Bug Fixes**
  * Improved error handling distinguishes unversioned workspaces from invalid or bare repositories.
  * Existing or unusable Git metadata is left unchanged.
  * Review status and start now provide appropriate guidance for untracked changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->