### PR TITLE
fix(windows): bring the full suite to parity

### DIFF
--- a/internal/agents/pi/model_routing.go
+++ b/internal/agents/pi/model_routing.go
@@ -172,7 +172,11 @@ func unsafeBinPath(value string) string {
 	if value == "" {
 		return "empty bin path"
 	}
-	if filepath.IsAbs(value) || filepath.VolumeName(value) != "" || windowsDrivePath(value) {
+	// A leading slash is an absolute claim in the manifest's slash-relative
+	// vocabulary even where filepath.IsAbs says otherwise: on Windows a
+	// rooted-but-driveless path is not IsAbs, and letting it through would
+	// classify the same manifest differently per platform.
+	if filepath.IsAbs(value) || strings.HasPrefix(value, "/") || filepath.VolumeName(value) != "" || windowsDrivePath(value) {
 		return "absolute bin path"
 	}
 	if strings.ContainsRune(value, '\\') {

--- a/internal/agents/pi/model_routing_test.go
+++ b/internal/agents/pi/model_routing_test.go
@@ -55,6 +55,13 @@ func TestResolvePackageBinForms(t *testing.T) {
 			}
 			root := t.TempDir()
 			want := writeTarget(t, root, tc.target, 0o755)
+			// ResolvePackageBin returns the canonical executable, so the
+			// expectation must be canonical too: on the Windows runners
+			// t.TempDir() is an 8.3 short name that resolves to its long
+			// spelling.
+			canonicalWant, err := filepath.EvalSymlinks(want)
+			must(t, err)
+			want = canonicalWant
 			if tc.link != "" {
 				bin := filepath.Join(root, "bin", "gentle-pi-models")
 				must(t, os.MkdirAll(filepath.Dir(bin), 0o755))

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -497,7 +497,7 @@ func danglingAncestor(homeDir, path string) (string, error) {
 			// sync cannot mkdir below a regular file. POSIX surfaces this as
 			// ENOTDIR at the final lstat, but Windows reports it as not-exist,
 			// which is how the walk gets here.
-			return "", fmt.Errorf("ancestor %s is not a directory", ancestor)
+			return "", fmt.Errorf("ancestor %s is not a directory", ancestor) // refusal:by-design world-action: the caller embeds this cause in a warn that already names the continuation (inspect or repair the path, re-run 'gentle-ai doctor'); the repair itself happens on the filesystem, not through a command
 		}
 		if _, err := os.Stat(ancestor); os.IsNotExist(err) {
 			return ancestor, nil

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -490,7 +490,14 @@ func danglingAncestor(homeDir, path string) (string, error) {
 			return "", err
 		}
 		if info.Mode()&os.ModeSymlink == 0 {
-			return "", nil // nearest existing ancestor is real; path is genuinely missing
+			if info.IsDir() {
+				return "", nil // nearest existing ancestor is real; path is genuinely missing
+			}
+			// A non-directory ancestor blocks both inspection and restoration:
+			// sync cannot mkdir below a regular file. POSIX surfaces this as
+			// ENOTDIR at the final lstat, but Windows reports it as not-exist,
+			// which is how the walk gets here.
+			return "", fmt.Errorf("ancestor %s is not a directory", ancestor)
 		}
 		if _, err := os.Stat(ancestor); os.IsNotExist(err) {
 			return ancestor, nil

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -376,7 +376,16 @@ func TestCheckStateJSON_ManagedConfigPathUnreadable(t *testing.T) {
 	if got.Status != CheckStatusWarn {
 		t.Fatalf("expected warn for unreadable managed config path, got %s: %s", got.Status, got.Detail)
 	}
-	for _, want := range []string{configPath, statErr.Error(), "inspect or repair", "gentle-ai doctor"} {
+	wants := []string{configPath, "inspect or repair", "gentle-ai doctor"}
+	if runtime.GOOS == "windows" {
+		// Windows reports a file-blocked path as not-exist, so the warn is
+		// produced by the ancestor walk naming the blocking file rather than
+		// by forwarding the final lstat error.
+		wants = append(wants, configRoot)
+	} else {
+		wants = append(wants, statErr.Error())
+	}
+	for _, want := range wants {
 		if !strings.Contains(got.Detail, want) {
 			t.Fatalf("unreadable path result missing %q: %s", want, got.Detail)
 		}

--- a/internal/cli/review_atomic_start_integration_test.go
+++ b/internal/cli/review_atomic_start_integration_test.go
@@ -109,7 +109,7 @@ func TestAtomicStartPlainRouteAlwaysCreatesCompact(t *testing.T) {
 func TestAtomicStartLinkedWorktreesAreIndependentAndReplayExactly(t *testing.T) {
 	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)
-	linked := filepath.Join(t.TempDir(), "linked")
+	linked := filepath.Join(canonicalReviewCLITempDir(t), "linked")
 	runReviewCLIGit(t, repo, "worktree", "add", "--detach", linked, "HEAD")
 	for _, root := range []string{repo, linked} {
 		if err := os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("same overlapping candidate\n"), 0o644); err != nil {
@@ -167,7 +167,7 @@ func TestAtomicStartLinkedWorktreesAreIndependentAndReplayExactly(t *testing.T) 
 func TestAtomicStartBurnRecreateAndCrossWorktreeConflictStayScoped(t *testing.T) {
 	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)
-	linked := filepath.Join(t.TempDir(), "linked")
+	linked := filepath.Join(canonicalReviewCLITempDir(t), "linked")
 	runReviewCLIGit(t, repo, "worktree", "add", "--detach", linked, "HEAD")
 	for _, root := range []string{repo, linked} {
 		writeAtomicStartDocumentationCandidate(t, root)

--- a/internal/cli/review_new_lineage_switch_test.go
+++ b/internal/cli/review_new_lineage_switch_test.go
@@ -25,6 +25,9 @@ func TestReviewStartAlwaysCreatesCompactAuthority(t *testing.T) {
 		t.Fatal(err)
 	}
 	runReviewCLIGit(t, repo, "add", "docs/atomic-start.md")
+	// Windows has no executable bit: record the fixture's 0o755 intent in the
+	// index so risk classification matches POSIX.
+	runReviewCLIGit(t, repo, "update-index", "--chmod=+x", "docs/atomic-start.md")
 
 	var out bytes.Buffer
 	if err := RunReviewFacadeStart([]string{"--cwd", repo}, &out); err != nil {

--- a/internal/cli/review_opaque_typed_cause_test.go
+++ b/internal/cli/review_opaque_typed_cause_test.go
@@ -157,7 +157,14 @@ func TestOpaqueRepositoryContextCaptureNamesDistinctCauses(t *testing.T) {
 			messages[tt.name] = message
 		})
 	}
-	assertPairwiseDistinct(t, messages, len(cases))
+	wantMessages := len(cases)
+	if runtime.GOOS == "windows" {
+		// blockCanonicalAuthorityWrite requires POSIX permissions, so Windows
+		// exercises only the occupied-slot root while retaining its
+		// distinct-cause proof.
+		wantMessages--
+	}
+	assertPairwiseDistinct(t, messages, wantMessages)
 }
 
 // TestOpaqueRepositoryContextCauseIsScrubbed is the other half of the contract:

--- a/internal/cli/review_start_contract_test.go
+++ b/internal/cli/review_start_contract_test.go
@@ -1200,6 +1200,12 @@ func writeReviewStartCandidate(t *testing.T, repo, path, contents string, mode o
 	}
 	if !tracked {
 		runReviewCLIGit(t, repo, "add", "--", path)
+		if mode&0o111 != 0 {
+			// Windows has no executable bit, so record the fixture's intent in
+			// the index: the candidate then carries the same 100755 mode git
+			// snapshots on POSIX, and risk classification stays identical.
+			runReviewCLIGit(t, repo, "update-index", "--chmod=+x", "--", path)
+		}
 	}
 }
 

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -238,12 +238,22 @@ func assertReviewGateResult(t *testing.T, payload []byte, want reviewtransaction
 	}
 }
 
-func initReviewCLIRepo(t *testing.T) string {
+// canonicalReviewCLITempDir returns t.TempDir() in its canonical spelling.
+// Production resolvers answer with the canonical form, so a fixture that keeps
+// the raw spelling compares unequal to its own repository: on the Windows
+// runners TEMP is an 8.3 short name, and on macOS /var symlinks /private/var.
+func canonicalReviewCLITempDir(t *testing.T) string {
 	t.Helper()
-	repo, err := filepath.EvalSymlinks(t.TempDir())
+	dir, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
+	return dir
+}
+
+func initReviewCLIRepo(t *testing.T) string {
+	t.Helper()
+	repo := canonicalReviewCLITempDir(t)
 	runReviewCLIGit(t, repo, "init", "-q")
 	runReviewCLIGit(t, repo, "config", "user.email", "test@example.com")
 	runReviewCLIGit(t, repo, "config", "user.name", "Test")

--- a/internal/releaseprovenance/provenance.go
+++ b/internal/releaseprovenance/provenance.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 )
 
 const (
@@ -169,6 +170,16 @@ func readReleaseConfiguration(configPath string) ([]byte, error) {
 	return config, nil
 }
 
+// manifestPerm is what a just-written 0o644 manifest reads back as. Windows
+// has no POSIX permission bits: Go projects the read-only attribute onto the
+// mode, so a writable regular file always reports 0o666 there.
+func manifestPerm() os.FileMode {
+	if runtime.GOOS == "windows" {
+		return 0o666
+	}
+	return 0o644
+}
+
 func writeManifestOnce(output string, payload []byte) error {
 	parent, err := os.Stat(filepath.Dir(output))
 	if err != nil || !parent.IsDir() {
@@ -190,7 +201,7 @@ func writeManifestOnce(output string, payload []byte) error {
 		return errors.New("release provenance output cannot be closed")
 	}
 	info, err := os.Lstat(output)
-	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0o644 {
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != manifestPerm() {
 		return errors.New("release provenance output is invalid")
 	}
 	readback, err := os.ReadFile(output)

--- a/internal/releaseprovenance/provenance_test.go
+++ b/internal/releaseprovenance/provenance_test.go
@@ -61,7 +61,7 @@ func TestWriteCreatesCanonicalFileOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	info, err := os.Lstat(output)
-	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o644 {
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != manifestPerm() {
 		t.Fatalf("output metadata = %#v, %v", info, err)
 	}
 	if err := Write(output, config, validInput()); err == nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1983

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Turns the Windows Full Suite fully green for the first time: the dispatched run on this branch's head passes 10/10 shards ([run 33282057283](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/33282057283)).
- Fixes three production portability defects the lane exposed: `releaseprovenance` validated its written manifest against `Perm() == 0o644`, which Go can never report on Windows (read-only attribute projects as `0o666`/`0o444`), so every `Write` refused its own output; pi's `unsafeBinPath` classified the same manifest differently per platform because a rooted-but-driveless bin (`"/outside"`) is not `filepath.IsAbs` on Windows; and doctor's `danglingAncestor` reported a config path blocked by a regular-file ancestor as "missing" on Windows (where the final lstat says not-exist rather than ENOTDIR) although sync cannot restore it.
- Brings the remaining tests to Windows parity under the same policy as #3888: executable-bit fixtures record their `0o755` intent in the git index (`git update-index --chmod=+x`, a no-op on POSIX) so risk classification stops collapsing to `non_executable_only` and auto-approving; linked-worktree fixtures canonicalize `t.TempDir()`; `ResolvePackageBin` expectations compare the canonical target; the opaque-cause collapse count excludes the POSIX-permission root that already skips on Windows; and the doctor assertion accepts the ancestor-walk warning Windows produces.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/releaseprovenance/provenance.go` | Readback validates against the platform's reachable permission (`manifestPerm()`) |
| `internal/releaseprovenance/provenance_test.go` | Assert the same platform-aware permission |
| `internal/agents/pi/model_routing.go` | A leading `/` in a manifest bin is an absolute claim on every platform |
| `internal/agents/pi/model_routing_test.go` | Compare the canonical resolved target |
| `internal/cli/doctor.go` | A non-directory ancestor blocks inspection/restoration instead of reading as "missing" |
| `internal/cli/doctor_test.go` | Accept the ancestor-walk warning on Windows |
| `internal/cli/review_start_contract_test.go` | `writeReviewStartCandidate` records exec-bit intent in the index |
| `internal/cli/review_new_lineage_switch_test.go` | Same exec-bit intent for its manual fixture |
| `internal/cli/review_atomic_start_integration_test.go` | Linked worktrees build on a canonical temp dir |
| `internal/cli/review_test.go` | New `canonicalReviewCLITempDir` helper; `initReviewCLIRepo` reuses it |
| `internal/cli/review_opaque_typed_cause_test.go` | Windows expects one collapse message (the POSIX-permission root skips) |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Diagnosed the failing-shard inventory, identified the production defects and parity roots, authored the fixes and test edits.

**Verification performed:** Reproduced the path-spelling class on Linux via symlinked `TMPDIR` (red before, green after); ran the affected packages and the full Linux unit suite plus `gofmtcheck`; `GOOS=windows go vet` on all touched packages; dispatched the Windows Full Suite twice on the branch — final head is 10/10 green.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — Windows portability fixes in provenance/pi/doctor plus test parity; no review-lifecycle, gate, recovery, delivery, or benchmark behavior changes on POSIX (exec-bit index recording is a no-op there).

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Manually tested locally

Windows evidence: [dispatched Windows Full Suite on this branch — 10/10 shards green](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/33282057283). Baseline on `main` at `31343151` fails 4 shards with exactly the 14 tests this PR fixes.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Production Go changes in `internal/cli` (doctor) and two other packages; none adds or changes a security/integrity/admission/repair/governance guard, so `.guard-population-baseline.txt` is untouched. The new doctor refusal is annotated `refusal:by-design world-action` because its caller already names the continuation.

#1983 also asks to fold the lane back into `ci.yml` as a required check once green. Deliberately NOT in this PR: the 2s-budget contention class was historically intermittent, so gating deserves its own change after a few stable green scheduled runs.

https://claude.ai/code/session_01Y58Ztn25s8jq3mQKgyA1x2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of absolute paths across Windows and other platforms.
  * Improved diagnostics when a missing path is blocked by a non-directory file.
  * Fixed release manifest validation on Windows.
  * Preserved executable file permissions in review snapshots and candidate changes.

* **Tests**
  * Improved cross-platform path, permission, temporary-directory, and diagnostic validation for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->