### PR TITLE
fix(sdd): reconcile replayed intended-untracked selections against the index

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -830,6 +830,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue3776Journeys()...)
 	journeys = append(journeys, issue3766Journeys()...)
 	journeys = append(journeys, issue3813Journeys()...)
+	journeys = append(journeys, issue3842Journeys()...)
 	journeys = append(journeys, handoffJourneys()...)
 	journeys = removeRetiredAtomicJourneys(journeys)
 	return declareCoreJourneyReviewModes(journeys)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -72,6 +72,7 @@ func journeySources() []journeySource {
 		{"journeys_issue3776.go", issue3776Journeys()},
 		{"journeys_issue3766.go", issue3766Journeys()},
 		{"journeys_issue3813.go", issue3813Journeys()},
+		{"journeys_issue3842.go", issue3842Journeys()},
 	}
 	for index := range sources {
 		sources[index].Journeys = removeRetiredAtomicJourneys(sources[index].Journeys)

--- a/bench/journeys_issue3842.go
+++ b/bench/journeys_issue3842.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+// issue3842Journeys pins the replay reconciliation ratified by #3842. An SDD
+// attempt acquired with --untracked-scope=select --intended-untracked=<path>
+// records that selection immutably, and committing the selected file is the
+// ordinary END of the work unit — landing it was the whole point of selecting
+// it. Before the fix, every later capture replayed the recorded selection
+// verbatim into the snapshot builder, whose "intended-untracked path ... is
+// already tracked" refusal then dead-ended reset (and settle) with no exit.
+// After the fix, a replayed HISTORICAL selection is reconciled against the
+// current index first: a now-tracked path drops out of the overlay while the
+// candidate tree stays byte-identical, so reset publishes and the next work
+// unit can open. The expectation holds because only replays reconcile — a
+// fresh caller-supplied selection of a tracked path keeps failing loudly as
+// the scope declaration error it is.
+func issue3842Journeys() []Journey {
+	return []Journey{{
+		ID:     "j124-sdd-attempt-reset-after-selected-untracked-lands",
+		Review: reviewOptedIn,
+		Title:  "SDD attempt: a landed selected-untracked file no longer dead-ends reset",
+		Source: "#3842: replayed intended-untracked selections reconcile against the current index instead of tripping the already-tracked refusal",
+		Steps: []Step{
+			{Name: "fixture: runtime repository", Fixture: sddRuntimeRepo},
+			{Name: "fixture: selected untracked candidate", Fixture: sddSelectedUntrackedCandidate},
+			{Name: "acquire selected scope and settle the objective passed",
+				Requires: sddSelectedUntrackedCapability, Composite: issue3842AcquireAndComplete},
+			{Name: "fixture: the selected file lands in a commit", Fixture: issue3842CommitSelectedFile},
+			{Name: "reset the completed objective with its exact revision",
+				Requires: sddAttemptResetCapability, Composite: issue3842ResetPublishes},
+		},
+	}}
+}
+
+// issue3842AcquireAndComplete mirrors the selected-untracked acquire shape of
+// j84: read the canonical untracked inventory from review status, acquire with
+// the explicit selection, make a small tracked edit so the passed settle is
+// legitimate work, and settle the objective to completion.
+func issue3842AcquireAndComplete(r *journeyRun) error {
+	selection, err := readStatusForContract(r, reviewContractV2)
+	if err != nil {
+		return err
+	}
+	digest := selection.argument("expected_untracked_inventory")
+	if digest == "" {
+		return fmt.Errorf("review status did not publish the canonical untracked inventory: %+v", selection.NextTransition)
+	}
+	acquire := r.run([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange, "--request-id", "issue3842-acquire",
+		"--work-unit", "land the selected untracked file", "--evidence-goal", "prove the selected work unit completes",
+		"--max-attempts", "2", "--max-changed-lines", "20", "--untracked-scope", "select",
+		"--expected-untracked-inventory", digest, "--intended-untracked", "docs/selected.md",
+	}, false)
+	var claimed sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(acquire.Stdout), &claimed); err != nil || acquire.ExitCode != 0 || claimed.State != "proceed" || claimed.Token == "" {
+		return fmt.Errorf("selected acquire = %#v parse=%v exit=%d", claimed, err, acquire.ExitCode)
+	}
+	if err := r.sandbox.write(filepath.Join(r.sandbox.Repo, "docs", "attempt.md"), "tracked change\n"); err != nil {
+		return err
+	}
+	if err := r.sandbox.write(filepath.Join(r.sandbox.Repo, "docs", "selected.md"), "final selected candidate\n"); err != nil {
+		return err
+	}
+	settled := r.run(append([]string{
+		"sdd-attempt", "settle", "--cwd", r.sandbox.Repo, "--change", sddChange, "--token", claimed.Token,
+		"--request-id", "issue3842-settle-passed", "--outcome", "passed", "--evidence-revision", sddCorrectedEvidence,
+	}, sddTerminalEvidence...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(settled.Stdout), &result); err != nil || settled.ExitCode != 0 || result.State != "complete" {
+		return fmt.Errorf("selected passed settle = %#v parse=%v exit=%d stderr=%s", result, err, settled.ExitCode, firstLine(settled.Stderr))
+	}
+	status, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if !status.Complete || status.ActiveAttempt != nil || status.NextAction != "complete" {
+		return fmt.Errorf("completed selected objective status = %#v", status)
+	}
+	return nil
+}
+
+// issue3842CommitSelectedFile is the exact user gesture #3842 dead-ended on:
+// the selected untracked file becomes tracked because the work unit landed.
+func issue3842CommitSelectedFile(sandbox *Sandbox) error {
+	tracked, err := gitOut(sandbox, sandbox.Repo, "ls-files", "docs/selected.md")
+	if err != nil {
+		return err
+	}
+	if tracked != "" {
+		return fmt.Errorf("fixture expects the selected file untracked before the landing commit, git tracks %q", tracked)
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "-A"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "commit", "-qm", "land the selected work unit"); err != nil {
+		return err
+	}
+	tracked, err = gitOut(sandbox, sandbox.Repo, "ls-files", "docs/selected.md")
+	if err != nil {
+		return err
+	}
+	if tracked != "docs/selected.md" {
+		return fmt.Errorf("fixture claims the selected file landed but git tracks %q", tracked)
+	}
+	return nil
+}
+
+// issue3842ResetPublishes drives the exact dead-end of #3842: reset the
+// completed objective AFTER its selected file became tracked. Before the fix
+// this invocation failed with "intended-untracked path docs/selected.md is
+// already tracked"; after it, the replayed selection reconciles and the reset
+// publishes a new revision that opens the next work unit.
+func issue3842ResetPublishes(r *journeyRun) error {
+	status, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	if !status.Complete || status.Revision == "" {
+		return fmt.Errorf("pre-reset runtime status = %#v", status)
+	}
+	reset := r.run(sddAttemptArgs(r, "reset", status.Revision, "issue3842-reset",
+		"--reason", "the selected work unit landed; open the next objective", "--actor", "bench"), false)
+	if reset.ExitCode != 0 {
+		return fmt.Errorf("reset after the selected file landed exited %d (the #3842 dead-end): %s",
+			reset.ExitCode, firstLine(reset.Stderr, reset.Stdout))
+	}
+	var after struct {
+		Revision      string    `json:"revision"`
+		Complete      bool      `json:"complete"`
+		NextAction    string    `json:"next_action"`
+		ActiveAttempt *struct{} `json:"active_attempt"`
+		LastReset     *struct {
+			Revision            string `json:"revision"`
+			PreviousObjectiveID string `json:"previous_objective_id"`
+		} `json:"last_reset"`
+	}
+	if err := proveJSON(r.sandbox, &after, "sdd-attempt", "status", "--cwd", r.sandbox.Repo, "--change", sddChange); err != nil {
+		return err
+	}
+	if after.Revision == "" || after.Revision == status.Revision || after.Complete || after.ActiveAttempt != nil ||
+		after.NextAction != "begin" || after.LastReset == nil || after.LastReset.Revision != after.Revision {
+		return fmt.Errorf("reset did not publish a fresh objective scope: %#v (previous revision %s)", after, status.Revision)
+	}
+	return nil
+}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -121,6 +121,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j121-rdd-tui-controls-global-mode":                                         reviewUntouched,
 	"j122-global-review-mode-from-non-git-cwd":                                  reviewUntouched,
 	"j123-rejected-provider-validator-starts-fresh-high-risk-review":            reviewOptedIn,
+	"j124-sdd-attempt-reset-after-selected-untracked-lands":                     reviewOptedIn,
 }
 
 func declareCoreJourneyReviewModes(journeys []Journey) []Journey {

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -21,6 +21,7 @@ j120-welcome-tui-runs-under-a-real-tty
 j121-rdd-tui-controls-global-mode
 j122-global-review-mode-from-non-git-cwd
 j123-rejected-provider-validator-starts-fresh-high-risk-review
+j124-sdd-attempt-reset-after-selected-untracked-lands
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token
 j17-bare-repository

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -719,6 +719,50 @@ func (builder SnapshotBuilder) ValidateIntendedUntrackedSelection(ctx context.Co
 	return selected, nil
 }
 
+// StillUntrackedIntended returns the subset of a HISTORICAL intended-untracked
+// selection whose paths are still absent from the real index, preserving the
+// recorded order.
+//
+// Issue #3842: a ledger that replays a recorded selection into a later capture
+// must first reconcile it against the index the capture will actually read. A
+// selected path the user has since committed is already part of the ordinary
+// candidate — its bytes live in HEAD/index/worktree — so keeping it in the
+// overlay list only trips buildCurrentChanges's "already tracked" refusal,
+// while dropping it keeps the candidate tree byte-identical. Snapshot
+// identity binds trees and paths, not the selection itself, so a bare
+// landing of the selection replays as zero drift and any further edit reads
+// as ordinary candidate drift — exactly the distinction the ledger's
+// reset/rescope split already routes on. This is strictly a replay-time
+// reconciliation: FRESH caller-supplied selections must never pass through
+// here, so an explicit selection of a tracked path keeps failing loudly as
+// the scope declaration error it is.
+//
+// A selection that landed completely returns a non-nil empty slice, because
+// snapshot targets demand an explicit selection rather than an absent one; an
+// empty (including nil) input short-circuits unchanged without touching the
+// repository.
+func (builder SnapshotBuilder) StillUntrackedIntended(ctx context.Context, intended []string) ([]string, error) {
+	if len(intended) == 0 {
+		return intended, nil
+	}
+	root, err := builder.ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	trackedOutput, err := runGitInventory(ctx, root, "ls-files", "--cached", "-z", "--")
+	if err != nil {
+		return nil, err
+	}
+	tracked := nulSeparatedPathSet(trackedOutput)
+	remaining := make([]string, 0, len(intended))
+	for _, path := range intended {
+		if _, isTracked := tracked[path]; !isTracked {
+			remaining = append(remaining, path)
+		}
+	}
+	return remaining, nil
+}
+
 func intendedUntrackedInventoryDigest(paths []string) string {
 	hash := sha256.New()
 	writeLengthPrefixed(hash, []byte("gentle-ai.intended-untracked-inventory/v1"))

--- a/internal/reviewtransaction/snapshot_still_untracked_test.go
+++ b/internal/reviewtransaction/snapshot_still_untracked_test.go
@@ -1,0 +1,44 @@
+package reviewtransaction
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// Issue #3842: StillUntrackedIntended reconciles a HISTORICAL intended-
+// untracked selection against the real index — paths that became tracked are
+// dropped, still-untracked paths survive in their recorded order, and a
+// selection that landed completely returns a non-nil empty slice because
+// snapshot targets demand an explicit selection, never an absent one.
+func TestSnapshotBuilderStillUntrackedIntendedReconcilesTrackedPaths(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "keep-a.txt", "a\n")
+	writeSnapshotFile(t, repo, "keep-b.txt", "b\n")
+	builder := SnapshotBuilder{Repo: repo}
+
+	got, err := builder.StillUntrackedIntended(context.Background(), []string{"keep-b.txt", "tracked.txt", "keep-a.txt"})
+	if err != nil {
+		t.Fatalf("StillUntrackedIntended over a mixed selection: %v", err)
+	}
+	// Recorded order is preserved; only the tracked path drops out.
+	if want := []string{"keep-b.txt", "keep-a.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("StillUntrackedIntended() = %v, want %v", got, want)
+	}
+
+	landed, err := builder.StillUntrackedIntended(context.Background(), []string{"tracked.txt", "deleted.txt"})
+	if err != nil {
+		t.Fatalf("StillUntrackedIntended over a fully-landed selection: %v", err)
+	}
+	if landed == nil || len(landed) != 0 {
+		t.Fatalf("fully-landed selection = %#v, want a non-nil empty slice", landed)
+	}
+
+	// An empty historical selection short-circuits without touching the
+	// repository at all — nil stays nil so absent provenance stays absent.
+	empty, err := builder.StillUntrackedIntended(context.Background(), nil)
+	if err != nil || empty != nil {
+		t.Fatalf("empty selection = %#v err=%v, want nil unchanged", empty, err)
+	}
+}

--- a/internal/sddstatus/runtime_admission.go
+++ b/internal/sddstatus/runtime_admission.go
@@ -101,7 +101,18 @@ func (store RuntimeStore) runtimeBeginAdmission(
 		if last.Outcome == AttemptRunning || last.FinishCandidateIdentity == "" || last.FinishCandidateTree == "" {
 			return runtimeBeginAdmissionResult{}, errors.New("SDD runtime objective has invalid terminal candidate provenance")
 		}
-		snapshot, err = captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, last.IntendedUntracked)
+		// #3842: the terminal capture replays the RECORDED selection, which
+		// the user may have legitimately committed since the last settle, so
+		// reconcile it against the current index first — a committed path then
+		// replays as zero drift or as ordinary candidate drift, never as a
+		// capture failure. The request-vs-recorded comparison below
+		// deliberately stays against the recorded list: what the caller must
+		// re-request is the scope the ledger holds, exactly as acquired.
+		var intended []string
+		intended, err = runtimeReplayedIntendedUntracked(ctx, store.Repo, last.IntendedUntracked)
+		if err == nil {
+			snapshot, err = captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
+		}
 		if err == nil && (snapshot.Identity != last.FinishCandidateIdentity || snapshot.CandidateTree != last.FinishCandidateTree) {
 			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status)
 		}

