### PR TITLE
fix(review): retry one corrected reviewer result and preserve refused payloads

### DIFF
--- a/.refusal-ratchet-baseline.txt
+++ b/.refusal-ratchet-baseline.txt
@@ -293,7 +293,6 @@ internal/reviewtransaction/artifact_admission.go	"artifact admission candidate-c
 internal/reviewtransaction/artifact_admission.go	"artifact admission candidate-causal finding IDs are not canonical"
 internal/reviewtransaction/artifact_admission.go	"artifact admission is not a completed binding"
 internal/reviewtransaction/artifact_admission.go	"reviewer payload contains multiple JSON objects"
-internal/reviewtransaction/artifact_admission.go	"reviewer payload contains no complete JSON object"
 internal/reviewtransaction/artifact_admission.go	"reviewer payload is empty or exceeds the native bound"
 internal/reviewtransaction/artifact_subject.go	"artifact subject authority binding is incomplete"
 internal/reviewtransaction/artifact_subject.go	"artifact subject correction identity is invalid"

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -304,6 +304,8 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		if adapterErr != nil {
 			return reviewPreflightError(adapterErr)
 		}
+		// --agent is refused together with --preflight above, so this branch
+		// never runs under preflight and its preservation needs no guard.
 		admitted, rawPayload, err = reviewProviderCaptureWithOneCorrection(ctx, reviewProviderCapture{
 			root: root, runtime: providerRuntime, adapter: adapter, state: state, frozen: frozen, subject: subject,
 		}, request.Invocation)
@@ -319,7 +321,8 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		if err != nil {
 			// A host-submitted result gets no corrective re-invocation, since
 			// the host owns the reviewer, but its rejected bytes are preserved
-			// the same way. --preflight persists nothing, as documented.
+			// the same way. This is the only branch --preflight can reach, and
+			// --preflight persists nothing, as documented.
 			if *preflight {
 				return reviewPreflightError(err)
 			}

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -275,6 +275,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		})
 	}
 	var rawPayload []byte
