### PR TITLE
fix(hooks): use powershell-safe claude skill hook

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
@@ -1801,7 +1802,7 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 		return false, err
 	}
 
-	const command = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" || true`
+	command := claudeSkillRegistryHookCommand(runtime.GOOS)
 	if claudeHookExists(root, command) {
 		return false, nil
 	}
@@ -1841,6 +1842,13 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 		return false, err
 	}
 	return wr.Changed, nil
+}
+
+func claudeSkillRegistryHookCommand(goos string) string {
+	if goos == "windows" {
+		return `if ($env:CLAUDE_PROJECT_DIR) { $d = $env:CLAUDE_PROJECT_DIR } else { $d = $PWD }; gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$d"; exit 0`
+	}
+	return `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" || true`
 }
 
 func claudeHookExists(root map[string]any, command string) bool {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1803,9 +1803,6 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	}
 
 	command := claudeSkillRegistryHookCommand(runtime.GOOS)
-	if claudeHookExists(root, command) {
-		return false, nil
-	}
 
 	hooksRaw, hasHooks := root["hooks"]
 	hooksMap, _ := hooksRaw.(map[string]any)
@@ -1814,6 +1811,22 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	}
 	if hooksMap == nil {
 		hooksMap = map[string]any{}
+	}
+	if found, changed := reconcileClaudeSkillRegistryHook(hooksMap, command); found {
+		if !changed {
+			return false, nil
+		}
+		root["hooks"] = hooksMap
+		out, err := json.MarshalIndent(root, "", "  ")
+		if err != nil {
+			return false, err
+		}
+		out = append(out, '\n')
+		wr, err := filemerge.WriteFileAtomic(settingsPath, out, 0o644)
+		if err != nil {
+			return false, err
+		}
+		return wr.Changed, nil
 	}
 	promptRaw, hasUserPromptSubmit := hooksMap["UserPromptSubmit"]
 	userPromptSubmit, _ := promptRaw.([]any)
@@ -1844,11 +1857,55 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	return wr.Changed, nil
 }
 
+const (
+	claudeSkillRegistryHookCommandPOSIX   = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" || true`
+	claudeSkillRegistryHookCommandWindows = `if ($env:CLAUDE_PROJECT_DIR) { $d = $env:CLAUDE_PROJECT_DIR } else { $d = $PWD }; gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$d"; exit 0`
+)
+
 func claudeSkillRegistryHookCommand(goos string) string {
 	if goos == "windows" {
-		return `if ($env:CLAUDE_PROJECT_DIR) { $d = $env:CLAUDE_PROJECT_DIR } else { $d = $PWD }; gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$d"; exit 0`
+		return claudeSkillRegistryHookCommandWindows
 	}
-	return `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" || true`
+	return claudeSkillRegistryHookCommandPOSIX
+}
+
+func reconcileClaudeSkillRegistryHook(hooksMap map[string]any, command string) (bool, bool) {
+	managed := map[string]bool{
+		claudeSkillRegistryHookCommandPOSIX:   true,
+		claudeSkillRegistryHookCommandWindows: true,
+	}
+	for _, key := range []string{"UserPromptSubmit", "SessionStart"} {
+		hookEntries, ok := hooksMap[key].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range hookEntries {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			hooks, ok := itemMap["hooks"].([]any)
+			if !ok {
+				continue
+			}
+			for _, hook := range hooks {
+				hookMap, ok := hook.(map[string]any)
+				if !ok {
+					continue
+				}
+				existing, _ := hookMap["command"].(string)
+				if !managed[existing] {
+					continue
+				}
+				if existing == command {
+					return true, false
+				}
+				hookMap["command"] = command
+				return true, true
+			}
+		}
+	}
+	return false, false
 }
 
 func claudeHookExists(root map[string]any, command string) bool {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1822,8 +1822,12 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 			return false, err
 		}
 		out = append(out, '\n')
+		previous, readErr := os.ReadFile(settingsPath)
 		wr, err := filemerge.WriteFileAtomic(settingsPath, out, 0o644)
 		if err != nil {
+			if readErr == nil {
+				_ = os.WriteFile(settingsPath, previous, 0o644)
+			}
 			return false, err
 		}
 		return wr.Changed, nil
@@ -1874,6 +1878,9 @@ func reconcileClaudeSkillRegistryHook(hooksMap map[string]any, command string) (
 		claudeSkillRegistryHookCommandPOSIX:   true,
 		claudeSkillRegistryHookCommandWindows: true,
 	}
