### PR TITLE
feat(installcmd): avoid sudo for android installs

### DIFF
--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/installcommands"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -72,7 +73,7 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 // advises "latest" rather than a pin: a human reads and runs this, and a
 // hardcoded version goes stale the moment a newer Codex ships.
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	return system.NpmInstallCommands(profile, "@openai/codex@latest"), nil
+	return installcommands.NpmInstallCommands(profile, "@openai/codex@latest"), nil
 }
 
 // --- Config paths ---

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -72,11 +72,7 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 // advises "latest" rather than a pin: a human reads and runs this, and a
 // hardcoded version goes stale the moment a newer Codex ships.
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	const pkg = "@openai/codex@latest"
-	if profile.OS == "linux" && !profile.NpmWritable {
-		return [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}, nil
-	}
-	return [][]string{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
+	return system.NpmInstallCommands(profile, "@openai/codex@latest"), nil
 }
 
 // --- Config paths ---

--- a/internal/agents/gemini/adapter.go
+++ b/internal/agents/gemini/adapter.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/installcommands"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -72,7 +73,7 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 // advises "latest" rather than a pin: a human reads and runs this, and a
 // hardcoded version goes stale the moment a newer Gemini CLI ships.
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	return system.NpmInstallCommands(profile, "@google/gemini-cli@latest"), nil
+	return installcommands.NpmInstallCommands(profile, "@google/gemini-cli@latest"), nil
 }
 
 // --- Config paths ---

--- a/internal/agents/gemini/adapter.go
+++ b/internal/agents/gemini/adapter.go
@@ -72,11 +72,7 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 // advises "latest" rather than a pin: a human reads and runs this, and a
 // hardcoded version goes stale the moment a newer Gemini CLI ships.
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	const pkg = "@google/gemini-cli@latest"
-	if profile.OS == "linux" && !profile.NpmWritable {
-		return [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}, nil
-	}
-	return [][]string{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
+	return system.NpmInstallCommands(profile, "@google/gemini-cli@latest"), nil
 }
 
 // --- Config paths ---

--- a/internal/agents/qwen/adapter.go
+++ b/internal/agents/qwen/adapter.go
@@ -76,11 +76,7 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 // advises "latest" rather than a pin: a human reads and runs this, and a
 // hardcoded version goes stale the moment a newer Qwen Code ships.
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	const pkg = "@qwen-code/qwen-code@latest"
-	if profile.OS == "linux" && !profile.NpmWritable {
-		return [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}, nil
-	}
-	return [][]string{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
+	return system.NpmInstallCommands(profile, "@qwen-code/qwen-code@latest"), nil
 }
 
 // --- Config paths ---

--- a/internal/agents/qwen/adapter.go
+++ b/internal/agents/qwen/adapter.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/installcommands"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -76,7 +77,7 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 // advises "latest" rather than a pin: a human reads and runs this, and a
 // hardcoded version goes stale the moment a newer Qwen Code ships.
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	return system.NpmInstallCommands(profile, "@qwen-code/qwen-code@latest"), nil
+	return installcommands.NpmInstallCommands(profile, "@qwen-code/qwen-code@latest"), nil
 }
 
 // --- Config paths ---

--- a/internal/components/installcommands/npm.go
+++ b/internal/components/installcommands/npm.go
@@ -1,0 +1,13 @@
+package installcommands
+
+import "github.com/gentleman-programming/gentle-ai/v2/internal/system"
+
+// NpmInstallCommands returns the display-only command for a global npm install.
+// Android/Termux has no sudo privilege path, regardless of its package manager.
+func NpmInstallCommands(profile system.PlatformProfile, packageName string) [][]string {
+	commands := [][]string{{"npm", "install", "-g", "--ignore-scripts", packageName}}
+	if profile.OS == "linux" && !profile.NpmWritable {
+		commands[0] = append([]string{"sudo"}, commands[0]...)
+	}
+	return commands
+}

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -66,11 +66,7 @@ func (profileResolver) ResolveAgentInstall(profile system.PlatformProfile, agent
 // hardcoded version goes wrong the moment a newer release ships (the same
 // drift this shape fixed for Codex's GPT-5.6 update advice).
 func resolveClaudeCodeInstall(profile system.PlatformProfile) CommandSequence {
-	const pkg = "@anthropic-ai/claude-code@latest"
-	if profile.OS == "linux" && !profile.NpmWritable {
-		return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}
-	}
-	return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}
+	return system.NpmInstallCommands(profile, "@anthropic-ai/claude-code@latest")
 }
 
 // resolveKilocodeInstall returns the npm install command sequence gentle-ai