--- a/internal/sddstatus/runtime_intended_untracked_tracked_test.go
+++ b/internal/sddstatus/runtime_intended_untracked_tracked_test.go
@@ -1,0 +1,288 @@
+package sddstatus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #3842: the runtime ledger records each attempt's intended-untracked
+// selection at acquire time, and every later operation that re-captures the
+// workspace candidate replayed that HISTORICAL list verbatim. Once the user
+// legitimately committed the selected paths — the ordinary end of a work
+// unit, and sometimes the work unit itself — the snapshot builder's
+// "already tracked" refusal fired on every replayed capture and the runtime
+// dead-ended across reset, settle, and admissibility probes. A path that
+// became tracked is already part of the ordinary candidate (its bytes live
+// in HEAD/index/worktree), so the fix reconciles replayed lists against the
+// current index before capture: dropped from the overlay, present in the
+// tree, byte-identical candidate. Only replayed history is reconciled;
+// FRESH caller-supplied selections stay strict.
+
+// The core field-report shape: a work unit selects an untracked path, passes,
+// completes its objective, and the user commits the path. Reset must succeed
+// and publish a reset record instead of dying on the replayed selection.
+func TestRuntimeResetSucceedsAfterIntendedUntrackedBecomesTracked(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "selected.txt"), []byte("selected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := mustRuntimeStore(t, repo, "tracked-selected-reset")
+	store.ReviewDisabled = true
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "tracked-reset-begin", WorkUnit: "apply", EvidenceGoal: "land the selected file",
+		MaxAttempts: 1, MaxChangedLines: 20, IntendedUntracked: []string{"selected.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "tracked-reset-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "selected work unit passed verification",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !completed.Complete {
+		t.Fatalf("passed selected objective did not complete: %#v", completed)
+	}
+	// The legitimate end of the work unit: the selected path is committed and
+	// is now tracked, so the recorded selection no longer names an untracked
+	// path.
+	runRuntimeLedgerGit(t, repo, "add", "selected.txt")
+	runRuntimeLedgerGit(t, repo, "commit", "-qm", "land selected.txt")
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: completed.Revision, RequestID: "tracked-reset",
+		Reason: "maintainer decision: open a successor scope after the selected file landed",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("reset after the selected path was committed: %v", err)
+	}
+	if reset.LastReset == nil || reset.LastReset.Revision != reset.Revision || reset.NextAction != RuntimeActionBegin {
+		t.Fatalf("reset after commit did not publish a reset record: %#v", reset)
+	}
+}
+
+// Settle mid-commit: some work units require committing the selected path as
+// part of the attempt itself. The finish capture replays the attempt's
+// selection over the begin candidate tree and must not refuse the now-tracked
+// path.
+func TestRuntimeSettleSucceedsAfterIntendedUntrackedCommittedMidAttempt(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "selected.txt"), []byte("selected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := mustRuntimeStore(t, repo, "tracked-selected-settle")
+	store.ReviewDisabled = true
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "tracked-settle-begin", WorkUnit: "apply", EvidenceGoal: "commit the selected file",
+		MaxAttempts: 2, MaxChangedLines: 20, IntendedUntracked: []string{"selected.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeLedgerGit(t, repo, "add", "selected.txt")
+	runRuntimeLedgerGit(t, repo, "commit", "-qm", "land selected.txt mid-attempt")
+	settled, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "tracked-settle-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "the selected file was committed as the work unit required",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatalf("settle after committing the selected path mid-attempt: %v", err)
+	}
+	if !settled.Complete || settled.ActiveAttempt != nil {
+		t.Fatalf("mid-commit settle = %#v", settled)
+	}
+	// The committed bytes were already part of the begin candidate as the
+	// selected overlay, so the candidate tree itself must not have moved.
+	last := settled.Attempts[len(settled.Attempts)-1]
+	if last.ChangedLines != 0 {
+		t.Fatalf("byte-identical mid-commit candidate charged %d changed lines", last.ChangedLines)
+	}
+}
+
+// Strictness preserved (#3842): reconciliation applies only to REPLAYED
+// ledger history. A fresh begin whose caller explicitly selects a tracked
+// path is a scope declaration error and must keep failing loudly.
+func TestRuntimeFreshBeginStillRefusesTrackedIntendedUntracked(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "tracked-selected-fresh")
+	_, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "tracked-fresh-begin", WorkUnit: "apply", EvidenceGoal: "reject a tracked selection",
+		MaxAttempts: 2, MaxChangedLines: 20, IntendedUntracked: []string{"tracked.txt"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "already tracked") {
+		t.Fatalf("fresh begin with a tracked selection = %v, want the already-tracked refusal", err)
+	}
+	status, statusErr := store.Status()
+	if statusErr != nil || status.Revision != "" || status.ActiveAttempt != nil {
+		t.Fatalf("refused fresh selection mutated authority: status=%#v err=%v", status, statusErr)
+	}
+}
+
+// After the selected path lands PLUS a further tracked edit, the candidate has
+// genuinely drifted, so reset must be admissible and the changed-objective
+// refusal must name the reset exit. Before #3842 the admissibility probes'
+// captures failed on the replayed selection, both probes answered false, and
+// the refusal fell back to re-offering the very begin the state refuses.
+func TestRuntimeResetAdmissibleAfterIntendedUntrackedCommitDrift(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "selected.txt"), []byte("selected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := mustRuntimeStore(t, repo, "tracked-selected-admissible")
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "tracked-admissible-begin", WorkUnit: "verify", EvidenceGoal: "independent verification",
+		MaxAttempts: 2, MaxChangedLines: 20, IntendedUntracked: []string{"selected.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "tracked-admissible-finish", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('c'), Diagnosis: "verification found a defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeLedgerGit(t, repo, "add", "selected.txt")
+	runRuntimeLedgerGit(t, repo, "commit", "-qm", "land selected.txt")
+	appendRuntimeLedgerFile(t, repo, "real candidate drift\n")
+	// A begin naming a different work unit reaches the changed-objective
+	// refusal, whose exit is chosen by the reset admissibility probe.
+	_, err = store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: failed.Revision, RequestID: "tracked-admissible-changed", WorkUnit: "other",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err == nil || !strings.Contains(err.Error(), "sdd-attempt reset") {
+		t.Fatalf("changed-objective refusal after commit drift = %v, want the reset exit named", err)
+	}
+	// And the reset the refusal names must actually run: its drift check and
+	// its fresh capture both replay the recorded selection.
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "tracked-admissible-reset",
+		Reason: "maintainer decision: the selected file landed and the candidate moved on",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("drift reset after the selected path was committed: %v", err)
+	}
+	if reset.LastReset == nil || reset.NextAction != RuntimeActionBegin {
+		t.Fatalf("drift reset did not publish a reset record: %#v", reset)
+	}
+}
+
+// The overlay identity binds only trees and paths, so committing the selected
+// path with no other edit keeps the candidate byte-identical — that is
+// rescope's zero-drift shape, not reset's. The changed-objective refusal must
+// name the rescope exit, the elective reset must stay refused, and the rescope
+// itself must run through both of its reconciled captures.
+func TestRuntimeRescopeAdmissibleAfterIntendedUntrackedLandsByteIdentical(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "selected.txt"), []byte("selected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := mustRuntimeStore(t, repo, "tracked-selected-zero-drift")
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "tracked-zero-drift-begin", WorkUnit: "verify", EvidenceGoal: "independent verification",
+		MaxAttempts: 2, MaxChangedLines: 20, IntendedUntracked: []string{"selected.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "tracked-zero-drift-finish", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('e'), Diagnosis: "verification found a defect",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeLedgerGit(t, repo, "add", "selected.txt")
+	runRuntimeLedgerGit(t, repo, "commit", "-qm", "land selected.txt only")
+	_, err = store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: failed.Revision, RequestID: "tracked-zero-drift-changed", WorkUnit: "other",
+		EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err == nil || !strings.Contains(err.Error(), "sdd-attempt rescope") {
+		t.Fatalf("changed-objective refusal after a byte-identical landing = %v, want the rescope exit named", err)
+	}
+	// The elective reset stays refused: the reconciled drift capture must
+	// succeed and answer zero drift instead of dying on the replayed
+	// selection.
+	if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "tracked-zero-drift-reset",
+		Reason: "elective reset over an unmoved candidate", Actor: "maintainer",
+	}); !errors.Is(err, ErrRuntimeResetNotAllowed) {
+		t.Fatalf("zero-drift reset after the landing = %v, want ErrRuntimeResetNotAllowed", err)
+	}
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "tracked-zero-drift-rescope",
+		WorkUnit: "narrower verify", EvidenceGoal: "narrower verification",
+		MaxAttempts: 2, MaxChangedLines: 10,
+		Reason: "maintainer decision: narrow the objective after the selected file landed",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("rescope after the byte-identical landing: %v", err)
+	}
+	if rescoped.LastRescope == nil || rescoped.Objective == nil || rescoped.Objective.WorkUnit != "narrower verify" {
+		t.Fatalf("rescope after the landing did not open the successor: %#v", rescoped)
+	}
+}
+
+// Partial landing: only one of two selected paths gets committed. The
+// replayed capture must keep the still-untracked path in the candidate
+// overlay while dropping only the tracked one.
+func TestRuntimeReplayedCapturePreservesRemainingUntrackedIntended(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	for name, content := range map[string]string{"sel-a.txt": "a\n", "sel-b.txt": "b\n"} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := mustRuntimeStore(t, repo, "tracked-selected-partial")
+	store.ReviewDisabled = true
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "tracked-partial-begin", WorkUnit: "apply", EvidenceGoal: "land one selected file",
+		MaxAttempts: 2, MaxChangedLines: 20, IntendedUntracked: []string{"sel-a.txt", "sel-b.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeLedgerGit(t, repo, "add", "sel-a.txt")
+	runRuntimeLedgerGit(t, repo, "commit", "-qm", "land sel-a.txt only")
+	if err := os.WriteFile(filepath.Join(repo, "sel-b.txt"), []byte("b\nstill selected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	settled, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "tracked-partial-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('d'), Diagnosis: "one selected file landed, the other kept working",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+	})
+	if err != nil {
+		t.Fatalf("settle after a partial selected landing: %v", err)
+	}
+	last := settled.Attempts[len(settled.Attempts)-1]
+	// Exactly the still-untracked path's edit is charged: sel-a's bytes were
+	// already in the begin candidate overlay, so committing them moved
+	// nothing, while sel-b's one added line is real candidate change — proof
+	// the remaining selection stayed in the capture.
+	if last.ChangedLines != 1 {
+		t.Fatalf("partial landing charged %d changed lines, want only sel-b's edit", last.ChangedLines)
+	}
+	// The finish record carries the selection this settlement's overlay
+	// actually used (#3806 records the resolved settle-time selection, #3842
+	// reconciles it): sel-a landed, so only sel-b remains. The begin record
+	// upstream still holds both paths as acquired.
+	if len(last.IntendedUntracked) != 1 || last.IntendedUntracked[0] != "sel-b.txt" {
+		t.Fatalf("recorded selection provenance = %#v", last.IntendedUntracked)
+	}
+}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -893,6 +893,18 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		// review freezes -- tracked changes plus whatever the user put in the
 		// index. Sweeping the worktree here would make drift detection and
 		// review disagree about what the candidate even is.
+		//
+		// #3842: the resolved selection can still carry begin-time paths the
+		// work unit committed mid-attempt (a settle-time declaration is
+		// validated against the current inventory, but the undeclared branches
+		// return the begin selection as recorded), so reconcile it against the
+		// current index before capture. The finish record below carries the
+		// reconciled list, because that is the selection this settlement's
+		// overlay actually used.
+		intendedUntracked, err = runtimeReplayedIntendedUntracked(ctx, store.Repo, intendedUntracked)
+		if err != nil {
+			return runtimeRecord{}, wrapRuntimeCandidateUnavailable("after attempt", err)
+		}
 		snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).Build(ctx, reviewtransaction.Target{
 			Kind: reviewtransaction.TargetBaseWorkspaceOverlay, BaseRef: active.BeginCandidateTree,
 			Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: intendedUntracked,
@@ -1110,7 +1122,15 @@ func (store RuntimeStore) Handoff(ctx context.Context, request HandoffAttemptReq
 		if err != nil {
 			return runtimeRecord{}, err
 		}
-		snapshot, err := captureRuntimeHandoffCandidate(ctx, request.DestinationWorktree, active.BeginCandidateTree, active.IntendedUntracked)
+		// #3842: reconcile the replayed selection against the DESTINATION
+		// worktree's index — that is where the capture below actually runs,
+		// and a linked worktree's checked-out branch may already track paths
+		// the source recorded as untracked at begin time.
+		intendedUntracked, err := runtimeReplayedIntendedUntracked(ctx, request.DestinationWorktree, active.IntendedUntracked)
+		if err != nil {
+			return runtimeRecord{}, fmt.Errorf("capture delegated SDD runtime candidate before handoff: %w", err)
+		}
+		snapshot, err := captureRuntimeHandoffCandidate(ctx, request.DestinationWorktree, active.BeginCandidateTree, intendedUntracked)
 		if err != nil {
 			return runtimeRecord{}, fmt.Errorf("capture delegated SDD runtime candidate before handoff: %w", err)
 		}
@@ -1302,7 +1322,14 @@ func (store RuntimeStore) runtimeObjectiveResetAdmissible(ctx context.Context, s
 		return true
 	}
 	last := status.Attempts[len(status.Attempts)-1]
-	candidate, err := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, last.IntendedUntracked)
+	// #3842: reconcile the replayed selection first — a selected path the user
+	// has since committed would otherwise fail the capture and this probe
+	// would answer false exactly when the commit made reset the right exit.
+	intended, err := runtimeReplayedIntendedUntracked(ctx, store.Repo, last.IntendedUntracked)
+	if err != nil {
+		return false
+	}
+	candidate, err := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
 	if err != nil {
 		return false
 	}
@@ -1322,7 +1349,13 @@ func (store RuntimeStore) runtimeObjectiveRescopeAdmissible(ctx context.Context,
 		return false
 	}
 	last := status.Attempts[len(status.Attempts)-1]
-	candidate, err := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, last.IntendedUntracked)
+	// #3842: same replay reconciliation as the reset probe, and for the same
+	// fail-closed reason — a reconcile error is a capture that could not run.
+	intended, err := runtimeReplayedIntendedUntracked(ctx, store.Repo, last.IntendedUntracked)
+	if err != nil {
+		return false
+	}
+	candidate, err := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
 	if err != nil {
 		return false
 	}
@@ -1404,6 +1437,14 @@ func (store RuntimeStore) Reset(ctx context.Context, request ResetObjectiveReque
 			return runtimeRecord{}, ErrRuntimeResetNotAllowed
 		}
 		last := status.Attempts[len(status.Attempts)-1]
+		// #3842: the recorded selection is a historical replay by reset time —
+		// the completed work unit's selected paths are ordinarily committed by
+		// now — so reconcile it once against the current index and feed the
+		// same reconciled list to both captures below.
+		intended, err := runtimeReplayedIntendedUntracked(ctx, store.Repo, last.IntendedUntracked)
+		if err != nil {
+			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate at objective reset: %w", err)
+		}
 		if !status.DecisionRequired && !status.Complete {
 			// The only remaining structurally-permitted scope is a terminal
 			// failed/interrupted attempt with budget still available: begin
@@ -1411,7 +1452,7 @@ func (store RuntimeStore) Reset(ctx context.Context, request ResetObjectiveReque
 			// begin is actually blocked by candidate drift. Otherwise an
 			// elective early reset would launder the per-objective budget
 			// (CumulativeAttempts resets to zero on every reset).
-			candidate, driftErr := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, last.IntendedUntracked)
+			candidate, driftErr := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
 			if driftErr != nil {
 				return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check reset drift eligibility: %w", driftErr)
 			}
@@ -1419,7 +1460,7 @@ func (store RuntimeStore) Reset(ctx context.Context, request ResetObjectiveReque
 				return runtimeRecord{}, store.runtimeZeroDriftResetRefusal(status)
 			}
 		}
-		snapshot, err := captureRuntimeCandidate(ctx, store.Repo, last.IntendedUntracked)
+		snapshot, err := captureRuntimeCandidate(ctx, store.Repo, intended)
 		if err != nil {
 			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate at objective reset: %w", err)
 		}
@@ -1485,7 +1526,15 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed
 		}
 		last := status.Attempts[len(status.Attempts)-1]
