### PR TITLE
fix(review): close rejected validator attempts atomically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
             completed_once("j111-approved-transaction-burns-and-shipped-gates-are-unmanaged") and
             completed_once("j113-correction-removes-candidate-only-path") and
             completed_once("j114-last-reviewer-capture-closes-and-burns") and
-            completed_once("j116-codex-committed-correction-runs-returned-status-continuation")
+            completed_once("j116-codex-committed-correction-runs-returned-status-continuation") and
+            completed_once("j123-rejected-provider-validator-starts-fresh-high-risk-review")
           ' "$RUNNER_TEMP/bench-portable.json"
           "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j105-compiled-provider-capture-retries-same-binding --out "$RUNNER_TEMP/bench-provider-capture.json"
           jq -e '

--- a/bench/journeys_captured_provider_validator.go
+++ b/bench/journeys_captured_provider_validator.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 )
 
 const capturedProviderValidatorLineage = "captured-provider-validator"
+const capturedProviderValidatorRejectionLineage = "captured-provider-validator-rejection"
 
 var capturedProviderValidatorStatusCapability = &Capability{Verb: []string{"review", "status"}, Flags: []string{
 	"--cwd", "--contract", "--agent", "--lineage", "--next-transition",
@@ -18,28 +20,53 @@ var capturedProviderValidatorStatusCapability = &Capability{Verb: []string{"revi
 // continuation with the native relay protocol. It deliberately drives relay
 // frames directly; this is not evidence about OpenCode Task-hook affinity.
 func capturedProviderValidatorJourneys() []Journey {
-	return []Journey{{
-		ID:     "j106-captured-provider-validator-terminal-capture",
-		Review: reviewOptedIn,
-		Title:  "#3587: captured provider validator closes only through its exact active lineage",
-		Source: "#3587 provider-slot continuation: an occupied Go-admitted validator slot is an exact active-lineage provider fact, and its capture is the terminal event",
-		Steps: []Step{
-			{Name: "fixture: repo", Fixture: baseRepo},
-			{Name: "fixture: stage correction candidate", Fixture: stageCaptureEvidenceDescriptorCorrection},
-			{Name: "start correction review with an exact active lineage", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", capturedProviderValidatorLineage)},
-			{Name: "capture correction finding and the full selected lens set for the exact active lineage", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
-				return captureExactSelectedReviewerSlots(r, capturedProviderValidatorLineage, true)
-			}},
-			{Name: "capture the Go-issued bounded correction plan", Requires: captureCorrectionPlanCapability, Composite: func(r *journeyRun) error {
-				return captureCorrectionPlanFor(r, capturedProviderValidatorLineage, 2)
-			}},
-			{Name: "fixture: correct the reviewed candidate", Fixture: writeCorrectedCandidate},
-			{Name: "capture the Go-issued validator Task through the native relay protocol", Requires: capturedProviderValidatorStatusCapability, Composite: captureProviderValidatorSlot},
-			{Name: "the terminal validator capture exposes acknowledgement before the exact lineage burns", Requires: statusCapability, Composite: func(r *journeyRun) error {
-				return requireAtomicLineageAcknowledged(r, capturedProviderValidatorLineage)
-			}},
+	return []Journey{
+		{
+			ID:     "j106-captured-provider-validator-terminal-capture",
+			Review: reviewOptedIn,
+			Title:  "#3587: captured provider validator closes only through its exact active lineage",
+			Source: "#3587 provider-slot continuation: an occupied Go-admitted validator slot is an exact active-lineage provider fact, and its capture is the terminal event",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "fixture: stage correction candidate", Fixture: stageCaptureEvidenceDescriptorCorrection},
+				{Name: "start correction review with an exact active lineage", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", capturedProviderValidatorLineage)},
+				{Name: "capture correction finding and the full selected lens set for the exact active lineage", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
+					return captureExactSelectedReviewerSlots(r, capturedProviderValidatorLineage, true)
+				}},
+				{Name: "capture the Go-issued bounded correction plan", Requires: captureCorrectionPlanCapability, Composite: func(r *journeyRun) error {
+					return captureCorrectionPlanFor(r, capturedProviderValidatorLineage, 2)
+				}},
+				{Name: "fixture: correct the reviewed candidate", Fixture: writeCorrectedCandidate},
+				{Name: "capture the Go-issued validator Task through the native relay protocol", Requires: capturedProviderValidatorStatusCapability, Composite: captureProviderValidatorSlot},
+				{Name: "the terminal validator capture exposes acknowledgement before the exact lineage burns", Requires: statusCapability, Composite: func(r *journeyRun) error {
+					return requireAtomicLineageAcknowledged(r, capturedProviderValidatorLineage)
+				}},
+			},
 		},
-	}}
+		{
+			ID:     "j123-rejected-provider-validator-starts-fresh-high-risk-review",
+			Review: reviewOptedIn,
+			Title:  "#3799: a rejected validator leaves a changed normal candidate for a fresh high-risk review",
+			Source: "#3799 Boundary B: inline actionable rejection evidence is terminal for its exact authority; a normal candidate edit receives only selectorless STATUS/START and all four new lenses",
+			Steps: []Step{
+				{Name: "fixture: repo", Fixture: baseRepo},
+				{Name: "fixture: stage high-risk correction candidate", Fixture: stageAtomicHighRiskCorrectionCandidate},
+				{Name: "start correction review with an exact active lineage", Requires: startNamedCapability, Args: productArgs("review", "start", "--lineage", capturedProviderValidatorRejectionLineage)},
+				{Name: "capture correction finding and all four selected lens slots", Requires: captureResultCapability, Composite: func(r *journeyRun) error {
+					return captureAtomicReviewerSlots(r, capturedProviderValidatorRejectionLineage, true)
+				}},
+				{Name: "capture the Go-issued bounded correction plan", Requires: captureCorrectionPlanCapability, Composite: func(r *journeyRun) error {
+					return captureCorrectionPlanFor(r, capturedProviderValidatorRejectionLineage, 2)
+				}},
+				{Name: "fixture: correct the reviewed candidate", Fixture: writeCorrectedCandidate},
+				{Name: "capture inline actionable rejection evidence from Boundary A", Requires: capturedProviderValidatorStatusCapability, Composite: func(r *journeyRun) error {
+					return captureRejectedProviderValidatorSlotFor(r, capturedProviderValidatorRejectionLineage)
+				}},
+				{Name: "fixture: make a normal candidate edit", Fixture: writeNormalCandidateAfterRejectedValidator},
+				{Name: "selectorless STATUS/START creates a different fresh lineage with all four required lenses", Requires: atomicReviewStatusCapability, Composite: startFreshRejectedValidatorReview},
+			},
+		},
+	}
 }
 
 func captureProviderValidatorSlot(r *journeyRun) error {
@@ -50,6 +77,14 @@ func captureProviderValidatorSlot(r *journeyRun) error {
 // that STATUS binds to one correction. The relay's successful completion is
 // the final event: it captures validation, approves, and exposes acknowledgement before the lineage burns.
 func captureProviderValidatorSlotFor(r *journeyRun, lineage string) error {
+	return captureProviderValidatorSlotWithResult(r, lineage, true)
+}
+
+func captureRejectedProviderValidatorSlotFor(r *journeyRun, lineage string) error {
+	return captureProviderValidatorSlotWithResult(r, lineage, false)
+}
+
+func captureProviderValidatorSlotWithResult(r *journeyRun, lineage string, passed bool) error {
 	status, err := readProviderValidatorStatus(r, lineage, true)
 	if err != nil {
 		return err
@@ -64,11 +99,15 @@ func captureProviderValidatorSlotFor(r *journeyRun, lineage string) error {
 		input.ProviderTask == nil || input.ProviderTask.Role != "targeted-validator" || input.ProviderTask.Prompt == "" {
 		return fmt.Errorf("provider slot task = %+v", input)
 	}
+	originalEvidence := "original acceptance check passed"
+	if !passed {
+		originalEvidence = "the corrected candidate still fails the original criterion"
+	}
 	payload, err := json.Marshal(map[string]any{
 		"targeted_validation_request_hash": status.ValidationRequest.RequestHash,
 		"correction_target_identity":       status.ValidationRequest.CorrectionTargetIdentity,
-		"original_criteria":                map[string]any{"passed": true, "evidence": []string{"original acceptance check passed"}},
-		"correction_regression":            map[string]any{"passed": true, "evidence": []string{"targeted regression check passed"}},
+		"original_criteria":                map[string]any{"passed": passed, "evidence": []string{originalEvidence}},
+		"correction_regression":            map[string]any{"passed": true, "evidence": []string{"the correction introduced no unrelated regression"}},
 		"follow_ups":                       []any{},
 	})
 	if err != nil {
@@ -112,7 +151,7 @@ func captureProviderValidatorSlotFor(r *journeyRun, lineage string) error {
 	if err != nil || observation.ExitCode != 0 {
 		return fmt.Errorf("native provider-slot relay = exit %d err=%v stderr=%s", observation.ExitCode, err, firstLine(observation.Stderr))
 	}
-	if !capturedProviderSlotReported(observation.Stdout) {
+	if !capturedProviderSlotReported(observation.Stdout, passed) {
 		return fmt.Errorf("native provider-slot relay did not report capture: %s", observation.Stdout)
 	}
 	return nil
@@ -177,7 +216,20 @@ func executeArgument(arguments []waveTransitionArgument, name string) string {
 	return ""
 }
 
-func capturedProviderSlotReported(stdout string) bool {
+func writeNormalCandidateAfterRejectedValidator(sandbox *Sandbox) error {
+	return sandbox.write(filepath.Join(sandbox.Repo, "candidate.go"), "package candidate\n\nfunc value() int { return 4 }\n")
+}
+
+func startFreshRejectedValidatorReview(r *journeyRun) error {
+	lineage, err := startAtomicTransactionFromSelectorlessStatus(r, capturedProviderValidatorRejectionLineage)
+	if err != nil {
+		return fmt.Errorf("selectorless START after rejected validator: %w", err)
+	}
+	r.sandbox.Lineage = lineage
+	return requireExplicitAtomicFourLensStatusFor(r, lineage)
+}
+
+func capturedProviderSlotReported(stdout string, passed bool) bool {
 	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
 		var frame struct {
 			Operation string `json:"operation"`
@@ -195,9 +247,9 @@ func capturedProviderSlotReported(stdout string) bool {
 			} `json:"acknowledgement"`
 		}
 		if json.Unmarshal([]byte(frame.Output), &closure) == nil &&
-			closure.Schema == "gentle-ai.review-last-event-closure/v1" &&
-			closure.Operation == "review/capture-validation" && closure.State == "approved" &&
-			closure.Acknowledgement.Operation == "review.acknowledge-approved" {
+			closure.Schema == "gentle-ai.review-last-event-closure/v1" && closure.Operation == "review/capture-validation" &&
+			(closure.State == "escalated" && !passed || closure.State == "approved" && passed &&
+				closure.Acknowledgement.Operation == "review.acknowledge-approved") {
 			return true
 		}
 	}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -120,6 +120,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j120-welcome-tui-runs-under-a-real-tty":                                    reviewUntouched,
 	"j121-rdd-tui-controls-global-mode":                                         reviewUntouched,
 	"j122-global-review-mode-from-non-git-cwd":                                  reviewUntouched,
+	"j123-rejected-provider-validator-starts-fresh-high-risk-review":            reviewOptedIn,
 }
 
 func declareCoreJourneyReviewModes(journeys []Journey) []Journey {

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -20,6 +20,7 @@ j12-rejected-capture-then-recapture
 j120-welcome-tui-runs-under-a-real-tty
 j121-rdd-tui-controls-global-mode
 j122-global-review-mode-from-non-git-cwd
+j123-rejected-provider-validator-starts-fresh-high-risk-review
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token
 j17-bare-repository

--- a/internal/cli/review_last_event_closure.go
+++ b/internal/cli/review_last_event_closure.go
@@ -16,15 +16,16 @@ const reviewLastEventClosureSchema = "gentle-ai.review-last-event-closure/v1"
 const reviewApprovedLastEventAcknowledgementAction = "the approved review completed on the last admitted event and awaits its exact acknowledgement"
 
 type reviewLastEventClosureResult struct {
-	Schema             string                                `json:"schema"`
-	Operation          string                                `json:"operation"`
-	LineageID          string                                `json:"lineage_id"`
-	State              reviewtransaction.State               `json:"state"`
-	Action             string                                `json:"action"`
-	AdvisoryFindings   *reviewtransaction.AdvisoryFindingSet `json:"advisory_findings,omitempty"`
-	StatusContinuation *ReviewTransitionExecution            `json:"status_continuation,omitempty"`
-	Acknowledgement    *ReviewTransitionExecution            `json:"acknowledgement,omitempty"`
-	StoreRevision      string                                `json:"store_revision"`
+	Schema                    string                                              `json:"schema"`
+	Operation                 string                                              `json:"operation"`
+	LineageID                 string                                              `json:"lineage_id"`
+	State                     reviewtransaction.State                             `json:"state"`
+	Action                    string                                              `json:"action"`
+	TargetedValidatorEvidence *reviewtransaction.CompactTargetedValidatorEvidence `json:"targeted_validator_evidence,omitempty"`
+	AdvisoryFindings          *reviewtransaction.AdvisoryFindingSet               `json:"advisory_findings,omitempty"`
+	StatusContinuation        *ReviewTransitionExecution                          `json:"status_continuation,omitempty"`
+	Acknowledgement           *ReviewTransitionExecution                          `json:"acknowledgement,omitempty"`
+	StoreRevision             string                                              `json:"store_revision"`
 }
 
 func reviewApprovedAcknowledgementTransition(repo string, acknowledgement reviewtransaction.ApprovedCompactAcknowledgement) *ReviewTransitionExecution {
@@ -119,6 +120,37 @@ func closeCorrectionOnCapturedValidator(
 		return nil, fmt.Errorf("targeted validator capture produced unsupported state %q", state.State) // refusal:by-design human-authority: an unmodeled terminal authority outcome requires maintainer inspection
 	}
 	return result, nil
+}
+
+// newCorrectionCapturedValidatorClosure returns the terminal evidence already
+// admitted with a rejected validator capture. It never performs another store
+// mutation, so an exact replay returns the same canonical closure.
+func newCorrectionCapturedValidatorClosure(repo string, state reviewtransaction.CompactState, revision string, request reviewtransaction.TargetedValidationRequest) (*reviewLastEventClosureResult, error) {
+	if err := reviewtransaction.ValidateTargetedValidationRequest(request); err != nil ||
+		state.State != reviewtransaction.StateEscalated || len(state.CorrectionAttempts) == 0 {
+		return nil, errors.New("targeted validator closure does not bind an escalated correction") // refusal:by-design human-authority: a terminal validator closure without its bound correction requires authority inspection
+	}
+	attempt := state.CorrectionAttempts[len(state.CorrectionAttempts)-1]
+	if request.RequestHash != attempt.TargetedValidationRequestHash || request.CorrectionTargetIdentity != attempt.CorrectionTargetIdentity {
+		return nil, errors.New("targeted validator closure request does not bind the terminal correction") // refusal:by-design human-authority: an unbound terminal validator closure requires authority inspection
+	}
+	evidence, found, err := state.AdmittedTargetedValidatorEvidence(request.ExpectedRevision, request.CorrectionTargetIdentity, request.RequestHash)
+	if err != nil || !found {
+		return nil, errors.New("targeted validator closure has no canonical rejection evidence") // refusal:by-design human-authority: missing terminal evidence requires authority inspection
+	}
+	validation := reviewtransaction.ScopedValidationResult{
+		LedgerIDs: append([]string(nil), state.FixFindingIDs...), FollowUps: evidence.FollowUps,
+		OriginalCriteria: attempt.OriginalCriteria, CorrectionRegression: attempt.CorrectionRegression,
+		TargetedValidationRequestHash: attempt.TargetedValidationRequestHash, CorrectionTargetIdentity: attempt.CorrectionTargetIdentity,
+	}
+	if err := evidence.Validate(request, validation); err != nil || validation.OriginalCriteria.Passed && validation.CorrectionRegression.Passed {
+		return nil, errors.New("targeted validator closure evidence does not match its rejected verdict") // refusal:by-design human-authority: inconsistent rejection evidence requires authority inspection
+	}
+	return &reviewLastEventClosureResult{
+		Schema: reviewLastEventClosureSchema, Operation: "review/capture-validation", LineageID: state.LineageID,
+		State: state.State, Action: "the targeted validator rejected the correction; maintainer action is informational",
+		TargetedValidatorEvidence: &evidence, AdvisoryFindings: reviewtransaction.AdvisoryFindingSetFor(state), StoreRevision: revision,
+	}, nil
 }
 
 // reviewLastCapturedLensClosureSuperseded recognizes a sibling capture that

--- a/internal/cli/review_last_event_closure_test.go
+++ b/internal/cli/review_last_event_closure_test.go
@@ -877,16 +877,48 @@ func TestTargetedValidatorCaptureEscalatesRejectedCorrectionWithoutFinalize(t *t
 		Operation string                  `json:"operation"`
 		State     reviewtransaction.State `json:"state"`
 		Action    string                  `json:"action"`
+		Evidence  json.RawMessage         `json:"targeted_validator_evidence"`
 	}
 	if err := json.Unmarshal(terminalOutput.Bytes(), &terminal); err != nil {
 		t.Fatal(err)
 	}
 	if terminal.Operation != "review/capture-validation" || terminal.State != reviewtransaction.StateEscalated ||
-		!strings.Contains(terminal.Action, "rejected") {
+		!strings.Contains(terminal.Action, "rejected") || len(terminal.Evidence) == 0 {
 		t.Fatalf("rejected validator terminal result = %#v", terminal)
 	}
 	after, err := store.Load()
 	if err != nil || after.State.State != reviewtransaction.StateEscalated || after.State.OriginalCriteria == nil || after.State.OriginalCriteria.Passed {
 		t.Fatalf("rejected validator authority = %#v, %v", after, err)
+	}
+	beforeReplay := after.Revision
+
+	var replayOutput bytes.Buffer
+	if err := RunReviewCaptureValidation([]string{
+		"--cwd", repo,
+		"--lineage", lineage,
+		"--target", request.CorrectionTargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision,
+		"--request-hash", request.RequestHash,
+		"--agent", string(model.AgentPi),
+		"--execute=true",
+	}, &replayOutput); err != nil {
+		t.Fatalf("replay rejected targeted validator: %v\\n%s", err, replayOutput.String())
+	}
+	var replay reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, replayOutput.Bytes(), &replay)
+	replayEvidence, err := json.Marshal(replay.TargetedValidatorEvidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var canonicalEvidence bytes.Buffer
+	if err := json.Compact(&canonicalEvidence, terminal.Evidence); err != nil {
+		t.Fatal(err)
+	}
+	if replay.Schema != reviewLastEventClosureSchema || replay.Operation != terminal.Operation || replay.State != terminal.State || replay.Action != terminal.Action || !bytes.Equal(replayEvidence, canonicalEvidence.Bytes()) {
+		t.Fatalf("replayed rejected validator closure = %#v, want %#v", replay, terminal)
+	}
+	afterReplay, err := store.Load()
+	if err != nil || afterReplay.Revision != beforeReplay {
+		t.Fatalf("replayed rejected validator capture mutated authority = %#v, %v", afterReplay, err)
 	}
 }

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -118,7 +118,8 @@ type compactProviderRefuterResult struct {
 }
 
 type compactProviderTargetedValidatorResult struct {
-	Outcome string `json:"outcome"`
+	Outcome  string                                             `json:"outcome"`
+	Evidence reviewtransaction.CompactTargetedValidatorEvidence `json:"evidence"`
 }
 
 type reviewProviderEvidence struct {
@@ -237,7 +238,12 @@ func reviewProviderNewTargetedValidatorRequest(ctx context.Context, repo string,
 	if err != nil {
 		return reviewProviderTargetedValidatorRequest{}, err
 	}
-	request, err := reviewtransaction.BuildTargetedValidationRequestFromSnapshot(ctx, repo, state, revision, correction)
+	var request reviewtransaction.TargetedValidationRequest
+	if state.State == reviewtransaction.StateEscalated {
+		request, err = reviewtransaction.RebuildAdmittedTargetedValidationRequest(state, revision)
+	} else {
+		request, err = reviewtransaction.BuildTargetedValidationRequestFromSnapshot(ctx, repo, state, revision, correction)
+	}
 	if err != nil {
 		return reviewProviderTargetedValidatorRequest{}, err
 	}
@@ -512,28 +518,69 @@ func reviewProviderCloseTargetedValidatorRaw(ctx context.Context, repo string, s
 		}
 		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
 	}
-	outcome := "failed"
-	if native.OriginalCriteria.Passed && native.CorrectionRegression.Passed {
-		outcome = "passed"
-	}
-	payload, err := canonicalProviderRoleResult(compactProviderTargetedValidatorResult{Outcome: outcome})
+	evidence := reviewProviderTargetedValidatorEvidence(result)
+	payload, err := canonicalProviderRoleResult(compactProviderTargetedValidatorResult{
+		Outcome: reviewProviderTargetedValidatorOutcome(native), Evidence: evidence,
+	})
 	if err != nil {
 		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
 	}
-	if err := store.CaptureAdmittedTargetedValidatorResult(ctx, reviewtransaction.CompactAdmittedTargetedValidatorResultRequest{
-		ExpectedRequest: request.ValidationRequest, Payload: payload,
-	}); err != nil {
+	capture := reviewtransaction.CompactAdmittedTargetedValidatorResultRequest{
+		ExpectedRequest: request.ValidationRequest, Payload: payload, Evidence: &evidence, Validation: &native,
+	}
+	if reviewProviderTargetedValidatorOutcome(native) == "failed" {
+		actual, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ChangedLines(ctx, correction)
+		if err != nil {
+			return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+		}
+		complete, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).BuildCorrectedCandidate(ctx, state.InitialSnapshot, correction)
+		if err != nil {
+			return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+		}
+		capture.Complete = func(next *reviewtransaction.CompactState) error {
+			return next.CompleteCorrectionVerification(correction, actual, native, complete)
+		}
+	}
+	if err := store.CaptureAdmittedTargetedValidatorResult(ctx, capture); err != nil {
 		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
 	}
 	current, err := store.LoadContext(ctx)
 	if err != nil {
 		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
 	}
-	closure, err := closeCorrectionOnCapturedValidator(ctx, repo, store, current, correction, request.ValidationRequest, native)
+	if reviewProviderTargetedValidatorOutcome(native) == "passed" {
+		closure, err := closeCorrectionOnCapturedValidator(ctx, repo, store, current, correction, request.ValidationRequest, native)
+		if err != nil {
+			return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+		}
+		return result, native, closure, nil
+	}
+	closure, err := newCorrectionCapturedValidatorClosure(repo, current.State, current.Revision, request.ValidationRequest)
 	if err != nil {
 		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
 	}
 	return result, native, closure, nil
+}
+
+func reviewProviderTargetedValidatorEvidence(result facadeValidationResult) reviewtransaction.CompactTargetedValidatorEvidence {
+	return reviewtransaction.CompactTargetedValidatorEvidence{
+		TargetedValidationRequestHash: result.TargetedValidationRequestHash,
+		CorrectionTargetIdentity:      result.CorrectionTargetIdentity,
+		OriginalCriteria: reviewtransaction.CompactTargetedValidatorCheckEvidence{
+			Passed: result.OriginalCriteria.Passed, Evidence: append([]string(nil), result.OriginalCriteria.Evidence...),
+		},
+		CorrectionRegression: reviewtransaction.CompactTargetedValidatorCheckEvidence{
+			Passed: result.CorrectionRegression.Passed, Evidence: append([]string(nil), result.CorrectionRegression.Evidence...),
+		},
+		FollowUps: append([]reviewtransaction.FollowUp{}, result.FollowUps...),
+	}
+}
+
+func reviewProviderTargetedValidatorOutcome(validation reviewtransaction.ScopedValidationResult) string {
+	if validation.OriginalCriteria.Passed && validation.CorrectionRegression.Passed {
+		return "passed"
+	}
+	return "failed"
 }
 
 func readCapturedProviderTargetedValidatorResult(ctx context.Context, repo, _ string, state reviewtransaction.CompactState, revision string) (string, error) {
@@ -565,6 +612,9 @@ func readCapturedProviderTargetedValidatorResult(ctx context.Context, repo, _ st
 }
 
 func reviewProviderTargetedValidatorCorrection(ctx context.Context, repo string, state reviewtransaction.CompactState) (reviewtransaction.Snapshot, error) {
+	if state.State == reviewtransaction.StateEscalated && len(state.CorrectionAttempts) > 0 {
+		return state.CorrectionAttempts[len(state.CorrectionAttempts)-1].Snapshot, nil
+	}
 	if state.State != reviewtransaction.StateCorrectionRequired || state.ProposedCorrectionLines == nil || state.CorrectionAttemptConsumed() {
 		return reviewtransaction.Snapshot{}, errors.New("provider targeted validator request requires an open correction") // refusal:by-design world-action: validator evidence applies only to one open forecasted correction
 	}

--- a/internal/cli/review_validation_inconclusive_test.go
+++ b/internal/cli/review_validation_inconclusive_test.go
@@ -47,6 +47,78 @@ func TestFacadeValidationRejectsInconclusiveEvidence(t *testing.T) {
 
 // A genuinely failed check with observed evidence is a real verdict and must
 // keep flowing into escalation unchanged.
+func TestTargetedValidatorEvidenceRejectsDigestAndBindingMismatch(t *testing.T) {
+	request := reviewtransaction.TargetedValidationRequest{
+		RequestHash:              "sha256:" + strings.Repeat("1", 64),
+		CorrectionTargetIdentity: "sha256:" + strings.Repeat("2", 64),
+	}
+	result := facadeValidationResult{
+		TargetedValidationRequestHash: request.RequestHash, CorrectionTargetIdentity: request.CorrectionTargetIdentity,
+		OriginalCriteria:     facadeValidationCheck{Passed: false, Evidence: []string{"the corrected candidate still fails the original criterion"}},
+		CorrectionRegression: facadeValidationCheck{Passed: true, Evidence: []string{"the correction introduced no unrelated regression"}},
+		FollowUps:            []reviewtransaction.FollowUp{},
+	}
+	native := reviewtransaction.ScopedValidationResult{
+		TargetedValidationRequestHash: request.RequestHash, CorrectionTargetIdentity: request.CorrectionTargetIdentity,
+		OriginalCriteria: reviewtransaction.ValidationCheck{
+			Passed: result.OriginalCriteria.Passed, EvidenceHash: facadeValueHash("original-criteria", result.OriginalCriteria),
+		},
+		CorrectionRegression: reviewtransaction.ValidationCheck{
+			Passed: result.CorrectionRegression.Passed, EvidenceHash: facadeValueHash("correction-regression", result.CorrectionRegression),
+		},
+		FollowUps: result.FollowUps,
+	}
+	evidence := reviewProviderTargetedValidatorEvidence(result)
+	if err := evidence.Validate(request, native); err != nil {
+		t.Fatalf("valid targeted-validator evidence rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*reviewtransaction.CompactTargetedValidatorEvidence)
+	}{
+		{name: "digest", mutate: func(value *reviewtransaction.CompactTargetedValidatorEvidence) {
+			value.OriginalCriteria.Evidence[0] = "different observation"
+		}},
+		{name: "binding", mutate: func(value *reviewtransaction.CompactTargetedValidatorEvidence) {
+			value.CorrectionTargetIdentity = "sha256:" + strings.Repeat("4", 64)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := evidence
+			candidate.OriginalCriteria.Evidence = append([]string(nil), evidence.OriginalCriteria.Evidence...)
+			tt.mutate(&candidate)
+			if err := candidate.Validate(request, native); err == nil {
+				t.Fatal("mismatched targeted-validator evidence was admitted")
+			}
+		})
+	}
+}
+
+func TestTargetedValidatorCaptureRejectsOutcomeOnlyTerminalFailureBeforeAuthorityMutation(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, lineage, request := providerCorrectionReadyWithoutVerificationEvidence(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CaptureAdmittedTargetedValidatorResult(t.Context(), reviewtransaction.CompactAdmittedTargetedValidatorResultRequest{
+		ExpectedRequest: request, Payload: []byte(`{"outcome":"failed"}`),
+		Complete: func(*reviewtransaction.CompactState) error { return nil },
+	}); err == nil {
+		t.Fatal("outcome-only terminal failed capture was admitted")
+	}
+	after, err := store.Load()
+	if err != nil || after.Revision != before.Revision || len(after.State.AdmittedRoleResults) != len(before.State.AdmittedRoleResults) {
+		t.Fatalf("outcome-only terminal capture mutated authority: before=%#v after=%#v err=%v", before, after, err)
+	}
+}
+
 func TestFacadeValidationKeepsGenuineFailedVerdicts(t *testing.T) {
 	request := reviewtransaction.TargetedValidationRequest{
 		RequestHash:              "sha256:" + strings.Repeat("1", 64),

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -1076,11 +1076,11 @@ func (state CompactState) CompactReviewView() (CompactReviewView, error) {
 				entry.CapturePhaseRevision != state.CapturePhaseRevision {
 				return CompactReviewView{}, invalidCompactReviewView("targeted-validator tuple is ambiguous or mismatched")
 			}
-			outcome, err := decodeCompactAdmittedTargetedValidatorValue(value)
+			admitted, err := decodeCompactAdmittedTargetedValidatorValue(value)
 			if err != nil {
 				return CompactReviewView{}, fmt.Errorf("decode active admitted targeted validator: %w", err)
 			}
-			view.TargetedValidatorOutcome = outcome
+			view.TargetedValidatorOutcome = admitted.Outcome
 		}
 	}
 	refuterByID := map[string]EvidenceResult{}

--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -3,12 +3,15 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -37,8 +40,25 @@ type compactAdmittedRefuterValue struct {
 	Results []EvidenceResult `json:"results"`
 }
 
+type CompactTargetedValidatorCheckEvidence struct {
+	Passed   bool     `json:"passed"`
+	Evidence []string `json:"evidence"`
+}
+
+// CompactTargetedValidatorEvidence is the canonical observed evidence for one
+// conclusive validator verdict. It remains in the admitted role value so a
+// terminal rejection can be replayed without reconstructing provider output.
+type CompactTargetedValidatorEvidence struct {
+	TargetedValidationRequestHash string                                `json:"targeted_validation_request_hash"`
+	CorrectionTargetIdentity      string                                `json:"correction_target_identity"`
+	OriginalCriteria              CompactTargetedValidatorCheckEvidence `json:"original_criteria"`
+	CorrectionRegression          CompactTargetedValidatorCheckEvidence `json:"correction_regression"`
+	FollowUps                     []FollowUp                            `json:"follow_ups"`
+}
+
 type compactAdmittedTargetedValidatorValue struct {
-	Outcome string `json:"outcome"`
+	Outcome  string                            `json:"outcome"`
+	Evidence *CompactTargetedValidatorEvidence `json:"evidence,omitempty"`
 }
 
 func decodeCompactAdmittedReviewerValue(value []byte) (compactAdmittedReviewerResult, error) {
@@ -71,12 +91,54 @@ func decodeCompactAdmittedRefuterValue(value []byte) ([]EvidenceResult, error) {
 	return append([]EvidenceResult(nil), payload.Results...), nil
 }
 
-func decodeCompactAdmittedTargetedValidatorValue(value []byte) (string, error) {
+func decodeCompactAdmittedTargetedValidatorValue(value []byte) (compactAdmittedTargetedValidatorValue, error) {
 	var payload compactAdmittedTargetedValidatorValue
 	if err := decodeCompactAdmittedRoleValue(value, &payload); err != nil || payload.Outcome != "passed" && payload.Outcome != "failed" {
-		return "", errors.New("admitted targeted-validator value is invalid") // refusal:by-design world-action: an immutable validator value must be replaced by its provider
+		return compactAdmittedTargetedValidatorValue{}, errors.New("admitted targeted-validator value is invalid") // refusal:by-design world-action: an immutable validator value must be replaced by its provider
 	}
-	return payload.Outcome, nil
+	return payload, nil
+}
+
+func compactTargetedValidatorEvidenceHashForDomain(domain string, check CompactTargetedValidatorCheckEvidence) string {
+	payload, _ := json.Marshal(check)
+	sum := sha256.Sum256(append([]byte("gentle-ai.facade-"+domain+"/v1\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (evidence CompactTargetedValidatorEvidence) Validate(request TargetedValidationRequest, validation ScopedValidationResult) error {
+	if evidence.TargetedValidationRequestHash != request.RequestHash || evidence.CorrectionTargetIdentity != request.CorrectionTargetIdentity ||
+		evidence.OriginalCriteria.Passed != validation.OriginalCriteria.Passed || evidence.CorrectionRegression.Passed != validation.CorrectionRegression.Passed ||
+		evidence.FollowUps == nil || !reflect.DeepEqual(evidence.FollowUps, validation.FollowUps) ||
+		compactTargetedValidatorEvidenceHashForDomain("original-criteria", evidence.OriginalCriteria) != validation.OriginalCriteria.EvidenceHash ||
+		compactTargetedValidatorEvidenceHashForDomain("correction-regression", evidence.CorrectionRegression) != validation.CorrectionRegression.EvidenceHash {
+		return errors.New("admitted targeted-validator evidence does not match its request and digests") // refusal:by-design world-action: exact validator evidence must bind the provider-issued request before it can consume correction authority
+	}
+	for _, check := range []CompactTargetedValidatorCheckEvidence{evidence.OriginalCriteria, evidence.CorrectionRegression} {
+		if len(check.Evidence) == 0 {
+			return errors.New("admitted targeted-validator evidence is empty") // refusal:by-design operator-knowledge: provide concrete observations for both validator checks
+		}
+		for _, item := range check.Evidence {
+			if strings.TrimSpace(item) == "" {
+				return errors.New("admitted targeted-validator evidence is not concrete") // refusal:by-design operator-knowledge: replace empty validator evidence with observed facts
+			}
+		}
+	}
+	return nil
+}
+
+// AdmittedTargetedValidatorEvidence reads one current canonical validator
+// value, refusing legacy outcome-only entries when actionable evidence is
+// required by a terminal rejection closure.
+func (state CompactState) AdmittedTargetedValidatorEvidence(phase, targetIdentity, requestHash string) (CompactTargetedValidatorEvidence, bool, error) {
+	value, found := state.AdmittedRoleResult(CompactRoleTargetedValidator, phase, targetIdentity, requestHash)
+	if !found {
+		return CompactTargetedValidatorEvidence{}, false, nil
+	}
+	admitted, err := decodeCompactAdmittedTargetedValidatorValue(value)
+	if err != nil || admitted.Evidence == nil {
+		return CompactTargetedValidatorEvidence{}, true, errors.New("admitted targeted-validator value has no actionable evidence") // refusal:by-design human-authority: a terminal rejection missing immutable evidence requires authority inspection
+	}
+	return *admitted.Evidence, true, nil
 }
 
 func decodeCompactAdmittedRoleValue(value []byte, target any) error {
@@ -452,6 +514,7 @@ func (store CompactStore) mergeAdmittedNonLensRoleResult(
 	payload []byte,
 	prepare func(CompactState) error,
 	validateCurrent func(CompactState) error,
+	complete func(*CompactState) error,
 ) error {
 	if ctx == nil {
 		return errors.New("capture admitted provider role result context is nil") // refusal:by-design world-action: this structural compact-authority invariant requires a provider code fix; no operator command can safely repair it
@@ -542,6 +605,11 @@ func (store CompactStore) mergeAdmittedNonLensRoleResult(
 		}
 		return leftEntry.SelectedOrder < rightEntry.SelectedOrder
 	})
+	if complete != nil {
+		if err := complete(&next); err != nil {
+			return err
+		}
+	}
 	_, recordPayload, err := makeCompactRecord(next)
 	if err != nil {
 		return err
@@ -617,7 +685,7 @@ func (store CompactStore) CaptureAdmittedRefuterResult(ctx context.Context, requ
 				return errors.New("refuter capture binding does not match the current reviewing authority") // refusal:by-design world-action: this structural compact-authority invariant requires a provider code fix; no operator command can safely repair it
 			}
 			return nil
-		},
+		}, nil,
 	)
 }
 
@@ -631,17 +699,43 @@ type CompactAdmittedRefuterResultRequest struct {
 }
 
 // CompactAdmittedTargetedValidatorResultRequest contains one conclusive
-// targeted-validator value. Rejected values are represented only by the bounded
-// hash-only attempt ledger.
+// targeted-validator value. Evidence and Complete are optional only for legacy
+// internal callers; new terminal captures require both to preserve observed
+// rejection evidence and close under the same authority write.
 type CompactAdmittedTargetedValidatorResultRequest struct {
 	ExpectedRequest    TargetedValidationRequest
 	Payload            []byte
+	Evidence           *CompactTargetedValidatorEvidence
+	Validation         *ScopedValidationResult
 	PreparePublication func(CompactState, TargetedValidationRequest) error
+	Complete           func(*CompactState) error
 }
 
 func (store CompactStore) CaptureAdmittedTargetedValidatorResult(ctx context.Context, request CompactAdmittedTargetedValidatorResultRequest) error {
 	if err := ValidateTargetedValidationRequest(request.ExpectedRequest); err != nil {
 		return err
+	}
+	if request.Evidence == nil || request.Validation == nil {
+		admitted, err := decodeCompactAdmittedTargetedValidatorValue(request.Payload)
+		if err != nil {
+			return err
+		}
+		if request.Complete != nil || admitted.Outcome == "failed" {
+			return errors.New("terminal targeted-validator capture requires canonical evidence and validation") // refusal:by-design world-action: terminal validator authority must retain its digest-bound verdict before it can advance
+		}
+	}
+	if request.Evidence != nil || request.Validation != nil {
+		if request.Evidence == nil || request.Validation == nil {
+			return errors.New("admitted targeted-validator evidence and validation must be supplied together") // refusal:by-design world-action: a conclusive validator capture must retain evidence and its digest-bound verdict together
+		}
+		if err := request.Evidence.Validate(request.ExpectedRequest, *request.Validation); err != nil {
+			return err
+		}
+		admitted, err := decodeCompactAdmittedTargetedValidatorValue(request.Payload)
+		if err != nil || admitted.Evidence == nil || !reflect.DeepEqual(*admitted.Evidence, *request.Evidence) ||
+			admitted.Outcome != targetedValidatorOutcome(*request.Validation) {
+			return errors.New("admitted targeted-validator payload does not match canonical evidence") // refusal:by-design world-action: validator evidence must be canonically bound before it can enter compact authority
+		}
 	}
 	return store.mergeAdmittedNonLensRoleResult(ctx, CompactRoleTargetedValidator,
 		request.ExpectedRequest.ExpectedRevision, request.ExpectedRequest.CorrectionTargetIdentity, request.ExpectedRequest.RequestHash, request.Payload,
@@ -652,14 +746,59 @@ func (store CompactStore) CaptureAdmittedTargetedValidatorResult(ctx context.Con
 			return request.PreparePublication(state, request.ExpectedRequest)
 		},
 		func(state CompactState) error {
-			if state.State != StateCorrectionRequired || state.ProposedCorrectionLines == nil ||
-				state.CapturePhaseRevision != request.ExpectedRequest.ExpectedRevision ||
+			if state.CapturePhaseRevision != request.ExpectedRequest.ExpectedRevision ||
 				state.InitialSnapshot.Identity != request.ExpectedRequest.TargetIdentity {
 				return errors.New("targeted validator capture binding does not match the current open correction authority") // refusal:by-design world-action: this structural compact-authority invariant requires a provider code fix; no operator command can safely repair it
 			}
+			if state.State == StateEscalated {
+				if _, found := state.AdmittedRoleResult(CompactRoleTargetedValidator, request.ExpectedRequest.ExpectedRevision, request.ExpectedRequest.CorrectionTargetIdentity, request.ExpectedRequest.RequestHash); found {
+					return nil
+				}
+			}
+			if state.State != StateCorrectionRequired || state.ProposedCorrectionLines == nil {
+				return errors.New("targeted validator capture binding does not match the current open correction authority") // refusal:by-design world-action: this structural compact-authority invariant requires a provider code fix; no operator command can safely repair it
+			}
 			return nil
-		},
+		}, request.Complete,
 	)
+}
+
+func targetedValidatorOutcome(validation ScopedValidationResult) string {
+	if validation.OriginalCriteria.Passed && validation.CorrectionRegression.Passed {
+		return "passed"
+	}
+	return "failed"
+}
+
+// RebuildAdmittedTargetedValidationRequest reconstructs only an already
+// admitted terminal validator request, allowing an exact rejected capture to
+// replay its canonical closure without reopening correction authority.
+func RebuildAdmittedTargetedValidationRequest(state CompactState, revision string) (TargetedValidationRequest, error) {
+	if err := state.Validate(); err != nil {
+		return TargetedValidationRequest{}, err
+	}
+	if state.State != StateEscalated || revision != state.CapturePhaseRevision || len(state.CorrectionAttempts) == 0 {
+		return TargetedValidationRequest{}, errors.New("admitted targeted-validator replay requires an escalated correction authority") // refusal:by-design operator-knowledge: replay only the exact rejected capture emitted by the active authority
+	}
+	attempt := state.CorrectionAttempts[len(state.CorrectionAttempts)-1]
+	request, err := targetedValidationRequestForCorrection(state, revision, attempt.Snapshot)
+	if err != nil {
+		return TargetedValidationRequest{}, err
+	}
+	evidence, found, err := state.AdmittedTargetedValidatorEvidence(revision, request.CorrectionTargetIdentity, request.RequestHash)
+	if err != nil || !found {
+		return TargetedValidationRequest{}, errors.New("admitted targeted-validator replay has no canonical evidence") // refusal:by-design human-authority: an escalated terminal capture missing its exact evidence requires authority inspection
+	}
+	validation := ScopedValidationResult{
+		LedgerIDs: append([]string(nil), state.FixFindingIDs...), FollowUps: evidence.FollowUps,
+		OriginalCriteria: attempt.OriginalCriteria, CorrectionRegression: attempt.CorrectionRegression,
+		TargetedValidationRequestHash: attempt.TargetedValidationRequestHash, CorrectionTargetIdentity: attempt.CorrectionTargetIdentity,
+	}
+	if request.RequestHash != attempt.TargetedValidationRequestHash || request.CorrectionTargetIdentity != attempt.CorrectionTargetIdentity ||
+		evidence.Validate(request, validation) != nil {
+		return TargetedValidationRequest{}, errors.New("admitted targeted-validator replay does not bind the terminal correction") // refusal:by-design human-authority: inconsistent terminal validator evidence requires authority inspection
+	}
+	return request, nil
 }
 
 // RecordInconclusiveTargetedValidatorAttempt appends one hash-only non-verdict

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -216,6 +216,10 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			continue
 		}
 		state := candidate.compact.State
+		if request.LineageID == "" && (compactRejectedTargetedValidatorTerminalForChangedTarget(state, live) ||
+			compactHistoricalFailedValidator(state) && compactEscalatedRecoveryTargetChanged(state.CurrentSnapshot, live)) {
+			continue
+		}
 		if request.LineageID != "" && request.Target.Kind == TargetCurrentChanges && request.Target.Projection != ProjectionStaged &&
 			!compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
 			eligible, pendingSlots, eligibilityErr := explicitReviewingCompactCandidate(ctx, repo, candidate)
@@ -384,6 +388,26 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 		}
 		return base, nil
 	}
+}
+
+// compactRejectedTargetedValidatorTerminalForChangedTarget recognizes only a
+// canonical evidence-bearing rejected validator terminal. Rebuild verifies the
+// admitted request/evidence binding; absent or malformed evidence stays in the
+// ordinary escalation path instead of being excluded from status candidates.
+func compactRejectedTargetedValidatorTerminalForChangedTarget(state CompactState, live Snapshot) bool {
+	if !compactEscalatedRecoveryTargetChanged(state.CurrentSnapshot, live) {
+		return false
+	}
+	request, err := RebuildAdmittedTargetedValidationRequest(state, state.CapturePhaseRevision)
+	if err != nil {
+		return false
+	}
+	value, found := state.AdmittedRoleResult(CompactRoleTargetedValidator, state.CapturePhaseRevision, request.CorrectionTargetIdentity, request.RequestHash)
+	if !found {
+		return false
+	}
+	validator, err := decodeCompactAdmittedTargetedValidatorValue(value)
+	return err == nil && validator.Outcome == "failed"
 }
 
 // explicitReviewingCompactCandidate admits a drifted reviewing authority only

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -608,6 +608,68 @@ func TestCompactAuthorityLockFailuresAreOperational(t *testing.T) {
 	}
 }
 
+// TestAssessTargetStatusTreatsChangedCanonicalRejectedValidatorAsUnrelated
+// proves a candidate-bound rejected validator does not govern a later normal
+// candidate edit.
+func TestAssessTargetStatusTreatsChangedCanonicalRejectedValidatorAsUnrelated(t *testing.T) {
+	repo, state := persistCanonicalRejectedValidatorAuthority(t, "status-canonical-rejection")
+	unchanged, err := AssessTargetStatus(context.Background(), repo, targetStatusCurrentChangesRequest())
+	if err != nil || unchanged.Applicability != TargetApplicabilityCurrent || unchanged.Action != TargetStatusActionStop {
+		t.Fatalf("unchanged canonical rejected validator status = %#v, err=%v", unchanged, err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "normal candidate after rejection\n")
+
+	status, err := AssessTargetStatus(context.Background(), repo, targetStatusCurrentChangesRequest())
+	if err != nil || status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart ||
+		status.ActionDisposition != "" || status.LineageID != "" || state.State != StateEscalated {
+		t.Fatalf("changed canonical rejected validator status = %#v, state=%#v, err=%v", status, state, err)
+	}
+}
+
+func persistCanonicalRejectedValidatorAuthority(t *testing.T, lineage string) (string, CompactState) {
+	t.Helper()
+	repo, state, revision, store := targetedValidationRequestFixture(t, lineage, true)
+	request, err := BuildTargetedValidationRequest(context.Background(), repo, state, revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetFixDiff, Projection: state.InitialSnapshot.Projection, BaseRef: state.CurrentSnapshot.CandidateTree,
+		IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := CompactTargetedValidatorEvidence{
+		TargetedValidationRequestHash: request.RequestHash, CorrectionTargetIdentity: request.CorrectionTargetIdentity,
+		OriginalCriteria:     CompactTargetedValidatorCheckEvidence{Evidence: []string{"the corrected candidate still fails the original criterion"}},
+		CorrectionRegression: CompactTargetedValidatorCheckEvidence{Passed: true, Evidence: []string{"the correction introduced no unrelated regression"}},
+		FollowUps:            []FollowUp{},
+	}
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := ScopedValidationResult{
+		LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: evidence.FollowUps,
+		OriginalCriteria:              ValidationCheck{EvidenceHash: compactTargetedValidatorEvidenceHashForDomain("original-criteria", evidence.OriginalCriteria), FixDeltaHash: fixHash},
+		CorrectionRegression:          ValidationCheck{EvidenceHash: compactTargetedValidatorEvidenceHashForDomain("correction-regression", evidence.CorrectionRegression), FixDeltaHash: fixHash, Passed: true},
+		TargetedValidationRequestHash: request.RequestHash, CorrectionTargetIdentity: request.CorrectionTargetIdentity,
+	}
+	payload, err := json.Marshal(compactAdmittedTargetedValidatorValue{Outcome: "failed", Evidence: &evidence})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CaptureAdmittedTargetedValidatorResult(context.Background(), CompactAdmittedTargetedValidatorResultRequest{
+		ExpectedRequest: request, Payload: payload, Evidence: &evidence, Validation: &validation,
+		Complete: func(next *CompactState) error { return next.CompleteCorrectionVerification(fix, 1, validation) },
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, record.State
+}
+
 // TestRecoveryStatusNamesTheDispositionRecoveryAccepts pins issue #1469 Case B:
 // every `recover` recommendation must name the --disposition that
 // ValidateCompactRecovery actually accepts, so an operator never has to guess
@@ -636,14 +698,15 @@ func TestRecoveryStatusNamesTheDispositionRecoveryAccepts(t *testing.T) {
 			t.Fatalf("contraction status = %#v, %v", status, err)
 		}
 	})
-	t.Run("historical failed validator with a changed target recovers as escalated", func(t *testing.T) {
-		repo, state, _ := persistHistoricalFailedValidatorAuthority(t, "disposition-historical")
-		writeSnapshotFile(t, repo, "tracked.txt", "changed recovery target\n")
+	t.Run("changed historical failed validator starts unrelated review", func(t *testing.T) {
+		repo, _, _ := persistHistoricalFailedValidatorAuthority(t, "disposition-historical")
+		writeSnapshotFile(t, repo, "tracked.txt", "changed normal candidate\n")
 		status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
-			Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: state.LineageID,
+			Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}},
 		})
-		if err != nil || status.Action != TargetStatusActionRecover || status.ActionDisposition != RecoveryEscalated {
-			t.Fatalf("historical failed validator status = %#v, %v", status, err)
+		if err != nil || status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart ||
+			status.ActionDisposition != "" || status.LineageID != "" {
+			t.Fatalf("changed historical failed validator status = %#v, %v", status, err)
 		}
 	})
 	t.Run("invalidated authority recovers as invalidated", func(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Fixes #3799

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Completes the #3799 feature-branch chain:

- Persist actionable targeted-validator rejection evidence and terminal completion atomically.
- Return the canonical rejection closure on exact replay without revision drift.
- Stop a terminal rejection from governing a later, changed candidate during selectorless STATUS.
- Start a completely fresh full review lineage for that changed candidate.
- Preserve unchanged rejection stops, explicit lineage recovery, accounting, receipts, retries, delivery gates, and unrelated escalation behavior.

No adapter changes, lineage inheritance, recovery bridge, public schema, command, flag, capability, store, or inspection path were added.

---

## 📂 Changes

| Boundary | PR | Review budget | Result |
|----------|----|---------------|--------|
| Atomic validator rejection closure | #3907 | 391 changed lines | Merged into tracker |
| Fresh review after candidate change | #3910 | 212 changed lines | Merged into tracker |

The tracker contains 603 raw changed lines because it integrates both independently reviewed boundaries. The final tracker tree is byte-identical to the verified chain tip (`95fd3290557da7bacad5e6e27ed305da1ebbd7e1`).

---

## 🔗 Chain

```text
main
└── fix/3799-atomic-terminal-rejection 📍
    ├── #3907 Boundary A: atomic rejection evidence
    └── #3910 Boundary B: fresh review after candidate change
```

This tracker is the only branch that merges to `main`. Both child PRs stayed below the 400-line review budget and passed their own fresh CI. The requested `size:exception` applies only to the integration tracker, not to either review boundary.

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used**

**Tool/model:** Pi coding agent with OpenAI Codex models.

**Material scope:** Root-cause mapping, strict-TDD implementation, benchmark journey construction, independent verification, native review orchestration, chain integration, and PR preparation.

**Verification performed:** Focused RED/GREEN tests, negative recovery controls, uncached full Go suites, contract inventory, actionlint, generated-manifest validation, full portable driven corpus, focused j123 execution, independent verification, child-PR CI, and chain-tip/tracker tree identity. Native RDD approved both pre-integration boundaries; after `main` introduced its own j122, the maintainer explicitly waived an RDD rerun for the collision-only j122→j123 remap and required fresh verification plus CI instead.

---

## 🧪 Test Plan

```bash
go test ./internal/reviewtransaction -count=1
go test ./... -count=1
(cd bench && go test ./... -count=1)
./scripts/test-review-contract-package.sh
actionlint
go run ./internal/gofmtcheck
git diff --check
```

Driven evidence from locally built binaries over the exact tracker tree:

- Full portable corpus: `60 completed, 0 unsupported, 0 failed`
- Focused j123: `1 completed, 0 unsupported, 0 failed`
- CI `completed_once(j123)` expression: `true`

Behavioral controls:

- [x] Failed targeted-validator capture atomically persists bound evidence and completion
- [x] Exact replay returns the same closure without revision drift
- [x] Changed canonical rejection permits a selectorless fresh START
- [x] Changed recognized historical rejection permits a selectorless fresh START
- [x] Unchanged rejection remains stopped
- [x] Explicit lineage recovery and accounting recovery remain intact
- [x] Fresh lineage differs and requests all four lenses
- [x] Tracker tree equals the verified chain-tip tree

---

## ✅ Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one PR type selection
- [x] Split implementation into two reviewable PRs below 400 changed lines
- [x] Documented the integration-only `size:exception` rationale
- [x] Ran applicable focused, full, driven, and CI checks
- [x] Used conventional commits
- [x] Reviewed the complete integrated diff
- [x] Disclosed material AI assistance
- [x] Added no `Co-Authored-By` trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retaining targeted-validator evidence, including checks, follow-ups, and result details.
  - Added a workflow for rejected provider validation to start a fresh high-risk review.
  - Added replay support for captured validation results without changing authoritative state.

- **Bug Fixes**
  - Changed candidates after rejected or failed validation now correctly begin unrelated reviews instead of resuming prior escalations.
  - Invalid or incomplete validation evidence is rejected before any state changes occur.

- **Tests**
  - Added coverage for evidence integrity, replay behavior, and the new review journey.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->