@@ -78,11 +74,7 @@ func resolveClaudeCodeInstall(profile system.PlatformProfile) CommandSequence {
 // Linux with system npm, sudo is required. With nvm/fnm/volta, it is not.
 // On Windows and macOS, sudo is never needed.
 func resolveKilocodeInstall(profile system.PlatformProfile) CommandSequence {
-	const pkg = "@kilocode/cli@latest"
-	if profile.OS == "linux" && !profile.NpmWritable {
-		return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}
-	}
-	return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}
+	return system.NpmInstallCommands(profile, "@kilocode/cli@latest")
 }
 
 // resolveKimiInstall returns the official Kimi install command sequence.
@@ -177,6 +169,9 @@ func validateKimiInstallPreflight(profile system.PlatformProfile) error {
 }
 
 func uvInstallHint(profile system.PlatformProfile) string {
+	if profile.OS == "android" {
+		return "apt-get install -y uv"
+	}
 	switch profile.PackageManager {
 	case "brew":
 		return "brew install uv"
@@ -209,17 +204,18 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 		return nil, fmt.Errorf("dependency name is required")
 	}
 
+	var commands CommandSequence
 	switch profile.PackageManager {
 	case "brew":
-		return CommandSequence{{"brew", "install", dependency}}, nil
+		commands = CommandSequence{{"brew", "install", dependency}}
 	case "apt":
-		return CommandSequence{{"sudo", "apt-get", "install", "-y", dependency}}, nil
+		commands = CommandSequence{{"sudo", "apt-get", "install", "-y", dependency}}
 	case "pacman":
-		return CommandSequence{{"sudo", "pacman", "-S", "--noconfirm", dependency}}, nil
+		commands = CommandSequence{{"sudo", "pacman", "-S", "--noconfirm", dependency}}
 	case "dnf":
-		return CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}, nil
+		commands = CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}
 	case "winget":
-		return CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}, nil
+		commands = CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}
 	default:
 		return nil, fmt.Errorf(
 			"unsupported package manager %q for os=%q distro=%q",
@@ -228,6 +224,14 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 			profile.LinuxDistro,
 		)
 	}
+	if profile.OS == "android" {
+		for i, command := range commands {
+			if len(command) > 0 && command[0] == "sudo" {
+				commands[i] = command[1:]
+			}
+		}
+	}
+	return commands, nil
 }
 
 // resolveOpenCodeInstall returns the display-only install command sequence
@@ -261,11 +265,8 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		// re-enumerating managers would silently narrow the probe's list
 		// (issue #2499). The gate keeps a probe-rejected Linux profile
 		// (empty PackageManager) on the unsupported arm.