-		drift, driftErr := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, last.IntendedUntracked)
+		// #3842: reconcile the replayed selection once and feed the SAME
+		// reconciled list to this drift capture and the fresh capture below,
+		// so the CandidateTree comparability contract between them holds over
+		// one selection rather than two.
+		intended, err := runtimeReplayedIntendedUntracked(ctx, store.Repo, last.IntendedUntracked)
+		if err != nil {
+			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check rescope drift eligibility: %w", err)
+		}
+		drift, driftErr := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
 		if driftErr != nil {
 			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check rescope drift eligibility: %w", driftErr)
 		}
@@ -1527,7 +1576,7 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 		// on it exactly because there is zero drift -- so this second capture
 		// is provably the same underlying content the drift check just
 		// verified, not a fresh unguarded read.
-		fresh, err := captureRuntimeCandidate(ctx, store.Repo, last.IntendedUntracked)
+		fresh, err := captureRuntimeCandidate(ctx, store.Repo, intended)
 		if err != nil {
 			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate at objective rescope: %w", err)
 		}
@@ -2911,6 +2960,27 @@ func validHarnessDisposition(disposition HarnessDisposition) bool {
 // compact boundary unclassified the way both of them did before #2114.
 func wrapRuntimeCandidateUnavailable(stage string, cause error) error {
 	return fmt.Errorf("%w %s: %w", ErrRuntimeCandidateUnavailable, stage, cause)
+}
+
+// runtimeReplayedIntendedUntracked reconciles a HISTORICAL intended-untracked
+// selection against the repository's current index before it is replayed into
+// a candidate capture (#3842). The ledger records the selection at
+// acquire/begin time, but the user legitimately commits the selected paths as
+// the ordinary end of a work unit — sometimes as the work unit itself — and a
+// verbatim replay of the recorded list then trips the snapshot builder's
+// "already tracked" refusal on every later capture: reset, rescope, settle,
+// handoff, and the read-only admissibility probes all dead-end. A path that
+// became tracked is already part of the ordinary candidate (its bytes live in
+// HEAD/index/worktree), so dropping it from the overlay keeps the candidate
+// tree byte-identical: a bare landing of the selection replays as zero drift,
+// and any further edit reads as ordinary candidate drift — exactly the
+// distinction the reset/rescope split already routes on. Only replayed
+// history passes through here: fresh caller-supplied selections stay strict,
+// and the immutable records themselves keep the selection exactly as
+// acquired.
+func runtimeReplayedIntendedUntracked(ctx context.Context, repo string, recorded []string) ([]string, error) {
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	return builder.StillUntrackedIntended(ctx, recorded)
 }
 
 func captureRuntimeCandidate(ctx context.Context, repo string, intendedUntracked []string) (reviewtransaction.Snapshot, error) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3842

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- The SDD runtime ledger replayed each attempt's recorded intended-untracked selection verbatim into every later candidate capture. Once the user committed the selected paths (the ordinary end of a work unit, sometimes the work unit itself), the snapshot builder's "already tracked" refusal dead-ended reset, rescope, settle, handoff, and both admissibility probes, with no native continuation. Ten equivalent field reports on `2.5.0-rc.1`/`rc.2` across OpenCode, Claude Code, and Pi.
- Replayed HISTORICAL selections are now reconciled against the current index before capture: paths that became tracked are dropped from the overlay list. The candidate tree stays byte-identical, so a bare landing of the selection replays as zero drift (rescope's shape) and any further edit as ordinary candidate drift (reset's shape), the exact split the ledger already routes on.
- Fresh caller-supplied selections stay strict: a new acquire/begin explicitly naming a tracked path keeps failing loudly as the scope declaration error it is. The immutable records keep the selection exactly as acquired.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | New `SnapshotBuilder.StillUntrackedIntended`: filters a historical selection through `git ls-files --cached`, order-preserving, non-nil empty when the whole selection landed |
| `internal/sddstatus/runtime_ledger.go` | New `runtimeReplayedIntendedUntracked` wrapper; reconciliation at Reset (drift check + capture, one shared list), Rescope (drift + fresh capture, one shared list), Finish, Handoff (against the destination worktree), and both admissibility probes (fail-closed) |
| `internal/sddstatus/runtime_admission.go` | Continuing-objective begin reconciles the replayed list before the terminal capture; the request-vs-recorded scope comparison stays against the recorded list |
| `internal/reviewtransaction/snapshot_still_untracked_test.go` | Unit coverage for the new helper (mixed tracked/untracked, order, all-landed) |
| `internal/sddstatus/runtime_intended_untracked_tracked_test.go` | TDD repros: reset after completion + commit, settle after mid-attempt commit, fresh-begin strictness preserved, admissibility routing, partial landing |
| `bench/journeys_issue3842.go` (+ wiring, manifest) | `j124-sdd-attempt-reset-after-selected-untracked-lands` pins the fixed lifecycle end to end through the real CLI |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Root-cause analysis, implementation, unit tests, and the bench journey, under maintainer direction and review.

**Verification performed:** TDD (each repro failed with the reported error before the fix, passes after), full unit suite, `GOOS=windows go vet`, gofmtcheck, and the driven benchmark corpus (below).

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```
All packages pass. New tests fail against pre-fix HEAD with the exact reported error (`intended-untracked path "..." is already tracked`) and pass with the fix.

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Clean.

**Benchmark Validation**

Driven mode against a locally built binary:

- Full corpus: `journeys: 54 completed, 0 unsupported, 0 failed`
- New journey only (`--only j124-sdd-attempt-reset-after-selected-untracked-lands`): `journeys: 1 completed, 0 unsupported, 0 failed`
- Defect-pinning proof: the same journey against a pre-fix binary built from HEAD reports `journeys: 0 completed, 0 unsupported, 1 failed`, failing at the reset step with the product's own already-tracked refusal
- No existing journey pinned the old dead-end (corpus grepped for the refusal text)

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented (623 authored lines; 330 are the TDD repro tests and 154 the corpus journey pinning the fix, split into two work-unit commits)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary (behavior documented in code comments referencing the issue)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

For production Go changes in `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus`:

- [x] Identify any qualifying security, integrity, admission, repair, or governance guard and challenge its legitimate input population against real-world evidence.
- [x] Confirm its `guard:population` direction and claim are adjacent and accurate, and that `.guard-population-baseline.txt` changed only when the guard contract intentionally changed.
- [x] Do not treat a passing declaration/registry check as proof that no qualifying guard was omitted or that the population claim is semantically complete.

The `already tracked` refusal in `snapshot.go` is untouched: this change narrows its input population to fresh caller-supplied selections only, which is the population the ten field reports show it was always meant to guard. Replayed history is reconciled upstream, never inside the guard. `.guard-population-baseline.txt` is unchanged.

A design note worth a close read: `Snapshot.Identity` binds kind/trees/paths digest and does not fold in the untracked proof, so a bare landing of the selection replays as zero drift. The new `TestRuntimeRescopeAdmissibleAfterIntendedUntrackedLandsByteIdentical` pins that routing (zero-drift reset still refused, rescope admitted).

https://claude.ai/code/session_01NDgsbYJCwUfuTSAZNCJJVJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay handling when files selected as untracked are committed during an SDD attempt.
  * Reset, rescope, handoff, and settlement flows now ignore selected paths that have since become tracked.
  * Preserved remaining untracked selections during partial changes.
  * Added coverage for related replay, drift, and admissibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->