### PR TITLE
fix(sdd): name stale and post-remediation verify blockers in blockedReasons

### DIFF
--- a/internal/assets/skills/_shared/sdd-status-contract.md
+++ b/internal/assets/skills/_shared/sdd-status-contract.md
@@ -150,4 +150,4 @@ Every command that acts on a change MUST show status before launching an executo
 - Artifact statuses and paths/topics used as context.
 - Task progress and unchecked task list when tasks exist.
 - Next recommended action.
-- `blockedReasons` when `nextRecommended` is not `verify`, plus any edit-root blockers.
+- `blockedReasons` whenever it is non-empty, including a `verify` route that must refresh stale or post-remediation evidence, plus any edit-root blockers.

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -46,6 +46,7 @@ The orchestrator should provide structured status from `skills/_shared/sdd-statu
 - If Strict TDD is active, load `strict-tdd-verify.md` from this skill directory; if inactive, never load it.
 - Return the Section D envelope from `../_shared/sdd-phase-common.md`.
 - Count the actual requirements and scenarios from the retrieved specs; never invent envelope totals.
+- Native status counts only `### Requirement:` / `### REQ-<n>:` and `#### Scenario:` headings. If the envelope totals differ from that count, status keeps `verify: ready` and names the mismatch in `blockedReasons`; fix the totals and re-verify instead of re-validating the same envelope.
 - Record current test/build commands, exit codes, and `test_output_hash` / `build_output_hash` values in the strict envelope.
 - Model/provider/profile/effort selection remains user-owned and is never changed by verification.
 - This is the one independent requirements/runtime final verification. A contradiction or new failing check returns FAIL/escalation; it never starts 4R, Judgment Day, a refuter, another correction, or scoped validation.

