### PR TITLE
fix(review): allow global mode outside git

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -829,6 +829,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue3772Journeys()...)
 	journeys = append(journeys, issue3776Journeys()...)
 	journeys = append(journeys, issue3766Journeys()...)
+	journeys = append(journeys, issue3813Journeys()...)
 	journeys = append(journeys, handoffJourneys()...)
 	journeys = removeRetiredAtomicJourneys(journeys)
 	return declareCoreJourneyReviewModes(journeys)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -71,6 +71,7 @@ func journeySources() []journeySource {
 		{"journeys_issue3772.go", issue3772Journeys()},
 		{"journeys_issue3776.go", issue3776Journeys()},
 		{"journeys_issue3766.go", issue3766Journeys()},
+		{"journeys_issue3813.go", issue3813Journeys()},
 	}
 	for index := range sources {
 		sources[index].Journeys = removeRetiredAtomicJourneys(sources[index].Journeys)

--- a/bench/journeys_issue3813.go
+++ b/bench/journeys_issue3813.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// issue3813Journeys proves global review-mode controls from the place an
+// operator naturally runs machine-wide settings: a directory that is not inside
+// any Git repository. The sandbox owns HOME, so the journey can mutate global
+// review mode without reading or changing the real user's state.
+func issue3813Journeys() []Journey {
+	return []Journey{{
+		ID:     "j122-global-review-mode-from-non-git-cwd",
+		Review: reviewUntouched,
+		Title:  "#3813: global review mode works from a non-Git cwd",
+		Source: "#3813: global scope has no repository dimension and must not fail after writing isolated HOME state",
+		Steps: []Step{
+			{Name: "fixture: non-Git working directory", Fixture: nonGitReviewModeCWD},
+			{Name: "enable global review mode outside Git through a PTY",
+				Composite: issue3813RunTTY("enable", "global", "on", "review", "mode", "enable", "--scope", "global", "--json")},
+			{Name: "fresh status reports enabled global source outside Git through a PTY",
+				Composite: issue3813RunTTY("status", "global", "on", "review", "mode", "status", "--json")},
+			{Name: "disable global review mode outside Git through a PTY",
+				Composite: issue3813RunTTY("disable", "global", "off", "review", "mode", "disable", "--scope", "global", "--json")},
+		},
+	}}
+}
+
+func nonGitReviewModeCWD(sandbox *Sandbox) error {
+	nonGit := filepath.Join(sandbox.Root, "not-a-git-repo")
+	if err := os.MkdirAll(nonGit, 0o755); err != nil {
+		return err
+	}
+	sandbox.Repo = nonGit
+	return nil
+}
+
+func issue3813RunTTY(operation, source, global string, args ...string) func(*journeyRun) error {
+	return func(run *journeyRun) error {
+		observation, err := run.runTTY(args, false, issue3813NoTTYInput)
+		if err != nil {
+			return err
+		}
+		return issue3813ModeStatus(operation, source, global)(run.sandbox, observation)
+	}
+}
+
+func issue3813NoTTYInput(_ *bufio.Reader, _ io.WriteCloser) error { return nil }
+
+func issue3813ModeStatus(operation, source, global string) func(*Sandbox, Observation) error {
+	return func(sandbox *Sandbox, observation Observation) error {
+		var result struct {
+			Operation string `json:"operation"`
+			Scope     string `json:"scope"`
+			Status    struct {
+				Effective  string `json:"effective"`
+				Source     string `json:"source"`
+				Global     string `json:"global"`
+				CloneLocal string `json:"clone_local"`
+			} `json:"status"`
+		}
+		if observation.ExitCode != 0 {
+			return fmt.Errorf("review mode %s outside Git exited %d: %s", operation, observation.ExitCode, firstLine(observation.Stderr, observation.Stdout))
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+			return fmt.Errorf("parse review mode %s JSON: %w", operation, err)
+		}
+		if result.Operation != operation || result.Status.Effective != global || result.Status.Source != source ||
+			result.Status.Global != global || result.Status.CloneLocal != "" {
+			return fmt.Errorf("review mode %s outside Git = operation=%q effective=%q source=%q global=%q clone=%q, want operation=%q source=%q global/effective=%q and unset clone", operation, result.Operation, result.Status.Effective, result.Status.Source, result.Status.Global, result.Status.CloneLocal, operation, source, global)
+		}
+		if _, err := os.Lstat(filepath.Join(sandbox.Repo, ".git")); !os.IsNotExist(err) {
+			return fmt.Errorf("review mode %s created Git metadata in non-Git cwd: %v", operation, err)
+		}
+		if !strings.HasPrefix(filepath.Clean(sandbox.Home), filepath.Clean(sandbox.Root)) {
+			return fmt.Errorf("journey HOME %s is outside sandbox root %s", sandbox.Home, sandbox.Root)
+		}
+		return nil
+	}
+}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -119,6 +119,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j119-global-review-mode-status-reports-persisted-source":                   reviewUntouched,
 	"j120-welcome-tui-runs-under-a-real-tty":                                    reviewUntouched,
 	"j121-rdd-tui-controls-global-mode":                                         reviewUntouched,
+	"j122-global-review-mode-from-non-git-cwd":                                  reviewUntouched,
 }
 
 func declareCoreJourneyReviewModes(journeys []Journey) []Journey {

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -19,6 +19,7 @@ j119-global-review-mode-status-reports-persisted-source
 j12-rejected-capture-then-recapture
 j120-welcome-tui-runs-under-a-real-tty
 j121-rdd-tui-controls-global-mode
+j122-global-review-mode-from-non-git-cwd
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token
 j17-bare-repository

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -279,14 +279,19 @@ func reviewModeUnsafePathRefusal(err error) error {
 	return nil
 }
 
+type reviewModeRepositoryRequiredError struct{ Cause error }
+
+func (err *reviewModeRepositoryRequiredError) Unwrap() error { return err.Cause }
+
+func (err *reviewModeRepositoryRequiredError) Error() string {
+	return "clone-local review mode requires a Git repository; rerun the original command with --cwd pointing at the intended repository, or use `gentle-ai review mode enable --scope global` or `gentle-ai review mode disable --scope global` for machine-wide state"
+}
+
 func reviewModeRepositoryRequiredRefusal(err error) error {
 	if !reviewtransaction.ReviewRootResolutionReportsNoRepository(err) {
 		return nil
 	}
-	return fmt.Errorf(
-		"clone-local review mode requires a Git repository; rerun with --cwd pointing at the intended repository, or use --scope global for machine-wide state: %w",
-		err,
-	)
+	return &reviewModeRepositoryRequiredError{Cause: err}
 }
 
 func reviewModeCommandsByVerb(commands []string, verb string) []string {

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -123,7 +123,31 @@ func reviewModeStatus(ctx context.Context, repo string) (reviewtransaction.RDDMo
 		return reviewtransaction.RDDModeStatus{Schema: reviewtransaction.RDDModeStatusSchema, Effective: reviewtransaction.RDDModeOff}, err
 	}
 	status, err := reviewtransaction.ResolveRDDMode(ctx, repo, global)
+	if err != nil && reviewtransaction.ReviewRootResolutionReportsNoRepository(err) {
+		return globalOnlyReviewModeStatus(global), nil
+	}
 	return status, reviewModeUnreadable(ctx, repo, global, err)
+}
+
+func globalOnlyReviewModeStatus(global reviewtransaction.RDDGlobalMode) reviewtransaction.RDDModeStatus {
+	status := reviewtransaction.RDDModeStatus{
+		Schema:     reviewtransaction.RDDModeStatusSchema,
+		Global:     reviewtransaction.RDDModeUnset,
+		CloneLocal: reviewtransaction.RDDModeUnset,
+		Effective:  reviewtransaction.RDDModeOff,
+		Source:     reviewtransaction.RDDModeSourceDefault,
+	}
+	switch strings.TrimSpace(global.Value) {
+	case string(reviewtransaction.RDDModeOn):
+		status.Global = reviewtransaction.RDDModeOn
+		status.Effective = reviewtransaction.RDDModeOn
+		status.Source = reviewtransaction.RDDModeSourceGlobal
+	case string(reviewtransaction.RDDModeOff):
+		status.Global = reviewtransaction.RDDModeOff
+		status.Effective = reviewtransaction.RDDModeOff
+		status.Source = reviewtransaction.RDDModeSourceGlobal
+	}
+	return status
 }
 
 // ReviewModeUnreadableScope names one kill-switch source whose persisted value
@@ -255,6 +279,16 @@ func reviewModeUnsafePathRefusal(err error) error {
 	return nil
 }
 
+func reviewModeRepositoryRequiredRefusal(err error) error {
+	if !reviewtransaction.ReviewRootResolutionReportsNoRepository(err) {
+		return nil
+	}
+	return fmt.Errorf(
+		"clone-local review mode requires a Git repository; rerun with --cwd pointing at the intended repository, or use --scope global for machine-wide state: %w",
+		err,
+	)
+}
+
 func reviewModeCommandsByVerb(commands []string, verb string) []string {
 	selected := make([]string, 0, len(commands))
 	for _, command := range commands {
@@ -283,6 +317,9 @@ func reviewModeUnreadable(
 	}
 	if unsafePath := reviewModeUnsafePathRefusal(err); unsafePath != nil {
 		return unsafePath
+	}
+	if repoRequired := reviewModeRepositoryRequiredRefusal(err); repoRequired != nil {
+		return repoRequired
 	}
 	scopes := make([]ReviewModeUnreadableScope, 0, 2)
 	if reviewtransaction.RDDModeValueUnintelligible(global.Value) {

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -86,6 +86,75 @@ func TestReviewModeDisableGlobalWinsOverEveryRepository(t *testing.T) {
 	}
 }
 
+func TestReviewModeGlobalScopeWorksFromNonGitDirectory(t *testing.T) {
+	home := reviewModeHome(t)
+	nonGit := t.TempDir()
+
+	var output bytes.Buffer
+	if err := RunReviewMode([]string{"status", "--cwd", nonGit, "--json"}, &output); err != nil {
+		t.Fatalf("unset global status from non-Git cwd error = %v\n%s", err, output.String())
+	}
+	if before := decodeReviewModeResult(t, output.Bytes()); before.Status.Effective != reviewtransaction.RDDModeOff ||
+		before.Status.Source != reviewtransaction.RDDModeSourceDefault ||
+		before.Status.Global != reviewtransaction.RDDModeUnset || before.Status.CloneLocal != reviewtransaction.RDDModeUnset {
+		t.Fatalf("unset global status from non-Git cwd = %#v", before.Status)
+	}
+
+	output.Reset()
+	if err := RunReviewMode([]string{"enable", "--cwd", nonGit, "--scope", "global", "--json"}, &output); err != nil {
+		t.Fatalf("global enable from non-Git cwd error = %v\n%s", err, output.String())
+	}
+	result := decodeReviewModeResult(t, output.Bytes())
+	if result.Operation != "enable" || result.Scope != reviewModeScopeGlobal ||
+		result.Status.Effective != reviewtransaction.RDDModeOn ||
+		result.Status.Source != reviewtransaction.RDDModeSourceGlobal ||
+		result.Status.Global != reviewtransaction.RDDModeOn ||
+		result.Status.CloneLocal != reviewtransaction.RDDModeUnset {
+		t.Fatalf("global enable from non-Git cwd = %#v", result)
+	}
+	persisted, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read error = %v", err)
+	}
+	if persisted.RDDMode != string(reviewtransaction.RDDModeOn) || persisted.RDDModeRecordedAt == nil {
+		t.Fatalf("global enable did not persist an explicit on: %#v", persisted)
+	}
+	if entries, err := os.ReadDir(nonGit); err != nil || len(entries) != 0 {
+		t.Fatalf("global enable touched non-Git cwd: entries=%v err=%v", entries, err)
+	}
+
+	output.Reset()
+	if err := RunReviewMode([]string{"status", "--cwd", nonGit, "--json"}, &output); err != nil {
+		t.Fatalf("global status from non-Git cwd error = %v\n%s", err, output.String())
+	}
+	status := decodeReviewModeResult(t, output.Bytes())
+	if status.Operation != "status" || status.Scope != reviewModeScopeBoth ||
+		status.Status.Effective != reviewtransaction.RDDModeOn ||
+		status.Status.Source != reviewtransaction.RDDModeSourceGlobal ||
+		status.Status.Global != reviewtransaction.RDDModeOn ||
+		status.Status.CloneLocal != reviewtransaction.RDDModeUnset {
+		t.Fatalf("global status from non-Git cwd = %#v", status)
+	}
+}
+
+func TestReviewModeCloneScopeOutsideGitFailsBeforeWriting(t *testing.T) {
+	home := reviewModeHome(t)
+	nonGit := t.TempDir()
+
+	var output bytes.Buffer
+	err := RunReviewMode([]string{"disable", "--cwd", nonGit, "--scope", "clone", "--json"}, &output)
+	if err == nil || !strings.Contains(err.Error(), "clone-local review mode requires a Git repository") ||
+		!strings.Contains(err.Error(), "--scope global") {
+		t.Fatalf("clone disable outside Git error = %v", err)
+	}
+	if _, readErr := state.Read(home); !errors.Is(readErr, os.ErrNotExist) {
+		t.Fatalf("clone disable outside Git mutated global state: %v", readErr)
+	}
+	if entries, readErr := os.ReadDir(nonGit); readErr != nil || len(entries) != 0 {
+		t.Fatalf("clone disable outside Git touched cwd: entries=%v err=%v", entries, readErr)
+	}
+}
+
 func TestWriteGlobalRDDModeSerializesWithInstallStateAndPreservesFreshFields(t *testing.T) {
 	home := reviewModeHome(t)
 	lock, err := reviewtransaction.AcquireAuthorityFileLock(installStateLockPath(home))

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -144,14 +144,29 @@ func TestReviewModeCloneScopeOutsideGitFailsBeforeWriting(t *testing.T) {
 	var output bytes.Buffer
 	err := RunReviewMode([]string{"disable", "--cwd", nonGit, "--scope", "clone", "--json"}, &output)
 	if err == nil || !strings.Contains(err.Error(), "clone-local review mode requires a Git repository") ||
-		!strings.Contains(err.Error(), "--scope global") {
+		!strings.Contains(err.Error(), "--cwd") || !strings.Contains(err.Error(), "--scope global") ||
+		strings.Contains(err.Error(), "fatal:") || strings.Contains(err.Error(), "git rev-parse") || strings.Contains(err.Error(), "exit code 128") {
 		t.Fatalf("clone disable outside Git error = %v", err)
+	}
+	if !reviewtransaction.ReviewRootResolutionReportsNoRepository(err) {
+		t.Fatalf("clone disable outside Git lost its typed no-repository classification: %v", err)
 	}
 	if _, readErr := state.Read(home); !errors.Is(readErr, os.ErrNotExist) {
 		t.Fatalf("clone disable outside Git mutated global state: %v", readErr)
 	}
 	if entries, readErr := os.ReadDir(nonGit); readErr != nil || len(entries) != 0 {
 		t.Fatalf("clone disable outside Git touched cwd: entries=%v err=%v", entries, readErr)
+	}
+}
+
+func TestReviewModeRepositoryRequiredRefusalDoesNotDependOnGitStderrLanguage(t *testing.T) {
+	localized := &reviewtransaction.GitCommandError{Args: []string{"rev-parse", "--show-toplevel"}, ExitCode: 128, Output: "fatal: no es un repositorio Git"}
+	refusal := reviewModeRepositoryRequiredRefusal(localized)
+	if refusal == nil || !reviewtransaction.ReviewRootResolutionReportsNoRepository(refusal) {
+		t.Fatalf("localized no-repository error was not classified: %v", refusal)
+	}
+	if strings.Contains(refusal.Error(), localized.Output) {
+		t.Fatalf("localized Git stderr reached the operator refusal: %v", refusal)
 	}
 }
 

--- a/internal/reviewtransaction/repository_bootstrap.go
+++ b/internal/reviewtransaction/repository_bootstrap.go
@@ -47,6 +47,14 @@ func PrepareReviewRepositoryRoot(ctx context.Context, workspace string) (string,
 	return (SnapshotBuilder{Repo: workspace}).ResolveRepositoryRoot(ctx)
 }
 
+// ReviewRootResolutionReportsNoRepository reports the bounded Git discovery
+// failure for a cwd outside any repository. It lets higher-level command
+// surfaces decide whether repository identity was truly required instead of
+// matching localized Git stderr text.
+func ReviewRootResolutionReportsNoRepository(err error) bool {
+	return reviewRootResolutionReportsNoRepository(err)
+}
+
 func reviewRootResolutionReportsNoRepository(err error) bool {
 	return reviewGitCommandExited128(err, "rev-parse", "--show-toplevel")
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3813

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Allows global review-mode status and enable/disable operations to complete from a non-Git working directory. Global RDD mode has no repository dimension, so a missing Git repository now falls back to a global-only status projection instead of reporting failure after the global write has already committed.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_mode.go` | Added global-only status fallback for non-Git cwd and a clearer clone-local repository precondition error. |
| `internal/reviewtransaction/repository_bootstrap.go` | Exposed the existing no-repository Git resolution classifier for CLI surfaces. |
| `internal/cli/review_mode_test.go` | Added regression coverage for global status/enable outside Git and clone-scope fail-before-write behavior. |
| `bench/journeys_issue3813.go` + registry files | Added a permanent black-box journey for global review-mode controls from a non-Git cwd with isolated HOME. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi / el Gentleman with OpenAI Codex subagent mapping.

**Material scope:** Codebase mapping, implementation, test authoring, benchmark journey authoring, and PR drafting.

**Verification performed:** Commands listed below were run locally; results are reported exactly.

---

## 🧪 Test Plan

**Focused unit tests**
```bash
go test -p 1 ./internal/cli -run 'TestReviewMode(GlobalScopeWorksFromNonGitDirectory|CloneScopeOutsideGitFailsBeforeWriting)' -count=1 -v -timeout 120s
# PASS
```

**Reviewtransaction classifier smoke**
```bash
go test -p 1 ./internal/reviewtransaction -run '^TestSnapshotBuilderResolveRepositoryRootDoesNotBootstrap$' -count=1 -v
# PASS
```

**Benchmark corpus checks**
```bash
cd bench
go test ./... -run 'TestJourneyIDsAreUniqueAcrossSourceFiles|TestJourneySourcesCoverTheWholeCorpus|TestCorpusDeclarationsAreValid|TestRegisteredJourneysMatchTheManifest|TestCorpusJourneysDeclareReviewMode' -count=1
# PASS
```

**Builds**
```bash
go build -trimpath -o %TEMP%/gentle-ai-3813.exe ./cmd/gentle-ai
cd bench && go build -o %TEMP%/gentle-ai-bench-3813.exe .
# PASS
```

**Go Format**
```bash
go run ./internal/gofmtcheck
# PASS
```

**Manual non-PTY Windows black-box check**
```bash
# Built candidate binary, isolated HOME/USERPROFILE/XDG_*, non-Git cwd
gentle-ai.exe review mode enable --scope global --json
# exit 0, status.global/effective/source = on/on/global
gentle-ai.exe review mode status --json
# exit 0, status.global/effective/source = on/on/global
# non-Git cwd remained empty
```

**Benchmark driven-mode note**

The PR adds `j122-global-review-mode-from-non-git-cwd` as the permanent black-box journey required by #3813. Local Windows PTY execution in this Pi harness failed before product execution with `The handle is invalid`; WSL also failed to start with `HCS_E_CONNECTION_TIMEOUT`. CI's Linux benchmark lane is expected to provide the PTY-backed driven proof.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 204 changed lines locally, below the 400-line budget |
| Check Issue Reference | ⏳ | PR body contains `Closes #3813` |
| Check Issue Has `status:approved` | ⏳ | Issue #3813 has `status:approved` |
| Check PR Has `type:*` Label | ⏳ | Pending maintainer/repository workflow action |
| Unit Tests | ⏳ | CI will run full suite |
| Go Format | ⏳ | Local gofmtcheck passed |
| E2E Tests | ⏳ | CI/repository workflow |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR, pending maintainer/repository workflow action
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary, N/A beyond benchmark corpus metadata
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is intentionally scoped to the command truthfulness bug in #3813. It does not change clone-local RDD storage semantics. Clone-scoped writes still require repository identity and now fail before any state write when run outside Git.

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global review mode can now be checked and enabled from directories outside a Git repository.
  * Global status reports the effective setting without requiring repository metadata.
* **Bug Fixes**
  * Clone-scoped review mode now provides a clear error outside a Git repository, including guidance to use global scope.
  * Prevented unintended changes to the working directory or global settings when clone-scoped operations are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->