### PR TITLE
fix(skills): normalize relative --cwd before skill-registry scope

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -363,6 +363,15 @@ func resolveSkillRegistryDirs(cwd string) (string, string, error) {
 		if err != nil {
 			return "", "", fmt.Errorf("resolve cwd: %w", err)
 		}
+	} else {
+		// An explicit --cwd may be relative (e.g. "."). Normalize it to an
+		// absolute path so skill-registry list/refresh scope the same project
+		// identity whether the caller passes "." or "$PWD".
+		var err error
+		cwd, err = filepath.Abs(cwd)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve cwd: %w", err)
+		}
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/app/skill_registry_cwd_test.go
+++ b/internal/app/skill_registry_cwd_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveSkillRegistryDirsNormalizesRelativeCwd ensures an explicit
+// relative --cwd (e.g. ".") is canonicalized to an absolute path. Without
+// this, skill-registry list/refresh classify project-local skills as
+// user-scoped and emit relative paths (see issue #3565).
+func TestResolveSkillRegistryDirsNormalizesRelativeCwd(t *testing.T) {
+	cwd, home, err := resolveSkillRegistryDirs(".")
+	if err != nil {
+		t.Fatalf("resolveSkillRegistryDirs(\".\") error = %v", err)
+	}
+	want, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("filepath.Abs(\".\") error = %v", err)
+	}
+	if cwd != want {
+		t.Errorf("relative cwd not normalized: got %q, want %q", cwd, want)
+	}
+	if !filepath.IsAbs(cwd) {
+		t.Errorf("expected absolute cwd, got %q", cwd)
+	}
+	if home == "" {
+		t.Errorf("expected non-empty home directory")
+	}
+}
+
+// TestResolveSkillRegistryDirsDefaultUsesProcessCwd confirms the default
+// (empty) cwd resolves to an absolute process working directory.
+func TestResolveSkillRegistryDirsDefaultUsesProcessCwd(t *testing.T) {
+	cwd, _, err := resolveSkillRegistryDirs("")
+	if err != nil {
+		t.Fatalf("resolveSkillRegistryDirs(\"\") error = %v", err)
+	}
+	if !filepath.IsAbs(cwd) {
+		t.Errorf("default cwd should be absolute, got %q", cwd)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3565. An explicit relative `--cwd` (e.g. `.`) was passed through to the
skill-registry list/refresh scope calculation unchanged, so project-local skills
were classified as `scope:user` with relative paths. `resolveSkillRegistryDirs`
now canonicalizes an explicit `--cwd` to an absolute path via `filepath.Abs`,
matching the behavior of an absolute `--cwd`.

## Scope

- `internal/app/app.go`: normalize an explicit `--cwd` to absolute in
  `resolveSkillRegistryDirs` (shared by `skill-registry list` and `refresh`).
- `internal/app/skill_registry_cwd_test.go`: regression test for relative and
  default cwd resolution.

## Verification

- `go test ./...` passes (full suite, EXIT_GATE=0).
- Manual repro from repo root: `skill-registry list --json --cwd .` and
  `--cwd "$PWD"` now both report `scope:project` and an absolute path for
  `skills/cognitive-doc-design`.

## AI Assistance Disclosure

Material assistance: produced with the **el Gentleman** coding-agent harness (Pi),
driven by an Anthropic Claude model.

- Scope: diagnosis, fix, and regression test.
- Verification: every changed line was reviewed, the root cause was confirmed
  against the source, `go test ./...` was run, and the before/after behavior was
  reproduced manually. No `Co-Authored-By` trailer is included, per AI_POLICY.md.

Closes #3565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit relative working-directory paths are now resolved to absolute paths for more consistent skill registry behavior.
  * Default working-directory handling continues to use the process’s current directory.

* **Tests**
  * Added coverage for both relative and default working-directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->