### PR TITLE
test(bench): execute provider-issued START continuation

### DIFF
--- a/bench/journeys_atomic_review_test.go
+++ b/bench/journeys_atomic_review_test.go
@@ -7,6 +7,23 @@ import (
 	"testing"
 )
 
+func TestDecodeAtomicStartContinuationIgnoresStringProjection(t *testing.T) {
+	observation := Observation{Stdout: `{"action":"created","lineage_id":"atomic-four-lens-correction","state":"reviewing","projection":"compact","next_transition":{"kind":"execute","reason_code":"start_completed","execute":{"operation":"review.status","command":"gentle-ai review status --next-transition --token=abc","arguments":[{"name":"cwd","value":"/repo","token":"abc"}]}}}`}
+
+	continuation, err := decodeAtomicStartContinuation(observation)
+	if err != nil {
+		t.Fatalf("decode START continuation: %v", err)
+	}
+	if continuation.NextTransition.Kind != "execute" || continuation.NextTransition.Execute.Operation != "review.status" ||
+		continuation.NextTransition.Execute.Command == "" || len(continuation.NextTransition.Execute.Arguments) != 1 {
+		t.Fatalf("continuation = %+v, want provider-issued review.status transition", continuation.NextTransition)
+	}
+	argument := continuation.NextTransition.Execute.Arguments[0]
+	if argument.Name != "cwd" || argument.Value != "/repo" || argument.Token != "abc" {
+		t.Fatalf("continuation argument = %+v, want ordered token argument", argument)
+	}
+}
+
 func TestCorpusJourneysDeclareReviewMode(t *testing.T) {
 	for _, journey := range allDeclaredJourneys() {
 		if journey.Review != reviewOptedIn && journey.Review != reviewUntouched {
@@ -167,6 +184,40 @@ func TestCurrentTerminalJourneysRequireAcknowledgementBeforeBurn(t *testing.T) {
 		}
 		if !strings.Contains(declaration, "acknowledgement") {
 			t.Errorf("terminal journey %q omits the pending acknowledgement continuation: %s", id, declaration)
+		}
+	}
+}
+
+func TestJ60UsesProviderIssuedStartContinuation(t *testing.T) {
+	var journey *Journey
+	for _, candidate := range Journeys() {
+		if candidate.ID == "j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow" {
+			copy := candidate
+			journey = &copy
+			break
+		}
+	}
+	if journey == nil {
+		t.Fatal("j60 must remain registered")
+	}
+	var startStep *Step
+	for index := range journey.Steps {
+		step := &journey.Steps[index]
+		if strings.Contains(strings.ToLower(step.Name), "start") {
+			startStep = step
+			break
+		}
+	}
+	if startStep == nil || startStep.Composite == nil || startStep.Args != nil {
+		t.Fatal("j60 START/continuation must be one Composite, not direct Args")
+	}
+	declaration := strings.ToLower(journey.Source + " " + journey.Title)
+	for _, step := range journey.Steps {
+		declaration += " " + strings.ToLower(step.Name)
+	}
+	for _, phrase := range []string{"#2423", "#3914", "provider-issued", "review.status", "ordered", "token"} {
+		if !strings.Contains(declaration, strings.ToLower(phrase)) {
+			t.Fatalf("j60 declaration must name %q: %s", phrase, declaration)
 		}
 	}
 }

--- a/bench/journeys_wave3.go
+++ b/bench/journeys_wave3.go
@@ -94,6 +94,32 @@ func decodeAtomicReviewStart(observation Observation, wantLineage string) (atomi
 	return started, nil
 }
 
+// decodeAtomicStartContinuation extracts only START's transition. START and
+// STATUS use different projection shapes, so decoding the whole START into a
+// statusEnvelope would reject an otherwise valid provider-issued continuation.
+func decodeAtomicStartContinuation(observation Observation) (statusEnvelope, error) {
+	var start struct {
+		NextTransition json.RawMessage `json:"next_transition"`
+	}
+	if err := json.Unmarshal([]byte(observation.Stdout), &start); err != nil {
+		return statusEnvelope{}, fmt.Errorf("parse successful START continuation: %w", err)
+	}
+	if len(start.NextTransition) == 0 || string(start.NextTransition) == "null" {
+		return statusEnvelope{}, fmt.Errorf("parse successful START continuation: missing next_transition")
+	}
+	wrapped, err := json.Marshal(struct {
+		NextTransition json.RawMessage `json:"next_transition"`
+	}{NextTransition: start.NextTransition})
+	if err != nil {
+		return statusEnvelope{}, fmt.Errorf("wrap successful START continuation: %w", err)
+	}
+	var continuation statusEnvelope
+	if err := json.Unmarshal(wrapped, &continuation); err != nil {
+		return statusEnvelope{}, fmt.Errorf("parse successful START continuation: %w", err)
+	}
+	return continuation, nil
+}
+
 // resolveAtomicStartConsentAt executes the granted invocation emitted by the
 // product only after the exact rendered START has returned its consent envelope.
 // The benchmark never substitutes --consent itself or hand-assembles a START.
@@ -209,6 +235,10 @@ func requireExplicitAtomicFourLensStatus(r *journeyRun) error {
 	if err != nil {
 		return err
 	}
+	return requireExplicitAtomicFourLensStatusEnvelope(status)
+}
+
+func requireExplicitAtomicFourLensStatusEnvelope(status statusEnvelope) error {
 	if status.Authority.LineageID != atomicCorrectionLineage || status.Authority.State != "reviewing" ||
 		status.NextTransition.Kind != "collect" || status.NextTransition.ReasonCode != "reviewer_results_required" ||
 		len(status.NextTransition.Collect.Inputs) != 4 {
@@ -610,6 +640,58 @@ func captureAtomicCorrectableFinding(r *journeyRun) error {
 	return captureAtomicReviewerSlots(r, atomicCorrectionLineage, true)
 }
 
+func startAndContinueAtomicCorrection(r *journeyRun) error {
+	status, err := readAtomicReviewStatus(r, atomicCorrectionLineage)
+	if err != nil {
+		return err
+	}
+	if status.NextTransition.Kind != "execute" || status.NextTransition.Execute.Operation != "review.start" ||
+		status.executeArgument("lineage") != atomicCorrectionLineage || status.NextTransition.Execute.Command == "" {
+		return fmt.Errorf("negotiated v2 STATUS = %+v, want a runnable START bound to %q", status.NextTransition, atomicCorrectionLineage)
+	}
+	for index, argument := range status.NextTransition.Execute.Arguments {
+		if argument.Name == "" || argument.Value == "" || argument.Token == "" {
+			return fmt.Errorf("START argument %d = %+v, want non-empty value and token", index, argument)
+		}
+	}
+	started, err := runPrintedTransition(r, status)
+	if err != nil {
+		return err
+	}
+	started, err = resolveAtomicStartConsentAt(r, r.sandbox.Repo, status, started)
+	if err != nil {
+		return err
+	}
+	if _, err := decodeAtomicReviewStart(started, atomicCorrectionLineage); err != nil {
+		return err
+	}
+	continuation, err := decodeAtomicStartContinuation(started)
+	if err != nil {
+		return err
+	}
+	if continuation.NextTransition.Kind != "execute" || continuation.NextTransition.Execute.Operation != "review.status" ||
+		continuation.NextTransition.Execute.Command == "" || len(continuation.NextTransition.Execute.Arguments) == 0 {
+		return fmt.Errorf("successful START continuation = %+v, want provider-issued review.status", continuation.NextTransition)
+	}
+	for index, argument := range continuation.NextTransition.Execute.Arguments {
+		if argument.Name == "" || argument.Value == "" || argument.Token == "" {
+			return fmt.Errorf("provider-issued STATUS argument %d = %+v, want ordered non-empty value and token", index, argument)
+		}
+	}
+	statusObservation, err := runPrintedTransition(r, continuation)
+	if err != nil {
+		return err
+	}
+	if statusObservation.ExitCode != 0 {
+		return fmt.Errorf("provider-issued STATUS exited %d: %s", statusObservation.ExitCode, firstLine(statusObservation.Stderr))
+	}
+	var returned statusEnvelope
+	if err := json.Unmarshal([]byte(statusObservation.Stdout), &returned); err != nil {
+		return fmt.Errorf("parse provider-issued STATUS: %w", err)
+	}
+	return requireExplicitAtomicFourLensStatusEnvelope(returned)
+}
+
 func waveThreeJourneys() []Journey {
 	return []Journey{
 		{
@@ -626,13 +708,12 @@ func waveThreeJourneys() []Journey {
 		{
 			ID:     "j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow",
 			Review: reviewOptedIn,
-			Title:  "#3587: explicit active lineage keeps its exact four lenses through correction and validator flow",
-			Source: "#3587: active compact authority continues only through its bound four-lens correction plan and terminal validator capture",
+			Title:  "#3587/#2423/#3914: explicit active lineage executes provider-issued post-START STATUS before its four lenses, correction, and validator flow",
+			Source: "#3587/#2423/#3914: negotiated v2 STATUS binds START, consent, and the provider-issued ordered-token review.status continuation",
 			Steps: []Step{
 				{Name: "fixture: repository", Fixture: baseRepo},
 				{Name: "fixture: high-risk correction candidate", Fixture: stageAtomicHighRiskCorrectionCandidate},
-				{Name: "START the compact high-risk transaction", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", atomicCorrectionLineage)},
-				{Name: "explicit active STATUS exposes exactly four compact lenses", Requires: atomicReviewStatusCapability, Composite: requireExplicitAtomicFourLensStatus},
+				{Name: "execute provider-issued START then ordered-token review.status continuation and apply the four-lens assertion", Requires: atomicReviewStatusCapability, Composite: startAndContinueAtomicCorrection},
 				{Name: "capture a correction finding and every remaining compact lens", Requires: captureResultCapability, Composite: captureAtomicCorrectableFinding},
 				{Name: "capture the status-bound bounded correction plan", Requires: captureCorrectionPlanCapability, Composite: func(r *journeyRun) error {
 					return captureCorrectionPlanFor(r, atomicCorrectionLineage, 2)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2423

This is the narrow executable restart-continuation slice requested in the maintainer review, rebased after #3894 was fixed by #3914.

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Replaces the retired j90 declaration-only proof with executable coverage in its registered replacement, j60.
- Executes the exact provider-issued post-START `review.status` continuation added by #3914.
- Preserves j60's existing four-lens correction, validator, and terminal acknowledgement flow.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `bench/journeys_wave3.go` | Negotiates and executes the printed START, resolves provider-issued consent, decodes only `next_transition`, executes its exact ordered-token STATUS command, and applies the existing four-lens assertions to the returned envelope. |
| `bench/journeys_atomic_review_test.go` | Proves j60 remains registered, uses the composite continuation flow, and accepts START's string projection while decoding the transition. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi / el Gentleman with OpenAI Codex subagents and OpenCode review fallback

**Material scope:** Maintainer-feedback analysis, current-main journey mapping, TDD implementation, driven benchmark diagnosis, and verification.

**Verification performed:** Focused Go tests, `go vet`, compile validation, diff checks, and a locally built driven j60 run. Human review is still required before merge.

---

## 🧪 Test Plan

**Focused declaration and decoder tests**
```bash
cd bench
go test ./... -run '^(TestDecodeAtomicStartContinuationIgnoresStringProjection|TestJ60UsesProviderIssuedStartContinuation|TestAtomicReviewJourneysRatifyAcknowledgementContract)$' -count=1
```

**Benchmark module validation**
```bash
cd bench
go build -o <temp>/gentle-ai-bench .
go vet ./...
```

**Driven benchmark proof**
```bash
go build -trimpath -o <temp>/gentle-ai ./cmd/gentle-ai
<temp>/gentle-ai-bench run \
  --binary <temp>/gentle-ai \
  --only j60-explicit-active-lineage-keeps-four-lens-correction-and-validator-flow \
  --out <temp>/bench-j60.json
```

Result:
```text
journeys: 1 completed, 0 unsupported, 0 failed
```

- [x] Focused unit tests pass
- [x] `go vet ./...` passes in `bench/`
- [x] Driven j60 execution passes
- [x] `git diff --check` passes
- [ ] Full Linux CI passes

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Maintainer has applied the appropriate `type:*` label
- [x] Focused tests pass
- [x] Benchmark validation completed in driven mode
- [x] Commit follows Conventional Commits
- [x] No `Co-Authored-By` trailers
- [x] I understand, reviewed, and take responsibility for the complete submission

---

## 💬 Notes for Reviewers

Current main explicitly retires j90 and maps it to j60. This revision therefore does not revive j90's obsolete durable-receipt semantics. It places the executable #2423/#3914 continuation proof in the active j60 flow and runs the exact provider-issued command rather than reconstructing STATUS flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded journey coverage for atomic review corrections and continuation handling.
  * Added validation that provider-issued continuations preserve ordered token arguments and execute the expected review status transition.
  * Updated the J60 journey to verify the complete four-lens correction and validator flow through a composite start-and-continue sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->