-		if profile.OS == "linux" && profile.PackageManager != "" {
-			if profile.NpmWritable {
-				return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
-			}
-			return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}, nil
+		if (profile.OS == "linux" || profile.OS == "android") && profile.PackageManager != "" {
+			return system.NpmInstallCommands(profile, pkg), nil
 		}
 		return nil, fmt.Errorf(
 			"unsupported platform for opencode: os=%q distro=%q pm=%q",

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/installcommands"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/versions"
@@ -66,7 +67,7 @@ func (profileResolver) ResolveAgentInstall(profile system.PlatformProfile, agent
 // hardcoded version goes wrong the moment a newer release ships (the same
 // drift this shape fixed for Codex's GPT-5.6 update advice).
 func resolveClaudeCodeInstall(profile system.PlatformProfile) CommandSequence {
-	return system.NpmInstallCommands(profile, "@anthropic-ai/claude-code@latest")
+	return installcommands.NpmInstallCommands(profile, "@anthropic-ai/claude-code@latest")
 }
 
 // resolveKilocodeInstall returns the npm install command sequence gentle-ai
@@ -74,7 +75,7 @@ func resolveClaudeCodeInstall(profile system.PlatformProfile) CommandSequence {
 // Linux with system npm, sudo is required. With nvm/fnm/volta, it is not.
 // On Windows and macOS, sudo is never needed.
 func resolveKilocodeInstall(profile system.PlatformProfile) CommandSequence {
-	return system.NpmInstallCommands(profile, "@kilocode/cli@latest")
+	return installcommands.NpmInstallCommands(profile, "@kilocode/cli@latest")
 }
 
 // resolveKimiInstall returns the official Kimi install command sequence.
@@ -266,7 +267,7 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		// (issue #2499). The gate keeps a probe-rejected Linux profile
 		// (empty PackageManager) on the unsupported arm.
 		if (profile.OS == "linux" || profile.OS == "android") && profile.PackageManager != "" {
-			return system.NpmInstallCommands(profile, pkg), nil
+			return installcommands.NpmInstallCommands(profile, pkg), nil
 		}
 		return nil, fmt.Errorf(
 			"unsupported platform for opencode: os=%q distro=%q pm=%q",

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -168,6 +168,12 @@ func TestResolveDependencyInstall(t *testing.T) {
 			want:    CommandSequence{{"sudo", "apt-get", "install", "-y", "somepkg"}},
 		},
 		{
+			name:    "android termux resolves apt command without sudo",
+			profile: system.PlatformProfile{OS: "android", PackageManager: "apt"},
+			dep:     "somepkg",
+			want:    CommandSequence{{"apt-get", "install", "-y", "somepkg"}},
+		},
+		{
 			name:    "arch resolves pacman command",
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroArch, PackageManager: "pacman"},
 			dep:     "somepkg",
@@ -297,6 +303,12 @@ func TestResolveAgentInstall(t *testing.T) {
 		{
 			name:    "claude-code on darwin uses npm without sudo",
 			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			agent:   model.AgentClaudeCode,
+			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "@anthropic-ai/claude-code@latest"}},
+		},
+		{
+			name:    "claude-code on android never uses sudo",
+			profile: system.PlatformProfile{OS: "android", PackageManager: "apt"},
 			agent:   model.AgentClaudeCode,
 			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "@anthropic-ai/claude-code@latest"}},
 		},

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -99,15 +99,34 @@ func Detect(ctx context.Context) (DetectionResult, error) {
 	return result, nil
 }
 
-// detectNpmWritable checks if npm's global prefix is under the user's home
-// directory (nvm, fnm, volta, etc.), meaning sudo is not needed for global installs.
-func detectNpmWritable(homeDir string) bool {
-	out, err := exec.Command("npm", "config", "get", "prefix").Output()
+// npmConfigPrefix is package-level for testing the real prefix writability probe.
+var npmConfigPrefix = func() ([]byte, error) {
+	return exec.Command("npm", "config", "get", "prefix").Output()
+}
+
+// detectNpmWritable probes the npm global prefix itself. Prefix location is not
+// a reliable writability signal: a user may have write access outside $HOME,
+// and a home-prefixed directory may still be read-only.
+func detectNpmWritable(_ string) bool {
+	out, err := npmConfigPrefix()
 	if err != nil {
 		return false
 	}
 	prefix := strings.TrimSpace(string(out))
-	return strings.HasPrefix(prefix, homeDir)
+	if prefix == "" {
+		return false
+	}
+
+	probe, err := os.CreateTemp(prefix, ".gentle-ai-npm-writable-*")
+	if err != nil {
+		return false
+	}
+	name := probe.Name()
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(name)
+		return false
+	}
+	return os.Remove(name) == nil
 }
 
 func detectFromInputs(goos, arch, shell, linuxOSRelease string, tools map[string]ToolStatus, configs []ConfigState) DetectionResult {

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -117,7 +118,11 @@ func detectNpmWritable(_ string) bool {
 		return false
 	}
 
-	probe, err := os.CreateTemp(prefix, ".gentle-ai-npm-writable-*")
+	return writableDirectory(filepath.Join(prefix, "lib", "node_modules")) && writableDirectory(filepath.Join(prefix, "bin"))
+}
+
+func writableDirectory(path string) bool {
+	probe, err := os.CreateTemp(path, ".gentle-ai-npm-writable-*")
 	if err != nil {
 		return false
 	}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -2,17 +2,18 @@ package system
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestDetectNpmWritableRequiresWritablePrefix(t *testing.T) {
-	writable := t.TempDir()
+func TestDetectNpmWritableRequiresWritableGlobalInstallTargets(t *testing.T) {
+	writable := writableNpmPrefix(t)
 	orig := npmConfigPrefix
 	t.Cleanup(func() { npmConfigPrefix = orig })
 	npmConfigPrefix = func() ([]byte, error) { return []byte(writable + "\n"), nil }
 	if !detectNpmWritable(t.TempDir()) {
-		t.Fatal("detectNpmWritable() = false, want true for writable npm prefix")
+		t.Fatal("detectNpmWritable() = false, want true for writable npm install targets")
 	}
 
 	missing := filepath.Join(t.TempDir(), "missing")
@@ -21,12 +22,39 @@ func TestDetectNpmWritableRequiresWritablePrefix(t *testing.T) {
 		t.Fatal("detectNpmWritable() = true, want false for unusable npm prefix")
 	}
 
-	outsideHome := t.TempDir()
+	outsideHome := writableNpmPrefix(t)
 	home := t.TempDir()
 	npmConfigPrefix = func() ([]byte, error) { return []byte(outsideHome), nil }
 	if !detectNpmWritable(home) {
-		t.Fatal("detectNpmWritable() = false, want true when prefix is writable outside home")
+		t.Fatal("detectNpmWritable() = false, want true when npm install targets are writable outside home")
 	}
+}
+
+func TestDetectNpmWritableRequiresBinAndNodeModulesTargets(t *testing.T) {
+	prefix := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(prefix, "lib", "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prefix, "bin"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := npmConfigPrefix
+	t.Cleanup(func() { npmConfigPrefix = orig })
+	npmConfigPrefix = func() ([]byte, error) { return []byte(prefix), nil }
+	if detectNpmWritable(t.TempDir()) {
+		t.Fatal("detectNpmWritable() = true, want false when npm bin target is not writable")
+	}
+}
+
+func writableNpmPrefix(t *testing.T) string {
+	t.Helper()
+	prefix := t.TempDir()
+	for _, dir := range []string{filepath.Join(prefix, "lib", "node_modules"), filepath.Join(prefix, "bin")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return prefix
 }
 
 func TestDetectNpmWritableCommandFailure(t *testing.T) {

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -1,6 +1,42 @@
 package system
 
-import "testing"
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectNpmWritableRequiresWritablePrefix(t *testing.T) {
+	writable := t.TempDir()
+	orig := npmConfigPrefix
+	t.Cleanup(func() { npmConfigPrefix = orig })
+	npmConfigPrefix = func() ([]byte, error) { return []byte(writable + "\n"), nil }
+	if !detectNpmWritable(t.TempDir()) {
+		t.Fatal("detectNpmWritable() = false, want true for writable npm prefix")
+	}
+
+	missing := filepath.Join(t.TempDir(), "missing")
+	npmConfigPrefix = func() ([]byte, error) { return []byte(missing), nil }
+	if detectNpmWritable(t.TempDir()) {
+		t.Fatal("detectNpmWritable() = true, want false for unusable npm prefix")
+	}
+
+	outsideHome := t.TempDir()
+	home := t.TempDir()
+	npmConfigPrefix = func() ([]byte, error) { return []byte(outsideHome), nil }
+	if !detectNpmWritable(home) {
+		t.Fatal("detectNpmWritable() = false, want true when prefix is writable outside home")
+	}
+}
+
+func TestDetectNpmWritableCommandFailure(t *testing.T) {
+	orig := npmConfigPrefix
+	t.Cleanup(func() { npmConfigPrefix = orig })
+	npmConfigPrefix = func() ([]byte, error) { return nil, fmt.Errorf("npm unavailable") }
+	if detectNpmWritable(t.TempDir()) {
+		t.Fatal("detectNpmWritable() = true, want false after npm probe failure")
+	}
+}
 
 func TestIsSupportedOS(t *testing.T) {
 	tests := []struct {

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -138,16 +138,6 @@ func InstallCommandsForDep(name string, profile PlatformProfile) [][]string {
 	return withoutSudo(profile, commands)
 }
 
-// NpmInstallCommands returns the display-only command for a global npm install.
-// Android/Termux has no sudo privilege path, regardless of its package manager.
-func NpmInstallCommands(profile PlatformProfile, packageName string) [][]string {
-	commands := [][]string{{"npm", "install", "-g", "--ignore-scripts", packageName}}
-	if profile.OS == "linux" && !profile.NpmWritable {
-		commands[0] = append([]string{"sudo"}, commands[0]...)
-	}
-	return commands
-}
-
 func withoutSudo(profile PlatformProfile, commands [][]string) [][]string {
 	if profile.OS != "android" {
 		return commands

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -135,16 +135,11 @@ func InstallCommandsForDep(name string, profile PlatformProfile) [][]string {
 	default:
 		return nil
 	}
-	return withoutSudo(profile, commands)
-}
-
-func withoutSudo(profile PlatformProfile, commands [][]string) [][]string {
-	if profile.OS != "android" {
-		return commands
-	}
-	for i, command := range commands {
-		if len(command) > 0 && command[0] == "sudo" {
-			commands[i] = append([]string(nil), command[1:]...)
+	if profile.OS == "android" {
+		for i, command := range commands {
+			if len(command) > 0 && command[0] == "sudo" {
+				commands[i] = append([]string(nil), command[1:]...)
+			}
 		}
 	}
 	return commands

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -5,6 +5,8 @@ import "fmt"
 // installHintGit returns the platform-specific install hint for git.
 func installHintGit(profile PlatformProfile) string {
 	switch {
+	case profile.OS == "android":
+		return "apt-get install -y git"
 	case profile.OS == "darwin":
 		return "brew install git"
 	case profile.OS == "windows":
@@ -23,6 +25,8 @@ func installHintGit(profile PlatformProfile) string {
 // installHintCurl returns the platform-specific install hint for curl.
 func installHintCurl(profile PlatformProfile) string {
 	switch {
+	case profile.OS == "android":
+		return "apt-get install -y curl"
 	case profile.OS == "darwin":
 		return "brew install curl"
 	case profile.OS == "windows":
@@ -41,6 +45,8 @@ func installHintCurl(profile PlatformProfile) string {
 // installHintNode returns the platform-specific install hint for Node.js.
 func installHintNode(profile PlatformProfile) string {
 	switch {
+	case profile.OS == "android":
+		return "apt-get install -y nodejs"
 	case profile.OS == "darwin":
 		return "brew install node"
 	case profile.OS == "windows":
@@ -70,6 +76,8 @@ func installHintBrew() string {
 // installHintGo returns the platform-specific install hint for Go.
 func installHintGo(profile PlatformProfile) string {
 	switch {
+	case profile.OS == "android":
+		return "apt-get install -y golang"
 	case profile.OS == "darwin":
 		return "brew install go"
 	case profile.OS == "windows":
@@ -109,23 +117,47 @@ func InstallHintForDep(name string, profile PlatformProfile) string {
 // InstallCommandsForDep returns the command sequence to install a missing dependency.
 // Returns nil if no automatic install is available.
 func InstallCommandsForDep(name string, profile PlatformProfile) [][]string {
+	var commands [][]string
 	switch name {
 	case "git":
-		return installCommandsGit(profile)
+		commands = installCommandsGit(profile)
 	case "curl":
-		return installCommandsCurl(profile)
+		commands = installCommandsCurl(profile)
 	case "node":
-		return installCommandsNode(profile)
+		commands = installCommandsNode(profile)
 	case "npm":
 		// npm comes with node; installing node installs npm.
 		return nil
 	case "brew":
-		return installCommandsBrew(profile)
+		commands = installCommandsBrew(profile)
 	case "go":
-		return installCommandsGo(profile)
+		commands = installCommandsGo(profile)
 	default:
 		return nil
 	}
+	return withoutSudo(profile, commands)
+}
+
+// NpmInstallCommands returns the display-only command for a global npm install.
+// Android/Termux has no sudo privilege path, regardless of its package manager.
+func NpmInstallCommands(profile PlatformProfile, packageName string) [][]string {
+	commands := [][]string{{"npm", "install", "-g", "--ignore-scripts", packageName}}
+	if profile.OS == "linux" && !profile.NpmWritable {
+		commands[0] = append([]string{"sudo"}, commands[0]...)
+	}
+	return commands
+}
+
+func withoutSudo(profile PlatformProfile, commands [][]string) [][]string {
+	if profile.OS != "android" {
+		return commands
+	}
+	for i, command := range commands {
+		if len(command) > 0 && command[0] == "sudo" {
+			commands[i] = append([]string(nil), command[1:]...)
+		}
+	}
+	return commands
 }
 
 func installCommandsGit(profile PlatformProfile) [][]string {
@@ -165,6 +197,9 @@ func installCommandsCurl(profile PlatformProfile) [][]string {
 
 func installCommandsNode(profile PlatformProfile) [][]string {
 	switch {
+	case profile.OS == "android":
+		// Termux has no sudo privilege path; apt is provided by the Termux package manager.
+		return [][]string{{"apt-get", "install", "-y", "nodejs"}}
 	case profile.OS == "darwin":
 		return [][]string{{"brew", "install", "node"}}
 	case profile.OS == "windows":

--- a/internal/system/install_deps_test.go
+++ b/internal/system/install_deps_test.go
@@ -106,6 +106,23 @@ func TestInstallCommandsForDepGitUbuntu(t *testing.T) {
 	}
 }
 
+func TestInstallCommandsForDepAndroidNeverUsesSudo(t *testing.T) {
+	profile := PlatformProfile{OS: "android", PackageManager: "apt"}
+	for _, dep := range []string{"git", "curl", "node", "go"} {
+		cmds := InstallCommandsForDep(dep, profile)
+		if len(cmds) == 0 {
+			t.Fatalf("InstallCommandsForDep(%q) returned no commands", dep)
+		}
+		for _, cmd := range cmds {
+			for _, arg := range cmd {
+				if strings.Contains(arg, "sudo") {
+					t.Fatalf("InstallCommandsForDep(%q) = %v, must not use sudo on Android", dep, cmds)
+				}
+			}
+		}
+	}
+}
+
 func TestInstallCommandsForDepNodeUbuntuHasTwoSteps(t *testing.T) {
 	profile := PlatformProfile{OS: "linux", PackageManager: "apt", LinuxDistro: "ubuntu"}
 	cmds := InstallCommandsForDep("node", profile)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2502

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Keeps the #2502 slice scoped to Android/Termux privilege behavior and npm-prefix writability:

- Android install-command profiles no longer produce `sudo`-prefixed dependency or npm install commands.
- Shared npm install command generation removes duplicated sudo logic from npm-based agent adapters.
- npm global writability now probes the actual npm prefix by creating/removing a temporary file, instead of inferring writability from whether the prefix path is under `$HOME`.

This intentionally does not implement #2501 Android platform detection or package-manager probing.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/installcmd/resolver.go` | Removes sudo from Android dependency/npm command generation and reuses shared npm install command handling. |
| `internal/system/install_deps.go` | Adds Android no-sudo dependency hints/commands and shared npm install command helper. |
| `internal/system/detect.go` | Replaces npm-prefix home-shape heuristic with a real write probe. |
| `internal/agents/{codex,gemini,qwen}/adapter.go` | Reuses shared npm install command helper instead of local Linux sudo logic. |
| Tests | Adds focused Android no-sudo and npm writability probe coverage. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi / el Gentleman with OpenAI Codex subagents

**Material scope:** Issue availability verification, code mapping, implementation, regression test drafting, and local verification.

**Verification performed:** Focused Go tests, Android cross-build, and diff checks listed below. Human review is still required before merge.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/installcmd ./internal/system ./internal/agents/codex ./internal/agents/gemini ./internal/agents/qwen -count=1
go test ./internal/agents/claude ./internal/agents/kilocode ./internal/installcmd ./internal/system -count=1
```

**Go Format**
```bash
git diff --check
```

**Android cross-build**
```bash
GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/gentle-ai
```

**E2E Tests** (Docker required)
```bash
# Not run, focused install-command and system-detection unit coverage only.
```

**Benchmark Validation**

N/A, this change affects install command generation and npm-prefix writability detection, not benchmark, review-lifecycle, gate, recovery, delivery, corpus, classifier, or measured product-behavior surfaces.

- [x] Unit tests pass (focused commands above)
- [x] Go format passes (`git diff --check`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (focused commands above)
- [x] Go format passes (`git diff --check`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

RDD was not used because this local checkout still has an unrelated malformed compact-v2 review authority entry that blocks new review transactions before START. No RDD lineage was created for this candidate.

This PR intentionally avoids #2501 Android platform detection and package-manager probing. It only makes already-constructed Android profiles no-sudo and replaces npm writability inference with a real prefix write probe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Android/Termux support for installing required tools and command-line applications.
  - Installation commands now avoid `sudo` on Android environments.
  - Standardized npm installation handling across supported applications and platforms.

- **Bug Fixes**
  - Improved detection of writable npm installation locations.
  - Prevented unnecessary or invalid elevated-permission prompts during installations.

- **Tests**
  - Added coverage for Android installation commands and npm permission detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->