### PR TITLE
test(windows): compare bootstrap roots by path identity

### DIFF
--- a/internal/cli/review_repository_bootstrap_test.go
+++ b/internal/cli/review_repository_bootstrap_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathidentity"
 )
 
 func TestReviewLifecycleBootstrapsGenuinelyUnversionedWorkspace(t *testing.T) {
@@ -78,7 +80,9 @@ func TestReviewStatusReusesContainingWorktreeWithoutNestedMetadata(t *testing.T)
 	if _, err := os.Lstat(filepath.Join(nested, ".git")); !os.IsNotExist(err) {
 		t.Fatalf("nested workspace metadata = %v, want no nested .git", err)
 	}
-	if root := strings.TrimSpace(runReviewCLIGit(t, nested, "rev-parse", "--show-toplevel")); root != repo {
+	// Identity, not string equality: on Windows the runner's TEMP is an 8.3
+	// short name that Git reports back in its long spelling.
+	if root := strings.TrimSpace(runReviewCLIGit(t, nested, "rev-parse", "--show-toplevel")); !pathidentity.SameDirectory(root, repo) {
 		t.Fatalf("nested workspace root = %q, want %q", root, repo)
 	}
 }

--- a/internal/reviewtransaction/repository_bootstrap_test.go
+++ b/internal/reviewtransaction/repository_bootstrap_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/pathidentity"
 )
 
 func TestPrepareReviewRepositoryRootInitializesOnlyGenuinelyUnversionedWorkspace(t *testing.T) {
@@ -21,7 +23,9 @@ func TestPrepareReviewRepositoryRootInitializesOnlyGenuinelyUnversionedWorkspace
 		if err != nil {
 			t.Fatalf("prepare local Git repository: %v", err)
 		}
-		if root != repo {
+		// Identity, not string equality: on Windows the runner's TEMP is an
+		// 8.3 short name that Git reports back in its long spelling.
+		if !pathidentity.SameDirectory(root, repo) {
 			t.Fatalf("prepared root = %q, want %q", root, repo)
 		}
 		if info, statErr := os.Stat(filepath.Join(repo, ".git")); statErr != nil || !info.IsDir() {
@@ -43,7 +47,7 @@ func TestPrepareReviewRepositoryRootInitializesOnlyGenuinelyUnversionedWorkspace
 		if err != nil {
 			t.Fatalf("prepare containing repository: %v", err)
 		}
-		if root != repo {
+		if !pathidentity.SameDirectory(root, repo) {
 			t.Fatalf("prepared root = %q, want containing root %q", root, repo)
 		}
 		if _, statErr := os.Lstat(filepath.Join(nested, ".git")); !errors.Is(statErr, os.ErrNotExist) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3887

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Brings the #3885 local-Git bootstrap tests to Windows parity: they asserted the resolved repository root with string equality against the raw `t.TempDir()` spelling, which fails on the Windows runners where `TEMP` is an 8.3 short name (`RUNNER~1`) while Git reports the long spelling (`runneradmin`).
- Replaces the three string comparisons with `pathidentity.SameDirectory`, the identity policy the production boundary (`ResolveRepositoryRoot`, `repositoryRoot`) already follows.
- Restores the `reviewtransaction-l-z` shard of Windows Full Suite, green until #3885, and removes the new failures #3885 added to the `cli` shards. The pre-existing red shards stay tracked by #1983.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/repository_bootstrap_test.go` | Compare prepared roots by path identity instead of string equality (2 assertions) |
| `internal/cli/review_repository_bootstrap_test.go` | Compare the nested-workspace toplevel by path identity instead of string equality (1 assertion) |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Diagnosed the Windows Full Suite failures, identified the spelling-vs-identity mismatch, and authored the test edits.

**Verification performed:** Reproduced the failure class on Linux with a symlinked `TMPDIR` (red before the change, green after), ran the affected packages plus the full unit suite and `gofmtcheck`, and `GOOS=windows go vet` on both touched packages.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — test-only assertion change; no review-lifecycle, gate, recovery, delivery, or benchmark behavior changes.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI; test-only change
- [x] Manually tested locally

Reproduced the Windows failure class on Linux by pointing `TMPDIR` through a symlink so `t.TempDir()` returns a non-canonical spelling: both failing tests reproduced the exact CI error before the change and pass after it. `GOOS=windows go vet ./internal/reviewtransaction ./internal/cli` is clean.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Test-only change: no production Go changes, so the guard-population checklist does not apply. The remaining Windows Full Suite failures (provenance, 2s budgets, closed/approved START replays) predate #3885 and stay with the #1983 umbrella.

https://claude.ai/code/session_01Y58Ztn25s8jq3mQKgyA1x2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved repository and workspace path comparisons in automated tests.
  * Added cross-platform handling for equivalent Windows temporary-directory paths, including short and long path formats.
  * Increased test reliability when validating nested workspaces and containing worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->