--- a/internal/sddstatus/issue3538_stale_report_reason_test.go
+++ b/internal/sddstatus/issue3538_stale_report_reason_test.go
@@ -1,0 +1,68 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression for #3538. Reporters saw `verify: ready`, `archive: blocked`,
+// `nextRecommended: verify` with an empty blockedReasons even though every
+// task was complete and a verify-report existed. Two paths produced that
+// silent tuple: a stale report whose totals disagree with the native heading
+// count (published only when Incomplete), and the post-remediation override
+// whose refresh instruction reached phaseInstructions only. This test pins
+// the stale-report shape: the persisted envelope was admitted against the
+// totals the caller supplied, yet native counting of the specs disagrees.
+func TestStaleVerifyReportNamesNativeTotalsInBlockedReasons(t *testing.T) {
+	const spec = "### Requirement: Auth\n#### Scenario: Expected behavior\n"
+	report := testVerifyEnvelope("pass", 0, 0, "13/13", "46/46", 0, 0)
+	if admission := ValidateVerifyReportAdmission(report, SpecCounts{Requirements: 13, Scenarios: 46}); !admission.Valid {
+		t.Fatalf("admission with caller-supplied totals = %#v, want valid", admission)
+	}
+
+	for _, backend := range []string{"openspec", "engram"} {
+		t.Run(backend, func(t *testing.T) {
+			root := t.TempDir()
+			var status Status
+			var err error
+			switch backend {
+			case "openspec":
+				changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+				write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), spec)
+				write(t, filepath.Join(changeRoot, "verify-report.md"), report)
+				status, err = Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			case "engram":
+				mkdir(t, filepath.Join(root, ".engram"))
+				project := strings.ToLower(filepath.Base(root))
+				restore := stubEngramExport(t, []engramObservation{
+					{Title: "sdd/thin/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+					{Title: "sdd/thin/spec", Content: spec, Project: project, Scope: "project"},
+					{Title: "sdd/thin/design", Content: "# Design\n", Project: project, Scope: "project"},
+					{Title: "sdd/thin/tasks", Content: "- [x] 1.1 Done\n", Project: project, Scope: "project"},
+					{Title: "sdd/thin/verify-report", Content: report, Project: project, Scope: "project"},
+				})
+				defer restore()
+				status, err = Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			}
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+			if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+				t.Fatalf("status = verify %q archive %q next %q, want ready/blocked/verify", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
+			}
+			if !status.TaskProgress.AllComplete {
+				t.Fatalf("TaskProgress = %#v, want all complete", status.TaskProgress)
+			}
+			joined := strings.Join(status.BlockedReasons, "\n")
+			for _, want := range []string{
+				"does not match actual requirement count 1",
+				"rerun SDD verification",
+			} {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/sddstatus/runtime_status_test.go
+++ b/internal/sddstatus/runtime_status_test.go
@@ -178,13 +178,16 @@ func TestResolveExplainsFreshVerificationAfterEvidenceOnlyRuntimeRemediation(t *
 			if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
 				t.Fatalf("post-remediation routing: verify=%q archive=%q next=%q", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
 			}
-			if len(status.BlockedReasons) != 0 {
-				t.Fatalf("BlockedReasons = %v, want empty for healthy sequencing", status.BlockedReasons)
+			const want = "A passing native remediation settlement completed after the persisted verification report; run fresh verification and persist a report bound after that settlement before archive."
+			// The refresh obligation must reach blockedReasons, not only the
+			// opt-in phase instructions, so a status without --instructions
+			// never projects a silent verify-ready tuple (#3538).
+			if occurrences := strings.Count(strings.Join(status.BlockedReasons, "\n"), want); occurrences != 1 {
+				t.Fatalf("BlockedReasons = %v, want the post-remediation refresh instruction exactly once, found %d", status.BlockedReasons, occurrences)
 			}
 			if status.PhaseInstructions == nil {
 				t.Fatal("PhaseInstructions is nil")
 			}
-			const want = "A passing native remediation settlement completed after the persisted verification report; run fresh verification and persist a report bound after that settlement before archive."
 			if instructions := strings.Join(status.PhaseInstructions.Verify, "\n"); !strings.Contains(instructions, want) {
 				t.Fatalf("verify instructions omit the post-remediation fresh-report obligation:\n%s", instructions)
 			}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -536,8 +536,10 @@ func resolveByPreferenceOrder(options ResolveOptions) (Status, error) {
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress)
-	if artifacts["verifyReport"] == ArtifactDone && verifyResult.Incomplete {
-		blockedReasons.genuine = append(blockedReasons.genuine, verifyResult.Reason)
+	if artifacts["verifyReport"] == ArtifactDone {
+		if reason := verifyReportRefreshReason(verifyResult); reason != "" {
+			blockedReasons.genuine = append(blockedReasons.genuine, reason)
+		}
 	}
 	applyState, unauthorizedRoots := applyEditAuthorityBlock(applyState, &blockedReasons, readText(firstPath(artifactPaths.Tasks)), workspaceRoot, append([]string{workspaceRoot}, grantedRoots...))
 	var consent *SDDIntegrationConsentResult
@@ -575,6 +577,7 @@ func resolveByPreferenceOrder(options ResolveOptions) (Status, error) {
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
 		remediationState = RemediationState{}
+		blockedReasons.genuine = appendMissingReason(blockedReasons.genuine, runtimeRemediationVerifyRefreshInstruction)
 	}
 	if len(unauthorizedRoots) == 0 && runtimeStatus != nil && runtimeStatusErr == nil {
 		applyRuntimeTopologyBlock(context.Background(), &applyState, &dependencies, &nextRecommended, &blockedReasons, readText(firstPath(artifactPaths.Tasks)), workspaceRoot, changeName)
@@ -658,6 +661,30 @@ func workspaceHasGitMetadata(workspaceRoot string) bool {
 		}
 		current = parent
 	}
+}
+
+// verifyReportRefreshReason names why a persisted verification report cannot
+// stand as final evidence. A report that exists yet leaves verify at ready
+// must never project a silent tuple (#3538): the stale reason carries the
+// exact native totals the report has to match, so the agent re-verifies
+// against the current specs instead of re-validating the same envelope.
+func verifyReportRefreshReason(verify verifyResultEvaluation) string {
+	switch {
+	case verify.Incomplete:
+		return verify.Reason
+	case verify.Stale:
+		return "persisted verification report is stale: " + verify.Reason + "; rerun SDD verification and persist a report whose totals match the current specs before archive"
+	}
+	return ""
+}
+
+// appendMissingReason appends reason unless the list already carries it, so a
+// route that is explained from two sites never repeats itself.
+func appendMissingReason(reasons []string, reason string) []string {
+	if contains(reasons, reason) {
+		return reasons
+	}
+	return append(reasons, reason)
 }
 
 func nativeRuntimeCompletesRemediation(runtimeStatus *RuntimeStatus, attemptTokens map[int]string, verify verifyResultEvaluation) bool {
@@ -809,8 +836,10 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress)
-	if artifacts["verifyReport"] == ArtifactDone && verifyResult.Incomplete {
-		blockedReasons.genuine = append(blockedReasons.genuine, verifyResult.Reason)
+	if artifacts["verifyReport"] == ArtifactDone {
+		if reason := verifyReportRefreshReason(verifyResult); reason != "" {
+			blockedReasons.genuine = append(blockedReasons.genuine, reason)
+		}
 	}
 	applyState, unauthorizedRoots := applyEditAuthorityBlock(applyState, &blockedReasons, artifactsByType["tasks"].Content, workspaceRoot, []string{workspaceRoot})
 	runtimeRemediationComplete := nativeRuntimeCompletesRemediation(runtimeStatus, runtimeAttemptTokens, verifyResult)
@@ -832,6 +861,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
 		remediationState = RemediationState{}
+		blockedReasons.genuine = appendMissingReason(blockedReasons.genuine, runtimeRemediationVerifyRefreshInstruction)
 	}
 	if len(unauthorizedRoots) == 0 && runtimeStatus != nil && runtimeStatusErr == nil {
 		applyRuntimeTopologyBlock(context.Background(), &applyState, &dependencies, &nextRecommended, &blockedReasons, artifactsByType["tasks"].Content, workspaceRoot, changeName)

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -828,19 +828,25 @@ func TestResolveStaleOrIncompleteVerificationReroutesToFreshVerify(t *testing.T)
 	const staleSpec = completeSpec + "#### Scenario: Added after verification\n"
 	invalidOutputHash := "sha256:" + strings.Repeat("b", 64)
 	tests := []struct {
-		name   string
-		spec   string
-		report string
+		name        string
+		spec        string
+		report      string
+		wantReasons []string
 	}{
 		{
 			name:   "stale complete pass after a spec scenario is added",
 			spec:   staleSpec,
 			report: testVerifyEnvelope("pass", 0, 0, "1/1", "1/1", 0, 0),
+			wantReasons: []string{
+				"verify result total 1 does not match actual scenario count 2",
+				"rerun SDD verification",
+			},
 		},
 		{
-			name:   "current-format incomplete failed evidence",
-			spec:   completeSpec,
-			report: testVerifyEnvelope("fail", 1, 0, "0/1", "0/1", 1, 1),
+			name:        "current-format incomplete failed evidence",
+			spec:        completeSpec,
+			report:      testVerifyEnvelope("fail", 1, 0, "0/1", "0/1", 1, 1),
+			wantReasons: []string{"failed verification evidence is incomplete"},
 		},
 		{
 			name: "malformed failed evidence with an invalid output hash",
@@ -851,6 +857,7 @@ func TestResolveStaleOrIncompleteVerificationReroutesToFreshVerify(t *testing.T)
 				"test_output_hash: sha256:invalid",
 				1,
 			),
+			wantReasons: []string{"verification evidence is incomplete"},
 		},
 	}
 
@@ -891,6 +898,14 @@ func TestResolveStaleOrIncompleteVerificationReroutesToFreshVerify(t *testing.T)
 				}
 				if strings.Contains(strings.Join(status.BlockedReasons, "\n"), "missing_review_authority") {
 					t.Fatalf("BlockedReasons = %v, want no legacy missing_review_authority routing", status.BlockedReasons)
+				}
+				// A verify route that exists only to refresh evidence must name
+				// why the persisted report cannot stand (#3538).
+				joined := strings.Join(status.BlockedReasons, "\n")
+				for _, want := range tt.wantReasons {
+					if !strings.Contains(joined, want) {
+						t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
+					}
 				}
 			})
 		}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3538

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- `sdd-status` could project `verify: ready`, `archive: blocked`, `nextRecommended: verify` with an empty `blockedReasons` even though a verify-report existed and every task was complete. Two paths produced that silent tuple.
- Stale report: when the envelope totals differ from the native `### Requirement:` / `### REQ-<n>:` and `#### Scenario:` heading count, `parseVerifyResult` already computes the mismatch reason, but both resolvers only published it for incomplete evidence. This is the reporter shape: `sdd-verify-validate` admits whatever `--requirements/--scenarios` the caller supplies, so `valid: true` never proved status would agree.
- Post-remediation override: a passing native remediation settlement after the persisted report re-enters verification, but its refresh instruction reached only `phaseInstructions`, never `blockedReasons`.
- Both stores (OpenSpec and Engram) now publish the stale reason with the exact native totals, and the post-remediation refresh instruction, into `blockedReasons`. Routing (`dependencies`, `nextRecommended`) is unchanged; this is contract-consistent with the existing rule that a `verify` route with blockers may run only to refresh evidence.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | `verifyReportRefreshReason` publishes incomplete and stale reasons; both resolvers append `runtimeRemediationVerifyRefreshInstruction` to `blockedReasons` (deduplicated) inside the post-remediation override. |
| `internal/sddstatus/issue3538_stale_report_reason_test.go` | New regression: a `13/13` + `46/46` pass envelope that the validator admits with caller-supplied counts, over specs with 1 requirement and 1 scenario, names the native totals in `blockedReasons` on both stores. |
| `internal/sddstatus/status_test.go` | Stale and incomplete reroute cases assert the published reasons. |
| `internal/sddstatus/runtime_status_test.go` | Post-remediation case now requires the refresh instruction exactly once in `blockedReasons`. |
| `internal/assets/skills/_shared/sdd-status-contract.md` | Status output shows `blockedReasons` whenever non-empty, including a `verify` refresh route. |
| `internal/assets/skills/sdd-verify/SKILL.md` | Documents which headings native status counts and what to do on a totals mismatch. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with one delegated writer agent.

**Material scope:** Root-cause analysis of both silent paths, test authoring (red first, then green), production change, and documentation wording.

**Verification performed:** `go test ./...` (73 packages ok), `go run ./internal/gofmtcheck`, `go vet` including `GOOS=windows` for `internal/sddstatus`, and the driven bench corpus against a locally built binary. E2E Docker suite left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

Driven corpus against a locally built binary (same invocation as CI): `journeys: 61 completed, 0 unsupported, 0 failed`. `j44-sdd-historical-requirement-stale-pass` was driven on its own first, since it pins the stale PASS route and rejects any blocker mentioning remediation; the new stale reason keeps it `completed`. No journey pinned the empty `blockedReasons` shape after a persisted report; the four `len(BlockedReasons) != 0` pins in `journeys_sdd.go` are all pre-verify fixtures without a report.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No security, integrity, admission, repair, or governance guard is added or changed; `.guard-population-baseline.txt` is untouched. The change only adds explanatory strings to `blockedReasons`.

The previous conclusion on this issue cluster was that the tuple reproduces only when the report evidence revision predates a terminal remediation settlement. That path is real, but the reports on rc.2 and rc.3 with identical evidence revisions are explained by the stale path instead: the ledger refuses `evidence_revision == remediates_evidence_revision` at settle, so the override cannot fire with aligned revisions, while a totals mismatch against native heading counts can, silently.

Receipt-driven review: the native four-lens review was started for this exact candidate; three lenses were admitted (risk, readability, resilience) and the reliability lens failed native admission on every relaunch. That provider defect was reported with consent at https://github.com/Gentleman-Programming/gentle-ai/issues/3942 and the candidate was declined once (candidate-scoped, not the kill switch). Delivery therefore follows ordinary repository policy, unmanaged; no receipt claims approval.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification status now clearly reports when evidence is stale, incomplete, or requires refreshed verification.
  * Blocked reasons are consistently displayed, including after remediation and when report totals do not match the underlying requirements.
  * Verification remains pending until mismatched requirement and scenario counts are corrected and rechecked.
  * Improved status handling across supported verification backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->