+	found := false
+	changed := false
+	kept := false
 	for _, key := range []string{"UserPromptSubmit", "SessionStart"} {
 		hookEntries, ok := hooksMap[key].([]any)
 		if !ok {
@@ -1888,24 +1895,36 @@ func reconcileClaudeSkillRegistryHook(hooksMap map[string]any, command string) (
 			if !ok {
 				continue
 			}
+			reconciledHooks := hooks[:0]
 			for _, hook := range hooks {
 				hookMap, ok := hook.(map[string]any)
 				if !ok {
+					reconciledHooks = append(reconciledHooks, hook)
 					continue
 				}
 				existing, _ := hookMap["command"].(string)
 				if !managed[existing] {
+					reconciledHooks = append(reconciledHooks, hook)
 					continue
 				}
-				if existing == command {
-					return true, false
+				found = true
+				if !kept {
+					if existing != command {
+						hookMap["command"] = command
+						changed = true
+					}
+					reconciledHooks = append(reconciledHooks, hookMap)
+					kept = true
+					continue
 				}
-				hookMap["command"] = command
-				return true, true
+				changed = true
+			}
+			if len(reconciledHooks) != len(hooks) {
+				itemMap["hooks"] = reconciledHooks
 			}
 		}
 	}
-	return false, false
+	return found, changed
 }
 
 func claudeHookExists(root map[string]any, command string) bool {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6978,6 +6978,56 @@ func TestClaudeSkillRegistryHookCommandUsesPowerShellSafeWindowsSyntax(t *testin
 	}
 }
 
+func TestEnsureClaudeSkillRegistryHookReplacesLegacyManagedCommand(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := fmt.Sprintf(`{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": %q}
+        ]
+      }
+    ]
+  }
+}`, claudeSkillRegistryHookCommandPOSIX)
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := ensureClaudeSkillRegistryHook(settingsPath)
+	if err != nil {
+		t.Fatalf("ensureClaudeSkillRegistryHook() error = %v", err)
+	}
+	if runtime.GOOS == "windows" && !changed {
+		t.Fatal("Windows migration changed = false, want true")
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Count(text, "gentle-ai skill-registry refresh") != 1 {
+		t.Fatalf("managed hook count mismatch after migration:\n%s", text)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("decode migrated settings: %v", err)
+	}
+	if !claudeHookExists(root, claudeSkillRegistryHookCommand(runtime.GOOS)) {
+		t.Fatalf("managed hook was not migrated to current command:\n%s", text)
+	}
+	if runtime.GOOS == "windows" && claudeHookExists(root, claudeSkillRegistryHookCommandPOSIX) {
+		t.Fatalf("legacy POSIX hook survived Windows migration:\n%s", text)
+	}
+}
+
 func TestEnsureClaudeSkillRegistryHookAppendsIdempotently(t *testing.T) {
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".claude", "settings.json")

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -6975,6 +6976,35 @@ func TestClaudeSkillRegistryHookCommandUsesPowerShellSafeWindowsSyntax(t *testin
 	posix := claudeSkillRegistryHookCommand("linux")
 	if !strings.Contains(posix, `${CLAUDE_PROJECT_DIR:-$PWD}`) || !strings.Contains(posix, `|| true`) {
 		t.Fatalf("POSIX hook command lost existing fallback/error suppression syntax: %s", posix)
+	}
+}
+
+func TestReconcileClaudeSkillRegistryHookRemovesDuplicateManagedCommands(t *testing.T) {
+	hooksMap := map[string]any{
+		"UserPromptSubmit": []any{
+			map[string]any{"matcher": "", "hooks": []any{
+				map[string]any{"type": "command", "command": claudeSkillRegistryHookCommandWindows},
+				map[string]any{"type": "command", "command": claudeSkillRegistryHookCommandPOSIX},
+				map[string]any{"type": "command", "command": "echo keep"},
+			}},
+		},
+	}
+
+	found, changed := reconcileClaudeSkillRegistryHook(hooksMap, claudeSkillRegistryHookCommandWindows)
+	if !found || !changed {
+		t.Fatalf("reconcile found=%v changed=%v, want true true", found, changed)
+	}
+	entries := hooksMap["UserPromptSubmit"].([]any)
+	hooks := entries[0].(map[string]any)["hooks"].([]any)
+	commands := []string{}
+	for _, hook := range hooks {
+		commands = append(commands, hook.(map[string]any)["command"].(string))
+	}
+	if strings.Count(strings.Join(commands, "\n"), "gentle-ai skill-registry refresh") != 1 {
+		t.Fatalf("managed hook was not deduped: %#v", commands)
+	}
+	if !slices.Contains(commands, claudeSkillRegistryHookCommandWindows) || !slices.Contains(commands, "echo keep") {
+		t.Fatalf("reconcile commands = %#v", commands)
 	}
 }
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -6958,6 +6959,25 @@ func TestInjectClaudeSubAgentsScopedTools(t *testing.T) {
 	}
 }
 
+func TestClaudeSkillRegistryHookCommandUsesPowerShellSafeWindowsSyntax(t *testing.T) {
+	windows := claudeSkillRegistryHookCommand("windows")
+	for _, forbidden := range []string{`${CLAUDE_PROJECT_DIR:-$PWD}`, `|| true`} {
+		if strings.Contains(windows, forbidden) {
+			t.Fatalf("Windows hook command contains PowerShell 5.1-incompatible syntax %q: %s", forbidden, windows)
+		}
+	}
+	for _, want := range []string{`$env:CLAUDE_PROJECT_DIR`, `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd`, `exit 0`} {
+		if !strings.Contains(windows, want) {
+			t.Fatalf("Windows hook command missing %q: %s", want, windows)
+		}
+	}
+
+	posix := claudeSkillRegistryHookCommand("linux")
+	if !strings.Contains(posix, `${CLAUDE_PROJECT_DIR:-$PWD}`) || !strings.Contains(posix, `|| true`) {
+		t.Fatalf("POSIX hook command lost existing fallback/error suppression syntax: %s", posix)
+	}
+}
+
 func TestEnsureClaudeSkillRegistryHookAppendsIdempotently(t *testing.T) {
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
@@ -7010,6 +7030,14 @@ func TestEnsureClaudeSkillRegistryHookAppendsIdempotently(t *testing.T) {
 	text := string(data)
 	if strings.Count(text, "gentle-ai skill-registry refresh") != 1 {
 		t.Fatalf("hook command count mismatch:\n%s", text)
+	}
+	if runtime.GOOS == "windows" {
+		if strings.Contains(text, `|| true`) || strings.Contains(text, `${CLAUDE_PROJECT_DIR:-$PWD}`) {
+			t.Fatalf("Windows hook contains PowerShell 5.1-incompatible syntax:\n%s", text)
+		}
+		if !strings.Contains(text, `$env:CLAUDE_PROJECT_DIR`) {
+			t.Fatalf("Windows hook missing PowerShell environment fallback:\n%s", text)
+		}
 	}
 	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo existing") {
 		t.Fatalf("existing hooks not preserved:\n%s", text)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2124

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Generates a PowerShell 5.1-safe Claude `UserPromptSubmit` skill-registry refresh hook on Windows, while preserving the existing POSIX hook command on non-Windows platforms.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/inject.go` | Selects the Claude skill-registry hook command by target OS, using PowerShell-compatible environment fallback and `exit 0` on Windows. |
| `internal/components/sdd/inject_test.go` | Adds regression coverage for the Windows hook syntax and preserves existing POSIX command behavior. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi / el Gentleman with OpenAI Codex subagents

**Material scope:** Issue triage, code navigation, implementation of the focused fix, regression test drafting, and local verification.

**Verification performed:** Focused Go tests and formatting checks listed below. Human review is still required before merge.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/sdd -run 'TestClaudeSkillRegistryHookCommandUsesPowerShellSafeWindowsSyntax|TestEnsureClaudeSkillRegistryHookAppendsIdempotently' -count=1
go test ./internal/components/uninstall -count=1
```

Attempted broader package validation:

```bash
go test ./internal/components/sdd ./internal/components/uninstall -count=1
```

This timed out locally after 240s before producing a failure. The focused SDD regression and uninstall package passed separately.

**Go Format**
```bash
git diff --check
gofmt -w internal/components/sdd/inject.go internal/components/sdd/inject_test.go
```

**E2E Tests** (Docker required)
```bash
# Not run, focused hook-generation regression only.
```

**Benchmark Validation**

N/A, this change only affects Claude hook command generation and does not touch benchmark, review-lifecycle, gate, recovery, delivery, corpus, classifier, or measured product-behavior surfaces.

- [x] Unit tests pass (focused commands above)
- [x] Go format passes (`git diff --check`, `gofmt`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (focused commands above)
- [x] Go format passes (`git diff --check`, `gofmt`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

RDD was not used because this local checkout still has an unrelated malformed compact-v2 review authority entry that blocks new review transactions before START. No RDD lineage was created for this candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude skill-registry hook installation on Windows with PowerShell-compatible commands.
  * Windows hooks now correctly resolve the project directory and exit cleanly.
  * Existing managed hooks are updated when their command needs refreshing.
  * Existing behavior remains unchanged on non-Windows platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->