+	var admitted reviewProviderAdmittedResult
 	if providerExecution {
 		request, materializeErr := reviewProviderMaterialize(ctx, reviewLensContextDependencies(), root, contextHandle, *lens, reviewtransaction.ReviewRepositoryContextBinding{
 			LineageID: *lineage, TargetIdentity: *target, Revision: *revision,
@@ -303,19 +304,29 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		if adapterErr != nil {
 			return reviewPreflightError(adapterErr)
 		}
-		rawPayload, err = adapter.Review(ctx, request.Invocation)
+		admitted, rawPayload, err = reviewProviderCaptureWithOneCorrection(ctx, reviewProviderCapture{
+			root: root, runtime: providerRuntime, adapter: adapter, state: state, frozen: frozen, subject: subject,
+		}, request.Invocation)
 		if err != nil {
-			return reviewPreflightError(fmt.Errorf("invoke provider reviewer: %w", err))
+			return reviewPreflightError(err)
 		}
 	} else {
 		rawPayload, err = readFacadeBytes(*input)
 		if err != nil {
 			return reviewPreflightError(fmt.Errorf("read reviewer result: %w", err))
 		}
-	}
-	admitted, err := reviewProviderAdmitRaw(ctx, root, state, state.CapturePhaseRevision, frozen, subject, rawPayload)
-	if err != nil {
-		return reviewPreflightError(err)
+		admitted, err = reviewProviderAdmitRaw(ctx, root, state, state.CapturePhaseRevision, frozen, subject, rawPayload)
+		if err != nil {
+			// A host-submitted result gets no corrective re-invocation, since
+			// the host owns the reviewer, but its rejected bytes are preserved
+			// the same way. --preflight persists nothing, as documented.
+			if *preflight {
+				return reviewPreflightError(err)
+			}
+			return reviewPreflightError(fmt.Errorf("%w%s", err, reviewRejectedResultClause(ctx, root, reviewRejectedResultMeta{
+				LineageID: state.LineageID, Lens: *lens, Attempt: 1, Reason: err.Error(),
+			}, rawPayload)))
+		}
 	}
 	frozen, subject = admitted.Frozen, admitted.Subject
 	if *preflight {

--- a/internal/cli/review_opencode_transport.go
+++ b/internal/cli/review_opencode_transport.go
@@ -445,6 +445,11 @@ func openCodeTransportComplete(ctx context.Context, session openCodeTransportSes
 	}
 	admitted, err := reviewProviderAdmitRaw(ctx, session.root, record.State, record.State.CapturePhaseRevision, session.lensRequest.Frozen, session.lensRequest.Subject, hostOutput)
 	if err != nil {
+		// The host relay owns its reviewer and gets no corrective
+		// re-invocation, but the refused bytes are preserved for the report.
+		_ = reviewRejectedResultClause(ctx, session.root, reviewRejectedResultMeta{
+			LineageID: record.State.LineageID, Lens: session.lensRequest.Binding.Lens, Attempt: 1, Reason: err.Error(),
+		}, hostOutput)
 		return openCodeTransportEnvelope{}, openCodeTransportFailure("opencode_reviewer_result_refused")
 	}
 	captured, err := store.CaptureAdmittedReviewerResult(ctx, reviewtransaction.CompactAdmittedReviewerResultRequest{

--- a/internal/cli/review_provider_correction.go
+++ b/internal/cli/review_provider_correction.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// Every in-process reviewer runtime returns free text, and one out-of-schema
+// nested field or one truncated array used to end the capture with the only
+// exit being a relaunch of the same slot that failed the same way (issues
+// #3942, #2791). The runtime never learned what was wrong. The capture now
+// grants exactly one corrective re-invocation whose prompt is the original
+// materialized prompt plus the exact admission error and the three rules the
+// result broke. The bound is a named constant, the retry lives only here, and
+// it never applies to --input submissions or the OpenCode host relay: those
+// hosts own their reviewer and receive the same preserved payload instead.
+const (
+	maxReviewerResultAdmissionAttempts     = 2
+	reviewProviderCorrectiveFeedbackHeader = "GENTLE_AI_REVIEW_ADMISSION_FEEDBACK"
+)
+
+// reviewProviderCapture is everything one in-process lens capture needs to
+// invoke, admit, preserve, and name its continuation.
+type reviewProviderCapture struct {
+	root    string
+	runtime model.AgentID
+	adapter reviewerprovider.Adapter
+	state   reviewtransaction.CompactState
+	frozen  reviewtransaction.FrozenCandidateContext
+	subject reviewtransaction.ArtifactSubject
+}
+
+func (capture reviewProviderCapture) admit(ctx context.Context, raw []byte) (reviewProviderAdmittedResult, error) {
+	return reviewProviderAdmitRaw(ctx, capture.root, capture.state, capture.state.CapturePhaseRevision, capture.frozen, capture.subject, raw)
+}
+
+func (capture reviewProviderCapture) preserve(ctx context.Context, attempt int, admission error, raw []byte) string {
+	return reviewRejectedResultClause(ctx, capture.root, reviewRejectedResultMeta{
+		LineageID: capture.state.LineageID, Lens: capture.subject.Lens, Attempt: attempt, Reason: admission.Error(),
+	}, raw)
+}
+
+func (capture reviewProviderCapture) continuation() string {
+	return fmt.Sprintf("gentle-ai review status --cwd <repo> --contract %s --agent %s --lineage %s --next-transition", ReviewIntegrationContractV2, capture.runtime, capture.state.LineageID)
+}
+
+// reviewProviderCaptureWithOneCorrection invokes the reviewer, admits its raw
+// bytes, and on an admission failure invokes it once more with feedback. A
+// transport failure is not an admission failure and is returned as is.
+func reviewProviderCaptureWithOneCorrection(ctx context.Context, capture reviewProviderCapture, invocation reviewerprovider.Invocation) (reviewProviderAdmittedResult, []byte, error) {
+	raw, err := capture.adapter.Review(ctx, invocation)
+	if err != nil {
+		return reviewProviderAdmittedResult{}, nil, fmt.Errorf("invoke provider reviewer: %w", err)
+	}
+	admitted, firstErr := capture.admit(ctx, raw)
+	if firstErr == nil {
+		return admitted, raw, nil
+	}
+	firstClause := capture.preserve(ctx, 1, firstErr, raw)
+	corrective := reviewProviderCorrectivePrompt(invocation.Prompt(), firstErr)
+	if len(corrective) > reviewLensContextByteBudget {
+		return reviewProviderAdmittedResult{}, nil, fmt.Errorf("%w%s; the corrective re-invocation was skipped because its prompt exceeds the native reviewer context budget; re-query %s and run the reoffered capture", firstErr, firstClause, capture.continuation())
+	}
+	raw, err = capture.adapter.Review(ctx, reviewerprovider.NewInvocation(corrective))
+	if err != nil {
+		return reviewProviderAdmittedResult{}, nil, fmt.Errorf("invoke provider reviewer on corrective attempt %d of %d: %w (attempt 1 was refused: %v%s)", maxReviewerResultAdmissionAttempts, maxReviewerResultAdmissionAttempts, err, firstErr, firstClause)
+	}
+	admitted, secondErr := capture.admit(ctx, raw)
+	if secondErr == nil {
+		return admitted, raw, nil
+	}
+	secondClause := capture.preserve(ctx, maxReviewerResultAdmissionAttempts, secondErr, raw)
+	return reviewProviderAdmittedResult{}, nil, fmt.Errorf("provider reviewer result was refused on both admission attempts for lens %q: attempt 1: %v%s; corrective attempt %d: %w%s; re-query %s and run the reoffered capture", capture.subject.Lens, firstErr, firstClause, maxReviewerResultAdmissionAttempts, secondErr, secondClause, capture.continuation())
+}
+
+// reviewProviderCorrectivePrompt appends the Go-owned feedback section to the
+// original materialized prompt. The section quotes the exact admission error
+// and restates the three rules every rejected result so far has broken.
+func reviewProviderCorrectivePrompt(original []byte, admission error) []byte {
+	var prompt bytes.Buffer
+	prompt.Write(original)
+	prompt.WriteString("\n\n" + reviewProviderCorrectiveFeedbackHeader + "\n")
+	fmt.Fprintf(&prompt, "Your previous result for this exact binding was rejected and nothing was admitted. Admission error: %s\n", admission)
+	prompt.WriteString("This is the single corrective attempt. Three hard rules:\n")
+	prompt.WriteString("1. Return exactly one JSON object and nothing else: no prose, no code fence, no second object.\n")
+	prompt.WriteString("2. Close every object and array; a truncated payload is rejected.\n")
+	prompt.WriteString("3. Use only the fields declared in the " + reviewLensContextResultSchema + " block: \"inspection\" accepts only \"status\" and \"paths\"; \"lens\" is allowed only at the top level and inside findings; any other field is rejected.\n")
+	prompt.WriteString(reviewProviderCorrectiveFeedbackHeader + "_END\n")
+	return prompt.Bytes()
+}

--- a/internal/cli/review_provider_correction_test.go
+++ b/internal/cli/review_provider_correction_test.go
@@ -274,3 +274,23 @@ func TestRawInputCapturePreservesRejectedResultWithoutInvokingProvider(t *testin
 		assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 1, invalid)
 	}
 }
+
+func TestProviderCaptureRefusesPreflightBeforeInvocationOrPreservation(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) {
+			t.Fatal("--preflight must refuse before the provider is invoked")
+			return nil, nil
+		},
+	)
+	err := RunReviewCaptureResult(append(binding, "--agent", string(model.AgentClaudeCode), "--preflight"), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "--agent cannot be combined with --preflight") {
+		t.Fatalf("preflight with a provider runtime = %v", err)
+	}
+	if len(*prompts) != 0 {
+		t.Fatalf("provider reviewer invocations = %d, want none", len(*prompts))
+	}
+	if _, statErr := os.Stat(rejectedResultsDir(t, repo, record.State.LineageID)); !os.IsNotExist(statErr) {
+		t.Fatalf("preflight preserved a rejected result: %v", statErr)
+	}
+}

--- a/internal/cli/review_provider_correction_test.go
+++ b/internal/cli/review_provider_correction_test.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// Issues #3942, #2791 and #1867: an in-process reviewer runtime returns free
+// text, so one out-of-schema or truncated result used to be a dead end. The
+// capture now grants exactly one corrective re-invocation that carries the
+// exact admission error, and every rejected payload is preserved outside the
+// authority store so a report can quote the bytes.
+
+// reviewerPayloadWithNestedLens injects the #3942 shape: a `lens` field
+// inside `inspection`, which the strict decoder rejects as unknown.
+func reviewerPayloadWithNestedLens(t *testing.T, valid []byte) []byte {
+	t.Helper()
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(valid, &object); err != nil {
+		t.Fatal(err)
+	}
+	var inspection map[string]any
+	if err := json.Unmarshal(object["inspection"], &inspection); err != nil {
+		t.Fatal(err)
+	}
+	inspection["lens"] = "review-reliability"
+	nested, err := json.Marshal(inspection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	object["inspection"] = nested
+	payload, err := json.Marshal(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+// recordingProviderAdapter installs a fake in-process reviewer that answers
+// the scripted payloads in order and records every prompt it received.
+func recordingProviderAdapter(t *testing.T, answers ...func() ([]byte, error)) *[][]byte {
+	t.Helper()
+	prompts := &[][]byte{}
+	previous := reviewProviderAdapterFor
+	reviewProviderAdapterFor = func(_ reviewerprovider.Contract, agent model.AgentID) (reviewerprovider.Adapter, error) {
+		if agent != model.AgentClaudeCode {
+			return nil, errors.New("unexpected runtime")
+		}
+		return providerTestAdapterFunc(func(_ context.Context, invocation reviewerprovider.Invocation) ([]byte, error) {
+			*prompts = append(*prompts, invocation.Prompt())
+			if len(*prompts) > len(answers) {
+				t.Fatalf("provider reviewer was invoked %d times, want at most %d", len(*prompts), len(answers))
+			}
+			return answers[len(*prompts)-1]()
+		}), nil
+	}
+	t.Cleanup(func() { reviewProviderAdapterFor = previous })
+	return prompts
+}
+
+func rejectedResultsDir(t *testing.T, repo, lineage string) string {
+	t.Helper()
+	lease, err := reviewtransaction.OpenRepositoryIdentityLease(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(lease.Identity().GitCommonDir, "gentle-ai", reviewRejectedResultDirName, lineage)
+}
+
+func readRejectedResults(t *testing.T, dir string) map[string]reviewRejectedResultEnvelope {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read rejected results %s: %v", dir, err)
+	}
+	envelopes := map[string]reviewRejectedResultEnvelope{}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+			t.Fatalf("rejected result %s mode = %o, want 0600", path, info.Mode().Perm())
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var envelope reviewRejectedResultEnvelope
+		decodeStrictReviewJSON(t, payload, &envelope)
+		envelopes[path] = envelope
+	}
+	return envelopes
+}
+
+func assertRejectedEnvelope(t *testing.T, envelope reviewRejectedResultEnvelope, lineage, lens string, attempt int, raw []byte) {
+	t.Helper()
+	digest := sha256.Sum256(raw)
+	if envelope.Schema != reviewRejectedResultSchema || envelope.LineageID != lineage || envelope.Lens != lens ||
+		envelope.Attempt != attempt || envelope.RawSHA256 != hex.EncodeToString(digest[:]) || envelope.Raw != string(raw) ||
+		envelope.Reason == "" || envelope.CapturedAt == "" {
+		t.Fatalf("rejected result envelope = %#v, want lineage %q lens %q attempt %d", envelope, lineage, lens, attempt)
+	}
+}
+
+func TestProviderCaptureRetriesOnceWithAdmissionFeedback(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	lens := record.State.SelectedLenses[0]
+	valid, err := json.Marshal(admittedReviewerResultForTest(t, repo, record, lens, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid := reviewerPayloadWithNestedLens(t, valid)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return invalid, nil },
+		func() ([]byte, error) { return valid, nil },
+	)
+
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult(append(binding, "--agent", string(model.AgentClaudeCode)), &output); err != nil {
+		t.Fatalf("capture with one corrective attempt: %v\n%s", err, output.String())
+	}
+	if len(*prompts) != 2 {
+		t.Fatalf("provider reviewer invocations = %d, want exactly 2", len(*prompts))
+	}
+	first, second := (*prompts)[0], (*prompts)[1]
+	if !bytes.HasPrefix(second, first) {
+		t.Fatal("corrective prompt does not start with the original materialized prompt")
+	}
+	for _, want := range []string{reviewProviderCorrectiveFeedbackHeader, `unknown field "lens"`, "exactly one JSON object", reviewLensContextResultSchema} {
+		if !bytes.Contains(second, []byte(want)) {
+			t.Fatalf("corrective prompt lacks %q:\n%s", want, second[len(first):])
+		}
+	}
+	if bytes.Contains(first, []byte(reviewProviderCorrectiveFeedbackHeader)) {
+		t.Fatal("first prompt already carries admission feedback")
+	}
+
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved rejected results = %d, want 1", len(preserved))
+	}
+	for path, envelope := range preserved {
+		if !strings.HasPrefix(filepath.Base(path), lens+"-1-") {
+			t.Fatalf("rejected result file name = %q, want <lens>-1-<sha>.json", filepath.Base(path))
+		}
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 1, invalid)
+	}
+}
+
+func TestProviderCaptureRefusesAfterTwoRejectedResultsAndPreservesBoth(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	lens := record.State.SelectedLenses[0]
+	valid, err := json.Marshal(admittedReviewerResultForTest(t, repo, record, lens, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid := reviewerPayloadWithNestedLens(t, valid)
+	truncated := []byte(`{"subject_hash":"sha256:0","inspection":{"status":"completed","paths":["tracked.txt"]},"findings":[{"id":"R3-001","proof_refs":["x"`)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return invalid, nil },
+		func() ([]byte, error) { return truncated, nil },
+	)
+
+	var output bytes.Buffer
+	err = RunReview(append(append([]string{"capture-result"}, binding...), "--agent", string(model.AgentClaudeCode)), &output)
+	failure := decodeCaptureRefusalEnvelope(t, err, output.Bytes())
+	if failure.Code != reviewIntegrationInvalidRequestCode || failure.MutationOutcome != ReviewMutationNotStarted {
+		t.Fatalf("second rejection envelope = %#v", failure)
+	}
+	if len(*prompts) != 2 {
+		t.Fatalf("provider reviewer invocations = %d, want exactly 2", len(*prompts))
+	}
+
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 2 {
+		t.Fatalf("preserved rejected results = %d, want 2", len(preserved))
+	}
+	for path, envelope := range preserved {
+		if !strings.Contains(err.Error(), path) {
+			t.Fatalf("refusal does not name preserved payload %s: %v", path, err)
+		}
+		switch envelope.Attempt {
+		case 1:
+			assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 1, invalid)
+		case 2:
+			assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 2, truncated)
+		default:
+			t.Fatalf("unexpected preserved attempt %#v", envelope)
+		}
+	}
+	for _, want := range []string{`unknown field "lens"`, "no complete JSON object", "gentle-ai review status"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("refusal lacks %q: %v", want, err)
+		}
+	}
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, record.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.State.State != reviewtransaction.StateReviewing || !reflect.DeepEqual(after.State, record.State) {
+		t.Fatalf("two rejected results mutated reviewing authority: before=%#v after=%#v", record.State, after.State)
+	}
+}
+
+func TestProviderCaptureTransportErrorSkipsCorrectionAndPreservation(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return nil, errors.New("reviewer subprocess exited 137") },
+		func() ([]byte, error) { t.Fatal("transport failure must not be retried"); return nil, nil },
+	)
+	err := RunReviewCaptureResult(append(binding, "--agent", string(model.AgentClaudeCode)), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "invoke provider reviewer") || !strings.Contains(err.Error(), "exited 137") {
+		t.Fatalf("transport failure = %v", err)
+	}
+	if len(*prompts) != 1 {
+		t.Fatalf("provider reviewer invocations = %d, want exactly 1", len(*prompts))
+	}
+	if _, statErr := os.Stat(rejectedResultsDir(t, repo, record.State.LineageID)); !os.IsNotExist(statErr) {
+		t.Fatalf("transport failure preserved a rejected result: %v", statErr)
+	}
+}
+
+func TestRawInputCapturePreservesRejectedResultWithoutInvokingProvider(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	lens := record.State.SelectedLenses[0]
+	valid, err := json.Marshal(admittedReviewerResultForTest(t, repo, record, lens, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid := reviewerPayloadWithNestedLens(t, valid)
+	prompts := recordingProviderAdapter(t)
+	input := filepath.Join(t.TempDir(), "rejected.json")
+	if err := os.WriteFile(input, invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = RunReviewCaptureResult(append(binding, "--input", input), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), `unknown field "lens"`) {
+		t.Fatalf("raw input rejection = %v", err)
+	}
+	if len(*prompts) != 0 {
+		t.Fatalf("raw input capture invoked the provider reviewer %d times", len(*prompts))
+	}
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved rejected results = %d, want 1", len(preserved))
+	}
+	for path, envelope := range preserved {
+		if !strings.Contains(err.Error(), path) {
+			t.Fatalf("refusal does not name preserved payload %s: %v", path, err)
+		}
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 1, invalid)
+	}
+}

--- a/internal/cli/review_rejected_result.go
+++ b/internal/cli/review_rejected_result.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// A reviewer result that admission refuses used to be discarded, so a defect
+// report could only quote the refusal and never the bytes that earned it
+// (issues #3942, #2791). Every refused payload is now preserved verbatim under
+// <GitCommonDir>/gentle-ai/rejected-results/<lineage>/, outside the working
+// tree and outside the review-transactions authority store: it is evidence,
+// never authority, and nothing reads it back into a lineage.
+const (
+	reviewRejectedResultSchema  = "gentle-ai.review-rejected-result/v1"
+	reviewRejectedResultDirName = "rejected-results"
+)
+
+type reviewRejectedResultMeta struct {
+	LineageID string
+	Lens      string
+	Attempt   int
+	Reason    string
+}
+
+type reviewRejectedResultEnvelope struct {
+	Schema     string `json:"schema"`
+	LineageID  string `json:"lineage_id"`
+	Lens       string `json:"lens"`
+	Attempt    int    `json:"attempt"`
+	Reason     string `json:"reason"`
+	RawSHA256  string `json:"raw_sha256"`
+	CapturedAt string `json:"captured_at"`
+	Raw        string `json:"raw"`
+}
+
+// writeReviewRejectedResult persists one refused payload and returns its path.
+func writeReviewRejectedResult(ctx context.Context, root string, meta reviewRejectedResultMeta, raw []byte) (string, error) {
+	lease, err := reviewtransaction.OpenRepositoryIdentityLease(ctx, root)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository identity for rejected result: %w", err)
+	}
+	digest := sha256.Sum256(raw)
+	rawSHA256 := hex.EncodeToString(digest[:])
+	dir := filepath.Join(lease.Identity().GitCommonDir, "gentle-ai", reviewRejectedResultDirName, reviewRejectedResultPathComponent(meta.LineageID))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create rejected result directory: %w", err)
+	}
+	content, err := json.Marshal(reviewRejectedResultEnvelope{
+		Schema: reviewRejectedResultSchema, LineageID: meta.LineageID, Lens: meta.Lens, Attempt: meta.Attempt,
+		Reason: meta.Reason, RawSHA256: rawSHA256, CapturedAt: time.Now().UTC().Format(time.RFC3339), Raw: string(raw),
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode rejected result: %w", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%s-%d-%s.json", reviewRejectedResultPathComponent(meta.Lens), meta.Attempt, rawSHA256[:12]))
+	if err := os.WriteFile(path, append(content, '\n'), 0o600); err != nil {
+		return "", fmt.Errorf("write rejected result: %w", err)
+	}
+	return path, nil
+}
+
+// reviewRejectedResultPathComponent keeps a lineage or lens identifier inside
+// one path component.
+func reviewRejectedResultPathComponent(value string) string {
+	var component strings.Builder
+	for _, r := range value {
+		if r == '-' || r == '.' || r == '_' || (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			component.WriteRune(r)
+		} else {
+			component.WriteByte('_')
+		}
+	}
+	if component.Len() == 0 {
+		return "unknown"
+	}
+	return component.String()
+}
+
+// reviewRejectedResultClause preserves the payload and returns the clause a
+// refusal appends. Persistence failure degrades to an empty clause, exactly
+// like reviewGenerateToolFaultDefectReport: the original refusal is always
+// what the caller sees, never a second unrelated error.
+func reviewRejectedResultClause(ctx context.Context, root string, meta reviewRejectedResultMeta, raw []byte) string {
+	path, err := writeReviewRejectedResult(ctx, root, meta, raw)
+	if err != nil {
+		return ""
+	}
+	return "; the rejected reviewer payload was preserved at " + path
+}

--- a/internal/reviewtransaction/artifact_admission.go
+++ b/internal/reviewtransaction/artifact_admission.go
@@ -475,10 +475,15 @@ func ExtractBoundedSingleJSONObject(payload []byte, limit int) ([]byte, Artifact
 	candidates := []candidate{}
 	start, depth := -1, 0
 	inString, escaped := false, false
+	// The census below is what a truncated payload reports (issue #2791): a
+	// bare "no complete object" could not say whether an array, a nested
+	// object, or the whole payload was left open, nor where the scan stopped.
+	var census jsonStructuralCensus
 	for index, value := range payload {
 		if depth == 0 {
 			if value == '{' {
 				start, depth, inString, escaped = index, 1, false, false
+				census.count(index, &census.objectsOpened)
 			}
 			continue
 		}
@@ -498,10 +503,16 @@ func ExtractBoundedSingleJSONObject(payload []byte, limit int) ([]byte, Artifact
 		switch value {
 		case '"':
 			inString = true
+		case '[':
+			census.count(index, &census.arraysOpened)
+		case ']':
+			census.count(index, &census.arraysClosed)
 		case '{':
 			depth++
+			census.count(index, &census.objectsOpened)
 		case '}':
 			depth--
+			census.count(index, &census.objectsClosed)
 			if depth == 0 {
 				var object map[string]json.RawMessage
 				fragment := bytes.TrimSpace(payload[start : index+1])
@@ -513,13 +524,42 @@ func ExtractBoundedSingleJSONObject(payload []byte, limit int) ([]byte, Artifact
 		}
 	}
 	if depth != 0 || len(candidates) == 0 {
-		return nil, ArtifactAdmissionIncomplete, errors.New("reviewer payload contains no complete JSON object")
+		return nil, ArtifactAdmissionIncomplete, fmt.Errorf("reviewer payload contains no complete JSON object: %s", census.describe(len(payload))) // refusal:by-design operator-knowledge: only the reviewer runtime can return one complete JSON object; the census names what it left open
 	}
 	if len(candidates) != 1 {
 		return nil, ArtifactAdmissionAmbiguous, errors.New("reviewer payload contains multiple JSON objects")
 	}
 	match := candidates[0]
 	return append([]byte(nil), bytes.TrimSpace(payload[match.start:match.end])...), ArtifactAdmissionCompleted, nil
+}
+
+// jsonStructuralCensus counts the structural tokens ExtractBoundedSingleJSONObject
+// consumed outside strings and remembers how far the scan got, so an
+// incomplete payload is refused with a diagnosis instead of a verdict.
+type jsonStructuralCensus struct {
+	objectsOpened, objectsClosed, arraysOpened, arraysClosed int
+	lastStructuralEnd                                        int
+}
+
+func (census *jsonStructuralCensus) count(index int, counter *int) {
+	*counter++
+	census.lastStructuralEnd = index + 1
+}
+
+func (census jsonStructuralCensus) describe(length int) string {
+	if census.objectsOpened == 0 {
+		return fmt.Sprintf("no object start was found in %d bytes", length)
+	}
+	return fmt.Sprintf("%s opened, %d closed; %s opened, %d closed; scan ended at byte %d",
+		pluralCount(census.objectsOpened, "object"), census.objectsClosed,
+		pluralCount(census.arraysOpened, "array"), census.arraysClosed, census.lastStructuralEnd)
+}
+
+func pluralCount(count int, noun string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", noun)
+	}
+	return fmt.Sprintf("%d %ss", count, noun)
 }
 
 var artifactFindingID = regexp.MustCompile(`^R[1-4]-[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -793,6 +833,11 @@ func evidenceReportsUnavailableInspection(value string) bool {
 		"could not be inspected", "cannot be inspected", "can not be inspected",
 		"was not able to be inspected", "were not able to be inspected",
 		"no candidate contents were available", "no candidate content was available",
+		// Read failures reported as such (issue #1867). "read the manifest"
+		// alone would match a completed inspection, so every phrase here
+		// carries its own negation.
+		"read denied", "denied by filesystem", "cannot read diff", "cannot read manifest",
+		"could not read the candidate", "unable to read the candidate",
 	} {
 		if strings.Contains(value, phrase) {
 			return true

--- a/internal/reviewtransaction/artifact_admission_test.go
+++ b/internal/reviewtransaction/artifact_admission_test.go
@@ -646,3 +646,66 @@ func TestAdmitArtifactResolvesUnambiguousBasenameCitations(t *testing.T) {
 		}
 	})
 }
+
+// TestExtractBoundedSingleJSONObjectReportsStructuralCensus is #2791: a
+// truncated reviewer payload used to be refused with one bare sentence, so a
+// report could not say whether an array, an object, or the whole payload was
+// left open. The refusal now keeps its prefix and appends a census.
+func TestExtractBoundedSingleJSONObjectReportsStructuralCensus(t *testing.T) {
+	for _, test := range []struct {
+		name, payload, want string
+	}{
+		{
+			name:    "unclosed array inside a finding",
+			payload: `{"findings":[{"id":"R3-001","proof_refs":["x"`,
+			want:    "reviewer payload contains no complete JSON object: 2 objects opened, 0 closed; 2 arrays opened, 0 closed; scan ended at byte 42",
+		},
+		{
+			name:    "unclosed inspection object",
+			payload: `{"subject_hash":"sha256:0","inspection":{"status":"completed","paths":["a.go"]`,
+			want:    "reviewer payload contains no complete JSON object: 2 objects opened, 0 closed; 1 array opened, 1 closed; scan ended at byte 78",
+		},
+		{
+			name:    "prose only",
+			payload: "I inspected the candidate and found nothing to report.",
+			want:    "reviewer payload contains no complete JSON object: no object start was found in 54 bytes",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, decision, err := ExtractBoundedSingleJSONObject([]byte(test.payload), 4096)
+			if decision != ArtifactAdmissionIncomplete || err == nil || err.Error() != test.want {
+				t.Fatalf("ExtractBoundedSingleJSONObject() = %q, %v; want incomplete with %q", decision, err, test.want)
+			}
+		})
+	}
+	extracted, decision, err := ExtractBoundedSingleJSONObject([]byte("done\n{\"findings\":[],\"evidence\":[\"[unclosed in string\"]}\n"), 4096)
+	if err != nil || decision != ArtifactAdmissionCompleted || string(extracted) != `{"findings":[],"evidence":["[unclosed in string"]}` {
+		t.Fatalf("complete payload = %q, %q, %v", extracted, decision, err)
+	}
+}
+
+// TestEvidenceReportsUnavailableInspectionPhrases is #1867: the phrases a
+// reviewer writes when the immutable candidate could not be read must be
+// classified as an unavailable inspection, while a completed inspection that
+// merely mentions reading stays a genuine result.
+func TestEvidenceReportsUnavailableInspectionPhrases(t *testing.T) {
+	for _, test := range []struct {
+		evidence string
+		want     bool
+	}{
+		{"Read denied on the immutable candidate tree", true},
+		{"the frozen tree was denied by filesystem policy", true},
+		{"cannot read diff for the candidate", true},
+		{"Cannot read manifest of changed paths", true},
+		{"the reviewer could not read the candidate at all", true},
+		{"unable to read the candidate tree sha256:9f2c", true},
+		{"inspection blocked by the sandbox", true},
+		{"could not be inspected with read-only Git access", true},
+		{"read the manifest and inspected every path", false},
+		{"inspected the tree: the loop still stops one entry short", false},
+	} {
+		if got := evidenceReportsUnavailableInspection(test.evidence); got != test.want {
+			t.Fatalf("evidenceReportsUnavailableInspection(%q) = %v, want %v", test.evidence, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3942
Closes #2791

Bounded slice of the early-capture gap described in the latest handoff on issue 1867 (rejected payload preservation and read-failure phrases); that issue stays open for its remaining tracks.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Every reviewer runtime returns free text (claude `--output-format text`, codex `--output-last-message`, pi `--mode text`) and all four runtimes converge on one strict admission chokepoint. One out-of-schema nested field (`inspection.lens`, `inspection.paths_note`) or one unclosed array ended the capture, the raw bytes were discarded, and the only exit was relaunching the same slot, which failed the same way stochastically.
- In-process runtimes (claude-code, codex) now get exactly one corrective re-invocation: the original materialized prompt plus the exact admission error and the three rules the result broke. The retry lives only in the provider-execution branch of `RunReviewCaptureResult`; `--input` submissions (pi host relay) and the OpenCode live transport own their reviewer and get no re-invocation.
- Every refused payload, on every runtime, is preserved verbatim under `<GitCommonDir>/gentle-ai/rejected-results/<lineage>/` (0700/0600) as evidence outside the authority store, and the refusal names the path.
- `ExtractBoundedSingleJSONObject` reports a structural census (objects and arrays opened vs closed, byte where the scan stopped) instead of a bare verdict, which is what the unclosed-terminator reports asked for.
- `evidenceReportsUnavailableInspection` recognizes read failures reported as such (`read denied`, `denied by filesystem`, `cannot read diff`, `cannot read manifest`, ...).

Where the defect became reachable: the claude-code native capture path only started reaching admission with #3820 and #3826 (v2.5.0-rc.2); the timeline is on the linked issue.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_provider_correction.go` | New: `reviewProviderCaptureWithOneCorrection`, `maxReviewerResultAdmissionAttempts = 2`, the `GENTLE_AI_REVIEW_ADMISSION_FEEDBACK` corrective prompt section, and the runnable continuation in the final refusal. |
| `internal/cli/review_rejected_result.go` | New: `writeReviewRejectedResult` and the degrading `reviewRejectedResultClause` (`gentle-ai.review-rejected-result/v1` envelope). |
| `internal/cli/review_artifact.go` | Provider-execution branch routes through the one-correction helper; `--input` branch preserves the refused payload (not under `--preflight`). |
| `internal/cli/review_opencode_transport.go` | Preserves the refused host output before the existing typed refusal. |
| `internal/reviewtransaction/artifact_admission.go` | Structural census on incomplete payloads; read-failure phrases. |
| `.refusal-ratchet-baseline.txt` | One entry removed (the reworded message now carries its by-design annotation); the baseline only shrinks. |
| Tests | `review_provider_correction_test.go` (retry succeeds, both attempts refused, transport error skips correction, `--input` preserved without invoking the provider), `artifact_admission_test.go` (census cases, phrase table). |

Size: 609 changed lines (269 production, 340 tests). The four CLI scenarios are the proof that the retry is bounded and never leaks into the relay paths; dropping them to fit 400 would leave the bound unproven. Requesting `size:exception` on that basis.

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with one mapping agent and one writer agent.

**Material scope:** Call-chain mapping across runtimes, design, tests (red first), production change, ratchet annotation.

**Verification performed:** `go test ./...`, `go run ./internal/gofmtcheck`, `go vet` including `GOOS=windows` for `internal/cli`, driven bench corpus against a locally built binary (summary in Test Plan). E2E Docker left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

Review-lifecycle change: driven corpus against a binary built from this branch (same invocation as CI): `journeys: 61 completed, 0 unsupported, 0 failed`.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented (requested above)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Guards: no new `guard:population` declaration and `.guard-population-baseline.txt` is untouched. The one reworded refusal (`reviewer payload contains no complete JSON object: <census>`) carries a `refusal:by-design operator-knowledge` annotation; the refusal ratchet baseline shrinks by one line. The retry loop is deliberately outside `internal/reviewerprovider` so the adapter minimality guard keeps adapters free of loops, parsing, and admission.

Receipt-driven review: a binary built from this branch reviewed this candidate end to end (four lenses, all admitted on the first attempt, no rejected payload preserved). The review returned two corroborated CRITICAL findings about the `--preflight` invariant on the provider branch; since `--agent` is refused together with `--preflight` at flag validation, the bounded correction (a88f915a: two comments plus `TestProviderCaptureRefusesPreflightBeforeInvocationOrPreservation`) states and proves that invariant. The targeted validator approved and the exact acknowledgement burned the lineage. Review outcomes are informational; delivery follows ordinary repository policy.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG
