### PR TITLE
fix(skills): canonicalize relative skill-registry cwd

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -363,6 +363,12 @@ func resolveSkillRegistryDirs(cwd string) (string, string, error) {
 		if err != nil {
 			return "", "", fmt.Errorf("resolve cwd: %w", err)
 		}
+	} else if !filepath.IsAbs(cwd) {
+		var err error
+		cwd, err = filepath.Abs(cwd)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve cwd: %w", err)
+		}
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +30,50 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/update"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/update/upgrade"
 )
+
+func TestRunArgsSkillRegistryListRelativeCwdMatchesAbsoluteCwd(t *testing.T) {
+	project := t.TempDir()
+	home := t.TempDir()
+	setupMockHome(t, home)
+	t.Chdir(project)
+
+	skillPath := filepath.Join(project, "skills", "local", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("---\nname: local\ndescription: Local skill\n---\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	type skillRow struct {
+		Name  string `json:"name"`
+		Scope string `json:"scope"`
+		Path  string `json:"path"`
+	}
+	list := func(cwd string) skillRow {
+		var output bytes.Buffer
+		if err := RunArgs([]string{"skill-registry", "list", "--json", "--cwd", cwd}, &output); err != nil {
+			t.Fatalf("RunArgs(skill-registry list --cwd %s): %v", cwd, err)
+		}
+		var rows []skillRow
+		if err := json.Unmarshal(output.Bytes(), &rows); err != nil {
+			t.Fatalf("decode output for --cwd %s: %v\n%s", cwd, err, output.String())
+		}
+		if len(rows) != 1 {
+			t.Fatalf("got %d rows for --cwd %s, want 1: %s", len(rows), cwd, output.String())
+		}
+		return rows[0]
+	}
+
+	absolute := list(project)
+	relative := list(".")
+	if absolute != relative {
+		t.Fatalf("relative and absolute cwd rows differ: absolute=%+v relative=%+v", absolute, relative)
+	}
+	if absolute.Name != "local" || absolute.Scope != "project" || absolute.Path != skillPath {
+		t.Fatalf("row = %+v, want local project skill at %s", absolute, skillPath)
+	}
+}
 
 // TestListBackupsNewestFirst verifies that ListBackups returns manifests sorted
 // newest-first by CreatedAt timestamp, matching the spec "newest first" ordering.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3565

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Canonicalizes explicit relative `skill-registry --cwd` values before resolving registry entries, so `--cwd .` and an absolute cwd report the same project identity.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/app.go` | Converts non-empty relative `--cwd` values to absolute paths in skill-registry directory resolution. |
| `internal/app/app_test.go` | Adds regression coverage comparing `--cwd .` against an absolute cwd for JSON skill-registry output. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi / el Gentleman with OpenAI Codex subagents

**Material scope:** Issue triage, code navigation, implementation of the focused fix, regression test drafting, and local verification.

**Verification performed:** Focused Go tests and formatting checks listed below. Human review is still required before merge.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/app -run TestRunArgsSkillRegistryListRelativeCwdMatchesAbsoluteCwd -count=1
go test ./internal/app -run 'TestRunArgsSkillRegistryListRelativeCwdMatchesAbsoluteCwd|TestSkillRegistry' -count=1
go test ./internal/skillregistry -run TestListReturnsDedupedEntriesWithoutWriting -count=1
```

**Go Format**
```bash
git diff --check
gofmt -d internal/app/app.go internal/app/app_test.go
```

**E2E Tests** (Docker required)
```bash
# Not run, focused CLI app-level regression only.
```

**Benchmark Validation**

N/A, this change only affects skill-registry cwd normalization and does not touch benchmark, review-lifecycle, gate, recovery, delivery, corpus, classifier, or measured product-behavior surfaces.

- [x] Unit tests pass (`go test ./internal/app ...`, `go test ./internal/skillregistry ...`)
- [x] Go format passes (`git diff --check`, `gofmt -d ...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./internal/app ...`, `go test ./internal/skillregistry ...`)
- [x] Go format passes (`git diff --check`, `gofmt -d ...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

RDD was intentionally not used for this small fix because the local checkout has an unrelated malformed compact-v2 review authority entry (`review-d929caa624ff71c2`) that blocks new review transactions before START. No RDD lineage was created for this candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project-scoped skill registry listings to behave consistently when using relative or absolute working-directory paths.
  * Relative paths are now resolved correctly, ensuring accurate skill names, scopes, and locations in JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->