### PR TITLE
fix(sdd): name the runnable exit for every compact settle refusal and complete verdict

### DIFF
--- a/internal/cli/sdd_attempt_compact_test.go
+++ b/internal/cli/sdd_attempt_compact_test.go
@@ -286,7 +286,7 @@ func TestRunSDDAttemptCompactPreservesTokenCASAndIdempotentReplay(t *testing.T) 
 	settleArgs := compactSettleArgs(repo, change, first.Token, "replay-settle", "passed")
 	completed, completedPayload := runCompactSDDAttempt(t, settleArgs)
 	completedReplay, completedReplayPayload := runCompactSDDAttempt(t, settleArgs)
-	if completed != (compactAttemptOutput{State: "complete"}) || completedReplay != completed || !bytes.Equal(completedPayload, completedReplayPayload) {
+	if completed.State != "complete" || completed.Exit == "" || completed.Detail != completed.Exit || completedReplay != completed || !bytes.Equal(completedPayload, completedReplayPayload) {
 		t.Fatalf("settle replay completed=%#v replayed=%#v", completed, completedReplay)
 	}
 	status, err := store.Status()
@@ -429,7 +429,7 @@ func TestRunSDDAttemptSettleSurvivesOffToOnReviewModeTransition(t *testing.T) {
 	settled, _ := runCompactSDDAttempt(t, append(compactSettleArgsWithEvidence(repo, change, correction.Token, "correction-settle", "passed", cliAttemptHash('b')),
 		"--remediates-evidence-revision", failedEvidence,
 	))
-	if settled != (compactAttemptOutput{State: "complete"}) {
+	if settled.State != "complete" || settled.Exit == "" {
 		t.Fatalf("correction settle after off-to-on review transition = %#v", settled)
 	}
 	status := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})

--- a/internal/cli/sdd_attempt_settle_exit_test.go
+++ b/internal/cli/sdd_attempt_settle_exit_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestSettleRefusesReusedAcquireRequestIDAndNamesTheExit is #3872: settle
+// with acquire's own --request-id found a begin receipt, refused, and sent the
+// caller to status, whose live attempt was exactly the one being settled.
+func TestSettleRefusesReusedAcquireRequestIDAndNamesTheExit(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const change = "settle-reused-request-id"
+	acquired, _ := runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "unit-1", 2))
+	reused, _ := runCompactSDDAttempt(t, compactSettleArgs(repo, change, acquired.Token, "unit-1", "passed"))
+	if reused.State != "blocked" || reused.Reason != "invalid_continuation" || reused.Detail != reused.Exit {
+		t.Fatalf("reused-request-id settle = %#v", reused)
+	}
+	assertExitNames(t, reused.Exit, "distinct --request-id", "unit-1", "`gentle-ai sdd-attempt status --cwd <repo> --change <change>`")
+	settled, _ := runCompactSDDAttempt(t, compactSettleArgs(repo, change, acquired.Token, "unit-1-settle", "passed"))
+	if settled.State != "complete" || !strings.Contains(settled.Exit, "--work-unit \"<a different label>\"") {
+		t.Fatalf("distinct-request-id settle = %#v, want complete naming the successor", settled)
+	}
+}
+
+// TestSettleNamesMalformedTokenWithoutMentioningFinish is #3879: a malformed
+// --token surfaced as "finish requires an exact expected runtime revision",
+// naming a flag settle does not accept.
+func TestSettleNamesMalformedTokenWithoutMentioningFinish(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const change = "settle-malformed-token"
+	runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "unit-1", 2))
+	var output bytes.Buffer
+	err := RunSDDAttempt(compactSettleArgs(repo, change, "not-a-token", "unit-1-settle", "passed"), &output)
+	if err == nil {
+		t.Fatalf("malformed token settle succeeded: %s", output.String())
+	}
+	if strings.Contains(err.Error(), "expected runtime revision") {
+		t.Fatalf("malformed token settle named finish's flag: %v", err)
+	}
+	assertExitNames(t, err.Error(), "--token", "`gentle-ai sdd-attempt status --cwd <repo> --change <change>`", "`gentle-ai sdd-attempt settle`")
+}
+
+// TestCompleteNamesTheSuccessorWorkUnit is #3884: a completed objective
+// answered `complete` with no exit, and rescope refused without naming the
+// successor acquire that has existed since v2.3.0.
+func TestCompleteNamesTheSuccessorWorkUnit(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const change = "complete-successor"
+	first, _ := runCompactSDDAttempt(t, compactWorkUnitAcquireArgs(repo, change, "slice-1-acquire", "slice-1"))
+	if settled, _ := runCompactSDDAttempt(t, compactSettleArgs(repo, change, first.Token, "slice-1-settle", "passed")); settled.State != "complete" {
+		t.Fatalf("settle = %#v, want complete", settled)
+	}
+
+	repeated, payload := runCompactSDDAttempt(t, compactWorkUnitAcquireArgs(repo, change, "slice-1-again", "slice-1"))
+	if repeated.State != "complete" || repeated.Detail != repeated.Exit {
+		t.Fatalf("repeated acquire = %#v, want complete with detail mirroring exit", repeated)
+	}
+	assertExitNames(t, repeated.Exit, "different label", "slice-1", "`gentle-ai sdd-attempt acquire --cwd <repo> --change <change>")
+	assertCompactPayloadKeys(t, payload, "state", "exit", "detail")
+
+	status := runSDDAttemptStatus(t, []string{
+		"status", "--cwd", repo, "--change", change, "--work-unit", "slice-1", "--evidence-goal", "prove compact attempt",
+		"--max-attempts", "2", "--max-changed-lines", "20",
+	})
+	if status.BlockedExit != repeated.Exit {
+		t.Fatalf("status blocked_exit = %q, want acquire's complete exit %q", status.BlockedExit, repeated.Exit)
+	}
+
+	var output bytes.Buffer
+	err := RunSDDAttempt([]string{
+		"rescope", "--cwd", repo, "--change", change, "--expected-revision", status.Revision, "--request-id", "slice-1-rescope",
+		"--work-unit", "slice-1-narrow", "--evidence-goal", "prove compact attempt", "--max-attempts", "1", "--max-changed-lines", "10",
+		"--reason", "narrowing a completed objective", "--actor", "maintainer",
+	}, &output)
+	if err == nil {
+		t.Fatalf("rescope of a completed objective succeeded: %s", output.String())
+	}
+	assertExitNames(t, err.Error(), "different --work-unit", "`gentle-ai sdd-attempt acquire --cwd <repo> --change <change>")
+
+	successor, _ := runCompactSDDAttempt(t, compactWorkUnitAcquireArgs(repo, change, "slice-2-acquire", "slice-2"))
+	if successor.State != "proceed" || successor.Token == "" {
+		t.Fatalf("successor acquire = %#v, want proceed with token", successor)
+	}
+}
+
+func compactWorkUnitAcquireArgs(repo, change, requestID, workUnit string) []string {
+	return []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", requestID,
+		"--work-unit", workUnit, "--evidence-goal", "prove compact attempt",
+		"--max-attempts", "2", "--max-changed-lines", "20",
+	}
+}
+
+func assertExitNames(t *testing.T, exit string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(exit, want) {
+			t.Fatalf("exit does not name %q:\n%s", want, exit)
+		}
+	}
+}

--- a/internal/sddstatus/runtime_admission.go
+++ b/internal/sddstatus/runtime_admission.go
@@ -196,7 +196,10 @@ func (store RuntimeStore) AdmissionStatus(ctx context.Context, request BeginAtte
 	normalized = runtimeRescopeSuccessorRequest(status, normalized, inheritIntendedUntracked)
 	if result, terminal := runtimeReadiness(runtimeReadinessInput{
 		Status: status, AttemptTokens: replay.AttemptTokens, Request: normalized,
-	}); terminal && result.State == CompactStateBlocked {
+	}); terminal && result.State != CompactStateProceed {
+		// A complete verdict has no block reason, but its exit (the successor
+		// acquire, #3884) rides BlockedExit rather than a new field, so the
+		// read-only surface names the same continuation acquire does.
 		status.BlockedReason, status.BlockedExit = result.Reason, result.Exit
 		// An exhausted budget is a decision, so it asks instead of ending the
 		// conversation. The grant is the reset the ledger already admits at

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -189,7 +189,7 @@ func runtimeReadiness(in runtimeReadinessInput) (CompactAttemptResult, bool) {
 		if in.Request.WorkUnit != "" && runtimeObjectiveAdvanceAdmissible(in.Status, in.Request) {
 			return CompactAttemptResult{}, false
 		}
-		return CompactAttemptResult{State: CompactStateComplete}, true
+		return compactCompleteResult(in.Status, in.Request), true
 	case in.Status.DecisionRequired:
 		return compactBlocked(CompactBlockMaintainerDecision, ""), true
 	case in.Status.ActiveAttempt != nil:
@@ -281,7 +281,7 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		}
 		finish, ok := compactSettleReplayRequest(replay, record, request)
 		if !ok {
-			return compactBlocked(CompactBlockInvalidContinuation, ""), nil
+			return compactBlockedWithExit(CompactBlockInvalidContinuation, compactSettleReceiptExit(record, request.RequestID)), nil
 		}
 		if _, err := store.Finish(ctx, finish); err != nil {
 			return store.compactMutationFailure(err, true, BeginAttemptRequest{}), nil
@@ -300,7 +300,9 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		Status: replay.Status, AttemptTokens: replay.AttemptTokens, PresentedToken: request.Token,
 	})
 	if !terminal {
-		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
+		return compactBlockedWithExit(CompactBlockInvalidContinuation,
+			"no attempt is active for this change, so there is nothing to settle; run "+compactStatusCommand+
+				" to read the ledger, then acquire with "+compactAcquireCommand("<label>")+" before settling"), nil
 	}
 	if readiness.State != CompactStateProceed {
 		return readiness, nil
@@ -315,11 +317,20 @@ func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleReque
 		ExpectedUntrackedInventory: request.ExpectedUntrackedInventory,
 	}
 	failedEvidence, hasFailedEvidence := runtimeChainFailedEvidence(status.Attempts)
-	if request.RemediatesEvidenceRevision != "" && (!hasFailedEvidence || failedEvidence != request.RemediatesEvidenceRevision) {
-		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
+	if request.RemediatesEvidenceRevision != "" && !hasFailedEvidence {
+		return compactBlockedWithExit(CompactBlockInvalidContinuation,
+			"the attempt chain holds no unremediated failed evidence, so --remediates-evidence-revision "+request.RemediatesEvidenceRevision+
+				" names nothing; run "+compactStatusCommand+" to read the chain, then rerun this settle without that flag"), nil
+	}
+	if request.RemediatesEvidenceRevision != "" && failedEvidence != request.RemediatesEvidenceRevision {
+		return compactBlockedWithExit(CompactBlockInvalidContinuation,
+			"the chain's unremediated failed evidence is "+failedEvidence+", not "+request.RemediatesEvidenceRevision+
+				"; run "+compactStatusCommand+" to read the chain, then rerun this settle with --remediates-evidence-revision "+failedEvidence), nil
 	}
 	if request.Outcome == AttemptPassed && hasFailedEvidence && request.RemediatesEvidenceRevision == "" {
-		return compactBlocked(CompactBlockInvalidContinuation, ""), nil
+		return compactBlockedWithExit(CompactBlockInvalidContinuation,
+			"this passed settle was refused: "+runtimeSettleObligation(status)+" Run "+compactStatusCommand+
+				" to read the chain, then rerun this settle with that flag."), nil
 	}
 	finish.RemediatesEvidenceRevision = request.RemediatesEvidenceRevision
 	if _, err := store.Finish(ctx, finish); err != nil {
@@ -355,6 +366,13 @@ func failedEvidenceRemediationSettleable(status RuntimeStatus, failedEvidence st
 func normalizeCompactSettleRequest(request CompactSettleRequest) error {
 	if request.Outcome == AttemptInterrupted && request.EvidenceRevision != "" {
 		return errors.New("interrupted evidence_revision must be empty; rerun `gentle-ai sdd-attempt settle` without --evidence-revision")
+	}
+	// The token is settle's own flag (#3879): checked here so a malformed one
+	// never surfaces as finish's "expected runtime revision", a flag settle
+	// does not accept.
+	if !runtimeRevisionPattern.MatchString(request.Token) {
+		return errors.New("token must be the exact sha256:<64-lowercase-hex> value acquire returned; run " + compactStatusCommand +
+			" to read the live attempt's token, then rerun `gentle-ai sdd-attempt settle` with --token <that value>")
 	}
 	_, err := normalizeFinishAttemptRequest(FinishAttemptRequest{
 		ExpectedRevision: request.Token, RequestID: request.RequestID, Outcome: request.Outcome,
@@ -641,6 +659,58 @@ func runtimeSettleObligation(status RuntimeStatus) string {
 func compactBlocked(reason CompactBlockReason, token string) CompactAttemptResult {
 	exit := compactBlockedExitText(reason, token)
 	return CompactAttemptResult{State: CompactStateBlocked, Reason: reason, Token: token, Exit: exit, Detail: exit}
+}
+
+// compactBlockedWithExit is compactBlocked for a cause whose runnable exit is
+// narrower than its reason's fixed text (#3872): the reason vocabulary stays
+// closed so consumers keep routing, and only the exit names the real cause.
+func compactBlockedWithExit(reason CompactBlockReason, exit string) CompactAttemptResult {
+	return CompactAttemptResult{State: CompactStateBlocked, Reason: reason, Exit: exit, Detail: exit}
+}
+
+const compactStatusCommand = "`gentle-ai sdd-attempt status --cwd <repo> --change <change>`"
+
+const compactResetCommand = "`gentle-ai sdd-attempt reset --cwd <repo> --change <change> --expected-revision <the revision that status prints> " +
+	"--request-id \"<unique-request-id>\" --reason \"<why-the-objective-is-being-reset>\" --actor \"<actor>\"`"
+
+func compactAcquireCommand(workUnit string) string {
+	return "`gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id \"<unique-request-id>\" --work-unit \"" + workUnit +
+		"\" --evidence-goal \"<stable-goal>\" --max-attempts <count> --max-changed-lines <count>`"
+}
+
+// compactSettleReceiptExit names why a settle's --request-id already holds a
+// receipt that is not a replay of this settle: the caller reused acquire's id
+// (#3872's "same --request-id"), or an earlier settle with different fields.
+func compactSettleReceiptExit(record runtimeRecord, requestID string) string {
+	if record.Operation == runtimeOperationFinish {
+		return "--request-id " + requestID + " already recorded a settle with different fields; a replay must repeat that settle exactly, " +
+			"otherwise rerun this settle with a new --request-id; run " + compactStatusCommand + " to read the live attempt"
+	}
+	return "--request-id " + requestID + " already identifies this attempt's acquire; settle needs its own distinct --request-id, and reuses " +
+		"one only to replay the identical settle; run " + compactStatusCommand + " to confirm the live attempt, then rerun this settle with a new --request-id"
+}
+
+// compactCompleteResult names the successor route a completed objective
+// leaves open (#3884): acquire with a different --work-unit has been the
+// advance since v2.3.0, and nothing named it, so callers reached for rescope,
+// which a complete objective refuses.
+func compactCompleteResult(status RuntimeStatus, request BeginAttemptRequest) CompactAttemptResult {
+	workUnit := ""
+	if status.Objective != nil {
+		workUnit = status.Objective.WorkUnit
+	}
+	exit := "this change's runtime objective (" + workUnit + ") is complete; to continue with the next ordered work unit, run " +
+		compactAcquireCommand("<a different label>") + "; rescope applies only to an objective that is not complete, and reset discards this scope instead of succeeding it"
+	switch {
+	case request.WorkUnit == "":
+	case request.WorkUnit == workUnit:
+		exit += "; --work-unit \"" + request.WorkUnit + "\" restates the completed objective; choose a different label"
+	case len(status.Attempts) > 0 && status.Attempts[len(status.Attempts)-1].ChangedLineBudgetExceeded:
+		exit += "; the last attempt exceeded its changed-line budget, so no successor may advance from it; a maintainer reset is required: " + compactResetCommand
+	case len(status.Attempts) > 0 && (status.Attempts[len(status.Attempts)-1].FinishCandidateIdentity == "" || status.Attempts[len(status.Attempts)-1].FinishCandidateTree == ""):
+		exit += "; the last passed attempt recorded no finish candidate identity (a record written by an older binary), so a successor cannot bind to it; a maintainer reset is required: " + compactResetCommand
+	}
+	return CompactAttemptResult{State: CompactStateComplete, Exit: exit, Detail: exit}
 }
 
 // compactForeignAcquireToken names the exact continuation for a losing

--- a/internal/sddstatus/runtime_compact_settle_exit_test.go
+++ b/internal/sddstatus/runtime_compact_settle_exit_test.go
@@ -1,0 +1,125 @@
+package sddstatus
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// #3872, #3879, and #3884 share one root class: a compact ledger answer that
+// does not name its runnable exit. Settle collapsed five causes into one
+// generic invalid_continuation text, and complete carried no exit at all.
+
+func TestSettleWithoutActiveAttemptNamesAcquire(t *testing.T) {
+	store := mustRuntimeStore(t, initRuntimeLedgerRepo(t), "settle-nothing-active")
+	result, err := store.Settle(context.Background(), compactSettleFixture("idle-settle", runtimeTestHash('1'), AttemptPassed, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSettleBlockedExit(t, result, "nothing to settle", "`gentle-ai sdd-attempt acquire --cwd <repo> --change <change>")
+}
+
+func TestSettlePassedWithoutRemediatesNamesTheChainEvidence(t *testing.T) {
+	store := seedUnremediatedFailure(t, "settle-owes-remediation")
+	attempt := acquireRegressionAttempt(t, store, "b-acquire", "sdd-remediate", "correct failed verification A", "", 2)
+	result, err := store.Settle(context.Background(), compactSettleFixture("b-settle", attempt.Token, AttemptPassed, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSettleBlockedExit(t, result, "this passed settle was refused", regressionFailedEvidence, "--remediates-evidence-revision")
+}
+
+func TestSettleRemediatesMismatchNamesTheChainEvidence(t *testing.T) {
+	other := runtimeTestHash('c')
+	store := seedUnremediatedFailure(t, "settle-remediates-mismatch")
+	attempt := acquireRegressionAttempt(t, store, "b-acquire", "sdd-remediate", "correct failed verification A", "", 2)
+	result, err := store.Settle(context.Background(), compactSettleFixture("b-settle", attempt.Token, AttemptPassed, other))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSettleBlockedExit(t, result, "not "+other, "--remediates-evidence-revision "+regressionFailedEvidence)
+
+	fresh := mustRuntimeStore(t, initRuntimeLedgerRepo(t), "settle-remediates-nothing")
+	attempt = acquireRegressionAttempt(t, fresh, "a-acquire", "sdd-apply", "apply the change", "", 2)
+	result, err = fresh.Settle(context.Background(), compactSettleFixture("a-settle", attempt.Token, AttemptPassed, other))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSettleBlockedExit(t, result, "names nothing", other, "without that flag")
+}
+
+// The changed-line and older-binary preconditions cannot be reached through
+// the CLI (a finish that exceeds its budget never completes), so they are
+// driven through the pure readiness predicate on a constructed ledger state.
+func TestCompleteExitNamesEachSuccessorPrecondition(t *testing.T) {
+	objective := &RuntimeObjective{ID: runtimeTestHash('o'), WorkUnit: "slice-1"}
+	passed := RuntimeAttempt{
+		ObjectiveID: objective.ID, Outcome: AttemptPassed,
+		FinishCandidateIdentity: runtimeTestHash('i'), FinishCandidateTree: strings.Repeat("a", 40),
+	}
+	exceeded, unbound := passed, passed
+	exceeded.ChangedLineBudgetExceeded = true
+	unbound.FinishCandidateIdentity, unbound.FinishCandidateTree = "", ""
+	for _, tt := range []struct {
+		name     string
+		last     RuntimeAttempt
+		workUnit string
+		want     []string
+	}{
+		{name: "no work unit", last: passed, want: []string{"(slice-1) is complete", "--work-unit \"<a different label>\""}},
+		{name: "same label", last: passed, workUnit: "slice-1", want: []string{"--work-unit \"slice-1\" restates the completed objective; choose a different label"}},
+		{name: "budget exceeded", last: exceeded, workUnit: "slice-2", want: []string{"exceeded its changed-line budget", "`gentle-ai sdd-attempt reset --cwd <repo> --change <change>"}},
+		{name: "older binary", last: unbound, workUnit: "slice-2", want: []string{"no finish candidate identity", "older binary", "`gentle-ai sdd-attempt reset --cwd <repo> --change <change>"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			status := RuntimeStatus{Complete: true, Objective: objective, Attempts: []RuntimeAttempt{tt.last}}
+			result, terminal := runtimeReadiness(runtimeReadinessInput{Status: status, Request: BeginAttemptRequest{WorkUnit: tt.workUnit}})
+			if !terminal || result.State != CompactStateComplete || result.Exit == "" || result.Detail != result.Exit {
+				t.Fatalf("readiness = %#v terminal=%v, want complete with a named exit", result, terminal)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(result.Exit, want) {
+					t.Fatalf("complete exit does not name %q:\n%s", want, result.Exit)
+				}
+			}
+		})
+	}
+}
+
+func seedUnremediatedFailure(t *testing.T, change string) RuntimeStore {
+	t.Helper()
+	store := mustRuntimeStore(t, initRuntimeLedgerRepo(t), change)
+	failed := acquireRegressionAttempt(t, store, "a-acquire", "sdd-verify", "record failed verification A", "", 1)
+	settleRegressionAttempt(t, store, "a-settle", failed.Token, AttemptFailed, regressionFailedEvidence, "")
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: status.Revision, RequestID: "a-reset", Reason: "maintainer authorizes remediation B", Actor: "maintainer",
+	}); err != nil {
+		t.Fatalf("authorized reset: %v", err)
+	}
+	return store
+}
+
+func compactSettleFixture(requestID, token string, outcome AttemptOutcome, remediates string) CompactSettleRequest {
+	return CompactSettleRequest{
+		RequestID: requestID, Token: token, Outcome: outcome, EvidenceRevision: regressionPassedEvidence,
+		Diagnosis: "settle exit fixture " + requestID, HarnessDisposition: HarnessReused,
+		CleanupEvidence: "fixture has no external resources", ProcessEvidence: "fixture process scan found no descendants",
+		RemediatesEvidenceRevision: remediates,
+	}
+}
+
+func assertSettleBlockedExit(t *testing.T, result CompactAttemptResult, wants ...string) {
+	t.Helper()
+	if result.State != CompactStateBlocked || result.Reason != CompactBlockInvalidContinuation || result.Detail != result.Exit {
+		t.Fatalf("settle = %#v, want blocked(invalid_continuation) with detail mirroring exit", result)
+	}
+	for _, want := range append(wants, "`gentle-ai sdd-attempt status --cwd <repo> --change <change>`") {
+		if !strings.Contains(result.Exit, want) {
+			t.Fatalf("settle exit does not name %q:\n%s", want, result.Exit)
+		}
+	}
+}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -75,8 +75,14 @@ var (
 	// continuation: the reset it refers to needs six flags the message never
 	// listed, and it is itself refused when the candidate has not drifted.
 	ErrRuntimeObjectiveChange = errors.New("SDD runtime objective changed without an explicit reset")
-	ErrRuntimeObjectiveDone   = errors.New("SDD runtime objective is complete; " + runtimeLedgerStatusPointer)
-	ErrRuntimeNoObjective     = errors.New("SDD runtime ledger has no objective to reset; " + runtimeLedgerStatusPointer)
+	// ErrRuntimeObjectiveDone names the successor route (#3884): a complete
+	// objective continues through acquire with a different --work-unit, and
+	// rescope refuses it, so pointing at status alone left callers circling.
+	ErrRuntimeObjectiveDone = errors.New("SDD runtime objective is complete; it continues through a successor objective, so run " +
+		"`gentle-ai sdd-attempt acquire --cwd <repo> --change <change> --request-id \"<unique-request-id>\" --work-unit \"<a different label>\" " +
+		"--evidence-goal \"<stable-goal>\" --max-attempts <count> --max-changed-lines <count>` with a different --work-unit (rescope applies only " +
+		"to an objective that is not complete); " + runtimeLedgerStatusPointer)
+	ErrRuntimeNoObjective = errors.New("SDD runtime ledger has no objective to reset; " + runtimeLedgerStatusPointer)
 	// ErrRuntimeResetNotAllowed named a STATE and no continuation, which is the
 	// same defect class as the sentinels above: an operator holding it knows
 	// what is refused and not one command that moves. The state it named was
@@ -1521,6 +1527,11 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 		objective := status.Objective
 		if objective == nil {
 			return runtimeRecord{}, ErrRuntimeNoObjective
+		}
+		// A complete objective is refused by the sentinel that names its
+		// successor (#3884), not by the generic structural refusal.
+		if status.Complete {
+			return runtimeRecord{}, ErrRuntimeObjectiveDone
 		}
 		if !runtimeObjectiveRescopeStructurallyPermitted(status) {
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3872
Closes #3879
Closes #3884

Same root class: a compact ledger answer that does not name its runnable exit. Canonical #3326 stays open for the item-scoped attempt design (#3465); this PR removes the dead end its duplicates reported.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- `Settle` collapsed four causes into one `invalid_continuation` whose fixed exit said "reissue this call against that state": a reused acquire `--request-id` (#3872's exact shape), a replay with different fields, no active attempt, a `--remediates-evidence-revision` that does not match the chain, and a passed settle that owed the chain's failed evidence. Each now names its own runnable exit; `reason` stays `invalid_continuation` so consumers keep routing.
- A malformed `--token` surfaced as `finish requires an exact expected runtime revision`, a flag settle does not accept (#3879). The token is validated first as settle's own flag.
- A completed objective returned `complete` with no exit; the successor route (acquire with a different `--work-unit`) has existed since v2.3.0 but nothing named it, so #3884 reached for `rescope`, which refused without naming it either. `complete` now names the successor acquire and the precondition that refused an advance (same label, changed-line budget exceeded, record without a finish identity); `rescope` on a complete objective returns `ErrRuntimeObjectiveDone`, which now names the route; the read-only admission status carries the complete exit through `BlockedExit` (no new field).

No new state, reason, verb, or flag.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_compact.go` | `compactBlockedWithExit`, `compactSettleReceiptExit`, `compactCompleteResult`, shared command text consts; five settle causes with their own exit; token validated in `normalizeCompactSettleRequest`. |
| `internal/sddstatus/runtime_ledger.go` | `ErrRuntimeObjectiveDone` names the successor acquire (same sentinel identity); `Rescope` returns it for a complete objective. |
| `internal/sddstatus/runtime_admission.go` | `AdmissionStatus` populates `BlockedExit` for the complete verdict. |
| `internal/sddstatus/runtime_compact_settle_exit_test.go`, `internal/cli/sdd_attempt_settle_exit_test.go` | New: each reported scenario driven through the store and through `RunSDDAttempt`; every test was run first on the unmodified tree and failed on the generic or empty exit text. |
| `internal/cli/sdd_attempt_compact_test.go` | Two assertions that pinned the bare `{"state":"complete"}` envelope now accept the exit a passed settle carries. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with one triage agent, one reproduction agent, and one writer agent.

**Material scope:** Backlog triage by root class, reproduction of the reported scenarios on current main, tests (red first), production change.

**Verification performed:** `go test ./...`, `go run ./internal/gofmtcheck`, `go vet` including `GOOS=windows`, refusal ratchet unchanged, driven bench corpus against a locally built binary (summary appended). E2E Docker left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

SDD runtime lifecycle change: driven corpus against a binary built from this branch (same invocation as CI). Summary line: `journeys: 61 completed, 0 unsupported, 0 failed`.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Guards: no admission, integrity, or governance predicate changed; `.guard-population-baseline.txt` and `.refusal-ratchet-baseline.txt` untouched (every new message names a runnable `gentle-ai sdd-attempt ...` continuation). The one behavioural change beyond text: `Rescope` on a complete objective now returns `ErrRuntimeObjectiveDone` instead of the generic `ErrRuntimeRescopeNotAllowed`; no test pinned the old sentinel for that case.

Receipt-driven review: four lenses (risk, resilience, readability, reliability) admitted on the first capture, verdict approved; the exact acknowledgement burned lineage review-60161c88356c019c (consent applied under the maintainer's standing authorization for this sweep). Review outcomes are informational; delivery follows ordinary repository policy.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG
